### PR TITLE
Support trailing slashes in urls

### DIFF
--- a/app/lib/route-helpers.coffee
+++ b/app/lib/route-helpers.coffee
@@ -1,15 +1,19 @@
 RouteParser = require 'route-parser'
+zipObject = require 'lodash.zipobject'
 
 a = document.createElement 'a'
 
+queryStringPairs = (queryString) ->
+  queryString?.split('&').map (keyval) -> keyval.split '='
+
 module.exports =
   parseLocation: ->
-    a.href = location.hash.slice 1
+    [path, queryString] = location.hash.slice(1).split('?')
 
-    query = {}
-    for keyAndValue in a.search.slice(1).split '&'
-      [key, value] = keyAndValue.split '='
-      query[key] = value
+    a.href = path
+      .replace(/\/$/g, '') # trim trailing slash
+
+    query = zipObject queryStringPairs(queryString)
 
     path: a.pathname
     hash: a.hash.slice 1

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "es6-promise": "^2.0.0",
     "function-bind": "^1.0.2",
     "json-api-client": "~0.0.8",
+    "lodash.zipobject": "^2.4.1",
     "marked": "^0.3.2",
     "nib": "^1.0.3",
     "publisssh": "^0.2.5",


### PR DESCRIPTION
@brian-c seems like we should support trailing slashes in urls--I added lodash.zipObject too since it'll return an empty object for free if there's no query string assigned and seemed elegant, but can take it out if you wish
