### PR TITLE
Add a couple components to help with async rendering

### DIFF
--- a/app/components/change-listener.cjsx
+++ b/app/components/change-listener.cjsx
@@ -1,0 +1,57 @@
+React = require 'react'
+
+# TODO: Maybe infer the on/off methods from a list if none is specified:
+# ON_OFF_METHODS =
+#   addEventListener: 'removeEventListener' # DOM elements
+#   addListener: 'removeListener' # Node EventEmitter class
+#   listen: 'stopListening' # Panoptes Model and JSONAPIClient Resource classes (change this to match Node?)
+#   on: 'off' # jQuery-ish
+
+module.exports = React.createClass
+  displayName: 'ChangeListener'
+
+  propTypes:
+    target: React.PropTypes.any.isRequired
+    eventName: React.PropTypes.string
+    on: React.PropTypes.string
+    off: React.PropTypes.string
+    handler: React.PropTypes.func.isRequired
+
+  getDefaultProps: ->
+    on: 'listen'
+    off: 'stopListening'
+
+  getInitialState: ->
+    payload: []
+
+  componentDidMount: ->
+    @startListeningTo @props.target
+
+  componentWillReceiveProps: (nextProps) ->
+    unless nextProps.target is @props.target
+      @stopListeningTo @props.target
+      @startListeningTo nextProps.target
+
+  componentWillUnmount: ->
+    @stopListeningTo @props.target
+
+  startListeningTo: (target) ->
+    target[@props.on] @getListenerArgs()...
+
+  stopListeningTo: (target) ->
+    target[@props.off] @getListenerArgs()...
+
+  getListenerArgs: ->
+    args = [@handleTargetChange]
+    if @props.eventName?
+      args.unshift @props.eventName
+    args
+
+  handleTargetChange: (payload...) ->
+    if @isMounted()
+      @setState {payload}
+
+  render: ->
+    # TODO: Figure out why returning `@props.children` here fails to re-render them on change.
+    # Then we can remove the requirement for a separate `handler` function.
+    @props.handler @state.payload...

--- a/app/components/promise-renderer.cjsx
+++ b/app/components/promise-renderer.cjsx
@@ -1,0 +1,58 @@
+React = require 'react'
+
+DEFAULT_RENDER_FAILURE = ->
+  <strong>
+    <code>Error</code>
+  </strong>
+
+module.exports = React.createClass
+  displayName: 'PromiseRenderer'
+
+  propTypes:
+    promise: React.PropTypes.instanceOf(Promise).isRequired
+    then: React.PropTypes.func.isRequired
+    catch: React.PropTypes.func
+
+  getDefaultProps: ->
+    catch: DEFAULT_RENDER_FAILURE
+
+  getInitialState: ->
+    resolved: false
+    rejected: false
+    value: null
+    error: null
+
+  componentDidMount: ->
+    @attachTo @props.promise
+
+  componentWillReceiveProps: (nextProps) ->
+    unless nextProps.promise is @props.promise
+      @attachTo nextProps.promise
+
+  attachTo: (promise) ->
+    @setState @getInitialState()
+
+    promise.then (value) =>
+      @safelySetState
+        resolved: true
+        value: value
+
+    promise.catch (error) =>
+      @safelySetState
+        rejected: true
+        error: error
+
+  safelySetState: (state) ->
+    if @isMounted()
+      @setState state
+
+  render: ->
+    if @state.resolved
+      @props.then @state.value
+
+    else if @state.rejected
+      @props.catch @state.error
+
+    else
+      # Until the promise is resolved or rejected, show the given children.
+      @props.children ? null


### PR DESCRIPTION
It looks like wrapper components might be a better way to manage promises and events than mixins, since a component encapsulates its own lifecycle and state.

**ChangeListener**, given a target emitter object, will re-render whenever a (configurable) change event is emitted. Ran into an issue with children not re-rendering, which is solved by passing in a `handler` function, which is annoying, but not the end of the world.

**PromiseRenderer**, given a promise, a `then` function, and a `catch` function, waits for the promise to resolve and renders with the results of the appropriate function. This is less annoying, since it'll force us to organize different render methods a bit more.

I extracted these from another branch I'm working on, so there are no examples here. Here they are in use: https://github.com/zooniverse/Panoptes-Front-End/blob/95789ca0172d59fe472135d8d49e8f8a082358e9/app/pages/edit-project.cjsx This is a decent example of how each render method is responsible for one thing, and the component's state is properly used for internal state-y things instead of a place to hold references to promised values.

Thoughts, @parrish, @aweiksnar?
