### PR TITLE
Update dependencies, remove object assign polyfill from test runner

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,20 +11,20 @@
     "marked": "^0.3.2",
     "nib": "^1.0.4",
     "node-static": "^0.7.6",
-    "react": "^0.12.0",
+    "react": "^0.12.1",
     "react-translator": "~0.0.4",
     "route-parser": "^0.0.2",
-    "stylus": "^0.49.2"
+    "stylus": "^0.49.3"
   },
   "devDependencies": {
     "blue-tape": "^0.1.7",
-    "cjsx-loader": "^1.0.0",
+    "cjsx-loader": "^1.1.0",
     "coffee-loader": "^0.7.2",
     "csso": "^1.3.11",
     "publisssh": "^0.2.5",
-    "tap-spec": "^1.0.0",
+    "tap-spec": "^2.1.1",
     "testling": "^1.7.1",
-    "webpack": "^1.4.12"
+    "webpack": "^1.4.13"
   },
   "scripts": {
     "build": "NODE_ENV=production ./bin/build.sh",

--- a/test/runner.coffee
+++ b/test/runner.coffee
@@ -1,7 +1,6 @@
  # Polyfills for for PhantomJS:
 Function::bind ?= require 'function-bind'
 require('es6-promise').polyfill()
-require '../public/object-assign-polyfill'
 
 require './auth'
 require './api'


### PR DESCRIPTION
@brian-c The only major version bump was in tap-spec, This branch also removes a require statement for the now unused object-assign-polyfill
