### PR TITLE
Update the API layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,33 @@
-# Panoptes front end
+# Panoptes (front end)
 
-## Planning
+## Development
 
-**./sitemap.md** should describe the layout of the site in detail.
+Requires Node.js.
 
-## Dev
-
-Dependencies are managed with npm; run `npm install` to get started.
+Run `npm install` to get started.
 
 `npm start` runs **./bin/serve.sh**, which watches the main CoffeeScript and Stylus files and runs a little server out of **./public** on port 3735 (looks like EYES).
 
-`npm run stage` runs **./bin/build.sh** which builds and optimizes the site, and then deploys it to <https://demo.zooniverse.org/panoptes-front-end>.
+`npm run stage` runs **./bin/build.sh** which builds and optimizes the site, and then deploys it to <http://demo.zooniverse.org/panoptes-front-end>.
 
-## Architecture
+All the good stuff is in **./app**. Start at **./app/main.cjsx**
 
-### React
+## Use in custom projects
 
-Everything that renders on the page is a React component. They're fairly organized:
+If you're writing a custom project against the Panoptes API, you can use this module to handle authentication and data access.
 
-**Components** are generic content holders. They have no content of their own.
+```coffee
+panoptes = require 'panoptes'
 
-**Pages** are individual pages on the site.
+panoptes.auth.register {login, password, email}
+panoptes.auth.signOut()
+panoptes.auth.signIn {login, password}
+
+panoptes.api.type('projects').get(SOME_PROJECT_ID).then (project) ->
+  project.update display_name: 'A great project'
+  project.save()
+  project.link('workflows').then (workflows) ->
+    workflows[1].delete()
+```
+
+More at the Panoptes API docs: <http://docs.panoptes.apiary.io/>.

--- a/app/api/client.coffee
+++ b/app/api/client.coffee
@@ -20,7 +20,7 @@ apiClient.handleError = (request) ->
     errorMessage = errorMessage.join '\n'
 
   errorMessage ?= request.responseText || "#{request.status} #{request.statusText}"
-  Promise.reject new Error errorMessage
+  throw new Error errorMessage
 
 module.exports = apiClient
 window.zooAPI = apiClient

--- a/app/api/client.coffee
+++ b/app/api/client.coffee
@@ -1,8 +1,26 @@
 JSONAPIClient = require 'json-api-client'
 config = require './config'
 
-module.exports = new JSONAPIClient config.host + '/api',
+apiClient = new JSONAPIClient config.host + '/api',
   'Content-Type': 'application/json'
   'Accept': 'application/vnd.api+json; version=1'
 
-window.zooAPI = module.exports
+apiClient.handleError = (request) ->
+  response = try JSON.parse request.responseText
+  if response?.error?
+    errorMessage = response.error
+    if response.error_description?
+      errorMessage = "#{errorMessage} #{response.error_description}"
+  else if response?.errors?[0].message?
+    errorMessage = for {message} in response.errors
+      if typeof message is 'string'
+        message
+      else
+        ("#{key} #{error}" for key, error of message).join '\n'
+    errorMessage = errorMessage.join '\n'
+
+  errorMessage ?= request.responseText || "#{request.status} #{request.statusText}"
+  Promise.reject new Error errorMessage
+
+module.exports = apiClient
+window.zooAPI = apiClient

--- a/app/lib/promise-to-set-state.coffee
+++ b/app/lib/promise-to-set-state.coffee
@@ -1,41 +1,38 @@
 module.exports =
   getInitialState: ->
-    awaiting: []
-
-  componentWillMount: ->
-    @_statePromises = {}
+    pending: {}
+    rejected: {}
 
   promiseToSetState: (keysAndPromises, callback) ->
+    {pending, rejected} = @state
+
     for key, promise of keysAndPromises
       promiseHandler = @_handlePromisedState.bind this, key, promise
       promise.then promiseHandler.bind this, false
       promise.catch promiseHandler.bind this, true
-      @_statePromises[key] = promise
 
-    {awaiting} = @state
-    if key in awaiting
-      callback?()
-    else
-      awaiting.push key
-      @setState {awaiting}, callback
+      pending[key] = promise
+      delete rejected[key]
+
+    @setState {pending, rejected}, callback
 
   _handlePromisedState: (key, promise, caught, value) ->
     # Only change the state if its current value is the same promise that's resolving.
-    samePromise = @_statePromises[key] is promise
-    delete @_statePromises[key]
+    isThePromiseInState = promise is @state.pending[key]
 
-    if @isMounted() and samePromise
-      newState = {}
+    if @isMounted() and isThePromiseInState
+      {pending, rejected} = @state
+      newState = {pending, rejected}
 
-      if caught and value not instanceof Error
-        error = new Error value
-        error.message = value # Override string-only messages. Maybe this isn't a great idea.
-        value = error
+      delete pending[key]
 
-      newState[key] = value
-
-      {awaiting} = @state
-      awaiting.splice awaiting.indexOf(key), 1
-      newState.awaiting = awaiting
+      if caught
+        newState[key] = null
+        rejected[key] = value
+      else
+        newState[key] = value
+        delete rejected[key]
 
       @setState newState
+
+    null

--- a/app/pages/build.cjsx
+++ b/app/pages/build.cjsx
@@ -34,7 +34,7 @@ module.exports = React.createClass
   renderUser: (user) ->
     <div>
       <p>Projects owned by {user.display_name}:</p>
-      <PromiseRenderer promise={user.attr 'projects'} then={@renderProjectsList}>
+      <PromiseRenderer promise={user.link 'projects'} then={@renderProjectsList}>
         <span>Loading projects...</span>
       </PromiseRenderer>
       <hr />

--- a/app/pages/build.cjsx
+++ b/app/pages/build.cjsx
@@ -2,7 +2,6 @@ React = require 'react'
 {Link} = require 'react-router'
 ChangeListener = require '../components/change-listener'
 PromiseRenderer = require '../components/promise-renderer'
-PromiseToSetState = require '../lib/promise-to-set-state'
 auth = require '../api/auth'
 
 RequiresSession = React.createClass

--- a/app/pages/edit-project.cjsx
+++ b/app/pages/edit-project.cjsx
@@ -160,7 +160,7 @@ module.exports = React.createClass
   displayName: 'EditProjectPage'
 
   render: ->
-    <PromiseRenderer promise={apiClient.createType('projects').get @props.params.id} then={@renderProjectEditor}>
+    <PromiseRenderer promise={apiClient.type('projects').get @props.params.id} then={@renderProjectEditor}>
       <div className="content-container">
         <p>Loading project <code>{@props.params.id}</code>...</p>
       </div>

--- a/app/pages/new-project/review.cjsx
+++ b/app/pages/new-project/review.cjsx
@@ -61,7 +61,7 @@ module.exports = React.createClass
     {language: primary_language, name: display_name, introduction, description, scienceCase: science_case} = data
     projectData = {primary_language, display_name, introduction, description, science_case}
 
-    project = apiClient.createType('projects').createResource projectData
+    project = apiClient.type('projects').create projectData
     project.save()
       .then =>
         @setState log: @state.log.concat ['Saved project']
@@ -76,7 +76,7 @@ module.exports = React.createClass
       links:
         project: project.id
 
-    subjectSet = apiClient.createType('subject_sets').createResource subjectSetData
+    subjectSet = apiClient.type('subject_sets').create subjectSetData
     subjectSet.save()
       .then =>
         @setState log: @state.log.concat ['Saved subject set']
@@ -94,7 +94,7 @@ module.exports = React.createClass
         project: project.id
         subject_sets: [subjectSet.id]
 
-    workflow = apiClient.createType('workflows').createResource workflowData
+    workflow = apiClient.type('workflows').create workflowData
     workflow.save()
       .then =>
         @setState log: @state.log.concat ['Saved workflow']
@@ -117,7 +117,7 @@ module.exports = React.createClass
         # metadata: metadata
         links: sharedSubjectLinks
 
-      subject = apiClient.createType('subjects').createResource subjectData
+      subject = apiClient.type('subjects').create subjectData
 
       subjectFilesString = (name for {name} in files).join ', '
       @setState log: @state.log.concat ["Saving subject #{subjectFilesString}"]

--- a/app/pages/project/classify.cjsx
+++ b/app/pages/project/classify.cjsx
@@ -10,6 +10,11 @@ module.exports = React.createClass
 
   mixins: [PromiseToSetState]
 
+  getInitialState: ->
+    workflow: null
+    subject: null
+    classification: null
+
   componentDidMount: ->
     @switchToProject @props.project
 

--- a/app/pages/project/classify.cjsx
+++ b/app/pages/project/classify.cjsx
@@ -29,13 +29,13 @@ module.exports = React.createClass
     projectStatesInProgress[project.id] = {workflow, subject, classification}
 
   getWorkflow: (index) ->
-    @props.project.attr('workflows').then (workflows) ->
+    @props.project.link('workflows').then (workflows) ->
       randomIndex = Math.floor Math.random() * workflows.length
       workflows[index ? randomIndex]
 
   getSubject: (workflow) ->
     workflow.then (workflow) =>
-      apiClient.createType('subjects').get({
+      apiClient.type('subjects').get({
         project_id: @props.project.id
         workflow_id: workflow.id
         # sort: 'cellect'
@@ -45,7 +45,7 @@ module.exports = React.createClass
   createClassification: (workflow, subject) ->
     Promise.all([workflow, subject]).then ([workflow, subject]) =>
       firstAnnotation = task: workflow.first_task ? Object.keys(workflow.tasks)[0]
-      classification = apiClient.createType('classifications').createResource
+      classification = apiClient.type('classifications').create
         annotations: [firstAnnotation]
         links:
           project: @props.project.id

--- a/app/pages/project/index.cjsx
+++ b/app/pages/project/index.cjsx
@@ -68,7 +68,7 @@ module.exports = React.createClass
       @fetchProject nextProps.params.id
 
   fetchProject: (id) ->
-    @promiseToSetState project: apiClient.createType('projects').get id
+    @promiseToSetState project: apiClient.type('projects').get id
 
   render: ->
     if @state.project?

--- a/app/pages/project/index.cjsx
+++ b/app/pages/project/index.cjsx
@@ -71,7 +71,7 @@ module.exports = React.createClass
     @promiseToSetState project: apiClient.createType('projects').get id
 
   render: ->
-    if @state.project?.id?
+    if @state.project?
       <ProjectPage project={@state.project} />
     else
       null

--- a/app/pages/projects.cjsx
+++ b/app/pages/projects.cjsx
@@ -24,7 +24,7 @@ Pager = React.createClass
 
   makeRequest: (page) ->
     params = Object.assign {page}, @props?.query
-    apiClient.createType(@props.type).get params, Infinity, @handleResponse
+    apiClient.type(@props.type).get params, Infinity, @handleResponse
 
   handleResponse: (request) ->
     # NOTE: Handling request metadata is currently pretty gnarly.

--- a/app/pages/user-profile.cjsx
+++ b/app/pages/user-profile.cjsx
@@ -101,7 +101,7 @@ module.exports = React.createClass
       @loadUser nextProps.params.name
 
   loadUser: (name) ->
-    @promiseToSetState user: apiClient.createType('users').get(display_name: name, 1).then ([user]) ->
+    @promiseToSetState user: apiClient.type('users').get(display_name: name, 1).then ([user]) ->
       user
 
   render: ->

--- a/app/pages/user-profile.cjsx
+++ b/app/pages/user-profile.cjsx
@@ -93,6 +93,9 @@ module.exports = React.createClass
   displayName: 'UserProfilePage'
   mixins: [PromiseToSetState]
 
+  getInitialState: ->
+    user: null
+
   componentDidMount: ->
     @loadUser @props.params.name
 
@@ -101,11 +104,11 @@ module.exports = React.createClass
       @loadUser nextProps.params.name
 
   loadUser: (name) ->
-    @promiseToSetState user: apiClient.type('users').get(display_name: name, 1).then ([user]) ->
+    @promiseToSetState user: apiClient.type('users').get(display_name: name).then ([user]) ->
       user
 
   render: ->
-    if @state.user?.id?
+    if @state.user?
       <div>
         <strong><i className="fa fa-exclamation-triangle"></i> Placeholder</strong>
         <UserProfile user={@state.user} />

--- a/app/partials/main-header.cjsx
+++ b/app/partials/main-header.cjsx
@@ -11,6 +11,9 @@ module.exports = React.createClass
 
   mixins: [PromiseToSetState]
 
+  getInitialState: ->
+    user: null
+
   componentDidMount: ->
     @handleAuthChange()
     auth.listen @handleAuthChange

--- a/app/partials/register-form.cjsx
+++ b/app/partials/register-form.cjsx
@@ -34,7 +34,7 @@ counterpart.registerTranslations 'en',
     alreadySignedIn: 'Already signed in as %(name)s.'
     signOut: 'Sign out'
 
-users = apiClient.createType 'users'
+users = apiClient.type 'users'
 
 module.exports = React.createClass
   displayName: 'RegisterForm'

--- a/app/partials/register-form.cjsx
+++ b/app/partials/register-form.cjsx
@@ -70,7 +70,7 @@ module.exports = React.createClass
               <kbd key={char}>{char}</kbd>
             <Translate component="span" className="form-help error" content="registerForm.badChars" chars={chars} />
 
-          else if "loginConflict" in @state.awaiting
+          else if "loginConflict" of @state.pending
             <LoadingIndicator />
           else if loginConflict?
             if loginConflict
@@ -116,7 +116,7 @@ module.exports = React.createClass
         <label>
           <Translate content="registerForm.email" /> <Translate className="form-help" content="registerForm.required" /><br />
           <input type="text" name="email" disabled={@state.user?} ref="email" onChange={@handleEmailChange} />
-          {if 'emailConflict' in @state.awaiting
+          {if 'emailConflict' of @state.pending
             <LoadingIndicator />
           else if emailConflict?
             if emailConflict
@@ -153,11 +153,11 @@ module.exports = React.createClass
       <br />
 
       <div>
-        <button type="submit" disabled={not @isFormValid() or @state.awaiting.length isnt 0 or @state.user?}>
+        <button type="submit" disabled={not @isFormValid() or Object.keys(@state.pending).length isnt 0 or @state.user?}>
           <Translate content="registerForm.register" />
         </button>{' '}
 
-        {if 'user' in @state.awaiting
+        {if 'user' of @state.pending
           <LoadingIndicator />
         else if @state.user?
           <span className="form-help">

--- a/app/partials/sign-in-form.cjsx
+++ b/app/partials/sign-in-form.cjsx
@@ -1,7 +1,7 @@
 counterpart = require 'counterpart'
 React = require 'react'
 Translate = require 'react-translate-component'
-promiseToSetState = require '../lib/promise-to-set-state'
+PromiseToSetState = require '../lib/promise-to-set-state'
 auth = require '../api/auth'
 ChangeListener = require '../components/change-listener'
 PromiseRenderer = require '../components/promise-renderer'
@@ -18,7 +18,7 @@ counterpart.registerTranslations 'en',
 module.exports = React.createClass
   displayName: 'SignInForm'
 
-  mixins: [promiseToSetState]
+  mixins: [PromiseToSetState]
 
   getInitialState: ->
     user: null

--- a/app/partials/sign-in-form.cjsx
+++ b/app/partials/sign-in-form.cjsx
@@ -2,9 +2,11 @@ counterpart = require 'counterpart'
 React = require 'react'
 Translate = require 'react-translate-component'
 promiseToSetState = require '../lib/promise-to-set-state'
+auth = require '../api/auth'
+ChangeListener = require '../components/change-listener'
+PromiseRenderer = require '../components/promise-renderer'
 InPlaceForm = require '../components/in-place-form'
 LoadingIndicator = require '../components/loading-indicator'
-auth = require '../api/auth'
 
 counterpart.registerTranslations 'en',
   signInForm:
@@ -12,35 +14,34 @@ counterpart.registerTranslations 'en',
     signOut: 'Sign out'
     userName: 'User name'
     password: 'Password'
-    errors:
-      BAD_PASSWORD: 'Wrong username or password'
-      SERVER_ERROR: 'Something went wrong! Try again later.'
 
 module.exports = React.createClass
   displayName: 'SignInForm'
 
   mixins: [promiseToSetState]
 
-  componentDidMount: ->
-    @handleAuthChange()
-    auth.listen @handleAuthChange
-
-  componentWillUnmount: ->
-    auth.stopListening @handleAuthChange
-
-  handleAuthChange: ->
-    @promiseToSetState user: auth.checkCurrent()
+  getInitialState: ->
+    user: null
 
   render: ->
-    working = @state.user instanceof Promise
-    signedIn = @state.user? and (not @state.errors?) and (not working)
+    # console.log 'SignInForm', 'render', JSON.stringify @state
+    <ChangeListener target={auth} handler={@renderAuth} />
+
+  renderAuth: ->
+    # console.log 'SignInForm', 'renderAuth'
+    <PromiseRenderer promise={auth.checkCurrent()} then={@renderUser} catch={@renderUser} />
+
+  renderUser: (user) ->
+    # console.log 'SignInForm', 'renderUser', user?
+    working = @state.pending.user?
+    signedIn = user? and (not @state.rejected.user?) and (not working)
     disabled = working or signedIn
 
     <InPlaceForm onSubmit={@handleSubmit}>
       <div>
         <label>
           <Translate content="signInForm.userName" /><br />
-          <input type="text" name="login" value={@props.currentLogin?.display_name} disabled={disabled} ref="login" autoFocus="autoFocus" />
+          <input type="text" name="login" value={user?.display_name} disabled={disabled} ref="login" autoFocus="autoFocus" />
         </label>
       </div>
 
@@ -49,7 +50,7 @@ module.exports = React.createClass
       <div>
         <label>
           <Translate content="signInForm.password" /><br />
-          <input type="password" name="password" value={@props.currentLogin?.password} disabled={disabled} ref="password" />
+          <input type="password" name="password" value={user?.password} disabled={disabled} ref="password" />
         </label>
       </div>
 
@@ -61,10 +62,13 @@ module.exports = React.createClass
         </button>
 
         {if signedIn
-          <span className="form-help">Signed in as {@state.user.display_name} <button onClick={@handleSignOut}>Sign out</button></span>}
+          <span className="form-help">
+            Signed in as {user.display_name}
+            <button type="button" onClick={@handleSignOut}>Sign out</button>
+          </span>}
 
-        {if @state.errors?
-          <span className="form-help error">{@state.errors}</span>}
+        {if @state.rejected.user?
+          <span className="form-help error">{@state.rejected.user.message}</span>}
 
         {if working
           <LoadingIndicator />}
@@ -72,17 +76,11 @@ module.exports = React.createClass
     </InPlaceForm>
 
   handleSubmit: ->
-    login = @refs.login.getDOMNode().value
-    password = @refs.password.getDOMNode().value
-
-    auth.signIn {login, password}
-      .then =>
-        @setState errors: null
-
-      .catch (errors) =>
-        @setState errors: errors
+    login = @getDOMNode().querySelector('[name="login"]').value
+    password = @getDOMNode().querySelector('[name="password"]').value
+    @promiseToSetState user: auth.signIn {login, password}
 
   handleSignOut: ->
     auth.signOut().then =>
-      @refs.login.getDOMNode().value = ''
-      @refs.password.getDOMNode().value = ''
+      @getDOMNode().querySelector('[name="login"]').value = ''
+      @getDOMNode().querySelector('[name="password"]').value = ''

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -25,6 +25,7 @@ cp -av "$DEV_DIR" "$BUILD_DIR"
   $(flag_externals external) \
   --extension .cjsx \
   --extension .coffee \
+  --ignore-transform coffeeify \
   --transform coffee-reactify \
   --transform envify \
   --entry "$SRC_JS" \

--- a/bin/serve.sh
+++ b/bin/serve.sh
@@ -23,6 +23,7 @@ echo "$DEV_DIR/$VENDOR_JS:" $(cat "$DEV_DIR/$VENDOR_JS" | wc -c) "bytes"
   $(flag_externals external) \
   --extension .cjsx \
   --extension .coffee \
+  --ignore-transform coffeeify \
   --transform coffee-reactify \
   --entry $SRC_JS \
   --outfile $DEV_DIR/$OUT_JS \

--- a/bin/serve.sh
+++ b/bin/serve.sh
@@ -10,7 +10,6 @@ pids=""
 
 ./node_modules/.bin/browserify \
   --debug \
-  --transform envify \
   $(flag_externals require) \
   --outfile "$DEV_DIR/$VENDOR_JS"
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "postinstall": "npm run get-fallback-polyfills && npm run get-font-awesome",
     "stage": "npm run build && publisssh ./build demo.zooniverse.org/panoptes-front-end",
     "start": "./bin/serve.sh",
-    "test": "browserify ./test/runner.coffee --extension .coffee --transform coffee-reactify --transform envify | testling \"${TESTLING_ARGS:---pass}\" | tap-spec",
+    "test": "browserify ./test/runner.coffee --extension .coffee --transform coffee-reactify --transform envify --ignore-transform coffeeify | testling \"${TESTLING_ARGS:---pass}\" | tap-spec",
     "test-mac": "TESTLING_ARGS=\"-x open --new -a Google\\ Chrome --args --incognito\" npm run test"
   },
   "config": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "test-mac": "TESTLING_ARGS=\"-x open --new -a Google\\ Chrome --args --incognito\" npm run test"
   },
   "config": {
-    "fontAwesomeURL": "http://fortawesome.github.io/Font-Awesome/assets/font-awesome-4.2.0.zip",
+    "fontAwesomeURL": "https://github.com/FortAwesome/Font-Awesome/blob/8027c940b6/assets/font-awesome-4.2.0.zip?raw=true",
     "fallbackPolyfillsURL": "https://cdn.polyfill.io/v1/polyfill.min.js?features=default,es6&flags=gated&ua=(MSIE%209.0)"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "scripts": {
     "build": "NODE_ENV=production ./bin/build.sh",
-    "check-build-size": "npm run build && cat ./build/main.js | gzip --best | wc -c",
+    "check-build-size": "npm run build && cat ./build/{vendor,main}.js | gzip --best | wc -c",
     "get-fallback-polyfills": "curl \"$npm_package_config_fallbackPolyfillsURL\" > ./public/fallback-polyfills.js",
     "get-font-awesome": "rm -rf ./public/font-awesome; curl --location \"$npm_package_config_fontAwesomeURL\" --output ./fa.zip && unzip -q ./fa.zip -d ./fa.tmp && mkdir ./public/font-awesome && mv ./fa.tmp/*/{css,fonts} ./public/font-awesome; rm -rf ./fa.{zip,tmp}",
     "postinstall": "npm run get-fallback-polyfills && npm run get-font-awesome",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "counterpart": "^0.16.4",
     "debounce": "^1.0.0",
     "emojify.js": "^0.9.5",
-    "json-api-client": "~0.0.8",
+    "json-api-client": "~0.1.0",
     "lodash.merge": "^2.4.1",
     "marked": "^0.3.2",
     "react": "^0.12.1",

--- a/test/auth.coffee
+++ b/test/auth.coffee
@@ -124,20 +124,19 @@ test 'Signing in with good details works', (t) ->
     .catch ->
       t.fail 'Sign in should work'
 
-test.skip 'Deleting an account works', (t) ->
-  auth.checkCurrent().then (user) ->
-    user.delete()
-      .then ->
-        OLD_LOGIN_DETAILS =
-          login: TEST_LOGIN
-          password: TEST_PASSWORD
+test 'Disabling an account works', (t) ->
+  auth.disableAccount()
+    .then ->
+      OLD_LOGIN_DETAILS =
+        login: TEST_LOGIN
+        password: TEST_PASSWORD
 
-        auth.signIn OLD_LOGIN_DETAILS
-          .then (user) ->
-            t.fail 'Should not have been able to sign in to a deleted account'
+      auth.signIn OLD_LOGIN_DETAILS
+        .then (user) ->
+          t.fail 'Should not have been able to sign in to a disabled account'
 
-          .catch ->
-            t.pass 'Could not sign in to a deleted account'
+        .catch ->
+          t.pass 'Could not sign in to a disabled account'
 
-      .catch (error) ->
-        t.fail 'Failed to delete account'
+    .catch (error) ->
+      t.fail 'Failed to disable account'

--- a/test/auth.coffee
+++ b/test/auth.coffee
@@ -23,11 +23,10 @@ test 'Registering an account with no data fails', (t) ->
     .then ->
       t.fail 'Should not have been able to register'
 
-    .catch (errors) ->
-      t.ok errors?.length is 1, 'Should have gotten one error'
-      t.ok errors[0].message.login[0].indexOf('blank') isnt -1, 'Login error should mention "blank"'
-      t.ok errors[0].message.email[0].indexOf('blank') isnt -1, 'Email error should mention "blank"'
-      t.ok errors[0].message.password[0].indexOf('blank') isnt -1, 'Password error should mention "blank"'
+    .catch (error) ->
+      t.ok error.message.match(/^login(.+)blank/mi), 'Login error should mention "blank"'
+      t.ok error.message.match(/^email(.+)blank/mi), 'Email error should mention "blank"'
+      t.ok error.message.match(/^password(.+)blank/mi), 'Password error should mention "blank"'
 
 test 'Registering an account with a short password fails', (t) ->
   SHORT_PASSWORD_REGISTRATION =
@@ -39,9 +38,8 @@ test 'Registering an account with a short password fails', (t) ->
     .then ->
       t.fail 'Should not have been able to register'
 
-    .catch (errors) ->
-      t.ok errors?.length is 1, 'Should have gotten one error'
-      t.ok errors[0].message.password[0].indexOf('short') isnt -1, 'Password error should mention "short"'
+    .catch (error) ->
+      t.ok error.message.match(/^password(.+)short/mi), 'Password error should mention "short"'
 
 test 'Registering a new account works', (t) ->
   GOOD_REGISTRATION =
@@ -51,11 +49,11 @@ test 'Registering a new account works', (t) ->
 
   auth.register GOOD_REGISTRATION
     .then (user) ->
-      t.ok user?, 'Should have gotten a user'
+      t.ok user?, 'Should have gotten the new user'
       t.ok user.display_name is TEST_LOGIN, 'Display name should be whatever login was given'
 
     .catch ->
-      t.fail 'Should have worked'
+      t.fail 'Should have been able to register'
 
 test 'Registering keeps you signed in', (t) ->
   auth.checkCurrent()
@@ -84,10 +82,9 @@ test 'Registering an account with an already used login fails', (t) ->
     .then ->
       t.fail 'Should not have been able to register with a duplicate login'
 
-    .catch (errors) ->
-      t.ok errors?.length is 1, 'Should have gotten one error'
-      t.ok errors[0].message.login[0].indexOf('taken') isnt -1, 'Login error should mention "taken"'
-      t.ok errors[0].message.email[0].indexOf('taken') isnt -1, 'Email error should mention "taken"'
+    .catch (error) ->
+      t.ok error.message.match(/^login(.+)taken/mi), 'Login error should mention "taken"'
+      t.ok error.message.match(/^email(.+)taken/mi), 'Email error should mention "taken"'
 
 test 'Signing in with an unknown login fails', (t) ->
   BAD_LOGIN =
@@ -98,10 +95,9 @@ test 'Signing in with an unknown login fails', (t) ->
     .then ->
       t.fail 'Should not have been able to sign in with a bad login'
 
-    .catch (errors) ->
-      t.ok errors?.length is 1, 'Should have gotten one error'
+    .catch (error) ->
       # NOTE: A bad login should return the same error as a bad password.
-      t.ok errors[0].message.password[0].indexOf('incorrect') isnt -1, 'Password error should mention "incorrect"'
+      t.ok error.message.match(/^invalid(.+)password/mi), 'Error should mention "invalid" and "password"'
 
 test 'Signing in with the wrong password fails', (t) ->
   BAD_PASSWORD =
@@ -112,9 +108,8 @@ test 'Signing in with the wrong password fails', (t) ->
     .then ->
       t.fail 'Should not have been able to sign in with a bad password'
 
-    .catch (errors) ->
-      t.ok errors?.length is 1, 'Should have gotten one error'
-      t.ok errors[0].message.password[0].indexOf('incorrect') isnt -1, 'Password error should mention "incorrect"'
+    .catch (error) ->
+      t.ok error.message.match(/^invalid(.+)password/mi), 'Error should mention "invalid" and "password"'
 
 test 'Signing in with good details works', (t) ->
   GOOD_LOGIN_DETAILS =
@@ -124,25 +119,25 @@ test 'Signing in with good details works', (t) ->
   auth.signIn GOOD_LOGIN_DETAILS
     .then (user) ->
       t.ok user?, 'Should have gotten a user'
-      t.ok user.display_name is TEST_LOGIN, 'Display name should be original'
+      t.ok user.display_name is TEST_LOGIN, 'Display name should be the original'
 
     .catch ->
       t.fail 'Sign in should work'
 
-test 'Deleting an account works', (t) ->
-  auth.checkCurrent().then (user) ->
-    user.delete()
-      .then ->
-        OLD_LOGIN_DETAILS =
-          login: TEST_LOGIN
-          password: TEST_PASSWORD
+# test 'Deleting an account works', (t) ->
+#   auth.checkCurrent().then (user) ->
+#     user.delete()
+#       .then ->
+#         OLD_LOGIN_DETAILS =
+#           login: TEST_LOGIN
+#           password: TEST_PASSWORD
 
-        auth.signIn OLD_LOGIN_DETAILS
-          .then (user) ->
-            t.fail 'Should not have been able to sign in to a deleted account'
+#         auth.signIn OLD_LOGIN_DETAILS
+#           .then (user) ->
+#             t.fail 'Should not have been able to sign in to a deleted account'
 
-          .catch ->
-            t.pass 'Could not sign in to a deleted account'
+#           .catch ->
+#             t.pass 'Could not sign in to a deleted account'
 
-      .catch (errors) ->
-        t.fail 'Failed to delete account'
+#       .catch (error) ->
+#         t.fail 'Failed to delete account'

--- a/test/auth.coffee
+++ b/test/auth.coffee
@@ -124,20 +124,20 @@ test 'Signing in with good details works', (t) ->
     .catch ->
       t.fail 'Sign in should work'
 
-# test 'Deleting an account works', (t) ->
-#   auth.checkCurrent().then (user) ->
-#     user.delete()
-#       .then ->
-#         OLD_LOGIN_DETAILS =
-#           login: TEST_LOGIN
-#           password: TEST_PASSWORD
+test.skip 'Deleting an account works', (t) ->
+  auth.checkCurrent().then (user) ->
+    user.delete()
+      .then ->
+        OLD_LOGIN_DETAILS =
+          login: TEST_LOGIN
+          password: TEST_PASSWORD
 
-#         auth.signIn OLD_LOGIN_DETAILS
-#           .then (user) ->
-#             t.fail 'Should not have been able to sign in to a deleted account'
+        auth.signIn OLD_LOGIN_DETAILS
+          .then (user) ->
+            t.fail 'Should not have been able to sign in to a deleted account'
 
-#           .catch ->
-#             t.pass 'Could not sign in to a deleted account'
+          .catch ->
+            t.pass 'Could not sign in to a deleted account'
 
-#       .catch (error) ->
-#         t.fail 'Failed to delete account'
+      .catch (error) ->
+        t.fail 'Failed to delete account'

--- a/test/project-creation.coffee
+++ b/test/project-creation.coffee
@@ -39,69 +39,70 @@ WORKFLOW_DATA =
       ]
   primary_language: LANGUAGE
 
-projects = apiClient.createType 'projects'
-workflows = apiClient.createType 'workflows'
-subjects = apiClient.createType 'subjects'
-subjectSets = apiClient.createType 'subject_sets'
+projects = apiClient.type 'projects'
+workflows = apiClient.type 'workflows'
+subjects = apiClient.type 'subjects'
+subjectSets = apiClient.type 'subject_sets'
 
 # Save resources in an accessible scope.
 resources = {}
+
+clone = (object) ->
+  JSON.parse JSON.stringify object
 
 test 'Create a temporary user', ->
   auth.register(USER_DATA).then (user) ->
     resources.user = user
 
 test 'Create a project', (t) ->
-  projects.createResource(PROJECT_DATA).save().then (project) ->
+  projects.create(PROJECT_DATA).save().then (project) ->
     resources.project = project
     t.ok project?, 'Responded with a project resource'
     t.ok project?.id, 'Project got an ID'
 
-    project.update
-
 test 'Create a subject set',  (t) ->
-  subjectSetData = Object.create SUBJECT_SET_DATA
+  subjectSetData = clone SUBJECT_SET_DATA
   subjectSetData.links =
     project: resources.project.id
 
-  subjectSets.createResource(subjectSetData).save().then (subjectSet) ->
+  subjectSets.create(subjectSetData).save().then (subjectSet) ->
     resources.subjectSet = subjectSet
     t.ok subjectSet?, 'Responded with a subject set resource'
     t.ok subjectSet?.id, 'Subject set got an ID'
 
-    subjectSet.attr('project').then (subjectSetProject) ->
+    subjectSet.link('project').then (subjectSetProject) ->
       t.ok subjectSetProject?, 'Subject set is linked to a project'
       t.equal subjectSetProject?.id, resources.project.id, 'Subject set project is the one specified'
 
 test 'Create a subject', (t) ->
-  subjectData = Object.create SUBJECT_DATA
+  subjectData = clone SUBJECT_DATA
   subjectData.links =
     project: resources.project.id
 
-  subjects.createResource(subjectData).save().then (subject) ->
+  subjects.create(subjectData).save().then (subject) ->
     resources.subject = subject
     t.ok subject?, 'Responded with a subject'
     t.ok subject?.id?, 'Subject got an ID'
     t.ok subject?.locations[0]['image/jpeg'].indexOf('http') isnt -1, 'Subject got a place to PUT its JPEG'
 
 test 'Create a workflow', (t) ->
-  workflowData = Object.create WORKFLOW_DATA
+  workflowData = clone WORKFLOW_DATA
   workflowData.links =
     project: resources.project.id
     subject_sets: [resources.subjectSet.id]
 
-  workflows.createResource(workflowData).save().then (workflow) ->
+  workflows.create(workflowData).save().then (workflow) ->
     resources.workflow = workflow
     t.ok workflow?, 'Responded with a workflow resource'
     t.ok workflow?.id, 'Workflow got an ID'
 
-    workflow.attr('project').then (workflowProject) ->
+    workflow.link('project').then (workflowProject) ->
       t.ok workflowProject?, 'Workflow is linked to a project'
       t.equal workflowProject?.id, resources.project.id, 'Workflow project is the one specified'
 
-    workflow.attr('subject_sets').then (workflowSubjectSets) ->
-      t.equal workflowSubjectSets?.length, 1, 'Workflow is linked to one subject set'
-      t.equal workflowSubjectSets?[0]?.id, resources.subjectSet.id, 'Workflow subject set is the one specified'
+    workflow.link('subject_sets').then (workflowSubjectSets) ->
+      subjectSetIDs = (id for {id} in workflowSubjectSets)
+      t.ok resources.subjectSet.id in subjectSetIDs, 'The workflow knows about the subject set we created'
 
-test 'Delete temporary user', ->
+test.skip 'Delete temporary user', ->
   resources.user.delete()

--- a/test/project-creation.coffee
+++ b/test/project-creation.coffee
@@ -51,8 +51,7 @@ clone = (object) ->
   JSON.parse JSON.stringify object
 
 test 'Create a temporary user', ->
-  auth.register(USER_DATA).then (user) ->
-    resources.user = user
+  auth.register USER_DATA
 
 test 'Create a project', (t) ->
   projects.create(PROJECT_DATA).save().then (project) ->
@@ -104,5 +103,5 @@ test 'Create a workflow', (t) ->
       subjectSetIDs = (id for {id} in workflowSubjectSets)
       t.ok resources.subjectSet.id in subjectSetIDs, 'The workflow knows about the subject set we created'
 
-test.skip 'Delete temporary user', ->
-  resources.user.delete()
+test 'Delete temporary user', ->
+  auth.disableAccount()

--- a/test/runner.coffee
+++ b/test/runner.coffee
@@ -3,4 +3,4 @@ Function::bind ?= require 'function-bind'
 require('es6-promise').polyfill()
 
 require './auth'
-require './project-creation'
+# require './project-creation'

--- a/test/runner.coffee
+++ b/test/runner.coffee
@@ -3,4 +3,4 @@ Function::bind ?= require 'function-bind'
 require('es6-promise').polyfill()
 
 require './auth'
-# require './project-creation'
+require './project-creation'


### PR DESCRIPTION
I made some big changes to the json-api-client lib to make it more predictable and less clumsy to work with.

The JSON-API lib no longer attempts to handle errors on its own, instead promises for failed requests are simply reject with the request. The rejected requests are no processed by the api client instance (/app/api/client) to work around the fact that different back end modules pass errors in different ways. A bad request now now consistently throws an `instanceof Error`, with a simple string `message` property (multi-line if needed) that's the best attempt at how to express the error.

These changes also lead to some refactoring of the auth module and the PromiseToSetState component mixin.