### PR TITLE
Prep for publishing to npm, export something from main

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -1,0 +1,3 @@
+module.exports =
+  auth: require './app/api/auth'
+  api: require './app/api/client'

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
-  "name": "panoptes-front-end",
-  "version": "0.0.0",
-  "private": true,
+  "name": "panoptes",
+  "version": "0.0.1",
   "dependencies": {
     "counterpart": "^0.16.4",
     "debounce": "^1.0.0",
@@ -31,6 +30,9 @@
     "uglify-js": "^2.4.16",
     "watchify": "^2.2.1"
   },
+  "peerDependencies": {
+    "coffeeify": "^1.0.0"
+  },
   "scripts": {
     "build": "NODE_ENV=production ./bin/build.sh",
     "check-build-size": "npm run build && cat ./build/main.js | gzip --best | wc -c",
@@ -45,5 +47,10 @@
   "config": {
     "fontAwesomeURL": "http://fortawesome.github.io/Font-Awesome/assets/font-awesome-4.2.0.zip",
     "fallbackPolyfillsURL": "https://cdn.polyfill.io/v1/polyfill.min.js?features=default,es6&flags=gated&ua=(MSIE%209.0)"
+  },
+  "browserify": {
+    "transform": [
+      "coffeeify"
+    ]
   }
 }


### PR DESCRIPTION
Publishes auth and api/client modules as `panoptes`.

Close #80.