### PR TITLE
Save credited_name after registration

### DIFF
--- a/app/api/auth.coffee
+++ b/app/api/auth.coffee
@@ -84,10 +84,7 @@ module.exports = new Model
         registrationRequest = @_getAuthToken().then (token) =>
           data =
             authenticity_token: token
-            user:
-              display_name: display_name
-              email: email
-              password: password
+            user: {display_name, email, password}
 
           # This weird URL is actually out of the API, but returns a JSON-API response.
           client.post '/../users', data, JSON_HEADERS
@@ -132,9 +129,7 @@ module.exports = new Model
         signInRequest = @_getAuthToken().then (token) =>
           data =
             authenticity_token: token
-            user:
-              display_name: display_name
-              password: password
+            user: {display_name, password}
 
           makeHTTPRequest 'POST', config.host + '/users/sign_in', data, JSON_HEADERS
             .then =>

--- a/app/partials/register-form.cjsx
+++ b/app/partials/register-form.cjsx
@@ -246,10 +246,13 @@ module.exports = React.createClass
     display_name = @refs.name.getDOMNode().value
     password = @refs.password.getDOMNode().value
     email = @refs.email.getDOMNode().value
-    realName = @refs.realName.getDOMNode().value
+    credited_name = @refs.realName.getDOMNode().value
 
     @props.onSubmit?()
-    auth.register {display_name, password, email, realName}
+    registration = auth.register {display_name, password, email}
+      .then (user) ->
+        user.update({credited_name}).save()
+    registration
       .then @props.onSuccess
       .catch @props.onFailure
 


### PR DESCRIPTION
Include `credited_name` when registering. Closes #134.