### PR TITLE
Add initial talk functionality

### DIFF
--- a/app/api/talk.coffee
+++ b/app/api/talk.coffee
@@ -1,0 +1,19 @@
+JSONAPIClient = {Resource} = require 'json-api-client'
+apiClient = require './client'
+authClient = require './auth'
+
+# Staging:
+# https://talk-staging.zooniverse.org
+
+# Local:
+# http://127.0.0.1:3000
+
+talkClient = new JSONAPIClient 'https://talk-staging.zooniverse.org',
+  'Content-Type': 'application/json'
+  'Accept': 'application/json'
+
+talkClient.headers = apiClient.headers
+talkClient.handleError = apiClient.handleError
+
+window.talkClient = talkClient
+module.exports = talkClient

--- a/app/main.cjsx
+++ b/app/main.cjsx
@@ -34,9 +34,13 @@ routes = <Route handler={App}>
     <Route name="project-science-case" path="science-case" handler={require './pages/project/science-case'} />
     <Route name="project-results" path="results" handler={require './pages/project/results'} />
     <Route name="project-classify" path="classify" handler={require './pages/project/classify'} />
+    <Route name="project-talk" path="talk" handler={require './pages/project/talk'}>
+      <DefaultRoute name="project-talk-home" handler={require './talk/home'} />
+      <Route name="project-talk-board" path=":board" handler={require './talk/board'} />
+      <Route name="project-talk-discussion" path=":board/:discussion" handler={require './talk/discussion'} />
+    </Route>
     <Route name="project-faq" path="faq" handler={require './pages/project/faq'} />
     <Route name="project-education" path="education" handler={require './pages/project/education'} />
-    <Route name="project-talk" path="talk" handler={require './pages/project/talk'} />
   </Route>
 
   <Route name="build" handler={require './pages/build'} />
@@ -49,6 +53,12 @@ routes = <Route handler={App}>
   </Route>
   <Route name="edit-project" path="edit-project/:id" handler={require './pages/edit-project'} />
   <Route name="edit-workflow" path="edit-workflow/:id" handler={require './pages/edit-workflow'} />
+
+  <Route name="talk" path="talk" handler={require './talk'}>
+    <DefaultRoute name="talk-home" handler={require './talk/home'} />
+    <Route name="talk-board" path=":board" handler={require './talk/board'} />
+    <Route name="talk-discussion" path=":board/:discussion" handler={require './talk/discussion'} />
+  </Route>
 
   <Route path="todo/?*" handler={React.createClass render: -> <div className="content-container"><i className="fa fa-cogs"></i> TODO</div>} />
   <NotFoundRoute handler={React.createClass render: -> <div className="content-container"><i className="fa fa-frown-o"></i> Not found</div>} />

--- a/app/pages/project/index.cjsx
+++ b/app/pages/project/index.cjsx
@@ -116,7 +116,7 @@ module.exports = React.createClass
 
   render: ->
     if @state.project?
-      <ProjectPage project={@state.project} />
+      <ProjectPage {...@props} project={@state.project} />
     else
       <div className="content-container">
         {if @state.rejected.project?

--- a/app/pages/project/talk.cjsx
+++ b/app/pages/project/talk.cjsx
@@ -1,9 +1,13 @@
 React = require 'react'
+{RouteHandler} = require 'react-router'
+TalkInit = require '../../talk/init'
+TalkBreadcrumbs = require '../../talk/breadcrumbs'
 
 module.exports = React.createClass
   displayName: 'ProjectTalkPage'
 
   render: ->
-    <div className="project-text-content content-container">
-      <p>TODO: Project discussion page</p>
+    <div className="project-text-content talk project content-container">
+      <TalkBreadcrumbs {...@props} />
+      <RouteHandler {...@props} />
     </div>

--- a/app/partials/main-header.cjsx
+++ b/app/partials/main-header.cjsx
@@ -51,7 +51,7 @@ module.exports = React.createClass
       <nav className="main-nav">
         <span className="main-nav-item"><Translate content="mainNav.about" /></span>
         <Link to="projects" className="main-nav-item"><Translate content="mainNav.projects" /></Link>
-        <span className="main-nav-item"><Translate content="mainNav.discuss" /></span>
+        <Link to="talk" className="main-nav-item"><Translate content="mainNav.discuss" /></Link>
         <hr />
         {if @state.user?
           <Link to="build" className="main-nav-item"><Translate className="minor" content="mainNav.lab" /></Link>}

--- a/app/talk/board-preview.cjsx
+++ b/app/talk/board-preview.cjsx
@@ -1,0 +1,43 @@
+React = require 'react'
+{Link} = require 'react-router'
+{timestamp} = require './lib/time'
+resourceCount = require './lib/resource-count'
+talkClient = require '../api/talk'
+ChangeListener = require '../components/change-listener'
+PromiseRenderer = require '../components/promise-renderer'
+apiClient = require '../api/client'
+merge = require 'lodash.merge'
+
+module?.exports = React.createClass
+  displayName: 'TalkBoardDisplay'
+
+  propTypes:
+    data: React.PropTypes.object
+
+  projectPrefix: ->
+    if @props.project then 'project-' else ''
+
+  render: ->
+    <div className="talk-board-preview">
+      <Link to="#{@projectPrefix()}talk-board" params={merge({}, {board: @props.data.id}, @props.params)}>
+         <h1>{@props.data.title}</h1>
+      </Link>
+
+      <PromiseRenderer promise={talkClient.type('discussions').get({board_id: @props.data.id}).index(0)}>{(discussion) =>
+        if discussion?
+          <div>
+            Latest Discussion:&nbsp;
+            <Link to="talk-discussion" params={board: discussion.board_id, discussion: discussion.id}>{discussion.title}</Link>
+            <span> by </span>
+            <Link to="user-profile" params={name: discussion.user_display_name}>{discussion.user_display_name}</Link>
+          </div>
+      }</PromiseRenderer>
+
+
+      <p>
+        <i className="fa fa-user"></i> {resourceCount(@props.data.users_count, "Users")} |&nbsp;
+        <i className="fa fa-newspaper-o"></i> {resourceCount(@props.data.discussions_count, "Discussions") } |&nbsp;
+        <i className="fa fa-comment"></i> {resourceCount(@props.data.comments_count, "Comments")}</p>
+      <p>Last Updated: {timestamp(@props.data.updated_at)}</p>
+      <p>{@props.data.description}</p>
+    </div>

--- a/app/talk/board.cjsx
+++ b/app/talk/board.cjsx
@@ -1,0 +1,183 @@
+React = require 'react'
+DiscussionPreview = require './discussion-preview'
+talkClient = require '../api/talk'
+authClient = require '../api/auth'
+CommentBox = require './comment-box'
+commentValidations = require './lib/comment-validations'
+discussionValidations = require './lib/discussion-validations'
+{getErrors} = require './lib/validations'
+Router = require 'react-router'
+ChangeListener = require '../components/change-listener'
+PromiseRenderer = require '../components/promise-renderer'
+Paginator = require './lib/paginator'
+Moderation = require './lib/moderation'
+
+module?.exports = React.createClass
+  displayName: 'TalkBoard'
+  mixins: [Router.Navigation]
+
+  getInitialState: ->
+    discussions: []
+    board: {}
+    discussionsMeta: {}
+    newDiscussionOpen: false
+    discussionValidationErrors: []
+
+  componentWillMount: ->
+    @setDiscussions()
+    @setBoard()
+
+  goToPage: (n) ->
+    @transitionTo(@props.pathname, @props.params, {page: n})
+    @setDiscussions(n)
+
+  discussionsRequest: (page) ->
+    board_id = +@props.params.board
+    talkClient.type('discussions').get({board_id, page_size: 5, page})
+
+  setDiscussions: (page = 1) ->
+    @discussionsRequest(page)
+      .then (discussions) =>
+        discussionsMeta = discussions[0]?.getMeta()
+        @setState {discussions, discussionsMeta}
+      .catch (e) =>
+        console.log "failed to get discussion", e
+
+  boardRequest: ->
+    id = +@props.params.board
+    talkClient.type('boards').get({id})
+
+  setBoard: ->
+    @boardRequest()
+      .then (board) => @setState {board: board[0]}
+      .catch (e) => console.log "failed to get board", e
+
+  onSubmitDiscussion: (e, commentText, focusImage) ->
+    titleInput = @getDOMNode().querySelector('.talk-board-new-discussion input')
+    title = titleInput.value
+
+    return console.log "failed validation" unless title
+
+    authClient.checkCurrent()
+      .then (user) =>
+        user_id = user.id
+        board_id = +@props.params.board
+        body = commentText
+
+        discussion = {title, user_id, board_id, comments: [{user_id, body}]}
+
+        talkClient.type('discussions').create(discussion).save()
+          .then (discussion) =>
+            console.log "discussion save successful", discussion
+            @setState newDiscussionOpen: false
+            @setDiscussions()
+          .catch (e) =>
+            console.log "error saving discussion", e
+      .catch (e) => console.log "error checking auth", e
+
+  discussionValidations: (commentBody) ->
+    # TODO: return true if any additional validations fail
+    discussionTitle = @getDOMNode().querySelector('.new-discussion-title').value
+    commentErrors = getErrors(commentBody, commentValidations)
+    discussionErrors = getErrors(discussionTitle, discussionValidations)
+
+    discussionValidationErrors = commentErrors.concat(discussionErrors)
+    @setState {discussionValidationErrors}
+    !!discussionValidationErrors.length
+
+  discussionPreview: (discussion, i) ->
+    <DiscussionPreview {...@props} key={i} data={discussion} />
+
+  onClickDeleteBoard: ->
+    if window.confirm("Are you sure that you want to delete this board? All of the comments and discussions will be lost forever.")
+      @boardRequest().delete()
+        .then (deleted) =>
+          console.log "deleted", deleted
+          @transitionTo('talk')
+        .catch (e) -> console.log "error deleting", e
+
+  onPageChange: (page) ->
+    @goToPage(page)
+
+  onEditTitle: (e) ->
+    input = document.querySelector('.talk-edit-board-title-form input')
+    title = input.value
+
+    @boardRequest().update({title}).save()
+      .then (board) =>
+        @setState {board: board[0]}
+      .catch (e) ->
+        console.log "error on edit board title", e
+
+  onClickNewDiscussion: ->
+    @setState newDiscussionOpen: !@state.newDiscussionOpen
+
+  render: ->
+    <div className="talk-board">
+      <h1 className="talk-page-header">{@state.board?.title}</h1>
+      <Moderation>
+        <div>
+          <h2>Moderator Zone:</h2>
+          {if @state.board?.title
+            <form className="talk-edit-board-title-form" onSubmit={@onEditTitle}>
+              <h3>Edit Title:</h3>
+              <input onChange={@onChangeTitle} defaultValue={@state.board?.title}/>
+              <button type="submit">Update Title</button>
+            </form>}
+
+          <button onClick={@onClickDeleteBoard}>
+            Delete this board <i className="fa fa-close" />
+          </button>
+        </div>
+      </Moderation>
+
+      <ChangeListener target={authClient}>{=>
+        <PromiseRenderer promise={authClient.checkCurrent()}>{(user) =>
+          if user?
+            <section>
+              <button onClick={@onClickNewDiscussion}>
+                <i className="fa fa-#{if @state.newDiscussionOpen then 'close' else 'plus'}" />&nbsp;
+                New Discussion
+              </button>
+
+              {if @state.newDiscussionOpen
+                <div className="talk-board-new-discussion">
+                  <h2>Create a disussion +</h2>
+                  <input className="new-discussion-title" type="text" placeholder="Discussion Title"/><br/>
+                  <CommentBox
+                    header={null}
+                    validationCheck={@discussionValidations}
+                    validationErrors={@state.discussionValidationErrors}
+                    submitFeedback={"Discussion successfully created"}
+                    placeholder={"Add a comment here to start the discussion. This comment will appear at the start of the discussion."}
+                    onSubmitComment={@onSubmitDiscussion}
+                    submit="Create Discussion"/>
+                 </div>}
+             </section>
+           else
+             <p>Please sign in to create discussions</p>
+        }</PromiseRenderer>
+      }</ChangeListener>
+
+      <div className="talk-list-content">
+        <section>
+          {if @state.discussions.length
+            @state.discussions.map(@discussionPreview)
+           else
+            <p>There are currently no discussions in this board.</p>}
+        </section>
+
+        <div className="talk-sidebar">
+          <h2>Talk Sidebar</h2>
+          <section>
+            <h3>Description:</h3>
+            <p>{@state.board?.description}</p>
+            <h3>Join the Discussion</h3>
+            <p>Check out the existing posts or start a new discussion of your own</p>
+          </section>
+        </div>
+      </div>
+
+      <Paginator page={+@state.discussionsMeta?.page} onPageChange={@onPageChange} pageCount={@state.discussionsMeta?.page_count} />
+
+    </div>

--- a/app/talk/breadcrumbs.cjsx
+++ b/app/talk/breadcrumbs.cjsx
@@ -1,0 +1,41 @@
+React = require 'react'
+{Link} = require 'react-router'
+PromiseRenderer = require '../components/promise-renderer'
+merge = require 'lodash.merge'
+
+module?.exports = React.createClass
+  displayName: 'TalkBreadcrumbs'
+
+  projectPrefix: ->
+    if @props.project then 'project-' else ''
+
+  render: ->
+    params = @props.params
+
+    <div className="talk-breadcrumbs">
+      <div className="talk-breadcrumbs">
+        {if params.board?
+          <span>
+            <Link to="#{@projectPrefix()}talk" params={params}>
+              {if @props.project then params?.name else 'Zooniverse'} Talk
+            </Link>
+            &nbsp;>&nbsp;
+          </span>}
+
+        {if params.board? and not params.discussion?
+          <PromiseRenderer promise={talkClient.type('boards').get(params.board)}>{(board) =>
+            <span>{board.title}</span>}
+          </PromiseRenderer>}
+
+        {if params.board? and params.discussion?
+          <PromiseRenderer promise={talkClient.type('boards').get(params.board)}>{(board) =>
+            <span>
+              <Link to="#{@projectPrefix()}talk-board" params={merge({}, {board: board.id}, params)}>{board.title}</Link>
+              &nbsp;>&nbsp;
+              <PromiseRenderer promise={talkClient.type('discussions').get(params.discussion)}>{(discussion) =>
+                <span>{discussion.title}</span>}
+              </PromiseRenderer>
+            </span>}
+          </PromiseRenderer>}
+      </div>
+    </div>

--- a/app/talk/comment-box.cjsx
+++ b/app/talk/comment-box.cjsx
@@ -1,0 +1,235 @@
+React = require 'react'
+ToggleChildren = require './mixins/toggle-children'
+Feedback = require './mixins/feedback'
+CommentPreview = require './comment-preview'
+CommentHelp = require './comment-help'
+CommentImageSelector = require './comment-image-selector'
+getSubjectLocation = require '../lib/get-subject-location'
+
+m = require './lib/markdown-insert'
+
+module?.exports = React.createClass
+  displayName: 'Commentbox'
+  mixins: [ToggleChildren, Feedback]
+
+  propTypes:
+    submit: React.PropTypes.string
+    header: React.PropTypes.string
+    placeholder: React.PropTypes.string
+    submitFeedback: React.PropTypes.string
+    onSubmitComment: React.PropTypes.func # called on submit and passed (e, textarea-content, focusImage)
+    onCancelClick: React.PropTypes.func # adds cancel button and calls callback on click if supplied
+
+  getDefaultProps: ->
+    submit: "Submit"
+    header: "Add to the discussion +"
+    placeholder: "Type your comment here"
+    submitFeedback: "Comment Successfully Submitted"
+    content: null
+    focusImage: null
+
+  getInitialState: ->
+    focusImage: @props.focusImage
+    content: @props.content
+    reply: ''
+
+  componentWillReceiveProps: (nextProps) ->
+    if nextProps.reply
+      @setState {reply: nextProps.reply}
+
+  onSubmitComment: (e) ->
+    e.preventDefault()
+    textareaValue = @refs.textarea.getDOMNode().value
+    return if @props.validationCheck?(textareaValue)
+
+    fullComment = @state.reply.concat(textareaValue)
+    @props.onSubmitComment?(e, fullComment, @state.focusImage)
+    # optional function called on submit ^
+    # TODO: update this submit stuff for better reuse / prod
+
+    @refs.textarea.getDOMNode().value = ""
+    @hideChildren()
+    @setState content: ""
+    @setFeedback @props.submitFeedback
+
+  onPreviewClick: (e) ->
+    @toggleComponent('preview')
+
+  onHelpClick: (e) ->
+    @toggleComponent('help')
+
+  onImageSelectClick: (e) ->
+    @toggleComponent('image-selector')
+
+  onInsertLinkClick: (e) ->
+    @wrapSelectionIn(m.hrefLink)
+
+  onInsertImageClick: (e) ->
+    @wrapSelectionIn(m.imageLink)
+
+  onBoldClick: (e) ->
+    @wrapSelectionIn(m.bold)
+
+  onItalicClick: (e) ->
+    @wrapSelectionIn(m.italic)
+
+  onHeadingClick: (e) ->
+    @wrapSelectionIn(m.heading, ensureNewLine: true)
+
+  onQuoteClick: ->
+    @wrapSelectionIn(m.quote, ensureNewLine: true)
+
+  onHorizontalRuleClick: (e) ->
+    @wrapSelectionIn(m.horizontalRule, ensureNewLine: true)
+
+  onStrikethroughClick: (e) ->
+    @wrapSelectionIn(m.strikethrough)
+
+  onBulletClick: (e) ->
+    @wrapLinesIn(m.bullet, ensureNewLine: true)
+
+  onNumberClick: (e) ->
+    @wrapLinesIn(m.numberedList, ensureNewLine: true, incrementLines: true)
+
+  onSelectImage: (imageData) ->
+    @setState focusImage: imageData
+
+  onClearImageClick: (e) ->
+    @setState focusImage: null
+
+  onInputChange: ->
+    @setState content: @refs.textarea.getDOMNode().value
+
+  render: ->
+    validationErrors = @props.validationErrors.map (message, i) =>
+      <p key={i} className="talk-validation-error">{message}</p>
+
+    feedback = @renderFeedback()
+
+    <div className="talk-comment-box">
+      <h1>{@props.header}</h1>
+
+      {if @state.focusImage
+        <img className="talk-comment-focus-image" src={getSubjectLocation(@state.focusImage).src} />}
+
+      {feedback}
+
+      <div className="talk-comment-buttons-container">
+        <button title="link"className='talk-comment-insert-link-button' onClick={@onInsertLinkClick}>
+          <i className="fa fa-link"></i>
+        </button>
+        <button title="image" className='talk-comment-insert-image-button' onClick={@onInsertImageClick}>
+          <i className="fa fa-image"></i>
+        </button>
+        <button title="bold" className='talk-comment-bold-button' onClick={@onBoldClick}>
+          <i className="fa fa-bold"></i>
+        </button>
+        <button title="italic" className='talk-comment-italic-button' onClick={@onItalicClick}>
+          <i className="fa fa-italic"></i>
+        </button>
+        <button title="block quote" className='talk-comment-insert-quote-button' onClick={@onQuoteClick}>
+          <i className="fa fa-quote-left"></i> <i className="fa fa-quote-right"></i>
+        </button>
+        <button title="heading" className='talk-comment-heading-button' onClick={@onHeadingClick}>
+          <i className="fa fa-header"></i>
+        </button>
+        <button title="horizontal rule" className='talk-comment-hr-button' onClick={@onHorizontalRuleClick}>
+          <i className="fa fa-arrows-h"></i>
+        </button>
+        <button title="strikethrough" className='talk-comment-strikethrough-button' onClick={@onStrikethroughClick}>
+          <i className="fa fa-strikethrough"></i>
+        </button>
+        <button title="bulleted list" className='talk-comment-bullet-button' onClick={@onBulletClick}>
+          <i className="fa fa-list"></i>
+        </button>
+        <button title="numbered list" className='talk-comment-number-button' onClick={@onNumberClick}>
+          <i className="fa fa-list-ol"></i>
+        </button>
+      </div>
+
+      <form className="talk-comment-form" onSubmit={@onSubmitComment}>
+        {if @state.reply
+          <div>
+            <button onClick={=> @setState({reply: ''})}>&times; Remove reply</button>
+            <CommentPreview header={null} content={@state.reply}/>
+          </div>}
+
+        <textarea value={@state.content} onChange={@onInputChange} ref="textarea" placeholder={@props.placeholder} />
+        <section>
+          <button
+            type="button"
+            className="talk-comment-image-select-button #{if @state.showing is 'image-selector' then 'active' else ''}"
+            onClick={@onImageSelectClick}>
+            Featured Image
+            {if @state.showing is 'image-selector' then <span>&nbsp;<i className="fa fa-close" /></span>}
+          </button>
+
+          <button
+            type="button"
+            className="talk-comment-help-button #{if @state.showing is 'help' then 'active' else ''}"
+            onClick={@onHelpClick}>
+            Help
+            {if @state.showing is 'help' then <span>&nbsp;<i className="fa fa-close" /></span>}
+          </button>
+
+          <button
+            type="button"
+            className="talk-comment-preview-button #{if @state.showing is 'preview' then 'active' else ''}"
+            onClick={@onPreviewClick}>
+            Preview
+            {if @state.showing is 'preview' then <span>&nbsp;<i className="fa fa-close" /></span>}
+          </button>
+
+          <button type="submit" className='talk-comment-submit-button'>{@props.submit}</button>
+          {if @props.onCancelClick
+            <button
+              type="button"
+              className="button talk-comment-submit-button"
+              onClick={@props.onCancelClick}>
+             Cancel
+            </button>}
+        </section>
+        {validationErrors}
+      </form>
+
+      <div className="talk-comment-children">
+        {switch @state.showing
+          when 'image-selector'
+            <CommentImageSelector
+              onSelectImage={@onSelectImage}
+              onClearImageClick= {@onClearImageClick}/>
+          when 'preview'
+            <CommentPreview content={@state.content} />
+          when 'help'
+            <CommentHelp />}
+      </div>
+    </div>
+
+  wrapSelectionIn: (wrapFn, opts = {}) ->
+    # helper to call markdown-insert functions on the textarea
+    # wrapFn takes / returns a string (from ./lib/markdown-insert.cjsx)
+
+    textarea = @refs.textarea.getDOMNode()
+    selection = m.getSelection(textarea)
+    {text, cursor} = wrapFn(selection)
+
+    m.insertAtCursor(text, textarea, cursor, opts)
+    @onInputChange()
+
+  wrapLinesIn: (wrapFn, opts = {}) ->
+    textarea = @refs.textarea.getDOMNode()
+    lines = m.getSelection(textarea).split("\n")
+
+    formattedText = lines
+      .map (line) -> wrapFn(line).text
+      .join("\n")
+
+    # increment the line numbers in a list, if that option is specified
+    if opts.incrementLines and opts.ensureNewLine
+      begInputValue = textarea.value.substring(0, textarea.selectionStart) + "\n"
+      formattedText = m.incrementedListItems(begInputValue, formattedText)
+
+    cursor = {start: formattedText.length, end: formattedText.length}
+
+    m.insertAtCursor(formattedText, textarea, cursor, opts)
+    @onInputChange()

--- a/app/talk/comment-help.cjsx
+++ b/app/talk/comment-help.cjsx
@@ -1,0 +1,13 @@
+React = require 'react'
+
+module?.exports = React.createClass
+  displayName: 'TalkCommentHelp'
+
+  render: ->
+    <div className="talk-comment-help">
+      <h1>Guide to commenting on talk</h1>
+      <p>Talk comments are written in <a href='http://daringfireball.net/projects/markdown/basics'>markdown</a></p>
+      <p>Mention users with <em>@username</em></p>
+      <p>Mention subjects with <em>^subject_id</em></p>
+      <p>Create hashtags with <em>#hashtag</em></p>
+    </div>

--- a/app/talk/comment-image-selector.cjsx
+++ b/app/talk/comment-image-selector.cjsx
@@ -1,0 +1,68 @@
+React = require 'react'
+apiClient = require '../api/client'
+authClient = require '../api/auth'
+getSubjectLocation = require '../lib/get-subject-location'
+
+module?.exports = React.createClass
+  displayName: 'TalkCommentImageSelector'
+
+  getInitialState: ->
+    recents: []
+
+  getDefaultProps: ->
+    header: "Select a featured image"
+
+  componentWillMount: ->
+    @setRecents()
+
+  setRecents: ->
+    authClient.checkCurrent()
+      .then (user) => user.get('recents')
+        .then (recents) => @setState {recents}
+      .catch (e) ->
+        console.log "error setting recents", e
+
+  queryForImages: (query) ->
+    # this will make a db query and then return array of matching images
+    DEV_IMAGES.filter (img) => img.id.toLowerCase() is query.toLowerCase()
+
+  onSubmitSearch: (e) ->
+    e.preventDefault()
+    return @setRecents() # TODO un-disable search (remove this line)
+    ###
+    query = @refs.imageSearch.getDOMNode().value
+    if query is ""
+      @setInitialImages()
+    else
+      @setState images: @queryForImages(query)
+    ###
+
+  setFocusImage: (recentsData) ->
+    recentsData.get('subject')
+      .then (subject) =>
+        @props.onSelectImage(subject)
+      .catch (e) -> console.log "couldent get subject data", e
+
+  imageItem: (data, i) ->
+    {src} = getSubjectLocation(data)
+    <div key={i} className="talk-comment-image-item">
+      <img src={'http://' + src} />
+      <div className="image-card-select">
+        <button onClick={=> @setFocusImage(data)}>Select</button>
+      </div>
+    </div>
+
+  render: ->
+    <div className="talk-comment-image-selector">
+      <h1>{@props.header}</h1>
+
+      <form onSubmit={@onSubmitSearch}>
+        <input ref="imageSearch" type="search" placeholder="Search by ID"/>
+      </form>
+
+      <button className='talk-comment-clear-image-button' onClick={@props.onClearImageClick}>Clear image</button>
+
+      <div className="talk-comment-suggested-images">
+        {@state.recents?.map(@imageItem)}
+      </div>
+    </div>

--- a/app/talk/comment-link.cjsx
+++ b/app/talk/comment-link.cjsx
@@ -1,0 +1,11 @@
+React = require 'react'
+
+module?.exports = React.createClass
+  displayName: 'TalkCommentLink'
+
+  render: ->
+    <div className="talk-comment-link">
+      <a href="http://www.zooniverse.org/talk/comments/ex#anchor">
+        http://www.zooniverse.org/talk/comments/ex\#anchor
+      </a>
+    </div>

--- a/app/talk/comment-preview.cjsx
+++ b/app/talk/comment-preview.cjsx
@@ -1,0 +1,34 @@
+React = require 'react'
+MarkdownIt = require 'markdown-it'
+
+markdownIt = MarkdownIt()
+  .use require 'markdown-it-emoji'
+  .use require 'markdown-it-sub'
+  .use require 'markdown-it-sup'
+
+module?.exports = React.createClass
+  displayName: 'TalkCommentPreview'
+
+  propTypes:
+    content: React.PropTypes.string
+    header: React.PropTypes.string
+
+  getDefaultProps: ->
+    header: "Preview"
+
+  replaceSymbols: (string) ->
+    string
+      .replace(/@(\w+)/g, "<a href='#/users/$1'>$1</a>") # user mentions
+      .replace(/\^([A-Za-z]+[0-9]+)/g, "<a href='http://www.zooniverse.org/subjects/$1'>$1</a>") # subject mentions
+      .replace(/\#(\w+)/g, "<a href='http://www.zooniverse.org/tags/$1'>#$1</a>") # hashtags
+
+  markdownify: (input) ->
+    markdownIt.render(input)
+
+  render: ->
+    html = @replaceSymbols(@markdownify(@props.content ? ''))
+
+    <div className='talk-comment-preview'>
+      <h1>{@props.header}</h1>
+      <div className='talk-comment-preview-content' dangerouslySetInnerHTML={__html: html}></div>
+    </div>

--- a/app/talk/comment-report-form.cjsx
+++ b/app/talk/comment-report-form.cjsx
@@ -1,0 +1,29 @@
+React = require 'react'
+Feedback = require './mixins/feedback'
+
+module?.exports = React.createClass
+  displayName: 'TalkCommentReportForm'
+
+  mixins: [Feedback]
+
+  onSubmit: (e) ->
+    e.preventDefault()
+    comment = @refs.textarea.getDOMNode().value
+
+    @refs.textarea.getDOMNode().value = ''
+    @setFeedback "Comment Report successfully submitted"
+    # send comment id and report to server here
+
+  render: ->
+    feedback = @renderFeedback()
+
+    <div className="talk-comment-report-form">
+      <h1>Report a comment here</h1>
+
+      {feedback}
+
+      <form className="talk-comment-report-form-form" onSubmit={@onSubmit}>
+        <textarea ref="textarea" placeholder="Why are you reporting this comment?"></textarea>
+        <button type="submit">Report</button>
+      </form>
+    </div>

--- a/app/talk/comment.cjsx
+++ b/app/talk/comment.cjsx
@@ -1,0 +1,146 @@
+React = require 'react'
+ToggleChildren = require './mixins/toggle-children'
+commentValidations = require './lib/comment-validations'
+{getErrors} = require './lib/validations'
+Feedback = require './mixins/feedback'
+CommentBox = require './comment-box'
+CommentReportForm = require './comment-report-form'
+CommentLink = require './comment-link'
+upvotedByCurrentUser = require './lib/upvoted-by-current-user'
+CommentPreview = require './comment-preview'
+SubjectDisplay = require './subject-display'
+PromiseRenderer = require '../components/promise-renderer'
+PromiseToSetState = require '../lib/promise-to-set-state'
+{Link} = require 'react-router'
+{timestamp} = require './lib/time'
+apiClient = require '../api/client'
+
+module?.exports = React.createClass
+  displayName: 'TalkComment'
+  mixins: [ToggleChildren, Feedback, PromiseToSetState]
+
+  propTypes:
+    data: React.PropTypes.object
+    onUpdateComment: React.PropTypes.func # passed (textContent, focusImage, commentId) on update submit
+    onDeleteComment: React.PropTypes.func # passed (commentId) on click
+    onLikeComment: React.PropTypes.func # passed (commentId) on like
+    onClickReply: React.PropTypes.func # passed (user, comment) on click
+
+  getInitialState: ->
+    editing: false
+    commentValidationErrors: []
+
+  onClickReply: (e) ->
+    @props.onClickReply(@props.user, @props.data)
+
+  onClickLink: (e) ->
+    @toggleComponent('link')
+
+  onClickReport: (e) ->
+    @toggleComponent('report')
+
+  onClickEdit: (e) ->
+    @setState editing: true
+    @removeFeedback()
+
+  onClickDelete: (e) ->
+    @props.onDeleteComment(@props.data.id)
+
+  onCancelClick: (e) ->
+    @setState editing: false
+
+  onSubmitComment: (e, textContent, focusImage) ->
+    # update comment here...
+    @props.onUpdateComment?(textContent, focusImage, @props.data.id)
+    @setState editing: false
+    @setFeedback "Comment Updated"
+
+  commentValidations: (commentBody) ->
+    console.log "validating comment", commentBody
+    commentValidationErrors = getErrors(commentBody, commentValidations)
+    @setState {commentValidationErrors}
+    !!commentValidationErrors.length
+
+  onClickLike: ->
+    @props.onLikeComment(@props.data.id)
+
+  upvoteCount: ->
+    Object.keys(@props.data.upvotes).length
+
+  avatarPending: ->
+    <img alt="loading"/>
+
+  render: ->
+    feedback = @renderFeedback()
+
+    <div className="talk-comment">
+      <div className="talk-comment-author">
+        <PromiseRenderer pending={@avatarPending} promise={apiClient.type('users').get(id: @props.data.user_id).index(0)}>{(commentOwner) =>
+          <img src={commentOwner.avatar} alt={commentOwner.display_name}/>
+        }</PromiseRenderer>
+
+        <p>
+          <Link to="user-profile" params={name: @props.data.user_display_name}>{@props.data.user_display_name}</Link>
+        </p>
+      </div>
+
+      <div className="talk-comment-body">
+        {feedback}
+
+        {if not @state.editing
+          <div className="talk-comment-content">
+            <p className="talk-comment-date">{timestamp(@props.data.created_at)}</p>
+
+            {if @props.data.focus_id
+              <SubjectDisplay focusId={@props.data.focus_id} />}
+
+            <CommentPreview content={@props.data.body} header={null}/>
+
+            <div className="talk-comment-links">
+              <button className="talk-comment-like-button" onClick={@onClickLike}>
+                {if upvotedByCurrentUser(@props.user, @props.data)
+                  <i className="fa fa-thumbs-up upvoted" />
+                else
+                  <i className="fa fa-thumbs-o-up" />}
+                &nbsp;{@upvoteCount()}
+              </button>
+
+              <button className="talk-comment-reply-button" onClick={@onClickReply}>
+                <i className="fa fa-reply" /> Reply
+              </button>
+              <button className="talk-comment-link-button" onClick={@onClickLink}>
+                <i className="fa fa-link" /> Link
+              </button>
+              <button className="talk-comment-report-button" onClick={@onClickReport}>
+                <i className="fa fa-warning" /> Report
+              </button>
+              {if +@props.data?.user_id is +@props.user?.id
+                <span>
+                  <button className="talk-comment-edit-button" onClick={@onClickEdit}>
+                    <i className="fa fa-pencil" /> Edit
+                  </button>
+                  <button className="talk-comment-delete-button" onClick={@onClickDelete}>
+                    <i className="fa fa-remove" /> Delete
+                  </button>
+                </span>}
+            </div>
+
+            <div className="talk-comment-children">
+              {switch @state.showing
+                 when 'link' then <CommentLink />
+                 when 'report' then <CommentReportForm />}
+            </div>
+          </div>
+        else
+          <CommentBox
+            header={"Editing Comment..."}
+            content={@props.data.body}
+            validationCheck={@commentValidations}
+            validationErrors={@state.commentValidationErrors}
+            submitFeedback={"Comment will update here..."}
+            submit={"Update Comment"}
+            onCancelClick={@onCancelClick}
+            onSubmitComment={@onSubmitComment}/>}
+      </div>
+    </div>
+

--- a/app/talk/discussion-preview.cjsx
+++ b/app/talk/discussion-preview.cjsx
@@ -1,0 +1,25 @@
+React = require 'react'
+{Link} = require 'react-router'
+{timestamp} = require './lib/time'
+resourceCount = require './lib/resource-count'
+{State} = require 'react-router'
+merge = require 'lodash.merge'
+
+module?.exports = React.createClass
+  displayName: 'TalkDiscussionPreview'
+
+  propTypes:
+    data: React.PropTypes.object
+
+  projectPrefix: ->
+    if @props.project then 'project-' else ''
+
+  render: ->
+    <div className="talk-discussion-preview">
+      <Link to="#{@projectPrefix()}talk-discussion" params={merge({}, {board: @props.data.board_id, discussion: @props.data.id}, @props.params)}>
+        <h1>{@props.data.title}</h1>
+      </Link>
+      <p><i className="fa fa-user"></i> {resourceCount(@props.data.users_count, "Users")} |&nbsp;
+      <i className="fa fa-comment"></i> {resourceCount(@props.data.comments_count, "Comments")} </p>
+      <p className="talk-discussion-preview-author">Started by <Link to="user-profile" params={name: @props.data.user_display_name}>{@props.data.user_display_name}</Link> on {timestamp(@props.data.created_at)}</p>
+    </div>

--- a/app/talk/discussion.cjsx
+++ b/app/talk/discussion.cjsx
@@ -1,0 +1,210 @@
+React = require 'react'
+Comment = require './comment'
+CommentBox = require './comment-box'
+commentValidations = require './lib/comment-validations'
+{getErrors} = require './lib/validations'
+SubjectDisplay = require './subject-display'
+Router = require 'react-router'
+talkClient = require '../api/talk'
+authClient = require '../api/auth'
+Paginator = require './lib/paginator'
+ChangeListener = require '../components/change-listener'
+PromiseRenderer = require '../components/promise-renderer'
+PromiseToSetState = require '../lib/promise-to-set-state'
+upvotedByCurrentUser = require './lib/upvoted-by-current-user'
+Moderation = require './lib/moderation'
+{timestamp} = require './lib/time'
+{Link} = require 'react-router'
+merge = require 'lodash.merge'
+
+module?.exports = React.createClass
+  displayName: 'TalkDiscussion'
+  mixins: [Router.Navigation, PromiseToSetState]
+
+  getInitialState: ->
+    comments: []
+    discussion: {}
+    commentsMeta: {}
+    user: null
+    commentValidationErrors: []
+
+  componentDidMount: ->
+    @handleAuthChange()
+    authClient.listen @handleAuthChange
+
+  componentWillUnmount: ->
+    authClient.stopListening @handleAuthChange
+
+  handleAuthChange: ->
+    @promiseToSetState user: authClient.checkCurrent()
+
+  goToPage: (n) ->
+    @transitionTo(@props.path, @props.params, {page: n})
+    @setComments(n)
+
+  componentWillMount: ->
+    @setDiscussion()
+    page = @props.query?.page ? 1
+    @setComments(page)
+
+  commentsRequest: (page) ->
+    {board, discussion} = @props.params
+    talkClient.type('comments').get({discussion_id: discussion, page_size: 3, page})
+
+  discussionsRequest: ->
+    {discussion} = @props.params
+    talkClient.type('discussions').get({id: discussion})
+
+  setComments: (page = 1, callback) ->
+    @commentsRequest(page)
+      .then (comments) =>
+        commentsMeta = comments[0]?.getMeta()
+        @setState {comments, commentsMeta}, =>
+          callback?()
+      .catch (e) =>
+        console.log "e", e
+
+  setDiscussion: ->
+    @discussionsRequest()
+      .then (discussion) => @setState {discussion: discussion[0]}
+      .catch (e) => console.log "e", e
+
+  onUpdateComment: (textContent, focusImage, commentId) ->
+    {discussion} = @props.params
+    commentToUpdate = talkClient.type('comments').get(id: commentId)
+
+    discussion_id = +discussion
+    body = textContent
+    focus_id = +focusImage?.id ? null
+    comment = merge {}, {discussion_id, body}, ({focus_id} if !!focus_id)
+
+    commentToUpdate.update(comment).save()
+      .then (comment) =>
+        @setComments()
+      .catch (e) =>
+        console.log "comment update error", e
+
+  onDeleteComment: (commentId) ->
+    {board, discussion} = @props.params
+    if window.confirm("Are you sure that you want to delete this comment?")
+      talkClient.type('comments').get(id: commentId).delete()
+        .then (deleted) => @setComments()
+        .catch (e) => console.log "error deleting comment", e
+
+  onSubmitComment: (e, textContent, focusImage) ->
+    {discussion} = @props.params
+    user_id = @state.user.id
+    discussion_id = +discussion
+    body = textContent
+    focus_id = +focusImage?.id ? null
+    comment = merge {}, {user_id, discussion_id, body}, ({focus_id} if !!focus_id)
+
+    talkClient.type('comments').create(comment).save()
+      .then (comment) =>
+        @setComments(@state.commentsMeta?.page, => @goToPage(@state.commentsMeta?.page_count))
+      .catch (e) =>
+        console.log "comment create error", e
+
+  onLikeComment: (commentId) ->
+    user = @state.user
+
+    talkClient.type('comments').get(commentId.toString())
+      .then (comment) =>
+        return alert("Hey you can't upvote your own comment!") if +user.id is +comment.user_id
+
+        voteUrl = (comment.href + if upvotedByCurrentUser(user, comment) then '/remove_upvote' else '/upvote')
+        talkClient.request('put', voteUrl, null, {})
+          .then (voted) =>
+            @setComments(@state.commentsMeta?.page)
+          .catch (e) -> console.log "error upvoting", e
+      .then (e) -> console.log "error retreiving liked comment"
+
+  onClickReply: (user, comment) ->
+    # TODO: provide link to user / comment
+    reply = "> In reply to #{user.display_name}'s comment: \n#{comment.body}\n\n"
+    @setState {reply}
+
+  comment: (data, i) ->
+    <Comment
+      key={i}
+      data={data}
+      user={@state.user}
+      onClickReply={@onClickReply}
+      onLikeComment={@onLikeComment}
+      onUpdateComment={@onUpdateComment}
+      onDeleteComment={@onDeleteComment}/>
+
+  onPageChange: (page) ->
+    @goToPage(page)
+
+  onClickDeleteDiscussion: ->
+    if window.confirm("Are you sure that you want to delete this discussions? All of the comments and discussions will be lost forever.")
+      @discussionsRequest().delete()
+        .then (deleted) =>
+          @setComments()
+          @transitionTo('talk')
+        .catch (e) -> console.log "error deleting", e
+
+  commentValidations: (commentBody) ->
+    # TODO: return true if any additional validations fail
+    commentValidationErrors = getErrors(commentBody, commentValidations)
+    @setState {commentValidationErrors}
+    !!commentValidationErrors.length
+
+  onEditTitle: (e) ->
+    input = document.querySelector('.talk-edit-discussion-title-form input')
+    title = input.value
+
+    @discussionsRequest().update({title}).save()
+      .then (discussion) =>
+        @setState {discussion: discussion[0]}
+      .catch (e) ->
+        console.log "error on edit board title", e
+
+  render: ->
+    <div className="talk-discussion">
+      <h1 className="talk-page-header">{@state.discussion?.title}</h1>
+
+      <Moderation>
+        <div>
+          <h2>Moderator Zone:</h2>
+          {if @state.discussion?.title
+            <form className="talk-edit-discussion-title-form" onSubmit={@onEditTitle}>
+              <h3>Edit Title:</h3>
+              <input onChange={@onChangeTitle} defaultValue={@state.discussion?.title}/>
+              <button type="submit">Update Title</button>
+            </form>}
+
+          <button onClick={@onClickDeleteDiscussion}>
+            Delete this discussion <i className="fa fa-close" />
+          </button>
+        </div>
+      </Moderation>
+
+      {@state.comments.map(@comment)}
+
+      <Paginator page={+@state.commentsMeta.page} onPageChange={@onPageChange} pageCount={@state.commentsMeta.page_count} />
+
+      <ChangeListener target={authClient}>{=>
+        <PromiseRenderer promise={authClient.checkCurrent()}>{(user) =>
+          if user
+            <section>
+              <div className="talk-comment-author">
+                <img src={user.avatar} />
+                <p>
+                  <Link to="user-profile" params={name: user.display_name}>{user.display_name}</Link>
+                </p>
+              </div>
+
+              <CommentBox
+                validationCheck={@commentValidations}
+                validationErrors={@state.commentValidationErrors}
+                onSubmitComment={@onSubmitComment}
+                reply={@state.reply}
+                header={null} />
+            </section>
+          else
+            <p>Please sign in to contribute to the disucssion</p>
+        }</PromiseRenderer>
+      }</ChangeListener>
+    </div>

--- a/app/talk/home.cjsx
+++ b/app/talk/home.cjsx
@@ -1,0 +1,15 @@
+React = require 'react'
+TalkInit = require './init'
+
+module?.exports = React.createClass
+  displayName: 'TalkHome'
+
+  getSection: ->
+    # Use project id for section for project talks
+    # or 'zooniverse' for global-talk
+    @props.project?.id ? 'zooniverse'
+
+  render: ->
+    <div className="talk-home">
+      <TalkInit {...@props} section={@getSection()} />
+    </div>

--- a/app/talk/index.cjsx
+++ b/app/talk/index.cjsx
@@ -1,0 +1,20 @@
+React = require 'react'
+{RouteHandler, Link} = require 'react-router'
+PromiseRenderer = require '../components/promise-renderer'
+TalkBreadcrumbs = require './breadcrumbs.cjsx'
+talkClient = require '../api/talk'
+
+module?.exports = React.createClass
+  displayName: 'Talk'
+
+  render: ->
+    <div className="talk content-container">
+      <h1>Talk!</h1>
+      <TalkBreadcrumbs {...@props} />
+
+      <span>
+        Content to be shared across all talk pages and 
+        <input placeholder="a search bar..." />
+      </span>
+      <RouteHandler {...@props} />
+    </div>

--- a/app/talk/init.cjsx
+++ b/app/talk/init.cjsx
@@ -1,0 +1,97 @@
+React = require 'react'
+BoardPreview = require './board-preview'
+talkClient = require '../api/talk'
+authClient = require '../api/auth'
+ChangeListener = require '../components/change-listener'
+PromiseRenderer = require '../components/promise-renderer'
+Moderation = require './lib/moderation'
+ChangeListener = require '../components/change-listener'
+PromiseRenderer = require '../components/promise-renderer'
+
+module?.exports = React.createClass
+  displayName: 'TalkInit'
+
+  getInitialState: ->
+    boards: []
+    discussionsMeta: {}
+
+  propTypes:
+    section: React.PropTypes.string # 'zooniverse' for main-talk, 'project_id' for projects
+
+  componentWillMount: ->
+    @setBoards()
+    @setDiscussionsMeta()
+
+  setBoards: ->
+    talkClient.type('boards').get(section: @props.section)
+      .then (boards) =>
+        @setState {boards}
+      .catch (e) =>
+        console.log "error getting boards"
+
+  setDiscussionsMeta: ->
+    talkClient.type('discussions').get(section: @props.section)
+      .then (discussions) =>
+        @setState {discussionsMeta: discussions[0]?.getMeta()}
+      .catch (e) =>
+        console.log 'Error setting discussions meta'
+
+  onSubmitBoard: (e) ->
+    e.preventDefault()
+    titleInput = @getDOMNode().querySelector('form input')
+    descriptionInput = @getDOMNode().querySelector('form textarea')
+
+    title = titleInput.value
+    description = descriptionInput.value
+    section = @props.section
+
+    board = {title, description, section}
+    return console.log "failed validation" unless title and description and section
+
+    talkClient.type('boards').create(board).save()
+      .then (board) =>
+        titleInput.value = ''
+        descriptionInput.value = ''
+        console.log "board save successul", board
+        @setBoards()
+      .catch (e) =>
+        console.log "error saving board", e
+
+  boardPreview: (data, i) ->
+    <BoardPreview {...@props} key={i} data={data} />
+
+  tag: (t, i) ->
+    <p>#{t.name}</p>
+
+  render: ->
+    <div className="talk-home">
+      <Moderation>
+        <form onSubmit={@onSubmitBoard}>
+          <h2>Moderator Zone:</h2>
+          <h3>Add a board:</h3>
+          <input type="text" ref="boardTitle" placeholder="Board Title"/>
+          <textarea type="text" ref="boardDescription" placeholder="Board Description"></textarea><br />
+          <button type="submit"><i className="fa fa-plus-circle" /> Create Board</button>
+        </form>
+      </Moderation>
+
+      <div className="talk-list-content">
+        <section>
+          {if @state.boards.length
+            @state.boards.map(@boardPreview)
+           else
+            <p>There are currently no boards.</p>}
+        </section>
+
+        <div className="talk-sidebar">
+          <h2>Talk Sidebar</h2>
+          <p><strong>{@state.discussionsMeta?.count}</strong> Discussions</p>
+          <PromiseRenderer promise={talkClient.type('tags').get(section: @props.section)}>{(tags) =>
+            <section>
+              <h3>Latest Tags:</h3>
+              {tags.map(@tag)}
+            </section>
+          }</PromiseRenderer>
+        </div>
+      </div>
+    </div>

--- a/app/talk/lib/comment-validations.coffee
+++ b/app/talk/lib/comment-validations.coffee
@@ -1,0 +1,16 @@
+# Check should return a condition that the comment passses if good
+
+MAX_LENGTH = 10000 # characters
+
+module?.exports = [
+  # existence
+  {
+    check: (comment) -> comment.length > 0
+    error: "Comments cannot be empty"
+  }
+  # max-length
+  {
+    check: (comment) -> comment.length < MAX_LENGTH
+    error: "Comments cannot be more than #{MAX_LENGTH} characters"
+  }
+  ]

--- a/app/talk/lib/discussion-validations.coffee
+++ b/app/talk/lib/discussion-validations.coffee
@@ -1,0 +1,14 @@
+MAX_LENGTH = 255 # characters
+
+module?.exports = [
+  # existence
+  {
+    check: (comment) -> comment.length > 0
+    error: "Discussion title cannot be empty"
+  }
+  # max-length
+  {
+    check: (comment) -> comment.length < MAX_LENGTH
+    error: "Discussion title cannot be more than #{MAX_LENGTH} characters"
+  }
+  ]

--- a/app/talk/lib/markdown-insert.coffee
+++ b/app/talk/lib/markdown-insert.coffee
@@ -1,0 +1,105 @@
+makeMarkdownHelper = (prefix, string, suffix = '') ->
+  # (string) -> {text, cursor}
+  # text is the formatted markdown string
+  # cursor is the position in that string to put the cursor back
+
+  # wraps string in prefix & suffix
+  # returns object with {text: output string, cursor: {start, end}}
+  # * start and end are selection indexes
+  # probably easiest to access data with {text, cursor} = func()
+
+  text = prefix + string + suffix
+  start = prefix.length
+  end = start + string.length
+
+  cursor = {start, end}
+  {text, cursor}
+
+onNewLine = (string, cursorIndex) ->
+  charAtCursor = string.charAt(cursorIndex - 1)
+  (charAtCursor is '\n') or (cursorIndex is 0)
+
+module?.exports =
+  hrefLink: (title, url) ->
+    linkTitle = title or "Example Text"
+    linkUrl = url or "http://www.example.com"
+    makeMarkdownHelper("[#{linkTitle}](", linkUrl, ")")
+
+  imageLink: (url, title) ->
+    imageTitle = title or "Example Alt Text"
+    imageUrl = url or "http://bit.ly/15CY6wE"
+    makeMarkdownHelper("![#{imageTitle}](", imageUrl, ')')
+
+  bold: (string) ->
+    text = string or "Bold Text"
+    makeMarkdownHelper('**', text, '**')
+
+  italic: (string) ->
+    text = string or "Italic Text"
+    makeMarkdownHelper('*', text, '*')
+
+  quote: (string) ->
+    text = string or "Quoted Text"
+    makeMarkdownHelper('> ', text)
+
+  bullet: (string) ->
+    makeMarkdownHelper('- ', string)
+
+  numberedList: (string) ->
+    makeMarkdownHelper('1. ', string)
+
+  heading: (string) ->
+    text = string or "Heading"
+    makeMarkdownHelper('## ', text, ' ##')
+
+  horizontalRule: (string) ->
+    makeMarkdownHelper('----------\n', string)
+
+  strikethrough: (string) ->
+    text = string or "Strikethrough"
+    makeMarkdownHelper('~~', text, '~~') # github-flavored specific
+
+  getSelection: (input) ->
+    input.value.substring(input.selectionStart, input.selectionEnd)
+
+  insertAtCursor: (text, input, cursor, opts = {}) ->
+    inputVal = input.value                                 # input text value
+    cursorPos = input.selectionStart                       # current cursor position
+    cursorEnd = input.selectionEnd                         # end of highlight, if so
+    notOnNewLine = not onNewLine(inputVal, cursorPos)
+
+    # optional char for newline switch
+    newLineChar = if (opts.ensureNewLine and notOnNewLine) then '\n' else ''
+
+    # values to update input.value with
+    begInputValue = inputVal.substring(0, cursorPos) + newLineChar
+    midInputValue = text
+    endInputValue = inputVal.substring(cursorEnd, inputVal.length)
+
+    newSelectionStart = cursorPos + cursor.start + newLineChar.length
+    newSelectionEnd = cursorPos + cursor.end + newLineChar.length
+
+    # update input value with new values
+    input.value = begInputValue + midInputValue + endInputValue
+
+    # set cursor back to a meaningful location for continued typing
+    input.focus()
+    input.setSelectionRange?(newSelectionStart, newSelectionEnd)
+
+  incrementedListItems: (previousText, text) -> # TODO: limit prev lines length
+    numberedLi = /^[^\d]*(\d+)/ # matches something line "3."
+    splitPrevLines = previousText.split("\n")
+    prevLine = splitPrevLines[splitPrevLines.length - 2]
+    splitSelection = text.split("\n")
+
+    if splitSelection.length > 1 # user has multiple lines highlighted
+      splitSelection
+        .map (text, i) ->
+          text.replace numberedLi, (fullMatch, n) -> i + 1
+        .join("\n")
+    else
+      text.replace numberedLi, (fullMatch, n) ->
+        if prevLine and +prevLine.split(".")[0]
+          (+prevLine.split(".")[0] + 1)
+        else
+          1

--- a/app/talk/lib/moderation.cjsx
+++ b/app/talk/lib/moderation.cjsx
@@ -1,0 +1,29 @@
+React = require 'react'
+ChangeListener = require '../../components/change-listener'
+PromiseRenderer = require '../../components/promise-renderer'
+authClient = require '../../api/auth'
+
+module?.exports = React.createClass
+  displayName: 'Moderation'
+
+  getInitialState: ->
+    open: false
+
+  toggleModeration: (e) ->
+    @setState open: !@state.open
+
+  render: ->
+    <ChangeListener target={authClient}>{=>
+      <PromiseRenderer promise={authClient.checkCurrent()}>{(user) =>
+        if user? # TODO: if user?.moderator
+          <div className="talk-moderation">
+            <button onClick={@toggleModeration}>
+              <i className="fa fa-#{if @state.open then 'close' else 'warning'}" /> Moderator Controls
+            </button>
+            <div className="talk-moderation-children #{if @state.open then 'open' else 'closed'}">
+              {@props.children}
+            </div>
+          </div>
+      }</PromiseRenderer>
+    }</ChangeListener>
+

--- a/app/talk/lib/paginator.cjsx
+++ b/app/talk/lib/paginator.cjsx
@@ -1,0 +1,63 @@
+React = require 'react'
+
+module?.exports = React.createClass
+  displayName: 'Paginator'
+
+  propTypes:
+    pageCount: React.PropTypes.number
+    page: React.PropTypes.number # page number
+    onPageChange: React.PropTypes.func.isRequired # passed (page) on change
+
+  getDefaultProps: ->
+    page: 1
+
+  setPage: (activePage) ->
+    @props.onPageChange(activePage)
+
+  onClickNext: ->
+    {pageCount, page} = @props
+
+    nextPage = if page is pageCount then pageCount else page + 1
+    @setPage(nextPage)
+
+  onClickPrev: ->
+    {pageCount, page} = @props
+
+    prevPage = if page is 1 then page else page - 1
+    @setPage(prevPage)
+
+  onSelectPage: (e) ->
+    selectedPage = +@refs.pageSelect.getDOMNode().value
+    @setPage(selectedPage)
+
+  pageOption: (n, i) ->
+    <option
+      key={i}
+      value={n}
+      selected={if @props.page is n then true else false}>
+      {n}
+    </option>
+
+  render: ->
+    <div className="paginator">
+      <button
+        className="paginator-prev"
+        onClick={@onClickPrev}
+        disabled={if @props.page is 1 then true else false}>
+        <i className="fa fa-long-arrow-left" /> Previous
+      </button>
+
+      <div className="paginator-page-selector">
+        Page&nbsp;
+        <select onChange={@onSelectPage} ref="pageSelect">
+          {[1..@props.pageCount].map(@pageOption)}
+        </select> of {@props.pageCount}
+      </div>
+
+      <button
+        className="paginator-next"
+        onClick={@onClickNext}
+        disabled={if @props.page is @props.pageCount then true else false}>
+        Next <i className="fa fa-long-arrow-right" />
+      </button>
+    </div>

--- a/app/talk/lib/resource-count.coffee
+++ b/app/talk/lib/resource-count.coffee
@@ -1,0 +1,8 @@
+# resource-count.coffee
+
+# takes in a resource name and a number
+# and returns a string formatted "N Resource(s)"
+# trims trailing 's' if number is 1
+
+module?.exports = (count, string) ->
+  "#{count} #{if +count is 1 then string.replace(/[Ss]$/, '') else string}"

--- a/app/talk/lib/time.coffee
+++ b/app/talk/lib/time.coffee
@@ -1,0 +1,5 @@
+moment = require 'moment'
+
+module?.exports =
+  timestamp: (ts) ->
+    moment(ts).format('MMMM Do YYYY, h:mm a')

--- a/app/talk/lib/upvoted-by-current-user.coffee
+++ b/app/talk/lib/upvoted-by-current-user.coffee
@@ -1,0 +1,2 @@
+module?.exports = (user, comment) ->
+  user? and (Object.keys(comment.upvotes).indexOf(user.display_name) isnt -1)

--- a/app/talk/lib/validations.coffee
+++ b/app/talk/lib/validations.coffee
@@ -1,0 +1,11 @@
+# tests: an array of objects with `check` and `error` keys
+# check is a function that should be true of the input
+# error is the message if check fails
+
+module?.exports =
+  getErrors: (input, tests) ->
+    tests.reduce (errors, validation) ->
+      if not validation.check(input)
+        return errors.concat validation.error
+      errors
+    , []

--- a/app/talk/mixins/feedback.cjsx
+++ b/app/talk/mixins/feedback.cjsx
@@ -1,0 +1,19 @@
+# mixin --- feedback.cjsx
+
+React = require 'react'
+
+module?.exports =
+  getInitialState: ->
+    feedback: null
+
+  setFeedback: (text) ->
+    window.addEventListener 'click', @removeFeedback
+    @setState feedback: text
+
+  removeFeedback: ->
+    window.removeEventListener 'click', @removeFeedback
+    @setState feedback: null
+
+  renderFeedback: ->
+    if @state.feedback
+      <p className="talk-comment-feedback">{@state.feedback}</p>

--- a/app/talk/mixins/toggle-children.cjsx
+++ b/app/talk/mixins/toggle-children.cjsx
@@ -1,0 +1,11 @@
+# mixin --- toggle-children.cjsx
+
+module?.exports =
+  getInitialState: ->
+    showing: null # string name of child component to show
+
+  toggleComponent: (name) ->
+    @setState showing: if @state.showing is name then null else name
+
+  hideChildren: ->
+    @setState showing: null

--- a/app/talk/subject-display.cjsx
+++ b/app/talk/subject-display.cjsx
@@ -1,0 +1,23 @@
+React = require 'react'
+apiClient = require '../api/client'
+getSubjectLocation = require '../lib/get-subject-location'
+PromiseRenderer = require '../components/promise-renderer'
+loadImage = require '../lib/load-image'
+
+module?.exports = React.createClass
+  displayName: 'TalkSubjectDisplay'
+
+  propTypes:
+    focusId: React.PropTypes.number
+
+  render: ->
+    <div className="talk-subject-display">
+      <PromiseRenderer promise={apiClient.type('subjects').get(@props.focusId.toString())}>{(subject) =>
+        <div>
+          <a href={getSubjectLocation(subject).src} target="_blank">
+            <img src={getSubjectLocation(subject).src} />
+          </a>
+          <p>Subject {subject.id}</p>
+        </div>
+      }</PromiseRenderer>
+    </div>

--- a/css/common.styl
+++ b/css/common.styl
@@ -3,6 +3,10 @@ BACKGROUND = white
 MAIN_HIGHLIGHT = #43bbfd
 SECOND_HIGHLIGHT = #38b978
 
+LIGHT_GREY = #CBCCCB
+SUCCESS = #009E0C
+FAILURE = #A31400
+
 background-stripes(color1, color2, size)
   background-image: repeating-linear-gradient(-45deg, color1, color1 size / 2, color2 size / 2, color2 size)
 

--- a/css/main.styl
+++ b/css/main.styl
@@ -9,6 +9,7 @@
 @require "./tabbed-content"
 @require "./dialog"
 @require "./tooltip"
+@require "./paginator"
 @require './project-roles'
 
 @require "./main-header"
@@ -28,4 +29,6 @@
 @require './notification-viewer'
 @require './markdown-editor'
 
+@require './talk'
+@require './talk-project'
 @require './workflow-editor'

--- a/css/paginator.styl
+++ b/css/paginator.styl
@@ -1,0 +1,20 @@
+.paginator
+  text-align: center
+
+  .paginator-page-selector
+    display: inline-block
+    margin: 0 10px
+
+  .paginator-prev
+    background: none
+    color: FOREGROUND
+    &:hover
+      background: FAILURE
+      color: #fff
+
+  .paginator-next
+    background: none
+    color: FOREGROUND
+    &:hover
+      background: SUCCESS
+      color: #fff

--- a/css/talk-project.styl
+++ b/css/talk-project.styl
@@ -1,0 +1,12 @@
+.talk.project
+  background: transparent
+
+  .talk-discussion-preview
+    color: LIGHT_GREY
+
+  .paginator
+    .paginator-prev
+      color: LIGHT_GREY
+
+    .paginator-next
+      color: LIGHT_GREY

--- a/css/talk.styl
+++ b/css/talk.styl
@@ -1,0 +1,270 @@
+// talk default css rules
+TALK_BACKGROUND = #F2F1F1
+TALK_BORDER_RADIUS = 3px
+TALK_PADDING = 5px
+TALK_MARGIN = 10px auto
+
+.talk-module // shared styles among talk box shaped things
+  background: TALK_BACKGROUND
+  border-radius: TALK_BORDER_RADIUS
+  padding: TALK_PADDING
+  margin: TALK_MARGIN
+  box-sizing: border-box
+  color: black
+
+.talk-text-input // shared styles among talk text inputs
+  border: none
+
+.talk-left-buttons
+  margin: 2px 2px 2px 0
+
+.talk-page-header
+  font-weight: 100
+  text-align: center
+
+.polaroid-border
+  background: #fff
+  padding: 10px 10px 20px 10px
+  margin: 10px
+
+.talk
+  *
+    box-sizing: border-box
+
+  input, textarea
+    border: none
+    font-size: 1.0em
+    font-family: inherit
+
+  button
+    @extend .standard-button
+    padding: 0.2em 0.4em
+    background: LIGHT_GREY
+    font-size: 0.8em
+    border-radius: 3px
+
+  select
+    border: 2px solid LIGHT_GREY
+    background: #fff
+    border-radius: TALK_BORDER_RADIUS
+    font-size: 0.8em
+    padding: 0.2em
+
+  .talk-list-content
+    display: flex
+    section
+      width: 100%
+
+  .talk-sidebar
+    @extend .talk-module
+    width: 300px
+    margin: 10px 0 10px 10px
+
+  .talk-moderation
+    margin-bottom: 10px
+
+    > button
+      border: 1px solid LIGHT_GREY
+      color: LIGHT_GREY
+      background: transparent
+
+      &:hover
+        color: orangered
+
+    .talk-moderation-children
+      p
+        margin: 0
+
+      input
+        width: 50%
+        display: block
+
+      textarea
+        width: 100%
+
+      button
+        margin: 5px 0 10px 0
+
+      &.closed
+        overflow: hidden
+        max-height: 0
+      &.open
+        @extend .talk-module
+        margin-bottom: 10px
+        border-left: 4px solid orangered
+
+  .talk-board
+    .talk-board-new-discussion
+      @extend .talk-module
+      padding: 0px
+      input, h2
+        margin: TALK_PADDING
+      input
+        border: none
+        width: 50%
+
+    .talk-board-discussions
+      width: 80%
+      float: left
+
+  .talk-board-preview
+    @extend .talk-module
+
+  .talk-subject-display
+    @extend .talk-module
+    @extend .polaroid-border
+    display: inline-block
+    text-align: center
+
+    img
+      max-width: 300px
+
+    p
+      margin: 0
+      font-size: 0.8em
+
+    h1
+      font-size: 2.5em
+
+  .talk-discussion-preview
+    @extend .talk-module
+    background: transparent
+    border-radius: 0
+    border-top: 1px solid LIGHT_GREY
+
+    &:last-child
+      border-bottom: 1px solid LIGHT_GREY
+
+    h1
+      font-weight: 100
+    p
+      margin: 0
+    .talk-discussion-preview-author
+      font-size: 0.7em
+      margin-top: 0.3em
+
+  .talk-discussion
+    max-width: 960px
+    margin: 0 auto
+
+    .talk-comment-box
+      width: 80%
+
+  .talk-comment
+    overflow: auto
+
+    .talk-comment-preview-content
+      blockquote
+        opacity: 0.5
+
+  .talk-comment-author
+    @extend .talk-module
+    text-align: center
+    background: transparent
+    font-size: 0.75em
+    color: grey
+    float: left
+    width: 20%
+
+    img
+      border-radius: 50%
+
+    p
+      width: 40%
+      margin: 0 auto
+
+  .talk-comment-body
+    width: 80%
+    float: left
+    @extend .talk-module
+
+    .talk-comment-date
+      margin: 0
+      font-size: 0.6em
+
+    .talk-comment-report-form
+      button
+        display: block
+
+    .talk-comment-links
+      button:not(:last-child)
+        @extend .talk-left-buttons
+
+      .talk-comment-like-button i.upvoted
+        color: MAIN_HIGHLIGHT
+
+  .talk-comment-feedback
+    color: green
+    text-decoration: italic
+
+  .talk-comment-box
+    @extend .talk-module
+    width: 100%
+    overflow: auto
+
+    .talk-comment-focus-image
+      float: left
+      max-width: 150px
+
+    .talk-comment-form
+      float: left
+      width: 100%
+
+      textarea
+        @extend .talk-text-input
+        width: 100%
+        height: 150px
+
+      section button
+        &.active
+          opacity: 0.5
+        &:not(:last-child)
+          @extend .talk-left-buttons
+
+    .talk-comment-buttons-container
+      display: block
+      float: left
+      width: 100%
+
+      button:not(:last-child)
+        @extend .talk-left-buttons
+
+    .talk-comment-children
+      float: left
+      width: 100%
+
+    .talk-comment-image-selector
+      .talk-comment-suggested-images
+        overflow-x: scroll
+        overflow-y: hidden
+        white-space: nowrap
+
+      .talk-comment-image-item
+        @extend .polaroid-border
+        position: relative
+        display: inline-block
+
+        img
+          max-width: 300px
+          display: inline-block
+          vertical-align: top
+
+        .image-card-select
+          position: absolute
+          text-align: center
+          top: 0
+          left: 0
+          right: 0
+          bottom: 0
+
+          button
+            opacity: 0
+            position: absolute
+            transform: translate(-50%, -50%)
+            transition: opacity .25s
+            top: 50%
+
+          &:hover
+            background: rgba(255,255,255,0.5)
+            button
+              opacity: 1

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
     "counterpart": "^0.16.4",
     "debounce": "^1.0.0",
     "json-api-client": "^0.2.2",
+    "lodash.merge": "^2.4.1",
+    "moment": "^2.9.0",
     "markdown-it": "^4.0.1",
     "markdown-it-container": "^1.0.0",
     "markdown-it-emoji": "^1.0.0",


### PR DESCRIPTION
Here's a quick feature synopsis of where I'm at with talk right now:

**Working:** Comment/Board/Discussion create/edit/destroy, Markdown rendering, Upvotes, Project talk - main talk distinction, tags/user mentions, Talk auth , Pagination, Comment live preview, Comment/discussion validations

**Incomplete/TODO:** Featured Image, Avatar rendering, User roles/moderation, Copy, Feedback messaging after actions, Splitting up css

**Placeholders for the future:** Reply, Report, Comment Link, Search, Individual Subject links

Happy to re-organize/change things up if you notice anything looks odd or breaks convention