### PR TITLE
Fix displayName conflict

### DIFF
--- a/app/pages/edit-project.cjsx
+++ b/app/pages/edit-project.cjsx
@@ -11,7 +11,7 @@ MarkdownEditor = require '../components/markdown-editor'
 apiClient = require '../api/client'
 
 ProjectEditPage = React.createClass
-  displayName: 'EditProjectPage'
+  displayName: 'EditProject'
 
   mixins: [HandlePropChanges, PromiseToSetState]
 
@@ -97,7 +97,7 @@ ProjectEditPage = React.createClass
         @setState busy: false
 
 module.exports = React.createClass
-  displayName: 'EditProjectPageWrapper'
+  displayName: 'EditProjectWrapper'
 
   render: ->
     <ChangeListener target={auth}>{=>

--- a/app/pages/edit-workflow.cjsx
+++ b/app/pages/edit-workflow.cjsx
@@ -4,7 +4,7 @@ apiClient = require '../api/client'
 WorkflowTasksEditor = require '../components/workflow-tasks-editor'
 
 module.exports = React.createClass
-  displayName: 'EditWorkflowPage'
+  displayName: 'EditWorkflow'
 
   getDefaultProps: ->
     params: {}


### PR DESCRIPTION
Clicking the new subject set button on the lab page would sometimes render an error about duplicate display names, this just removes the ones that conflict with the new lab pages, and match the corresponding workflow page to those