### PR TITLE
Don't render "pending" promise if an old value exists

### DIFF
--- a/app/components/promise-renderer.cjsx
+++ b/app/components/promise-renderer.cjsx
@@ -53,10 +53,13 @@ module.exports = React.createClass
     result ? null
 
   renderPending: ->
-    if typeof @props.pending is 'string'
-      @defaultPending @props.pending
-    else if @props.pending?
-      @props.pending.call this
+    if @state.value?
+      @renderResolved @state.value
+    else
+      if typeof @props.pending is 'string'
+        @defaultPending @props.pending
+      else if @props.pending?
+        @props.pending.call this
 
   renderResolved: (value) ->
     if typeof @props.children is 'function'


### PR DESCRIPTION
This makes it so that when a previously-rendered PromiseRenderer gets a new promise, it shows its old data until the promise resolves instead of blanking out.

The tradeoff is that sometimes old data is displayed for a while. I think it's worth it, but just close this if I'm wrong.