### PR TITLE
Add touch events to drawing tools

### DIFF
--- a/app/classifier/drawing-tools/root.cjsx
+++ b/app/classifier/drawing-tools/root.cjsx
@@ -35,8 +35,11 @@ module.exports = React.createClass
       else
         STROKE_WIDTH / scale
 
+    unless toolProps.disabled
+      startHandler = toolProps.onSelect
+
     <g className="drawing-tool" {...rootProps} {...@props}>
-      <g className="drawing-tool-main" {...mainStyle} onMouseDown={toolProps.onSelect unless toolProps.disabled}>
+      <g className="drawing-tool-main" {...mainStyle} onMouseDown={startHandler} onTouchStart={startHandler}>
         {@props.children}
       </g>
     </g>

--- a/app/lib/draggable.cjsx
+++ b/app/lib/draggable.cjsx
@@ -25,6 +25,7 @@ module.exports = React.createClass
       cloneWithProps @props.children,
         className: 'draggable'
         onMouseDown: @handleStart
+        onTouchStart: @handleStart
 
   _rememberCoords: (e) ->
     @_previousEventCoords =
@@ -34,13 +35,19 @@ module.exports = React.createClass
   handleStart: (e) ->
     e.preventDefault()
 
+    [moveEvent, endEvent] = switch e.type
+      when 'mousedown' then ['mousemove', 'mouseup']
+      when 'touchstart' then ['touchmove', 'touchend']
+
+    e = e.touches?[0] ? e
+
     @_rememberCoords e
 
     # Prefix with this class to switch from `cursor:grab` to `cursor:grabbing`.
     document.body.classList.add 'dragging'
 
-    document.addEventListener 'mousemove', @handleDrag
-    document.addEventListener 'mouseup', @handleEnd
+    addEventListener moveEvent, @handleDrag
+    addEventListener endEvent, @handleEnd
 
     # If there's no `onStart`, `onDrag` will be called on start.
     startHandler = @props.onStart ? @handleDrag
@@ -48,6 +55,7 @@ module.exports = React.createClass
       startHandler e
 
   handleDrag: (e) ->
+    e = e.touches?[0] ? e
     d =
       x: e.pageX - @_previousEventCoords.x
       y: e.pageY - @_previousEventCoords.y
@@ -57,8 +65,14 @@ module.exports = React.createClass
     @_rememberCoords e
 
   handleEnd: (e) ->
-    document.removeEventListener 'mousemove', @handleDrag
-    document.removeEventListener 'mouseup', @handleEnd
+    [moveEvent, endEvent] = switch e.type
+      when 'mouseup' then ['mousemove', 'mouseup']
+      when 'touchend' then ['touchmove', 'touchend']
+
+    e = e.touches?[0] ? e
+
+    removeEventListener moveEvent, @handleDrag
+    removeEventListener endEvent, @handleEnd
 
     @props.onEnd? e
 

--- a/app/main.cjsx
+++ b/app/main.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+React.initializeTouchEvents true
 window.React = React
 Router = {RouteHandler, DefaultRoute, Route, NotFoundRoute} = require 'react-router'
 MainHeader = require './partials/main-header'


### PR DESCRIPTION
Just piggybacking the usual mouse events.

Tested in iOS simulator (works okay, a little sluggish), Android Chrome (works freakin' great) and Android Firefox (functional but awful, not sure what we can do about it).

Haven't tried on a real iOS device.

Closes #184.