### PR TITLE
Update board section key for api, Add roles inputs

### DIFF
--- a/app/talk/home.cjsx
+++ b/app/talk/home.cjsx
@@ -5,9 +5,13 @@ module?.exports = React.createClass
   displayName: 'TalkHome'
 
   getSection: ->
-    # Use project id for section for project talks
-    # or 'zooniverse' for global-talk
-    @props.project?.id ? 'zooniverse'
+    # Use "#{project.id}-#{project.name}" for section for project talks
+    # or "zooniverse" for global-talk
+
+    if @props.project?.id
+      "#{@props.project.id}-#{@props.project.title}"
+    else
+      'zooniverse'
 
   render: ->
     <div className="talk-home">

--- a/app/talk/init.cjsx
+++ b/app/talk/init.cjsx
@@ -7,6 +7,7 @@ PromiseRenderer = require '../components/promise-renderer'
 Moderation = require './lib/moderation'
 ChangeListener = require '../components/change-listener'
 PromiseRenderer = require '../components/promise-renderer'
+ROLES = require './lib/roles'
 
 module?.exports = React.createClass
   displayName: 'TalkInit'
@@ -41,11 +42,16 @@ module?.exports = React.createClass
     titleInput = @getDOMNode().querySelector('form input')
     descriptionInput = @getDOMNode().querySelector('form textarea')
 
+    # permissions
+    read = @getDOMNode().querySelector(".roles-read input[name='role-read']:checked").value
+    write = @getDOMNode().querySelector(".roles-write input[name='role-write']:checked").value
+    permissions = {read, write}
+
     title = titleInput.value
     description = descriptionInput.value
     section = @props.section
 
-    board = {title, description, section}
+    board = {title, description, section, permissions}
     return console.log "failed validation" unless title and description and section
 
     talkClient.type('boards').create(board).save()
@@ -63,6 +69,12 @@ module?.exports = React.createClass
   tag: (t, i) ->
     <p>#{t.name}</p>
 
+  roleReadLabel: (data, i) ->
+    <label><input type="radio" name="role-read" value={data}/>{data}</label>
+
+  roleWriteLabel: (data, i) ->
+    <label><input type="radio" name="role-write" value={data}/>{data}</label>
+
   render: ->
     <div className="talk-home">
       <Moderation>
@@ -70,7 +82,15 @@ module?.exports = React.createClass
           <h2>Moderator Zone:</h2>
           <h3>Add a board:</h3>
           <input type="text" ref="boardTitle" placeholder="Board Title"/>
+
           <textarea type="text" ref="boardDescription" placeholder="Board Description"></textarea><br />
+
+          <h4>Can Read:</h4>
+          <div className="roles-read">{ROLES.map(@roleReadLabel)}</div>
+
+          <h4>Can Write:</h4>
+          <div className="roles-write">{ROLES.map(@roleWriteLabel)}</div>
+
           <button type="submit"><i className="fa fa-plus-circle" /> Create Board</button>
         </form>
       </Moderation>
@@ -82,6 +102,7 @@ module?.exports = React.createClass
            else
             <p>There are currently no boards.</p>}
         </section>
+
 
         <div className="talk-sidebar">
           <h2>Talk Sidebar</h2>

--- a/app/talk/init.cjsx
+++ b/app/talk/init.cjsx
@@ -14,14 +14,12 @@ module?.exports = React.createClass
 
   getInitialState: ->
     boards: []
-    discussionsMeta: {}
 
   propTypes:
     section: React.PropTypes.string # 'zooniverse' for main-talk, 'project_id' for projects
 
   componentWillMount: ->
     @setBoards()
-    @setDiscussionsMeta()
 
   setBoards: ->
     talkClient.type('boards').get(section: @props.section)
@@ -29,13 +27,6 @@ module?.exports = React.createClass
         @setState {boards}
       .catch (e) =>
         console.log "error getting boards"
-
-  setDiscussionsMeta: ->
-    talkClient.type('discussions').get(section: @props.section)
-      .then (discussions) =>
-        @setState {discussionsMeta: discussions[0]?.getMeta()}
-      .catch (e) =>
-        console.log 'Error setting discussions meta'
 
   onSubmitBoard: (e) ->
     e.preventDefault()
@@ -106,7 +97,6 @@ module?.exports = React.createClass
 
         <div className="talk-sidebar">
           <h2>Talk Sidebar</h2>
-          <p><strong>{@state.discussionsMeta?.count}</strong> Discussions</p>
           <PromiseRenderer promise={talkClient.type('tags').get(section: @props.section)}>{(tags) =>
             if tags.length
               <section>

--- a/app/talk/lib/roles.coffee
+++ b/app/talk/lib/roles.coffee
@@ -1,0 +1,7 @@
+module?.exports = [
+# Role          | Can access:
+  "admin"       # admin, moderator, ream, all
+  "moderator"   # moderator, team, all
+  "team"        # team, all
+  "all"         # all *
+  ]

--- a/css/talk.styl
+++ b/css/talk.styl
@@ -23,7 +23,7 @@ TALK_MARGIN = 10px auto
   text-align: center
 
 .talk-form
-  input, textarea
+  input[type='text'], textarea
     border: none
     font-size: 1.0em
     font-family: inherit
@@ -81,7 +81,7 @@ TALK_MARGIN = 10px auto
       p
         margin: 0
 
-      input
+      input[type='text']
         width: 50%
         display: block
 


### PR DESCRIPTION
The talk-api now expects `section` values to be formatted as project_id-project_name. This also adds permissions assignment when creating a board