### PR TITLE
Project owner can configure allowing user choice of workflow

### DIFF
--- a/app/pages/lab/project-details.cjsx
+++ b/app/pages/lab/project-details.cjsx
@@ -28,6 +28,13 @@ module.exports = React.createClass
 
         <p>
           <label>
+            <input type="checkbox" name="configuration.user_choose_workflow" checked={@props.project.configuration?.user_choose_workflow} onChange={@handleChange} />
+            Volunteers can choose which workflow they work on
+          </label>
+        </p>
+
+        <p>
+          <label>
             <input type="checkbox" name="private" checked={@props.project.private} onChange={@handleChange} />
             Private project <small className="form-help">TODO: Explain</small>
           </label>

--- a/app/pages/lab/project-details.cjsx
+++ b/app/pages/lab/project-details.cjsx
@@ -28,7 +28,7 @@ module.exports = React.createClass
 
         <p>
           <label>
-            <input type="checkbox" name="configuration.user_choose_workflow" checked={@props.project.configuration?.user_choose_workflow} onChange={@handleChange} />
+            <input type="checkbox" name="configuration.user_chooses_workflow" checked={@props.project.configuration?.user_chooses_workflow} onChange={@handleChange} />
             Volunteers can choose which workflow they work on
           </label>
         </p>

--- a/app/pages/project/home.cjsx
+++ b/app/pages/project/home.cjsx
@@ -35,9 +35,14 @@ module.exports = React.createClass
       <div className="call-to-action-container content-container">
         <Markdown className="description">{@props.project.description}</Markdown>
 
-        {for workflow in @state.workflows
-          <Link to="project-classify" params={linkParams} query={workflow: workflow.id} key={workflow.id} className="call-to-action standard-button">
-            {workflow.display_name}
+        {if @props.project.configuration?.user_chooses_workflow
+          for workflow in @state.workflows
+            <Link to="project-classify" params={linkParams} query={workflow: workflow.id} key={workflow.id} className="call-to-action standard-button">
+              {workflow.display_name}
+            </Link>
+        else
+          <Link to="project-classify" params={linkParams} className="call-to-action standard-button">
+            Get started!
           </Link>}
       </div>
 


### PR DESCRIPTION
Allow project owner to specify a single or per-workflow button-to-classify on a project's home page.

Will test when zooniverse/Panoptes#760 is deployed.

Closes #189.