### PR TITLE
Workflow retirement rules

### DIFF
--- a/app/components/retirement-rules-editor.cjsx
+++ b/app/components/retirement-rules-editor.cjsx
@@ -16,8 +16,8 @@ module.exports = React.createClass
     classification_count: count: 15
 
   render: ->
-    criteria = @props.subjectSet.retirement?.criteria ? @defaultCriteria
-    options = @props.subjectSet.retirement?.options ? @defaultOptions[criteria]
+    criteria = @props.workflow.retirement?.criteria ? @defaultCriteria
+    options = @props.workflow.retirement?.options ? @defaultOptions[criteria]
 
     <span className="retirement-rules-editor">
       <select ref="criteriaSelect" value={criteria} disabled onChange={@handleChangeCriteria}>
@@ -31,16 +31,16 @@ module.exports = React.createClass
     </span>
 
   handleChangeCriteria: (e) ->
-    @props.subjectSet.update
+    @props.workflow.update
       'retirement.criteria': e.target.value
       'retirement.options': @defaultOptions[e.target.value]
 
   handleChangeOption: (e) ->
-    @props.subjectSet.update
-      'retirement.criteria': @props.subjectSet.retirement?.criteria ? @defaultCriteria
+    @props.workflow.update
+      'retirement.criteria': @props.workflow.retirement?.criteria ? @defaultCriteria
 
-    @props.subjectSet.update
-      'retirement.options': @props.subjectSet.retirement.options ? @defaultOptions[@props.subjectSet.retirement.criteria]
+    @props.workflow.update
+      'retirement.options': @props.workflow.retirement.options ? @defaultOptions[@props.workflow.retirement.criteria]
 
     updateKey = "retirement.options.#{e.target.name}"
     newOptionsData = {}
@@ -49,4 +49,4 @@ module.exports = React.createClass
     else
       e.target.value
 
-    @props.subjectSet.update newOptionsData
+    @props.workflow.update newOptionsData

--- a/app/pages/lab/subject-set.cjsx
+++ b/app/pages/lab/subject-set.cjsx
@@ -8,7 +8,6 @@ Papa = require 'papaparse'
 alert = require '../../lib/alert'
 SubjectUploader = require '../../partials/subject-uploader'
 BoundResourceMixin = require '../../lib/bound-resource-mixin'
-RetirementRulesEditor = require '../../components/retirement-rules-editor'
 UploadDropTarget = require '../../components/upload-drop-target'
 ManifestView = require '../../components/manifest-view'
 
@@ -37,7 +36,6 @@ EditSubjectSetPage = React.createClass
     <div>
       <form onSubmit={@handleSubmit}>
         <p>Name <input type="text" name="display_name" value={@props.subjectSet.display_name} className="standard-input" onChange={@handleChange} /></p>
-        <p>Retirement <RetirementRulesEditor subjectSet={@props.subjectSet} /></p>
 
         <p><button type="submit" className="standard-button" disabled={not @props.subjectSet.hasUnsavedChanges()}>Save changes</button> {@renderSaveStatus()}</p>
       </form>

--- a/app/pages/lab/workflow.cjsx
+++ b/app/pages/lab/workflow.cjsx
@@ -81,10 +81,6 @@ EditWorkflowPage = React.createClass
         <hr />
 
         <div>
-          <button type="button" className="minor-button" disabled={@state.reloadCellectInProgress} data-busy={@state.reloadCellectInProgress || null} onClick={@reloadCellect}>Reload Cellect</button>{' '}
-          {if @state.reloadCellectError
-            <span className="form-help error">There was an error reloading cellect</span>}
-          <p className="form-help">Reload Cellect after you’ve modified an associated subject set. TODO: Call this automatically when adding to a subject set.</p>
           <p>Subject retirement <RetirementRulesEditor workflow={@props.workflow} /></p>
         </div>
 

--- a/app/pages/lab/workflow.cjsx
+++ b/app/pages/lab/workflow.cjsx
@@ -5,6 +5,7 @@ WorkflowTasksEditor = require '../../components/workflow-tasks-editor'
 apiClient = require '../../api/client'
 ChangeListener = require '../../components/change-listener'
 BoundResourceMixin = require '../../lib/bound-resource-mixin'
+RetirementRulesEditor = require '../../components/retirement-rules-editor'
 {Navigation} = require 'react-router'
 tasks = require '../../classifier/tasks'
 
@@ -84,6 +85,7 @@ EditWorkflowPage = React.createClass
           {if @state.reloadCellectError
             <span className="form-help error">There was an error reloading cellect</span>}
           <p className="form-help">Reload Cellect after you’ve modified an associated subject set. TODO: Call this automatically when adding to a subject set.</p>
+          <p>Subject retirement <RetirementRulesEditor workflow={@props.workflow} /></p>
         </div>
 
         <hr />


### PR DESCRIPTION
Retirement rules now are now per-workflow instead of per-subject_set.

"Reload Cellect" button no longer needed.

Closes #246.