### PR TITLE
Move coffeeify to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "animated-scrollto": "~1.1.0",
     "counterpart": "~0.16.7",
     "debounce": "~1.0.0",
-    "json-api-client": "~0.2.3",
+    "json-api-client": "~0.2.6",
     "lodash.merge": "~2.4.1",
     "markdown-it": "~4.0.1",
     "markdown-it-container": "~1.0.0",
@@ -26,6 +26,7 @@
     "browserify": "~8.1.0",
     "cjsx-loader": "~1.1.0",
     "coffee-reactify": "~3.0.0",
+    "coffeeify": "~1.1.0",
     "csso": "~1.3.11",
     "envify": "~3.2.0",
     "es6-promise": "~2.0.0",
@@ -38,9 +39,6 @@
     "testling": "~1.7.1",
     "uglify-js": "~2.4.16",
     "watchify": "~2.2.1"
-  },
-  "peerDependencies": {
-    "coffeeify": "~1.0.0"
   },
   "scripts": {
     "build": "NODE_ENV=${NODE_ENV:-production} ./bin/build.sh",


### PR DESCRIPTION
Fixes preventative npm warning:
npm WARN peerDependencies The peer dependency coffeeify included from panoptes will no
npm WARN peerDependencies longer be automatically installed to fulfill the peerDependency 
npm WARN peerDependencies in npm 3+. Your application will need to depend on it explicitly.

Also updates json-api-client to 0.2.6