### PR TITLE
Simplify classifier wrapper, reset state between classifications

### DIFF
--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -4,7 +4,6 @@ ChangeListener = require '../components/change-listener'
 SubjectViewer = require './subject-viewer'
 ClassificationSummary = require './classification-summary'
 tasks = require './tasks'
-PromiseToSetState = require '../lib/promise-to-set-state'
 
 NOOP = Function.prototype
 
@@ -141,28 +140,38 @@ Classifier = React.createClass
 module.exports = React.createClass
   displayName: 'ClassifierWrapper'
 
-  mixins: [HandlePropChanges, PromiseToSetState]
-
   getDefaultProps: ->
-    classification: if process.env.NODE_ENV is 'production'
-        null
-      else
-        mockData.classification
+    classification: mockData?.classification ? {}
+    onLoad: NOOP
+    onComplete: NOOP
+    onClickNext: NOOP
 
   getInitialState: ->
     workflow: null
     subject: null
 
-  propChangeHandlers:
-    classification: (classification) ->
-      @promiseToSetState
-        # TODO: These underscored references are temporary stopgaps.
-        workflow: Promise.resolve classification._workflow ? classification.get 'workflow'
-        subject: Promise.resolve classification._subject ? classification.get('subjects').then ([subject]) ->
-          subject
+  componentDidMount: ->
+    @loadClassification @props.classification
+
+  componentWillReceiveProps: (nextProps) ->
+    unless nextProps.classification is @props.classification
+      @loadClassification nextProps.classification
+
+  loadClassification: (classification) ->
+    @setState @getInitialState()
+
+    # TODO: These underscored references are temporary stopgaps.
+
+    Promise.resolve(classification._workflow ? classification.get 'workflow').then (workflow) =>
+      @setState {workflow}
+
+    Promise.resolve(classification._subjects ? classification.get 'subjects').then ([subject]) =>
+      # We'll only handle one subject per classification right now.
+      # TODO: Support multi-subject classifications in the future.
+      @setState {subject}
 
   render: ->
     if @state.workflow? and @state.subject?
-      <Classifier {...@props} workflow={@state.workflow} subject={@state.subject} />
+      <Classifier {...@props} {...@state} />
     else
       <span>Loading classifier</span>

--- a/app/pages/project/classify.cjsx
+++ b/app/pages/project/classify.cjsx
@@ -98,7 +98,7 @@ module.exports = React.createClass
       # If the user hasn't interacted with a classification resource before,
       # we won't know how to resolve its links, so attach these manually.
       classification._workflow = workflow
-      classification._subject = subject
+      classification._subjects = [subject]
 
       classification
 


### PR DESCRIPTION
The classifier can get into a state between ending one classification and starting another where the old classification's workflow is still loaded but the new classification tries to render.

This PR resets the classifier's workflow and subject when a different classification is loaded. Also removes some of my mixins to make things more explicit.

Closes #289.