### PR TITLE
Better task removal

### DIFF
--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -62,9 +62,10 @@ Classifier = React.createClass
               when 'multiple'
                 waitingForAnswer = currentTask.required and currentAnnotation.value.length is 0
 
-            nextTaskKey = if currentTask.type is 'single' and currentAnswer?
+            # If the next task key exists, make sure the task it points to actually exists.
+            nextTaskKey = if currentTask.type is 'single' and currentAnswer? and @props.workflow.tasks[currentAnswer.next]?
               currentAnswer.next
-            else
+            else if @props.workflow.tasks[currentTask.next]?
               currentTask.next
 
             <div className="task-container">

--- a/app/components/workflow-tasks-editor.cjsx
+++ b/app/components/workflow-tasks-editor.cjsx
@@ -266,15 +266,16 @@ module.exports = React.createClass
 
   removeTask: (taskKey) ->
     for key, task of @props.workflow.tasks
+      # Remove the task from any task that declares it the next.
       if task.next is taskKey
         delete task.next
-      if task.type in ['single', 'multiple'] and task.answers?
+      if task.answers?
+        # Remove the task from any answer that declares it the next.
         for answer in task.answers when answer.next is taskKey
           delete answer.next
+    # Find a new first task, if we're removing the current one.
     if taskKey is @props.workflow.first_task
-      if @props.workflow.tasks[taskKey].next?
-        @props.workflow.first_task = @props.workflow.tasks[taskKey].next
-      else
-        delete @props.workflow.first_task
+      @props.workflow.update first_task: @props.workflow.tasks[taskKey].next ? Object.keys(@props.workflow.tasks)[0]
+
     delete @props.workflow.tasks[taskKey]
     @props.workflow.update 'tasks'


### PR DESCRIPTION
This

- Does a better job of cleaning out references to tasks when deleting them

- Allows the classifier work around workflows with references to deleted tasks just in case

Not entirely sure what was going on with the first one, but it should be fixed now, and the second one will make sure the classifier doesn't lock up in the event that it does happen.

Closes #289.