### PR TITLE
Add user avatars

### DIFF
--- a/app/components/image-selector.cjsx
+++ b/app/components/image-selector.cjsx
@@ -1,0 +1,127 @@
+React = require 'react'
+LoadingIndicator = require './loading-indicator'
+
+BASE_64_PNG_HEAD = 'data:image/png;base64,'
+BASE_64_JPEG_HEAD = 'data:image/jpeg;base64,'
+BASE_64_EXPANSION = 3 / 4
+
+module.exports = React.createClass
+  displayName: 'ImageSelector'
+
+  getDefaultProps: ->
+    accept: 'image/*'
+    maxSize: Infinity # In bytes
+    ratio: NaN # Width / height
+    quality: 0.8 # For JPEGs
+    minArea: 100 # Stop reducing when there are fewer than this many pixels.
+    reductionPerPass: 0.05
+    onChange: Function.prototype # No-op
+
+  getInitialState: ->
+    working: false
+    format: ''
+    size: NaN
+
+  componentDidMount: ->
+    canvas = @refs.preview.getDOMNode()
+    canvas.height = canvas.width * @props.ratio
+
+  render: ->
+    <span className="image-uploader" style={
+      display: 'inline-block'
+      minHeight: '1em'
+      background: 'rgba(128, 128, 128, 0.2)'
+      border: '1px solid rgba(128, 128, 128, 0.4)'
+      borderRadius: 5
+      position: 'relative'
+    }>
+      <canvas ref="preview" style={
+        display: 'block'
+        maxWidth: '100%'
+      } />
+
+      <input type="file" accept={@props.accept} disabled={@state.working} style={
+        cursor: 'pointer'
+        height: '100%'
+        left: 0
+        position: 'absolute'
+        opacity: 0
+        top: 0
+        width: '100%'
+      } onChange={@handleChange} />
+
+      {if @state.working
+        <span style={
+          fontSize: '2em'
+          left: '50%'
+          position: 'absolute'
+          top: '50%'
+          transform: 'translate(-50%, -50%)'
+        }>
+          <LoadingIndicator />
+        </span>}
+    </span>
+
+  handleChange: (e) ->
+    @setState
+      working: true
+      format: ''
+      size: NaN
+
+    reader = new FileReader
+    reader.onload = (e) =>
+      img = new Image
+      img.onload = =>
+        @cropImage img
+      img.src = e.target.result
+    reader.readAsDataURL e.target.files[0]
+
+  cropImage: (srcImg) ->
+    canvas = @refs.preview.getDOMNode()
+    canvas.width = srcImg.naturalWidth
+    canvas.height = srcImg.naturalHeight
+
+    unless isNaN @props.ratio
+      naturalRatio = srcImg.naturalWidth / srcImg.naturalHeight
+      if naturalRatio - @props.ratio < 0
+        canvas.height = canvas.width / @props.ratio
+      else
+        canvas.width = canvas.height * @props.ratio
+
+    ctx = canvas.getContext '2d'
+    ctx.drawImage srcImg, (srcImg.naturalWidth - canvas.width) / -2, (srcImg.naturalHeight - canvas.height) / -2
+
+    croppedImg = new Image
+    croppedImg.onload = =>
+      @reduceImage croppedImg
+    croppedImg.src = canvas.toDataURL()
+
+  reduceImage: (img, scale = 1) ->
+    canvas = @refs.preview.getDOMNode()
+    canvas.width = img.naturalWidth * scale
+    canvas.height = img.naturalHeight * scale
+
+    ctx = canvas.getContext '2d'
+    ctx.drawImage img, 0, 0, img.naturalWidth, img.naturalHeight, 0, 0, canvas.width, canvas.height
+
+    pngURL = canvas.toDataURL 'image/png'
+    pngSize = Math.round (pngURL.length - BASE_64_PNG_HEAD.length) * BASE_64_EXPANSION
+
+    jpegURL = canvas.toDataURL 'image/jpeg', @props.quality
+    jpegSize = Math.round (jpegURL.length - BASE_64_JPEG_HEAD.length) * BASE_64_EXPANSION
+
+    # NOTE: In Chrome at least, PNG is always pretty huge.
+    # I think it might not be doing any compression or something.
+
+    [url, format, size] = if pngSize < jpegSize
+      [pngURL, 'image/png', pngSize]
+    else
+      [jpegURL, 'image/jpeg', jpegSize]
+
+    if size > @props.maxSize and canvas.width * canvas.height > @props.minArea
+      # Keep trying until it's small enough.
+      @reduceImage img, scale - @props.reductionPerPass
+    else
+      working = false
+      @setState {format, size, working}
+      @props.onChange url, format

--- a/app/components/image-selector.cjsx
+++ b/app/components/image-selector.cjsx
@@ -1,5 +1,6 @@
 React = require 'react'
 LoadingIndicator = require './loading-indicator'
+toBlob = require 'data-uri-to-blob'
 
 BASE_64_PNG_HEAD = 'data:image/png;base64,'
 BASE_64_JPEG_HEAD = 'data:image/jpeg;base64,'
@@ -113,7 +114,7 @@ module.exports = React.createClass
     # NOTE: In Chrome at least, PNG is always pretty huge.
     # I think it might not be doing any compression or something.
 
-    [url, format, size] = if pngSize < jpegSize
+    [dataURL, format, size] = if pngSize < jpegSize
       [pngURL, 'image/png', pngSize]
     else
       [jpegURL, 'image/jpeg', jpegSize]
@@ -124,4 +125,4 @@ module.exports = React.createClass
     else
       working = false
       @setState {format, size, working}
-      @props.onChange url, format
+      @props.onChange toBlob dataURL

--- a/app/lib/put-file.coffee
+++ b/app/lib/put-file.coffee
@@ -1,0 +1,11 @@
+module.exports = (location, file) ->
+  new Promise (resolve, reject) =>
+    xhr = new XMLHttpRequest
+    xhr.onreadystatechange = (e) =>
+      if e.target.readyState is e.target.DONE
+        if 200 <= e.target.status < 300
+          resolve e.target
+        else
+          reject e.target
+    xhr.open 'PUT', location
+    xhr.send file

--- a/app/pages/settings.cjsx
+++ b/app/pages/settings.cjsx
@@ -3,6 +3,7 @@ BoundResourceMixin = require '../lib/bound-resource-mixin'
 ChangeListener = require '../components/change-listener'
 auth = require '../api/auth'
 PromiseRenderer = require '../components/promise-renderer'
+ImageSelector = require '../components/image-selector'
 
 UserSettingsPage = React.createClass
   displayName: 'UserSettingsPage'
@@ -18,7 +19,8 @@ UserSettingsPage = React.createClass
     <div>
       <div className="columns-container">
         <div className="content-container">
-          TODO: Avatar
+          Avatar<br />
+          <ImageSelector ratio={1} maxSize={65536} />
         </div>
 
         <hr />

--- a/app/pages/settings.cjsx
+++ b/app/pages/settings.cjsx
@@ -15,34 +15,44 @@ UserSettingsPage = React.createClass
     user: {}
 
   render: ->
-    <div className="content-container">
-      <table className="standard-table full">
-        <tr>
-          <th>Credited name</th>
-          <td>
-            <input type="text" className="standard-input full" name="credited_name" value={@props.user.credited_name} onChange={@handleChange} />
-            <div className="form-help">We’ll use this to give acknowledgement in papers, on posters, etc.</div>
-          </td>
-        </tr>
+    <div>
+      <div className="columns-container">
+        <div className="content-container">
+          TODO: Avatar
+        </div>
 
-        <tr>
-          <th>Any other stuff?</th>
-          <td>
-            TODO
-          </td>
-        </tr>
-      </table>
+        <hr />
 
-      <p>
-        <button type="button" disabled={@state.saveInProgress or not @props.user.hasUnsavedChanges()} onClick={@saveResource}>Save profile</button>{' '}
-        {@renderSaveStatus()}
-      </p>
+        <div className="content-container column">
+          <table className="standard-table full">
+            <tr>
+              <th>Credited name</th>
+              <td>
+                <input type="text" className="standard-input full" name="credited_name" value={@props.user.credited_name} onChange={@handleChange} />
+                <div className="form-help">Public; we’ll use this to give acknowledgement in papers, on posters, etc.</div>
+              </td>
+            </tr>
+
+            <tr>
+              <th>Any other stuff?</th>
+              <td>
+                TODO
+              </td>
+            </tr>
+          </table>
+
+          <p>
+            <button type="button" className="standard-button" disabled={@state.saveInProgress or not @props.user.hasUnsavedChanges()} onClick={@saveResource}>Save profile</button>{' '}
+            {@renderSaveStatus()}
+          </p>
+        </div>
+      </div>
 
       <hr />
-
-      <p><strong>Email preferences</strong></p>
-
-      <p>TODO</p>
+      <div className="content-container">
+        <p><strong>Email preferences</strong></p>
+        <p>TODO</p>
+      </div>
     </div>
 
 module.exports = React.createClass

--- a/app/pages/settings.cjsx
+++ b/app/pages/settings.cjsx
@@ -81,6 +81,9 @@ UserSettingsPage = React.createClass
       .then ([avatar]) =>
         console.log 'Will put file to', avatar.src
         putFile avatar.src, file
+      .then =>
+        @props.user.uncacheLink 'avatar'
+        @props.user.emit 'change'
       .catch (error) =>
         @setState avatarError: error
 

--- a/app/pages/settings.cjsx
+++ b/app/pages/settings.cjsx
@@ -4,6 +4,7 @@ ChangeListener = require '../components/change-listener'
 auth = require '../api/auth'
 PromiseRenderer = require '../components/promise-renderer'
 ImageSelector = require '../components/image-selector'
+apiClient = require '../api/client'
 
 UserSettingsPage = React.createClass
   displayName: 'UserSettingsPage'
@@ -20,7 +21,7 @@ UserSettingsPage = React.createClass
       <div className="columns-container">
         <div className="content-container">
           Avatar<br />
-          <ImageSelector ratio={1} maxSize={65536} />
+          <ImageSelector ratio={1} maxSize={65536} onChange={@handleAvatarChange} />
         </div>
 
         <hr />
@@ -56,6 +57,11 @@ UserSettingsPage = React.createClass
         <p>TODO</p>
       </div>
     </div>
+
+  handleAvatarChange: (file) ->
+    apiClient.put @props.user._getURL('avatar'), media: content_type: file.type
+      .then =>
+        console.log 'Posted image response:', arguments
 
 module.exports = React.createClass
   displayName: 'UserSettingsPageWrapper'

--- a/app/pages/settings.cjsx
+++ b/app/pages/settings.cjsx
@@ -59,7 +59,7 @@ UserSettingsPage = React.createClass
     </div>
 
   handleAvatarChange: (file) ->
-    apiClient.put @props.user._getURL('avatar'), media: content_type: file.type
+    apiClient.post @props.user._getURL('avatar'), media: content_type: file.type
       .then =>
         console.log 'Posted image response:', arguments
 

--- a/app/partials/account-bar.cjsx
+++ b/app/partials/account-bar.cjsx
@@ -25,11 +25,10 @@ module.exports = React.createClass
   render: ->
     <div className="account-bar">
       <img src={@props.user.avatar} className="avatar" />{' '}
-      <strong><Link to="user-profile" params={name: @props.user.display_name}>{@props.user.display_name}</Link></strong>{' '}
-
-      <Link to="inbox"><i className="fa fa-envelope#{if @state.unread then '' else '-o'}" /> </Link>
-      <button type="button" className="pill-button" onClick={@handleSignOutClick}>Sign out</button>{' '}
-      <Link to="settings" className="pill-button">Settings</Link>
+      <strong><Link to="user-profile" params={name: @props.user.display_name}>{@props.user.display_name}</Link></strong>&ensp;
+      <Link to="inbox"><i className="fa fa-envelope#{if @state.unread then '' else '-o'}"></i></Link>&ensp;
+      <Link to="settings"><i className="fa fa-cog"></i></Link>&ensp;
+      <button type="button" className="pill-button" onClick={@handleSignOutClick}>Sign out</button>
     </div>
 
   handleSignOutClick: ->

--- a/app/partials/account-bar.cjsx
+++ b/app/partials/account-bar.cjsx
@@ -1,5 +1,6 @@
 React = require 'react'
 PromiseRenderer = require '../components/promise-renderer'
+ChangeListener = require '../components/change-listener'
 {Link} = require 'react-router'
 auth = require '../api/auth'
 talkClient = require '../api/talk'
@@ -24,15 +25,17 @@ module.exports = React.createClass
       .catch (e) -> console.log "e unread messages", e
 
   render: ->
-    <div className="account-bar">
-      <PromiseRenderer promise={@props.user.get 'avatar'} then={([avatar]) =>
-        <img src={avatar.src} className="avatar" />
-      } catch={null} />{' '}
-      <strong><Link to="user-profile" params={name: @props.user.display_name}>{@props.user.display_name}</Link></strong>&ensp;
-      <Link to="inbox"><i className="fa fa-envelope#{if @state.unread then '' else '-o'}"></i></Link>&ensp;
-      <Link to="settings"><i className="fa fa-cog"></i></Link>&ensp;
-      <button type="button" className="pill-button" onClick={@handleSignOutClick}>Sign out</button>
-    </div>
+    <ChangeListener target={@props.user} handler={=>
+      <div className="account-bar">
+        <PromiseRenderer promise={@props.user.get 'avatar'} then={([avatar]) =>
+          <img src={avatar.src} className="avatar" />
+        } catch={null} />{' '}
+        <strong><Link to="user-profile" params={name: @props.user.display_name}>{@props.user.display_name}</Link></strong>&ensp;
+        <Link to="inbox"><i className="fa fa-envelope#{if @state.unread then '' else '-o'}"></i></Link>&ensp;
+        <Link to="settings"><i className="fa fa-cog"></i></Link>&ensp;
+        <button type="button" className="pill-button" onClick={@handleSignOutClick}>Sign out</button>
+      </div>
+    } />
 
   handleSignOutClick: ->
     auth.signOut()

--- a/app/partials/account-bar.cjsx
+++ b/app/partials/account-bar.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+PromiseRenderer = require '../components/promise-renderer'
 {Link} = require 'react-router'
 auth = require '../api/auth'
 talkClient = require '../api/talk'
@@ -24,7 +25,9 @@ module.exports = React.createClass
 
   render: ->
     <div className="account-bar">
-      <img src={@props.user.avatar} className="avatar" />{' '}
+      <PromiseRenderer promise={@props.user.get 'avatar'} then={([avatar]) =>
+        <img src={avatar.src} className="avatar" />
+      } catch={null} />{' '}
       <strong><Link to="user-profile" params={name: @props.user.display_name}>{@props.user.display_name}</Link></strong>&ensp;
       <Link to="inbox"><i className="fa fa-envelope#{if @state.unread then '' else '-o'}"></i></Link>&ensp;
       <Link to="settings"><i className="fa fa-cog"></i></Link>&ensp;

--- a/app/partials/subject-uploader.cjsx
+++ b/app/partials/subject-uploader.cjsx
@@ -1,19 +1,8 @@
 React = require 'react'
 apiClient = require '../api/client'
+putFile = require '../lib/put-file'
 
 NOOP = Function.prototype
-
-putFile = (location, file) ->
-  new Promise (resolve, reject) =>
-    xhr = new XMLHttpRequest
-    xhr.onreadystatechange = (e) =>
-      if e.target.readyState is e.target.DONE
-        if 200 <= e.target.status < 300
-          resolve e.target
-        else
-          reject e.target
-    xhr.open 'PUT', location
-    xhr.send file
 
 module.exports = React.createClass
   displayName: 'SubjectUploader'

--- a/css/tables.styl
+++ b/css/tables.styl
@@ -1,9 +1,20 @@
 .standard-table
   border-spacing: 0
 
-  td
-    padding: 0.3em 1vw 0.3em 0
-    border-bottom: 1px solid rgba(gray, 0.3)
+  &.full
+    width: 100%
 
-  tr:last-child > td
-    border-bottom: 0
+  th
+    opacity: 0.6
+    text-align: left
+
+  th,
+  td
+    border-bottom: 1px solid rgba(gray, 0.3)
+    padding: 0.3em 1vw 0.3em 0
+    vertical-align: top
+
+  tr:last-child
+    > th,
+    > td
+      border-bottom: 0

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "dependencies": {
     "animated-scrollto": "~1.1.0",
     "counterpart": "~0.16.7",
+    "data-uri-to-blob": "0.0.4",
     "debounce": "~1.0.0",
     "json-api-client": "~0.2.6",
     "lodash.merge": "~2.4.1",


### PR DESCRIPTION
This adds a drag-and-drop avatar field on the user settings page. This component can be used for project avatar and background image (coming soon).

Neat stuff: it optionally auto-crops images if you give it an aspect ratio (`1` is square) and optionally scales them down until they're under a size limit (in bytes).

Also preps for other user settings (email preferences to come real soon).

Probably needs some CSS work, but so does literally everything (again, soon).