### PR TITLE
Add favoriting, and start working towards collections features

### DIFF
--- a/app/collections/create-form.cjsx
+++ b/app/collections/create-form.cjsx
@@ -1,0 +1,29 @@
+React = require 'react'
+apiClient = require '../api/client'
+
+module?.exports = React.createClass
+  displayName: 'CollectionsCreateForm'
+
+  onSubmit: (e) ->
+    e.preventDefault()
+    form = React.findDOMNode(@).querySelector('form')
+    input = form.querySelector('input')
+
+    display_name = input.value
+    # links = {project: 76} # optional project attachment
+    collection = {display_name, links}
+
+    apiClient.type('collections').create(collection).save()
+      .then (collection) =>
+        console.log "collection created", collection
+        input.value = ''
+      .catch (e) ->
+        throw new Error(e)
+
+  render: ->
+    <div>
+      <form onSubmit={@onSubmit} className='collections-create-form'>
+        <input placeholder="Collection Name" />
+        <button type="submit">Add Collection</button>
+      </form>
+    </div>

--- a/app/collections/favorites-button.cjsx
+++ b/app/collections/favorites-button.cjsx
@@ -1,0 +1,89 @@
+React = require 'react'
+apiClient = require '../api/client'
+auth = require '../api/auth'
+getFavoritesName = require './get-favorites-name'
+alert = require '../lib/alert'
+
+module?.exports = React.createClass
+  displayName: 'CollectionFavoritesButton'
+
+  propTypes:
+    subject: React.PropTypes.object # a subject response from panoptes
+
+  getInitialState: ->
+    favorited: false
+
+  componentWillMount: ->
+    # see if the subject is in the project's favorites collection
+    # to see if it's favoriters
+    @props.subject.get('project')
+      .then (project) =>
+        project_id = project.id.toString()
+        apiClient.type('projects').get(project_id)
+          .then (project) =>
+            display_name = getFavoritesName(project)
+
+            apiClient.type('collections').get({project_id, display_name}).index(0)
+              .then (favorites) =>
+                if !!favorites
+                  apiClient.type('subjects').get(collection_id: favorites.id, id: @props.subject.id).index(0)
+                    .then (subject) =>
+                      @setState favorited: !!subject
+
+  addSubjectTo: (collection) ->
+    collection.addLink('subjects', [@props.subject.id.toString()])
+      .then (collection) => @setState favorited: true
+
+  removeSubjectFrom: (collection) ->
+    collection.removeLink('subjects', [@props.subject.id.toString()])
+      .then (collection) => @setState favorited: false
+
+  createFavorites: (user, project) ->
+    project_id = project.id.toString()
+    apiClient.type('projects').get(project_id)
+      .then (project) =>
+        display_name = getFavoritesName(project)
+        project = @props.subject.links.project
+
+        owner = {id: user.id.toString(), type: "users"} #--> must supply type
+        links = {project, owner}
+        collection = {display_name, links}
+
+        apiClient.type('collections').create(collection).save()
+          .then (favorites) =>
+            @addSubjectTo(favorites)
+
+  toggleFavorite: ->
+    project_id = @props.subject.links.project.toString()
+
+    @props.subject.get('project')
+      .then (project) =>
+        project_id = project.id.toString()
+        auth.checkCurrent().then (user) =>
+          if user?
+            apiClient.type('projects').get(project_id)
+              .then (project) =>
+                display_name = getFavoritesName(project)
+                # check for a favorites collection in project first
+                apiClient.type('collections').get({project_id, display_name}).index(0)
+                  .then (favorites) =>
+                    # try to request subject from favorites collection, otherwise create it
+                    if !!favorites
+                      apiClient.type('subjects').get(collection_id: favorites.id, id: @props.subject.id).index(0)
+                        .then (subject) =>
+                          if subject
+                            @removeSubjectFrom(favorites)
+                          else
+                            @addSubjectTo(favorites)
+                    else
+                      @createFavorites(user, project)
+          else
+            alert(<div className='content-container'>You must be logged in to favorite</div>)
+
+  render: ->
+    <button
+      className="favorites-button"
+      type="button"
+      onClick={@toggleFavorite}>
+      <i className="fa fa-heart#{if @state.favorited then '' else '-o'}" />
+    </button>

--- a/app/collections/get-favorites-name.cjsx
+++ b/app/collections/get-favorites-name.cjsx
@@ -1,0 +1,5 @@
+# Get the name of the favorites collection for a project
+module?.exports = (project) ->
+  #--> Naming Convention: "Favorites for #{project_id}"
+  #    Prevents global uniqueness validation conflict under project scope
+  "Favorites (#{project?.id})"

--- a/app/collections/home.cjsx
+++ b/app/collections/home.cjsx
@@ -1,0 +1,36 @@
+React = require 'react'
+CollectionCreateForm = require './create-form'
+talkClient = require '../api/talk'
+apiClient = require '../api/client'
+authClient = require '../api/auth'
+auth = require '../api/auth'
+{Link} = require 'react-router'
+ChangeListener = require '../components/change-listener'
+PromiseRenderer = require '../components/promise-renderer'
+
+module?.exports = React.createClass
+  displayName: 'CollectionsHome'
+
+  collectionLink: (d, i) ->
+    <div key={d.id}>
+      <Link to="collections-show" params={collection_id: d.id}>
+        {d.display_name}
+      </Link>
+    </div>
+
+  render: ->
+    <div className="collections-home">
+      <ChangeListener target={authClient}>{=>
+        <PromiseRenderer promise={authClient.checkCurrent()}>{(user) =>
+          if user?
+            <PromiseRenderer promise={user.get('collections')}>{(collections) =>
+              <div>
+                <CollectionCreateForm />
+                {collections.map(@collectionLink)}
+              </div>
+            }</PromiseRenderer>
+          else
+            <p>Please sign-in to view your collections</p>
+        }</PromiseRenderer>
+      }</ChangeListener>
+    </div>

--- a/app/collections/index.cjsx
+++ b/app/collections/index.cjsx
@@ -1,0 +1,11 @@
+React = require 'react'
+{RouteHandler} = require 'react-router'
+
+module?.exports = React.createClass
+  displayName: 'Collections'
+
+  render: ->
+    <div className="collections content-container">
+      <h1>Collections</h1>
+      <RouteHandler {...@props} />
+    </div>

--- a/app/collections/show.cjsx
+++ b/app/collections/show.cjsx
@@ -1,0 +1,54 @@
+React = require 'react'
+PromiseToSetState = require '../lib/promise-to-set-state'
+talkClient = require '../api/talk'
+apiClient = require '../api/client'
+getSubjectLocation = require '../lib/get-subject-location'
+Paginator = require '../talk/lib/paginator'
+{Navigation} = require 'react-router'
+
+module?.exports = React.createClass
+  displayName: 'CollectionShow'
+  mixins: [Navigation, PromiseToSetState]
+
+  getInitialState: ->
+    subjects: []
+    subjectsMeta: {}
+    collection: {}
+
+  componentWillMount: ->
+    @setData(1) # start on page 1
+
+  subjectsRequest: (page) ->
+    collection_id = @props.params?.collection_id
+    apiClient.type('subjects').get({page, collection_id})
+
+  collectionRequest: ->
+    apiClient.type('collections').get({id: +@props.params?.collection_id}).index(0)
+
+  setData: (page) ->
+    @subjectsRequest(page).then (subjects) =>
+      @setState {subjectsMeta: subjects[0]?.getMeta()}, =>
+        @promiseToSetState {
+          collection: @collectionRequest()
+          subjects: @subjectsRequest(page)
+          }
+
+  goToPage: (n) ->
+    @transitionTo(@props.path, @props.params, {page: n})
+    @setData(n)
+
+  subject: (d, i) ->
+    # 'http://' may need to prefix some older subjects...
+    <img key={d.id} src={getSubjectLocation(d).src} />
+
+  render: ->
+    <div className="collections-show">
+      Collection Show:
+      <section>{@state.collection?.display_name}</section>
+      <section>{@state.subjects.map(@subject)}</section>
+
+      <Paginator
+        page={+@state.subjectsMeta.page}
+        onPageChange={@goToPage}
+        pageCount={@state.subjectsMeta?.page_count} />
+    </div>

--- a/app/components/subject-viewer.cjsx
+++ b/app/components/subject-viewer.cjsx
@@ -1,5 +1,6 @@
 React = require 'react'
 LoadingIndicator = require '../components/loading-indicator'
+FavoritesButton = require '../collections/favorites-button'
 alert = require '../lib/alert'
 getSubjectLocation = require '../lib/get-subject-location'
 
@@ -66,6 +67,8 @@ module.exports = React.createClass
           {if @props.subject?.metadata?
             <button type="button" className="metadata-toggle" onClick={@showMetadata}><i className="fa fa-table fa-fw"></i></button>}
         </span>
+        {if @props.subject
+          <FavoritesButton subject={@props.subject} />}
       </div>
     </div>
 

--- a/app/main.cjsx
+++ b/app/main.cjsx
@@ -61,6 +61,11 @@ routes = <Route handler={App}>
     <Route name="talk-discussion" path=":board/:discussion" handler={require './talk/discussion'} />
   </Route>
 
+  <Route name="collections" path="collections" handler={require './collections'}>
+    <DefaultRoute name="collections-index" handler={require './collections/home'} />
+    <Route name="collections-show" path=":collection_id" handler={require './collections/show'} />
+  </Route>
+
   <Route name="lab" handler={require './pages/lab'} />
   <Route path="lab/:projectID" handler={require './pages/lab/project'}>
     <DefaultRoute name="edit-project-details" handler={require './pages/lab/project-details'} />

--- a/app/pages/project/home.cjsx
+++ b/app/pages/project/home.cjsx
@@ -47,6 +47,5 @@ module.exports = React.createClass
       </div>
 
       <hr />
-
       <Markdown className="introduction content-container">{@props.project.introduction ? ''}</Markdown>
     </div>

--- a/app/talk/board-preview.cjsx
+++ b/app/talk/board-preview.cjsx
@@ -33,7 +33,6 @@ module?.exports = React.createClass
           </div>
       }</PromiseRenderer>
 
-
       <p>
         <i className="fa fa-user"></i> {resourceCount(@props.data.users_count, "Users")} |&nbsp;
         <i className="fa fa-newspaper-o"></i> {resourceCount(@props.data.discussions_count, "Discussions") } |&nbsp;

--- a/app/talk/board.cjsx
+++ b/app/talk/board.cjsx
@@ -11,6 +11,8 @@ ChangeListener = require '../components/change-listener'
 PromiseRenderer = require '../components/promise-renderer'
 Paginator = require './lib/paginator'
 Moderation = require './lib/moderation'
+ROLES = require './lib/roles'
+merge = require 'lodash.merge'
 
 module?.exports = React.createClass
   displayName: 'TalkBoard'
@@ -40,17 +42,14 @@ module?.exports = React.createClass
       .then (discussions) =>
         discussionsMeta = discussions[0]?.getMeta()
         @setState {discussions, discussionsMeta}
-      .catch (e) =>
-        console.log "failed to get discussion", e
 
   boardRequest: ->
-    id = +@props.params.board
-    talkClient.type('boards').get({id})
+    id = @props.params.board.toString()
+    talkClient.type('boards').get(id)
 
   setBoard: ->
     @boardRequest()
-      .then (board) => @setState {board: board[0]}
-      .catch (e) => console.log "failed to get board", e
+      .then (board) => @setState {board}
 
   onSubmitDiscussion: (e, commentText, focusImage) ->
     titleInput = @getDOMNode().querySelector('.talk-board-new-discussion input')
@@ -68,12 +67,8 @@ module?.exports = React.createClass
 
         talkClient.type('discussions').create(discussion).save()
           .then (discussion) =>
-            console.log "discussion save successful", discussion
             @setState newDiscussionOpen: false
             @setDiscussions()
-          .catch (e) =>
-            console.log "error saving discussion", e
-      .catch (e) => console.log "error checking auth", e
 
   discussionValidations: (commentBody) ->
     # TODO: return true if any additional validations fail
@@ -92,25 +87,55 @@ module?.exports = React.createClass
     if window.confirm("Are you sure that you want to delete this board? All of the comments and discussions will be lost forever.")
       @boardRequest().delete()
         .then (deleted) =>
-          console.log "deleted", deleted
           @transitionTo('talk')
-        .catch (e) -> console.log "error deleting", e
 
   onPageChange: (page) ->
     @goToPage(page)
 
   onEditTitle: (e) ->
-    input = document.querySelector('.talk-edit-board-title-form input')
+    e.preventDefault()
+    form = React.findDOMNode(@).querySelector('.talk-edit-board-form')
+
+    input = form.querySelector('input')
     title = input.value
 
-    @boardRequest().update({title}).save()
-      .then (board) =>
-        @setState {board: board[0]}
-      .catch (e) ->
-        console.log "error on edit board title", e
+    # permissions
+    read = form.querySelector(".roles-read input[name='role-read']:checked").value
+    write = form.querySelector(".roles-write input[name='role-write']:checked").value
+    permissions = {read, write}
+    board = {title, permissions}
+
+    @boardRequest().update(board).save()
+      .then (board) => @setState {board}
 
   onClickNewDiscussion: ->
     @setState newDiscussionOpen: !@state.newDiscussionOpen
+
+  roleReadLabel: (data, i) ->
+    <label key={i}>
+      <input
+        type="radio"
+        name="role-read"
+        onChange={=>
+          @setState board: merge {}, @state.board, {permissions: read: data}
+        }
+        value={data}
+        checked={@state.board.permissions.read is data}/>
+      {data}
+    </label>
+
+  roleWriteLabel: (data, i) ->
+    <label key={i}>
+      <input
+        type="radio"
+        name="role-write"
+        onChange={=>
+          @setState board: merge {}, @state.board, {permissions: write: data}
+        }
+        checked={@state.board.permissions.write is data}
+        value={data}/>
+      {data}
+    </label>
 
   render: ->
     <div className="talk-board">
@@ -119,10 +144,17 @@ module?.exports = React.createClass
         <div>
           <h2>Moderator Zone:</h2>
           {if @state.board?.title
-            <form className="talk-edit-board-title-form" onSubmit={@onEditTitle}>
+            <form className="talk-edit-board-form" onSubmit={@onEditTitle}>
               <h3>Edit Title:</h3>
               <input onChange={@onChangeTitle} defaultValue={@state.board?.title}/>
-              <button type="submit">Update Title</button>
+
+              <h4>Can Read:</h4>
+              <div className="roles-read">{ROLES.map(@roleReadLabel)}</div>
+
+              <h4>Can Write:</h4>
+              <div className="roles-write">{ROLES.map(@roleWriteLabel)}</div>
+
+              <button type="submit">Update</button>
             </form>}
 
           <button onClick={@onClickDeleteBoard}>
@@ -179,5 +211,4 @@ module?.exports = React.createClass
       </div>
 
       <Paginator page={+@state.discussionsMeta?.page} onPageChange={@onPageChange} pageCount={@state.discussionsMeta?.page_count} />
-
     </div>

--- a/app/talk/comment-image-selector.cjsx
+++ b/app/talk/comment-image-selector.cjsx
@@ -19,8 +19,6 @@ module?.exports = React.createClass
     authClient.checkCurrent()
       .then (user) => user.get('recents')
         .then (recents) => @setState {recents}
-      .catch (e) ->
-        console.log "error setting recents", e
 
   queryForImages: (query) ->
     # this will make a db query and then return array of matching images
@@ -41,11 +39,10 @@ module?.exports = React.createClass
     recentsData.get('subject')
       .then (subject) =>
         @props.onSelectImage(subject)
-      .catch (e) -> console.log "couldent get subject data", e
 
   imageItem: (data, i) ->
     {src} = getSubjectLocation(data)
-    <div key={i} className="talk-comment-image-item">
+    <div key={data.id} className="talk-comment-image-item">
       <img src={'http://' + src} />
       <div className="image-card-select">
         <button onClick={=> @setFocusImage(data)}>Select</button>

--- a/app/talk/comment.cjsx
+++ b/app/talk/comment.cjsx
@@ -143,4 +143,3 @@ module?.exports = React.createClass
             onSubmitComment={@onSubmitComment}/>}
       </div>
     </div>
-

--- a/app/talk/discussion.cjsx
+++ b/app/talk/discussion.cjsx
@@ -61,13 +61,10 @@ module?.exports = React.createClass
         commentsMeta = comments[0]?.getMeta()
         @setState {comments, commentsMeta}, =>
           callback?()
-      .catch (e) =>
-        console.log "e", e
 
   setDiscussion: ->
     @discussionsRequest()
       .then (discussion) => @setState {discussion: discussion[0]}
-      .catch (e) => console.log "e", e
 
   onUpdateComment: (textContent, focusImage, commentId) ->
     {discussion} = @props.params
@@ -81,15 +78,12 @@ module?.exports = React.createClass
     commentToUpdate.update(comment).save()
       .then (comment) =>
         @setComments()
-      .catch (e) =>
-        console.log "comment update error", e
 
   onDeleteComment: (commentId) ->
     {board, discussion} = @props.params
     if window.confirm("Are you sure that you want to delete this comment?")
       talkClient.type('comments').get(id: commentId).delete()
         .then (deleted) => @setComments()
-        .catch (e) => console.log "error deleting comment", e
 
   onSubmitComment: (e, textContent, focusImage) ->
     {discussion} = @props.params
@@ -102,8 +96,7 @@ module?.exports = React.createClass
     talkClient.type('comments').create(comment).save()
       .then (comment) =>
         @setComments(@state.commentsMeta?.page, => @goToPage(@state.commentsMeta?.page_count))
-      .catch (e) =>
-        console.log "comment create error", e
+
 
   onLikeComment: (commentId) ->
     user = @state.user
@@ -116,8 +109,6 @@ module?.exports = React.createClass
         talkClient.request('put', voteUrl, null, {})
           .then (voted) =>
             @setComments(@state.commentsMeta?.page)
-          .catch (e) -> console.log "error upvoting", e
-      .then (e) -> console.log "error retreiving liked comment"
 
   onClickReply: (user, comment) ->
     # TODO: provide link to user / comment
@@ -126,7 +117,7 @@ module?.exports = React.createClass
 
   comment: (data, i) ->
     <Comment
-      key={i}
+      key={data.id}
       data={data}
       user={@state.user}
       onClickReply={@onClickReply}
@@ -143,7 +134,6 @@ module?.exports = React.createClass
         .then (deleted) =>
           @setComments()
           @transitionTo('talk')
-        .catch (e) -> console.log "error deleting", e
 
   commentValidations: (commentBody) ->
     # TODO: return true if any additional validations fail
@@ -158,8 +148,6 @@ module?.exports = React.createClass
     @discussionsRequest().update({title}).save()
       .then (discussion) =>
         @setState {discussion: discussion[0]}
-      .catch (e) ->
-        console.log "error on edit board title", e
 
   render: ->
     <div className="talk-discussion">

--- a/app/talk/inbox-conversation.cjsx
+++ b/app/talk/inbox-conversation.cjsx
@@ -28,24 +28,20 @@ module?.exports = React.createClass
           @setState {user}, @setConversation
         else
           @setState {user: null} # don't want the callback without a user...
-      .catch (e) -> console.log "error checking current auth inbox", e
 
   setConversation: ->
     conversation_id = @props.params?.conversation?.toString()
     # skip cache so messages marked as unread
-    talkClient.type('conversations').get(conversation_id, skipCache: true)
+    talkClient.type('conversations').get(conversation_id, {})
       .then (conversation) =>
         @setState {conversation}, @setMessagesMeta
-      .catch (e) -> console.log "error setting conversation", e
 
   setMessagesMeta: ->
     conversation_id = +@props.params.conversation
     talkClient.type('messages').get({conversation_id})
       .then (messages) =>
         messagesMeta = messages[0]?.getMeta()
-        console.log "messagesMeta", messagesMeta
         @setState {messagesMeta}, => @setMessages(messagesMeta.count)
-      .catch (e) -> console.log "e meta", e
 
   setMessages: (count = 10) ->
     conversation_id = +@props.params.conversation
@@ -53,10 +49,9 @@ module?.exports = React.createClass
       .then (messages) =>
         messagesMeta = messages[0].getMeta()
         @setState {messages, messagesMeta}
-      .catch (e) -> console.log "error setting messages", e
 
   message: (data, i) ->
-    <div className="conversation-message" key={i}>
+    <div className="conversation-message" key={data.id}>
       <PromiseRenderer promise={apiClient.type('users').get(data.user_id.toString())}>{(commentOwner) =>
         <strong><Link to="user-profile" params={name: commentOwner.display_name}>{commentOwner.display_name}</Link></strong>
       }</PromiseRenderer>
@@ -79,8 +74,6 @@ module?.exports = React.createClass
       .then (message) =>
         @setConversation()
         textarea.value = ''
-      .catch (e) ->
-        console.log "e message create", e
 
   render: ->
     <div className="inbox-conversation content-container">

--- a/app/talk/inbox.cjsx
+++ b/app/talk/inbox.cjsx
@@ -33,14 +33,12 @@ module?.exports = React.createClass
           @setState {user}, @setConversations
         else
           @setState {user: null} # don't want the callback without a user...
-      .catch (e) -> console.log "error checking current auth inbox", e
 
   setConversations: (page) ->
     talkClient.type('conversations').get({user_id: @state.user.id, page_size: PAGE_SIZE, page,sort: '-updated_at'})
       .then (conversations) =>
         conversationsMeta = conversations[0]?.getMeta()
         @setState {conversations, conversationsMeta}
-      .catch (e) -> console.log "e conversations", e
 
   onPageChange: (page) ->
     @goToPage(page)
@@ -50,7 +48,7 @@ module?.exports = React.createClass
     @setConversations(n)
 
   message: (data, i) ->
-    <p key={i} class>{data.body}</p>
+    <p key={data.id} class>{data.body}</p>
 
   conversationLink: (data, i) ->
     <div className="conversation-link">

--- a/app/talk/init.cjsx
+++ b/app/talk/init.cjsx
@@ -8,6 +8,7 @@ Moderation = require './lib/moderation'
 ChangeListener = require '../components/change-listener'
 PromiseRenderer = require '../components/promise-renderer'
 ROLES = require './lib/roles'
+auth = require '../api/auth'
 
 module?.exports = React.createClass
   displayName: 'TalkInit'
@@ -22,11 +23,10 @@ module?.exports = React.createClass
     @setBoards()
 
   setBoards: ->
-    talkClient.type('boards').get(section: @props.section)
-      .then (boards) =>
-        @setState {boards}
-      .catch (e) =>
-        console.log "error getting boards"
+    auth.checkCurrent().then =>
+      talkClient.type('boards').get(section: @props.section)
+        .then (boards) =>
+          @setState {boards}
 
   onSubmitBoard: (e) ->
     e.preventDefault()
@@ -49,22 +49,19 @@ module?.exports = React.createClass
       .then (board) =>
         titleInput.value = ''
         descriptionInput.value = ''
-        console.log "board save successul", board
         @setBoards()
-      .catch (e) =>
-        console.log "error saving board", e
 
   boardPreview: (data, i) ->
     <BoardPreview {...@props} key={i} data={data} />
 
   tag: (t, i) ->
-    <p>#{t.name}</p>
+    <p key={i}>#{t.name}</p>
 
   roleReadLabel: (data, i) ->
-    <label><input type="radio" name="role-read" value={data}/>{data}</label>
+    <label key={i}><input type="radio" name="role-read" value={data}/>{data}</label>
 
   roleWriteLabel: (data, i) ->
-    <label><input type="radio" name="role-write" value={data}/>{data}</label>
+    <label key={i}><input type="radio" name="role-write" value={data}/>{data}</label>
 
   render: ->
     <div className="talk-home">
@@ -93,7 +90,6 @@ module?.exports = React.createClass
            else
             <p>There are currently no boards.</p>}
         </section>
-
 
         <div className="talk-sidebar">
           <h2>Talk Sidebar</h2>

--- a/app/talk/private-message-form.cjsx
+++ b/app/talk/private-message-form.cjsx
@@ -23,7 +23,6 @@ module?.exports = React.createClass
     authClient.checkCurrent()
       .then (user) =>
         @setState {user}
-      .catch (e) -> console.log "error checking current auth inbox", e
 
   onSubmit: (e) ->
     e.preventDefault()
@@ -38,7 +37,6 @@ module?.exports = React.createClass
 
     apiClient.type('users').get(display_name: @props.params.name).index(0)
       .then (user) =>
-        console.log "user", user
         recipient_ids = [+user.id] # must be array
         conversation = {title, body, user_id, recipient_ids}
 
@@ -46,11 +44,7 @@ module?.exports = React.createClass
         console.log "conversation", conversation
         talkClient.type('conversations').create(conversation).save()
           .then (conversation) =>
-            console.log "conversation save successful", conversation
             @transitionTo('inbox-conversation', {conversation: conversation.id})
-
-          .catch (e) ->
-            console.log "e conversation", e
 
   render: ->
     <div className="talk talk-module">

--- a/app/talk/subject-display.cjsx
+++ b/app/talk/subject-display.cjsx
@@ -3,6 +3,7 @@ apiClient = require '../api/client'
 getSubjectLocation = require '../lib/get-subject-location'
 PromiseRenderer = require '../components/promise-renderer'
 loadImage = require '../lib/load-image'
+FavoritesButton = require '../collections/favorites-button'
 
 module?.exports = React.createClass
   displayName: 'TalkSubjectDisplay'
@@ -18,6 +19,7 @@ module?.exports = React.createClass
             <img src={getSubjectLocation(subject).src} />
           </a>
           <p>Subject {subject.id}</p>
+          <FavoritesButton subject={subject} />
         </div>
       }</PromiseRenderer>
     </div>

--- a/css/collections.styl
+++ b/css/collections.styl
@@ -1,0 +1,4 @@
+.collections
+  .collections-show
+    img
+      max-width: 250px

--- a/css/main.styl
+++ b/css/main.styl
@@ -35,5 +35,6 @@
 @require './talk'
 @require './talk-project'
 @require './inbox'
+@require './collections'
 
 @require './workflow-editor'

--- a/css/talk.styl
+++ b/css/talk.styl
@@ -29,8 +29,7 @@ TALK_MARGIN = 10px auto
     font-family: inherit
     display: block
 
-
-.polaroid-border
+.polaroid-image
   background: #fff
   padding: 10px 10px 20px 10px
   margin: 10px
@@ -118,9 +117,11 @@ TALK_MARGIN = 10px auto
 
   .talk-subject-display
     @extend .talk-module
-    @extend .polaroid-border
+    @extend .polaroid-image
+
     display: inline-block
     text-align: center
+    background: white
 
     img
       max-width: 300px
@@ -246,7 +247,7 @@ TALK_MARGIN = 10px auto
         white-space: nowrap
 
       .talk-comment-image-item
-        @extend .polaroid-border
+        @extend .polaroid-image
         position: relative
         display: inline-block
 


### PR DESCRIPTION
- Adds a favorite button 
  - It takes in a single 'subject' prop and handles itself from there
  - The code for this feels overly verbose / fragile. Any objections if I try bringing in flux or some other layer for components like this?
- Lets users (moderators) edit the permissions of their board via a group of radio buttons 
- Standardizes a bunch of errors to just throw the error message
- A very raw collections view (/collections or collections/:id), just a paginated list of subjects right now
  - You should see a favorites collection pop up here with any added subjects
  - the form here was for dev, but I'd like to build it out it for general collections use
