### PR TITLE
Project links

### DIFF
--- a/app/pages/lab/project-details.cjsx
+++ b/app/pages/lab/project-details.cjsx
@@ -1,6 +1,45 @@
 React = require 'react'
 BoundResourceMixin = require '../../lib/bound-resource-mixin'
 
+ExternalLinksEditor = React.createClass
+  displayName: 'ExternalLinksEditor'
+
+  mixins: [BoundResourceMixin]
+
+  boundResource: 'project'
+
+  getDefaultProps: ->
+    project: {}
+
+  render: ->
+    <div>
+      <table>
+        <thead>
+          <tr>
+            <th>Label</th>
+            <th>URL</th>
+          </tr>
+        </thead>
+        <tbody>
+          {for link, i in @props.project.external_links
+            link._key ?= Math.random()
+            <tr key={link._key}>
+              <td><input type="text" name="external_links.#{i}.label" value={link.label} onChange={@handleChange}/></td>
+              <td><input type="text" name="external_links.#{i}.url" value={link.url} onChange={@handleChange}/></td>
+            </tr>}
+        </tbody>
+      </table>
+
+      <button type="button" onClick={@handleAddLink}>Add a link</button>
+    </div>
+
+  handleAddLink: ->
+    changes = {}
+    changes["external_links.#{@props.project.external_links.length}"] =
+      label: 'Example'
+      url: 'https://example.com/'
+    @props.project.update changes
+
 module.exports = React.createClass
   displayName: 'EditProjectDetails'
 
@@ -56,6 +95,11 @@ module.exports = React.createClass
           Introduction<br />
           <textarea className="standard-input full" name="introduction" value={@props.project.introduction} rows="10" disabled={@state.saveInProgress} onChange={@handleChange} />
         </p>
+
+        <div>
+          External links<br />
+          <ExternalLinksEditor project={@props.project} />
+        </div>
 
         <p>
           <button type="button" className="major-button" disabled={@state.saveInProgress or not @props.project.hasUnsavedChanges()} onClick={@saveResource}>Save</button>{' '}

--- a/app/pages/lab/project-details.cjsx
+++ b/app/pages/lab/project-details.cjsx
@@ -21,11 +21,11 @@ ExternalLinksEditor = React.createClass
           </tr>
         </thead>
         <tbody>
-          {for link, i in @props.project.external_links
+          {for link, i in @props.project.urls
             link._key ?= Math.random()
             <tr key={link._key}>
-              <td><input type="text" name="external_links.#{i}.label" value={link.label} onChange={@handleChange}/></td>
-              <td><input type="text" name="external_links.#{i}.url" value={link.url} onChange={@handleChange}/></td>
+              <td><input type="text" name="urls.#{i}.label" value={link.label} onChange={@handleChange}/></td>
+              <td><input type="text" name="urls.#{i}.url" value={link.url} onChange={@handleChange}/></td>
             </tr>}
         </tbody>
       </table>
@@ -35,7 +35,7 @@ ExternalLinksEditor = React.createClass
 
   handleAddLink: ->
     changes = {}
-    changes["external_links.#{@props.project.external_links.length}"] =
+    changes["urls.#{@props.project.urls.length}"] =
       label: 'Example'
       url: 'https://example.com/'
     @props.project.update changes

--- a/app/pages/project/index.cjsx
+++ b/app/pages/project/index.cjsx
@@ -11,6 +11,21 @@ auth = require '../../api/auth'
 apiClient = window.api = require '../../api/client'
 LoadingIndicator = require '../../components/loading-indicator'
 
+SOCIAL_ICONS =
+  'bitbucket.com/': 'bitbucket'
+  'facebook.com/': 'facebook-square'
+  'github.com/': 'github'
+  'pinterest.com/': 'pinterest'
+  'plus.google.com/': 'google-plus'
+  'reddit.com/': 'reddit'
+  'tumblr.com/': 'tumblr'
+  'twitter.com/': 'twitter'
+  'vine.com/': 'vine'
+  'weibo.com/': 'weibo'
+  'wordpress.com/': 'wordpress'
+  'youtu.be/': 'youtube'
+  'youtube.com/': 'youtube'
+
 counterpart.registerTranslations 'en',
   project:
     loading: 'Loading project'
@@ -73,6 +88,16 @@ ProjectPage = React.createClass
             <Link to="project-talk" params={params} className="tabbed-content-tab">
               <Translate content="project.nav.discuss" />
             </Link>
+            {for link, i in @props.project.urls
+              link._key ?= Math.random()
+              {label} = link
+              unless label
+                for pattern, icon of SOCIAL_ICONS
+                  if link.url.indexOf(pattern) isnt -1
+                    socialIcon = icon
+                socialIcon ?= 'globe'
+                label = <i className="fa fa-#{socialIcon} fa-fw fa-2x"></i>
+              <a key={link._key} href={link.url} className="tabbed-content-tab" target="#{@props.project.id}-#{i}">{label}</a>}
           </nav>
 
           <RouteHandler {...@props} owner={owner} />


### PR DESCRIPTION
Allows adding external links to projects' navigation. Editor is barebones for now, just crammed onto the project details page.

Links without labels get a sweet icon.