### PR TITLE
Add transition, remove load state of account menu

### DIFF
--- a/app/partials/account-bar.cjsx
+++ b/app/partials/account-bar.cjsx
@@ -38,7 +38,7 @@ module.exports = React.createClass
       <div className="account-bar">
         <div className="account-info">
           <span className="display-name"><strong>{@props.user.display_name}</strong></span>
-          <PromiseRenderer promise={@props.user.get 'avatar'} then={([avatar]) =>
+          <PromiseRenderer promise={@props.user.get 'avatar'} pending={null} then={([avatar]) =>
             <img src={avatar.src} className="avatar" />
           } catch={null} />{' '}
           <Link to="inbox"><i className="fa fa-envelope#{if @state.unread then '' else '-o'}" /> </Link>

--- a/css/main-header.styl
+++ b/css/main-header.styl
@@ -35,7 +35,9 @@
       background: FOREGROUND
       border-radius: 4px
       color: white
-      display: none
+      opacity: 0
+      display: flex
+      transition: opacity 0.25s ease-out
       flex-direction: column
       font-size: 14px
       margin: 0 1.65em
@@ -54,7 +56,7 @@
 
     &:hover
       .account-menu
-        display: flex
+        opacity: 1
 
 .main-title
   align-items: baseline


### PR DESCRIPTION
Hey @srallen do you think this looks cool? 
It adds a quick opacity transition to the account-menu and removes the default 'loading' text of promise-renderer for that case