### PR TITLE
Links shouldn't affect workflow state

### DIFF
--- a/app/pages/lab/workflow.cjsx
+++ b/app/pages/lab/workflow.cjsx
@@ -21,8 +21,6 @@ EditWorkflowPage = React.createClass
 
   getInitialState: ->
     selectedTaskKey: @props.workflow.first_task
-    reloadCellectError: false
-    reloadCellectInProgress: false
 
   render: ->
     <div className="columns-container">
@@ -161,17 +159,6 @@ EditWorkflowPage = React.createClass
       @props.workflow.addLink 'subject_sets', [subjectSet.id]
     else
       @props.workflow.removeLink 'subject_sets', subjectSet.id
-
-  reloadCellect: ->
-    reloadEndpoint = apiClient.root + ['', 'workflows', @props.workflow.id, 'reload_cellect'].join '/'
-    @setState
-      reloadCellectError: false
-      reloadCellectInProgress: true
-    apiClient.post ['', 'workflows', @props.workflow.id, 'reload_cellect'].join '/'
-      .catch (error) =>
-        @setState reloadCellectError: true
-      .then =>
-        @setState reloadCellectInProgress: false
 
   afterDelete: ->
     @props.project.uncacheLink 'workflows'

--- a/app/pages/lab/workflow.cjsx
+++ b/app/pages/lab/workflow.cjsx
@@ -154,11 +154,18 @@ EditWorkflowPage = React.createClass
     @setState selectedTaskKey: nextTaskID
 
   handleSubjectSetToggle: (subjectSet, e) ->
-    # TODO: This is totally untested; I have no idea if this is right.
-    if e.target.checked
-      @props.workflow.addLink 'subject_sets', [subjectSet.id]
+    shouldAdd = e.target.checked
+
+    ensureSaved = if @props.workflow.hasUnsavedChanges()
+      @props.workflow.save()
     else
-      @props.workflow.removeLink 'subject_sets', subjectSet.id
+      Promise.resolve()
+
+    ensureSaved.then =>
+      if shouldAdd
+        @props.workflow.addLink 'subject_sets', [subjectSet.id]
+      else
+        @props.workflow.removeLink 'subject_sets', subjectSet.id
 
   afterDelete: ->
     @props.project.uncacheLink 'workflows'

--- a/app/pages/project/classify.cjsx
+++ b/app/pages/project/classify.cjsx
@@ -81,6 +81,7 @@ module.exports = React.createClass
     project.get('workflows').then (workflows) ->
       if workflows.length is 0
         throw new Error "No workflows for project #{project.id}"
+        project.uncacheLink 'workflows'
       else
         randomIndex = Math.floor Math.random() * workflows.length
         # console.log 'Chose random workflow', workflows[randomIndex].id

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "counterpart": "~0.16.7",
     "data-uri-to-blob": "0.0.4",
     "debounce": "~1.0.0",
-    "json-api-client": "~0.2.6",
+    "json-api-client": "~0.2.7",
     "lodash.merge": "~2.4.1",
     "markdown-it": "~4.0.1",
     "markdown-it-container": "~1.0.0",


### PR DESCRIPTION
This should fix zooniverse/Panoptes#839.

The API lib was not triggering "change" on resource refreshes, which made the save button active when no changes were made.

Also makes sure the classify page doesn't store an empty list of workflows for a project.