### PR TITLE
Allow the sign-in prompt to close

### DIFF
--- a/app/collections/favorites-button.cjsx
+++ b/app/collections/favorites-button.cjsx
@@ -15,9 +15,10 @@ module?.exports = React.createClass
     favorited: false
 
   promptToSignIn: ->
-    alert <SignInPrompt>
-      <p>You must be signed in to save your favorites.</p>
-    </SignInPrompt>
+    alert (resolve) ->
+      <SignInPrompt onChoose={resolve}>
+        <p>You must be signed in to save your favorites.</p>
+      </SignInPrompt>
 
   componentWillMount: ->
     # see if the subject is in the project's favorites collection


### PR DESCRIPTION
Screwed up the branching here, sorry.

The sign-in prompt just needed a way to trigger that an action has been taken.