### PR TITLE
Quick fix for Firefox's handling of images in flexed containers

### DIFF
--- a/app/components/image-selector.cjsx
+++ b/app/components/image-selector.cjsx
@@ -26,7 +26,7 @@ module.exports = React.createClass
     size: NaN
 
   render: ->
-    <span className="image-uploader" style={
+    <span className="image-selector" style={
       display: 'inline-block'
       minHeight: '1em'
       background: 'rgba(128, 128, 128, 0.2)'

--- a/css/image-selector.styl
+++ b/css/image-selector.styl
@@ -1,0 +1,2 @@
+.image-selector
+  max-width: 100px

--- a/css/main.styl
+++ b/css/main.styl
@@ -6,6 +6,7 @@
 @require './tables'
 @require './buttons'
 @require './upload-drop-target'
+@require './image-selector'
 @require "./forms"
 @require './avatars'
 @require "./tabbed-content"


### PR DESCRIPTION
Not a perfect solution, but it's fine for where we're using this component right now.