### PR TITLE
Follow project redirects

### DIFF
--- a/app/pages/lab/project-details.cjsx
+++ b/app/pages/lab/project-details.cjsx
@@ -116,6 +116,8 @@ module.exports = React.createClass
       </div>
 
       <div className="column">
+        {if @props.project.configuration?.redirect
+          <p className="form-help warning"><strong>Note: users who follow a link to this project will be redirected to <a href={@props.project.configuration.redirect}>{@props.project.configuration.redirect}</a>.</strong> Contact the Zooniverse to change this.</p>}
         <p>
           Name<br />
           <input type="text" className="standard-input full" name="display_name" value={@props.project.display_name} disabled={@state.saveInProgress} onChange={@handleChange} />

--- a/app/pages/project/index.cjsx
+++ b/app/pages/project/index.cjsx
@@ -142,7 +142,11 @@ module.exports = React.createClass
 
   render: ->
     if @state.project?
-      <ProjectPage {...@props} project={@state.project} />
+      if @state.project.configuration?.redirect
+        location.replace @state.project.configuration.redirect
+        null
+      else
+        <ProjectPage {...@props} project={@state.project} />
     else
       <div className="content-container">
         {if @state.rejected.project?

--- a/app/partials/project-card.cjsx
+++ b/app/partials/project-card.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+apiClient = require '../api/client'
 PromiseRenderer = require '../components/promise-renderer'
 {Link} = require 'react-router'
 
@@ -6,26 +7,41 @@ module.exports = React.createClass
   displayName: 'ProjectCard'
 
   render: ->
-    <PromiseRenderer promise={@props.project.get 'owner'} then={@renderWithOwner}>
-      {@renderWithOwner()}
+    getAvatar = apiClient.get @props.project._getURL 'avatar'
+      .then ([avatar]) ->
+        avatar.src
+      .catch ->
+        ''
+
+    getOwner = @props.project.get 'owner'
+
+    getAvatarAndOwner = Promise.all [getAvatar, getOwner]
+
+    <PromiseRenderer promise={getAvatarAndOwner} then={@renderWithDetails}>
+      {@renderWithDetails []}
     </PromiseRenderer>
 
-  renderWithOwner: (owner) ->
+  renderWithDetails: ([avatar, owner]) ->
     linkProps =
       to: 'project-home'
+
       params:
         owner: owner?.display_name ? 'LOADING'
         name: @props.project.display_name
 
       style:
-        backgroundImage: "url('#{@props.project.avatar}')" if @props.project.avatar
+        backgroundImage: "url('#{avatar}')" if avatar
 
-      'data-no-avatar': true unless @props.project.avatar
+      'data-no-avatar': true unless avatar
 
     <Link {...linkProps} className="project-card">
       <svg className="project-card-space-maker" viewBox="0 0 2 1" width="100%"></svg>
       <div className="details">
-        <div className="name">{@props.project.display_name}</div>
+        <div className="name">
+          {@props.project.display_name}{' '}
+          {if @props.project.configuration?.redirect
+            <small><i className="fa fa-external-link form-help" title="This project was built separate from the Zooniverse platform."></i></small>}
+        </div>
         <div className="owner">{owner?.display_name ? 'LOADING'}</div>
         <div className="description">{@props.project.description}</div>
       </div>


### PR DESCRIPTION
Landing on a project page with `configuration: redirect: 'http://example.com'` will now take you there when you land on its project page.

Also added avatars to the project card-style links.

For half of #217.