### PR TITLE
Use current_user_roles filter for lab pages

### DIFF
--- a/app/pages/lab/index.cjsx
+++ b/app/pages/lab/index.cjsx
@@ -50,7 +50,7 @@ module.exports = React.createClass
     # TODO: Make this a component instead of a function,
     # then `user.uncacheLink 'projects'` on mount and on project creation.
 
-    getProjects = user.get 'projects', page: @state.page
+    getProjects = apiClient.type('projects').get current_user_roles: 'owner,collaborator', page: @state.page
 
     <div>
       <p>Projects owned by {user.display_name}:</p>


### PR DESCRIPTION
Allows a visitor to the lab page to see all the projects they're allowed
to edit.

Closes #276