### PR TITLE
Replace classify links for redirected projects

### DIFF
--- a/app/pages/project/home.cjsx
+++ b/app/pages/project/home.cjsx
@@ -35,7 +35,12 @@ module.exports = React.createClass
       <div className="call-to-action-container content-container">
         <div className="description">{@props.project.description}</div>
 
-        {if @props.project.configuration?.user_chooses_workflow
+        {if @props.project.redirect
+          <a href={@props.project.redirect} className="call-to-action standard-button">
+            <strong>Visit the project</strong><br />
+            <small>at {@props.project.redirect}</small>
+          </a>
+        else if @props.project.configuration?.user_chooses_workflow
           for workflow in @state.workflows
             <Link to="project-classify" params={linkParams} query={workflow: workflow.id} key={workflow.id} className="call-to-action standard-button">
               {workflow.display_name}

--- a/app/pages/project/index.cjsx
+++ b/app/pages/project/index.cjsx
@@ -75,9 +75,12 @@ ProjectPage = React.createClass
               <Link to="project-results" params={params} className="tabbed-content-tab">
                 <Translate content="project.nav.results" />
               </Link>}
-            <Link to="project-classify" params={params} className="classify tabbed-content-tab">
-              <Translate content="project.nav.classify" />
-            </Link>
+            {if @props.project.redirect
+              <a href={@props.project.redirect} className="tabbed-content-tab">Visit project</a>
+            else
+              <Link to="project-classify" params={params} className="classify tabbed-content-tab">
+                <Translate content="project.nav.classify" />
+              </Link>}
             {if @props.project.faq
               <Link to="project-faq" params={params} className="tabbed-content-tab">
                 <Translate content="project.nav.faq" />


### PR DESCRIPTION
Projects with a `redirect` field should link to their external site instead of their classify page.