### PR TITLE
Add viewing page for subjects, other talk updates

### DIFF
--- a/app/main.cjsx
+++ b/app/main.cjsx
@@ -77,6 +77,8 @@ routes = <Route handler={App}>
     <Route name="collections-show" path=":collection_id" handler={require './collections/show'} />
   </Route>
 
+  <Route name="subjects" path="subjects/:id" handler = {require './subjects'} />
+
   <Route name="lab" handler={require './pages/lab'} />
   <Route path="lab/:projectID" handler={require './pages/lab/project'}>
     <DefaultRoute name="edit-project-details" handler={require './pages/lab/project-details'} />

--- a/app/partials/account-bar.cjsx
+++ b/app/partials/account-bar.cjsx
@@ -13,7 +13,6 @@ counterpart.registerTranslations 'en',
     settings: 'Settings'
     signOut: 'Sign Out'
 
-
 module.exports = React.createClass
   displayName: 'AccountBar'
 

--- a/app/partials/avatar.cjsx
+++ b/app/partials/avatar.cjsx
@@ -1,0 +1,21 @@
+React = require 'react'
+PromiseRenderer = require '../components/promise-renderer'
+
+DEFAULT_AVATAR = './assets/simple-avatar.jpg'
+
+module?.exports = React.createClass
+  displayName: 'Avatar'
+
+  propTypes:
+    user: React.PropTypes.object # User response
+
+  render: ->
+    <PromiseRenderer
+      promise={@props.user.get('avatar', {})}
+      pending={null}
+      then={([avatar]) =>
+        <img src={avatar.src} alt={"User Avatar"} />
+      }
+      catch={->
+        <img src={DEFAULT_AVATAR} alt={"User Avatar"} />
+      }/>

--- a/app/subjects/index.cjsx
+++ b/app/subjects/index.cjsx
@@ -6,6 +6,7 @@ getSubjectLocation = require '../lib/get-subject-location'
 FavoritesButton = require '../collections/favorites-button'
 ChangeListener = require '../components/change-listener'
 PromiseRenderer = require '../components/promise-renderer'
+SubjectViewer = require '../components/subject-viewer'
 NewDiscussionForm = require '../talk/discussion-new-form'
 {Navigation} = require 'react-router'
 
@@ -18,6 +19,10 @@ module?.exports = React.createClass
 
   componentWillMount: ->
     @setSubject()
+
+  componentWillReceiveProps: (nextProps) ->
+    if nextProps.params?.id isnt @props.params?.id
+      @setSubject()
 
   setSubject: ->
     subjectId = @props.params?.id.toString()
@@ -46,9 +51,7 @@ module?.exports = React.createClass
         <section>
           <h1>Subject {subject.id}</h1>
 
-          <img src={getSubjectLocation(subject).src} />
-
-          <div><FavoritesButton subject={subject} /></div>
+          <SubjectViewer subject={subject} />
 
           <PromiseRenderer promise={talkClient.type('comments').get({focus_id: subject.id})}>{(comments) =>
             if comments.length

--- a/app/subjects/index.cjsx
+++ b/app/subjects/index.cjsx
@@ -1,0 +1,81 @@
+React = require 'react'
+apiClient = require '../api/client'
+authClient = require '../api/auth'
+talkClient = require '../api/talk'
+getSubjectLocation = require '../lib/get-subject-location'
+FavoritesButton = require '../collections/favorites-button'
+ChangeListener = require '../components/change-listener'
+PromiseRenderer = require '../components/promise-renderer'
+NewDiscussionForm = require '../talk/discussion-new-form'
+{Navigation} = require 'react-router'
+
+module?.exports = React.createClass
+  displayName: 'Subject'
+  mixins: [Navigation]
+
+  getInitialState: ->
+    subject: null
+
+  componentWillMount: ->
+    @setSubject()
+
+  setSubject: ->
+    subjectId = @props.params?.id.toString()
+    apiClient.type('subjects').get(subjectId)
+      .then (subject) =>
+        @setState {subject}
+
+  comment: (data, i) ->
+    <div key={data.id} className="talk-module">
+      <strong>{data.user_display_name}</strong>
+      <br />
+      <span>{data.body}</span>
+    </div>
+
+  onCreateDiscussion: (discussion) ->
+    projectId = discussion.section.split('-')[0] # string
+    apiClient.type('projects').get(projectId).then (project) =>
+      project.get('owner').then (owner) =>
+        @transitionTo('project-talk-discussion', {owner: owner.slug, name: project.slug, board: discussion.board_id, discussion: discussion.id})
+
+  render: ->
+    {subject} = @state
+
+    <div className="subject talk content-container">
+      {if subject
+        <section>
+          <h1>Subject {subject.id}</h1>
+
+          <img src={getSubjectLocation(subject).src} />
+
+          <div><FavoritesButton subject={subject} /></div>
+
+          <PromiseRenderer promise={talkClient.type('comments').get({focus_id: subject.id})}>{(comments) =>
+            if comments.length
+              <div>
+                <h2>Comments mentioning this subject:</h2>
+                <p style={color:"red"}>Todo link to thread/comment</p>
+                <div>{comments.map(@comment)}</div>
+              </div>
+            else
+              <p>There are no comments focused on this subject</p>
+          }</PromiseRenderer>
+
+          <ChangeListener target={authClient}>{=>
+            <PromiseRenderer promise={authClient.checkCurrent()}>{(user) =>
+              if user?
+                {# these wrapping promises ensure that there are boards for a project}
+                {# & could be removed if a default board is put in place}
+                <PromiseRenderer promise={subject.get('project')}>{(project) =>
+                  <PromiseRenderer promise={talkClient.type('boards').get(section: "#{project.id}-#{project.title}")}>{(boards) =>
+                    if boards?.length
+                      <NewDiscussionForm
+                        focusImage={subject}
+                        onCreateDiscussion={@onCreateDiscussion} />
+                  }</PromiseRenderer>
+                }</PromiseRenderer>
+            }</PromiseRenderer>
+          }</ChangeListener>
+        </section>
+        }
+    </div>

--- a/app/talk/breadcrumbs.cjsx
+++ b/app/talk/breadcrumbs.cjsx
@@ -17,7 +17,7 @@ module?.exports = React.createClass
         {if params.board?
           <span>
             <Link to="#{@projectPrefix()}talk" params={params}>
-              {if @props.project then params?.name else 'Zooniverse'} Talk
+              {if @props.project then @props.project.display_name else 'Zooniverse'} Talk
             </Link>
             &nbsp;>&nbsp;
           </span>}

--- a/app/talk/comment-box.cjsx
+++ b/app/talk/comment-box.cjsx
@@ -5,6 +5,7 @@ CommentPreview = require './comment-preview'
 CommentHelp = require './comment-help'
 CommentImageSelector = require './comment-image-selector'
 getSubjectLocation = require '../lib/get-subject-location'
+Loading = require '../components/loading-indicator'
 
 m = require './lib/markdown-insert'
 
@@ -32,6 +33,7 @@ module?.exports = React.createClass
     focusImage: @props.focusImage
     content: @props.content
     reply: ''
+    loading: false
 
   componentWillReceiveProps: (nextProps) ->
     if nextProps.reply
@@ -41,11 +43,10 @@ module?.exports = React.createClass
     e.preventDefault()
     textareaValue = @refs.textarea.getDOMNode().value
     return if @props.validationCheck?(textareaValue)
-
+    @setState loading: false
     fullComment = @state.reply.concat(textareaValue)
+
     @props.onSubmitComment?(e, fullComment, @state.focusImage)
-    # optional function called on submit ^
-    # TODO: update this submit stuff for better reuse / prod
 
     @refs.textarea.getDOMNode().value = ""
     @hideChildren()
@@ -105,6 +106,7 @@ module?.exports = React.createClass
       <p key={i} className="talk-validation-error">{message}</p>
 
     feedback = @renderFeedback()
+    loader = if @state.loading then <Loading />
 
     <div className="talk-comment-box">
       <h1>{@props.header}</h1>
@@ -189,6 +191,7 @@ module?.exports = React.createClass
              Cancel
             </button>}
         </section>
+
         {validationErrors}
       </form>
 
@@ -203,6 +206,8 @@ module?.exports = React.createClass
           when 'help'
             <CommentHelp />}
       </div>
+
+      {loader}
     </div>
 
   wrapSelectionIn: (wrapFn, opts = {}) ->

--- a/app/talk/comment-image-selector.cjsx
+++ b/app/talk/comment-image-selector.cjsx
@@ -7,7 +7,7 @@ module?.exports = React.createClass
   displayName: 'TalkCommentImageSelector'
 
   getInitialState: ->
-    recents: []
+    subjects: []
 
   getDefaultProps: ->
     header: "Select a featured image"
@@ -18,22 +18,19 @@ module?.exports = React.createClass
   setRecents: ->
     authClient.checkCurrent()
       .then (user) => user.get('recents')
-        .then (recents) => @setState {recents}
+      .then (subjects) => @setState {subjects}
 
-  queryForImages: (query) ->
-    # this will make a db query and then return array of matching images
-    DEV_IMAGES.filter (img) => img.id.toLowerCase() is query.toLowerCase()
+  setQuery: (id) ->
+    apiClient.type('subjects').get({id: id})
+      .then (subjects) => @setState {subjects}
 
   onSubmitSearch: (e) ->
     e.preventDefault()
-    return @setRecents() # TODO un-disable search (remove this line)
-    ###
-    query = @refs.imageSearch.getDOMNode().value
+    query = @refs.imageSearch.getDOMNode().value.trim()
     if query is ""
-      @setInitialImages()
+      @setRecents()
     else
-      @setState images: @queryForImages(query)
-    ###
+      @setQuery(query)
 
   setFocusImage: (recentsData) ->
     recentsData.get('subject')
@@ -41,9 +38,8 @@ module?.exports = React.createClass
         @props.onSelectImage(subject)
 
   imageItem: (data, i) ->
-    {src} = getSubjectLocation(data)
     <div key={data.id} className="talk-comment-image-item">
-      <img src={'http://' + src} />
+      <img src={getSubjectLocation(data).src} />
       <div className="image-card-select">
         <button onClick={=> @setFocusImage(data)}>Select</button>
       </div>
@@ -60,6 +56,6 @@ module?.exports = React.createClass
       <button className='talk-comment-clear-image-button' onClick={@props.onClearImageClick}>Clear image</button>
 
       <div className="talk-comment-suggested-images">
-        {@state.recents?.map(@imageItem)}
+        {@state.subjects?.map(@imageItem)}
       </div>
     </div>

--- a/app/talk/comment.cjsx
+++ b/app/talk/comment.cjsx
@@ -15,6 +15,8 @@ PromiseToSetState = require '../lib/promise-to-set-state'
 {timestamp} = require './lib/time'
 apiClient = require '../api/client'
 
+DEFAULT_AVATAR = './assets/simple-avatar.jpg'
+
 module?.exports = React.createClass
   displayName: 'TalkComment'
   mixins: [ToggleChildren, Feedback, PromiseToSetState]
@@ -76,7 +78,7 @@ module?.exports = React.createClass
     <div className="talk-comment">
       <div className="talk-comment-author">
         <PromiseRenderer pending={@avatarPending} promise={apiClient.type('users').get(id: @props.data.user_id).index(0)}>{(commentOwner) =>
-          <img src={commentOwner.avatar} alt={commentOwner.display_name}/>
+          <img src={commentOwner.avatar ? DEFAULT_AVATAR} alt={commentOwner.display_name}/>
         }</PromiseRenderer>
 
         <p>

--- a/app/talk/comment.cjsx
+++ b/app/talk/comment.cjsx
@@ -14,6 +14,7 @@ PromiseToSetState = require '../lib/promise-to-set-state'
 {Link} = require 'react-router'
 {timestamp} = require './lib/time'
 apiClient = require '../api/client'
+Avatar = require '../partials/avatar'
 
 DEFAULT_AVATAR = './assets/simple-avatar.jpg'
 
@@ -69,16 +70,13 @@ module?.exports = React.createClass
   upvoteCount: ->
     Object.keys(@props.data.upvotes).length
 
-  avatarPending: ->
-    <img alt="loading"/>
-
   render: ->
     feedback = @renderFeedback()
 
     <div className="talk-comment">
       <div className="talk-comment-author">
-        <PromiseRenderer pending={@avatarPending} promise={apiClient.type('users').get(id: @props.data.user_id).index(0)}>{(commentOwner) =>
-          <img src={commentOwner.avatar ? DEFAULT_AVATAR} alt={commentOwner.display_name}/>
+        <PromiseRenderer promise={apiClient.type('users').get(id: @props.data.user_id).index(0)}>{(commentOwner) =>
+          <Avatar user={commentOwner} />
         }</PromiseRenderer>
 
         <p>

--- a/app/talk/discussion-new-form.cjsx
+++ b/app/talk/discussion-new-form.cjsx
@@ -1,0 +1,96 @@
+React = require 'react'
+CommentBox = require './comment-box'
+{getErrors} = require './lib/validations'
+commentValidations = require './lib/comment-validations'
+discussionValidations = require './lib/discussion-validations'
+talkClient = require '../api/talk'
+authClient = require '../api/auth'
+Loading = require '../components/loading-indicator'
+PromiseRenderer = require '../components/promise-renderer'
+merge = require 'lodash.merge'
+
+module?.exports = React.createClass
+  displayName: 'DiscussionNewForm'
+
+  propTypes:
+    boardId: React.PropTypes.number
+    onCreateDiscussion: React.PropTypes.func
+    focusImage: React.PropTypes.object # subject response for focus image
+
+  getInitialState: ->
+    discussionValidationErrors: []
+    loading: false
+
+  discussionValidations: (commentBody) ->
+    discussionTitle = @getDOMNode().querySelector('.new-discussion-title').value
+    commentErrors = getErrors(commentBody, commentValidations)
+    discussionErrors = getErrors(discussionTitle, discussionValidations)
+
+    discussionValidationErrors = commentErrors.concat(discussionErrors)
+
+    @setState {discussionValidationErrors}
+    !!discussionValidationErrors.length
+
+  onSubmitDiscussion: (e, commentText, focusImage) ->
+    @setState loading: true
+    form = @getDOMNode().querySelector('.talk-board-new-discussion')
+    titleInput = form.querySelector('input[type="text"]')
+    title = titleInput.value
+
+    authClient.checkCurrent()
+      .then (user) =>
+        user_id = user.id
+        board_id = @props.boardId ? +form.querySelector('label > input[type="radio"]:checked').value
+        body = commentText
+        focus_id = +@props.focusImage?.id
+
+        comments = [merge({}, {user_id, body}, ({focus_id} if !!focus_id))]
+        discussion = {title, user_id, board_id, comments}
+
+        talkClient.type('discussions').create(discussion).save()
+          .then (discussion) =>
+            @setState loading: false
+            titleInput.value = ''
+            @props.onCreateDiscussion?(discussion)
+
+  boardRadio: (board, i) ->
+    <label key={board.id}>
+      <input
+        type="radio"
+        name="board"
+        defaultChecked={i is 0} # pre-check the first
+        value={board.id} />
+      {board.title}
+    </label>
+
+  render: ->
+    <div className="discussion-new-form">
+      <div className="talk-board-new-discussion">
+        <h2>Create a disussion +</h2>
+        {if not @props.boardId
+          <PromiseRenderer promise={@props.focusImage.get('project')}>{(project) =>
+            <PromiseRenderer promise={talkClient.type('boards').get(section: "#{project.id}-#{project.title}")}>{(boards) =>
+              <div>
+                <h2>Board</h2>
+                {boards.map @boardRadio}
+              </div>
+            }</PromiseRenderer>
+          }</PromiseRenderer>
+          }
+        <input
+          className="new-discussion-title"
+          type="text"
+          placeholder="Discussion Title"/>
+        <CommentBox
+          header={null}
+          validationCheck={@discussionValidations}
+          validationErrors={@state.discussionValidationErrors}
+          submitFeedback={"Discussion successfully created"}
+          placeholder={"""Add a comment here to start the discussion.
+          This comment will appear at the start of the discussion."""}
+          onSubmitComment={@onSubmitDiscussion}
+          focusImage={@props.focusImage}
+          submit="Create Discussion"/>
+        {if @state.loading then <Loading />}
+      </div>
+    </div>

--- a/app/talk/discussion.cjsx
+++ b/app/talk/discussion.cjsx
@@ -16,8 +16,7 @@ Moderation = require './lib/moderation'
 {timestamp} = require './lib/time'
 {Link} = require 'react-router'
 merge = require 'lodash.merge'
-
-DEFAULT_AVATAR = './assets/simple-avatar.jpg'
+Avatar = require '../partials/avatar'
 
 module?.exports = React.createClass
   displayName: 'TalkDiscussion'
@@ -179,7 +178,7 @@ module?.exports = React.createClass
           if user
             <section>
               <div className="talk-comment-author">
-                <img src={user.avatar ? DEFAULT_AVATAR} />
+                <Avatar user={user} />
                 <p>
                   <Link to="user-profile" params={name: user.display_name}>{user.display_name}</Link>
                 </p>

--- a/app/talk/discussion.cjsx
+++ b/app/talk/discussion.cjsx
@@ -17,6 +17,8 @@ Moderation = require './lib/moderation'
 {Link} = require 'react-router'
 merge = require 'lodash.merge'
 
+DEFAULT_AVATAR = './assets/simple-avatar.jpg'
+
 module?.exports = React.createClass
   displayName: 'TalkDiscussion'
   mixins: [Router.Navigation, PromiseToSetState]
@@ -96,7 +98,6 @@ module?.exports = React.createClass
     talkClient.type('comments').create(comment).save()
       .then (comment) =>
         @setComments(@state.commentsMeta?.page, => @goToPage(@state.commentsMeta?.page_count))
-
 
   onLikeComment: (commentId) ->
     user = @state.user
@@ -178,7 +179,7 @@ module?.exports = React.createClass
           if user
             <section>
               <div className="talk-comment-author">
-                <img src={user.avatar} />
+                <img src={user.avatar ? DEFAULT_AVATAR} />
                 <p>
                   <Link to="user-profile" params={name: user.display_name}>{user.display_name}</Link>
                 </p>

--- a/app/talk/inbox.cjsx
+++ b/app/talk/inbox.cjsx
@@ -64,5 +64,5 @@ module?.exports = React.createClass
          <p>Please sign in to view your inbox</p>}
 
       {@state.conversations?.map(@conversationLink)}
-      <Paginator page={+@state.conversationsMeta.page} onPageChange={@onPageChange} pageCount={@state.conversationsMeta.page_count} />
+      <Paginator page={+@state.conversationsMeta.page} onPageChange={@onPageChange} pageCount={@state.conversationsMeta?.page_count} />
     </div>

--- a/css/main.styl
+++ b/css/main.styl
@@ -42,5 +42,6 @@
 @require './talk-project'
 @require './inbox'
 @require './collections'
+@require './subject'
 
 @require './workflow-editor'

--- a/css/subject.styl
+++ b/css/subject.styl
@@ -1,3 +1,5 @@
 .subject
-  img
+  .subject-container
     max-width: 100%
+    img
+      max-width: 100%

--- a/css/subject.styl
+++ b/css/subject.styl
@@ -1,0 +1,3 @@
+.subject
+  img
+    max-width: 100%

--- a/css/talk.styl
+++ b/css/talk.styl
@@ -98,22 +98,23 @@ TALK_MARGIN = 10px auto
         margin-bottom: 10px
         border-left: 4px solid orangered
 
-  .talk-board
-    .talk-board-new-discussion
-      @extend .talk-module
-      padding: 0px
-      input, h2
-        margin: TALK_PADDING
-      input
-        border: none
-        width: 50%
+  .talk-board-new-discussion
+    @extend .talk-module
+    padding: 0px
+    input, h2
+      margin: TALK_PADDING
+    input[type='text']
+      border: none
+      width: 50%
 
-    .talk-board-discussions
-      width: 80%
-      float: left
+  .talk-board-discussions
+    width: 80%
+    float: left
 
   .talk-board-preview
     @extend .talk-module
+    p
+      margin: 0.5em 0
 
   .talk-subject-display
     @extend .talk-module
@@ -175,6 +176,7 @@ TALK_MARGIN = 10px auto
 
     img
       border-radius: 50%
+      max-width: 50px
 
     p
       width: 40%


### PR DESCRIPTION
- Object page
  - View the subject
  - Favorite Button
  - Display comments mentioning that subject
  - Form to start a new discussion shown if there are boards for that project and you are logged in
    - Pre-filled the discussion comment with that image as the focus
- Some renaming
- Form fixes
- Setup subject mentioning selector to handle subject_id querys
- Default avatar