### PR TITLE
Send project_id with registration

### DIFF
--- a/app/api/auth.coffee
+++ b/app/api/auth.coffee
@@ -103,7 +103,7 @@ module.exports = new Model
         console?.error 'Failed to get session'
         throw error
 
-  register: ({display_name, email, password, credited_name, global_email_communication}) ->
+  register: ({display_name, email, password, credited_name, global_email_communication, project_id}) ->
     @checkCurrent().then (user) =>
       if user?
         @signOut().then =>
@@ -114,7 +114,7 @@ module.exports = new Model
         registrationRequest = @_getAuthToken().then (token) =>
           data =
             authenticity_token: token
-            user: {display_name, email, password, credited_name, global_email_communication}
+            user: {display_name, email, password, credited_name, global_email_communication, project_id}
 
           # This weird URL is actually out of the API, but returns a JSON-API response.
           client.post '/../users', data, JSON_HEADERS

--- a/app/pages/project/classify.cjsx
+++ b/app/pages/project/classify.cjsx
@@ -190,10 +190,10 @@ module.exports = React.createClass
       @maybePromptToSignIn()
 
   maybePromptToSignIn: ->
-    auth.checkCurrent().then (user) ->
+    auth.checkCurrent().then (user) =>
       if classificationsThisSession in PROMPT_TO_SIGN_IN_AFTER and not user?
-        alert (resolve) ->
-          <SignInPrompt onChoose={resolve}>
+        alert (resolve) =>
+          <SignInPrompt project={@props.project} onChoose={resolve}>
             <p><strong>You’ve done {classificationsThisSession} classifications, but you’re not signed in!</strong></p>
           </SignInPrompt>
 

--- a/app/partials/login-dialog.cjsx
+++ b/app/partials/login-dialog.cjsx
@@ -15,6 +15,7 @@ module.exports = React.createClass
 
   getDefaultProps: ->
     which: 'sign-in'
+    project: {}
 
   getInitialState: ->
     which: @props.which
@@ -34,7 +35,7 @@ module.exports = React.createClass
       <div className="content-container">
         {switch @state.which
           when 'sign-in' then <SignInForm onSuccess={@props.onSuccess} />
-          when 'register' then <RegisterForm onSuccess={@props.onSuccess} />}
+          when 'register' then <RegisterForm project={@props.project} onSuccess={@props.onSuccess} />}
       </div>
     </div>
 

--- a/app/partials/register-form.cjsx
+++ b/app/partials/register-form.cjsx
@@ -39,6 +39,9 @@ module.exports = React.createClass
 
   mixins: [PromiseToSetState]
 
+  getDefaultProps: ->
+    project: {}
+
   getInitialState: ->
     user: null
     badNameChars: null
@@ -240,10 +243,11 @@ module.exports = React.createClass
     email = @refs.email.getDOMNode().value
     credited_name = @refs.realName.getDOMNode().value
     global_email_communication = @refs.okayToEmail.getDOMNode().checked
+    project_id = @props.project?.id
 
     @setState error: null
     @props.onSubmit?()
-    auth.register {display_name, password, email, credited_name, global_email_communication}
+    auth.register {display_name, password, email, credited_name, global_email_communication, project_id}
       .then =>
         @props.onSuccess? arguments...
       .catch (error) =>

--- a/app/partials/sign-in-prompt.cjsx
+++ b/app/partials/sign-in-prompt.cjsx
@@ -6,6 +6,7 @@ module.exports = React.createClass
   displayName: 'SignInPrompt'
 
   getDefaultProps: ->
+    project: {}
     onChoose: Function.prototype # No-op
 
   render: ->
@@ -28,10 +29,10 @@ module.exports = React.createClass
 
   signIn: ->
     @props.onChoose()
-    alert (resolve) ->
-      <LoginDialog which="sign-in" onSuccess={resolve} />
+    alert (resolve) =>
+      <LoginDialog which="sign-in" project={@props.project} onSuccess={resolve} />
 
   register: ->
     @props.onChoose()
-    alert (resolve) ->
-      <LoginDialog which="register" onSuccess={resolve} />
+    alert (resolve) =>
+      <LoginDialog which="register" project={@props.project} onSuccess={resolve} />


### PR DESCRIPTION
If a user registers because they were prompted to while classifying, the project is now sent along with the registration.

Cleans up the check for available display_name and email before registration.

Cc: @camallen.

Closes #372.