### PR TITLE
Fix post-subject-creation counts

### DIFF
--- a/app/pages/lab/subject-set.cjsx
+++ b/app/pages/lab/subject-set.cjsx
@@ -119,7 +119,8 @@ EditSubjectSetPage = React.createClass
     files: {}
     deletionError: null
     deletionInProgress: false
-    creationSuccesses: []
+    successfulCreates: []
+    successfulUploads: []
     creationErrors: []
 
   render: ->
@@ -162,8 +163,8 @@ EditSubjectSetPage = React.createClass
 
         <button type="button" className="major-button" disabled={subjectsToCreate is 0} onClick={@createSubjects}>Upload {subjectsToCreate} new subjects</button>
 
-        {unless @state.creationSuccesses.length is 0
-          <div>{@state.creationSuccesses.length} subjects created!</div>}
+        {unless @state.successfulCreates.length is 0
+          <div>{@state.successfulCreates.length} subjects created (with {@state.successfulUploads.length} files uploaded).</div>}
 
         {unless @state.creationErrors.length is 0
           <div>
@@ -194,7 +195,8 @@ EditSubjectSetPage = React.createClass
 
   handleFileSelection: (files) ->
     @setState
-      creationSuccesses: []
+      successfulCreates: []
+      successfulUploads: []
       creationErrors: []
 
     for file in files when file.size isnt 0
@@ -256,9 +258,10 @@ EditSubjectSetPage = React.createClass
       </div>
 
     startUploading = alert uploadAlert
-      .then ({successes, errors}) =>
+      .then ({creates, uploads, errors}) =>
         @setState
-          creationSuccesses: successes
+          successfulCreates: creates
+          successfulUploads: uploads
           creationErrors: errors
           manifests: {}
           files: {}

--- a/app/partials/subject-uploader.cjsx
+++ b/app/partials/subject-uploader.cjsx
@@ -19,7 +19,8 @@ module.exports = React.createClass
     inProgress: false
     current: 0
     batch: []
-    successes: []
+    creates: []
+    uploads: []
     errors: []
 
   componentDidMount: ->
@@ -63,14 +64,17 @@ module.exports = React.createClass
           project: @props.project.id
 
       subject.save()
-        .then =>
+        .then (subject) =>
           uploads = for typeToUploadURL, i in subject.locations
             uploadURL = typeToUploadURL[Object.keys(typeToUploadURL)[0]]
             putFile uploadURL, @props.files[subjectData.locations[i]]
-          Promise.all uploads
+          Promise.all(uploads).then (uploads) =>
+            @setState
+              creates: @state.creates.concat subject
+            uploads
         .then (success) =>
           @setState
-            successes: @state.successes.concat success
+            uploads: @state.uploads.concat success
             batch: @state.batch.concat subject
         .catch (error) =>
           @setState
@@ -92,7 +96,8 @@ module.exports = React.createClass
 
           if @state.current is @props.subjects.length
             @props.onComplete
-              successes: @state.successes
+              creates: @state.creates
+              uploads: @state.uploads
               errors: @state.errors
 
         .catch (error) =>

--- a/app/partials/subject-uploader.cjsx
+++ b/app/partials/subject-uploader.cjsx
@@ -90,20 +90,19 @@ module.exports = React.createClass
   finish: ->
     unless @state.batch.length is 0
       newSubjectIDs = (id for {id} in @state.batch)
-      @props.subjectSet.addLink 'subjects', newSubjectIDs
+      linkToSubjectSet = @props.subjectSet.addLink 'subjects', newSubjectIDs
         .then =>
           @state.batch.splice 0
-
-          if @state.current is @props.subjects.length
-            @props.onComplete
-              creates: @state.creates
-              uploads: @state.uploads
-              errors: @state.errors
-
         .catch (error) =>
           @setState
             errors: @state.errors.concat error
 
-        .then =>
-          if @isMounted()
-            @setState inProgress: false
+    linkToSubjectSet ?= Promise.resolve()
+    linkToSubjectSet.then =>
+      if @state.current is @props.subjects.length
+        @props.onComplete
+          creates: @state.creates
+          uploads: @state.uploads
+          errors: @state.errors
+      if @isMounted()
+        @setState inProgress: false


### PR DESCRIPTION
Keep track of subject creation separately from file uploads. Display both numbers afterward.

Closes #485.