### PR TITLE
Basic search page

### DIFF
--- a/app/main.cjsx
+++ b/app/main.cjsx
@@ -69,6 +69,7 @@ routes = <Route handler={App}>
 
   <Route name="talk" path="talk" handler={require './talk'}>
     <DefaultRoute name="talk-home" handler={require './talk/home'} />
+    <Route name="talk-search" path="search" handler={require './talk/search'} />
     <Route name="talk-board" path=":board" handler={require './talk/board'} />
     <Route name="talk-discussion" path=":board/:discussion" handler={require './talk/discussion'} />
   </Route>

--- a/app/pages/project/talk.cjsx
+++ b/app/pages/project/talk.cjsx
@@ -2,12 +2,14 @@ React = require 'react'
 {RouteHandler} = require 'react-router'
 TalkInit = require '../../talk/init'
 TalkBreadcrumbs = require '../../talk/breadcrumbs'
+CurrentSection = require '../../talk/mixins/current-section' # @state.currentSection
 
 module.exports = React.createClass
   displayName: 'ProjectTalkPage'
+  mixins: [CurrentSection]
 
   render: ->
     <div className="project-text-content talk project content-container">
       <TalkBreadcrumbs {...@props} />
-      <RouteHandler {...@props} />
+      <RouteHandler {...@props} section={@state.currentSection}/>
     </div>

--- a/app/talk/home.cjsx
+++ b/app/talk/home.cjsx
@@ -4,16 +4,7 @@ TalkInit = require './init'
 module?.exports = React.createClass
   displayName: 'TalkHome'
 
-  getSection: ->
-    # Use "#{project.id}-#{project.name}" for section for project talks
-    # or "zooniverse" for global-talk
-
-    if @props.project?.id
-      "#{@props.project.id}-#{@props.project.title}"
-    else
-      'zooniverse'
-
   render: ->
     <div className="talk-home">
-      <TalkInit {...@props} section={@getSection()} />
+      <TalkInit {...@props} />
     </div>

--- a/app/talk/index.cjsx
+++ b/app/talk/index.cjsx
@@ -1,20 +1,27 @@
 React = require 'react'
-{RouteHandler, Link} = require 'react-router'
+{RouteHandler, Link, Navigation} = require 'react-router'
 PromiseRenderer = require '../components/promise-renderer'
 TalkBreadcrumbs = require './breadcrumbs.cjsx'
 talkClient = require '../api/talk'
+CurrentSection = require './mixins/current-section'
 
 module?.exports = React.createClass
   displayName: 'Talk'
+  mixins: [Navigation, CurrentSection]
+
+  onSearchSubmit: (e) ->
+    e.preventDefault()
+    @transitionTo 'talk-search', {}, { query: React.findDOMNode(@refs.talkSearchInput).value }
 
   render: ->
     <div className="talk content-container">
       <h1>Talk!</h1>
       <TalkBreadcrumbs {...@props} />
 
-      <span>
-        Content to be shared across all talk pages and 
-        <input placeholder="a search bar..." />
-      </span>
-      <RouteHandler {...@props} />
+      <form onSubmit={ @onSearchSubmit }>
+        <input type="text" defaultValue={@props.query?.query || 'search'} ref="talkSearchInput" />
+        <button type="submit">Search</button>
+      </form>
+
+      <RouteHandler {...@props} section={@state.currentSection} />
     </div>

--- a/app/talk/mixins/current-section.coffee
+++ b/app/talk/mixins/current-section.coffee
@@ -1,0 +1,10 @@
+React = require 'react'
+
+module.exports =
+  getInitialState: ->
+    currentSection = if @props.project?.id
+      "#{@props.project.id}-#{@props.project.title}"
+    else
+      'zooniverse'
+
+    { currentSection }

--- a/app/talk/search-result.cjsx
+++ b/app/talk/search-result.cjsx
@@ -1,0 +1,17 @@
+React = require 'react'
+DiscussionPreview = require './discussion-preview'
+CommentLink = require './comment-link'
+CommentPreview = require './comment-preview'
+
+# This isn't very reuseable as it's prop is a comment resource with it's
+# linked discussion added on. Probably a better way to approach this.
+
+module.exports = React.createClass
+  displayName: "TalkSearchResult"
+
+  render: ->
+    <div className="talk-search-result">
+      <CommentLink {...@props.data} />
+      <CommentPreview content={@props.data.body} header={null} />
+      <DiscussionPreview data={@props.data.discussion} />
+    </div>

--- a/app/talk/search-result.cjsx
+++ b/app/talk/search-result.cjsx
@@ -10,8 +10,10 @@ module.exports = React.createClass
   displayName: "TalkSearchResult"
 
   render: ->
+    discussion = @props.data.discussion
+
     <div className="talk-search-result">
-      <CommentLink {...@props.data} />
+      <CommentLink comment={@props.data}>Comment #{discussion.links.comments.indexOf(@props.data.id.toString()) + 1} in {discussion.title}</CommentLink>
       <CommentPreview content={@props.data.body} header={null} />
-      <DiscussionPreview data={@props.data.discussion} />
+      <DiscussionPreview data={discussion} />
     </div>

--- a/app/talk/search.cjsx
+++ b/app/talk/search.cjsx
@@ -1,0 +1,122 @@
+React = require 'react'
+{ Navigation } = require 'react-router'
+talkClient = require '../api/talk'
+Paginator = require './lib/paginator'
+TalkSearchResult = require './search-result'
+resourceCount = require './lib/resource-count'
+Loading = require '../components/loading-indicator'
+
+TALK_SEARCH_ERROR_MESSAGE = 'There was an error with your search. Please try again.'
+VALID_SEARCH_PARAMS = ['page', 'page_size', 'query', 'types', 'section']
+
+formTalkSearchParams = (object) ->
+  params = []
+
+  for key, val of object
+    if Array.isArray(val)
+      params.push "#{key}[]=#{val}"
+    else
+      params.push "#{key}=#{val}"
+
+  return params.join '&'
+
+status = (response) ->
+  if (response.status >= 200 && response.status < 300)
+    return response
+
+  throw new Error
+
+filterObjectKeys = (object, validKeys) ->
+  newObject = {}
+
+  for key, value of object
+    if validKeys.indexOf(key) > -1
+      newObject[key] = value
+
+  return newObject
+
+module.exports = React.createClass
+  displayName: 'TalkSearch'
+  mixins: [Navigation]
+
+  getInitialState: ->
+    errorThrown: false
+    isLoading: true
+    results: []
+    resultsMeta: {}
+
+  componentDidMount: ->
+    @runSearchQuery filterObjectKeys @props.query, VALID_SEARCH_PARAMS
+
+  componentWillReceiveProps: (nextProps) ->
+    @runSearchQuery filterObjectKeys nextProps.query, VALID_SEARCH_PARAMS
+
+  runSearchQuery: (params) ->
+    @setState
+      errorThrown: false
+      isLoading: true
+      results: []
+
+    defaultParams =
+      section: @props.section
+      types: ['comments']
+      page: 1
+      page_size: 10
+
+    paramsToUse = Object.assign defaultParams, params
+
+    params = formTalkSearchParams paramsToUse
+    url = talkClient.root + "/searches?" + params
+
+    fetch url, { method: 'get' }, talkClient.headers
+      .then(status)
+      .then (response) -> return response.json()
+      .then ({ searches, meta }) =>
+        discussionRequests = []
+        for comment in searches
+          do (comment) ->
+            discussionRequests.push talkClient.type('discussions').get(comment.discussion_id.toString()).then (discussionResult) ->
+              comment.discussion = discussionResult
+
+        Promise.all(discussionRequests).then =>
+          @setState
+            results: searches
+            resultsMeta: meta.searches
+      .catch =>
+        @setState errorThrown: true
+      .then =>
+        @setState isLoading: false
+
+  onPageChange: (page) ->
+    @goToPage page
+
+  goToPage: (n) ->
+    nextQuery = Object.assign @props.query, {page: n}
+    @transitionTo @props.path, @props.params, nextQuery
+
+  render: ->
+    numberOfResults = @state.results.length
+
+    <div className="talk-search">
+      {if @state.isLoading
+        <Loading />}
+
+      {if @state.errorThrown
+        <p className="form-help error">{TALK_SEARCH_ERROR_MESSAGE}</p>}
+
+      {if !@state.isLoading && numberOfResults == 0 && !@state.errorThrown
+        <p>No results found.</p>}
+
+      {if !@state.isLoading && numberOfResults > 0
+        <div className="talk-search-container">
+          <div className="talk-search-counts">
+            Your search returned {resourceCount @state.resultsMeta.count, 'results'}.
+          </div>
+
+          <div className="talk-search-results">
+            {@state.results.map (result, i) ->
+              <TalkSearchResult data={result} key={i} />}
+            <Paginator page={+@state.resultsMeta.page} onPageChange={@onPageChange} pageCount={@state.resultsMeta.page_count} />
+          </div>
+        </div>}
+    </div>

--- a/css/talk.styl
+++ b/css/talk.styl
@@ -288,3 +288,8 @@ TALK_MARGIN = 10px auto
             background: rgba(255,255,255,0.5)
             button
               opacity: 1
+
+  .talk-search-result
+    background: rgba(TALK_BACKGROUND, 0.5)
+    margin: TALK_MARGIN
+    padding: TALK_PADDING

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   },
   "config": {
     "fontAwesomeURL": "https://github.com/FortAwesome/Font-Awesome/blob/8027c940b6/assets/font-awesome-4.2.0.zip?raw=true",
-    "fallbackPolyfillsURL": "https://cdn.polyfill.io/v1/polyfill.min.js?features=default,es6,Promise&flags=gated&ua=(MSIE%209.0)"
+    "fallbackPolyfillsURL": "https://cdn.polyfill.io/v1/polyfill.min.js?features=default,es6,Promise,fetch&flags=gated&ua=(MSIE%209.0)"
   },
   "browserify": {
     "transform": [

--- a/public/index.erb
+++ b/public/index.erb
@@ -47,7 +47,7 @@
       });
     </script>
 
-    <script src="https://cdn.polyfill.io/v1/polyfill.min.js?features=default,es6,Promise&amp;flags=gated"></script>
+    <script src="https://cdn.polyfill.io/v1/polyfill.min.js?features=default,es6,Promise,fetch&amp;flags=gated"></script>
     <script>('assign' in Object) || document.write('<script src="./fallback-polyfills.js"></'+'script>');</script>
 
     <script src="./<%= ENV['VENDOR_JS'] %>"></script>


### PR DESCRIPTION
- Adds basic search page. Closes #375 
- Adds `current-section` mixin for easy checking on whether you are on a project-specific or Zooniverse-wide Talk.
- Adds the `fetch` polyfill, as there are incompatibilities with the way `makeHTTPRequest` formats array params to what the Talk-Api expects.

Note `<CommentLink />` doesn't do much now, so you can't actually click through to the result, though the discussion bit is active.

