### PR TITLE
Reset boards list when props are received

### DIFF
--- a/app/talk/init.cjsx
+++ b/app/talk/init.cjsx
@@ -23,6 +23,9 @@ module?.exports = React.createClass
   componentWillMount: ->
     @setBoards()
 
+  componentWillReceiveProps: ->
+    @setBoards()
+
   setBoards: ->
     auth.checkCurrent().then =>
       talkClient.type('boards').get(section: @props.section)


### PR DESCRIPTION
- Fixes an issue with project-linker where the boards list was not
  updated when changing between projects