### PR TITLE
Perhaps set width via prop?

### DIFF
--- a/app/components/image-selector.cjsx
+++ b/app/components/image-selector.cjsx
@@ -18,6 +18,7 @@ module.exports = React.createClass
     minArea: 100 # Stop reducing when there are fewer than this many pixels.
     reductionPerPass: 0.05
     onChange: Function.prototype # No-op
+    maxComponentWidth: 200
 
   getInitialState: ->
     working: false
@@ -32,6 +33,7 @@ module.exports = React.createClass
       background: 'rgba(128, 128, 128, 0.2)'
       border: '1px solid rgba(128, 128, 128, 0.4)'
       borderRadius: 5
+      maxWidth: @props.maxComponentWidth
       position: 'relative'
     }>
       {if @state.dataURL or @props.defaultValue

--- a/css/image-selector.styl
+++ b/css/image-selector.styl
@@ -1,2 +1,0 @@
-.image-selector
-  max-width: 100px


### PR DESCRIPTION
Putting this out there to see if people like the pattern. Not really ready to merge.

How about setting the width of `<ImageSelector />` via a prop? Somewhat solves the unbounded size problem when people upload big images. Also could be clever and create a mixin which tracks a component's current width as state and passes it down to this.

@brian-c @aweiksnar Thoughts?