### PR TITLE
Linking to single talk comments

### DIFF
--- a/app/talk/comment-link.cjsx
+++ b/app/talk/comment-link.cjsx
@@ -64,7 +64,9 @@ module?.exports = React.createClass
                   page: pageOfComment,
                   comment: comment.id
                 }
-            <a href={projectCommentUrl}>{projectCommentUrl}</a>
+            <a href={projectCommentUrl}>
+              {@props.children ? projectCommentUrl}
+            </a>
           }</PromiseRenderer>
 
         else
@@ -73,6 +75,8 @@ module?.exports = React.createClass
             @makeHref 'talk-discussion',
               {board: discussion.board_id, discussion: discussion.id},
               {page: pageOfComment, comment: comment.id}
-          <a href={mainTalkCommentUrl}>{mainTalkCommentUrl}</a>
+          <a href={mainTalkCommentUrl}>
+            {@props.children ? mainTalkCommentUrl}
+          </a>
           }
     </div>

--- a/app/talk/comment-link.cjsx
+++ b/app/talk/comment-link.cjsx
@@ -1,11 +1,78 @@
 React = require 'react'
+talkClient = require '../api/talk'
+apiClient = require '../api/client'
+PromiseRenderer = require '../components/promise-renderer'
+{Link, Navigation} = require 'react-router'
+
+PAGE_SIZE = 3
+
+getPageOfComment = (comment, discussion, pageSize) ->
+  # comment resource, discussion resource, integer
+  comments = discussion.links.comments
+  commentNumber = comments.indexOf(comment.id.toString()) + 1
+  Math.ceil commentNumber / pageSize
 
 module?.exports = React.createClass
   displayName: 'TalkCommentLink'
+  mixins: [Navigation]
+
+  propTypes:
+    comment: React.PropTypes.object  # Comment resource
+    pageSize: React.PropTypes.number # Optional: pass this in to override default PAGE_SIZE
+
+  getDefaultProps: ->
+    pageSize: PAGE_SIZE
+
+  getInitialState: ->
+    discussion: {}
+
+  componentWillMount: ->
+    @setDiscussion()
+
+  setDiscussion: ->
+    {comment} = @props
+    talkClient.type('discussions').get(comment.discussion_id.toString())
+      .then (discussion) => @setState {discussion}
+
+  projectComment: ->
+    @props.comment.section isnt 'zooniverse'
 
   render: ->
+    {discussion} = @state
+    {comment} = @props
+
     <div className="talk-comment-link">
-      <a href="http://www.zooniverse.org/talk/comments/ex#anchor">
-        http://www.zooniverse.org/talk/comments/ex\#anchor
-      </a>
+      {if discussion?.id        # Wait for discussion to be set
+        pageOfComment = getPageOfComment(comment, discussion, PAGE_SIZE)
+
+        if @projectComment()
+          projectId = discussion.section.split('-')[0]
+          project = apiClient.type('projects').get(projectId)
+          owner = project.then (project) => project.get('owner')
+
+          <PromiseRenderer promise={Promise.all [project, owner]}>{([project, owner]) =>
+            projectCommentUrl =
+              window.location.origin +
+              @makeHref 'project-talk-discussion',
+                {
+                  board: discussion.board_id,
+                  discussion: discussion.id,
+                  owner: owner.slug,
+                  name: project.slug
+                }
+                {
+                  page: pageOfComment,
+                  comment: comment.id
+                }
+            <a href={projectCommentUrl}>{projectCommentUrl}</a>
+          }</PromiseRenderer>
+
+        else
+          mainTalkCommentUrl =
+            window.location.origin +
+            @makeHref 'talk-discussion',
+              {board: discussion.board_id, discussion: discussion.id},
+              {page: pageOfComment, comment: comment.id}
+          <a href={mainTalkCommentUrl}>{mainTalkCommentUrl}</a>
+          }
     </div>

--- a/app/talk/comment.cjsx
+++ b/app/talk/comment.cjsx
@@ -28,6 +28,10 @@ module?.exports = React.createClass
     onDeleteComment: React.PropTypes.func # passed (commentId) on click
     onLikeComment: React.PropTypes.func # passed (commentId) on like
     onClickReply: React.PropTypes.func # passed (user, comment) on click
+    active: React.PropTypes.bool  # optional active switch
+
+  getDefaultProps: ->
+    active: false
 
   getInitialState: ->
     editing: false
@@ -72,8 +76,9 @@ module?.exports = React.createClass
 
   render: ->
     feedback = @renderFeedback()
+    activeClass = if @props.active then 'active' else ''
 
-    <div className="talk-comment">
+    <div className="talk-comment #{activeClass}">
       <div className="talk-comment-author">
         <PromiseRenderer promise={apiClient.type('users').get(id: @props.data.user_id).index(0)}>{(commentOwner) =>
           <Avatar user={commentOwner} />
@@ -138,7 +143,7 @@ module?.exports = React.createClass
 
             <div className="talk-comment-children">
               {switch @state.showing
-                 when 'link' then <CommentLink />
+                 when 'link' then <CommentLink comment={@props.data}/>
                  when 'report' then <CommentReportForm />}
             </div>
           </div>

--- a/app/talk/discussion.cjsx
+++ b/app/talk/discussion.cjsx
@@ -18,6 +18,8 @@ Moderation = require './lib/moderation'
 merge = require 'lodash.merge'
 Avatar = require '../partials/avatar'
 
+PAGE_SIZE = 3
+
 module?.exports = React.createClass
   displayName: 'TalkDiscussion'
   mixins: [Router.Navigation, PromiseToSetState]
@@ -50,7 +52,7 @@ module?.exports = React.createClass
 
   commentsRequest: (page) ->
     {board, discussion} = @props.params
-    talkClient.type('comments').get({discussion_id: discussion, page_size: 3, page})
+    talkClient.type('comments').get({discussion_id: discussion, page_size: PAGE_SIZE, page})
 
   discussionsRequest: ->
     {discussion} = @props.params
@@ -65,7 +67,8 @@ module?.exports = React.createClass
 
   setDiscussion: ->
     @discussionsRequest()
-      .then (discussion) => @setState {discussion: discussion[0]}
+      .then (discussion) =>
+        @setState {discussion: discussion[0]}
 
   onUpdateComment: (textContent, focusImage, commentId) ->
     {discussion} = @props.params
@@ -119,6 +122,7 @@ module?.exports = React.createClass
     <Comment
       key={data.id}
       data={data}
+      active={+data.id is +@props.query?.comment}
       user={@state.user}
       onClickReply={@onClickReply}
       onLikeComment={@onLikeComment}

--- a/css/talk.styl
+++ b/css/talk.styl
@@ -161,6 +161,10 @@ TALK_MARGIN = 10px auto
   .talk-comment
     overflow: auto
 
+    &.active
+      .talk-comment-body
+        background-color: gold
+
     .talk-comment-preview-content
       blockquote
         opacity: 0.5


### PR DESCRIPTION
- You should be able to click the ':link: Link' button under a comment to get a route for that individual comment
- The individual comment routes distinguish the comment by giving it an 'active' class (gold background)
- TalkCommentLink component updates
  - The big if/else clause in comment-link isn't my favorite piece of code, but I think it's worth isolating that project/owner params promise to project comment links
  - Takes in a comment resource prop. Should be usable for the search page too!
- Closes  #374