### PR TITLE
Added simple file ext comparison when Windows fails to detect MIME type

### DIFF
--- a/app/pages/lab/subject-set.cjsx
+++ b/app/pages/lab/subject-set.cjsx
@@ -210,6 +210,13 @@ EditSubjectSetPage = React.createClass
       else if file.type.indexOf('image/') is 0
         @state.files[file.name] = file
         gotFile = true
+      else if file.type? # When Windows fails to detect MIME type and returns an empty string for file.type
+        allowedFileExts = ['csv', 'tsv']
+        ext = file.name.split('.').pop()
+        if allowedFileExts.indexOf(ext) > -1
+          @_addManifest file
+          gotManifest = true
+
 
       if gotFile and not gotManifest
         @forceUpdate()


### PR DESCRIPTION
- Added another if statement to `handleFileSelection` when Windows returns and empty string for file.type
  - Fixed #479 
  - When initial browser detection fails, it falls back to OS and in this case Windows uses its system registry keys. If registry key doesn't exist, it returns an empty string for file.type which is why it is failing regardless of browser in Windows. More details:
      - http://stackoverflow.com/questions/1201945/how-is-mime-type-of-an-uploaded-file-determined-by-browser
      - http://stackoverflow.com/questions/26149389/mime-type-missing-for-rar-and-tar
      - http://stackoverflow.com/questions/11182968/determining-unknown-content-types-with-the-html5-file-api