### PR TITLE
Scaleable subject

### DIFF
--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -1,7 +1,7 @@
 React = require 'react'
 HandlePropChanges = require '../lib/handle-prop-changes'
 ChangeListener = require '../components/change-listener'
-SubjectViewer = require './subject-viewer'
+SubjectAnnotator = require './subject-annotator'
 ClassificationSummary = require './classification-summary'
 tasks = require './tasks'
 {Link} = require 'react-router'
@@ -54,7 +54,7 @@ Classifier = React.createClass
         currentTask = @props.workflow.tasks[currentAnnotation?.task]
 
       <div className="classifier">
-        <SubjectViewer user={@props.user} project={@props.project} subject={@props.subject} workflow={@props.workflow} classification={currentClassification} annotation={currentAnnotation} onLoad={@handleSubjectImageLoad} />
+        <SubjectAnnotator user={@props.user} project={@props.project} subject={@props.subject} workflow={@props.workflow} classification={currentClassification} annotation={currentAnnotation} onLoad={@handleSubjectImageLoad} />
 
         <div className="task-area">
           {if currentTask?

--- a/app/classifier/subject-annotator.cjsx
+++ b/app/classifier/subject-annotator.cjsx
@@ -11,7 +11,7 @@ getSubjectLocation = require '../lib/get-subject-location'
 NOOP = Function.prototype
 
 module.exports = React.createClass
-  displayName: 'SubjectViewer' # TODO: Rename this.
+  displayName: 'SubjectAnnotator'
 
   getDefaultProps: ->
     project: null

--- a/app/classifier/subject-annotator.cjsx
+++ b/app/classifier/subject-annotator.cjsx
@@ -24,6 +24,7 @@ module.exports = React.createClass
     naturalWidth: 0
     naturalHeight: 0
     viewbox: "0 0 0 0"
+    align: "xMidYMid"
     showWarning: false
     frame: 0
     selectedMark: null
@@ -92,7 +93,7 @@ module.exports = React.createClass
 
     <div className="subject-area">
       <SubjectViewer user={@props.user} project={@props.project} subject={@props.subject} frame={@state.frame} onLoad={@handleSubjectFrameLoad} onFrameChange={@handleFrameChange}>
-        <svg viewBox={@state.viewbox} preserveAspectRatio="xMidYMid meet" style={SubjectViewer.overlayStyle}>
+        <svg viewBox={@state.viewbox} preserveAspectRatio="#{@state.align} meet" style={SubjectViewer.overlayStyle}>
           {<SVGImage src={src} width={@state.naturalWidth} height={@state.naturalHeight} /> if type is 'image'}
           <rect ref="sizeRect" width={@state.naturalWidth} height={@state.naturalHeight} fill="rgba(0, 0, 0, 0.01)" fillOpacity="0.01" stroke="none" />
 
@@ -313,5 +314,17 @@ module.exports = React.createClass
     width = Math.min maxWidth, width
     height = Math.min maxHeight, height
     viewbox = [x,y,width,height].join ' '
-    @setState {viewbox}, @handleResize
+    align = @align x, y, width, height
+    @setState {viewbox, align}, @handleResize
+  
+  align: (x = 0, y = 0, width = @state.naturalWidth, height = @state.naturalHeight) ->
+    aspect = width / height
+    subject_aspect = @state.naturalWidth / @state.naturalHeight
+    align = 'xMidYMid'
+    align = 'xMinYMid' if x < width and aspect < (.5 * subject_aspect)
+    align = 'xMaxYMid' if (x + width) > (@state.naturalWidth - width) and aspect < (.5 * subject_aspect)
+    align = 'xMidYMin' if y < height and aspect > (2 * subject_aspect)
+    align = 'xMidYMax' if (y + height) > (@state.naturalHeight - height) and aspect > (2 * subject_aspect)
+    
+    align
 

--- a/app/classifier/subject-viewer.cjsx
+++ b/app/classifier/subject-viewer.cjsx
@@ -302,3 +302,16 @@ module.exports = React.createClass
     markIndex = annotation.value.indexOf mark
     annotation.value.splice markIndex, 1
     @updateAnnotations()
+
+  crop: (x = 0, y = 0, width = @state.naturalWidth, height = @state.naturalHeight) ->
+    x = Math.max 0, x
+    y = Math.max 0, y
+    x = Math.min @state.naturalWidth, x
+    y = Math.min @state.naturalHeight, y
+    maxWidth = @state.naturalWidth - x
+    maxHeight = @state.naturalHeight - y
+    width = Math.min maxWidth, width
+    height = Math.min maxHeight, height
+    viewbox = [x,y,width,height].join ' '
+    @setState {viewbox}, @handleResize
+

--- a/app/classifier/subject-viewer.cjsx
+++ b/app/classifier/subject-viewer.cjsx
@@ -94,11 +94,11 @@ module.exports = React.createClass
       <SubjectViewer user={@props.user} project={@props.project} subject={@props.subject} frame={@state.frame} onLoad={@handleSubjectFrameLoad} onFrameChange={@handleFrameChange}>
         <svg viewBox={@state.viewbox} preserveAspectRatio="xMidYMid meet" style={SubjectViewer.overlayStyle}>
           {<SVGImage src={src} width={@state.naturalWidth} height={@state.naturalHeight} /> if type is 'image'}
-          <rect ref="sizeRect" width="100%" height="100%" fill="rgba(0, 0, 0, 0.01)" fillOpacity="0.01" stroke="none" />
+          <rect ref="sizeRect" width={@state.naturalWidth} height={@state.naturalHeight} fill="rgba(0, 0, 0, 0.01)" fillOpacity="0.01" stroke="none" />
 
           {if @props.annotation?._toolIndex?
             <Draggable onStart={@handleInitStart} onDrag={@handleInitDrag} onEnd={@handleInitRelease}>
-              <rect className="marking-initializer" width="100%" height="100%" fill="transparent" stroke="none" />
+              <rect className="marking-initializer" width={@state.naturalWidth} height={@state.naturalHeight} fill="transparent" stroke="none" />
             </Draggable>}
 
           {for annotation in @props.classification.annotations

--- a/app/components/svg-image.cjsx
+++ b/app/components/svg-image.cjsx
@@ -19,6 +19,7 @@ module.exports = React.createClass
 
   componentDidUpdate: ->
     @fixWeirdSize()
+    @setHref()
   
   componentDidMount: ->
     @setHref()

--- a/app/components/svg-image.cjsx
+++ b/app/components/svg-image.cjsx
@@ -13,11 +13,15 @@ module.exports = React.createClass
     height: 0
 
   render: ->
-    imageHTML = "<image xlink:href='#{@props.src}' width='#{@props.width}' height='#{@props.height}' />"
-    <g {...@props} className="svg-image-container" dangerouslySetInnerHTML={__html: imageHTML} />
+    <g {...@props} className="svg-image-container">
+      <image preserveAspectRatio="xMidYMid meet" width={@props.width} height={@props.height} />
+    </g>
 
   componentDidUpdate: ->
     @fixWeirdSize()
+  
+  componentDidMount: ->
+    @setHref()
 
   # This fixes weird behavior observed in Mac Safari 7
   # where the image doesn't get a size on render.
@@ -29,3 +33,7 @@ module.exports = React.createClass
 
     unless image.height is @props.height
       image.setAttribute 'height', @props.height
+  
+  setHref: ->
+    image = @getDOMNode().querySelector 'image'
+    image.setAttributeNS 'http://www.w3.org/1999/xlink', 'href', @props.src

--- a/app/components/svg.cjsx
+++ b/app/components/svg.cjsx
@@ -1,0 +1,37 @@
+React = require 'react'
+
+module.exports = React.createClass
+  displayName: 'SVG'
+
+  getInitialState: ->
+    align: 'xMidYMid'
+    viewbox: ''
+  
+  render: ->
+    <svg viewBox={@state.viewbox} preserveAspectRatio="#{@state.align} meet" style={@props.style}>
+      {@props.children}
+    </svg>
+  
+  crop: (x = 0, y = 0, width = @props.naturalWidth, height = @props.naturalHeight) ->
+    x = Math.max 0, x
+    y = Math.max 0, y
+    x = Math.min @props.naturalWidth, x
+    y = Math.min @props.naturalHeight, y
+    maxWidth = @props.naturalWidth - x
+    maxHeight = @props.naturalHeight - y
+    width = Math.min maxWidth, width
+    height = Math.min maxHeight, height
+    viewbox = [x,y,width,height].join ' '
+    align = @align x, y, width, height
+    @setState {viewbox, align}, @props.handleResize
+  
+  align: (x = 0, y = 0, width = @props.naturalWidth, height = @props.naturalHeight) ->
+    aspect = width / height
+    subject_aspect = @props.naturalWidth / @props.naturalHeight
+    ratio = aspect / subject_aspect
+    align = switch
+      when ratio < .5 and x < width then 'xMinYMid'
+      when ratio < .5 and (x + width) > (@props.naturalWidth - width) then 'xMaxYMid'
+      when ratio > 2 and y < height then 'xMidYMin'
+      when ratio > 2 and (y + height) > (@props.naturalHeight - height) then 'xMidYMax'
+      else 'xMidYMid'


### PR DESCRIPTION
Work towards zooming subject images for #278 
- renames SubjectViewer to SubjectAnnotator, to avoid confusion with the shared SubjectViewer component
- adds an SVG image for image subjects
- sizes SVG elements to scale with the subject image
- adds a crop method to crop the view box to x, y, width, height