### PR TITLE
Disable owner role checkbox and add owner back

### DIFF
--- a/app/pages/lab/collaborators.cjsx
+++ b/app/pages/lab/collaborators.cjsx
@@ -66,7 +66,7 @@ CollaboratorCreator = React.createClass
           <tbody>
             {for role, _ of POSSIBLE_ROLES
               <tr>
-                <td><input id={ID_PREFIX + role} type="checkbox" name="role" value={role} /></td>
+                <td><input id={ID_PREFIX + role} type="checkbox" name="role" value={role} disabled={role is 'owner'}/></td>
                 <td><strong><label htmlFor={ID_PREFIX + role}>{ROLES_INFO[role].label}</label></strong></td>
                 <td>{ROLES_INFO[role].description}</td>
               </tr>}
@@ -155,8 +155,10 @@ module.exports = React.createClass
         <p className="form-help error">{@state.error.toString()}</p>}
       <PromiseRenderer promise={@fetchAllRoles()} then={(projectRoleSets) =>
         <div>
+          {ownerSet = projectRoleSets.filter((set) -> 'owner' in set.roles)[0]
+          <PromiseRenderer key={ownerSet.id} promise={ownerSet.get 'owner'} then={@renderUserRow.bind this, ownerSet} />}
           {if projectRoleSets.length > 1
-            for projectRoleSet in projectRoleSets
+            for projectRoleSet in projectRoleSets when 'owner' not in projectRoleSet.roles
               <PromiseRenderer key={projectRoleSet.id} promise={projectRoleSet.get 'owner'} then={@renderUserRow.bind this, projectRoleSet} />
           else
             <em className="form-help">None yet</em>}
@@ -170,24 +172,21 @@ module.exports = React.createClass
     </div>
 
   renderUserRow: (projectRoleSet, user) ->
-    if 'owner' in projectRoleSet.roles
-      null
-    else
-      <p>
-        <strong>{user.display_name}</strong>{' '}
-        <button type="button" className="secret-button" onClick={@removeRoleSet.bind this, projectRoleSet}>&times;</button>
-        <br />
+    <p>
+      <strong>{user.display_name}</strong>{' '}
+      <button type="button" className="secret-button" onClick={@removeRoleSet.bind this, projectRoleSet}>&times;</button>
+      <br />
 
-        <span className="columns-container inline">
-          {for role, _ of POSSIBLE_ROLES
-            toggleThisRole = @toggleRole.bind this, projectRoleSet, role
-            # TODO: Translate this.
-            <label key={role}>
-              <input type="checkbox" name={role} checked={role in projectRoleSet.roles} disabled={role is 'owner' or projectRoleSet.id in @state.saving} onChange={toggleThisRole} />{' '}
-              {role[...1].toUpperCase()}{role[1...]}
-            </label>}
-        </span>
-      </p>
+      <span className="columns-container inline">
+        {for role, _ of POSSIBLE_ROLES
+          toggleThisRole = @toggleRole.bind this, projectRoleSet, role
+          # TODO: Translate this.
+          <label key={role}>
+            <input type="checkbox" name={role} checked={role in projectRoleSet.roles} disabled={role is 'owner' or projectRoleSet.id in @state.saving or 'owner' in projectRoleSet.roles} onChange={toggleThisRole} />{' '}
+            {ROLES_INFO[role].label}
+          </label>}
+      </span>
+    </p>
 
   toggleRole: (projectRoleSet, role) ->
     index = projectRoleSet.roles.indexOf role

--- a/app/pages/lab/collaborators.cjsx
+++ b/app/pages/lab/collaborators.cjsx
@@ -182,7 +182,7 @@ module.exports = React.createClass
           toggleThisRole = @toggleRole.bind this, projectRoleSet, role
           # TODO: Translate this.
           <label key={role}>
-            <input type="checkbox" name={role} checked={role in projectRoleSet.roles} disabled={role is 'owner' or projectRoleSet.id in @state.saving or 'owner' in projectRoleSet.roles} onChange={toggleThisRole} />{' '}
+            <input type="checkbox" name={role} checked={role in projectRoleSet.roles} disabled={role is 'owner' or projectRoleSet.id in @state.saving} onChange={toggleThisRole} />{' '}
             {ROLES_INFO[role].label}
           </label>}
       </span>


### PR DESCRIPTION
I think it was confusing not seeing the project owner on the Roles list
at all, so this just adds them back with all the checkboxes
disabled. This also disables the owner checkbox when creating new roles
since there can only be a single owner.

Closes #548