### PR TITLE
Retina workflow by id not name

### DIFF
--- a/app/api/config.coffee
+++ b/app/api/config.coffee
@@ -14,6 +14,10 @@ TALK_HOSTS =
   production: 'https://talk.zooniverse.org'
   staging: 'https://talk-staging.zooniverse.org'
 
+RETINA_WORKFLOW_IDS =
+  production: 'TODO'
+  staging: '1039'
+
 hostFromBrowser = location?.search.match(/\W?panoptes-api-host=([^&]+)/)?[1]
 appFromBrowser = location?.search.match(/\W?panoptes-api-application=([^&]+)/)?[1]
 talkFromBrowser = location?.search.match(/\W?talk-host=([^&]+)/)?[1]
@@ -31,3 +35,4 @@ module.exports =
   host: hostFromBrowser ? hostFromShell ? API_HOSTS[env]
   clientAppID: appFromBrowser ? appFromShell ? API_APPLICATION_IDS[env]
   talkHost:  talkFromBrowser ? talkFromShell ? TALK_HOSTS[env]
+  retinaWorkflowId: RETINA_WORKFLOW_IDS[env]

--- a/app/classifier/subject-annotator.cjsx
+++ b/app/classifier/subject-annotator.cjsx
@@ -7,6 +7,7 @@ tasks = require './tasks'
 Tooltip = require '../components/tooltip'
 seenThisSession = require '../lib/seen-this-session'
 getSubjectLocation = require '../lib/get-subject-location'
+config = require '../api/config'
 
 NOOP = Function.prototype
 
@@ -75,7 +76,7 @@ module.exports = React.createClass
     {attachment, targetAttachment, offset, arrowStyle}
 
   componentWillReceiveProps: (nextProps) ->
-    @horribleRetinasHack nextProps if nextProps.workflow.id == '1039'
+    @horribleRetinasHack nextProps if nextProps.workflow.id is config.retinaWorkflowId
     unless nextProps.annotation is @props.annotation
       @selectMark null, null
     


### PR DESCRIPTION
Allow workflow name changes, use the id now. Also allow the workflow Id be configurable by the env.

@eatyourgreens - can you take a look? 