### PR TITLE
Limit subject looping

### DIFF
--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -111,7 +111,8 @@ Classifier = React.createClass
       <hr />
 
       <nav className="task-nav">
-        <Link to="project-talk-subject" params={owner: @props.owner.login, name: @props.project.slug, id: @props.subject.id} className="talk standard-button">Talk</Link>
+        {if @props.owner? and @props.project?
+          <Link to="project-talk-subject" params={owner: @props.owner.login, name: @props.project.slug, id: @props.subject.id} className="talk standard-button">Talk</Link>}
         <button type="button" className="continue major-button" onClick={@props.onClickNext}>Next</button>
       </nav>
     </div>

--- a/app/components/subject-viewer.cjsx
+++ b/app/components/subject-viewer.cjsx
@@ -10,7 +10,6 @@ NOOP = Function.prototype
 ROOT_STYLE = display: 'block'
 CONTAINER_STYLE = display: 'inline-block', position: 'relative'
 SUBJECT_STYLE = display: 'block'
-PLAYING_FRAME_DURATION = 667
 
 module.exports = React.createClass
   displayName: 'SubjectViewer'
@@ -25,6 +24,8 @@ module.exports = React.createClass
 
   getDefaultProps: ->
     subject: null
+    playFrameDuration: 667
+    playIterations: 3
     onFrameChange: NOOP
     onLoad: NOOP
 
@@ -108,9 +109,13 @@ module.exports = React.createClass
     @setState {playing}
     if playing
       @nextFrame()
-      @_playingInterval = setInterval @nextFrame, PLAYING_FRAME_DURATION
+      @_playingInterval = setInterval @nextFrame, @props.playFrameDuration
+
+      autoStopDelay = @props.subject.locations.length * @props.playFrameDuration * @props.playIterations
+      @_autoStop = setTimeout @setPlaying.bind(this, false), autoStopDelay
     else
       clearInterval @_playingInterval
+      clearTimeout @_autoStop
 
   nextFrame: ->
     @handleFrameChange (@state.frame + 1) %% @props.subject.locations.length

--- a/app/components/subject-viewer.cjsx
+++ b/app/components/subject-viewer.cjsx
@@ -10,7 +10,7 @@ NOOP = Function.prototype
 ROOT_STYLE = display: 'block'
 CONTAINER_STYLE = display: 'inline-block', position: 'relative'
 SUBJECT_STYLE = display: 'block'
-PLAYING_FRAME_DURATION = 333
+PLAYING_FRAME_DURATION = 667
 
 module.exports = React.createClass
   displayName: 'SubjectViewer'


### PR DESCRIPTION
- Renders the /dev/classifier page even though it doesn't have a project or owner
- Reduces the speed of subject frame playing
- Stops frame playing after three loops