### PR TITLE
Empty subject queue on auth change and subject set edit

### DIFF
--- a/app/pages/lab/subject-set.cjsx
+++ b/app/pages/lab/subject-set.cjsx
@@ -17,6 +17,9 @@ NOOP = Function.prototype
 VALID_SUBJECT_EXTENSIONS = ['.jpg', '.png', '.gif', '.svg']
 INVALID_FILENAME_CHARS = ['/', '\\', ':']
 
+announceSetChange = ->
+  apiClient.type('subject_sets').emit 'add-or-remove'
+
 SubjectSetListingRow = React.createClass
   displayName: 'SubjectSetListingRow'
 
@@ -102,7 +105,8 @@ SubjectSetListing = React.createClass
     </div>
 
   removeSubject: (subject) ->
-    @props.subjectSet.removeLink 'subjects', subject.id
+    @props.subjectSet.removeLink('subjects', subject.id).then =>
+      announceSetChange()
 
 EditSubjectSetPage = React.createClass
   displayName: 'EditSubjectSetPage'
@@ -276,6 +280,7 @@ EditSubjectSetPage = React.createClass
           creationErrors: errors
           manifests: {}
           files: {}
+        announceSetChange()
 
   deleteSubjectSet: ->
     @setState deletionError: null
@@ -287,6 +292,7 @@ EditSubjectSetPage = React.createClass
 
       this.props.subjectSet.delete()
         .then =>
+          announceSetChange()
           @props.project.uncacheLink 'subject_sets'
           @transitionTo 'edit-project-details', projectID: @props.project.id
         .catch (error) =>

--- a/app/pages/project/classify.cjsx
+++ b/app/pages/project/classify.cjsx
@@ -34,9 +34,17 @@ currentClassifications =
   forWorkflow: {}
 
 # Queue up subjects to classify here.
-# TODO: Should we clear this on sign-in and -out?
 upcomingSubjects =
   forWorkflow: {}
+
+emptySubjectQueue = ->
+  console?.log 'Emptying upcoming subjects queue'
+  for workflowID, queue of upcomingSubjects.forWorkflow
+    for subject in queue
+      subject.destroy()
+    queue.splice 0
+
+auth.listen 'change', emptySubjectQueue
 
 module.exports = React.createClass
   displayName: 'ProjectClassifyPage'

--- a/app/pages/project/classify.cjsx
+++ b/app/pages/project/classify.cjsx
@@ -45,6 +45,7 @@ emptySubjectQueue = ->
     queue.splice 0
 
 auth.listen 'change', emptySubjectQueue
+apiClient.type('subject_sets').listen 'add-or-remove', emptySubjectQueue
 
 module.exports = React.createClass
   displayName: 'ProjectClassifyPage'


### PR DESCRIPTION
Two things trigger emptying the queue of subjects to classify:

- Sign in or out, because a user might have seen or not seen the queued-up subjects.

- Adding or removing from a subject set, because a queued-up subject might have just been removed, or a user might have seen all the existing subjects and they want to see the classification interface after they've added more.

I'm not crazy about firing off a custom event in the second case, but it works for now. Maybe the subjects-to-classify queue should be broken out into a separate module in the future.

Closes #561.