### PR TITLE
Remove home page specific typography rules

### DIFF
--- a/css/home-page.styl
+++ b/css/home-page.styl
@@ -27,7 +27,7 @@
 
     .hero-tagline
       color: inherit
-      font-size: 1.6em
+      font-size: 1.1em
       line-height: 22px
       margin: 0 auto
       max-width: 600px
@@ -35,7 +35,7 @@
 
     .hero-button
       color: #fbfbfb
-      font-size: 1.6em
+      font-size: 1.1em
       font-weight: 400
       margin-bottom: 3vh
 

--- a/css/typography.styl
+++ b/css/typography.styl
@@ -42,9 +42,6 @@ h6
   margin: 0
 
 .on-home-page
-  font-size: 10px
-  line-height: 20px
-
   h1,
   h2,
   h3,


### PR DESCRIPTION
- Home page specific typography rules causing the dialog to render incorrectly.
- Removed them so the font size baseline is the same on the home page as everywhere else.

Before:
![](http://i.imgur.com/IuAlCPA.png)

After:
![](http://i.imgur.com/TMdpK81.png)
