### PR TITLE
Roles in talk user display

### DIFF
--- a/app/talk/comment.cjsx
+++ b/app/talk/comment.cjsx
@@ -16,6 +16,7 @@ apiClient = require '../api/client'
 talkClient = require '../api/talk'
 Avatar = require '../partials/avatar'
 SubjectViewer = require '../components/subject-viewer'
+DisplayRoles = require './lib/display-roles'
 
 DEFAULT_AVATAR = './assets/simple-avatar.jpg'
 
@@ -86,18 +87,16 @@ module?.exports = React.createClass
     <div className="talk-comment #{activeClass}">
       <div className="talk-comment-author">
         <PromiseRenderer promise={apiClient.type('users').get(id: @props.data.user_id).index(0)}>{(commentOwner) =>
-          <div>
-            <Avatar user={commentOwner} />
-            <PromiseRenderer promise={talkClient.type('roles').get(id: @props.data.user_id, section: @props.data.section)}>{(roles) =>
-              console.log(commentOwner.display_name, roles, @props.data.section)
-              <p>Print roles to screen here</p>
-            }</PromiseRenderer>
-          </div>
+          <Avatar user={commentOwner} />
         }</PromiseRenderer>
 
         <p>
           <Link to="user-profile" params={name: @props.data.user_login}>{@props.data.user_display_name}</Link>
         </p>
+
+        <PromiseRenderer promise={talkClient.type('roles').get(user_id: @props.data.user_id, section: ['zooniverse', @props.data.section])}>{(roles) =>
+          <DisplayRoles roles={roles} section={@props.data.section} />
+        }</PromiseRenderer>
       </div>
 
       <div className="talk-comment-body">

--- a/app/talk/comment.cjsx
+++ b/app/talk/comment.cjsx
@@ -13,6 +13,7 @@ PromiseToSetState = require '../lib/promise-to-set-state'
 {Link} = require 'react-router'
 {timestamp} = require './lib/time'
 apiClient = require '../api/client'
+talkClient = require '../api/talk'
 Avatar = require '../partials/avatar'
 SubjectViewer = require '../components/subject-viewer'
 
@@ -85,7 +86,13 @@ module?.exports = React.createClass
     <div className="talk-comment #{activeClass}">
       <div className="talk-comment-author">
         <PromiseRenderer promise={apiClient.type('users').get(id: @props.data.user_id).index(0)}>{(commentOwner) =>
-          <Avatar user={commentOwner} />
+          <div>
+            <Avatar user={commentOwner} />
+            <PromiseRenderer promise={talkClient.type('roles').get(id: @props.data.user_id, section: @props.data.section)}>{(roles) =>
+              console.log(commentOwner.display_name, roles, @props.data.section)
+              <p>Print roles to screen here</p>
+            }</PromiseRenderer>
+          </div>
         }</PromiseRenderer>
 
         <p>

--- a/app/talk/discussion.cjsx
+++ b/app/talk/discussion.cjsx
@@ -17,6 +17,7 @@ Moderation = require './lib/moderation'
 {Link} = require 'react-router'
 merge = require 'lodash.merge'
 Avatar = require '../partials/avatar'
+DisplayRoles = require './lib/display-roles'
 
 PAGE_SIZE = 3
 
@@ -182,13 +183,16 @@ module?.exports = React.createClass
 
       <ChangeListener target={authClient}>{=>
         <PromiseRenderer promise={authClient.checkCurrent()}>{(user) =>
-          if user
+          if user?
             <section>
               <div className="talk-comment-author">
                 <Avatar user={user} />
                 <p>
                   <Link to="user-profile" params={name: user.login}>{user.display_name}</Link>
                 </p>
+                <PromiseRenderer promise={talkClient.type('roles').get(user_id: user.id, section: ['zooniverse', discussion.section])}>{(roles) =>
+                  <DisplayRoles roles={roles} section={discussion.section} />
+                }</PromiseRenderer>
               </div>
 
               <CommentBox

--- a/app/talk/lib/display-roles.cjsx
+++ b/app/talk/lib/display-roles.cjsx
@@ -1,0 +1,37 @@
+React = require 'react'
+
+zooniverseAdminRole = (role) ->
+  role.section is 'zooniverse' and role.name is 'admin'
+
+researcherRole = (role) ->
+  userIsResearcher = ['admin', 'scientist', 'owner'].indexOf(role.name) isnt -1
+  role.section isnt 'zooniverse' and userIsResearcher
+
+getDisplayRoles = (roles, section) ->
+  roles.reduce((roleList, role) ->
+    if zooniverseAdminRole(role) # show zooniverse admins everywhere as 'team'
+      roleList.concat "Zooniverse Team"
+    else if researcherRole(role) # project admins, scientists, owners
+      roleList.concat "Researcher"
+    else if (role.section is section) # other current section roles
+      roleList.concat role.name
+  , [])
+
+DisplayRoles = React.createClass
+  displayName: 'TalkDisplayRoles'
+
+  propTypes:
+    roles: React.PropTypes.array    # roles resources
+    section: React.PropTypes.string # talk section
+
+  roleName: (name, i) ->
+    <p key={i} className="project-role">{name}</p>
+
+  render: ->
+    roleNames = getDisplayRoles(@props.roles, @props.section)
+
+    <div className="talk-display-roles">
+      {roleNames.map(@roleName)}
+    </div>
+
+module?.exports = DisplayRoles


### PR DESCRIPTION
- Display user role titles under avatar in talk comments
- `Zooniverse Team`, `Researcher` & `Moderator` are the initial set per @DarrenMcRoy 
- `Researcher` is a term that umbrellas project-admins, scientists, & project-owners
- Closes #578 
- Closes #553