### PR TITLE
Show open connections

### DIFF
--- a/app/main.cjsx
+++ b/app/main.cjsx
@@ -4,6 +4,7 @@ window.React = React
 Router = {RouteHandler, DefaultRoute, Route, NotFoundRoute} = require 'react-router'
 MainHeader = require './partials/main-header'
 MainFooter = require './partials/main-footer'
+IOStatus = require './partials/io-status'
 
 logDeployedCommit = require './lib/log-deployed-commit'
 logDeployedCommit()
@@ -18,6 +19,7 @@ App = React.createClass
         <RouteHandler {...@props} />
       </div>
       <MainFooter />
+      <IOStatus />
     </div>
 
 routes = <Route handler={App}>

--- a/app/main.cjsx
+++ b/app/main.cjsx
@@ -14,12 +14,12 @@ App = React.createClass
 
   render: ->
     <div className="panoptes-main">
+      <IOStatus />
       <MainHeader />
       <div className="main-content">
         <RouteHandler {...@props} />
       </div>
       <MainFooter />
-      <IOStatus />
     </div>
 
 routes = <Route handler={App}>

--- a/app/partials/io-status.cjsx
+++ b/app/partials/io-status.cjsx
@@ -6,17 +6,18 @@ module.exports = React.createClass
   displayName: 'IOStatus'
 
   render: ->
-    <ChangeListener target={apiClient} handler={@really} />
+    <ChangeListener target={apiClient}>{=>
+      {reads, writes} = apiClient
 
-  really: ->
-    <span className="io-status">
-      <span style={opacity: 0.4 if apiClient.reads is 0}>
-        <i className="fa fa-chevron-down fa-fw"></i>
-        {apiClient.reads}
+      <span className="io-status" style={pointerEvents: 'none'}>
+        <span style={opacity: 0.3 if reads is 0}>
+          <i className="fa fa-chevron-down fa-fw"></i>
+          {reads}
+        </span>
+        {' '}
+        <span style={opacity: 0.3 if writes is 0}>
+          <i className="fa fa-chevron-up fa-fw"></i>
+          {writes}
+        </span>
       </span>
-      {' '}
-      <span style={opacity: 0.3 if apiClient.reads is 0}>
-        <i className="fa fa-chevron-up fa-fw"></i>
-        {apiClient.writes}
-      </span>
-    </span>
+    }</ChangeListener>

--- a/app/partials/io-status.cjsx
+++ b/app/partials/io-status.cjsx
@@ -1,23 +1,74 @@
 React = require 'react'
-ChangeListener = require '../components/change-listener'
 apiClient = require '../api/client'
 
 module.exports = React.createClass
   displayName: 'IOStatus'
 
-  render: ->
-    <ChangeListener target={apiClient}>{=>
-      {reads, writes} = apiClient
+  getDefaultProps: ->
+    target: apiClient
+    style:
+      background: 'rgba(0, 0, 0, 0.5)'
+      borderRadius: '0 0 0.3em 0.3em'
+      color: 'white'
+      fontSize: '11px'
+      fontWeight: 'bold'
+      left: '50%'
+      padding: '0 1.5em'
+      position: 'fixed'
+      textTransform: 'uppercase'
+      top: 0
+      transform: 'translateX(-50%)'
 
-      <span className="io-status" style={pointerEvents: 'none'}>
+  getInitialState: ->
+    reads: @props.target.reads
+    writes: @props.target.writes
+
+  componentDidMount: ->
+    console.log 'IOStatus componentDidMount'
+    @props.target.listen 'change', @handleTargetChange
+
+  componentWillReceiveProps: (nextProps) ->
+    console.log 'IOStatus componentWillReceiveProps'
+    @props.target.stopListening 'change', @handleTargetChange
+    nextProps.target.listen 'change', @handleTargetChange
+
+  componentWillUnmount: ->
+    console.log 'IOStatus componentWillUnmount'
+    @props.target.stopListening 'change', @handleTargetChange
+
+  handleTargetChange: ->
+    setTimeout => # TODO: I have no idea why this is necessary.
+      {reads, writes} = @props.target
+      console.log 'IOStatus handleTargetChange', this, {reads, writes}
+      @setState {reads, writes}
+
+  render: ->
+    {reads, writes} = @state
+
+    console.log 'IOStatus render', {reads, writes}
+
+    rootStyle =
+      pointerEvents: 'none'
+      zIndex: 1
+    if reads is 0 and writes is 0
+      rootStyle.display = 'none'
+
+    <span style={rootStyle}>
+      <span className="io-status" style={@props.style}>
+        <span style={visibility: 'hidden' if reads is 0 and writes is 0}>
+          <i className="fa fa-spinner fa-spin fa-fw"></i>
+        </span>
+        {' '}
+        Loading
+        &ensp;
         <span style={opacity: 0.3 if reads is 0}>
           <i className="fa fa-chevron-down fa-fw"></i>
           {reads}
         </span>
-        {' '}
+        &ensp;
         <span style={opacity: 0.3 if writes is 0}>
           <i className="fa fa-chevron-up fa-fw"></i>
           {writes}
         </span>
       </span>
-    }</ChangeListener>
+    </span>

--- a/app/partials/io-status.cjsx
+++ b/app/partials/io-status.cjsx
@@ -1,0 +1,22 @@
+React = require 'react'
+ChangeListener = require '../components/change-listener'
+apiClient = require '../api/client'
+
+module.exports = React.createClass
+  displayName: 'IOStatus'
+
+  render: ->
+    <ChangeListener target={apiClient} handler={@really} />
+
+  really: ->
+    <span className="io-status">
+      <span style={opacity: 0.4 if apiClient.reads is 0}>
+        <i className="fa fa-chevron-down fa-fw"></i>
+        {apiClient.reads}
+      </span>
+      {' '}
+      <span style={opacity: 0.3 if apiClient.reads is 0}>
+        <i className="fa fa-chevron-up fa-fw"></i>
+        {apiClient.writes}
+      </span>
+    </span>

--- a/app/partials/io-status.cjsx
+++ b/app/partials/io-status.cjsx
@@ -24,28 +24,22 @@ module.exports = React.createClass
     writes: @props.target.writes
 
   componentDidMount: ->
-    console.log 'IOStatus componentDidMount'
     @props.target.listen 'change', @handleTargetChange
 
   componentWillReceiveProps: (nextProps) ->
-    console.log 'IOStatus componentWillReceiveProps'
     @props.target.stopListening 'change', @handleTargetChange
     nextProps.target.listen 'change', @handleTargetChange
 
   componentWillUnmount: ->
-    console.log 'IOStatus componentWillUnmount'
     @props.target.stopListening 'change', @handleTargetChange
 
   handleTargetChange: ->
     setTimeout => # TODO: I have no idea why this is necessary.
       {reads, writes} = @props.target
-      console.log 'IOStatus handleTargetChange', this, {reads, writes}
       @setState {reads, writes}
 
   render: ->
     {reads, writes} = @state
-
-    console.log 'IOStatus render', {reads, writes}
 
     rootStyle =
       pointerEvents: 'none'

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "counterpart": "~0.16.7",
     "data-uri-to-blob": "0.0.4",
     "debounce": "~1.0.0",
-    "json-api-client": "~0.2.10",
+    "json-api-client": "~0.3.0",
     "lodash.merge": "~2.4.1",
     "markdown-it": "~4.0.1",
     "markdown-it-container": "~1.0.0",


### PR DESCRIPTION
This is just a little box that pops up when there's a server connection open that tells the user how many requests the front end is waiting on. I think it'll help reduce confusion about when things are saving. I'd like to see what folks think.

Depends on a new version of the JSONAPIClient, so `npm install`.

Ran into some nasty behavior solved by the noted timeout. I'm thinking it has to do with the router, but I couldn't track it all the way down. I think the timeout is fine for now.