### PR TITLE
Force polygon completion when switching tools

### DIFF
--- a/app/classifier/drawing-tools/polygon.cjsx
+++ b/app/classifier/drawing-tools/polygon.cjsx
@@ -30,6 +30,9 @@ module.exports = React.createClass
     isComplete: (mark) ->
       mark.closed
 
+    forceComplete: (mark) ->
+      mark.closed = true
+
   render: ->
     averageScale = (@props.scale.horizontal + @props.scale.vertical) / 2
     finisherRadius = FINISHER_RADIUS / averageScale


### PR DESCRIPTION
Tools can now define a `forceComplete` function that'll run on any unfinished marks when switching tools.

Currently only applies to the polygon tool. Closes #228.