### PR TITLE
Update projects listing query

### DIFF
--- a/app/pages/projects.cjsx
+++ b/app/pages/projects.cjsx
@@ -9,6 +9,7 @@ counterpart.registerTranslations 'en',
     title: 'All Projects'
     countMessage: 'Showing %(count)s found'
     button: 'Get Started'
+    notFoundMessage: 'Sorry, no projects found'
 
 module.exports = React.createClass
   displayName: 'ProjectsPage'

--- a/app/pages/projects.cjsx
+++ b/app/pages/projects.cjsx
@@ -19,11 +19,10 @@ module.exports = React.createClass
   title: 'Projects'
 
   listProjects: ->
-    query = Object.create @props.query ? {}
-    query.private ?= false
-    query.beta ?= true # Temporary
-    query.approved ?= true
-    query.include ?= 'owners,avatar'
+    query =
+      launch_approved: true
+      include:'owners,avatar'
+    Object.assign query, @props.query
 
     apiClient.type('projects').get query
 


### PR DESCRIPTION
I think this is right. Projects can't be `launch_approved` without being `live`, correct?

Try `/?env=production#/projects` on a locally-running client to see this with some projects.