### PR TITLE
Filter talk roles by visibility

### DIFF
--- a/app/talk/comment.cjsx
+++ b/app/talk/comment.cjsx
@@ -94,7 +94,7 @@ module?.exports = React.createClass
           <Link to="user-profile" params={name: @props.data.user_login}>{@props.data.user_display_name}</Link>
         </p>
 
-        <PromiseRenderer promise={talkClient.type('roles').get(user_id: @props.data.user_id, section: ['zooniverse', @props.data.section])}>{(roles) =>
+        <PromiseRenderer promise={talkClient.type('roles').get(user_id: @props.data.user_id, section: ['zooniverse', @props.data.section], is_shown: true)}>{(roles) =>
           <DisplayRoles roles={roles} section={@props.data.section} />
         }</PromiseRenderer>
       </div>

--- a/app/talk/discussion.cjsx
+++ b/app/talk/discussion.cjsx
@@ -190,7 +190,7 @@ module?.exports = React.createClass
                 <p>
                   <Link to="user-profile" params={name: user.login}>{user.display_name}</Link>
                 </p>
-                <PromiseRenderer promise={talkClient.type('roles').get(user_id: user.id, section: ['zooniverse', discussion.section])}>{(roles) =>
+                <PromiseRenderer promise={talkClient.type('roles').get(user_id: user.id, section: ['zooniverse', discussion.section], is_shown: true)}>{(roles) =>
                   <DisplayRoles roles={roles} section={discussion.section} />
                 }</PromiseRenderer>
               </div>


### PR DESCRIPTION
This supports the use case of a collaborator needing a role, but not wanting to be publicly identified as that role -- e.g. a scientist needs moderation access, but only wants to be known as a researcher.