### PR TITLE
Delete subject if an error occurred in creation steps

### DIFF
--- a/app/partials/subject-uploader.cjsx
+++ b/app/partials/subject-uploader.cjsx
@@ -77,6 +77,8 @@ module.exports = React.createClass
             uploads: @state.uploads.concat success
             batch: @state.batch.concat subject
         .catch (error) =>
+          subject.delete()
+
           @setState
             errors: @state.errors.concat error
         .then =>


### PR DESCRIPTION
- Closes #510 
- The catch block should trigger when any error in thrown during the upload process. If this happen, delete the subject from the subject set.