### PR TITLE
Fix image uploaders

### DIFF
--- a/app/components/image-selector.cjsx
+++ b/app/components/image-selector.cjsx
@@ -2,9 +2,15 @@ React = require 'react'
 LoadingIndicator = require './loading-indicator'
 toBlob = require 'data-uri-to-blob'
 
-BASE_64_PNG_HEAD = 'data:image/png;base64,'
-BASE_64_JPEG_HEAD = 'data:image/jpeg;base64,'
 BASE_64_EXPANSION = 3 / 4
+
+DEFAULT_STYLE =
+  display: 'inline-block'
+  minHeight: '1em'
+  background: 'rgba(128, 128, 128, 0.2)'
+  border: '1px solid rgba(128, 128, 128, 0.4)'
+  borderRadius: 5
+  position: 'relative'
 
 module.exports = React.createClass
   displayName: 'ImageSelector'
@@ -13,17 +19,15 @@ module.exports = React.createClass
     accept: 'image/*'
     maxSize: Infinity # In bytes
     ratio: NaN # Width / height
+    defaultValue: ''
     placeholder: ''
-    quality: 0.8 # For JPEGs
-    minArea: 100 # Stop reducing when there are fewer than this many pixels.
+    minArea: 300 # Stop reducing when there are fewer than this many pixels.
     reductionPerPass: 0.05
     onChange: Function.prototype # No-op
 
   getInitialState: ->
     working: false
     dataURL: ''
-    format: ''
-    size: NaN
 
   render: ->
     <span className="image-selector">
@@ -61,21 +65,17 @@ module.exports = React.createClass
   handleChange: (e) ->
     [file] = e.target.files
 
-    @setState
-      working: true
-      format: ''
-      size: NaN
+    @setState working: true
 
     reader = new FileReader
     reader.onload = (e) =>
       img = new Image
-      img.title = file.name
       img.onload = =>
-        @cropImage img
+        @cropImage img, file
       img.src = e.target.result
     reader.readAsDataURL file
 
-  cropImage: (srcImg) ->
+  cropImage: (srcImg, srcFile) ->
     canvas = document.createElement 'canvas'
     canvas.width = srcImg.naturalWidth
     canvas.height = srcImg.naturalHeight
@@ -91,12 +91,11 @@ module.exports = React.createClass
     ctx.drawImage srcImg, (srcImg.naturalWidth - canvas.width) / -2, (srcImg.naturalHeight - canvas.height) / -2
 
     croppedImg = new Image
-    croppedImg.title = srcImg.title
     croppedImg.onload = =>
-      @reduceImage croppedImg
+      @reduceImage croppedImg, srcFile
     croppedImg.src = canvas.toDataURL()
 
-  reduceImage: (img, _scale = 1) ->
+  reduceImage: (img, srcFile, _scale = 1) ->
     canvas = document.createElement 'canvas'
     canvas.width = img.naturalWidth * _scale
     canvas.height = img.naturalHeight * _scale
@@ -104,25 +103,24 @@ module.exports = React.createClass
     ctx = canvas.getContext '2d'
     ctx.drawImage img, 0, 0, img.naturalWidth, img.naturalHeight, 0, 0, canvas.width, canvas.height
 
-    pngURL = canvas.toDataURL 'image/png'
-    pngSize = Math.round (pngURL.length - BASE_64_PNG_HEAD.length) * BASE_64_EXPANSION
+    dataURL = canvas.toDataURL srcFile.type
+    @setState {dataURL}
 
-    jpegURL = canvas.toDataURL 'image/jpeg', @props.quality
-    jpegSize = Math.round (jpegURL.length - BASE_64_JPEG_HEAD.length) * BASE_64_EXPANSION
+    try
+      size = dataURL.split(';base64,')[1].length * BASE_64_EXPANSION
 
-    # NOTE: In Chrome at least, PNG is always pretty huge.
-    # I think it might not be doing any compression or something.
+      if size > @props.maxSize and canvas.width * canvas.height > @props.minArea
+        # Keep trying until it's small enough.
+        @reduceImage img, srcFile, _scale - @props.reductionPerPass
+      else
+        @setState working: false
 
-    [dataURL, format, size] = if pngSize < jpegSize
-      [pngURL, 'image/png', pngSize]
-    else
-      [jpegURL, 'image/jpeg', jpegSize]
+        img.title = srcFile.name
+        @props.onChange toBlob(dataURL), img
 
-    @setState {dataURL, format, size}
+    catch
+      @setState
+        dataURL: ''
+        working: false
 
-    if size > @props.maxSize and canvas.width * canvas.height > @props.minArea
-      # Keep trying until it's small enough.
-      @reduceImage img, _scale - @props.reductionPerPass
-    else
-      @setState working: false
-      @props.onChange toBlob(dataURL), img
+      alert 'Error reducing image. Try a smaller one.'

--- a/app/components/image-selector.cjsx
+++ b/app/components/image-selector.cjsx
@@ -4,14 +4,6 @@ toBlob = require 'data-uri-to-blob'
 
 BASE_64_EXPANSION = 3 / 4
 
-DEFAULT_STYLE =
-  display: 'inline-block'
-  minHeight: '1em'
-  background: 'rgba(128, 128, 128, 0.2)'
-  border: '1px solid rgba(128, 128, 128, 0.4)'
-  borderRadius: 5
-  position: 'relative'
-
 module.exports = React.createClass
   displayName: 'ImageSelector'
 


### PR DESCRIPTION
Image uploader no longer tries to switch formats. It should end up with more sensible images, so this closes #655. We can re-open if it doesn't help, but then the only thing we can do is reject images that's too large, which I feel like would be annoying.