### PR TITLE
Disable live workflow editing

### DIFF
--- a/app/pages/lab/project.cjsx
+++ b/app/pages/lab/project.cjsx
@@ -83,7 +83,7 @@ EditProjectPage = React.createClass
                   <ChangeListener key={workflow.id} target={workflow} eventName="save" handler={renderWorkflowListItem.bind this, workflow} />}
 
                 <li className="nav-list-item">
-                  <button type="button" onClick={@createNewWorkflow} disabled={@state.workflowCreationInProgress} title="A workflow is the sequence of tasks that you’re asking volunteers to perform.">
+                  <button type="button" onClick={@createNewWorkflow} disabled={@props.project.live or @state.workflowCreationInProgress} title="A workflow is the sequence of tasks that you’re asking volunteers to perform.">
                     New workflow{' '}
                     <LoadingIndicator off={not @state.workflowCreationInProgress} />
                   </button>{' '}

--- a/app/pages/lab/workflow.cjsx
+++ b/app/pages/lab/workflow.cjsx
@@ -26,9 +26,15 @@ EditWorkflowPage = React.createClass
     selectedTaskKey: @props.workflow.first_task
 
   render: ->
+    disabledStyle =
+      opacity: 0.4
+      pointerEvents: 'none'
+
     <div>
       <p className="form-help">A workflow is the sequence of tasks that you’re asking volunteers to perform. For example, you might want to ask volunteers to answer questions about your images, or to mark features in your images, or both.</p>
-      <div className="columns-container">
+      {if @props.project.live
+        <p className="form-help warning"><strong>You cannot edit a project’s workflows once it’s gone live.</strong></p>}
+      <div className="columns-container" style={disabledStyle if @props.project.live}>
         <div className="column">
           <div>
             <AutoSave tag="label" resource={@props.workflow}>


### PR DESCRIPTION
Here's a quick hack for disabling workflow editors on live projects.

We should go back later and disable these controls for real, or replace the editor with something else.

Closes #673.

@edpaget I think this should be enforced on the back end too.