### PR TITLE
Lock json-api-client to v3.0.0 until fixed

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "counterpart": "~0.16.7",
     "data-uri-to-blob": "0.0.4",
     "debounce": "~1.0.0",
-    "json-api-client": "~0.3.0",
+    "json-api-client": "0.3.0",
     "lodash.merge": "~2.4.1",
     "markdown-it": "~4.0.1",
     "markdown-it-container": "~1.0.0",


### PR DESCRIPTION
- Version update cause of #763 #765 and possibly #764
- https://github.com/zooniverse/json-api-client/issues/5