### PR TITLE
Hide empty feed and stats pages. Redirect depending on current user

### DIFF
--- a/app/main.cjsx
+++ b/app/main.cjsx
@@ -41,7 +41,7 @@ routes = <Route handler={App}>
   <Route name="privacy" handler={require './pages/privacy-policy'} />
 
   <Route name="user-profile" path="users/:name" handler={require './pages/profile'}>
-    <DefaultRoute name="user-profile-feed" handler={require './pages/profile/feed'} />
+    <DefaultRoute name="user-profile-private-message" handler={require './pages/profile/private-message'} />
     <Route name="user-profile-stats" path="stats" handler={require './pages/profile/stats'} />
  </Route>
 

--- a/app/pages/profile/index.cjsx
+++ b/app/pages/profile/index.cjsx
@@ -70,8 +70,6 @@ UserProfilePage = React.createClass
               />
           }</PromiseRenderer>
           <nav className="hero-nav">
-            <Link to="user-profile-feed" params={name: @props.params.name}><Translate content="profile.nav.feed" /></Link>
-            <Link to="user-profile-stats" params={name: @props.params.name}><Translate content="profile.nav.stats" /></Link>
             <Link to="collections-user" params={owner: @props.params.name}><Translate content="profile.nav.collections" /></Link>
             <PromiseRenderer promise={authClient.checkCurrent()} pending={null}>{(currentUser) =>
               if currentUser?
@@ -85,11 +83,7 @@ UserProfilePage = React.createClass
       </section>
 
       <section className="user-profile-content">
-        <RouteHandler />
-        <PromiseRenderer promise={authClient.checkCurrent()} pending={null}>{(user) =>
-          if user?.login isnt @props.params?.name
-            <PrivateMessageForm {...@props} />
-        }</PromiseRenderer>
+        <RouteHandler params={@props.params} />
       </section>
     </div>
 

--- a/app/pages/profile/private-message.cjsx
+++ b/app/pages/profile/private-message.cjsx
@@ -1,0 +1,29 @@
+counterpart = require 'counterpart'
+React = require 'react'
+PrivateMessageForm = require '../../talk/private-message-form'
+PromiseRenderer = require '../../components/promise-renderer'
+authClient = require '../../api/auth'
+{Navigation} = require 'react-router'
+
+
+module.exports = React.createClass
+  displayName: 'PrivateMessagePage'
+  mixins: [Navigation]
+
+  render: ->
+    <PromiseRenderer promise={authClient.checkCurrent()} pending={null}>{(user) =>
+      if user?
+        if user?.login isnt @props.params?.name
+          <PrivateMessageForm {...@props} />
+        else
+          @redirectToMessages()
+      else
+        @redirectToCollections()
+    }</PromiseRenderer>
+
+  redirectToMessages: ->
+    @transitionTo 'inbox'
+
+  redirectToCollections: ->
+    @transitionTo 'collections-user', owner: @props.params?.name
+

--- a/app/partials/account-bar.cjsx
+++ b/app/partials/account-bar.cjsx
@@ -43,7 +43,6 @@ module.exports = React.createClass
           <Link to="inbox" params={name: @props.user.login} className="message-link"><i className="fa fa-envelope#{if @state.unread then '' else '-o'}" /> </Link>
         </div>
         <div className="account-menu" ref="accountMenu">
-          <Link to="user-profile" params={name: @props.user.login}><Translate content="accountMenu.profile" /></Link>
           <Link to="settings" params={name: @props.user.login}><Translate content="accountMenu.settings" /></Link>
           <Link to="collections-user" params={{owner: @props.user.login}}>
             <Translate content="accountMenu.collections" />

--- a/css/main-header.styl
+++ b/css/main-header.styl
@@ -8,10 +8,12 @@
   .on-home-page &
     position: absolute
     width: 100%
+    z-index: 1
 
   .on-secondary-page &
     position: absolute
     width: 100%
+    z-index: 1
 
   a
     text-decoration: none

--- a/css/owned-card.styl
+++ b/css/owned-card.styl
@@ -59,7 +59,7 @@
   max-height: 445px
 
   svg
-    height: 210px
+    height: 215px
 
   .details
     height: 200px


### PR DESCRIPTION
- Hides feed and stats out of nav
- Pulls private message into its own component and sets it as default route
  - Redirects to a user's collections if logged out
  - Redirects to inbox if logged in and name param matches current user
- Fixed #797, fixed #749