### PR TITLE
More durable external link checking

### DIFF
--- a/app/pages/projects.cjsx
+++ b/app/pages/projects.cjsx
@@ -31,8 +31,12 @@ module.exports = React.createClass
       .then (avatar) -> avatar.src
 
   cardLink: (project) ->
-    link = project.redirect
-    link ?= 'project-home'
+    link = if !!project.redirect
+      project.redirect
+    else
+      'project-home'
+
+    return link
 
   render: ->
     <OwnedCardList


### PR DESCRIPTION
- `project.redirect` somes back sometimes as `null`, sometimes as an empty string. This handles both those cases.