### PR TITLE
Form for quick object comments

### DIFF
--- a/app/subjects/index.cjsx
+++ b/app/subjects/index.cjsx
@@ -11,7 +11,11 @@ NewDiscussionForm = require '../talk/discussion-new-form'
 CommentLink = require '../talk/comment-link'
 projectSection = require '../talk/lib/project-section'
 parseSection = require '../talk/lib/parse-section'
+QuickSubjectCommentForm= require '../talk/quick-subject-comment-form'
 {Navigation} = require 'react-router'
+
+indexOf = (elem) ->
+  (elem while elem = elem.previousSibling).length
 
 module?.exports = React.createClass
   displayName: 'Subject'
@@ -19,6 +23,7 @@ module?.exports = React.createClass
 
   getInitialState: ->
     subject: null
+    tab: 0
 
   componentWillMount: ->
     @setSubject()
@@ -70,15 +75,39 @@ module?.exports = React.createClass
 
           <ChangeListener target={authClient}>{=>
             <PromiseRenderer promise={authClient.checkCurrent()}>{(user) =>
-              if user?
+              if user
                 {# these wrapping promises ensure that there are boards for a project}
                 {# & could be removed if a default board is put in place}
+                {# TODO remove subject.get('project'), replace with params but browser freezes on get to projects with slug}
                 <PromiseRenderer promise={subject.get('project')}>{(project) =>
                   <PromiseRenderer promise={talkClient.type('boards').get(section: projectSection(project))}>{(boards) =>
                     if boards?.length
-                      <NewDiscussionForm
-                        subject={subject}
-                        onCreateDiscussion={@onCreateDiscussion} />
+                      <div>
+                        <div className="tabbed-content">
+                          <div className="tabbed-content-tabs">
+                            <div className="subject-page-tabs">
+                              <div className="tabbed-content-tab #{if @state.tab is 0 then 'active' else ''}" onClick={=> @setState({tab: 0})}>
+                                <span>Add a note about this subject</span>
+                              </div>
+
+                              <div className="tabbed-content-tab #{if @state.tab is 1 then 'active' else ''}" onClick={=> @setState({tab: 1})}>
+                                <span>or Start a new discussion</span>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                        <div>
+                          {if @state.tab is 0
+                            <QuickSubjectCommentForm subject={subject} user={user} />
+                           else if @state.tab is 1
+                            <NewDiscussionForm
+                              subject={subject}
+                              onCreateDiscussion={@onCreateDiscussion} />
+                              }
+                        </div>
+                      </div>
+                    else
+                      <p>There are no discussion boards setup for this project yet. Check back soon!</p>
                   }</PromiseRenderer>
                 }</PromiseRenderer>
             }</PromiseRenderer>

--- a/app/talk/comment-link.cjsx
+++ b/app/talk/comment-link.cjsx
@@ -5,13 +5,9 @@ PromiseRenderer = require '../components/promise-renderer'
 parseSection = require '../talk/lib/parse-section'
 {Link, Navigation} = require 'react-router'
 
-PAGE_SIZE = 3
+PAGE_SIZE = 10
 
-getPageOfComment = (comment, discussion, pageSize) ->
-  # comment resource, discussion resource, integer
-  comments = discussion.links.comments
-  commentNumber = comments.indexOf(comment.id.toString()) + 1
-  Math.ceil commentNumber / pageSize
+getPageOfComment = require './lib/get-page-of-comment'
 
 module?.exports = React.createClass
   displayName: 'TalkCommentLink'

--- a/app/talk/comment.cjsx
+++ b/app/talk/comment.cjsx
@@ -138,9 +138,7 @@ module?.exports = React.createClass
               <button className="talk-comment-link-button" onClick={@onClickLink}>
                 <i className="fa fa-link" /> Link
               </button>
-              <button className="talk-comment-report-button" onClick={@onClickReport}>
-                <i className="fa fa-warning" /> Report
-              </button>
+              {#TODO <button className="talk-comment-report-button" onClick={@onClickReport}><i className="fa fa-warning" /> Report</button>#}
               {if +@props.data?.user_id is +@props.user?.id
                 <span>
                   <button className="talk-comment-edit-button" onClick={@onClickEdit}>

--- a/app/talk/comment.cjsx
+++ b/app/talk/comment.cjsx
@@ -44,7 +44,8 @@ module?.exports = React.createClass
       React.findDOMNode(@).scrollIntoView()
 
   onClickReply: (e) ->
-    @props.onClickReply(@props.user, @props.data)
+    apiClient.type('users').get(id: @props.data.user_id).index(0).then (commentOwner) =>
+      @props.onClickReply(commentOwner, @props.data)
 
   onClickLink: (e) ->
     @toggleComponent('link')

--- a/app/talk/discussion.cjsx
+++ b/app/talk/discussion.cjsx
@@ -19,7 +19,7 @@ merge = require 'lodash.merge'
 Avatar = require '../partials/avatar'
 DisplayRoles = require './lib/display-roles'
 
-PAGE_SIZE = 3
+PAGE_SIZE = 10
 
 module?.exports = React.createClass
   displayName: 'TalkDiscussion'

--- a/app/talk/inbox.cjsx
+++ b/app/talk/inbox.cjsx
@@ -72,7 +72,7 @@ module?.exports = React.createClass
       else if not user
         <p>Please sign in to view your inbox</p>
       else if conversations?.length is 0
-        <p>You have not started any private conversations yet</p>
+        <p>You have not started any private conversations yet. Send users private messages by visiting their profile page.'</p>
       else if conversations?.length
         <div>
           {conversations?.map(@conversationLink)}

--- a/app/talk/init.cjsx
+++ b/app/talk/init.cjsx
@@ -13,6 +13,9 @@ auth = require '../api/auth'
 {Link} = require 'react-router'
 Loading = require '../components/loading-indicator'
 
+DEFAULT_BOARD_TITLE = 'Notes'            # Name of board to put subject comments
+DEFAULT_BOARD_DESCRIPTION = 'General comment threads about individual subjects'
+
 module?.exports = React.createClass
   displayName: 'TalkInit'
 
@@ -74,24 +77,47 @@ module?.exports = React.createClass
   roleWriteLabel: (data, i) ->
     <label key={i}><input type="radio" name="role-write" defaultChecked={i is ROLES.length-1}value={data}/>{data}</label>
 
+  createSubjectDefaultBoard: ->
+    board = {
+      title: DEFAULT_BOARD_TITLE,
+      description: DEFAULT_BOARD_DESCRIPTION
+      subject_default: true,
+      permissions: {read: 'all', write: 'all'}
+      section: @props.section
+      }
+
+    talkClient.type('boards').create(board).save()
+      .then (board) =>
+        console.log "board", board
+        @setBoards()
+
   render: ->
     <div className="talk-home">
       <Moderation section={@props.section}>
-        <form onSubmit={@onSubmitBoard}>
+        <div>
           <h2>Moderator Zone:</h2>
-          <h3>Add a board:</h3>
-          <input type="text" ref="boardTitle" placeholder="Board Title"/>
+          {if @props.section isnt 'zooniverse'
+            <PromiseRenderer promise={talkClient.type('boards').get({section: @props.section, subject_default: true}).index(0)}>{(defaultBoard) =>
+              if not defaultBoard?
+                <button onClick={@createSubjectDefaultBoard}><i className="fa fa-photo" /> Activate Talk Subject Comments Board</button>
+            }</PromiseRenderer>
+            }
 
-          <textarea ref="boardDescription" placeholder="Board Description"></textarea><br />
+          <form onSubmit={@onSubmitBoard}>
+            <h3>Add a board:</h3>
+            <input type="text" ref="boardTitle" placeholder="Board Title"/>
 
-          <h4>Can Read:</h4>
-          <div className="roles-read">{ROLES.map(@roleReadLabel)}</div>
+            <textarea ref="boardDescription" placeholder="Board Description"></textarea><br />
 
-          <h4>Can Write:</h4>
-          <div className="roles-write">{ROLES.map(@roleWriteLabel)}</div>
+            <h4>Can Read:</h4>
+            <div className="roles-read">{ROLES.map(@roleReadLabel)}</div>
 
-          <button type="submit"><i className="fa fa-plus-circle" /> Create Board</button>
-        </form>
+            <h4>Can Write:</h4>
+            <div className="roles-write">{ROLES.map(@roleWriteLabel)}</div>
+
+            <button type="submit"><i className="fa fa-plus-circle" /> Create Board</button>
+          </form>
+        </div>
       </Moderation>
 
       <div className="talk-list-content">

--- a/app/talk/lib/get-page-of-comment.coffee
+++ b/app/talk/lib/get-page-of-comment.coffee
@@ -1,0 +1,5 @@
+module?.exports = (comment, discussion, pageSize) ->
+  # comment resource, discussion resource, integer
+  comments = discussion.links.comments
+  commentNumber = comments.indexOf(comment.id.toString()) + 1
+  Math.ceil commentNumber / pageSize

--- a/app/talk/lib/parse-section.coffee
+++ b/app/talk/lib/parse-section.coffee
@@ -1,4 +1,5 @@
 module?.exports = (section) ->
+
   # returns the project_id of a project talk section,
   # or 'zooniverse' if section is zooniverse global talk
 

--- a/app/talk/quick-subject-comment-form.cjsx
+++ b/app/talk/quick-subject-comment-form.cjsx
@@ -1,0 +1,101 @@
+React = require 'react'
+CommentBox = require './comment-box'
+talkClient = require '../api/talk'
+apiClient = require '../api/client'
+parseSection = require './lib/parse-section'
+projectSection = require './lib/project-section'
+{State, Navigation} = require 'react-router'
+merge = require 'lodash.merge'
+getPageOfComment = require './lib/get-page-of-comment'
+{getErrors} = require './lib/validations'
+commentValidations = require './lib/comment-validations'
+
+BOARD_TITLE = 'Notes'            # Name of board to put subject comments
+BOARD_DESCRIPTION = 'General comment threads about individual subjects'
+
+defaultDiscussionTitle = (subject) ->
+  "Subject #{subject.id}"
+
+PAGE_SIZE = 10
+
+module?.exports = React.createClass
+  displayName: 'TalkQuickSubjectCommentForm'
+  mixins: [State, Navigation]
+
+  propTypes:
+    subject: React.PropTypes.object
+    user: React.PropTypes.object
+
+  getInitialState: ->
+    commentValidationErrors: []
+
+  commentValidations: (commentBody) ->
+    commentErrors = getErrors(commentBody, commentValidations)
+    @setState {commentValidationErrors}
+    !!commentErrors.length
+
+  onSubmitComment: (e, commentText, subject) ->
+    e.preventDefault()
+    {name, owner} = @getParams() # of project, maybe better to pass in as prop later
+
+    # get project
+    apiClient.type('projects').get({slug: name})
+      .then ([project]) =>
+        section = projectSection(project)
+
+        # check for a default board
+        talkClient.type('boards').get({section, subject_default: true}).index(0)
+          .then (board) =>
+            if board?
+              discussionTitle = defaultDiscussionTitle(@props.subject)
+
+              talkClient.type('discussions').get(board_id: board.id, title: discussionTitle, subject_default: true).index(0)
+                .then (discussion) =>
+                  if discussion?
+                    user_id = @props.user?.id
+                    body = commentText
+                    discussion_id = discussion.id
+
+                    comment = merge {}, {user_id, discussion_id, body}
+
+                    talkClient.type('comments').create(comment).save()
+                      .then (comment) =>
+                        pageOfComment = getPageOfComment(comment, discussion, PAGE_SIZE)
+                        @transitionTo('project-talk-discussion', {owner: owner, name: project.slug, board: discussion.board_id, discussion: discussion.id}, {page: pageOfComment, comment: comment.id})
+
+                  else
+                    focus_id = +@props.subject?.id
+                    focus_type = 'Subject' if !!focus_id
+                    user_id = @props.user?.id
+                    body = commentText
+
+                    comments = [merge({}, {user_id, body}, ({focus_id, focus_type} if !!focus_id))]
+
+                    discussion = {
+                      title: "Subject #{@props.subject.id}"
+                      user_id: @props.user?.id
+                      subject_default: true,
+                      board_id: board.id
+                      comments: comments
+                      }
+                    talkClient.type('discussions').create(discussion).save()
+                      .then (discussion) =>
+                        @transitionTo('project-talk-discussion', {owner: owner, name: project.slug, board: discussion.board_id, discussion: discussion.id})
+
+            else
+              console.log "no default board setup for this project"
+
+
+  render: ->
+    <div className="quick-subject-comment-form talk-module">
+      <h1>Leave a note about this subject</h1>
+      <CommentBox
+        header={null}
+        validationCheck={@commentErrors}
+        validationErrors={@state.commentValidationErrors}
+        submitFeedback={"Comment successfully added"}
+        placeholder={"Add a note about this subject."}
+        onSubmitComment={@onSubmitComment}
+        subject={@props.subject}
+        submit="Add Your Comment"/>
+    </div>

--- a/css/project-roles.styl
+++ b/css/project-roles.styl
@@ -18,4 +18,4 @@
     color: green
 
   &.admin
-    color: tomato
+    color: navy

--- a/css/subject.styl
+++ b/css/subject.styl
@@ -9,3 +9,7 @@
   .talk-comment-link
     a
       text-decoration: none
+    &:hover
+      .talk-module
+        background-color: darken(TALK_BACKGROUND, 10%)
+        border-color: darken(TALK_BACKGROUND, 20%)


### PR DESCRIPTION
- Quick last minute hacking for #660, I tried to keep most of the terribleness to `quick-subject-comment-form.cjsx` so it can be refactored later
- Adds a form for adding subject comments to a default board - titled 'Notes', but editable
- Mods need to click a "Activate Talk Subject Comments Board" in the mod controls on a talk boards page in a project to create the default board for subject comments, since they are the only ones who can create boards
- After that there should be 2 tabs on the bottom of the object page, one to leave a comment in the subject's discussion in the default board, and one to start a new discussion
- I'll keep pushing to this branch until we deploy