### PR TITLE
Update publisssh

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "function-bind": "~1.0.2",
     "nib": "~1.0.4",
     "node-static": "~0.7.6",
-    "publisssh": "~0.2.5",
+    "publisssh": "~1.0.0",
     "stylus": "~0.49.3",
     "tap-spec": "~2.1.1",
     "testling": "~1.7.1",


### PR DESCRIPTION
I updated the AWS library in publisssh, so 1.0.0 finally works with Node 0.12.