### PR TITLE
Owned cards are inline-block

### DIFF
--- a/css/owned-card.styl
+++ b/css/owned-card.styl
@@ -4,6 +4,7 @@
   column-width: 14.66em
   max-width: 1200px
   margin: 0 auto
+  text-align: center
   // Added styles below to fix Chrome bug: https://code.google.com/p/chromium/issues/detail?id=297782
   overflow: hidden
   position: relative
@@ -13,11 +14,12 @@
   background-size: cover
   border-radius: 6px
   vendor("column-break-inside", avoid)
-  display: block
+  display: inline-block
   margin: 0 auto 1em
   max-height: 325px
   max-width: 220px
   overflow: hidden
+  text-align: left
 
   svg
     height: 150px


### PR DESCRIPTION
I couldn't get it to reproduce super consistently, but this should close #752.