### PR TITLE
View workflow

### DIFF
--- a/app/pages/lab/workflow.cjsx
+++ b/app/pages/lab/workflow.cjsx
@@ -216,7 +216,6 @@ EditWorkflowPage = React.createClass
       @transitionTo 'edit-project-details', projectID: @props.project.id
 
   handleTaskChange: (taskKey, path, value) ->
-    console?.log 'Handling task change', arguments...
     changes = {}
     changes["tasks.#{taskKey}.#{path}"] = value
     @props.workflow.update changes
@@ -239,7 +238,6 @@ module.exports = React.createClass
   render: ->
     <PromiseRenderer promise={apiClient.type('workflows').get @props.params.workflowID}>{(workflow) =>
       <ChangeListener target={workflow}>{=>
-        console.log 'Workflow changed', JSON.stringify workflow
         <EditWorkflowPage {...@props} workflow={workflow} />
       }</ChangeListener>
     }</PromiseRenderer>

--- a/app/pages/lab/workflow.cjsx
+++ b/app/pages/lab/workflow.cjsx
@@ -24,6 +24,7 @@ EditWorkflowPage = React.createClass
 
   getInitialState: ->
     selectedTaskKey: @props.workflow.first_task
+    forceReloader: 0
 
   render: ->
     disabledStyle =
@@ -121,13 +122,19 @@ EditWorkflowPage = React.createClass
 
           <hr />
 
-          <div>
+          <div style={pointerEvents: 'all'}>
             <PromiseRenderer promise={@props.project.get 'owner'}>{(owner) =>
               # React-router completely overrides clicking on links. Unbelievable.
               viewParams = owner: owner.login, name: @props.project.slug
               viewQuery = workflow: @props.workflow.id
-              viewHref = @makeHref 'project-classify', viewParams, viewQuery
-              <a href={viewHref} className="standard-button" target="_blank">View this workflow</a>
+              currentLocation = location.origin + location.pathname + location.search
+              currentLocation += if location.search is ''
+                '?'
+              else
+                '&'
+              currentLocation += "reload=#{@state.forceReloader}"
+              viewHash = @makeHref 'project-classify', viewParams, viewQuery
+              <a href={currentLocation + viewHash} className="standard-button" target="from-lab" onClick={@handleViewClick}>View this workflow</a>
             }</PromiseRenderer>
           </div>
 
@@ -231,6 +238,10 @@ EditWorkflowPage = React.createClass
     changes = {}
     changes["tasks.#{taskKey}.#{path}"] = value
     @props.workflow.update changes
+
+  handleViewClick: ->
+    setTimeout =>
+      @setState forceReloader: @state.forceReloader + 1
 
   handleTaskDelete: (taskKey) ->
     changes = {}

--- a/app/pages/lab/workflow.cjsx
+++ b/app/pages/lab/workflow.cjsx
@@ -127,7 +127,7 @@ EditWorkflowPage = React.createClass
               viewParams = owner: owner.login, name: @props.project.slug
               viewQuery = workflow: @props.workflow.id
               viewHref = @makeHref 'project-classify', viewParams, viewQuery
-              <a href={viewHref} className="standard-button" target="view-workflow">View this workflow</a>
+              <a href={viewHref} className="standard-button" target="_blank">View this workflow</a>
             }</PromiseRenderer>
           </div>
 

--- a/app/pages/lab/workflow.cjsx
+++ b/app/pages/lab/workflow.cjsx
@@ -122,6 +122,18 @@ EditWorkflowPage = React.createClass
           <hr />
 
           <div>
+            <PromiseRenderer promise={@props.project.get 'owner'}>{(owner) =>
+              # React-router completely overrides clicking on links. Unbelievable.
+              viewParams = owner: owner.login, name: @props.project.slug
+              viewQuery = workflow: @props.workflow.id
+              viewHref = @makeHref 'project-classify', viewParams, viewQuery
+              <a href={viewHref} className="standard-button" target="view-workflow">View this workflow</a>
+            }</PromiseRenderer>
+          </div>
+
+          <hr />
+
+          <div>
             <small>
               <button type="button" className="minor-button" disabled={@state.deleteInProgress} data-busy={@state.deleteInProgress || null} onClick={@handleDelete}>
                 Delete this workflow


### PR DESCRIPTION
Add a "view" link from the workflow editor to a new window.

I was adding more "view" links around the other project editor pages, but then I realized that they don't reload, so the second page will see old data. That's why there's a `reload=0` param. So for now, there's just a link from the workflow editor. It might be possible to generalize this in the future.

Closes #253.