### PR TITLE
Record subject dimensions

### DIFF
--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -133,7 +133,7 @@ Classifier = React.createClass
     {naturalWidth, naturalHeight, clientWidth, clientHeight} = e.target
 
     changes = {}
-    changes["metadata.dimensions.#{frameIndex}"] = {naturalWidth, naturalHeight, clientWidth, clientHeight}
+    changes["metadata.subject_dimensions.#{frameIndex}"] = {naturalWidth, naturalHeight, clientWidth, clientHeight}
 
     @props.classification.update changes
 

--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -168,6 +168,10 @@ Classifier = React.createClass
     @props.classification.update
       completed: true
       'metadata.finished_at': (new Date).toISOString()
+      'metadata.viewport':
+        width: innerWidth
+        height: innerHeight
+
     @props.onComplete?()
 
   toggleExpertClassification: (value) ->

--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -127,8 +127,16 @@ Classifier = React.createClass
       </nav>
     </div>
 
-  handleSubjectImageLoad: (e) ->
+  handleSubjectImageLoad: (e, frameIndex) ->
     @setState subjectLoading: false
+
+    {naturalWidth, naturalHeight, clientWidth, clientHeight} = e.target
+
+    changes = {}
+    changes["metadata.dimensions.#{frameIndex}"] = {naturalWidth, naturalHeight, clientWidth, clientHeight}
+
+    @props.classification.update changes
+
     @props.onLoad? arguments...
 
   updateAnnotations: (classification) ->

--- a/app/classifier/subject-viewer.cjsx
+++ b/app/classifier/subject-viewer.cjsx
@@ -163,7 +163,7 @@ module.exports = React.createClass
         @handleResize()
       else
         @setState {naturalWidth, naturalHeight}, @handleResize
-      @props.onLoad? arguments...
+      @props.onLoad? e, @state.frame
 
   handleFrameChange: (frame) ->
     @setState {frame}

--- a/app/pages/project/classify.cjsx
+++ b/app/pages/project/classify.cjsx
@@ -121,6 +121,7 @@ module.exports = React.createClass
           user_agent: navigator.userAgent
           user_language: counterpart.getLocale()
           utc_offset: ((new Date).getTimezoneOffset() * 60).toString() # In seconds
+          subject_dimensions: (null for location in subject.locations)
         links:
           project: project.id
           workflow: workflow.id


### PR DESCRIPTION
This adds some metadata to classifications:

- The viewport size (on classification submission) as `metadata.viewport.width` and `.height`

- Each subject frame's actual size as `metadata.subject_dimensions.(frame index).naturalWidth` and `.naturalHeight`, and displayed size as `.clientWidth` and `.clientHeight`. This is recorded after viewing the frame; if the user never actually loads a frame of a multi-`locations` image, no dimensions are recorded for it.

Closes #986.