### PR TITLE
display zooniverse section team roles as 'Zooniverse Team'

### DIFF
--- a/app/talk/lib/display-roles.cjsx
+++ b/app/talk/lib/display-roles.cjsx
@@ -1,14 +1,14 @@
 React = require 'react'
 
-zooniverseAdminRole = (role) ->
-  role.section is 'zooniverse' and role.name is 'admin'
+zooniverseTeamRole = (role) ->
+  role.section is 'zooniverse' and [ 'admin', 'team' ].indexOf(role.name) isnt -1
 
 researcherRole = (role) ->
   userIsResearcher = ['admin', 'scientist', 'owner'].indexOf(role.name) isnt -1
   role.section isnt 'zooniverse' and userIsResearcher
 
 roleDisplayName = (role, section) ->
-  if zooniverseAdminRole(role) # show zooniverse admins everywhere as 'team'
+  if zooniverseTeamRole(role) # show zooniverse admins everywhere as 'team'
     "Zooniverse Team"
   else if researcherRole(role) # project admins, scientists, owners
     "Researcher"
@@ -23,7 +23,7 @@ DisplayRoles = React.createClass
     section: React.PropTypes.string # talk section
 
   role: (role, i) ->
-    zooTeamName = if zooniverseAdminRole(role) then 'zoo-team'
+    zooTeamName = if zooniverseTeamRole(role) then 'zoo-team'
     <p key={role.id} className="project-role #{zooTeamName ? role.name}">
       {roleDisplayName(role, @props.section)}
     </p>


### PR DESCRIPTION
For #817 

Not everyone on the team needs admin rights but they should be labelled as Zoo Team on talk. We now just need to setup the zooniverse section team talk roles for everyone.