### PR TITLE
Towards user as an app wide prop

### DIFF
--- a/app/collections/create-form.cjsx
+++ b/app/collections/create-form.cjsx
@@ -1,6 +1,5 @@
 React = require 'react'
 apiClient = require '../api/client'
-auth = require '../api/auth'
 counterpart = require 'counterpart'
 Translate = require 'react-translate-component'
 

--- a/app/collections/favorites-button.cjsx
+++ b/app/collections/favorites-button.cjsx
@@ -1,6 +1,5 @@
 React = require 'react'
 apiClient = require '../api/client'
-auth = require '../api/auth'
 getFavoritesName = require './get-favorites-name'
 alert = require '../lib/alert'
 SignInPrompt = require '../partials/sign-in-prompt'
@@ -12,10 +11,12 @@ module?.exports = React.createClass
   propTypes:
     subject: React.PropTypes.object # a subject response from panoptes
     project: React.PropTypes.object # a project response from panoptes
+    user: React.PropTypes.object # a project response from panoptes
 
   getDefaultProps: ->
     subject: null
     project: null
+    user: null
 
   getInitialState: ->
     favoritesPromise: null
@@ -70,18 +71,17 @@ module?.exports = React.createClass
       @setState favoritedPromise: Promise.resolve(true)
 
   toggleFavorite: ->
-    auth.checkCurrent().then (user) =>
-      if user?
-        Promise.all([@state.favoritesPromise, @state.favoritedPromise])
-          .then ([favorites, favorited])=>
-            if not favorites?
-              @createFavorites(user)
-            else if favorited
-              @removeSubjectFrom(favorites)
-            else
-              @addSubjectTo(favorites)
-      else
-        @promptToSignIn()
+    if @props.user?
+      Promise.all([@state.favoritesPromise, @state.favoritedPromise])
+        .then ([favorites, favorited]) =>
+          if not favorites?
+            @createFavorites @props.user
+          else if favorited
+            @removeSubjectFrom(favorites)
+          else
+            @addSubjectTo(favorites)
+    else
+      @promptToSignIn()
 
   render: ->
     <PromiseRenderer promise={@state.favoritedPromise}>{(favorited) =>

--- a/app/collections/home.cjsx
+++ b/app/collections/home.cjsx
@@ -1,12 +1,7 @@
 React = require 'react'
 CollectionCreateForm = require './create-form'
-talkClient = require '../api/talk'
 apiClient = require '../api/client'
-authClient = require '../api/auth'
-auth = require '../api/auth'
 {Link} = require 'react-router'
-ChangeListener = require '../components/change-listener'
-PromiseRenderer = require '../components/promise-renderer'
 
 module?.exports = React.createClass
   displayName: 'CollectionsHome'
@@ -20,17 +15,13 @@ module?.exports = React.createClass
 
   render: ->
     <div className="collections-home">
-      <ChangeListener target={authClient}>{=>
-        <PromiseRenderer promise={authClient.checkCurrent()}>{(user) =>
-          if user?
-            <PromiseRenderer promise={user.get('collections')}>{(collections) =>
-              <div>
-                <CollectionCreateForm />
-                {collections.map(@collectionLink)}
-              </div>
-            }</PromiseRenderer>
-          else
-            <p>Please sign-in to view your collections</p>
+      {if @props.user?
+        <PromiseRenderer promise={@props.user.get('collections')}>{(collections) =>
+          <div>
+            <CollectionCreateForm />
+            {collections.map(@collectionLink)}
+          </div>
         }</PromiseRenderer>
-      }</ChangeListener>
+      else
+        <p>Please sign-in to view your collections</p>}
     </div>

--- a/app/collections/home.cjsx
+++ b/app/collections/home.cjsx
@@ -15,7 +15,7 @@ module?.exports = React.createClass
 
   render: ->
     <div className="collections-home">
-      {if @props.user?
+      {if @props.user
         <PromiseRenderer promise={@props.user.get('collections')}>{(collections) =>
           <div>
             <CollectionCreateForm />

--- a/app/collections/manager-icon.cjsx
+++ b/app/collections/manager-icon.cjsx
@@ -1,31 +1,20 @@
 React = require 'react'
 CollectionsManager = require './manager'
 alert = require '../lib/alert'
-PromiseRenderer = require '../components/promise-renderer'
-ChangeListener = require '../components/change-listener'
-auth = require '../api/auth'
 
 # Shows an icon to logged-in users that pops up a collections manager
 module?.exports = React.createClass
   displayName: 'CollectionsManagerIcon'
 
-  getDefaultProps: ->
-    subject: React.PropTypes.object
-
-  toggleCollectionsManagerPopup: (user) ->
+  toggleCollectionsManagerPopup: ->
     alert (resolve) =>
       <div className="content-container">
-        <CollectionsManager user={user} project={@props.project} subject={@props.subject} onSuccess={resolve} />
+        <CollectionsManager user={@props.user} project={@props.project} subject={@props.subject} onSuccess={resolve} />
       </div>
 
   render: ->
-    <ChangeListener target={auth}>{=>
-      <PromiseRenderer promise={auth.checkCurrent()}>{(user) =>
-        if user?
-          <button
-            className="collections-manager-icon"
-            onClick={@toggleCollectionsManagerPopup.bind this, user}>
-            <i className="fa fa-list" />
-          </button>
-      }</PromiseRenderer>
-    }</ChangeListener>
+    <button
+      className="collections-manager-icon"
+      onClick={@toggleCollectionsManagerPopup}>
+      <i className="fa fa-list" />
+    </button>

--- a/app/collections/manager.cjsx
+++ b/app/collections/manager.cjsx
@@ -1,7 +1,5 @@
 React = require 'react'
 apiClient = require '../api/client'
-PromiseRenderer = require '../components/promise-renderer'
-auth = require '../api/auth'
 CollectionsCreateForm = require './create-form'
 CollectionSearch = require '../components/collection-search'
 

--- a/app/collections/settings.cjsx
+++ b/app/collections/settings.cjsx
@@ -1,7 +1,6 @@
 React = require 'react'
 {Navigation} = require 'react-router'
 DisplayNameSlugEditor = require '../partials/display-name-slug-editor'
-auth = require '../api/auth'
 apiClient = require '../api/client'
 alert = require '../lib/alert'
 SetToggle = require '../lib/set-toggle'
@@ -65,13 +64,12 @@ module.exports = React.createClass
     @transitionTo 'collections'
 
   checkUserRole: ->
-    auth.checkCurrent().then (user) =>
-      if user
-        apiClient.type('collection_roles').get(collection_id: @props.collection.id, user_id: user?.id)
-          .catch ->
-            []
-          .then ([roles]) ->
-            roles?
+    if @props.user
+      apiClient.type('collection_roles').get(collection_id: @props.collection.id, user_id: user?.id)
+        .catch ->
+          []
+        .then ([roles]) ->
+          roles?
 
   confirmDelete: ->
     alert (resolve) =>
@@ -84,7 +82,7 @@ module.exports = React.createClass
       <ChangeListener target={@props.collection}>{=>
         <DisplayNameSlugEditor resource={@props.collection} resourceType="collection" />
       }</ChangeListener>
-      
+
       <hr />
 
       <span className="form-label">Visibility</span>

--- a/app/collections/show-list.cjsx
+++ b/app/collections/show-list.cjsx
@@ -61,7 +61,7 @@ module?.exports = React.createClass
   render: ->
     subjectNode = (subject) =>
       <div className="collection-subject-viewer" key={subject.id}>
-        <SubjectViewer defaultStyle={false} subject={subject}>
+        <SubjectViewer defaultStyle={false} subject={subject} user={@props.user}>
           {if @isOwnerOrCollaborator()
             <button type="button" className="collection-subject-viewer-delete-button" onClick={@handleDeleteSubject.bind @, subject}>
               <i className="fa fa-close" />

--- a/app/collections/show.cjsx
+++ b/app/collections/show.cjsx
@@ -34,17 +34,12 @@ CollectionPage = React.createClass
     document.documentElement.classList.remove 'on-collection-page'
 
   render: ->
-    userAndOwner = Promise.all [
-      auth.checkCurrent(),
-      @props.collection.get 'owner'
-    ]
-
-    <PromiseRenderer promise={userAndOwner}>{([user, owner] = []) =>
+    <PromiseRenderer promise={@props.collection.get('owner')}>{(owner) =>
       params =
         owner: owner.login or owner.name
         name: @props.collection.slug
 
-      isOwner = user?.id is owner.id
+      isOwner = @props.user?.id is owner.id
 
       <div className="collections-page">
         <nav className="collection-nav tabbed-content-tabs">
@@ -86,7 +81,6 @@ module.exports = React.createClass
 
   getInitialState: ->
     collection: null
-    user: null
     roles: null
     error: false
     loading: false
@@ -98,34 +92,26 @@ module.exports = React.createClass
   fetchCollection: ->
     @setState loading: true
 
-    auth.checkCurrent().then (user) =>
-      apiClient.type('collections')
-        .get(owner: @props.params?.owner, slug: @props.params?.name, include: 'owner')
-        .then ([collection]) =>
-          unless collection then @setState error: true
+    apiClient.type('collections')
+      .get(owner: @props.params?.owner, slug: @props.params?.name, include: 'owner')
+      .then ([collection]) =>
+        unless collection then @setState error: true
 
-          apiClient.type('collection_roles')
-            .get(collection_id: collection.id)
-            .then (roles) =>
-              @setState
-                collection: collection
-                user: user
-                roles: roles
-        .catch =>
-          @setState error: true
-        .then =>
-          @setState loading: false
-
-  componentDidMount: ->
-    auth.listen 'change', @fetchCollection
-
-  componentWillUnmount: ->
-    auth.stopListening 'change', @fetchCollection
+        apiClient.type('collection_roles')
+          .get(collection_id: collection.id)
+          .then (roles) =>
+            @setState
+              collection: collection
+              roles: roles
+      .catch =>
+        @setState error: true
+      .then =>
+        @setState loading: false
 
   render: ->
     <div className="cotent-container">
       {if @state.collection
-        <CollectionPage {...@props} user={@state.user} collection={@state.collection} roles={@state.roles} />}
+        <CollectionPage {...@props} collection={@state.collection} roles={@state.roles} />}
 
       {if @state.error
         <Translate compontent="p" content="collectionsPageWrapper.error" />}

--- a/app/components/owned-card-list.cjsx
+++ b/app/components/owned-card-list.cjsx
@@ -32,7 +32,6 @@ module.exports = React.createClass
       'All'
 
   render: ->
-    
     <div className="secondary-page all-resources-page">
       <section className={"hero #{@props.heroClass}"}>
         <div className="hero-container">

--- a/app/components/subject-viewer.cjsx
+++ b/app/components/subject-viewer.cjsx
@@ -24,6 +24,7 @@ module.exports = React.createClass
 
   getDefaultProps: ->
     subject: null
+    user: null
     playFrameDuration: 667
     playIterations: 3
     onFrameChange: NOOP
@@ -81,10 +82,11 @@ module.exports = React.createClass
         <span>
           {if @props.subject?.metadata?
             <button type="button" className="metadata-toggle" onClick={@showMetadata}><i className="fa fa-table fa-fw"></i></button>}
-          {if @props.subject
+
+          {if @props.subject && @props.user
             <span>
-              <FavoritesButton project={@props.project} subject={@props.subject} />
-              <CollectionsManagerIcon project={@props.project} subject={@props.subject} />
+              <FavoritesButton project={@props.project} subject={@props.subject} user={@props.user} />
+              <CollectionsManagerIcon project={@props.project} subject={@props.subject} user={@props.user} />
             </span>}
         </span>
       </div>

--- a/app/main.cjsx
+++ b/app/main.cjsx
@@ -6,20 +6,41 @@ MainHeader = require './partials/main-header'
 MainFooter = require './partials/main-footer'
 IOStatus = require './partials/io-status'
 
+auth = require './api/auth'
+api = require './api/client'
+
 logDeployedCommit = require './lib/log-deployed-commit'
 logDeployedCommit()
 
 App = React.createClass
   displayName: 'PanoptesApp'
 
+  getInitialState: ->
+    user: null
+    initialLoadComplete: false
+
+  componentDidMount: ->
+    auth.listen 'change', @handleAuthChange
+    @handleAuthChange()
+
+  componentWillUnmount: ->
+    auth.stopListening 'change', @handleAuthChange
+
+  handleAuthChange: ->
+    auth.checkCurrent().then (user) =>
+      @setState
+        user: user
+        initialLoadComplete: true
+
   render: ->
     <div className="panoptes-main">
       <IOStatus />
-      <MainHeader />
+      <MainHeader user={@state.user} />
       <div className="main-content">
-        <RouteHandler {...@props} />
+        {if @state.initialLoadComplete
+          <RouteHandler {...@props} user={@state.user} />}
       </div>
-      <MainFooter />
+      <MainFooter user={@state.user} />
     </div>
 
 routes = <Route handler={App}>

--- a/app/pages/collections.cjsx
+++ b/app/pages/collections.cjsx
@@ -3,8 +3,6 @@ React = require 'react'
 TitleMixin = require '../lib/title-mixin'
 apiClient = require '../api/client'
 OwnedCardList = require '../components/owned-card-list'
-PromiseRenderer = require '../components/promise-renderer'
-ChangeListener = require '../components/change-listener'
 Translate = require 'react-translate-component'
 {Link} = require 'react-router'
 
@@ -22,7 +20,7 @@ CollectionsNav = React.createClass
 
   render: ->
     <nav className="hero-nav">
-      {if @props.user?
+      {if @props.user
         <Link to="collections-user" params={{owner: @props.user.login}}>
           <Translate content="collectionsPage.myCollections" />
         </Link>}
@@ -30,9 +28,7 @@ CollectionsNav = React.createClass
 
 CollectionsPage = React.createClass
   displayName: 'CollectionsPage'
-
   mixins: [TitleMixin]
-
   title: 'Collections'
 
   imagePromise: (collection) ->
@@ -48,7 +44,6 @@ CollectionsPage = React.createClass
     'collection-show'
 
   listCollections: ->
-    console.log 'listing collections'
     query = Object.create @props.query ? {}
     query.owner = @props.params.owner if @props.params?.owner?
     query.include = 'owner'
@@ -56,18 +51,15 @@ CollectionsPage = React.createClass
     apiClient.type('collections').get query
 
   render: ->
-    <OwnedCardList
-      translationObjectName="collectionsPage"
-      listPromise={@listCollections()}
-      linkTo="collections"
-      heroNav={<CollectionsNav />}
-      heroClass="collections-hero"
-      ownerName={@props.params?.owner}
-      imagePromise={@imagePromise}
-      cardLink={@cardLink} />
+    listProps =
+      translationObjectName: 'collectionsPage'
+      listPromise: @listCollections()
+      linkTo: 'collections'
+      heroNav: <CollectionsNav user={@props.user} />
+      ownerName: @props.params?.owner
+      imagePromise: @imagePromise
+      cardLink: @cardLink
 
-module.exports = React.createClass
-  displayName: 'CollectionsPageWrapper'
+    <OwnedCardList {...listProps} />
 
-  render: ->
-    <CollectionsPage {...@props} />
+module.exports = CollectionsPage

--- a/app/pages/settings/index.cjsx
+++ b/app/pages/settings/index.cjsx
@@ -55,15 +55,9 @@ module.exports = React.createClass
   displayName: 'UserSettingsPageWrapper'
 
   render: ->
-    <ChangeListener target={auth} handler={=>
-      <PromiseRenderer promise={auth.checkCurrent()} then={(user) =>
-        if user?
-          <ChangeListener target={user} handler={=>
-            <UserSettingsPage user={user} />
-          } />
-        else
-          <div className="content-container">
-            <p>You’re not signed in.</p>
-          </div>
-      } />
-    } />
+    if @props.user?
+      <UserSettingsPage {...@props} />
+    else
+      <div className="content-container">
+        <p>You’re not signed in.</p>
+      </div>

--- a/app/partials/account-bar.cjsx
+++ b/app/partials/account-bar.cjsx
@@ -35,22 +35,20 @@ module.exports = React.createClass
       .catch (e) -> console.log "e unread messages", e
 
   render: ->
-    <ChangeListener target={@props.user} handler={=>
-      <div className="account-bar">
-        <div className="account-info">
-          <span className="display-name"><strong>{@props.user.display_name}</strong></span>
-          <Avatar user={@props.user} />
-          <Link to="inbox" params={name: @props.user.login} className="message-link"><i className="fa fa-envelope#{if @state.unread then '' else '-o'}" /> </Link>
-        </div>
-        <div className="account-menu" ref="accountMenu">
-          <Link to="settings" params={name: @props.user.login}><Translate content="accountMenu.settings" /></Link>
-          <Link to="collections-user" params={{owner: @props.user.login}}>
-            <Translate content="accountMenu.collections" />
-          </Link>
-          <button className="secret-button sign-out-button" type="button" onClick={@handleSignOutClick}><Translate content="accountMenu.signOut" /></button>
-        </div>
+    <div className="account-bar">
+      <div className="account-info">
+        <span className="display-name"><strong>{@props.user.display_name}</strong></span>
+        <Avatar user={@props.user} />
+        <Link to="inbox" params={name: @props.user.login} className="message-link"><i className="fa fa-envelope#{if @state.unread then '' else '-o'}" /> </Link>
       </div>
-    } />
+      <div className="account-menu" ref="accountMenu">
+        <Link to="settings" params={name: @props.user.login}><Translate content="accountMenu.settings" /></Link>
+        <Link to="collections-user" params={{owner: @props.user.login}}>
+          <Translate content="accountMenu.collections" />
+        </Link>
+        <button className="secret-button sign-out-button" type="button" onClick={@handleSignOutClick}><Translate content="accountMenu.signOut" /></button>
+      </div>
+    </div>
 
   handleSignOutClick: ->
     auth.signOut()

--- a/app/partials/login-bar.cjsx
+++ b/app/partials/login-bar.cjsx
@@ -23,5 +23,5 @@ module.exports = React.createClass
     </div>
 
   showLoginDialog: (which) ->
-    alert (resolve) ->
-      <LoginDialog which={which} onSuccess={resolve} />
+    alert (resolve) =>
+      <LoginDialog user={@props.user} which={which} onSuccess={resolve} />

--- a/app/partials/login-dialog.cjsx
+++ b/app/partials/login-dialog.cjsx
@@ -35,7 +35,7 @@ module.exports = React.createClass
 
       <div className="content-container">
         {switch @state.which
-          when 'login-change' then <LoginChangeForm user={@state.user} onSuccess={@props.onSuccess} />
+          when 'login-change' then <LoginChangeForm user={@props.user} onSuccess={@props.onSuccess} />
           when 'sign-in' then <SignInForm onSuccess={@onSuccessOrLoginChange} />
           when 'register' then <RegisterForm project={@props.project} onSuccess={@props.onSuccess} />}
       </div>
@@ -46,8 +46,6 @@ module.exports = React.createClass
 
   onSuccessOrLoginChange: (user) ->
     if user.login_prompt
-      @setState {which: 'login-change', user: user}
+      @setState {which: 'login-change'}
     else
-      @props.onSuccess(user)
-
-
+      @props.onSuccess()

--- a/app/partials/main-footer.cjsx
+++ b/app/partials/main-footer.cjsx
@@ -3,7 +3,6 @@ React = require 'react'
 Translate = require 'react-translate-component'
 {Link} = require 'react-router'
 ZooniverseLogoType = require './zooniverse-logotype'
-auth = require '../api/auth'
 apiClient = require '../api/client'
 
 counterpart.registerTranslations 'en',
@@ -57,20 +56,6 @@ AdminToggle = React.createClass
 module.exports = React.createClass
   displayName: 'MainFooter'
 
-  getInitialState: ->
-    user: null
-
-  componentDidMount: ->
-    auth.listen 'change', @handleAuthChange
-    @handleAuthChange()
-
-  componentWillUnmount: ->
-    auth.stopListening 'change', @handleAuthChange
-
-  handleAuthChange: ->
-    auth.checkCurrent().then (user) =>
-      @setState {user}
-
   render: ->
     <footer className="main-footer">
       <div className="centered-grid main-footer-flex">
@@ -79,7 +64,7 @@ module.exports = React.createClass
             <ZooniverseLogoType />
           </Link>
           <br />
-          {if @state.user?.admin or @state.user?.id is '3' # brian-testing
+          {if @props.user?.admin or @props.user?.id is '3' # brian-testing
             <AdminToggle />}
         </div>
         <nav className="site-map">

--- a/app/partials/main-header.cjsx
+++ b/app/partials/main-header.cjsx
@@ -7,7 +7,6 @@ LoadingIndicator = require '../components/loading-indicator'
 AccountBar = require './account-bar'
 LoginBar = require './login-bar'
 PromiseToSetState = require '../lib/promise-to-set-state'
-auth = require '../api/auth'
 
 counterpart.registerTranslations 'en',
   mainNav:
@@ -23,18 +22,10 @@ counterpart.registerTranslations 'en',
 module.exports = React.createClass
   displayName: 'MainHeader'
 
-  mixins: [PromiseToSetState]
-
-  getInitialState: ->
-    user: null
-
   componentDidMount: ->
-    @handleAuthChange()
-    auth.listen @handleAuthChange
     @addEventListeners()
 
   componentWillUnmount: ->
-    auth.stopListening @handleAuthChange
     @removeEventListeners()
 
   addEventListeners: ->
@@ -55,9 +46,6 @@ module.exports = React.createClass
   checkIfOnHome: ->
     return true if window.location.hash is '#/'
 
-  handleAuthChange: ->
-    @promiseToSetState user: auth.checkCurrent()
-
   render: ->
     <header className="main-header">
       <div className="main-title" ref="mainTitle">
@@ -74,8 +62,8 @@ module.exports = React.createClass
           <hr />
           <Link to="lab" className="main-nav-item nav-build"><Translate className="minor" content="mainNav.lab" /></Link>
         </nav>
-        {if @state.user?
-          <AccountBar user={@state.user} />
+        {if @props.user?
+          <AccountBar {...@props} />
         else
           <LoginBar />}
       </div>


### PR DESCRIPTION
Putting this out there for discussion, not for merging. I only made the changes to a fraction of the codebase.

This PR would remove any and all `auth.checkCurrent()` from anywhere within the app, except for at the top-level `<App/>` component and have it's currrent value passed down via props throughout the entire app.

Benefits:

- No need for any ChangeListeners, PromiseRenderers, or PromiseToSetState for the user resource anywhere in the app, except at the top. Simply make your render method depend upon @props.user and you are good.
- Formalize the user resource as app-level state, which is what it is.
- Followed correctly, would eliminate bugs where component-level user state gets out of sync with app-level user state, e.g. #969, #879, and others.

Cons:

- Have to pass user down the entire tree of components, as far as is needed.

Thoughts?