### PR TITLE
Better user profiles

### DIFF
--- a/app/main.cjsx
+++ b/app/main.cjsx
@@ -44,7 +44,8 @@ routes = <Route handler={App}>
   <Route name="privacy" handler={require './pages/privacy-policy'} />
 
   <Route name="user-profile" path="users/:name" handler={require './pages/profile'}>
-    <DefaultRoute name="user-profile-private-message" handler={require './pages/profile/private-message'} />
+    <DefaultRoute name="user-profile-feed" handler={require './pages/profile/feed'} />
+    <Route name="user-profile-private-message" handler={require './pages/profile/private-message'} />
     <Route name="user-profile-stats" path="stats" handler={require './pages/profile/stats'} />
  </Route>
 

--- a/app/main.cjsx
+++ b/app/main.cjsx
@@ -45,7 +45,7 @@ routes = <Route handler={App}>
 
   <Route path="users/:name" handler={require './pages/profile'}>
     <DefaultRoute name="user-profile" handler={require './pages/profile/feed'} />
-    <Route name="user-profile-private-message" handler={require './pages/profile/private-message'} />
+    <Route name="user-profile-private-message" path="message" handler={require './pages/profile/private-message'} />
     <Route name="user-profile-stats" path="stats" handler={require './pages/profile/stats'} />
  </Route>
 

--- a/app/main.cjsx
+++ b/app/main.cjsx
@@ -43,8 +43,8 @@ routes = <Route handler={App}>
   </Route>
   <Route name="privacy" handler={require './pages/privacy-policy'} />
 
-  <Route name="user-profile" path="users/:name" handler={require './pages/profile'}>
-    <DefaultRoute name="user-profile-feed" handler={require './pages/profile/feed'} />
+  <Route path="users/:name" handler={require './pages/profile'}>
+    <DefaultRoute name="user-profile" handler={require './pages/profile/feed'} />
     <Route name="user-profile-private-message" handler={require './pages/profile/private-message'} />
     <Route name="user-profile-stats" path="stats" handler={require './pages/profile/stats'} />
  </Route>

--- a/app/pages/profile/feed.cjsx
+++ b/app/pages/profile/feed.cjsx
@@ -50,7 +50,7 @@ CommentLink = React.createClass
           <span title={moment(@props.comment.created_at).toISOString()}>{moment(@props.comment.created_at).fromNow()}</span> in{' '}
           {if @state.project? and @state.owner
             <span>
-              <strong className="project">{@state.owner.display_name}/{@state.project.display_name}</strong>
+              <strong className="project" title="#{@state.owner.display_name}/#{@state.project.display_name}">{@state.project.display_name}</strong>
               ➞
             </span>}
           <strong className="board">{@state.board?.title}</strong>

--- a/app/pages/profile/feed.cjsx
+++ b/app/pages/profile/feed.cjsx
@@ -2,6 +2,7 @@ React = require 'react'
 moment = require 'moment'
 apiClient = require '../../api/client'
 talkClient = require '../../api/talk'
+Markdown = require '../../components/markdown'
 
 CommentLink = React.createClass
   displayName: 'CommentLink'
@@ -44,24 +45,26 @@ CommentLink = React.createClass
           @setState({href})
 
   render: ->
-    <a href={@state.href} style={color: 'inherit', textDecoration: 'inherit'}>
+    <div className="profile-feed-comment-link">
       <header>
-        <small>
-          <span title={moment(@props.comment.created_at).toISOString()}>{moment(@props.comment.created_at).fromNow()}</span> in{' '}
+        <span className="comment-timestamp"title={moment(@props.comment.created_at).toISOString()}>
+          {moment(@props.comment.created_at).fromNow()}
+        </span>{' '}
+        in{' '}
+        <a href={@state.href}>
           {if @state.project? and @state.owner
             <span>
-              <strong className="project" title="#{@state.owner.display_name}/#{@state.project.display_name}">{@state.project.display_name}</strong>
+              <strong className="comment-project" title="#{@state.owner.display_name}/#{@state.project.display_name}">{@state.project.display_name}</strong>
               ➞
             </span>}
-          <strong className="board">{@state.board?.title}</strong>
+          <strong className="comment-board">{@state.board?.title}</strong>
           ➞
-          <strong className="discussion">{@state.discussion?.title}</strong>
-        </small>
+          <strong className="comment-discussion">{@state.discussion?.title}</strong>
+        </a>
       </header>
-      {# TODO: Markdown}
-      <div className="">{@props.comment.body}</div>
-      <hr />
-    </a>
+
+      <Markdown className="comment-body" content={@props.comment.body} />
+    </div>
 
 module.exports = React.createClass
   displayName: 'UserProfileFeed'

--- a/app/pages/profile/feed.cjsx
+++ b/app/pages/profile/feed.cjsx
@@ -1,8 +1,86 @@
-counterpart = require 'counterpart'
 React = require 'react'
+moment = require 'moment'
+apiClient = require '../../api/client'
+talkClient = require '../../api/talk'
 
-module.exports = React.createClass
-  displayName: 'UserFeed'
+CommentLink = React.createClass
+  displayName: 'CommentLink'
+
+  getDefaultProps: ->
+    comment: null
+
+  getInitialState: ->
+    href: '#'
+
+  componentDidMount: ->
+    @getCommentHREF(@props.comment)
+
+  componentWillReceiveProps: (nextProps) ->
+    unless nextProps.comment is @props.comment
+      @getCommentHREF(nextProps.comment)
+
+  getCommentHREF: (comment) ->
+    console.log 'sec', comment.section.split('-')
+    projectID = comment.section.split('-')[1]
+
+    @setState({href: '#'})
+    talkClient.type('discussions').get(comment.discussion_id).then (discussion) =>
+      talkClient.type('boards').get(discussion.board_id).then (board) =>
+        if projectID?
+          apiClient.type('projects').get(projectID).then (project) =>
+            project.get('owner').then (owner) =>
+              @setState({href: "#/projects/#{owner.login}/#{project.slug}/talk/#{board.id}/#{discussion.id}?comment=#{comment.id}"})
+        else
+          @setState({href: "#/talk/#{board.id}/#{discussion.id}?comment=#{comment.id}"})
 
   render: ->
-    <div className="user-profile-feed content-container">User profile feed</div>
+    <a href={@state.href}>
+      <header>
+        <span title={moment(@props.comment.created_at).toISOString()}>{moment(@props.comment.created_at).fromNow()}</span>{' '}
+      </header>
+      <div className="content-container">{@props.comment.body}</div>
+    </a>
+
+module.exports = React.createClass
+  displayName: 'UserProfileFeed'
+
+  getDefaultProps: ->
+    user: null
+    query:
+      page: 1
+
+  getInitialState: ->
+    comments: null
+    error: null
+
+  componentDidMount: ->
+    @getComments(@props.user, @props.query.page)
+
+  componentWillReceiveProps: (nextProps) ->
+    unless nextProps is @props.user and nextProps.query.page is @props.query.page
+      @getComments(nextProps.user, nextProps.query.page)
+
+  getComments: (user, page) ->
+    @setState({
+      comments: null
+      error: null
+    })
+    talkClient.type('comments').get({user_id: user.id, page: page, sort: '-created_at'})
+      .catch (error) =>
+        @setState({error})
+      .then (comments) =>
+        @setState({comments})
+
+  render: ->
+    <div className="content-container">
+      {if @state.comments?.length is 0
+        <p className="form-help">No recent comments</p>
+      else if @state.comments?
+        # TODO: Pagination.
+        for comment in @state.comments
+          <CommentLink key={comment.id} comment={comment} />
+      else if @state.error?
+        <p className="form-help error">{@state.error.toString()}</p>
+      else
+        null}
+    </div>

--- a/app/pages/profile/feed.cjsx
+++ b/app/pages/profile/feed.cjsx
@@ -3,6 +3,7 @@ moment = require 'moment'
 apiClient = require '../../api/client'
 talkClient = require '../../api/talk'
 Markdown = require '../../components/markdown'
+Paginator = require '../../talk/lib/paginator'
 
 CommentLink = React.createClass
   displayName: 'CommentLink'
@@ -108,28 +109,10 @@ module.exports = React.createClass
           {for comment in @state.comments
             <CommentLink key={comment.id} comment={comment} />}
 
-          <select value={@props.query.page} disabled={meta.page_count is 1} onChange={@handlePageChange}>
-            {for page in [1..meta.page_count]
-              <option key={page}>{page}</option>}
-          </select>
+          <Paginator pageCount={meta.page_count} page={meta.page} />
         </div>
       else if @state.error?
         <p className="form-help error">{@state.error.toString()}</p>
       else
         null}
     </div>
-
-  changeSearchString: (search = '', changes) ->
-    params = {}
-    for keyValue in search.slice(1).split('&')
-      [key, value] = keyValue.split('=')
-      params[key] = value
-    for key, value of changes
-      params[key] = value
-    "?#{([key, value].join('=') for key, value of params).join('&')}"
-
-  handlePageChange: (e) ->
-    [beforeQ, afterQ] = location.hash.split('?')
-    oldSearch = '?' + afterQ
-    newSearch = @changeSearchString(oldSearch, {page: e.target.value})
-    location.hash = beforeQ + newSearch

--- a/app/pages/profile/index.cjsx
+++ b/app/pages/profile/index.cjsx
@@ -2,7 +2,6 @@ counterpart = require 'counterpart'
 React = require 'react'
 PrivateMessageForm = require '../../talk/private-message-form'
 PromiseRenderer = require '../../components/promise-renderer'
-authClient = require '../../api/auth'
 apiClient = require '../../api/client'
 ChangeListener = require '../../components/change-listener'
 Translate = require 'react-translate-component'
@@ -21,69 +20,51 @@ counterpart.registerTranslations 'en',
 UserProfilePage = React.createClass
   displayName: 'UserProfilePage'
 
+  getDefaultProps: ->
+    user: null
+
+  getInitialState: ->
+    profileHeader: null
+
   componentDidMount: ->
     document.documentElement.classList.add 'on-secondary-page'
-
-    @getUser()
+    @getProfileHeader(@props.user)
 
   componentWillReceiveProps: (nextProps) ->
-    if nextProps.params.name isnt @props.params.name
-      @getUser()
+    unless nextProps.user is @props.user
+      @getProfileHeader(nextProps.user)
 
   componentWillUnmount: ->
     document.documentElement.classList.remove 'on-secondary-page'
 
-  getUser: ->
-    authClient.checkCurrent()
-      .then (currentUser) =>
-        if currentUser? and currentUser.display_name is @props.params.name
-          @getProfileHeader(currentUser)
-        else
-          apiClient.type('users').get(login: @props.params.name)
-            .then ([fetchedUser]) =>
-              @getProfileHeader(fetchedUser)
-
   getProfileHeader: (user) ->
-    profileHero = React.findDOMNode(@refs.userProfileHero)
-
-    user.get('profile_header')
-      .then ([profile_header]) ->
-        profileHero.style.backgroundImage = "url(#{profile_header.src})"
-      .catch ->
-        profileHero.style.backgroundImage = ''
-        profileHero.style.backgroundColor = "#0072ff"
+    # TODO: Why's this return an array?
+    # The user should have an ID in its links.
+    @props.user.get('profile_header')
+      .catch =>
+        []
+      .then ([profileHeader]) =>
+        @setState({profileHeader})
 
   render: ->
+    if @state.profileHeader?
+      headerStyle = backgroundImage: "url(#{@state.profileHeader.src})"
+
     <div className="secondary-page user-profile">
-      <section className="hero user-profile-hero" ref="userProfileHero">
+      <section className="hero user-profile-hero" style={headerStyle}>
         <div className="overlay"></div>
         <div className="hero-container">
-          <PromiseRenderer promise={authClient.checkCurrent()} pending={null}>{(currentUser) =>
-            if currentUser? and currentUser.display_name is @props.params.name
-              <Translate name={currentUser.display_name} content="profile.title" component="h1" />
-            else
-              <PromiseRenderer
-                promise={apiClient.type('users').get(login: @props.params?.name)}
-                pending={null}
-                then={([fetchedUser]) =>
-                  <h1>{fetchedUser.display_name}</h1>}
-              />
-          }</PromiseRenderer>
+          <h1>{@props.user.display_name}</h1>
           <nav className="hero-nav">
-            <Link to="collections-user" params={owner: @props.params.name}><Translate content="profile.nav.collections" /></Link>
-            <PromiseRenderer promise={authClient.checkCurrent()} pending={null}>{(currentUser) =>
-              if currentUser?
-                <span>
-                  <Link to="inbox"><Translate content="profile.nav.messages" /></Link>
-                  <Link to="settings"><Translate content="profile.nav.settings" /></Link>
-                </span>
-            }</PromiseRenderer>
+            <Link to="collections-user" params={owner: @props.user.login}>
+              <Translate content="profile.nav.collections" />
+            </Link>
           </nav>
         </div>
       </section>
 
       <section className="user-profile-content">
-        <RouteHandler params={@props.params} />
+        <RouteHandler {...@props} />
       </section>
     </div>
 
@@ -91,6 +72,9 @@ module.exports = React.createClass
   displayName: 'UserProfilePageWrapper'
 
   render: ->
-    <ChangeListener target={authClient} handler={=>
-      <UserProfilePage params={@props.params} />
-    }/>
+    <PromiseRenderer promise={apiClient.type('users').get({login: @props.params.name})} then={([user]) =>
+      if user?
+        <UserProfilePage user={user} />
+      else
+        <p>Sorry, we couldn’t find any user going by <strong>{@props.params.name}</strong>.</p>
+    } />

--- a/app/pages/profile/index.cjsx
+++ b/app/pages/profile/index.cjsx
@@ -11,7 +11,7 @@ counterpart.registerTranslations 'en',
   profile:
     title: "Hi, %(name)s!"
     nav:
-      feed: "Feed"
+      comments: "Recent comments"
       stats: "Stats"
       collections: "Collections"
       messages: "Messages"
@@ -56,6 +56,10 @@ UserProfilePage = React.createClass
         <div className="hero-container">
           <h1>{@props.user.display_name}</h1>
           <nav className="hero-nav">
+            <Link to="user-profile" params={name: @props.user.login}>
+              <Translate content="profile.nav.comments" />
+            </Link>
+            {' '}
             <Link to="collections-user" params={owner: @props.user.login}>
               <Translate content="profile.nav.collections" />
             </Link>

--- a/app/pages/profile/index.cjsx
+++ b/app/pages/profile/index.cjsx
@@ -3,6 +3,7 @@ React = require 'react'
 PrivateMessageForm = require '../../talk/private-message-form'
 PromiseRenderer = require '../../components/promise-renderer'
 apiClient = require '../../api/client'
+auth = require '../../api/auth'
 ChangeListener = require '../../components/change-listener'
 Translate = require 'react-translate-component'
 {Link, RouteHandler} = require 'react-router'
@@ -14,7 +15,7 @@ counterpart.registerTranslations 'en',
       comments: "Recent comments"
       stats: "Stats"
       collections: "Collections"
-      messages: "Messages"
+      message: "Message"
       settings: "Settings"
 
 UserProfilePage = React.createClass
@@ -63,6 +64,17 @@ UserProfilePage = React.createClass
             <Link to="collections-user" params={owner: @props.user.login}>
               <Translate content="profile.nav.collections" />
             </Link>
+            {' '}
+            <ChangeListener target={auth}>{=>
+              <PromiseRenderer promise={auth.checkCurrent()}>{(user) =>
+                if user is @props.user
+                  null
+                else
+                  <Link to="user-profile-private-message" params={name: @props.user.login}>
+                    <Translate content="profile.nav.message" />
+                  </Link>
+              }</PromiseRenderer>
+            }</ChangeListener>
           </nav>
         </div>
       </section>

--- a/app/pages/profile/private-message.cjsx
+++ b/app/pages/profile/private-message.cjsx
@@ -1,29 +1,31 @@
-counterpart = require 'counterpart'
 React = require 'react'
 PrivateMessageForm = require '../../talk/private-message-form'
+ChangeListener = require '../../components/change-listener'
 PromiseRenderer = require '../../components/promise-renderer'
-authClient = require '../../api/auth'
-{Navigation} = require 'react-router'
-
+auth = require '../../api/auth'
 
 module.exports = React.createClass
   displayName: 'PrivateMessagePage'
-  mixins: [Navigation]
 
   render: ->
-    <PromiseRenderer promise={authClient.checkCurrent()} pending={null}>{(user) =>
-      if user?
-        if user?.login isnt @props.params?.name
-          <PrivateMessageForm {...@props} />
+
+    <ChangeListener target={auth} handler={=>
+      <PromiseRenderer promise={auth.checkCurrent()} then={(user) =>
+        if user?
+          <div className="content-container">
+            <h2>
+              Send a private message to {@props.user.display_name}
+              {' '}
+              {if user is @props.user
+                <span>
+                  <br />
+                  <small className="form-help">(Hey wait, that’s you!)</small>
+                </span>}
+            </h2>
+
+            <PrivateMessageForm {...@props} />
+          </div>
         else
-          @redirectToMessages()
-      else
-        @redirectToCollections()
-    }</PromiseRenderer>
-
-  redirectToMessages: ->
-    @replaceWith 'inbox'
-
-  redirectToCollections: ->
-    @transitionTo 'collections-user', owner: @props.params?.name
-
+          <p>Sign in to send this user a message.</p>
+      } />
+    } />

--- a/app/partials/account-bar.cjsx
+++ b/app/partials/account-bar.cjsx
@@ -43,6 +43,7 @@ module.exports = React.createClass
           <Link to="inbox" params={name: @props.user.login} className="message-link"><i className="fa fa-envelope#{if @state.unread then '' else '-o'}" /> </Link>
         </div>
         <div className="account-menu" ref="accountMenu">
+          <Link to="user-profile" params={name: @props.user.login}><Translate content="accountMenu.profile" /></Link>
           <Link to="settings" params={name: @props.user.login}><Translate content="accountMenu.settings" /></Link>
           <Link to="collections-user" params={{owner: @props.user.login}}>
             <Translate content="accountMenu.collections" />

--- a/app/talk/lib/paginator.cjsx
+++ b/app/talk/lib/paginator.cjsx
@@ -1,5 +1,20 @@
 React = require 'react'
 
+changeSearchString = (searchString, changes) ->
+  params = {}
+  for keyValue in searchString.slice(1).split('&')
+    [key, value] = keyValue.split('=')
+    params[key] = value
+  for key, value of changes
+    params[key] = value
+  "?#{([key, value].join('=') for key, value of params when value?).join('&')}"
+
+updatePageQueryParam = (page) ->
+  [beforeQuestionMark, afterQuestionMark] = location.hash.split('?')
+  oldSearch = '?' + afterQuestionMark
+  newSearch = changeSearchString(oldSearch, {page})
+  location.hash = beforeQuestionMark + newSearch
+
 module?.exports = React.createClass
   displayName: 'Paginator'
 
@@ -12,6 +27,7 @@ module?.exports = React.createClass
 
   getDefaultProps: ->
     page: 1
+    onPageChange: updatePageQueryParam
     firstAndLast: true
     scrollOnChange: true
 

--- a/css/main.styl
+++ b/css/main.styl
@@ -34,6 +34,7 @@
 @require './edit-media-page'
 
 @require "./user-profile"
+@require "./profile-feed-comment-link"
 @require "./settings"
 
 @require "./loading-indicator"

--- a/css/profile-feed-comment-link.styl
+++ b/css/profile-feed-comment-link.styl
@@ -1,0 +1,13 @@
+.profile-feed-comment-link
+  background: white
+  border: 1px solid rgba(gray, 0.2)
+  border-radius: 0.3em
+  color: inherit
+  display: block
+  font-size: 14px
+  margin: 0.5em 0
+  padding: 0.5em 1em
+  text-decoration: none
+
+  > header
+    font-size: 12px


### PR DESCRIPTION
This does a couple things, sorry:

- Restores the feed to the user profile page. It's just a list of user comments for now. In the future it could include "Created a collection" and "Added to this collection" and that type of event, I think. I think there was an issue for this but I can't find it now.

- Adds a default `onPageChange` to the paginator, which updates the hash's `?page=n` param, which I think is what we'll want 90% of the time, right?

- The "Message" link now brings up the form to send that user a message. Before it had all kinds of redirects (to inbox and collections), which was sorta confusing. If I've misunderstood something here, let me know.