### PR TITLE
Polygon hint line

### DIFF
--- a/app/classifier/drawing-tools/polygon.cjsx
+++ b/app/classifier/drawing-tools/polygon.cjsx
@@ -33,6 +33,18 @@ module.exports = React.createClass
     forceComplete: (mark) ->
       mark.closed = true
 
+  componentWillMount: ->
+    @setState
+      mouseX: @props.mark.points[0].x
+      mouseY: @props.mark.points[0].y
+      mouseWithinViewer: true
+
+  componentDidMount: ->
+    document.addEventListener 'mousemove', @handleMouseMove
+
+  componentWillUnmount: ->
+    document.removeEventListener 'mousemove', @handleMouseMove
+
   render: ->
     averageScale = (@props.scale.horizontal + @props.scale.vertical) / 2
     finisherRadius = FINISHER_RADIUS / averageScale
@@ -62,7 +74,10 @@ module.exports = React.createClass
         <g>
           <DeleteButton tool={this} x={deleteButtonPosition.x} y={deleteButtonPosition.y} />
 
-          {if not @props.mark.closed and  @props.mark.points.length > 2
+          {if not @props.mark.closed and @props.mark.points.length and @state.mouseWithinViewer
+            <line className="guideline" x1={lastPoint.x} y1={lastPoint.y} x2={@state.mouseX} y2={@state.mouseY} />}
+
+          {if not @props.mark.closed and @props.mark.points.length > 2
             <line className="guideline" x1={lastPoint.x} y1={lastPoint.y} x2={firstPoint.x} y2={firstPoint.y} />}
 
           {for point, i in @props.mark.points
@@ -76,7 +91,25 @@ module.exports = React.createClass
         </g>}
     </DrawingToolRoot>
 
+  handleMouseMove: (e) ->
+    xPos = e.pageX - pageXOffset
+    yPos = e.pageY - pageYOffset
+
+    mouseWithinViewer = if xPos < @props.containerRect.left || xPos > @props.containerRect.right
+      false
+    else if yPos < @props.containerRect.top || yPos > @props.containerRect.bottom
+      false
+    else
+      true
+
+    @setState
+      mouseX: (xPos - @props.containerRect.left) / @props.scale.horizontal
+      mouseY: (yPos - @props.containerRect.top) / @props.scale.vertical
+      mouseWithinViewer: mouseWithinViewer
+
   handleFinishClick: ->
+    document.removeEventListener 'mousemove', @handleMouseMove
+
     @props.mark.closed = true
     @props.onChange()
 

--- a/app/classifier/subject-viewer.cjsx
+++ b/app/classifier/subject-viewer.cjsx
@@ -30,9 +30,11 @@ module.exports = React.createClass
 
   componentDidMount: ->
     addEventListener 'resize', @handleResize
+    addEventListener 'scroll', @handleResize
 
   componentWillUnmount: ->
     removeEventListener 'resize', @handleResize
+    removeEventListener 'scroll', @handleResize
 
   getScale: ->
     ALMOST_ZERO = 0.01 # Prevent divide-by-zero errors when there is no image.
@@ -100,6 +102,7 @@ module.exports = React.createClass
                   mark._key ?= Math.random()
                   toolDescription = taskDescription.tools[mark.tool]
                   toolEnv =
+                    containerRect: @state.sizeRect
                     scale: @getScale()
                     disabled: isPriorAnnotation
                     selected: mark is @state.selectedMark

--- a/css/drawing-tool.styl
+++ b/css/drawing-tool.styl
@@ -40,6 +40,7 @@
 
   .guideline
     animation: guideline-marching-ants 0.5s linear infinite
+    pointer-events: none
     stroke-dasharray: 2 3
 
 .aggregate-mark


### PR DESCRIPTION
- Adds a line that follows the mouse while marking a polygon. Useful for both training new users and allowing veterans to be more precise.
- Closes #650 maybe?

Pinging @aliburchard and @mkosmala for confirmation, demo at http://demo.zooniverse.org/panoptes-front-end/polygon-hint/#/dev/classifier