### PR TITLE
Quick fix for site not showing in Safari.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "react": "~0.13.2",
     "react-interpolate-component": "~0.7.1",
     "react-router": "~0.13.2",
-    "react-select": "edpaget/react-select#close-after-click",
+    "react-select": "^0.4.9",
     "react-translate-component": "~0.9.0",
     "sugar-client": "^1.0.1",
     "tether": "HubSpot/tether#df8cd44",


### PR DESCRIPTION
Roll back to react-select to 0.4.9.
Might reopen #528.