### PR TITLE
a11y fixes for dialogs

### DIFF
--- a/app/components/dialog.cjsx
+++ b/app/components/dialog.cjsx
@@ -1,6 +1,6 @@
 React = require 'react'
 
-FOCUSABLES = 'input, textarea, button, select, [tabindex]'
+FOCUSABLES = "a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), iframe, object, embed, *[tabindex], *[contenteditable]"
 
 ESC_KEY = 27
 TAB_KEY = 9
@@ -13,7 +13,7 @@ module.exports = React.createClass
 
   render: ->
     <div className="dialog-underlay" onKeyDown={@handleKeyDown}>
-      <div className="dialog">
+      <div aria-role='dialog' className="dialog">
         <div className="dialog-controls">
           <div className="wrapper">{@props.controls}</div>
         </div>
@@ -32,16 +32,11 @@ module.exports = React.createClass
 
       when TAB_KEY
         {shiftKey} = e # Save this; React recycles the event object.
-        setTimeout => # Give document.activeElement time to change.
-          if document.activeElement not in @getDOMNode().querySelectorAll '*'
-            if shiftKey
-              @focusLast()
-            else
-              @focusFirst()
+        focusables = @getDOMNode().querySelectorAll FOCUSABLES
+        if shiftKey and document.activeElement == focusables[0]
+          focusables[focusables.length - 1]?.focus()
+          e.preventDefault()
+        else if !shiftKey and document.activeElement == focusables[focusables.length - 1]
+          focusables[0]?.focus()
+          e.preventDefault()
 
-  focusFirst: ->
-    @getDOMNode().querySelector(FOCUSABLES)?.focus()
-
-  focusLast: ->
-    focusables = @getDOMNode().querySelectorAll FOCUSABLES
-    focusables[focusables.length - 1]?.focus()

--- a/app/lib/alert.cjsx
+++ b/app/lib/alert.cjsx
@@ -19,7 +19,7 @@ module.exports = (message) ->
 
   previousActiveElement = document.activeElement
 
-  closeButton = <button onClick={defer.resolve}>&times;</button>
+  closeButton = <button aria-label='Close' onClick={defer.resolve}>&times;</button>
   React.render <Dialog className="alert" controls={closeButton} onEscape={defer.resolve}>
     {message}
   </Dialog>, container


### PR DESCRIPTION
Labels the close button so it's read as 'close', not 'times', by VoiceOver.
Adds the dialog role to the containing div. Should be announced by VoiceOver.
Fixes the keydown handler so that focus cannot leave the dialog when it is open.