### PR TITLE
Only (un)subscribe from the talk component when (un)mounting the zooniverse talk section

### DIFF
--- a/app/talk/init.cjsx
+++ b/app/talk/init.cjsx
@@ -30,10 +30,10 @@ module?.exports = React.createClass
     loading: true
 
   componentWillMount: ->
-    sugarClient.subscribeTo @props.section
+    sugarClient.subscribeTo('zooniverse') if @props.section is 'zooniverse'
 
   componentWillUnmount: ->
-    sugarClient.unsubscribeFrom @props.section
+    sugarClient.unsubscribeFrom('zooniverse') if @props.section is 'zooniverse'
 
   setBoards: ->
     talkClient.type('boards').get(section: @props.section)


### PR DESCRIPTION
This fixes a really subtle bug.  Currently, the subscription flow is

- visit #/projects/user/name
  - pages/project mounts --  subscribes to project-123
- visit #/projects/user/name/talk
  - talk/init mounts -- subscribes to project-123
- visit #/projects/user/name
  - talk/init unmounts -- unsubscribes from project-123 even though the user is still active on the project



Basically, the talk/init component only needs to handle notification channel subscriptions when visiting the zooniverse global talk (it's the only time when the talk/init component mounts without the pages/project component).