### PR TITLE
Link to subjects when in project and set as focus

### DIFF
--- a/app/talk/comment.cjsx
+++ b/app/talk/comment.cjsx
@@ -16,6 +16,7 @@ talkClient = require '../api/talk'
 Avatar = require '../partials/avatar'
 SubjectViewer = require '../components/subject-viewer'
 DisplayRoles = require './lib/display-roles'
+merge = require 'lodash.merge'
 
 DEFAULT_AVATAR = './assets/simple-avatar.jpg'
 
@@ -80,6 +81,17 @@ module?.exports = React.createClass
   upvoteCount: ->
     Object.keys(@props.data.upvotes).length
 
+  commentSubjectTitle: (comment, subject) ->
+    {owner, name} = @props.params
+    if (comment.focus_type is 'Subject') and (owner and name)
+      <Link
+        to="project-talk-subject"
+        params={merge {id: comment.focus_id}, {owner, name}}>
+        Subject {subject.id}
+      </Link>
+    else
+      <span>Subject {subject.id}</span>
+
   render: ->
     feedback = @renderFeedback()
     activeClass = if @props.active then 'active' else ''
@@ -114,7 +126,7 @@ module?.exports = React.createClass
                 }
                 then={(subject) =>
                   <div className="polaroid-image">
-                    Subject {subject.id}
+                    {@commentSubjectTitle(@props.data, subject)}
                     <SubjectViewer subject={subject} user={@props.user} />
                   </div>
                 }

--- a/app/talk/discussion.cjsx
+++ b/app/talk/discussion.cjsx
@@ -143,6 +143,7 @@ module?.exports = React.createClass
 
   comment: (data, i) ->
     <Comment
+      {...@props}
       key={data.id}
       data={data}
       active={+data.id is +@props.query?.comment}


### PR DESCRIPTION
- Closes #916
- Right now only from projects ~ #1020
- Can be seen on demo at
  - `#/projects/alex-panoptes/test-proj/talk/42/51`
  - `#/talk/20/82`
- I've got another branch up called `link-to-subjects-in-discussion-titles` where the links happen in titles, but I think this is a bit cleaner