### PR TITLE
Use a generic MediaArea component for projects

### DIFF
--- a/app/components/dropdown-form.cjsx
+++ b/app/components/dropdown-form.cjsx
@@ -18,6 +18,11 @@ DropdownForm = React.createClass
     right: 0
     top: 0
 
+  pointerStyle:
+    bottom: '100%'
+    position: 'absolute'
+    transform: 'translate(-50%, -50%) rotate(45deg)'
+
   formStyle:
     position: 'absolute'
 
@@ -38,16 +43,20 @@ DropdownForm = React.createClass
 
   reposition: (e) ->
     form = @refs.form.getDOMNode()
+    pointer = @refs.pointer.getDOMNode()
     anchorRect = @props.anchor.getBoundingClientRect()
-
-    top = anchorRect.bottom
 
     left = anchorRect.left - ((form.offsetWidth - @props.anchor.offsetWidth) / 2)
     left = Math.max left, 0
     left = Math.min left, innerWidth - form.offsetWidth
 
-    form.style.top = "#{top}px"
+    top = anchorRect.bottom
+
     form.style.left = "#{left}px"
+    form.style.top = "#{top}px"
+
+    pointer.style.left = "#{anchorRect.left + (@props.anchor.offsetWidth / 2)}px"
+    pointer.style.top = "#{top + parseFloat(getComputedStyle(form).marginTop)}px"
 
   handleGlobalKeyDown: (e) ->
     unless @props.required
@@ -56,7 +65,8 @@ DropdownForm = React.createClass
 
   render: ->
     <div className="dropdown-form-underlay" style={@underlayStyle} onClick={@handleUnderlayClick}>
-      <form ref="form" className="dropdown-form" style={@formStyle} onSubmit={@handleSubmit}>
+      <div ref="pointer" className="dropdown-form-pointer" style={@pointerStyle}></div>
+      <form ref="form" className="dropdown-form" style={@formStyle} action="POST" onSubmit={@handleSubmit}>
         {@props.children}
       </form>
     </div>

--- a/app/components/file-button.cjsx
+++ b/app/components/file-button.cjsx
@@ -1,0 +1,61 @@
+React = require 'react'
+
+module.exports = React.createClass
+  displayName: 'FileButton'
+
+  getDefaultProps: ->
+    tag: 'label'
+    className: ''
+    accept: '*/*'
+    multiple: false
+    disabled: false
+    onSelect: Function.prototype
+
+  getInitialState: ->
+    resetting: false
+
+  rootStyle:
+    position: 'relative'
+
+  containerStyle:
+    height: '100%'
+    left: 0
+    opacity: 0.01
+    overflow: 'hidden'
+    position: 'absolute'
+    top: 0
+    width: '100%'
+
+  inputStyle:
+    cursor: 'pointer'
+    height: '300%'
+    left: '-100%'
+    opacity: 0.01
+    position: 'absolute'
+    top: '-100%'
+    width: '300%'
+
+  render: ->
+    input = if @state.resetting
+      null
+    else
+      {accept, multiple, disabled} = @props
+      passedProps = {accept, multiple, disabled}
+      <input type="file" {...passedProps} style={@inputStyle} onChange={@handleChange} />
+
+    React.createElement @props.tag,
+      className: "file-button #{@props.className}".trim()
+      style: Object.assign {}, @rootStyle, @props.style
+      'data-accept': @props.accept
+      'data-disabled': @props.disabled || null
+      'data-multiple': @props.multiple || null
+      <span style={@containerStyle}>{input}</span>,
+      @props.children
+
+  handleChange: ->
+    @props.onSelect arguments...
+    @setState resetting: true
+
+  componentDidUpdate: ->
+    if @state.resetting
+      @setState resetting: false

--- a/app/components/media-area.cjsx
+++ b/app/components/media-area.cjsx
@@ -1,0 +1,254 @@
+React = require 'react'
+Thumbnail = require './thumbnail'
+PromiseRenderer = require './promise-renderer'
+DropdownForm = require './dropdown-form'
+FileButton = require './file-button'
+apiClient = require '../api/client'
+putFile = require '../lib/put-file'
+
+FileDropTarget = React.createClass
+  displayName: 'DragAndDropTarget'
+
+  getDefaultProps: ->
+    className: ''
+    filterFiles: null
+    onDrop: Function.prototype
+
+  getInitialState: ->
+    canDrop: false
+
+  eventsToMakeDropWork: ->
+    onDragEnter: @handleDragEnter
+    onDragOver: @handleDragOver
+    onDragLeave: @handleDragLeave
+    onDrop: @handleDrop
+
+  render: ->
+    className = "file-drop-target #{@props.className}".trim()
+    <div {...@props} className={className} data-can-drop={@state.canDrop || null} {...@eventsToMakeDropWork()}>
+      {@props.children}
+    </div>
+
+  handleDragEnter: (e) ->
+    e.preventDefault()
+    files = Array::filter.call e.dataTransfer.files, @props.filterFiles ? Boolean
+    @setState canDrop: files.length is e.dataTransfer.files.length
+
+  handleDragOver: (e) ->
+    e.preventDefault()
+
+  handleDragLeave: (e) ->
+    e.preventDefault()
+    @setState canDrop: false
+
+  handleDrop: (e) ->
+    e.preventDefault()
+    if @state.canDrop
+      @props.onDrop arguments...
+      @setState canDrop: false
+
+MediaIcon = React.createClass
+  displayName: 'MediaIcon'
+
+  getDefaultProps: ->
+    resource: null
+    height: 80
+    onDelete: Function.prototype
+
+  getInitialState: ->
+    deleting: false
+
+  getMarkdown: (resource) ->
+    "![#{resource.metadata.filename}](#{resource.src})"
+
+  render: ->
+    <div className="media-icon" style={opacity: 0.5 if @state.deleting}>
+      <div className="media-icon-thumbnail-container">
+        <DropdownForm label={
+          <Thumbnail className="media-icon-thumbnail" src={@props.resource.src} height={@props.height} style={position: 'relative'} />
+        }>
+          <div className="content-container">
+            <img src={@props.resource.src} style={
+              maxHeight: '80vh'
+              maxWidth: '60vw'
+            } />
+          </div>
+        </DropdownForm>
+        <button type="button" className="media-icon-delete-button" disabled={@state.deleting} onClick={@handleDelete}>&times;</button>
+      </div>
+      <div className="media-icon-label" style={position: 'relative'}>{@props.resource.metadata.filename}</div>
+      <textarea className="media-icon-markdown" value={@getMarkdown @props.resource} readOnly style={position: 'relative'} onFocus={@handleMarkdownFocus} />
+    </div>
+
+  handleDelete: ->
+    console.log "Deleting media resource #{@props.resource.id}"
+    @setState deleting: true
+    @props.resource.delete().then =>
+      @setState deleting: false
+      @props.onDelete @props.resource
+
+  handleMarkdownFocus: (e) ->
+    e.target.setSelectionRange 0, e.target.value.length
+
+module.exports = React.createClass
+  displayName: 'MediaArea'
+
+  getDefaultProps: ->
+    resource: null
+    link: 'attached_images'
+    pageSize: 200
+    onAdd: Function.prototype
+    onDelete: Function.prototype
+
+  getInitialState: ->
+    pendingFiles: []
+    pendingMedia: []
+    errors: []
+
+  addButtonStyle:
+    height: '80px'
+    lineHeight: '100px'
+    width: '100px'
+
+  render: ->
+    window.lastRenderedMediaArea = this
+    console.log('Pending', @state.pendingFiles.length, @state.pendingFiles);
+
+    @cachedMediaRequest = @props.resource.get @props.link, page_size: @props.pageSize
+      .catch ->
+        []
+
+    <PromiseRenderer promise={@cachedMediaRequest}>{(media) =>
+      media = [].concat media
+
+      <div className="media-area" style={position: 'relative'}>
+        <FileDropTarget style={
+          bottom: '3px'
+          left: '3px'
+          position: 'absolute'
+          right: '3px'
+          top: '3px'
+        } onDrop={@handleDrop} />
+
+        {if media.length is 0
+          <small>
+            <em>No media</em>
+          </small>}
+
+        <ul className="media-area-list">
+          {media.map (resource) =>
+            if resource in @state.pendingMedia
+              null
+            else
+              <li key={resource.id} className="media-area-item">
+                <MediaIcon resource={resource} onDelete={@handleDelete} />
+              </li>}
+
+          <li className="media-area-item" style={alignSelf: 'stretch'}>
+            <div className="media-icon">
+              <FileButton className="media-area-add-button" accept="image/*" multiple style={@addButtonStyle} onSelect={@handleFileSelection}>
+                <i className="fa fa-plus fa-3x"></i>
+              </FileButton>
+              <div className="media-icon-label">Select files</div>
+            </div>
+          </li>
+        </ul>
+
+        {if @props.children?
+          <hr />}
+        {@props.children}
+
+        {unless @state.pendingFiles.length is 0
+          <hr />}
+        {@state.pendingFiles.map (file) =>
+          <div key={file.name}>
+            <small>
+              <i className="fa fa-spinner fa-spin"></i>{' '}
+              <strong>{file.name}</strong>
+            </small>
+          </div>}
+
+        {unless @state.errors.length is 0
+          <hr />}
+        {@state.errors.map ({file, error}) =>
+          <div key={file.name}>{error.toString()} ({file.name})</div>}
+      </div>
+    }</PromiseRenderer>
+
+  handleDrop: (e) ->
+    @addFiles Array::slice.call e.dataTransfer.files
+
+  handleDelete: ->
+    @refresh()
+    @props.onDelete arguments...
+
+  refresh: ->
+    console.log 'Refreshing media area'
+    @cachedMediaRequest = null
+    @forceUpdate()
+
+  handleFileSelection: (e) ->
+    console.log "Handling #{e.target.files.length} selected files"
+    @addFiles Array::slice.call e.target.files
+
+  addFiles: (files) ->
+    console.log "Adding #{files.length} files"
+    files.forEach @addFile
+
+  addFile: (file) ->
+    console.log "Adding media #{file.name}"
+    @state.pendingFiles.push file
+    @setState pendingFiles: @state.pendingFiles
+
+    @createLinkedResource file
+      .then @uploadMedia.bind this, file
+      .then @handleSuccess
+      .catch @handleError.bind this, file
+      .then @removeFromPending.bind this, file
+
+  createLinkedResource: (file) ->
+    console.log "Creating resource for #{file.name}, #{(file.type)}"
+    payload =
+      media:
+        content_type: file.type
+        metadata:
+          filename: file.name
+
+    apiClient.post @props.resource._getURL(@props.link), payload
+      .then (media) =>
+        # We get an array here for some reason. Pull the resource out.
+        # TODO: Look into this.
+        media = [].concat(media)[0]
+        @state.pendingMedia.push media
+        media
+
+  uploadMedia: (file, media) ->
+    console.log "Uploading #{file.name} => #{media.src}"
+    putFile media.src, file
+      .then =>
+        media.refresh().then (media) =>
+          # Another weird array.
+          [].concat(media)[0]
+      .catch (error) =>
+        media.delete()
+          .then =>
+            throw error
+
+  handleSuccess: (media) ->
+    console.log "Success! #{media.metadata.filename}"
+    pendingMediaIndex = @state.pendingMedia.indexOf media
+    @state.pendingMedia.splice pendingMediaIndex, 1
+    @setState pendingMedia: @state.pendingMedia
+    @props.onAdd media
+    media
+
+  handleError: (file, error) ->
+    console.log "Got error #{error.message} for #{file.name}"
+    @state.errors.push {file, error}
+    @setState errors: @state.errors
+
+  removeFromPending: (file) ->
+    console.log "No longer pendingFiles: #{file.name}"
+    pendingFileIndex = @state.pendingFiles.indexOf file
+    @state.pendingFiles.splice pendingFileIndex, 1
+    @setState pendingFiles: @state.pendingFiles

--- a/app/components/thumbnail.cjsx
+++ b/app/components/thumbnail.cjsx
@@ -1,0 +1,19 @@
+React = require 'react'
+
+MAX_THUMBNAIL_DIMENSION = 999
+
+module.exports = React.createClass
+  displayName: 'Thumbnail'
+
+  getDefaultProps: ->
+    src: ''
+    width: MAX_THUMBNAIL_DIMENSION
+    height: MAX_THUMBNAIL_DIMENSION
+    origin: 'https://thumbnails.zooniverse.org'
+
+  getThumbnailSrc: ({origin, width, height, src}) ->
+    srcPath = src.split('//').pop()
+    "#{origin}/#{width}x#{height}/#{srcPath}"
+
+  render: ->
+    <img {...@props} src={@getThumbnailSrc @props} width={null} height={null} />

--- a/app/pages/lab/media.cjsx
+++ b/app/pages/lab/media.cjsx
@@ -1,120 +1,5 @@
 React = require 'react'
-PromiseRenderer = require '../../components/promise-renderer'
-ImageSelector = require '../../components/image-selector'
-apiClient = require '../../api/client'
-putFile = require '../../lib/put-file'
-
-MAX_MEDIA_COUNT = 30
-MAX_MEDIA_SIZE = 500000
-
-# For use on click.
-selectTarget = (e) =>
-  e.target.select()
-
-MediaItem = React.createClass
-  displayName: 'MediaItem'
-
-  getDefaultProps: ->
-    medium: {}
-    onDelete: Function.prototype
-
-  getInitialState: ->
-    width: NaN
-    height: NaN
-    loading: true
-    loadError: null
-    deleting: false
-    deleteError: null
-
-  render: ->
-    <span className="media-item">
-      <span className="media-item-container">
-        <button type="button" className="media-item-delete-button" disabled={@state.loading or @state.deleting} onClick={@handleDelete}>&times;</button>
-        {if @props.medium.content_type.indexOf 'image/' is 0
-          <img ref="img" className="media-item-image" src={@props.medium.src} onLoad={@handleLoad} onError={@handleLoadError} />}
-      </span>
-      <br />
-      {@props.medium.metadata?.filename ? <i>Untitled</i>}
-      <br />
-      {if @state.loading
-        <span>Loading...</span>
-      if @state.loadError
-        <span>{@state.loadError.toString()}</span>
-      else if @state.deleting
-        <span>Deleting...</span>
-      else if @state.deleteError
-        <span>{@state.deleteError.toString()}</span>
-      else unless isNaN(@state.width) or isNaN(@state.height)
-        <small>{@state.width}&times;{@state.height}</small>}
-      <br />
-      <textarea className="media-item-src" defaultValue="![#{@props.medium.metadata?.filename}](#{@props.medium.src})" readOnly onClick={selectTarget} />
-    </span>
-
-  handleLoad: ->
-    media = @refs.img.getDOMNode()
-    @setState
-      loading: false
-      width: media.naturalWidth
-      height: media.naturalHeight
-
-  handleLoadError: ->
-    @setState
-      loading: false
-      loadError: 'Failed to load media'
-
-  handleDelete: (e) ->
-    confirmed = e.shiftKey or confirm 'Really delete?'
-    if confirmed
-      @setState
-        deleting: true
-        deleteError: null
-
-      @props.medium.delete()
-        .catch (error) =>
-          @setState deleteError: error
-        .then =>
-          @setState deleting: false
-          @props.onDelete()
-
-MediaUploadArea = React.createClass
-  displayName: 'MediaUploadArea'
-
-  getDefaultProps: ->
-    project: {}
-    onUpload: Function.prototype
-
-  getInitialState: ->
-    uploading: false
-    uploadError: null
-
-  render: ->
-    <span className="media-upload-area">
-      <ImageSelector placeholder="Drop an image here" onChange={@handleImageSelection} />
-      {if @state.uploading
-        <span>Working...</span>}
-      {if @state.uploadError
-        <span>{@state.uploadError.toString()}</span>}
-    </span>
-
-  handleImageSelection: (file, img) ->
-    @setState
-      uploading: true
-      uploadError: null
-
-    payload =
-      media:
-        content_type: file.type
-        metadata:
-          filename: img.title
-
-    apiClient.post @props.project._getURL('attached_images'), payload
-      .then ([media]) =>
-        putFile media.src, file
-      .catch (error) =>
-        @setState uploadError: error
-      .then =>
-        @setState uploading: false
-        @props.onUpload()
+MediaArea = require '../../components/media-area'
 
 module.exports = React.createClass
   displayName: 'EditMediaPage'
@@ -123,33 +8,10 @@ module.exports = React.createClass
     project: {}
 
   render: ->
-    @getMedia ?= apiClient.get @props.project._getURL('attached_images'), page_size: MAX_MEDIA_COUNT
-
     <div className="edit-media-page">
       <div className="content-container">
         <p><strong>You can add images here to use in your project’s content.</strong> Just copy and paste the image’s Markdown code: <code>![title](url)</code>.</p>
-        <PromiseRenderer promise={@getMedia} then={(media) =>
-          <div className="media-list">
-            {for medium in media
-              <MediaItem key={medium.id} medium={medium} onDelete={@handleChange} />}
-          </div>
-        } catch={=>
-          <div>No media</div>
-        } />
-      </div>
-
-      <hr />
-
-      <div className="content-container">
-        <PromiseRenderer promise={@getMedia.catch -> []} then={(media) =>
-          if media.length < MAX_MEDIA_COUNT
-            <div>
-              Add an image<br />
-              <MediaUploadArea project={@props.project} onUpload={@handleChange} />
-            </div>
-          else
-            <p>You’ve reached the limit of {MAX_MEDIA_COUNT} images for this project. Delete some images to add new ones.</p>
-        } />
+        <MediaArea resource={@props.project} />
       </div>
     </div>
 

--- a/css/dropdown-form.styl
+++ b/css/dropdown-form.styl
@@ -4,11 +4,17 @@
 .dropdown-form-underlay
   background: rgba(gray, 0.2)
 
+.dropdown-form-pointer
+  background: white
+  box-shadow: 0 0 5px rgba(black 0.3)
+  height: 1em
+  width: 1em
+
 .dropdown-form
   background: white
   border-radius: 3px
-  box-shadow: 0 5px 20px -5px rgba(black, 0.5)
+  box-shadow: 0 5px 15px -5px rgba(black, 0.5)
   color: black
   font-size: 14px
-  margin-top: 3px
+  margin: 0.5em 3vw
   padding: 0.5em 1em

--- a/css/main.styl
+++ b/css/main.styl
@@ -6,6 +6,7 @@
 @require './tables'
 @require './buttons'
 @require './upload-drop-target'
+@require './media-area'
 @require './image-selector'
 @require "./forms"
 @require './avatars'

--- a/css/media-area.styl
+++ b/css/media-area.styl
@@ -1,0 +1,73 @@
+.media-area
+  background: rgba(gray, 0.1)
+  border: 1px solid rgba(gray, 0.2)
+  border-radius: 5px
+  padding: 0.5em 0.5em 1em
+  text-align: center
+
+.file-drop-target
+  border: 2px dashed transparent
+  border-radius: 3px
+
+  &[data-can-drop]
+    border-color: MAIN_HIGHLIGHT
+
+.media-area-list
+  align-items: baseline
+  display: flex
+  flex-wrap: wrap
+  justify-content: center
+  margin: 0
+  padding: 0
+
+.media-area-item
+  display: block
+  flex-basis: 25ch
+  margin: 1px
+  padding: 0.5em
+
+.media-icon
+  font-size: 12px
+  text-align: center
+
+.media-icon-thumbnail
+  box-shadow: 0 3px 10px -3px rgba(black, 0.5)
+
+.media-icon-thumbnail-container
+  display: inline-block
+  position: relative
+
+.media-icon-delete-button
+  @extends $reset-button
+  background: gray
+  border-radius: 50%
+  color: white
+  font-size: 16px
+  height: 1em
+  line-height: 1
+  position: absolute
+  right: -0.5em
+  top: -0.3em
+  width: 1em
+
+.media-icon-thumbnail
+  font-size: 12px
+
+.media-icon-markdown
+  border: 0
+  background: transparent
+  color: inherit
+  font: inherit
+  font-size: 10px
+  height: 4.2em
+  white-space: pre
+  width: 100%
+
+.media-area-add-button
+  border: 2px dashed
+  border-radius: 5px
+  color: MAIN_HIGHLIGHT
+  display: inline-block
+
+  &:active
+    color: black


### PR DESCRIPTION
This is phase one of the survey task editor. Surveys have images, and we needed a decent way to manage 'em, so this is a generic interface for working with resources' `linked_images`.

Here it replaces the project lab's Media page.

The Thumbnail component uses our cool little thumbnail auto-generator.

The FileButton component is like a `<select type="file" />`, but it passes its value straight into `@props.onSelect` instead of storing it.

I don't think the FileDropTarget is quite square yet, but once it is we can use it to simplify a few other components.

I can see the Thumbnail component being extended in the future to support Media resources and Subjects directly. To-do for later.