### PR TITLE
Improve tag regex boundaries in markdown

### DIFF
--- a/app/components/markdown.cjsx
+++ b/app/components/markdown.cjsx
@@ -45,7 +45,7 @@ module.exports = React.createClass
       .replace /\B@(\b[\w-]+\b)/g, "<a href='#/users/$1'>@$1</a>"
 
       # hashtags #tagname
-      .replace /\B\#(\w+)/g, (fullTag, tagName) ->
+      .replace /(?!\B.*\/)\B#(\b[\w+-\/]+\b)/g, (fullTag, tagName) ->
         if owner and name
           "<a href='#/projects/#{owner}/#{name}/talk/search?query=#{tagName}'>#{fullTag}</a>"
         else


### PR DESCRIPTION
- Closes #1269
- Prevents conflicts with hashed URLs and slugs
- Supports all of the following cases/delimiters
  - `#test-tag`
  - `#test_tag`
  - `#test/tag`
  - `http://docs.panoptes.apiary.io/#reference/user/users-collection/list-all-users`
