### PR TITLE
Set a flex-basis on dialog-content

### DIFF
--- a/css/dialog.styl
+++ b/css/dialog.styl
@@ -16,7 +16,6 @@
   background: white
   box-shadow: 0 1px 3px -1px black
   color: black
-  display: flex
   flex-direction: column
   left: 50%
   max-height: 90%
@@ -48,6 +47,8 @@
 
 .dialog-content
   overflow: auto
+  display: flex
+  flex: 1 0 800px
 
   img
     max-width: 100%


### PR DESCRIPTION
...to restrict dialog width in Internet Explorer

Currently IE11 and below don't corrently implement flex-basis auto or
flex-basis content, so flexed content will always expand to fill the
largest space possible unless an explicity flex-basis is set.

This just sets flex-basis for the dialog-container to 800px, which seems
like a reasonable maximum.

Closes #1296; Closes #1191