### PR TITLE
add private field info to subject uploader

### DIFF
--- a/app/pages/lab/subject-set.cjsx
+++ b/app/pages/lab/subject-set.cjsx
@@ -155,6 +155,7 @@ EditSubjectSetPage = React.createClass
         <UploadDropTarget accept="text/csv, text/tab-separated-values, image/*" multiple onSelect={@handleFileSelection}>
           <strong>Drag-and-drop or click to upload manifests and subject images here.</strong><br />
           Manifests must be <code>.csv</code> or <code>.tsv</code>. The first row should define metadata headers. All other rows should include at least one reference to an image filename in the same directory as the manifest.<br />
+          Headers that begin with "#" or "//" denote private fields that will not be visible to classifiers.<br />
           Subject images can be up to {MAX_FILE_SIZE/1000}KB and any of: {<span key={ext}><code>{ext}</code>{', ' if VALID_SUBJECT_EXTENSIONS[i + 1]?}</span> for ext, i in VALID_SUBJECT_EXTENSIONS}{' '} 
           and may not contain {<span key={char}><kbd>{char}</kbd>{', ' if INVALID_FILENAME_CHARS[i + 1]?}</span> for char, i in INVALID_FILENAME_CHARS}<br />
         </UploadDropTarget>


### PR DESCRIPTION
Adds 1-line description on the subject uploader page about the existence of private fields in manifest.
Closes #1327.