### PR TITLE
Fix task area at 50ch

### DIFF
--- a/app/classifier/mock-data.coffee
+++ b/app/classifier/mock-data.coffee
@@ -180,9 +180,9 @@ subject = apiClient.type('subjects').create
   id: 'MOCK_SUBJECT_FOR_CLASSIFIER'
 
   locations: [
-    {'image/jpeg': if navigator.onLine then 'http://lorempixel.com/150/100/animals/1' else BLANK_IMAGE}
-    {'image/jpeg': if navigator.onLine then 'http://lorempixel.com/150/100/animals/2' else BLANK_IMAGE}
-    {'image/jpeg': if navigator.onLine then 'http://lorempixel.com/150/100/animals/3' else BLANK_IMAGE}
+    {'image/jpeg': if navigator.onLine then 'http://lorempixel.com/900/600/animals/1' else BLANK_IMAGE}
+    {'image/jpeg': if navigator.onLine then 'http://lorempixel.com/900/600/animals/2' else BLANK_IMAGE}
+    {'image/jpeg': if navigator.onLine then 'http://lorempixel.com/900/600/animals/3' else BLANK_IMAGE}
   ]
 
   metadata:

--- a/css/classify.styl
+++ b/css/classify.styl
@@ -76,10 +76,9 @@
     transform: rotate(-15deg)
 
   > .task-area
-    // We want this fixed at 50h, but don't completely disable flex-shrink because
-    // when it wraps to its own line it shouldn't be cropped by small windows.
-    flex: 0 0.01 50ch
+    flex: 0 0 50ch
     margin-bottom: 1em
+    max-width: 100%
 
   .task-nav
     display: flex

--- a/css/classify.styl
+++ b/css/classify.styl
@@ -76,10 +76,10 @@
     transform: rotate(-15deg)
 
   > .task-area
-    flex: 1 1
+    // We want this fixed at 50h, but don't completely disable flex-shrink because
+    // when it wraps to its own line it shouldn't be cropped by small windows.
+    flex: 0 0.01 50ch
     margin-bottom: 1em
-    max-width: 60ch
-    min-width: 30ch
 
   .task-nav
     display: flex


### PR DESCRIPTION
Make the task area fixed width, because survey tasks show up in a three-across grid, and we can't have the width shifting around randomly between tasks.

cc: @aliburchard