### PR TITLE
Break out DropdownForm into its own module

### DIFF
--- a/app/components/dropdown-form.cjsx
+++ b/app/components/dropdown-form.cjsx
@@ -1,84 +1,5 @@
 React = require 'react'
-
-ESC_KEY = 27
-
-DropdownForm = React.createClass
-  displayName: 'DropdownForm'
-
-  getDefaultProps: ->
-    anchor: null
-    required: false
-    onSubmit: Function.prototype
-    onCancel: Function.prototype
-
-  underlayStyle:
-    bottom: 0
-    left: 0
-    position: 'fixed'
-    right: 0
-    top: 0
-
-  pointerStyle:
-    bottom: '100%'
-    position: 'absolute'
-    transform: 'translate(-50%, -50%) rotate(45deg)'
-
-  formStyle:
-    position: 'absolute'
-
-  componentDidMount: ->
-    @reposition()
-    addEventListener 'scroll', @reposition
-    addEventListener 'resize', @reposition
-    for img in @getDOMNode().querySelectorAll 'img'
-      img.addEventListener 'load', @reposition
-    addEventListener 'keydown', @handleGlobalKeyDown
-
-  componentWillUnmount: ->
-    removeEventListener 'scroll', @reposition
-    removeEventListener 'resize', @reposition
-    for img in @getDOMNode().querySelectorAll 'img'
-      img.removeEventListener 'load', @reposition
-    removeEventListener 'keydown', @handleGlobalKeyDown
-
-  reposition: (e) ->
-    form = @refs.form.getDOMNode()
-    pointer = @refs.pointer.getDOMNode()
-    anchorRect = @props.anchor.getBoundingClientRect()
-
-    left = anchorRect.left - ((form.offsetWidth - @props.anchor.offsetWidth) / 2)
-    left = Math.max left, 0
-    left = Math.min left, innerWidth - form.offsetWidth
-
-    top = anchorRect.bottom
-
-    form.style.left = "#{left}px"
-    form.style.top = "#{top}px"
-
-    pointer.style.left = "#{anchorRect.left + (@props.anchor.offsetWidth / 2)}px"
-    pointer.style.top = "#{top + parseFloat(getComputedStyle(form).marginTop)}px"
-
-  handleGlobalKeyDown: (e) ->
-    unless @props.required
-      if e.which is ESC_KEY
-        @props.onCancel arguments...
-
-  render: ->
-    <div className="dropdown-form-underlay" style={@underlayStyle} onClick={@handleUnderlayClick}>
-      <div ref="pointer" className="dropdown-form-pointer" style={@pointerStyle}></div>
-      <form ref="form" className="dropdown-form" style={@formStyle} action="POST" onSubmit={@handleSubmit}>
-        {@props.children}
-      </form>
-    </div>
-
-  handleSubmit: (e) ->
-    e.preventDefault()
-    @props.onSubmit arguments...
-
-  handleUnderlayClick: (e) ->
-    unless @props.required
-      if e.target is @getDOMNode()
-        @props.onCancel arguments...
+ModalForm = require 'modal-form'
 
 module.exports = React.createClass
   displayName: 'DropdownFormButton'
@@ -104,9 +25,9 @@ module.exports = React.createClass
 
     @setState {root}
 
-    React.render <DropdownForm anchor={@getDOMNode()} required={@props.required} onSubmit={@handleSubmit} onCancel={@handleCancel}>
+    React.render <ModalForm anchor={@getDOMNode()} required={@props.required} onSubmit={@handleSubmit} onCancel={@handleCancel}>
       {@props.children}
-    </DropdownForm>, root
+    </ModalForm>, root
 
   close: ->
     @getDOMNode().focus()

--- a/css/dropdown-form.styl
+++ b/css/dropdown-form.styl
@@ -8,6 +8,7 @@
   background: white
   box-shadow: 0 0 5px rgba(black 0.3)
   height: 1em
+  transform: translateX(0.3em) rotate(45deg)
   width: 1em
 
 .dropdown-form

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "lodash.merge": "~2.4.1",
     "lodash.pick": "~3.1.0",
     "markdownz": "^1.0.0",
+    "modal-form": "~0.0.1",
     "moment": "~2.9.0",
     "papaparse": "mholt/PapaParse#cada171",
     "react": "~0.13.2",


### PR DESCRIPTION
Here's my stab at pulling out a mini module. https://github.com/zooniverse-ui/modal-form

Zuul and Sauce are pretty much exactly how I've always wanted to run tests. I wrote them in tape because I'm used to it, but I can switch to mocha. Anyway, they're super sloppy, and no Travis yet.