### PR TITLE
Set drawing tool icon width explicitly

### DIFF
--- a/css/classify.styl
+++ b/css/classify.styl
@@ -121,6 +121,7 @@
     height: 1.5em
     stroke: currentColor
     stroke-width: 5
+    width: 1.5em
 
   .drawing-tool-input
     display: none


### PR DESCRIPTION
For IE.

Close #1333, close #1359.