### PR TITLE
Delegate annotation completion check to its task

### DIFF
--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -54,6 +54,7 @@ Classifier = React.createClass
         @props.subject.expert_classification_data
       else
         @props.classification
+      window.classification = currentClassification
 
       if currentClassification is @props.classification and not @props.classification.completed
         currentAnnotation = currentClassification.annotations[currentClassification.annotations.length - 1]
@@ -84,12 +85,8 @@ Classifier = React.createClass
 
     onFirstAnnotation = classification.annotations.indexOf(annotation) is 0
 
-    switch TaskComponent
-      when tasks.single
-        currentAnswer = task.answers?[annotation.value]
-        waitingForAnswer = task.required and not currentAnswer
-      when tasks.multiple
-        waitingForAnswer = task.required and annotation.value.length is 0
+    if TaskComponent.isAnnotationComplete?
+      waitingForAnswer = not TaskComponent.isAnnotationComplete task, annotation
 
     # If the next task key exists, make sure the task it points to actually exists.
     nextTaskKey = if TaskComponent is tasks.single and currentAnswer? and @props.workflow.tasks[currentAnswer.next]?

--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -54,7 +54,6 @@ Classifier = React.createClass
         @props.subject.expert_classification_data
       else
         @props.classification
-      window.classification = currentClassification
 
       if currentClassification is @props.classification and not @props.classification.completed
         currentAnnotation = currentClassification.annotations[currentClassification.annotations.length - 1]

--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -1,13 +1,10 @@
 React = require 'react'
-HandlePropChanges = require '../lib/handle-prop-changes'
 ChangeListener = require '../components/change-listener'
 SubjectAnnotator = require './subject-annotator'
 ClassificationSummary = require './classification-summary'
-tasks = require './tasks'
 {Link} = require 'react-router'
+tasks = require './tasks'
 drawingTools = require './drawing-tools'
-
-NOOP = Function.prototype
 
 unless process.env.NODE_ENV is 'production'
   mockData = require './mock-data'
@@ -15,32 +12,41 @@ unless process.env.NODE_ENV is 'production'
 Classifier = React.createClass
   displayName: 'Classifier'
 
-  mixins: [HandlePropChanges]
-
   _lastAnnotationAndTool: ''
 
   getDefaultProps: ->
-    unless process.env.NODE_ENV is 'production'
+    user: null
+    if mockData?
       {workflow, subject, classification} = mockData
     workflow: workflow
     subject: subject
     classification: classification
-    onLoad: NOOP
-
-  propChangeHandlers:
-    subject: ->
-      @setState subjectLoading: true
-    classification: (classification) ->
-      window.classification = classification
-      setTimeout =>
-        classification.annotations ?= []
-        if classification.annotations.length is 0
-          @addAnnotationForTask @props.workflow.first_task
+    onLoad: Function.prototype
 
   getInitialState: ->
     subjectLoading: false
     showingExpertClassification: false
     selectedExpertAnnotation: -1
+
+  componentDidMount: ->
+    @loadSubject @props.subject
+    @prepareToClassify @props.classification
+
+  componentWillReceiveProps: (nextProps) ->
+    if nextProps.subject isnt @props.subject
+      @loadSubject subject
+    if nextProps.classification isnt @props.classification
+      @prepareToClassify nextProps.classification
+
+  loadSubject: (subject) ->
+    @setState subjectLoading: true
+    # TODO: Pre-cache subject images here and change loading state back.
+
+  prepareToClassify: (classification) ->
+    setTimeout => # TODO: Why is this here?
+      classification.annotations ?= []
+      if classification.annotations.length is 0
+        @addAnnotationForTask @props.workflow.first_task
 
   render: ->
     <ChangeListener target={@props.classification}>{=>
@@ -54,52 +60,63 @@ Classifier = React.createClass
         currentTask = @props.workflow.tasks[currentAnnotation?.task]
 
       <div className="classifier">
-        <SubjectAnnotator user={@props.user} project={@props.project} subject={@props.subject} workflow={@props.workflow} classification={currentClassification} annotation={currentAnnotation} onLoad={@handleSubjectImageLoad} />
+        <SubjectAnnotator
+          user={@props.user}
+          project={@props.project}
+          subject={@props.subject}
+          workflow={@props.workflow}
+          classification={currentClassification}
+          annotation={currentAnnotation}
+          onLoad={@handleSubjectImageLoad}
+        />
 
         <div className="task-area">
           {if currentTask?
-            TaskComponent = tasks[currentTask.type]
-
-            onFirstAnnotation = currentClassification.annotations.indexOf(currentAnnotation) is 0
-
-            switch currentTask.type
-              when 'single'
-                currentAnswer = currentTask.answers?[currentAnnotation.value]
-                waitingForAnswer = currentTask.required and not currentAnswer
-              when 'multiple'
-                waitingForAnswer = currentTask.required and currentAnnotation.value.length is 0
-
-            # If the next task key exists, make sure the task it points to actually exists.
-            nextTaskKey = if currentTask.type is 'single' and currentAnswer? and @props.workflow.tasks[currentAnswer.next]?
-              currentAnswer.next
-            else if @props.workflow.tasks[currentTask.next]?
-              currentTask.next
-
-            disabledStyle =
-              opacity: 0.5
-              pointerEvents: 'none'
-
-            <div className="task-container" style={disabledStyle if @state.subjectLoading}>
-              <TaskComponent task={currentTask} annotation={currentAnnotation} onChange={@updateAnnotations.bind this, currentClassification} />
-
-              <hr />
-
-              <nav className="task-nav">
-                <button type="button" className="back minor-button" disabled={onFirstAnnotation} onClick={@destroyCurrentAnnotation}>Back</button>
-                {if nextTaskKey
-                  <button type="button" className="continue major-button" disabled={waitingForAnswer} onClick={@addAnnotationForTask.bind this, nextTaskKey}>Next</button>
-                else
-                  <button type="button" className="continue major-button" disabled={waitingForAnswer} onClick={@completeClassification}>Done</button>}
-              </nav>
-            </div>
-
+            @renderTask currentClassification, currentAnnotation, currentTask
           else # Classification is complete.
             @renderSummary currentClassification}
         </div>
       </div>
     }</ChangeListener>
 
-  renderSummary: (currentClassification) ->
+  renderTask: (classification, annotation, task) ->
+    TaskComponent = tasks[task.type]
+
+    onFirstAnnotation = classification.annotations.indexOf(annotation) is 0
+
+    switch TaskComponent
+      when tasks.single
+        currentAnswer = task.answers?[annotation.value]
+        waitingForAnswer = task.required and not currentAnswer
+      when tasks.multiple
+        waitingForAnswer = task.required and annotation.value.length is 0
+
+    # If the next task key exists, make sure the task it points to actually exists.
+    nextTaskKey = if TaskComponent is tasks.single and currentAnswer? and @props.workflow.tasks[currentAnswer.next]?
+      currentAnswer.next
+    else if @props.workflow.tasks[task.next]?
+      task.next
+
+    # TODO: Actually disable things that should be.
+    disabledStyle =
+      opacity: 0.5
+      pointerEvents: 'none'
+
+    <div className="task-container" style={disabledStyle if @state.subjectLoading}>
+      <TaskComponent task={task} annotation={annotation} onChange={@updateAnnotations.bind this, classification} />
+
+      <hr />
+
+      <nav className="task-nav">
+        <button type="button" className="back minor-button" disabled={onFirstAnnotation} onClick={@destroyCurrentAnnotation}>Back</button>
+        {if nextTaskKey
+          <button type="button" className="continue major-button" disabled={waitingForAnswer} onClick={@addAnnotationForTask.bind this, nextTaskKey}>Next</button>
+        else
+          <button type="button" className="continue major-button" disabled={waitingForAnswer} onClick={@completeClassification}>Done</button>}
+      </nav>
+    </div>
+
+  renderSummary: (classification) ->
     <div>
       Thanks!
 
@@ -116,7 +133,7 @@ Classifier = React.createClass
         'Expert classification:'
       else
         'Your classification:'}
-      <ClassificationSummary workflow={@props.workflow} classification={currentClassification} />
+      <ClassificationSummary workflow={@props.workflow} classification={classification} />
 
       <hr />
 
@@ -186,14 +203,16 @@ Classifier = React.createClass
   toggleExpertClassification: (value) ->
     @setState showingExpertClassification: value
 
+
 module.exports = React.createClass
   displayName: 'ClassifierWrapper'
 
   getDefaultProps: ->
+    user: null
     classification: mockData?.classification ? {}
-    onLoad: NOOP
-    onComplete: NOOP
-    onClickNext: NOOP
+    onLoad: Function.prototype
+    onComplete: Function.prototype
+    onClickNext: Function.prototype
 
   getInitialState: ->
     workflow: null
@@ -207,7 +226,9 @@ module.exports = React.createClass
       @loadClassification nextProps.classification
 
   loadClassification: (classification) ->
-    @setState @getInitialState()
+    @setState
+      workflow: null
+      subject: null
 
     # TODO: These underscored references are temporary stopgaps.
 
@@ -221,6 +242,6 @@ module.exports = React.createClass
 
   render: ->
     if @state.workflow? and @state.subject?
-      <Classifier {...@props} {...@state} />
+      <Classifier {...@props} workflow={@state.workflow} subject={@state.subject} />
     else
-      <span>Loading classifier</span>
+      <span>Loading classifier...</span>

--- a/app/classifier/mock-data.coffee
+++ b/app/classifier/mock-data.coffee
@@ -8,7 +8,7 @@ BLANK_IMAGE = ['data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAoAAAAHgAQMAAAA',
 workflow = apiClient.type('workflows').create
   id: 'MOCK_WORKFLOW_FOR_CLASSIFIER'
 
-  first_task: 'survey'
+  first_task: 'draw'
   tasks:
     survey:
       type: 'survey'
@@ -147,7 +147,7 @@ workflow = apiClient.type('workflows').create
 
     draw:
       type: 'drawing'
-      required: 3
+      required: true
       instruction: 'Draw something.'
       help: '''
         Do this:
@@ -161,9 +161,10 @@ workflow = apiClient.type('workflows').create
           color: 'red'
           details: [{
             type: 'single'
+            required: true
             question: 'Cool?'
             answers: [
-              {label: 'Yeah, this is pretty cool, in fact I’m going to write a big long sentence describe just how cool I think it is.'}
+              {label: 'Yeah'}
               {label: 'Nah'}
             ]
           }, {
@@ -206,9 +207,9 @@ subject = apiClient.type('subjects').create
   id: 'MOCK_SUBJECT_FOR_CLASSIFIER'
 
   locations: [
-    {'image/jpeg': if navigator.onLine then 'http://lorempixel.com/900/600/animals/1' else BLANK_IMAGE}
-    {'image/jpeg': if navigator.onLine then 'http://lorempixel.com/900/600/animals/2' else BLANK_IMAGE}
-    {'image/jpeg': if navigator.onLine then 'http://lorempixel.com/900/600/animals/3' else BLANK_IMAGE}
+    {'image/jpeg': if navigator.onLine then 'http://lorempixel.com/100/75/animals/1' else BLANK_IMAGE}
+    {'image/jpeg': if navigator.onLine then 'http://lorempixel.com/100/75/animals/2' else BLANK_IMAGE}
+    {'image/jpeg': if navigator.onLine then 'http://lorempixel.com/100/75/animals/3' else BLANK_IMAGE}
   ]
 
   metadata:

--- a/app/classifier/mock-data.coffee
+++ b/app/classifier/mock-data.coffee
@@ -8,7 +8,7 @@ BLANK_IMAGE = ['data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAoAAAAHgAQMAAAA',
 workflow = apiClient.type('workflows').create
   id: 'MOCK_WORKFLOW_FOR_CLASSIFIER'
 
-  first_task: 'survey'
+  first_task: 'draw'
   tasks:
     survey:
       type: 'survey'
@@ -53,7 +53,7 @@ workflow = apiClient.type('workflows').create
               label: 'Green'
               image: '//placehold.it/64.png?text=Green'
 
-      choicesOrder: ['aa', 'ar', 'to', 'aa', 'ar', 'to', 'aa', 'ar', 'to', 'aa', 'ar', 'to', 'aa', 'ar', 'to', 'aa', 'ar', 'to', 'aa', 'ar', 'to', 'aa', 'ar', 'to', 'aa', 'ar', 'to', 'aa', 'ar', 'to', 'aa', 'ar', 'to', 'aa', 'ar', 'to', 'aa', 'ar', 'to', 'aa', 'ar', 'to', 'aa', 'ar', 'to', 'aa', 'ar']
+      choicesOrder: ['aa', 'ar', 'to']
       choices:
         aa:
           label: 'Aardvark'
@@ -83,7 +83,7 @@ workflow = apiClient.type('workflows').create
           confusions: {}
 
         to:
-          label: 'Tortoise, the longest-named animal in the whole entire world'
+          label: 'Tortoise'
           description: 'Little green house with legs'
           images: [
             '//placehold.it/320x240.png?text=Tortoise 1'

--- a/app/classifier/mock-data.coffee
+++ b/app/classifier/mock-data.coffee
@@ -8,10 +8,11 @@ BLANK_IMAGE = ['data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAoAAAAHgAQMAAAA',
 workflow = apiClient.type('workflows').create
   id: 'MOCK_WORKFLOW_FOR_CLASSIFIER'
 
-  first_task: 'draw'
+  first_task: 'survey'
   tasks:
     survey:
       type: 'survey'
+      required: true
       characteristicsOrder: ['pa', 'co']
       characteristics:
         pa:
@@ -142,8 +143,11 @@ workflow = apiClient.type('workflows').create
       images: {}
       # next: 'draw'
 
+      next: 'draw'
+
     draw:
       type: 'drawing'
+      required: 3
       instruction: 'Draw something.'
       help: '''
         Do this:

--- a/app/classifier/subject-annotator.cjsx
+++ b/app/classifier/subject-annotator.cjsx
@@ -132,7 +132,7 @@ module.exports = React.createClass
               </g>}
         </SVG>
 
-        {if @state.alreadySeen 
+        {if @state.alreadySeen
           <button type="button" className="warning-banner" onClick={@toggleWarning}>
             Already seen!
             {if @state.showWarning
@@ -153,7 +153,8 @@ module.exports = React.createClass
           </button>}
 
         {if @state.toolRect? and @state.selectedMark?
-          toolDescription = @props.workflow.tasks[@props.annotation.task].tools[@state.selectedMark.tool]
+          taskDescription = @props.workflow.tasks[@props.annotation.task]
+          toolDescription = taskDescription.tools[@state.selectedMark.tool]
           if toolDescription?.details?.length > 0
 
             <Tooltip ref="detailsTooltip" {...@getDetailsTooltipProps()}>
@@ -162,7 +163,7 @@ module.exports = React.createClass
                 TaskComponent = tasks[detailTask.type]
                 <TaskComponent key={detailTask._key} task={detailTask} annotation={@state.selectedMark.details[i]} onChange={@updateAnnotations} />}
               <div className="actions">
-                <button type="button" className="standard-button" onClick={@selectMark.bind this, null, null}>Close</button>
+                <button type="button" className="standard-button" disabled={not tasks[taskDescription.type].areMarksComplete(taskDescription, @props.annotation)} onClick={@selectMark.bind this, null, null}>Close</button>
               </div>
             </Tooltip>}
       </SubjectViewer>
@@ -303,5 +304,3 @@ module.exports = React.createClass
     markIndex = annotation.value.indexOf mark
     annotation.value.splice markIndex, 1
     @updateAnnotations()
-
-

--- a/app/classifier/tasks/drawing.cjsx
+++ b/app/classifier/tasks/drawing.cjsx
@@ -97,6 +97,14 @@ module.exports = React.createClass
       _toolIndex: 0
       value: []
 
+    isMarkComplete: (tool, mark) ->
+      # TODO: See below.
+
+    isAnnotationComplete: (task, annotation) ->
+      # TODO: Check details per mark.
+      # Also use that to disable closing the tooltip.
+      annotation.value.length >= task.required
+
   getDefaultProps: ->
     task: null
     annotation: null

--- a/app/classifier/tasks/drawing.cjsx
+++ b/app/classifier/tasks/drawing.cjsx
@@ -97,13 +97,22 @@ module.exports = React.createClass
       _toolIndex: 0
       value: []
 
-    isMarkComplete: (tool, mark) ->
-      # TODO: See below.
+    areMarksComplete: (task, annotation) ->
+      tasks = require './index' # Circular
+      for mark in annotation.value
+        toolDescription = task.tools[mark.tool]
+        for detail, i in toolDescription.details when detail.required
+          subAnnotation = mark.details[i]
+          DetailTaskComponent = tasks[detail.type]
+          if DetailTaskComponent.isAnnotationComplete?
+            unless DetailTaskComponent.isAnnotationComplete detail, subAnnotation
+              return false
+      true
 
     isAnnotationComplete: (task, annotation) ->
       # TODO: Check details per mark.
       # Also use that to disable closing the tooltip.
-      annotation.value.length >= task.required
+      @areMarksComplete(task, annotation) and annotation.value.length >= task.required
 
   getDefaultProps: ->
     task: null

--- a/app/classifier/tasks/multiple.cjsx
+++ b/app/classifier/tasks/multiple.cjsx
@@ -67,6 +67,10 @@ module.exports = React.createClass
     getDefaultAnnotation: ->
       value: []
 
+    isAnnotationComplete: (task, annotation) ->
+      # Booleans compare to numbers as expected: true = 1, false = 0.
+      annotation.value.length >= task.required
+
   getDefaultProps: ->
     task: null
     annotation: null

--- a/app/classifier/tasks/single.cjsx
+++ b/app/classifier/tasks/single.cjsx
@@ -65,6 +65,9 @@ module.exports = React.createClass
     getDefaultAnnotation: ->
       value: null
 
+    isAnnotationComplete: (task, annotation) ->
+      annotation.value? or not task.required
+
   getDefaultProps: ->
     task: null
     annotation: null

--- a/app/classifier/tasks/survey.cjsx
+++ b/app/classifier/tasks/survey.cjsx
@@ -313,6 +313,11 @@ module.exports = React.createClass
     getDefaultAnnotation: ->
       value: []
 
+    isAnnotationComplete: (task, annotation) ->
+      # Booleans compare to numbers as expected: true = 1, false = 0.
+      annotation.value.length >= task.required and not annotation._choiceInProgress
+
+
   getDefaultProps: ->
     task: null
     annotation: null
@@ -338,13 +343,17 @@ module.exports = React.createClass
     @setState filters: @state.filters
 
   handleChoice: (choiceID) ->
+    @props.annotation._choiceInProgress = true
     @setState selectedChoiceID: choiceID
+    @props.onChange()
 
   clearFilters: ->
     @setState filters: {}
 
   clearSelection: ->
+    @props.annotation._choiceInProgress = false
     @setState selectedChoiceID: ''
+    @props.onChange()
 
   handleAnnotation: (choice, answers, e) ->
     filters = JSON.parse JSON.stringify @state.filters


### PR DESCRIPTION
This begins a big cleanup and refactor of the classification interface. The eventual goal is for the classifier to become a dumb subject-and-workflow display with a bunch of hooks for tasks to be able to be able to inject appropriate stuff where they need it.

This PR makes each task responsible for knowing when one of its annotations is complete. In the process I added support for the `required` property for surveys and drawing tasks, and drawing details subtasks can be marked required too. None of this is exposed in the task editor yet, since the volunteer-facing interface will need some work to make it obvious that a task isn't complete unless you do _x_.