### PR TITLE
Show recents first in talk image selector

### DIFF
--- a/app/talk/comment-image-selector.cjsx
+++ b/app/talk/comment-image-selector.cjsx
@@ -15,7 +15,7 @@ module?.exports = React.createClass
     @setRecents()
 
   setRecents: ->
-    @props.user.get('recents')
+    @props.user.get('recents', {sort: '-created_at'})
       .then (subjects) => @setState {subjects}
 
   setQuery: (id) ->


### PR DESCRIPTION
- Closes #1264 
- Currently only on panoptes staging I believe, so should be ok to merge on the next production deploy