### PR TITLE
Fix comment linking issue

### DIFF
--- a/app/talk/discussion.cjsx
+++ b/app/talk/discussion.cjsx
@@ -42,7 +42,7 @@ module?.exports = React.createClass
       @setDiscussion(nextProps.params.discussion)
         .then => @setComments(nextProps.query.page ? 1)
     else if nextProps.query.page isnt @props.query.page
-      @setComments(nextProps.query.page ? 1)
+      @setComments(nextProps.query.page)
 
   componentDidMount: ->
     @shouldScrollToBottom = true if @props.query?.scrollToLastComment


### PR DESCRIPTION
- Fixes issue where if users click a comment link url it would go to
  page 1 instead of the comment's page
- To test:
  1. Click the link to the url of a comment
  2. It should keep you on the page of the comment, instead of taking you to the first page