### PR TITLE
Fix choice thumbnails loading, crop to the same size

### DIFF
--- a/app/classifier/tasks/survey/chooser.cjsx
+++ b/app/classifier/tasks/survey/chooser.cjsx
@@ -79,8 +79,10 @@ module.exports = React.createClass
             choice = @props.task.choices[choiceID]
             <button key={choiceID + i} type="button" className="survey-task-chooser-choice" onClick={@props.onChoose.bind null, choiceID}>
               {unless choice.images.length is 0
-                  <img src={@props.task.images[choice.images[0]]} className="survey-task-chooser-choice-thumbnail" />}
-              <div className="survey-task-chooser-choice-label">{choice.label}</div>
+                <span className="survey-task-chooser-choice-thumbnail-container">
+                  <span className="survey-task-chooser-choice-thumbnail" style={backgroundImage: "url(#{@props.task.images[choice.images[0]]})"}></span>
+                </span>}
+              <span className="survey-task-chooser-choice-label">{choice.label}</span>
             </button>}
       </div>
       <div style={textAlign: 'center'}>

--- a/css/survey-task.styl
+++ b/css/survey-task.styl
@@ -77,22 +77,27 @@ $survey-task-pill-button
     margin: 0.3em 0.6em
 
 .survey-task-chooser-choice-thumbnail
+  background-size: cover
+  background-position: 50% 50%
   border-radius: 3px
   display: inline-block
   vertical-align: middle
 
-  [data-breakpoint="Infinity"] &,
-  [data-breakpoint="40"] &
+  [data-breakpoint="Infinity"] &-container,
+  [data-breakpoint="40"] &-container
     display: none
 
   [data-breakpoint="20"] &
-    height: 2em
+    height: 1.5em
+    width: 2em
 
   [data-breakpoint="10"] &
-    height: 4em
+    height: 3em
+    width: 4em
 
   [data-breakpoint="5"] &
-    height: 8em
+    height: 6em
+    width: 8em
 
 .survey-task-chooser-choice-label
   display: inline-block


### PR DESCRIPTION
The survey task previously loaded its choices' thumbnails in `<img` tags, set to `display: none` when not shown. They loaded anyway, for whatever reason. It ends up being like 30MB on a 50-choice project.

This switches them to be `background-image`s with a `display: none` parent, as described [here](http://timkadlec.com/2012/04/media-query-asset-downloading-results/). so they only load when they're viewed. This also allows up to crop them to all be the same size.

Used on #/projects/brian-testing/ghosts/classify for dev.