### PR TITLE
Added html5 video player and mp4 to readable formats. Minor layout an…

### DIFF
--- a/app/components/subject-viewer.cjsx
+++ b/app/components/subject-viewer.cjsx
@@ -42,7 +42,11 @@ module.exports = React.createClass
 
     mainDisplay = switch type
       when 'image'
-        <img className="subject" src={src} style={SUBJECT_STYLE} onLoad={@handleImageLoad} />
+        <img className="subject" src={src} style={SUBJECT_STYLE} onLoad={@handleLoad} />
+      when 'video'
+        <video src={src} type={"#{type}/#{format}"} controls onLoad={@handleLoad}>
+          Your browser does not support the video format. Please upgrade your browser.
+        </video>
 
     tools = switch type
       when 'image'
@@ -50,6 +54,7 @@ module.exports = React.createClass
           null
         else
           <span>
+          {unless @props.subject?.locations.indexOf "video/mp4"
             <span className="subject-frame-play-controls">
               {if @state.playing
                 <button type="button" className="secret-button" onClick={@setPlaying.bind this, false}>
@@ -59,11 +64,7 @@ module.exports = React.createClass
                 <button type="button" className="secret-button" onClick={@setPlaying.bind this, true}>
                   <i className="fa fa-play fa-fw"></i>
                 </button>}
-            </span>
-            <span className="subject-frame-pips">
-              {for i in [0...@props.subject?.locations.length ? 0]
-                <button type="button" key={i} className="subject-frame-pip #{if i is @state.frame then 'active' else ''}" value={i} onClick={@handleFrameChange.bind this, i}>{i + 1}</button>}
-            </span>
+            </span>}
           </span>
 
     <div className="subject-viewer" style={ROOT_STYLE if @props.defaultStyle}>
@@ -80,6 +81,13 @@ module.exports = React.createClass
 
       <div className="subject-tools">
         <span>{tools}</span>
+        {if @props.subject?.locations.length >= 2
+          <span>
+            <span className="subject-frame-pips">
+              {for i in [0...@props.subject?.locations.length ? 0]
+                <button type="button" key={i} className="subject-frame-pip #{if i is @state.frame then 'active' else ''}" value={i} onClick={@handleFrameChange.bind this, i}>{i + 1}</button>}
+            </span>
+        </span>}
         <span>
           {if @props.subject?.metadata?
             <button type="button" title="Metadata" className="metadata-toggle" onClick={@showMetadata}><i className="fa fa-info-circle fa-fw"></i></button>}
@@ -141,6 +149,6 @@ module.exports = React.createClass
       </table>
     </div>
 
-  handleImageLoad: (e) ->
+  handleLoad: (e) ->
     @setState loading: false
     @props.onLoad? arguments...

--- a/app/lib/get-subject-location.coffee
+++ b/app/lib/get-subject-location.coffee
@@ -1,5 +1,6 @@
 READABLE_FORMATS =
   image: ['jpeg', 'png', 'svg+xml', 'gif']
+  video: ['mp4']
 
 module.exports = (subject, frame) ->
   frame ?= Math.floor Object.keys(subject.locations).length / 2

--- a/css/subject.styl
+++ b/css/subject.styl
@@ -1,6 +1,11 @@
 .subject-viewer
   min-width: 0
   max-width: 100%
+  
+  .subject-frame-pips  
+    .subject-frame-pip
+      &.active
+        font-weight: 700
 
 .subject
   .subject-tools


### PR DESCRIPTION
- Added mp4 to readable formats 
- Added HTML5 video player and check for video type to subject viewer
- Hide frame play button if video is present
- Moved frame pagination out of image type to be a part of subject tools layout 
- Added a style to see active frame for the pagination

Added this since I'm working on uploading mammoth-bats data and it'd be nice to be able to play the videos in the subject viewer.