### PR TITLE
Followed discussions

### DIFF
--- a/app/talk/discussion.cjsx
+++ b/app/talk/discussion.cjsx
@@ -18,6 +18,7 @@ talkConfig = require './config'
 SignInPrompt = require '../partials/sign-in-prompt'
 alert = require '../lib/alert'
 merge = require 'lodash.merge'
+FollowDiscussion = require './follow-discussion'
 
 PAGE_SIZE = talkConfig.discussionPageSize
 
@@ -270,6 +271,10 @@ module?.exports = React.createClass
       {if discussion?.locked
         @lockedMessage()
         }
+
+      {if discussion and @props.user
+        <FollowDiscussion user={@props.user} discussion={discussion} />
+      }
 
       <Paginator page={+@state.commentsMeta.page} pageCount={@state.commentsMeta.page_count} />
 

--- a/app/talk/follow-discussion.cjsx
+++ b/app/talk/follow-discussion.cjsx
@@ -1,0 +1,86 @@
+React = require 'react'
+talkClient = require '../api/talk'
+
+module?.exports = React.createClass
+  displayName: 'FollowDiscussion'
+
+  propTypes:
+    discussion: React.PropTypes.object.isRequired
+    user: React.PropTypes.object.isRequired
+
+  getInitialState: ->
+    followed: null
+    participating: false
+
+  componentWillReceiveProps: (nextProps)->
+    discussionId = nextProps.discussion?.id
+    @getSubscriptionsFor(discussionId) if discussionId and discussionId isnt @props.discussion?.id
+
+  toggleFollowed: (e) ->
+    e.preventDefault()
+    subscription = @state.subscriptions.followed_discussions
+    if subscription
+      @toggle subscription
+    else
+      @follow()
+
+  toggleParticipating: (e) ->
+    e.preventDefault()
+    @toggle @state.subscriptions.participating_discussions
+
+  toggle: (subscription) ->
+    subscription.update(enabled: not subscription.enabled).save().then =>
+      @getSubscriptionsFor @props.discussion.id
+
+  follow: ->
+    talkClient.type('subscriptions').create
+      source_id: @props.discussion.id
+      source_type: 'Discussion'
+      category: 'followed_discussions'
+    .save().then =>
+      @getSubscriptionsFor @props.discussion.id
+
+  buttonLabel: ->
+    if @state.followed or @state.participating
+      'Unsubscribe'
+    else
+      'Subscribe'
+
+  followedText: ->
+    if @state.followed
+      "You're receiving notifications because you've subscribed to this discussion"
+    else
+      "Subscribe to receive notifications for updates to this discussion"
+
+  getSubscriptionsFor: (id) ->
+    talkClient.type('subscriptions').get
+      source_id: id
+      source_type: 'Discussion'
+    .then (subscriptions) =>
+      newState = subscriptions: { }, followed: null, participating: null, loaded: true
+
+      for subscription in subscriptions
+        newState.subscriptions[subscription.category] = subscription
+        newState.followed = subscription.enabled if subscription.category is 'followed_discussions'
+        newState.participating = subscription.enabled if subscription.category is 'participating_discussions'
+
+      @setState newState
+
+  render: ->
+    <div className="talk-discussion-follow">
+      {if @props.user and @state.loaded
+        <div>
+          {if @state.participating
+            <div>
+              <button onClick={@toggleParticipating}>{ @buttonLabel() }</button>
+              <p className="description">You're receiving notifications from this discussion because you've joined it</p>
+            </div>
+          else
+            <div>
+              <button onClick={@toggleFollowed}>{@buttonLabel()}</button>
+              <p className="description">{@followedText()}</p>
+            </div>
+          }
+        </div>
+      }
+    </div>

--- a/css/talk.styl
+++ b/css/talk.styl
@@ -350,6 +350,14 @@ COPY_GREY_LIGHT = #afaeae
       i
         font-size: 12px
 
+    .talk-discussion-follow
+      margin: 10px auto
+
+      .description
+        display: inline-block
+        margin: auto 10px
+        color: #989898
+
   .talk-comment
     overflow: auto
 


### PR DESCRIPTION
This lets a user manage subscriptions (participating and followed) for discussions.

I'm not 100% on how we want to align this on the page though.

This is good to go for staging ~~, but not production yet~~ and production.