### PR TITLE
add data exports page to projects

### DIFF
--- a/app/pages/lab/data-dumps.cjsx
+++ b/app/pages/lab/data-dumps.cjsx
@@ -1,0 +1,75 @@
+React = require 'react'
+handleInputChange = require '../../lib/handle-input-change'
+PromiseRenderer = require '../../components/promise-renderer'
+apiClient = require '../../api/client'
+counterpart = require 'counterpart'
+DataExportButton = require '../../partials/data-export-button'
+TalkDataExportButton = require '../../talk/data-export-button'
+
+counterpart.registerTranslations 'en',
+  projectDetails:
+    classificationExport: "Request new classification export"
+    subjectExport: "Request new subject export"
+    workflowExport: "Request new workflow export"
+    workflowContentsExport: "Request new workflow contents export"
+    commentsExport: "Request new talk comments export"
+    tagsExport: "Request new talk tags export"
+
+module.exports = React.createClass
+  displayName: 'GetDataExports'
+
+  getDefaultProps: ->
+    project: {}
+
+  getInitialState: ->
+    avatarError: null
+    backgroundError: null
+
+  render: ->
+    <div>
+      <p className="form-help">Get your project's data exports</p>
+      <div className="columns-container">
+        <div>
+          Project Data<br />
+          <p>
+            <DataExportButton
+              project={@props.project}
+              buttonKey="projectDetails.classificationExport"
+              exportType="classifications_export"  />
+          </p>
+          <p>
+            <DataExportButton
+              project={@props.project}
+              buttonKey="projectDetails.subjectExport"
+              exportType="subjects_export"  />
+          </p>
+          <p>
+            <DataExportButton
+              project={@props.project}
+              buttonKey="projectDetails.workflowExport"
+              exportType="workflows_export"  />
+          </p>
+          <p>
+            <DataExportButton
+              project={@props.project}
+              buttonKey="projectDetails.workflowContentsExport"
+              exportType="workflow_contents_export"  />
+          </p>
+          <hr />
+
+          Talk Data<br />
+          <p>
+            <TalkDataExportButton
+              project={@props.project}
+              exportType="comments"
+              label="Request new Talk comments export" />
+          </p>
+          <p>
+            <TalkDataExportButton
+              project={@props.project}
+              exportType="tags"
+              label="Request new Talk tags export" />
+          </p>
+        </div>
+      </div>
+    </div>

--- a/app/pages/lab/project-details.cjsx
+++ b/app/pages/lab/project-details.cjsx
@@ -6,8 +6,6 @@ ImageSelector = require '../../components/image-selector'
 apiClient = require '../../api/client'
 putFile = require '../../lib/put-file'
 counterpart = require 'counterpart'
-DataExportButton = require '../../partials/data-export-button'
-TalkDataExportButton = require '../../talk/data-export-button'
 DisplayNameSlugEditor = require '../../partials/display-name-slug-editor'
 TagSearch = require '../../components/tag-search'
 {MarkdownEditor} = require 'markdownz'
@@ -15,11 +13,6 @@ markdownHelp = require '../../lib/markdown-help'
 
 MAX_AVATAR_SIZE = 64000
 MAX_BACKGROUND_SIZE = 256000
-
-counterpart.registerTranslations 'en',
-  projectDetails:
-    classificationExport: "Request new classification export"
-    subjectExport: "Request new subject export"
 
 ExternalLinksEditor = React.createClass
   displayName: 'ExternalLinksEditor'
@@ -182,27 +175,6 @@ module.exports = React.createClass
             <small className="form-help">Adding an external link will make it appear as a new tab alongside the science, classify, and talk tabs.</small>
             <ExternalLinksEditor project={@props.project} />
           </div>
-
-          <hr />
-
-          Data export<br />
-          <DataExportButton
-            project={@props.project}
-            buttonKey="projectDetails.classificationExport"
-            exportType="classifications_export"  />
-          <DataExportButton
-            project={@props.project}
-            buttonKey="projectDetails.subjectExport"
-            exportType="subjects_export"  />
-
-          <TalkDataExportButton
-            project={@props.project}
-            exportType="comments"
-            label="Request new Talk comments export" />
-          <TalkDataExportButton
-            project={@props.project}
-            exportType="tags"
-            label="Request new Talk tags export" />
         </div>
       </div>
     </div>

--- a/app/pages/lab/project.cjsx
+++ b/app/pages/lab/project.cjsx
@@ -67,6 +67,9 @@ EditProjectPage = React.createClass
           <li><Link to="edit-project-talk" params={linkParams} className="nav-list-item" title="Setup project specific discussion boards">
             Talk
           </Link></li>
+          <li><Link to="get-data-exports" params={linkParams} className="nav-list-item" title="Get your project's data exports">
+            Data Exports
+          </Link></li>
 
           <li>
             <br />

--- a/app/router.cjsx
+++ b/app/router.cjsx
@@ -97,6 +97,7 @@ routes =
     <Route name="edit-project-subject-set" path="subject-set/:subjectSetID/?" handler={require './pages/lab/subject-set'} />
     <Route name="edit-project-visibility" path="visibility/?" handler={require './pages/lab/visibility'} />
     <Route name="edit-project-talk" path="talk/?" handler={require './pages/lab/talk'} />
+    <Route name="get-data-exports" path="data-exports" handler={require './pages/lab/data-dumps'} />
   </Route>
   <Route name="lab-policies" path="lab-policies/?" handler={require './pages/lab/lab-policies'} />
   <Route name="lab-how-to" path="lab-how-to/?" handler={require './pages/lab/how-to-page'} />


### PR DESCRIPTION
closes #1045 - added separate page for data dumps and linked up the workflow & contents export. 

Please check i've included only the necessary requires for the data-dump page and i haven't removed too much in the project-details one.