### PR TITLE
Slightly customize the home page for users

### DIFF
--- a/app/components/project-icon.cjsx
+++ b/app/components/project-icon.cjsx
@@ -1,0 +1,47 @@
+React = require 'react'
+{Link} = require 'react-router'
+
+module.exports = React.createClass
+  displayName: 'ProjectIcon'
+
+  getDefaultProps: ->
+    project: null
+    badge: ''
+    defaultAvatarSrc: '/assets/simple-avatar.jpg'
+
+  getInitialState: ->
+    href: ''
+    avatar: null
+
+  componentDidMount: ->
+    @getDetails @props.project
+
+  componentWillReceiveProps: (nextProps) ->
+    unless nextProps.project is @props.project
+      @getDetails nextProps.project
+
+  getDetails: (project) ->
+    project.get 'owner'
+      .then (owner) =>
+        @setState {owner}
+    project.get 'avatar'
+      .catch =>
+        null
+      .then (avatar) =>
+        @setState {avatar}
+
+  render: ->
+    content = [
+      <img key="image" src={@state.avatar?.src ? @props.defaultAvatarSrc} />
+      <div key="label" className="label">
+        <span className="owner">{@state.owner?.display_name}</span><br />
+        <span className="display-name"><strong>{@props.project.display_name}</strong></span>
+      </div>
+      <div key="badge" className="badge">{@props.badge}</div> if @props.badge
+    ]
+
+    if !!@props.project.redirect
+      <a href={@props.project.redirect} className="stats-project-icon">{content}</a>
+    else
+      [owner, name] = @props.project.slug.split '/'
+      <Link to="project-home" params={owner: owner, name: name} className="stats-project-icon">{content}</Link>

--- a/app/pages/home.cjsx
+++ b/app/pages/home.cjsx
@@ -35,7 +35,9 @@ counterpart.registerTranslations 'en',
       button: 'See all projects'
     recentProjects:
       title: "Welcome back! Jump into one of your recent projects..."
+      altTitle: "Welcome! Jump into a new project..."
       button: 'See all your projects'
+      altButton: 'See all our projects'
 
 FeaturedProjects = React.createClass
   displayName: "FeaturedProjects"
@@ -75,22 +77,38 @@ module.exports = React.createClass
         <ZooniverseLogoType />
         {if @props.user
           <PromiseRenderer promise={@lastFourProjects()}>{(projectPreferences) =>
-            <div className="recent-projects">
-              <Translate component="h5" content="home.recentProjects.title" />
-              <div className="recent-projects-list">
-                {projectPreferences.map (projectPreference) =>
-                  <PromiseRenderer key={projectPreference.id} promise={projectPreference.get 'project'} catch={null} then={(project) =>
-                    if project?
-                      <div>
-                        <ProjectIcon project={project} badge={projectPreference.activity_count} />
-                        &ensp;
-                      </div>
-                    else
-                      null
-                  } />}
+            console.log(projectPreferences)
+            if projectPreferences.length > 0
+              <div className="recent-projects">
+                <Translate component="h5" content="home.recentProjects.title" />
+                <div className="recent-projects-list">
+                  {projectPreferences.map (projectPreference) =>
+                    <PromiseRenderer key={projectPreference.id} promise={projectPreference.get 'project'} catch={null} then={(project) =>
+                      if project?
+                        <div>
+                          <ProjectIcon project={project} badge={projectPreference.activity_count} />
+                          &ensp;
+                        </div>
+                      else
+                        null
+                    } />}
+                </div>
+                <Link to="user-profile-stats" params={{name: @props.user.login}} className="call-to-action standard-button x-large"><Translate content="home.recentProjects.button" /></Link>
               </div>
-            <Link to="user-profile-stats" params={{name: @props.user.login}} className="call-to-action standard-button x-large"><Translate content="home.recentProjects.button" /></Link>
-            </div>
+            else
+              <div className="recent-projects">
+                <Translate component="h5" content="home.recentProjects.altTitle" />
+                <PromiseRenderer promise={apiClient.type('projects').get(launch_approved: true, page_size: 4)}>{(projects) =>
+                  <div className="recent-projects-list">
+                    {projects.map (project) ->
+                      <div>
+                        <ProjectIcon key={project.id} project={project} />
+                        &ensp;
+                      </div>}
+                  </div>
+                }</PromiseRenderer>
+                <Link to="projects" className="call-to-action standard-button hero-button x-large"><Translate content="home.recentProjects.altButton" /></Link>
+              </div>
           }</PromiseRenderer>
          else
           <div>

--- a/app/pages/home.cjsx
+++ b/app/pages/home.cjsx
@@ -34,7 +34,7 @@ counterpart.registerTranslations 'en',
       loggedTitle: 'Get started on a new project right now!'
       button: 'See all projects'
     recentProjects:
-      title: "Welcome back! Jump into one of your recent projects"
+      title: "Welcome back! Jump into one of your recent projects..."
       button: 'See all your projects'
 
 FeaturedProjects = React.createClass

--- a/app/pages/home.cjsx
+++ b/app/pages/home.cjsx
@@ -8,6 +8,7 @@ ZooniverseLogoType = require '../partials/zooniverse-logotype'
 OwnedCard = require '../partials/owned-card'
 FEATURED_PRODUCT_IDS = require '../lib/featured-projects'
 {Markdown} = require 'markdownz'
+ProjectIcon = require '../components/project-icon'
 
 counterpart.registerTranslations 'en',
   home:
@@ -30,7 +31,29 @@ counterpart.registerTranslations 'en',
         content: '''Our platform offers many opportunities for education, from using projects in classrooms to sharing information between volunteers. You can even use the [Zooniverse Project Builder](/lab) to create your very own project!'''
     featuredProjects:
       title: 'Get started on a project right now!'
+      loggedTitle: 'Get started on a new project right now!'
       button: 'See all projects'
+    recentProjects:
+      title: "Welcome back! Jump into one of your recent projects"
+      button: 'See all your projects'
+
+FeaturedProjects = React.createClass
+  displayName: "FeaturedProjects"
+
+  render: ->
+    <div className="featured-projects">
+      <PromiseRenderer promise={apiClient.type('projects').get(FEATURED_PRODUCT_IDS)}>{(projects) =>
+        if projects?
+          <div className="featured-projects-list">
+          {for project in projects
+            avatarSrc = project.get('avatar').then (avatar) ->
+              avatar.src
+            <OwnedCard key={project.id} resource={project} linkTo="project-home" translationObjectName="projectsPage" imagePromise={avatarSrc} />
+          }
+          </div>
+      }</PromiseRenderer>
+      <Link to="projects" className="call-to-action standard-button x-large"><Translate content="home.featuredProjects.button" /></Link>
+    </div>
 
 module.exports = React.createClass
   displayName: 'HomePage'
@@ -41,46 +64,64 @@ module.exports = React.createClass
   componentWillUnmount: ->
     document.documentElement.classList.remove 'on-home-page'
 
+  lastFourProjects: ->
+    @props.user.get("project_preferences", page_size: 4, sort: '+updated_at')
+
   render: ->
     aboutItems = ['contribute', 'explore', 'collaborate', 'discover']
 
     <div className="home-page">
       <section className="hero on-dark">
         <ZooniverseLogoType />
-        <h3 className="hero-title"><Translate content="home.hero.title" /></h3>
-        <p className="hero-tagline"><Translate content="home.hero.tagline" /></p>
-        <Link to="projects" className="call-to-action standard-button hero-button x-large"><Translate content="home.hero.button" /></Link>
+        {if @props.user
+          <PromiseRenderer promise={@lastFourProjects()}>{(projectPreferences) =>
+            <div className="recent-projects">
+              <Translate component="h5" content="home.recentProjects.title" />
+              <div className="recent-projects-list">
+                {projectPreferences.map (projectPreference) =>
+                  <PromiseRenderer key={projectPreference.id} promise={projectPreference.get 'project'} catch={null} then={(project) =>
+                    if project?
+                      <div>
+                        <ProjectIcon project={project} badge={projectPreference.activity_count} />
+                        &ensp;
+                      </div>
+                    else
+                      null
+                  } />}
+              </div>
+            <Link to="user-profile-stats" params={{name: @props.user.login}} className="call-to-action standard-button x-large"><Translate content="home.recentProjects.button" /></Link>
+            </div>
+          }</PromiseRenderer>
+         else
+          <div>
+            <h3 className="hero-title"><Translate content="home.hero.title" /></h3>
+            <p className="hero-tagline"><Translate content="home.hero.tagline" /></p>
+            <Link to="projects" className="call-to-action standard-button hero-button x-large"><Translate content="home.hero.button" /></Link>
+          </div>}
       </section>
-      <section className="about-zooniverse">
-        <div className="about-items-list">
-          {for item in aboutItems
-            <div key={item} className="about-item">
-              <div className="about-item-wrapper">
-                <img className="about-image" src="./assets/home-#{item}.gif" alt="" />
-                <div className="about-item-content">
-                  <Translate component="h5" content="home.about.#{item}.title" />
-                  <Markdown>{counterpart "home.about.#{item}.content"}</Markdown>
+      {unless @props.user?
+        <section className="about-zooniverse">
+          <div className="about-items-list">
+            {for item in aboutItems
+              <div key={item} className="about-item">
+                <div className="about-item-wrapper">
+                  <img className="about-image" src="./assets/home-#{item}.gif" alt="" />
+                  <div className="about-item-content">
+                    <Translate component="h5" content="home.about.#{item}.title" />
+                    <Markdown>{counterpart "home.about.#{item}.content"}</Markdown>
+                  </div>
                 </div>
               </div>
-            </div>
-          }
-        </div>
-      </section>
-      <section className="featured-projects content-container">
-        <Translate component="h5" content="home.featuredProjects.title" />
-        <PromiseRenderer promise={apiClient.type('projects').get(FEATURED_PRODUCT_IDS)}>{(projects) =>
-          if projects?
-            <div className="featured-projects-list">
-            {for project in projects
-              avatarSrc = project.get('avatar').then (avatar) ->
-                avatar.src
-              <OwnedCard key={project.id} resource={project} linkTo="project-home" translationObjectName="projectsPage" imagePromise={avatarSrc} />
             }
-            </div>
-        }</PromiseRenderer>
-        <Link to="projects" className="call-to-action standard-button x-large"><Translate content="home.featuredProjects.button" /></Link>
+          </div>
+        </section>}
+      <section className="featured-projects content-container">
+        {if @props.user?
+           <Translate component="h5" content="home.featuredProjects.loggedTitle" />
+         else
+           <Translate component="h5" content="home.featuredProjects.title" />}
+        <FeaturedProjects />
       </section>
-
     </div>
 
   showLoginDialog: (which) ->

--- a/app/pages/profile/stats.cjsx
+++ b/app/pages/profile/stats.cjsx
@@ -1,52 +1,7 @@
 React = require 'react'
-{Link} = require 'react-router'
 ClassificationsRibbon = require '../../components/classifications-ribbon'
 PromiseRenderer = require '../../components/promise-renderer'
-
-ProjectIcon = React.createClass
-  displayName: 'ProjectIcon'
-
-  getDefaultProps: ->
-    project: null
-    badge: ''
-    defaultAvatarSrc: '/assets/simple-avatar.jpg'
-
-  getInitialState: ->
-    href: ''
-    avatar: null
-
-  componentDidMount: ->
-    @getDetails @props.project
-
-  componentWillReceiveProps: (nextProps) ->
-    unless nextProps.project is @props.project
-      @getDetails nextProps.project
-
-  getDetails: (project) ->
-    project.get 'owner'
-      .then (owner) =>
-        @setState {owner}
-    project.get 'avatar'
-      .catch =>
-        null
-      .then (avatar) =>
-        @setState {avatar}
-
-  render: ->
-    content = [
-      <img key="image" src={@state.avatar?.src ? @props.defaultAvatarSrc} />
-      <div key="label" className="label">
-        <span className="owner">{@state.owner?.display_name}</span><br />
-        <span className="display-name"><strong>{@props.project.display_name}</strong></span>
-      </div>
-      <div key="badge" className="badge">{@props.badge}</div> if @props.badge
-    ]
-
-    if !!@props.project.redirect
-      <a href={@props.project.redirect} className="stats-project-icon">{content}</a>
-    else
-      [owner, name] = @props.project.slug.split '/'
-      <Link to="project-home" params={owner: owner, name: name} className="stats-project-icon">{content}</Link>
+ProjectIcon = require '../../components/project-icon'
 
 module.exports = React.createClass
   getDefaultProps: ->

--- a/app/talk/lib/paginator.cjsx
+++ b/app/talk/lib/paginator.cjsx
@@ -20,7 +20,7 @@ updatePageQueryParam = (page) ->
     location.hash = beforeQuestionMark + newSearch
   else
     newSearch = changeSearchString(location.search, {page})
-    @transitionTo(location.pathname, {}, newSearch)
+    @transitionTo(@getPath(), {}, newSearch)
 
 module?.exports = React.createClass
   displayName: 'Paginator'

--- a/css/home-page.styl
+++ b/css/home-page.styl
@@ -43,7 +43,7 @@
       &:hover
         background: lighten(COBOLT_BLUE, 20%)
 
-  .featured-projects
+  .featured-projects, .recent-projects
     align-items: center
     display: flex
     flex-direction: column
@@ -54,7 +54,7 @@
     h5
       font-weight: 300
 
-    .featured-projects-list
+    .featured-projects-list, .recent-projects-list
       column-width: 22em
       column-gap: 2.5em
       display: flex
@@ -62,6 +62,12 @@
       margin: 4.6em 3vw
       max-width: 960px
       width: 100%
+
+    .recent-projects-list
+      justify-content: center
+
+  .recent-projects
+    padding: 2.5em 0
 
   .about-zooniverse
     align-items: center
@@ -103,8 +109,3 @@
 
             p
               color: #5a5a5a
-
-
-
-
-


### PR DESCRIPTION
Returning users will now see the four projects they most recently
classified on and the four featured projects instead of seeing the
explanation of the Zooniverse like they do now.

<img width="1680" alt="screen shot 2015-09-08 at 2 19 48 pm" src="https://cloud.githubusercontent.com/assets/108177/9744993/c3f4c8d0-5634-11e5-9b9d-a0b06e582eb4.png">
