### PR TITLE
Fetch sidebar projects list from user prefs

### DIFF
--- a/app/talk/init.cjsx
+++ b/app/talk/init.cjsx
@@ -93,7 +93,7 @@ module?.exports = React.createClass
         <div className="talk-sidebar">
           <h2>Talk Sidebar</h2>
 
-          <ProjectLinker />
+          <ProjectLinker user={@props.user} />
 
           <section>
             <PopularTags


### PR DESCRIPTION
- Fetches sidebar projects from user prefs, or falls back to launch
  approved projects
- Short-term solution so that list isn't hard-coded anymore
- Wouldn't mind extra eyes on this in case I'm missing something ; dev projects are pretty different from production ones
