### PR TITLE
Remove nested AutoSave

### DIFF
--- a/app/pages/lab/project-details.cjsx
+++ b/app/pages/lab/project-details.cjsx
@@ -40,11 +40,9 @@ ExternalLinksEditor = React.createClass
                 <input type="text" name="urls.#{i}.url" value={@props.project.urls[i].url} onChange={handleInputChange.bind @props.project} />
               </td>
               <td>
-                <AutoSave resource={@props.project}>
-                  <button type="button" onClick={@handleRemoveLink.bind this, link}>
-                    <i className="fa fa-remove"></i>
-                  </button>
-                </AutoSave>
+                <button type="button" onClick={@handleRemoveLink.bind this, link}>
+                  <i className="fa fa-remove"></i>
+                </button>
               </td>
             </AutoSave>}
         </tbody>


### PR DESCRIPTION
Unnecessary nested AutoSave element was losing its event, so it was impossible to remove external project links. cc: @aliburchard.