### PR TITLE
Change sidebar dropdown to links, improve request

### DIFF
--- a/app/talk/active-users.cjsx
+++ b/app/talk/active-users.cjsx
@@ -93,6 +93,6 @@ module?.exports = React.createClass
         {@state.users.map(@userLink)}
       </ul>
       {if @state.pageCount > 1
-        <Paginator page={+@state.page} onPageChange={@onPageChange} pageCount={@state.pageCount} scrollOnChange={false} />
+        <Paginator page={+@state.page} onPageChange={@onPageChange} pageCount={@state.pageCount} scrollOnChange={false} firstAndLast={false} pageSelector={false} />
       }
     </div>

--- a/app/talk/lib/paginator.cjsx
+++ b/app/talk/lib/paginator.cjsx
@@ -31,11 +31,13 @@ module?.exports = React.createClass
     onPageChange: React.PropTypes.func.isRequired # passed (page) on change
     firstAndLast: React.PropTypes.bool            # optional, add 'first' & 'last' buttons
     scrollOnChange: React.PropTypes.bool          # optional, scroll to top of page on change
+    pageSelector: React.PropTypes.bool # show page selector?
 
   getDefaultProps: ->
     page: 1
     onPageChange: updatePageQueryParam
     firstAndLast: true
+    pageSelector: true
     scrollOnChange: true
 
   mixins: [Navigation]
@@ -84,12 +86,14 @@ module?.exports = React.createClass
         <i className="fa fa-long-arrow-left" /> Previous
       </button>
 
-      <div className="paginator-page-selector">
-        Page&nbsp;
-        <select value={page} onChange={@onSelectPage} ref="pageSelect">
-          {[1..pageCount].map(@pageOption)}
-        </select> of {pageCount}
-      </div>
+      {if @props.pageSelector
+        <div className="paginator-page-selector">
+          Page&nbsp;
+          <select value={page} onChange={@onSelectPage} ref="pageSelect">
+            {[1..pageCount].map(@pageOption)}
+          </select> of {pageCount}
+        </div>
+        }
 
       <button
         className="paginator-next"

--- a/css/talk.styl
+++ b/css/talk.styl
@@ -161,10 +161,6 @@ COPY_GREY_LIGHT = #afaeae
           white-space: nowrap
           text-overflow: ellipsis
 
-      .paginator
-        .paginator-first, .paginator-page-selector, .paginator-last
-          display: none
-
   .talk-moderation
     margin-bottom: 10px
 


### PR DESCRIPTION
- Populates the sidebar project list with any projects that are non-redirected
  - Bit of work to get here on the frontend, but essentially keeps requesting/filtering until it gets 10 projects , unless it's at the last page
  - Updates the ui in batches of 10
- Sidebar just holds a list of collapsible project links instead of the previous dropdown, should be less clicking this way
