### PR TITLE
Synthetic replacement for hashchange events

### DIFF
--- a/app/main.cjsx
+++ b/app/main.cjsx
@@ -11,6 +11,7 @@ if process.env.NON_ROOT isnt 'true' and location.hash isnt ""
   location.pathname = location.hash.slice(1)
 
 router.run (Handler, handlerProps) ->
+  window.dispatchEvent new Event 'pagechange'
   React.render(<Handler {...handlerProps} />, mainContainer);
 
 logDeployedCommit = require './lib/log-deployed-commit'

--- a/app/main.cjsx
+++ b/app/main.cjsx
@@ -11,7 +11,7 @@ if process.env.NON_ROOT isnt 'true' and location.hash isnt ""
   location.pathname = location.hash.slice(1)
 
 router.run (Handler, handlerProps) ->
-  window.dispatchEvent new Event 'pagechange'
+  window.dispatchEvent new Event 'locationchange'
   React.render(<Handler {...handlerProps} />, mainContainer);
 
 logDeployedCommit = require './lib/log-deployed-commit'

--- a/app/partials/account-bar.cjsx
+++ b/app/partials/account-bar.cjsx
@@ -28,11 +28,11 @@ module.exports = React.createClass
     expanded: false
 
   componentDidMount: ->
-    window.addEventListener 'pagechange', @setUnread
+    window.addEventListener 'locationchange', @setUnread
     @setUnread()
 
   componentWillUnmount: ->
-    window.removeEventListener 'pagechange', @setUnread
+    window.removeEventListener 'locationchange', @setUnread
 
   setUnread: ->
     talkClient.type('conversations').get({user_id: @props.user.id, unread: true, page_size: 1})

--- a/app/partials/account-bar.cjsx
+++ b/app/partials/account-bar.cjsx
@@ -28,11 +28,11 @@ module.exports = React.createClass
     expanded: false
 
   componentDidMount: ->
-    window.addEventListener 'hashchange', @setUnread
+    window.addEventListener 'pagechange', @setUnread
     @setUnread()
 
   componentWillUnmount: ->
-    window.removeEventListener 'hashchange', @setUnread
+    window.removeEventListener 'pagechange', @setUnread
 
   setUnread: ->
     talkClient.type('conversations').get({user_id: @props.user.id, unread: true, page_size: 1})

--- a/app/partials/main-header.cjsx
+++ b/app/partials/main-header.cjsx
@@ -28,13 +28,13 @@ module.exports = React.createClass
 
   componentDidMount: ->
     if @checkIfOnHome() then document.addEventListener 'scroll', @onScroll
-    window.addEventListener 'pagechange', @onPageChange
+    window.addEventListener 'locationchange', @onLocationChange
 
   componentWillUnmount: ->
     document.removeEventListener 'scroll', @onScroll
-    window.removeEventListener 'pagechange', @onPageChange
+    window.removeEventListener 'locationchange', @onLocationChange
 
-  onPageChange: ->
+  onLocationChange: ->
     if @checkIfOnHome()
       document.addEventListener 'scroll', @onScroll
     else

--- a/app/partials/main-header.cjsx
+++ b/app/partials/main-header.cjsx
@@ -28,13 +28,13 @@ module.exports = React.createClass
 
   componentDidMount: ->
     if @checkIfOnHome() then document.addEventListener 'scroll', @onScroll
-    window.addEventListener 'hashchange', @onHashChange
+    window.addEventListener 'pagechange', @onPageChange
 
   componentWillUnmount: ->
     document.removeEventListener 'scroll', @onScroll
-    window.removeEventListener 'hashchange', @onHashChange
+    window.removeEventListener 'pagechange', @onPageChange
 
-  onHashChange: ->
+  onPageChange: ->
     if @checkIfOnHome()
       document.addEventListener 'scroll', @onScroll
     else


### PR DESCRIPTION
Closes #1540 

Since we don't have hashchange events anymore, I'm just dispatching a fake event on route changes.

I think `new Event` and `.dispatchEvent` don't have compatibility issues, but somebody may want to double check me.