### PR TITLE
Change to CustomEvent for IE 11

### DIFF
--- a/app/main.cjsx
+++ b/app/main.cjsx
@@ -11,7 +11,7 @@ if process.env.NON_ROOT isnt 'true' and location.hash isnt ""
   location.pathname = location.hash.slice(1)
 
 router.run (Handler, handlerProps) ->
-  window.dispatchEvent new Event 'locationchange'
+  window.dispatchEvent new CustomEvent 'locationchange'
   React.render(<Handler {...handlerProps} />, mainContainer);
 
 logDeployedCommit = require './lib/log-deployed-commit'


### PR DESCRIPTION
Changed from `Event` to `CustomEvent` object because [IE 11 doesn't support it](http://stackoverflow.com/questions/26596123/internet-explorer-9-10-11-event-constructor-doesnt-work). Since Edge is out, I'm assuming I don't need to worry about adding the polyfill for older IE browsers. Also checked Edge and it's ok there.

I have a few modern.ie VMs setup, so ping me if anyone needs me to check support for IE/Edge.

