### PR TITLE
Treat empty redirects as false in project list

### DIFF
--- a/app/talk/lib/project-linker.cjsx
+++ b/app/talk/lib/project-linker.cjsx
@@ -8,7 +8,7 @@ Paginator = require './paginator'
 take = (n, arr) -> arr.slice(0, n)
 
 filterNonRedirected = (projects) ->
-  projects.filter (p) -> p and (not p.redirect?)
+  projects.filter (p) -> p and (not p.redirect)
 
 module?.exports = React.createClass
   displayName: 'ProjectLinker'


### PR DESCRIPTION
- The api stores some of these as `null` and some as empty strings, so
  this will add Planet four and Wildebeest Watch to the list of projects
  for #1596