### PR TITLE
Render null crop summary

### DIFF
--- a/app/classifier/tasks/crop/summary.cjsx
+++ b/app/classifier/tasks/crop/summary.cjsx
@@ -4,12 +4,19 @@ module.exports = React.createClass
   displayName: 'CropSummary'
 
   render: ->
-    {x, y, width, height} = @props.annotation.value
+    summaryContent = if @props.annotation.value?
+      {x, y, width, height} = @props.annotation.value
+      <span>
+        {Math.round width} &times; {Math.round height} at {Math.round x}, {Math.round y}
+      </span>
+    else
+      <small>No area cropped</small>
+
     <div className="classification-task-summary">
       <div className="question">
         {@props.task.instruction}
       </div>
       <div className="answer">
-        {Math.round width} &times; {Math.round height} at {Math.round x}, {Math.round y}
+        {summaryContent}
       </div>
     </div>


### PR DESCRIPTION
Whoops, moving past a crop task without cropping anything would break at the summary screen.