### PR TITLE
Improve empty state of subject page

### DIFF
--- a/app/subjects/index.cjsx
+++ b/app/subjects/index.cjsx
@@ -10,7 +10,7 @@ CommentLink = require '../talk/comment-link'
 projectSection = require '../talk/lib/project-section'
 parseSection = require '../talk/lib/parse-section'
 QuickSubjectCommentForm= require '../talk/quick-subject-comment-form'
-{Navigation} = require 'react-router'
+{Navigation, Link} = require 'react-router'
 {Markdown} = require 'markdownz'
 alert = require '../lib/alert'
 SignInPrompt = require '../partials/sign-in-prompt'
@@ -57,6 +57,10 @@ module?.exports = React.createClass
       [owner, name] = project.slug.split('/')
       @transitionTo('project-talk-discussion', {owner: owner, name: name, board: discussion.board_id, discussion: discussion.id})
 
+  linkToClassifier: (text) ->
+    [owner, name] = @props.project.slug.split('/')
+    <Link to="project-classify" params={{owner, name}}>{text}</Link>
+
   render: ->
     {subject} = @state
 
@@ -78,40 +82,48 @@ module?.exports = React.createClass
           }</PromiseRenderer>
 
           {if @props.user
-            {# these wrapping promises ensure that there are boards for a project}
-            {# & could be removed if a default board is put in place}
             {# TODO remove subject.get('project'), replace with params but browser freezes on get to projects with slug}
-            <PromiseRenderer promise={subject.get('project')}>{(project) =>
-              <PromiseRenderer promise={talkClient.type('boards').get(section: projectSection(project))}>{(boards) =>
-                if boards?.length
-                  <div>
-                    <div className="tabbed-content">
-                      <div className="tabbed-content-tabs">
-                        <div className="subject-page-tabs">
-                          <div className="tabbed-content-tab #{if @state.tab is 0 then 'active' else ''}" onClick={=> @setState({tab: 0})}>
-                            <span>Add a note about this subject</span>
-                          </div>
+            project = subject.get('project')
+            boards = project.then (project) -> talkClient.type('boards').get(section: projectSection(project), subject_default: false)
+            subjectDefaultBoard = project.then (project) -> talkClient.type('boards').get(section: projectSection(project), subject_default: true)
 
-                          <div className="tabbed-content-tab #{if @state.tab is 1 then 'active' else ''}" onClick={=> @setState({tab: 1})}>
-                            <span>or Start a new discussion</span>
-                          </div>
+            <PromiseRenderer promise={Promise.all([boards, subjectDefaultBoard])}>{([boards, subjectDefaultBoard]) =>
+              defaultExists = subjectDefaultBoard.length
+              if boards.length or defaultExists
+                <div>
+                  <div className="tabbed-content">
+                    <div className="tabbed-content-tabs">
+                      <div className="subject-page-tabs">
+                        <div className="tabbed-content-tab #{if @state.tab is 0 then 'active' else ''}" onClick={=> @setState({tab: 0})}>
+                          <span>Add a note about this subject</span>
+                        </div>
+
+                        <div className="tabbed-content-tab #{if @state.tab is 1 then 'active' else ''}" onClick={=> @setState({tab: 1})}>
+                          <span>Start a new discussion</span>
                         </div>
                       </div>
                     </div>
-                    <div>
-                      {if @state.tab is 0
-                        <QuickSubjectCommentForm subject={subject} user={@props.user} />
-                       else if @state.tab is 1
-                        <NewDiscussionForm
-                          user={@props.user}
-                          subject={subject}
-                          onCreateDiscussion={@onCreateDiscussion} />
-                          }
-                    </div>
                   </div>
-                else
-                  <p>There are no discussion boards setup for this project yet. Check back soon!</p>
-              }</PromiseRenderer>
+                  <div>
+                    {if @state.tab is 0
+                      if defaultExists
+                        <QuickSubjectCommentForm subject={subject} user={@props.user} />
+                      else
+                        <p>
+                          There is no default board for subject comments setup yet, Please{' '}
+                          <button className="link-style" onClick={=> @setState(tab: 1)}>start a new discussion</button>{' '}
+                          or {@linkToClassifier('return to classifying')}
+                        </p>
+                     else if @state.tab is 1
+                      <NewDiscussionForm
+                        user={@props.user}
+                        subject={subject}
+                        onCreateDiscussion={@onCreateDiscussion} />
+                        }
+                  </div>
+                </div>
+              else
+                <p>There are no discussion boards setup for this project yet. Check back soon!</p>
             }</PromiseRenderer>
           else
             <p>Please <button className="link-style" type="button" onClick={promptToSignIn}>sign in</button> to contribute to subject discussions</p>}


### PR DESCRIPTION
- Notifies volunteers earlier if there is no subject default board setup
  - Since adding the steps to setup talk in the project builder too, hopefully this will be a less common case
- Closes  #1344 