### PR TITLE
Only disable action buttons in locked discussions

### DIFF
--- a/app/talk/comment.cjsx
+++ b/app/talk/comment.cjsx
@@ -32,9 +32,11 @@ module?.exports = React.createClass
     active: React.PropTypes.bool  # optional active switch: scroll window to comment and apply styling
     user: React.PropTypes.object  # Current user
     index: React.PropTypes.number # The index of the comment in a discussion
+    locked: React.PropTypes.bool  # disable action buttons
 
   getDefaultProps: ->
     active: false
+    locked: false
 
   getInitialState: ->
     editing: false
@@ -196,7 +198,7 @@ module?.exports = React.createClass
 
             <Markdown content={@props.data.body} project={@props.project} header={null}/>
 
-            <div className="talk-comment-links">
+            <div className="talk-comment-links #{if @props.locked then 'locked' else ''}">
               <button className="talk-comment-like-button" onClick={@onClickLike}>
                 {if upvotedByCurrentUser(@props.user, @props.data)
                   <i className="fa fa-thumbs-up upvoted" />

--- a/app/talk/discussion.cjsx
+++ b/app/talk/discussion.cjsx
@@ -161,6 +161,7 @@ module?.exports = React.createClass
       data={data}
       active={+data.id is +@props.query?.comment}
       user={@props.user}
+      locked={@state.discussion?.locked}
       project={@props.project}
       onClickReply={@onClickReply}
       onLikeComment={@onLikeComment}

--- a/css/talk.styl
+++ b/css/talk.styl
@@ -365,10 +365,6 @@ COPY_GREY_LIGHT = #afaeae
     &-locked
       color: FAILURE
 
-    &-comments
-      &.locked
-        pointer-events: none
-        opacity: 0.6
     h1
       input
         margin: 0 auto
@@ -479,6 +475,10 @@ COPY_GREY_LIGHT = #afaeae
     .talk-comment-links
       button:not(:last-child)
         @extend .talk-left-buttons
+
+      &.locked
+        pointer-events: none
+        opacity: 0.3
 
       .talk-comment-like-button i.upvoted
         color: MAIN_HIGHLIGHT


### PR DESCRIPTION
- Only disables action buttons in locked discussions instead of the
  whole thread, so people can still follow links
- Closes https://github.com/zooniverse/scribeAPI/issues/395