### PR TITLE
Require subtasks

### DIFF
--- a/app/classifier/drawing-tools/root.cjsx
+++ b/app/classifier/drawing-tools/root.cjsx
@@ -5,11 +5,12 @@ ChangeListener = require '../../components/change-listener'
 STROKE_WIDTH = 1.5
 SELECTED_STROKE_WIDTH = 2.5
 
-NON_MODAL_STYLE =
-  bottom: null
-  height: 0
-  right: null
-  width: '100%' # `0` makes for too-skinny children.
+SEMI_MODAL_FORM_STYLE =
+  pointerEvents: 'all'
+
+SEMI_MODAL_UNDERLAY_STYLE =
+  pointerEvents: 'none'
+  backgroundColor: 'rgba(0, 0, 0, 0.3)'
 
 module.exports = React.createClass
   displayName: 'DrawingToolRoot'
@@ -53,7 +54,6 @@ module.exports = React.createClass
 
       {if toolProps.selected and toolProps.details? and toolProps.details.length isnt 0
         tasks = require '../tasks'
-        <StickyModalForm ref="detailsForm" underlayStyle={NON_MODAL_STYLE} onSubmit={@handleDetailsFormClose} onCancel={@handleDetailsFormClose}>
 
         detailsAreComplete = toolProps.details.every (detailTask, i) =>
           TaskComponent = tasks[detailTask.type]
@@ -62,6 +62,7 @@ module.exports = React.createClass
           else
             true
 
+        <StickyModalForm ref="detailsForm" style={SEMI_MODAL_FORM_STYLE} underlayStyle={SEMI_MODAL_UNDERLAY_STYLE} onSubmit={@handleDetailsFormClose} onCancel={@handleDetailsFormClose}>
           {for detailTask, i in toolProps.details
             detailTask._key ?= Math.random()
             TaskComponent = tasks[detailTask.type]

--- a/app/classifier/drawing-tools/root.cjsx
+++ b/app/classifier/drawing-tools/root.cjsx
@@ -54,13 +54,21 @@ module.exports = React.createClass
       {if toolProps.selected and toolProps.details? and toolProps.details.length isnt 0
         tasks = require '../tasks'
         <StickyModalForm ref="detailsForm" underlayStyle={NON_MODAL_STYLE} onSubmit={@handleDetailsFormClose} onCancel={@handleDetailsFormClose}>
+
+        detailsAreComplete = toolProps.details.every (detailTask, i) =>
+          TaskComponent = tasks[detailTask.type]
+          if TaskComponent.isAnnotationComplete?
+            TaskComponent.isAnnotationComplete detailTask, toolProps.mark.details[i]
+          else
+            true
+
           {for detailTask, i in toolProps.details
             detailTask._key ?= Math.random()
             TaskComponent = tasks[detailTask.type]
             <TaskComponent key={detailTask._key} task={detailTask} annotation={toolProps.mark.details[i]} onChange={toolProps.onChange} />}
           <hr />
           <p style={textAlign: 'center'}>
-            <button type="submit" className="standard-button">OK</button>
+            <button type="submit" className="standard-button" disabled={not detailsAreComplete}>OK</button>
           </p>
         </StickyModalForm>}
     </g>

--- a/app/classifier/tasks/crop/index.cjsx
+++ b/app/classifier/tasks/crop/index.cjsx
@@ -43,7 +43,7 @@ module.exports = React.createClass
     onChange: Function.prototype
 
   render: ->
-    <GenericTask question={@props.task.instruction} help={@props.task.help}>
+    <GenericTask question={@props.task.instruction} help={@props.task.help} required={@props.task.required}>
       <p>
         <button type="button" disabled={not @props.annotation.value?} onClick={@handleClear}>Clear current crop</button>
       </p>

--- a/app/classifier/tasks/drawing/index.cjsx
+++ b/app/classifier/tasks/drawing/index.cjsx
@@ -74,7 +74,7 @@ module.exports = React.createClass
           <span className="tool-count">({count})</span>}
       </label>
 
-    <GenericTask question={@props.task.instruction} help={@props.task.help} answers={tools} />
+    <GenericTask question={@props.task.instruction} help={@props.task.help} answers={tools} required={@props.task.required} />
 
   handleChange: (index, e) ->
     @constructor.closeAllMarks @props.task, @props.annotation

--- a/app/classifier/tasks/generic.cjsx
+++ b/app/classifier/tasks/generic.cjsx
@@ -10,6 +10,7 @@ module.exports = React.createClass
   getDefaultProps: ->
     question: ''
     help: ''
+    required: false
     answers: []
 
   getInitialState: ->
@@ -23,17 +24,31 @@ module.exports = React.createClass
         {React.Children.map @props.answers, (answer) ->
           cloneWithProps answer,  className: 'answer'}
       </div>
+
+      {if @props.required
+        <div>
+          <p>
+            <small>
+              <strong>This step is required.</strong>
+              <br />
+              If you’re not allowed to continue, make sure it’s complete.
+            </small>
+          </p>
+        </div>}
+
       {if @props.help
-        <p className="help">
-          <br />
-          <small>
-            <strong>
-              <button type="button" className="minor-button" onClick={@showHelp}>
-                Need some help?
-              </button>
-            </strong>
-          </small>
-        </p>}
+        <div>
+          <hr />
+          <p>
+            <small>
+              <strong>
+                <button type="button" className="minor-button" onClick={@showHelp}>
+                  Need some help?
+                </button>
+              </strong>
+            </small>
+          </p>
+        </div>}
     </div>
 
   showHelp: ->

--- a/app/classifier/tasks/multiple.cjsx
+++ b/app/classifier/tasks/multiple.cjsx
@@ -84,7 +84,7 @@ module.exports = React.createClass
         <Markdown>{answer.label}</Markdown>
       </label>
 
-    <GenericTask question={@props.task.question} help={@props.task.help} answers={answers} />
+    <GenericTask question={@props.task.question} help={@props.task.help} answers={answers} required={@props.task.required} />
 
   handleChange: (index, e) ->
     answers = @props.annotation.value

--- a/app/classifier/tasks/single.cjsx
+++ b/app/classifier/tasks/single.cjsx
@@ -81,7 +81,7 @@ module.exports = React.createClass
         <Markdown>{answer.label}</Markdown>
       </label>
 
-    <GenericTask question={@props.task.question} help={@props.task.help} answers={answers} />
+    <GenericTask question={@props.task.question} help={@props.task.help} answers={answers} required={@props.task.required} />
 
   handleChange: (index, e) ->
     if e.target.checked


### PR DESCRIPTION
For #1563:

This disables the "OK" button in the drawing subtasks popup until required subtasks are complete.

It does **not** prevent the user from interacting with the page (this would make it impossible for users to modify or delete the selected mark, for example) so it's still possible to create a new mark while the current subtasks are incomplete.

I believe preventing this would require a fairly big rewrite of how drawing is handled. We can do that in the future.

Instead I've darkened the page behind the subtasks popup to discourage interaction until the "OK" button is pressed, and I've added a "this task is required" note to any required tasks.