### PR TITLE
Defer moderation loading until opened

### DIFF
--- a/app/talk/board.cjsx
+++ b/app/talk/board.cjsx
@@ -32,6 +32,7 @@ module?.exports = React.createClass
     discussionsMeta: {}
     newDiscussionOpen: false
     loading: true
+    moderationOpen: false
 
   getDefaultProps: ->
     query: page: 1
@@ -135,45 +136,54 @@ module?.exports = React.createClass
     <div className="talk-board">
       <h1 className="talk-page-header">{board?.title}</h1>
       {if board && @props.user?
-        <Moderation section={board.section} user={@props.user}>
-          <div>
-            <h2>Moderator Zone:</h2>
-
-            <Link
-              to="#{if @props.section isnt 'zooniverse' then 'project-' else ''}talk-moderations"
-              params={
-                if (@props.params?.owner and @props.params?.name)
-                  {owner: @props.params.owner, name: @props.params.name}
-                else
-                  {}
-              }>
-              View Reported Comments
-            </Link>
-
-            {if board?.title
-              <form className="talk-edit-board-form" onSubmit={@onEditBoard}>
-                <h3>Edit Title:</h3>
-                <input defaultValue={board?.title}/>
-
-                <h3>Edit Description</h3>
-                <textarea defaultValue={board?.description}></textarea>
-
-                <h4>Can Read:</h4>
-                <div className="roles-read">{ROLES.map(@roleReadLabel)}</div>
-
-                <h4>Can Write:</h4>
-                <div className="roles-write">{ROLES.map(@roleWriteLabel)}</div>
-
-                <button type="submit">Update</button>
-              </form>}
-
-            <button onClick={@onClickDeleteBoard}>
-              Delete this board <i className="fa fa-close" />
+        <div className="talk-moderation">
+          <Moderation user={@props.user} section={@props.section}>
+            <button onClick={=> @setState moderationOpen: !@state.moderationOpen}>
+              <i className="fa fa-#{if @state.moderationOpen then 'close' else 'warning'}" /> Moderator Controls
             </button>
+          </Moderation>
 
-            <StickyDiscussionList board={board} />
-          </div>
-        </Moderation>}
+          {if @state.moderationOpen
+            <div className="talk-moderation-children talk-module">
+              <h2>Moderator Zone:</h2>
+
+              <Link
+                to="#{if @props.section isnt 'zooniverse' then 'project-' else ''}talk-moderations"
+                params={
+                  if (@props.params?.owner and @props.params?.name)
+                    {owner: @props.params.owner, name: @props.params.name}
+                  else
+                    {}
+                }>
+                View Reported Comments
+              </Link>
+
+              {if board?.title
+                <form className="talk-edit-board-form" onSubmit={@onEditBoard}>
+                  <h3>Edit Title:</h3>
+                  <input defaultValue={board?.title}/>
+
+                  <h3>Edit Description</h3>
+                  <textarea defaultValue={board?.description}></textarea>
+
+                  <h4>Can Read:</h4>
+                  <div className="roles-read">{ROLES.map(@roleReadLabel)}</div>
+
+                  <h4>Can Write:</h4>
+                  <div className="roles-write">{ROLES.map(@roleWriteLabel)}</div>
+
+                  <button type="submit">Update</button>
+                </form>}
+
+              <button onClick={@onClickDeleteBoard}>
+                Delete this board <i className="fa fa-close" />
+              </button>
+
+              <StickyDiscussionList board={board} />
+            </div>
+          }
+        </div>
+        }
 
       {if @props.user?
         <section>

--- a/app/talk/discussion.cjsx
+++ b/app/talk/discussion.cjsx
@@ -33,6 +33,7 @@ module?.exports = React.createClass
     commentValidationErrors: []
     editingTitle: false
     reply: null
+    moderationOpen: false
 
   getDefaultProps: ->
     query: page: 1
@@ -239,39 +240,48 @@ module?.exports = React.createClass
         }
 
       {if discussion and @props.user?
-        <Moderation section={discussion.section} user={@props.user}>
-          <div>
-            <h2>Moderator Zone:</h2>
-            {if discussion?.title
-              <form className="talk-edit-discussion-form" onSubmit={@onEditSubmit}>
-                <h3>Edit Title:</h3>
-                <input name="title" type="text" defaultValue={discussion?.title}/>
-                <label className="toggle">Sticky:
-                  <input name="sticky" type="checkbox" defaultChecked={discussion?.sticky}/>
-                </label>
-                <label className="toggle">Locked:
-                  <input name="locked" type="checkbox" defaultChecked={discussion?.locked}/>
-                </label>
-
-                <PromiseRenderer promise={talkClient.type('boards').get({section: discussion.section, page_size: 100})}>{(boards) =>
-                  <div>
-                    <p><strong>Board:</strong></p>
-                    <select onChange={@onChangeSelect}>
-                      {boards.map (board, i) =>
-                        <option key={board.id} value={board.id} selected={board.id is discussion.board_id}>{board.title}</option>
-                        }
-                    </select>
-                  </div>
-                }</PromiseRenderer>
-
-                <button type="submit">Update</button>
-              </form>}
-
-            <button onClick={@onClickDeleteDiscussion}>
-              Delete this discussion <i className="fa fa-close" />
+        <div className="talk-moderation">
+          <Moderation user={@props.user} section={@props.section}>
+            <button onClick={=> @setState moderationOpen: !@state.moderationOpen}>
+              <i className="fa fa-#{if @state.moderationOpen then 'close' else 'warning'}" /> Moderator Controls
             </button>
-          </div>
-        </Moderation>}
+          </Moderation>
+
+          {if @state.moderationOpen
+            <div className="talk-moderation-children talk-module">
+              <h2>Moderator Zone:</h2>
+              {if discussion?.title
+                <form className="talk-edit-discussion-form" onSubmit={@onEditSubmit}>
+                  <h3>Edit Title:</h3>
+                  <input name="title" type="text" defaultValue={discussion?.title}/>
+                  <label className="toggle">Sticky:
+                    <input name="sticky" type="checkbox" defaultChecked={discussion?.sticky}/>
+                  </label>
+                  <label className="toggle">Locked:
+                    <input name="locked" type="checkbox" defaultChecked={discussion?.locked}/>
+                  </label>
+
+                  <PromiseRenderer promise={talkClient.type('boards').get({section: discussion.section, page_size: 100})}>{(boards) =>
+                    <div>
+                      <p><strong>Board:</strong></p>
+                      <select onChange={@onChangeSelect}>
+                        {boards.map (board, i) =>
+                          <option key={board.id} value={board.id} selected={board.id is discussion.board_id}>{board.title}</option>
+                          }
+                      </select>
+                    </div>
+                  }</PromiseRenderer>
+
+                  <button type="submit">Update</button>
+                </form>}
+
+              <button onClick={@onClickDeleteDiscussion}>
+                Delete this discussion <i className="fa fa-close" />
+              </button>
+            </div>
+          }
+        </div>
+      }
 
       {if discussion?.locked
         @lockedMessage()

--- a/app/talk/discussion.cjsx
+++ b/app/talk/discussion.cjsx
@@ -264,9 +264,9 @@ module?.exports = React.createClass
                   <PromiseRenderer promise={talkClient.type('boards').get({section: discussion.section, page_size: 100})}>{(boards) =>
                     <div>
                       <p><strong>Board:</strong></p>
-                      <select onChange={@onChangeSelect}>
+                      <select value={discussion.board_id}>
                         {boards.map (board, i) =>
-                          <option key={board.id} value={board.id} selected={board.id is discussion.board_id}>{board.title}</option>
+                          <option key={board.id} value={board.id}>{board.title}</option>
                           }
                       </select>
                     </div>

--- a/app/talk/index.cjsx
+++ b/app/talk/index.cjsx
@@ -17,6 +17,7 @@ module?.exports = React.createClass
           Zooniverse Talk
         </Link>
       </h1>
+
       <TalkBreadcrumbs {...@props} />
 
       <form className="talk-search-form" onSubmit={ @onSearchSubmit }>

--- a/app/talk/init.cjsx
+++ b/app/talk/init.cjsx
@@ -31,6 +31,7 @@ module?.exports = React.createClass
   getInitialState: ->
     boards: []
     loading: true
+    moderationOpen: false
 
   componentWillMount: ->
     sugarClient.subscribeTo('zooniverse') if @props.section is 'zooniverse'
@@ -49,36 +50,45 @@ module?.exports = React.createClass
   render: ->
     <div className="talk-home">
       {if @props.user?
-        <Moderation section={@props.section} user={@props.user}>
-          <div>
-            <h2>Moderator Zone:</h2>
+        <div className="talk-moderation">
+          <Moderation user={@props.user} section={@props.section}>
+            <button onClick={=> @setState moderationOpen: !@state.moderationOpen}>
+              <i className="fa fa-#{if @state.moderationOpen then 'close' else 'warning'}" /> Moderator Controls
+            </button>
+          </Moderation>
 
-            {if @props.section isnt 'zooniverse'
-              <CreateSubjectDefaultButton
-                section={@props.section}
-                onCreateBoard={=> @setBoards()} />
-              }
+          {if @state.moderationOpen
+            <div className="talk-moderation-children talk-module">
+              <h2>Moderator Zone:</h2>
 
-            <ZooniverseTeam user={@props.user} section={@props.section}>
-              <button className="link-style" type="button" onClick={=> alert (resolve) -> <AddZooTeamForm/>}>
-                Invite someone to the Zooniverse team
-              </button>
-            </ZooniverseTeam>
+              {if @props.section isnt 'zooniverse'
+                <CreateSubjectDefaultButton
+                  section={@props.section}
+                  onCreateBoard={=> @setBoards()} />
+                }
 
-            <Link
-              to="#{if @props.section isnt 'zooniverse' then 'project-' else ''}talk-moderations"
-              params={
-                if (@props.params?.owner and @props.params?.name)
-                  {owner: @props.params.owner, name: @props.params.name}
-                else
-                  {}
-              }>
-              View Reported Comments
-            </Link>
+              <ZooniverseTeam user={@props.user} section={@props.section}>
+                <button className="link-style" type="button" onClick={=> alert (resolve) -> <AddZooTeamForm/>}>
+                  Invite someone to the Zooniverse team
+                </button>
+              </ZooniverseTeam>
 
-            <CreateBoardForm section={@props.section} onSubmitBoard={=> @setBoards()}/>
-          </div>
-        </Moderation>}
+              <Link
+                to="#{if @props.section isnt 'zooniverse' then 'project-' else ''}talk-moderations"
+                params={
+                  if (@props.params?.owner and @props.params?.name)
+                    {owner: @props.params.owner, name: @props.params.name}
+                  else
+                    {}
+                }>
+                View Reported Comments
+              </Link>
+
+              <CreateBoardForm section={@props.section} onSubmitBoard={=> @setBoards()}/>
+            </div>
+            }
+        </div>
+        }
 
       <div className="talk-list-content">
         <section>

--- a/app/talk/lib/moderation.cjsx
+++ b/app/talk/lib/moderation.cjsx
@@ -10,28 +10,11 @@ module?.exports = React.createClass
     section: React.PropTypes.string.isRequired # talk section
     user: React.PropTypes.object.isRequired
 
-  getInitialState: ->
-    open: false
-
-  toggleModeration: (e) ->
-    @setState open: !@state.open
-
   render: ->
-    {section} = @props
-
-    <div>
-      <PromiseRenderer pending={null} promise={talkClient.type('roles').get(user_id: @props.user.id, section: ['zooniverse', section], page_size: 100)}>{(roles) =>
-        if userIsModerator(@props.user, roles, section)
-          <div className="talk-moderation">
-            <button onClick={@toggleModeration}>
-              <i className="fa fa-#{if @state.open then 'close' else 'warning'}" /> Moderator Controls
-            </button>
-            <div className="talk-moderation-children #{if @state.open then 'open' else 'closed'}">
-              {if @state.open
-                  @props.children
-                else
-                  null}
-            </div>
-          </div>
-      }</PromiseRenderer>
-    </div>
+    {section, user} = @props
+    <PromiseRenderer pending={null} promise={talkClient.type('roles').get(user_id: user.id, section: ['zooniverse', section], page_size: 100)}>{(roles) =>
+      if userIsModerator(user, roles, section)
+        @props.children
+      else
+         null
+    }</PromiseRenderer>


### PR DESCRIPTION
- The moderation component does not hold the button / open-closed state anymore
  - It just renders children if the supplied user is a moderator for the section
- This looks like a big diff, but is mostly markup indentation
- Closes #1556
