### PR TITLE
Gold standard mode toggle

### DIFF
--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -117,7 +117,7 @@ Classifier = React.createClass
                     <TriggeredModalForm trigger={
                       <i className="fa fa-question-circle"></i>
                     }>
-                      <p>A "demo" classification won’t be counted during aggregation. Use this to give quick demos of your project without </p>
+                      <p>A "throwaway" classification will be stored, but it won’t be counted during aggregation. Use this to give quick demos of your project without throwing off your data.</p>
                     </TriggeredModalForm>
                     <br />
                     <label>

--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -97,10 +97,15 @@ Classifier = React.createClass
                 <div>
                   <hr />
                   <p className="gold-standard-controls">
-                    <strong>Expert classification options</strong><br />
+                    <strong>Expert classification options:</strong><br />
 
                     <label>
-                      <input type="radio" name="expert-options" value="gold_standard" checked={@props.classification.metadata.gold_standard} onChange={@handleExpertOptionsChange} />{' '}
+                      <input type="radio" name="expert-options" checked={not @props.classification.gold_standard} onChange={@handleExpertOptionsChange} />{' '}
+                      Normal
+                    </label>
+                    <br />
+                    <label>
+                      <input type="radio" name="expert-options" value="gold_standard" checked={@props.classification.gold_standard} onChange={@handleExpertOptionsChange} />{' '}
                       Gold standard
                     </label>{' '}
                     <TriggeredModalForm trigger={
@@ -108,22 +113,6 @@ Classifier = React.createClass
                     }>
                       <p>A “gold standard” classification is one that is known to be completely accurate. We’ll compare other classifications against it during aggregation.</p>
                     </TriggeredModalForm>
-                    <br />
-
-                    <label>
-                      <input type="radio" name="expert-options" value="throwaway" checked={@props.classification.metadata.throwaway} onChange={@handleExpertOptionsChange} />{' '}
-                      Demo/throwaway
-                    </label>{' '}
-                    <TriggeredModalForm trigger={
-                      <i className="fa fa-question-circle"></i>
-                    }>
-                      <p>A "throwaway" classification will be stored, but it won’t be counted during aggregation. Use this to give quick demos of your project without throwing off your data.</p>
-                    </TriggeredModalForm>
-                    <br />
-                    <label>
-                      <input type="radio" name="expert-options" checked={not (@props.classification.metadata.gold_standard or @props.classification.metadata.throwaway)} onChange={@handleExpertOptionsChange} />{' '}
-                      Normal
-                    </label>
                   </p>
                 </div>
             }</PromiseRenderer>}
@@ -168,10 +157,8 @@ Classifier = React.createClass
           <button type="button" className="continue major-button" disabled={waitingForAnswer} onClick={@addAnnotationForTask.bind this, classification, nextTaskKey}>Next</button>
         else
           <button type="button" className="continue major-button" disabled={waitingForAnswer} onClick={@completeClassification}>
-            {if @props.classification.metadata.gold_standard
-              <i className="fa fa-star fa-fw"></i>
-            else if @props.classification.metadata.throwaway
-              <i className="fa fa-trash fa-fw"></i>}
+            {if @props.classification.gold_standard
+              <i className="fa fa-star fa-fw"></i>}
             Done
           </button>}
       </nav>
@@ -243,15 +230,7 @@ Classifier = React.createClass
   handleExpertOptionsChange: ->
     element = React.findDOMNode this
     goldStandardCheckbox = element.querySelector '[name="expert-options"][value="gold_standard"]'
-    throwawayCheckbox = element.querySelector '[name="expert-options"][value="throwaway"]'
-
-    @props.classification.update
-      'metadata.gold_standard': goldStandardCheckbox.checked
-      'metadata.throwaway': throwawayCheckbox.checked
-
-    @props.onChangeExpertOptions
-      newClassificationsAreGoldStandard: @props.classification.metadata.gold_standard
-      newClassificationsAreThrowaway: @props.classification.metadata.throwaway
+    @props.classification.update gold_standard: goldStandardCheckbox.checked
 
   toggleExpertClassification: (value) ->
     @setState showingExpertClassification: value

--- a/app/pages/project/classify.cjsx
+++ b/app/pages/project/classify.cjsx
@@ -62,8 +62,6 @@ module.exports = React.createClass
     workflow: null
     subject: null
     classification: null
-    newClassificationsAreGoldStandard: false
-    newClassificationsAreThrowaway: false
 
   propChangeHandlers:
     project: 'loadAppropriateClassification'
@@ -117,6 +115,7 @@ module.exports = React.createClass
       # console.log 'Creating a new classification'
       classification = apiClient.type('classifications').create
         annotations: []
+        gold_standard: false
         metadata:
           workflow_version: workflow.version
           started_at: (new Date).toISOString()
@@ -124,8 +123,6 @@ module.exports = React.createClass
           user_language: counterpart.getLocale()
           utc_offset: ((new Date).getTimezoneOffset() * 60).toString() # In seconds
           subject_dimensions: (null for location in subject.locations)
-          gold_standard: @state.newClassificationsAreGoldStandard
-          throwaway: @state.newClassificationsAreThrowaway
         links:
           project: project.id
           workflow: workflow.id
@@ -203,7 +200,6 @@ module.exports = React.createClass
           onLoad={@scrollIntoView}
           onComplete={@saveClassification}
           onClickNext={@loadAnotherSubject}
-          onChangeExpertOptions={@handleExpertOptionsChange}
         />
       else if @state.rejected.classification?
         <code>{@state.rejected.classification.toString()}</code>
@@ -233,9 +229,6 @@ module.exports = React.createClass
         classification.destroy()
       classificationsThisSession += 1
       @maybePromptToSignIn()
-
-  handleExpertOptionsChange: (options) ->
-    @setState options
 
   maybePromptToSignIn: ->
     if classificationsThisSession in PROMPT_TO_SIGN_IN_AFTER and not @props.user?


### PR DESCRIPTION
This adds a section to the classification interface below the task for expert users to change expert classification settings.

Currently gold-standard mode is the only option. A demo/throwaway mode should be coming soon.

@aliburchard: In demo mode, did you want the classifications saved with a `throwaway: true` flag, or should they not be saved at all?