### PR TITLE
Board positions

### DIFF
--- a/css/talk.styl
+++ b/css/talk.styl
@@ -216,6 +216,19 @@ COPY_GREY_LIGHT = #afaeae
               background: MAIN_HIGHLIGHT
               color: white
 
+      .talk-reorder-boards
+        padding: 30px 0 30px 40px
+        margin: 0
+
+        li, .bars
+          cursor: default
+
+        li
+          list-style: none outside none
+
+          .bars
+            margin-right: 5px
+
   .talk-board
     .talk-page-header
       text-align: left

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "counterpart": "~0.16.7",
     "data-uri-to-blob": "0.0.4",
     "debounce": "~1.0.0",
+    "drag-reorderable": "~0.0.1",
     "json-api-client": "~0.4.0",
     "lodash.intersection": "~3.2.0",
     "lodash.merge": "~2.4.1",


### PR DESCRIPTION
This allows boards to be ordered by most recent activity or in a static/manual order.

Closes #1665.

This is currently broken in Firefox until zooniverse-ui/drag-reorderable#1 is merged.

Also, touch support is currently missing.