### PR TITLE
Revert "Update auth client to handle response from superagent"

### DIFF
--- a/app/api/auth.coffee
+++ b/app/api/auth.coffee
@@ -18,8 +18,8 @@ module.exports = new Model
   _getAuthToken: ->
     console?.log 'Getting auth token'
     makeHTTPRequest 'GET', config.host + "/users/sign_in/?now=#{Date.now()}", null, JSON_HEADERS
-      .then (resp) ->
-        authToken = resp.headers['x-csrf-token']
+      .then (request) ->
+        authToken = request.getResponseHeader 'X-CSRF-Token'
         console?.info "Got auth token #{authToken[...6]}..."
         authToken
 
@@ -47,8 +47,8 @@ module.exports = new Model
           console?.error 'Failed to get bearer token'
           client.handleError request
 
-  _handleNewBearerToken: (resp) ->
-    response = resp.body
+  _handleNewBearerToken: (request) ->
+    response = JSON.parse request.responseText
 
     @_bearerToken = response.access_token
     client.headers['Authorization'] = "Bearer #{@_bearerToken}"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "data-uri-to-blob": "0.0.4",
     "debounce": "~1.0.0",
     "drag-reorderable": "~0.0.1",
-    "json-api-client": "~1.0.1",
+    "json-api-client": "~0.4.0",
     "lodash.intersection": "~3.2.0",
     "lodash.merge": "~2.4.1",
     "lodash.pick": "~3.1.0",


### PR DESCRIPTION
Reverts zooniverse/Panoptes-Front-End#1439

Merged too quickly. With additional testing, json-api-client is not passing errors back correctly, resulting in confusing or otherwise incorrect error messages. Try registering a user with a username thats already taken, or inputting a login and compare to live.