### PR TITLE
Add longer `.jpeg` extension to those permitted in subject set uploader

### DIFF
--- a/app/pages/lab/subject-set.cjsx
+++ b/app/pages/lab/subject-set.cjsx
@@ -15,7 +15,7 @@ isAdmin = require '../../lib/is-admin'
 
 NOOP = Function.prototype
 
-VALID_SUBJECT_EXTENSIONS = ['.jpg', '.png', '.gif', '.svg']
+VALID_SUBJECT_EXTENSIONS = ['.jpg', '.jpeg', '.png', '.gif', '.svg']
 INVALID_FILENAME_CHARS = ['/', '\\', ':']
 MAX_FILE_SIZE = 600000
 


### PR DESCRIPTION
As discussed at https://github.com/zooniverse/panoptes-subject-uploader/pull/3#issuecomment-145567220