### PR TITLE
Use local node modules for testing, rather than assuming global installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "stage": "NON_ROOT=true NODE_ENV=staging npm run build && publisssh ./build \"demo.zooniverse.org/panoptes-front-end/$DEPLOY_SUBDIR\"",
     "stage-branch": "NON_ROOT=true DEPLOY_SUBDIR=$(git symbolic-ref --short HEAD) npm run stage",
     "start": "./bin/serve.sh",
-    "test": "browserify ./test/runner.coffee --extension .coffee --extension .cjsx --transform coffee-reactify --transform envify --ignore-transform coffeeify | testling \"${TESTLING_ARGS:---pass}\" | tap-spec",
+    "test": "node node_modules/browserify/bin/cmd ./test/runner.coffee --extension .coffee --extension .cjsx --transform coffee-reactify --transform envify --ignore-transform coffeeify|node node_modules/testling/bin/cmd \"${TESTLING_ARGS:---pass}\" | node node_modules/tap-spec/bin/cmd",
     "test-mac": "TESTLING_ARGS=\"-x open --new -a Google\\ Chrome --args --incognito\" npm run test"
   },
   "config": {


### PR DESCRIPTION
`npm test` requires browserify, testling and tap-spec to be available in the users `PATH` (i.e. installed globally), but this isn't mentioned in the README. I suggest using the local modules, which has two benefits:

- No global installs required
- Control over the version of the testing tools

I'm not sure how commonplace this is in node development, but it's a pattern I've recently adopted for the above reasons.

If this isn't to the project's taste, however, I can always create a PR adding the install lines to the README.

(Confession: I haven't managed to get the tests to run properly in any case, but I think that's because I haven't set up the config to point to a local backend)