### PR TITLE
Provide fallback card image

### DIFF
--- a/app/pages/projects.cjsx
+++ b/app/pages/projects.cjsx
@@ -30,6 +30,7 @@ module.exports = React.createClass
   imagePromise: (project) ->
     project.get('avatar')
       .then (avatar) -> avatar.src
+      .catch -> '/assets/simple-avatar.jpg'
 
   cardLink: (project) ->
     link = if !!project.redirect


### PR DESCRIPTION
Adds a fallback for projects without an avatar. Noticed these went away at some point but couldn't find anything indicating why in the git history