### PR TITLE
Hide subtasks' "required" warning

### DIFF
--- a/app/classifier/tasks/generic.cjsx
+++ b/app/classifier/tasks/generic.cjsx
@@ -26,7 +26,7 @@ module.exports = React.createClass
       </div>
 
       {if @props.required
-        <div>
+        <div className="required-task-warning">
           <p>
             <small>
               <strong>This step is required.</strong>

--- a/css/classify.styl
+++ b/css/classify.styl
@@ -115,6 +115,9 @@
       margin-left: 0.5em
       opacity: 0.7
 
+  .modal-form & .required-task-warning
+    display: none
+
   .drawing-tool-icon > svg
     fill-opacity: 0.1
     height: 1.5em


### PR DESCRIPTION
This hides tasks' "required" warning if they appear in subtasks for #1666. This is a hack. We eventually need a real solution than this.