### PR TITLE
Tag search

### DIFF
--- a/app/router.cjsx
+++ b/app/router.cjsx
@@ -52,6 +52,7 @@ module.exports =
       <Route name="project-talk-moderations" path="moderations/?" handler={require './talk/moderations'}/>
       <Route name="project-talk-subject" path="subjects/:id/?" handler={require './subjects'}/>
       <Route name="project-talk-board-recents" path="recents/:board/?" handler={require './talk/recents'} />
+      <Route name="project-talk-tags" path="tags/:tag/?" handler={require './talk/tags'} />
       <Route name="project-talk-board" path=":board/?" handler={require './talk/board'} />
       <Route name="project-talk-discussion" path=":board/:discussion/?" handler={require './talk/discussion'} />
     </Route>

--- a/app/talk/popular-tags.cjsx
+++ b/app/talk/popular-tags.cjsx
@@ -13,12 +13,13 @@ module?.exports = React.createClass
   tagsRequest: ->
     talkClient.type('tags/popular').get section: @props.section, limit: 20, page_size: 20
 
-  tag: (tag, i) ->
+  tag: (talkTag, i) ->
+    tag = talkTag.name
     {owner, name} = @props.params
     if owner and name
-      <div key={tag.id}><Link params={{owner, name}} query={query: tag.name} to="project-talk-search">#{tag.name}</Link>{' '}</div>
+      <div key={talkTag.id}><Link params={{owner, name, tag}} to="project-talk-tags">#{tag}</Link>{' '}</div>
     else
-      <div key={tag.id}><Link query={query: tag.name} to="talk-search">#{tag.name}</Link>{' '}</div>
+      <div key={talkTag.id}><Link query={query: tag} to="talk-search">#{tag}</Link>{' '}</div>
 
   render: ->
     <div className="talk-popular-tags">

--- a/app/talk/tags.cjsx
+++ b/app/talk/tags.cjsx
@@ -1,5 +1,5 @@
 React = require 'react'
-{ Navigation } = require '@edpaget/react-router'
+{Link,Navigation} = require '@edpaget/react-router'
 talkClient = require '../api/talk'
 apiClient = require '../api/client'
 Paginator = require './lib/paginator'
@@ -54,11 +54,20 @@ module.exports = React.createClass
 
           <div className="talk-search-results">
             {for tag in @state.tags
-              <div className="tagged-subject">
+              <div className="tagged-subject talk-search-result talk-module" key="tag-#{ tag.id }">
                 <SubjectViewer subject={tag.subject} user={@props.user} project={@props.project}/>
                 <ul className="tag-list">
                   {for subjectTag in tag.subjectTags
-                    <li key={"tag-#{ tag.id }-#{ subjectTag.id }"}>{subjectTag.name}</li>}
+                    <li key={"tag-#{ tag.id }-#{ subjectTag.id }"}>
+                      <Link to="project-talk-tags"
+                        {...@props}
+                        params={
+                          owner: @props.params.owner
+                          name: @props.params.name
+                          tag: subjectTag.name}>
+                        #{subjectTag.name}
+                      </Link>
+                    </li>}
                 </ul>
               </div>
             }

--- a/css/talk.styl
+++ b/css/talk.styl
@@ -637,6 +637,12 @@ COPY_GREY_LIGHT = #afaeae
     margin: TALK_MARGIN
     padding: TALK_PADDING
 
+    .subject-container, .subject-viewer
+      max-width: 640px
+
+      img
+        max-width: 100%
+
     .tag-list
       padding: 0 TALK_PADDING
 

--- a/css/talk.styl
+++ b/css/talk.styl
@@ -637,6 +637,14 @@ COPY_GREY_LIGHT = #afaeae
     margin: TALK_MARGIN
     padding: TALK_PADDING
 
+    .tag-list
+      padding: 0 TALK_PADDING
+
+      li
+        list-style: none outside none
+        display: inline-block
+        margin: 0 TALK_PADDING
+
   .private-message-form input
     margin-left: 5px
     width: 50%


### PR DESCRIPTION
Provides a subject search by tag.  Closes #1648

I'm linking project popular tags to this (subjects tagged with #tagname)

Non-project popular tags still link to text search.

I *think* that's probably the right thing to do.