### PR TITLE
Add max-width to column under edit-workflow-page

### DIFF
--- a/css/workflow-editor.styl
+++ b/css/workflow-editor.styl
@@ -78,3 +78,6 @@
 .edit-workflow-page
   select
     max-width: 100%
+    
+  .column
+    max-width: 500px


### PR DESCRIPTION
Fixed #1725 by adding max-width to column class when under edit-workflow-page class. Flex-shrink is a bit buggy in Firefox, so this may pop up elsewhere.