### PR TITLE
Use apiClient headers as talkClient headers

### DIFF
--- a/app/api/talk.coffee
+++ b/app/api/talk.coffee
@@ -7,18 +7,7 @@ talkClient = new JSONAPIClient config.talkHost,
   'Content-Type': 'application/json'
   'Accept': 'application/json'
 
-authClient.listen 'change', ->
-  authClient.checkCurrent()
-    .then (user) ->
-      if user
-        token = authClient._bearerToken
-        talkClient.headers['Authorization'] = "Bearer #{token}"
-      else
-        delete talkClient.headers['Authorization']
-    .catch (e) ->
-      throw new Error "Failed to checkCurrent auth from talk api client"
-
-# talkClient.headers = apiClient.headers
+talkClient.headers = apiClient.headers
 talkClient.handleError = apiClient.handleError
 
 window?.talkClient = talkClient


### PR DESCRIPTION
- Fix for #1052, which *seems* to be due bearer-tokens syncing between clients
- I tested this out by refreshing the token every second and am consistently able to submit comments
- This is how the client was originally setup. It seems the move away from this style may have been intended to fix an unrelated problem