### PR TITLE
Switch where we show the "required" task messaging

### DIFF
--- a/css/classify.styl
+++ b/css/classify.styl
@@ -115,7 +115,8 @@
       margin-left: 0.5em
       opacity: 0.7
 
-  .modal-form & .required-task-warning
+  // Only show the "required" warning when a task is outside the normal flow.
+  .classifier > .task-area & .required-task-warning
     display: none
 
   .drawing-tool-icon > svg


### PR DESCRIPTION
I got this reversed the first time.

For #1666.