### PR TITLE
Reduce the height and opacity of deleted comments

### DIFF
--- a/css/talk.styl
+++ b/css/talk.styl
@@ -404,6 +404,11 @@ COPY_GREY_LIGHT = #afaeae
         border-color: MAIN_HIGHLIGHT
 
     &.deleted
+      opacity: 0.5
+
+      .talk-comment-author img
+        height: 25px
+
       .polaroid-image, .talk-comment-links, .talk-comment-children
         display: none
 


### PR DESCRIPTION
As discussed in #1681

<img width="940" alt="deleted_comment" src="https://cloud.githubusercontent.com/assets/122990/10491727/b2cab2b8-726d-11e5-9a73-9254a508ff50.png">


I reduced the avatar image size to match the height of the comment box without the toolbar buttons.