### PR TITLE
Assign search query to new object instead of props

### DIFF
--- a/app/talk/search.cjsx
+++ b/app/talk/search.cjsx
@@ -49,7 +49,7 @@ module.exports = React.createClass
       page: 1
       page_size: 10
 
-    paramsToUse = Object.assign defaultParams, params
+    paramsToUse = Object.assign {}, defaultParams, params
 
     talkClient.type('searches').get(paramsToUse).then (searches) =>
       @setState
@@ -64,7 +64,7 @@ module.exports = React.createClass
     @goToPage page
 
   goToPage: (n) ->
-    nextQuery = Object.assign @props.query, {page: n}
+    nextQuery = Object.assign {}, @props.query, {page: n}
 
     @transitionTo location.pathname, @props.params, nextQuery
 


### PR DESCRIPTION
Don't think this is causing any harm, but am doing some debugging on the search page and think that `nextQuery` doesn't need to directly assign to props