### PR TITLE
transitionTo lab index page if signed out of project builder.

### DIFF
--- a/app/pages/lab/project.cjsx
+++ b/app/pages/lab/project.cjsx
@@ -7,6 +7,7 @@ HandlePropChanges = require '../../lib/handle-prop-changes'
 apiClient = require '../../api/client'
 counterpart = require 'counterpart'
 ChangeListener = require '../../components/change-listener'
+Router = require '@edpaget/react-router'
 
 DEFAULT_WORKFLOW_NAME = 'Untitled workflow'
 DEFAULT_SUBJECT_SET_NAME = 'Untitled subject set'
@@ -216,8 +217,16 @@ EditProjectPage = React.createClass
 
 module.exports = React.createClass
   displayName: 'EditProjectPageWrapper'
-  mixins: [TitleMixin]
+  mixins: [TitleMixin, Router.Navigation]
   title: 'Edit'
+
+  componentDidMount: ->
+    unless @props.user
+      @transitionTo "lab"
+
+  componentWillReceiveProps: (nextProps) ->
+    unless nextProps.user
+      @transitionTo "lab"
 
   getDefaultProps: ->
     params:

--- a/app/partials/account-bar.cjsx
+++ b/app/partials/account-bar.cjsx
@@ -6,7 +6,6 @@ counterpart = require 'counterpart'
 Translate = require 'react-translate-component'
 Avatar = require '../partials/avatar'
 TriggeredModalForm = require 'modal-form/triggered'
-Router = require '@edpaget/react-router'
 
 UP = 38
 DOWN = 40
@@ -21,7 +20,6 @@ counterpart.registerTranslations 'en',
 
 module.exports = React.createClass
   displayName: 'AccountBar'
-  mixins: [Router.Navigation, Router.State]
 
   propTypes:
     user: React.PropTypes.object.isRequired
@@ -112,6 +110,3 @@ module.exports = React.createClass
 
   handleSignOutClick: ->
     auth.signOut()
-
-    if @getPathname().indexOf("lab") > -1 and @getParams()?
-      @transitionTo "lab" 

--- a/app/partials/account-bar.cjsx
+++ b/app/partials/account-bar.cjsx
@@ -6,6 +6,7 @@ counterpart = require 'counterpart'
 Translate = require 'react-translate-component'
 Avatar = require '../partials/avatar'
 TriggeredModalForm = require 'modal-form/triggered'
+Router = require '@edpaget/react-router'
 
 UP = 38
 DOWN = 40
@@ -20,6 +21,7 @@ counterpart.registerTranslations 'en',
 
 module.exports = React.createClass
   displayName: 'AccountBar'
+  mixins: [Router.Navigation, Router.State]
 
   propTypes:
     user: React.PropTypes.object.isRequired
@@ -110,3 +112,6 @@ module.exports = React.createClass
 
   handleSignOutClick: ->
     auth.signOut()
+
+    if @getPathname().indexOf("lab") > -1 and @getParams()?
+      @transitionTo "lab" 


### PR DESCRIPTION
Fixed #1125 by adding a transitionTo to the lab index page if on a lab editor page with projectID when signing out.