### PR TITLE
Uniquely filter roles based on display name

### DIFF
--- a/app/talk/lib/display-roles.cjsx
+++ b/app/talk/lib/display-roles.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+uniq = require 'lodash.uniq'
 
 zooniverseTeamRole = (role) ->
   role.section is 'zooniverse' and [ 'admin', 'team' ].indexOf(role.name) isnt -1
@@ -7,34 +8,29 @@ researcherRole = (role) ->
   userIsResearcher = ['admin', 'scientist', 'owner'].indexOf(role.name) isnt -1
   role.section isnt 'zooniverse' and userIsResearcher
 
-roleDisplayName = (role, section) ->
+roleDisplayName = (role) ->
   if zooniverseTeamRole(role) # show zooniverse admins everywhere as 'team'
     "Zooniverse Team"
   else if researcherRole(role) # project admins, scientists, owners
     "Researcher"
-  else if (role.section is section) # other current section roles
+  else
     role.name
-
-uniqueRoles = (roles) ->
-  roleSections = roles.map((role) -> role.section)
-  roles.filter((role) -> roleSections.indexOf(role.section) isnt -1)
 
 DisplayRoles = React.createClass
   displayName: 'TalkDisplayRoles'
 
   propTypes:
-    roles: React.PropTypes.array    # roles resources
-    section: React.PropTypes.string # talk section
+    roles: React.PropTypes.array # roles resources
 
   role: (role, i) ->
     zooTeamName = if zooniverseTeamRole(role) then 'zoo-team'
     <p key={role.id} className="project-role #{zooTeamName ? role.name}">
-      {roleDisplayName(role, @props.section)}
+      {roleDisplayName(role)}
     </p>
 
   render: ->
     <div className="talk-display-roles">
-      {uniqueRoles(@props.roles).map(@role)}
+      {uniq(@props.roles, roleDisplayName).map(@role)}
     </div>
 
 module?.exports = DisplayRoles

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "lodash.intersection": "~3.2.0",
     "lodash.merge": "~2.4.1",
     "lodash.pick": "~3.1.0",
+    "lodash.uniq": "^3.2.2",
     "markdownz": "^3.0.0",
     "modal-form": "~1.1.0",
     "moment": "~2.9.0",
@@ -27,8 +28,8 @@
     "react-swipe": "~2.3.0",
     "react-translate-component": "~0.9.0",
     "sugar-client": "^1.0.1",
-    "tether": "HubSpot/tether#df8cd44",
     "swipe-js-iso": "~2.0.1",
+    "tether": "HubSpot/tether#df8cd44",
     "window-shim": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Closes #1806 

I probably missed something here, but putting it out there anyway.

This PR does two things:

1. Remove section filtering from the roles display component. Bit worried about this part, but it doesn't look like anything was actually being filtered out?
2. Uniquely filters the given roles by whatever display name would be output.