### PR TITLE
Fix notifications page when not logged in

### DIFF
--- a/app/pages/notifications.cjsx
+++ b/app/pages/notifications.cjsx
@@ -24,8 +24,9 @@ module?.exports = React.createClass
     @getNotifications() if @props.user
 
   componentWillUnmount: ->
-    @markAsRead('first')()
-    @markAsRead('last')()
+    if @props.user
+      @markAsRead('first')()
+      @markAsRead('last')()
 
   componentWillReceiveProps: (nextProps) ->
     pageChanged = nextProps.query.page isnt @props.query.page


### PR DESCRIPTION
- Notifications#markAsRead only needs to be called if a user is logged
  in