### PR TITLE
Fix file upload regex check in admin mode

### DIFF
--- a/app/pages/lab/subject-set.cjsx
+++ b/app/pages/lab/subject-set.cjsx
@@ -16,7 +16,7 @@ isAdmin = require '../../lib/is-admin'
 NOOP = Function.prototype
 
 VALID_SUBJECT_EXTENSIONS = ['.jpg', '.jpeg', '.png', '.gif', '.svg']
-INVALID_FILENAME_CHARS = ['/', '\\', ':']
+INVALID_FILENAME_CHARS = ['/', '\\', ':', ',']
 MAX_FILE_SIZE = 600000
 
 announceSetChange = ->
@@ -273,7 +273,7 @@ EditSubjectSetPage = React.createClass
   _findFilesInMetadata: (metadata) ->
     filesInMetadata = []
     for key, value of metadata
-      extensions = if isAdmin() then '' else "(?:#{VALID_SUBJECT_EXTENSIONS.join '|'})"
+      extensions = if isAdmin() then '\\.\\w{2,4}' else "(?:#{VALID_SUBJECT_EXTENSIONS.join '|'})"
       filesInValue = value.match? ///([^#{INVALID_FILENAME_CHARS.join ''}]+#{extensions})///gi
       if filesInValue?
         filesInMetadata.push filesInValue...


### PR DESCRIPTION
At the moment, uploading subjects doesn't work if you have admin mode turned on. What's happening is the regex looking for the file field in the manifest can't find a valid entry, tries to treat every field as an image location, and can't find any subjects.

This matches anything that looks like a filename with a 2-4 character extension and uses that.

Thanks to @camallen for helping me solve this one :)