### PR TITLE
Subject discussion list

### DIFF
--- a/app/subjects/comment-list.cjsx
+++ b/app/subjects/comment-list.cjsx
@@ -43,10 +43,10 @@ module?.exports = React.createClass
             <Comment key={comment.id} data={comment} locked={true} linked={true} />}
         </div>
 
-        <Paginator
-          page={+@state.meta.page}
-          pageCount={+@state.meta.page_count}
-        />
+        {if +@state.meta.page_count > 1
+          <Paginator
+            page={+@state.meta.page}
+            pageCount={+@state.meta.page_count} />}
       </div>
     else
       <p>There are no comments yet</p>

--- a/app/subjects/discussion-list.cjsx
+++ b/app/subjects/discussion-list.cjsx
@@ -1,0 +1,42 @@
+React = require 'react'
+talkClient = require '../api/talk'
+DiscussionPreview = require '../talk/discussion-preview'
+Loading = require '../components/loading-indicator'
+
+module?.exports = React.createClass
+  displayName: 'SubjectDiscussionList'
+
+  componentWillMount: ->
+    @getDiscussions()
+
+  getInitialState: ->
+    discussions: null
+
+  getDiscussions: ->
+    query =
+      section: @props.section
+      focus_id: @props.subject.id
+      focus_type: 'Subject'
+      page_size: 20
+      sort: '-created_at'
+
+    talkClient.type('discussions').get(query).then (discussions) =>
+      @setState {discussions}
+
+  render: ->
+    return <Loading /> unless @state.discussions
+
+    if @state.discussions.length > 0
+      <div>
+        <h2>Discussions:</h2>
+        <div>
+          {for discussion in @state.discussions
+            <DiscussionPreview
+              key={"discussion-#{ discussion.id }"}
+              discussion={discussion}
+              locked={true}
+              linked={true} />}
+        </div>
+      </div>
+    else
+      <p>There are no discussions yet</p>

--- a/app/subjects/index.cjsx
+++ b/app/subjects/index.cjsx
@@ -7,6 +7,7 @@ ActiveUsers = require '../talk/active-users'
 ProjectLinker = require '../talk/lib/project-linker'
 SubjectCommentForm = require './comment-form'
 SubjectCommentList = require './comment-list'
+SubjectDiscussionList = require './discussion-list'
 
 module?.exports = React.createClass
   displayName: 'Subject'
@@ -40,6 +41,7 @@ module?.exports = React.createClass
                 linkToFullImage={true}/>
 
               <SubjectCommentList subject={@state.subject} {...@props} />
+              <SubjectDiscussionList subject={@state.subject} {...@props} />
               <SubjectCommentForm subject={@state.subject} {...@props} />
             </div>}
         </section>

--- a/css/subject-page.styl
+++ b/css/subject-page.styl
@@ -5,6 +5,10 @@
     img
       max-width: 100%
 
+  .talk-discussion-preview
+    .subject-preview
+      display: none
+
   .talk-comment-box
     .talk-comment-focus-image
 

--- a/css/subject-page.styl
+++ b/css/subject-page.styl
@@ -1,9 +1,15 @@
-.subject-page
+.talk .subject-page
   margin: 0 auto
   .subject-container
     width: 100%
     img
       max-width: 100%
+
+  .talk-comment-box
+    .talk-comment-focus-image
+
+    .talk-comment-form .talk-comment-image-select-button
+      display: none
 
   .talk-comment-link
     a


### PR DESCRIPTION
Depends on #1855 (merge that one first).

I'm also not attempting to paginate the subject discussion list.  Aside from having to dance around multiple page query params, I doubt we really care about anything but the 20 most recent discussions about a subject.  Happy to change later on if that becomes an issue.