### PR TITLE
Fix render return value on sidebar notifications

### DIFF
--- a/app/talk/lib/sidebar-notifications.cjsx
+++ b/app/talk/lib/sidebar-notifications.cjsx
@@ -32,7 +32,7 @@ module?.exports = React.createClass
       'Notifications'
 
   render: ->
-    return null unless @props.user and @state.unreadCount?
+    return <span></span> unless @props.user and @state.unreadCount?
 
     {project, user} = @props
     {section, owner, name} = @props.params


### PR DESCRIPTION
From #1825

`Uncaught (in promise) Error: Invariant Violation: SidebarNotifications.render(): A valid ReactComponent must be returned. You may have returned undefined, an array or some other invalid object.(…)`