### PR TITLE
closes  #1628 - Changed volunteers to registered volunteers on project landing page

### DIFF
--- a/app/pages/project/metadata.cjsx
+++ b/app/pages/project/metadata.cjsx
@@ -18,7 +18,7 @@ module?.exports = React.createClass
       <div className="project-metadata-stats">
         <div className="project-metadata-stat">
           <div>{project.classifiers_count}</div>
-          <div>Volunteers</div>
+          <div>Registered Volunteers</div>
         </div>
 
         <div className="project-metadata-stat">


### PR DESCRIPTION
Volunteer Count isn’t looking at ip addresses. Changing to ‘registered
volunteers’ makes it a bit clearer what value is being reported

closes #1628
