### PR TITLE
Add help section to PB sidebar

### DIFF
--- a/app/pages/lab/project.cjsx
+++ b/app/pages/lab/project.cjsx
@@ -130,9 +130,23 @@ EditProjectPage = React.createClass
               </ul>
             }</PromiseRenderer>
           </li>
-        </ul>
-        <br />
 
+          <li>
+            <br />
+            <div className="nav-list-header">Need some help?</div>
+            <ul className="nav-list">
+              <li>
+                <Link className="nav-list-item" to="lab-how-to">Read a tutorial</Link>
+              </li>
+              <li>
+                <a href="https://www.zooniverse.org/talk/18/" className="nav-list-item">Ask for help on talk</a>
+              </li>
+            </ul>
+          </li>
+        </ul>
+
+        <br />
+        <div className="nav-list-header">Other actions</div>
         <small><button type="button" className="minor-button" disabled={@state.deletionInProgress} onClick={@deleteProject}>Delete this project <LoadingIndicator off={not @state.deletionInProgress} /></button></small>{' '}
         {if @state.deletionError?
           <div className="form-help error">{@state.deletionError.message}</div>}


### PR DESCRIPTION
During the Zoominar today it came up that the project builder was maybe not the most intuitive looking page of our sites. I figured the least we could do was make it easy to get help.

![edit_ _marten_s_testproject_ _zooniverse](https://cloud.githubusercontent.com/assets/277/10944749/90601370-8312-11e5-98ab-187c52336276.png)
