### PR TITLE
pass props down to discussion preview component

### DIFF
--- a/app/subjects/discussion-list.cjsx
+++ b/app/subjects/discussion-list.cjsx
@@ -32,6 +32,7 @@ module?.exports = React.createClass
         <div>
           {for discussion in @state.discussions
             <DiscussionPreview
+              {...@props}
               key={"discussion-#{ discussion.id }"}
               discussion={discussion}
               locked={true}


### PR DESCRIPTION
pretty sure this fixes the issue @vrooje reports [here](https://github.com/zooniverse/Panoptes-Front-End/issues/1894#issuecomment-155027541) but make sure i got this right.

> When I click from that subject page to go to the Subject Notes thread in GZ Bar Lengths, it actually takes me to the Notes thread as a Zooniverse Talk page instead of a project Talk page, and I can't favorite it at all: