### PR TITLE
Styles for slide tutorial

### DIFF
--- a/css/tutorial.styl
+++ b/css/tutorial.styl
@@ -1,4 +1,6 @@
 .modal-form.tutorial-dialog
+  border-radius: 8px
+  max-width: 400px
   padding: 0 0 1.5em
 
 .tutorial-steps


### PR DESCRIPTION
- Added a couple of styles to the `tutorial-dialog` class: 
  - `border-radius` to copy how the slide tutorial looks in older custom projects. 
  - `max-width` to keep the modal from being _slightly_ larger than the tutorial slide content. The modal form was a few decimal points larger in width causing a little white border on the right side.