### PR TITLE
Use markdown editor for help text in the workflow editor

### DIFF
--- a/app/classifier/tasks/generic-editor.cjsx
+++ b/app/classifier/tasks/generic-editor.cjsx
@@ -6,6 +6,8 @@ drawingTools = require '../drawing-tools'
 alert = require '../../lib/alert'
 DrawingTaskDetailsEditor = require './drawing-task-details-editor'
 NextTaskSelector = require './next-task-selector'
+{MarkdownEditor} = require 'markdownz'
+markdownHelp = require ('../../lib/markdown-help')
 
 module.exports = React.createClass
   displayName: 'GenericTaskEditor'
@@ -40,7 +42,7 @@ module.exports = React.createClass
           <AutoSave resource={@props.workflow}>
             <span className="form-label">Help text</span>
             <br />
-            <textarea  name="#{@props.taskPrefix}.help" value={@props.task.help ? ""} rows="7" className="standard-input full" onChange={handleChange} />
+            <MarkdownEditor name="#{@props.taskPrefix}.help" onHelp={markdownHelp} value={@props.task.help ? ""} rows="7" className="full" onChange={handleChange} />
           </AutoSave>
           <small className="form-help">Add text and images for a window that pops up when volunteers click “Need some help?” You can use markdown to format this text and add images. The help text can be as long as you need, but you should try to keep it simple and avoid jargon.</small>
         </div>}


### PR DESCRIPTION
To make editing and previewing task help text easier in the workflow editor.  Address https://github.com/zooniverse/Panoptes-Front-End/issues/1727

![screen shot 2015-11-17 at 2 54 07 pm](https://cloud.githubusercontent.com/assets/6557526/11218271/114aad68-8d4c-11e5-9014-c2d6826fac54.png)
