### PR TITLE
Constrain images within columns

### DIFF
--- a/css/layout.styl
+++ b/css/layout.styl
@@ -33,6 +33,11 @@ body
 
   > .column
     flex-grow: 5
+    // Constrain images to column width
+    min-width: 0
+    img
+      max-width: 100%
+
 
   > hr
     border-width: 0 0 0 1px


### PR DESCRIPTION
Fixes #1948 
I did a quick trawl through the various different pages. Apart from research, the column classes seem to be used mainly on the lab/user settings pages, and I didn't see any adverse impacts there.