### PR TITLE
collection search list defaults

### DIFF
--- a/app/components/collection-search.cjsx
+++ b/app/components/collection-search.cjsx
@@ -15,7 +15,8 @@ module.exports = React.createClass
 
   searchCollections: (value, callback) ->
     query =
-      page_size: 10
+      page_size: 20
+      favorite: false
       current_user_roles: 'owner,collaborator'
     query.search = "#{value}" unless value is ''
 


### PR DESCRIPTION
closes #1950 - bump default collection page size and exclude fav's by default

@aweiksnar perhaps we should add a checkbox to include / exclude favs (default to exclude) as the fav button makes sense for fav collecting.