### PR TITLE
Return of the finished project banner

### DIFF
--- a/app/pages/project/classify.cjsx
+++ b/app/pages/project/classify.cjsx
@@ -6,6 +6,7 @@ PromiseToSetState = require '../../lib/promise-to-set-state'
 apiClient = require '../../api/client'
 animatedScrollTo = require 'animated-scrollto'
 counterpart = require 'counterpart'
+FinishedBanner = require './finished-banner'
 Classifier = require '../../classifier'
 alert = require '../../lib/alert'
 SignInPrompt = require '../../partials/sign-in-prompt'
@@ -199,6 +200,8 @@ module.exports = React.createClass
 
   render: ->
     <div className="classify-page content-container">
+      <FinishedBanner project={@props.project} />
+
       {if @state.classification?
         <Classifier
           {...@props}

--- a/app/pages/project/finished-banner.cjsx
+++ b/app/pages/project/finished-banner.cjsx
@@ -1,0 +1,62 @@
+React = require 'react'
+{Link} = require '@edpaget/react-router'
+
+module.exports = React.createClass
+  getDefaultProps: ->
+    project: null
+
+  getInitialState: ->
+    projectIsComplete: false
+    hasResultsPage: false
+
+  componentDidMount: ->
+    @refresh @props.project
+
+  componentWillReceiveProps: (nextProps) ->
+    unless nextProps.project is @props.project
+      @refresh nextProps.project
+
+  refresh: (project) ->
+    @setState
+      projectIsComplete: false
+      hasResultsPage: false
+    Promise.all([
+      @getCompleteness project
+      @getResultsPageExistence project
+    ]).then ([projectIsComplete, hasResultsPage]) =>
+      @setState {projectIsComplete, hasResultsPage}
+
+  getCompleteness: (project) ->
+    if project.redirect
+      Promise.resolve false
+    else
+      project.get('workflows').then (allWorkflows) ->
+        activeWorkflows = allWorkflows.filter (workflow) ->
+          workflow.active
+        if activeWorkflows.length is 0
+          # No active workflows? This is probably a custom project.
+          false
+        else
+          activeUnfinishedWorkflows = activeWorkflows.filter (workflow) ->
+            not workflow.finished_at?
+          activeUnfinishedWorkflows.length is 0
+
+  getResultsPageExistence: (project) ->
+    project.get('pages').then (pages) ->
+      resultsPages = pages.filter (page) ->
+        page.url_key is 'result'
+      resultsPages[0]?
+
+  render: ->
+    if @state.projectIsComplete
+      <div className="project-finished-banner">
+        <strong>Great work!</strong>{' '}
+        Looks like this project is out of data at the moment!{' '}
+        {if @state.hasResultsPage
+          [owner, name] = @props.project.slug.split '/'
+          <strong>
+            <Link to="project-results" params={{owner, name}}>See the results.</Link>
+          </strong>}
+      </div>
+    else
+      null

--- a/app/pages/project/home.cjsx
+++ b/app/pages/project/home.cjsx
@@ -3,6 +3,7 @@ React = require 'react'
 HandlePropChanges = require '../../lib/handle-prop-changes'
 PromiseToSetState = require '../../lib/promise-to-set-state'
 PromiseRenderer = require '../../components/promise-renderer'
+FinishedBanner = require './finished-banner'
 ProjectMetadata = require './metadata'
 {Link} = require '@edpaget/react-router'
 
@@ -33,6 +34,8 @@ module.exports = React.createClass
 
     <div className="project-home-page">
       <div className="call-to-action-container content-container">
+        <FinishedBanner project={@props.project} />
+
         <div className="description">{@props.project.description}</div>
         {if @props.project.workflow_description? and @props.project.workflow_description isnt ''
           <div className="workflow-description">{@props.project.workflow_description}</div>}

--- a/css/project-page.styl
+++ b/css/project-page.styl
@@ -63,6 +63,7 @@
   color: SECOND_HIGHLIGHT
   margin: 0 auto 1em
   padding: 0.5em 2em
+  text-align: center
   width: max-content
 
   a

--- a/css/project-page.styl
+++ b/css/project-page.styl
@@ -55,6 +55,19 @@
     vertical-align: middle
     width: 4em
 
+.project-finished-banner
+  background: white
+  border: 2px solid
+  border-radius: 0.2em
+  box-shadow: 0 2px 4px rgba(black, 0.3)
+  color: SECOND_HIGHLIGHT
+  margin: 0 auto 1em
+  padding: 0.5em 2em
+  width: max-content
+
+  a
+    color: inherit
+
 .project-home-page
   display: flex
   flex-direction: column
@@ -81,7 +94,7 @@
   .workflow-description
     line-height: 1.5em
     margin: 10px 0 30px 0
-    
+
   .standard-button
     margin-top: 10px
     font-weight: 700
@@ -107,7 +120,7 @@
       max-width: 800px
       margin: 0 auto 1em
 
-   .markdown 
+   .markdown
       color: #989898
       line-height: 1.4em
       text-align: center


### PR DESCRIPTION
Let's try again.

This time I'm skipping `redirect`ed projects and projects with no active workflows, and using the proper (for now) `Link` component.

It now only appears on the landing and classify pages.

There's also a "dismiss" button that'll hide it for three days, which is arbitrary but sane, I think.