### PR TITLE
Fix Linux scripts

### DIFF
--- a/bin/postinstall.sh
+++ b/bin/postinstall.sh
@@ -9,5 +9,5 @@ rm -rf ./public/font-awesome
 curl --location "$FONT_AWESOME_URL" --output ./.font-awesome.zip
 unzip -q ./.font-awesome.zip -d ./.font-awesome.tmp
 mkdir ./public/font-awesome
-mv ./.font-awesome.tmp/*/{css,fonts} ./public/.font-awesome
+mv ./.font-awesome.tmp/*/{css,fonts} ./public/font-awesome
 rm -rf ./.font-awesome.{zip,tmp}

--- a/bin/postinstall.sh
+++ b/bin/postinstall.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+FALLBACK_POLYFILLS_URL="https://cdn.polyfill.io/v1/polyfill.min.js?features=default,es6,Promise,fetch&flags=gated&ua=(MSIE%209.0)"
+FONT_AWESOME_URL="https://github.com/FortAwesome/Font-Awesome/blob/8027c940b6/assets/font-awesome-4.2.0.zip?raw=true"
+
+curl "$FALLBACK_POLYFILLS_URL" > ./public/fallback-polyfills.js
+
+rm -rf ./public/font-awesome
+curl --location "$FONT_AWESOME_URL" --output ./.font-awesome.zip
+unzip -q ./.font-awesome.zip -d ./.font-awesome.tmp
+mkdir ./public/font-awesome
+mv ./.font-awesome.tmp/*/{css,fonts} ./public/.font-awesome
+rm -rf ./.font-awesome.{zip,tmp}

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "scripts": {
     "build": "NODE_ENV=${NODE_ENV:-production} ./bin/build.sh",
-    "check-build-size": "npm run build && cat ./build/{vendor,main}.js | gzip --best | wc -c",
+    "check-build-size": "npm run build && cat ./build/vendor.*.js ./build/main.*.js | gzip --best | wc -c",
     "postinstall": "./bin/postinstall.sh",
     "deploy": "npm run build && publisssh ./build zooniverse-static/www.zooniverse.org/$DEPLOY_SUBDIR",
     "deploy-branch": "NON_ROOT=true DEPLOY_SUBDIR=$(git symbolic-ref --short HEAD) npm run deploy",

--- a/package.json
+++ b/package.json
@@ -57,9 +57,7 @@
   "scripts": {
     "build": "NODE_ENV=${NODE_ENV:-production} ./bin/build.sh",
     "check-build-size": "npm run build && cat ./build/{vendor,main}.js | gzip --best | wc -c",
-    "get-fallback-polyfills": "curl \"$npm_package_config_fallbackPolyfillsURL\" > ./public/fallback-polyfills.js",
-    "get-font-awesome": "rm -rf ./public/font-awesome; curl --location \"$npm_package_config_fontAwesomeURL\" --output ./fa.zip && unzip -q ./fa.zip -d ./fa.tmp && mkdir ./public/font-awesome && mv ./fa.tmp/*/{css,fonts} ./public/font-awesome; rm -rf ./fa.{zip,tmp}",
-    "postinstall": "npm run get-fallback-polyfills && npm run get-font-awesome",
+    "postinstall": "./bin/postinstall.sh",
     "deploy": "npm run build && publisssh ./build zooniverse-static/www.zooniverse.org/$DEPLOY_SUBDIR",
     "deploy-branch": "NON_ROOT=true DEPLOY_SUBDIR=$(git symbolic-ref --short HEAD) npm run deploy",
     "stage": "NON_ROOT=true NODE_ENV=staging npm run build && publisssh ./build \"zooniverse-static/preview.zooniverse.org/panoptes-front-end/$DEPLOY_SUBDIR\"",
@@ -67,10 +65,6 @@
     "start": "./bin/serve.sh",
     "test": "browserify ./test/runner.coffee --extension .coffee --extension .cjsx --transform coffee-reactify --transform envify --ignore-transform coffeeify | testling \"${TESTLING_ARGS:---pass}\" | tap-spec",
     "test-mac": "TESTLING_ARGS=\"-x open --new -a Google\\ Chrome --args --incognito\" npm run test"
-  },
-  "config": {
-    "fontAwesomeURL": "https://github.com/FortAwesome/Font-Awesome/blob/8027c940b6/assets/font-awesome-4.2.0.zip?raw=true",
-    "fallbackPolyfillsURL": "https://cdn.polyfill.io/v1/polyfill.min.js?features=default,es6,Promise,fetch&flags=gated&ua=(MSIE%209.0)"
   },
   "browserify": {
     "transform": [


### PR DESCRIPTION
Closes #1896. From what I can tell, in Linux `npm run-script` uses `sh` instead of the user's shell. I just pulled out the script the uses brace expansion and explicitly made it a bash script (and tweaked another one).