### PR TITLE
Scroll up between project list pages

### DIFF
--- a/app/components/owned-card-list.cjsx
+++ b/app/components/owned-card-list.cjsx
@@ -31,6 +31,9 @@ module.exports = React.createClass
     else
       'All'
 
+  onPageChange: (page) ->
+    @props.onPageChange? page
+
   render: ->
     <div className="secondary-page all-resources-page">
       <section className={"hero #{@props.heroClass}"}>
@@ -65,7 +68,7 @@ module.exports = React.createClass
                 {if meta
                   <nav className="pagination">
                     {for page in [1..meta.page_count]
-                      <Link to={@props.linkTo} query={{page}} key={page} className="pill-button" style={border: "2px solid" if page is 1 and window.location.search is ""}>{page}</Link>}
+                      <Link onClick={@onPageChange.bind this, page} to={@props.linkTo} query={{page}} key={page} className="pill-button" style={border: "2px solid" if page is 1 and window.location.search is ""}>{page}</Link>}
                   </nav>}
               </nav>
             </div>

--- a/app/pages/projects.cjsx
+++ b/app/pages/projects.cjsx
@@ -40,6 +40,9 @@ module.exports = React.createClass
 
     return link
 
+  onPageChange: (page) ->
+    window.scrollTo 0, 0
+
   render: ->
     <OwnedCardList
       translationObjectName="projectsPage"
@@ -47,4 +50,5 @@ module.exports = React.createClass
       linkTo="projects"
       cardLink={@cardLink}
       heroClass="projects-hero"
-      imagePromise={@imagePromise} />
+      imagePromise={@imagePromise}
+      onPageChange={@onPageChange} />


### PR DESCRIPTION
Added this as a callback on the card list - i.e. the parent component/page decides what to do on page change - I can imagine cases where you wouldn't want to jump to the top of the document when changing the list page (e.g. a list buried halfway down a long page)