### PR TITLE
Allow running postinstall in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,4 @@ WORKDIR /src/
 
 ADD . /src/
 
-RUN npm install
+RUN npm install --unsafe-perm

--- a/bin/postinstall.sh
+++ b/bin/postinstall.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 FALLBACK_POLYFILLS_URL="https://cdn.polyfill.io/v1/polyfill.min.js?features=default,es6,Promise,fetch&flags=gated&ua=(MSIE%209.0)"
 FONT_AWESOME_URL="https://github.com/FortAwesome/Font-Awesome/blob/8027c940b6/assets/font-awesome-4.2.0.zip?raw=true"
 


### PR DESCRIPTION
It wasn't running before because of a permissions issue (npm drops privs
by default, whereas Docker builds as root by default).

Also make sure postinstall.sh fails on errors.

**This is dependent on the [pfe-base build currently running on Docker Hub](https://hub.docker.com/r/zooniverse/pfe-base/builds/bz9x3hfdaxxbiqrx9neuufg/). Don't merge until that's finished.**