### PR TITLE
Tutorial dialog and button changes

### DIFF
--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -165,15 +165,21 @@ Classifier = React.createClass
               <i className="fa fa-star fa-fw"></i>}
             {' '}Done
           </button>}
-
         {if not nextTaskKey and @props.workflow.configuration?.hide_classification_summaries and @props.owner? and @props.project?
           [ownerName, name] = @props.project.slug.split('/')
           <Link onClick={@completeClassification} to="/projects/#{ownerName}/#{name}/talk/subjects/#{@props.subject.id}" className="talk standard-button">Done &amp; Talk</Link>}
-
-        <TutorialButton user={@props.user} project={@props.project} />
-
         {@renderExpertOptions()}
       </nav>
+
+      <p>
+        <small>
+          <strong>
+            <TutorialButton className="minor-button" user={@props.user} project={@props.project} title="Project tutorial" aria-label="Show the project tutorial" style={marginTop: '2em'}>
+              Show the project tutorial
+            </TutorialButton>
+          </strong>
+        </small>
+      </p>
 
       {if @props.demoMode
         <p style={textAlign: 'center'}>

--- a/app/classifier/tasks/generic.cjsx
+++ b/app/classifier/tasks/generic.cjsx
@@ -42,7 +42,7 @@ module.exports = React.createClass
             <small>
               <strong>
                 <button type="button" className="minor-button" onClick={@showHelp}>
-                  Need some help?
+                  Need some help with this task?
                 </button>
               </strong>
             </small>

--- a/app/classifier/tutorial-button.cjsx
+++ b/app/classifier/tutorial-button.cjsx
@@ -24,8 +24,8 @@ module.exports = React.createClass
 
   render: ->
     if @state.tutorial? and @state.tutorial.steps.length isnt 0
-      <button type="button" className="secret-button" title="Project tutorial" aria-label="Show the project tutorial" onClick={Tutorial.start.bind(Tutorial, @props.user, @props.project)}>
-        <i className="fa fa-graduation-cap fa-fw" />
+      <button type="button" {...@props} onClick={Tutorial.start.bind(Tutorial, @props.user, @props.project)}>
+        {@props.children}
       </button>
     else
       null

--- a/app/lib/tutorial.cjsx
+++ b/app/lib/tutorial.cjsx
@@ -43,7 +43,11 @@ module.exports = React.createClass
                   mediaByID[mediaResource.id] = mediaResource
 
                 TutorialComponent = this
-                Dialog.alert <TutorialComponent steps={tutorial.steps} media={mediaByID} />, className: 'tutorial-dialog'
+                Dialog.alert(<TutorialComponent steps={tutorial.steps} media={mediaByID} />, {
+                  className: 'tutorial-dialog',
+                  required: true,
+                  closeButton: true
+                })
                   .catch =>
                     null # We don't really care if the user canceled or completed the tutorial.
                   .then =>

--- a/css/modal-form.styl
+++ b/css/modal-form.styl
@@ -19,5 +19,27 @@
   color: black
   font-size: 14px
   margin: 0.5em 3vw
-  overflow: auto
   padding: 0.5em 1em
+
+.modal-dialog-toolbar
+  bottom: 100%
+  margin-bottom: 0.5em
+  position: absolute
+  right: 0
+
+.modal-dialog-toolbar-button
+  @extends $reset-button
+  background: rgba(black, 0.5)
+  border-radius: 2em
+  color: white
+  height: 1em
+  font-size: 2em
+  line-height: 1
+  min-width: 1em
+  text-shadow: 0 2px 4px black
+
+  &:hover
+    background: rgba(black, 0.8)
+
+  &:active
+    background: black

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "lodash.pick": "~3.1.0",
     "lodash.uniq": "~3.2.2",
     "markdownz": "~4.0.2",
-    "modal-form": "~2.0.0",
+    "modal-form": "~2.1.0",
     "moment": "~2.9.0",
     "papaparse": "mholt/PapaParse#cada171",
     "sugar-client": "~1.0.1",


### PR DESCRIPTION
~~To merge after zooniverse-ui/modal-form#13 and a minor version bump.~~ Ready.

This:

- Relabels the task "help" button "Need some help with this task?" and relabels the tutorial button "Show the project tutorial".

- Moves the tutorial button onto its own line. (In the future, I think people want it next to the task help button, that's more work than I can invest in this at the moment though).

- Makes the tutorial dialog `required`, which means it can't be closed by clicking off the dialog

- Adds the new standard dialog close box.

- Closes #1967.