### PR TITLE
Media related help text suggested updates - closes #2012

### DIFF
--- a/app/pages/lab/how-to-page.cjsx
+++ b/app/pages/lab/how-to-page.cjsx
@@ -175,8 +175,6 @@ counterpart.registerTranslations 'en',
 
       Once the image has uploaded, it will appear above the "Add an image" box. You can then copy the markdown text beneath the image into your project, or add another image.
 
-      Currently there is a limit of 20 uploaded images per project.
-
       ### DETAILS - Visibility
 
       This page is where you decide whether your project is public and whether it's ready to go live. For more information on the different project stages, see our [project builder policies](/lab-policies).

--- a/app/pages/lab/media.cjsx
+++ b/app/pages/lab/media.cjsx
@@ -1,6 +1,8 @@
 React = require 'react'
 MediaArea = require '../../components/media-area'
 
+VALID_SUBJECT_EXTENSIONS = ['.jpg', '.jpeg', '.png', '.gif', '.svg']
+
 module.exports = React.createClass
   displayName: 'EditMediaPage'
 
@@ -10,7 +12,7 @@ module.exports = React.createClass
   render: ->
     <div className="edit-media-page">
       <div className="content-container">
-        <p><strong>You can add images here to use in your project’s content.</strong> Just copy and paste the image’s Markdown code: <code>![title](url)</code>.</p>
+        <p><strong>You can add images here to use in your project’s content.</strong>  Just copy and paste the image’s Markdown code: <code>![title](url)</code>. Images can be any of: {<span key={ext}><code>{ext}</code>{', ' if VALID_SUBJECT_EXTENSIONS[i + 1]?}</span> for ext, i in VALID_SUBJECT_EXTENSIONS}{' '} </p>
         <MediaArea resource={@props.project} />
       </div>
     </div>


### PR DESCRIPTION
Removed incorrect media limit upload from help document and added what types of images are supported on the media page 

The media limit is well above 20, and I found that confusing when I checked the help documentation to see what things I had to do prepare Comet Hunters for the request for official Zooniverse approval 

I had tried previously to add a tiff and then realized after attempting to upload that it probably wasn't supported since it wasn't supported for subjects @brian-c I emulated what you did for the subject-set page, but since I don't have the set up can't test it 

@aliburchard I just deleted the line about the 20 image media upload limit .Seems like it's large enough it's not an issue and maybe doesn't need a mention there or at least temporarily would avoid the confusion I had. 