### PR TITLE
Flexible survey

### DIFF
--- a/app/classifier/mock-data.coffee
+++ b/app/classifier/mock-data.coffee
@@ -189,6 +189,9 @@ workflow = apiClient.type('workflows').create
           confusionsOrder: []
           confusions: {}
 
+      questionsMap:
+        ar: ['ho', 'be']
+        to: ['ho', 'be', 'in', 'bt']
       questionsOrder: ['ho', 'be', 'in', 'hr']
       questions:
         ho:
@@ -232,6 +235,17 @@ workflow = apiClient.type('workflows').create
           answers:
             y:
               label: 'Present'
+        bt:
+          required: true
+          multiple: false
+          label: 'Are tortoises awesome?'
+          answersOrder: ['y','Y']
+          answers:
+            y:
+              label: 'yes'
+            Y:
+              label: 'HECK YES'
+
       next: 'init'
 
 subject = apiClient.type('subjects').create

--- a/app/classifier/tasks/flexible-survey/annotation-view.cjsx
+++ b/app/classifier/tasks/flexible-survey/annotation-view.cjsx
@@ -1,0 +1,35 @@
+React = require 'react'
+
+module.exports = React.createClass
+  displayName: 'SurveyAnnotationView'
+
+  getDefaultProperties: ->
+    task: null
+    classification: null
+    annotation: null
+
+  render: ->
+    <div>
+      {for identification, i in @props.annotation.value
+        identification._key ?= Math.random()
+
+        answersByQuestion = @props.task.questionsOrder.map (questionID) =>
+          if questionID of identification.answers
+            answerLabels = [].concat(identification.answers[questionID]).map (answerID) =>
+              @props.task.questions[questionID].answers[answerID].label
+            answerLabels.join ', '
+        answersList = answersByQuestion.filter(Boolean).join '; '
+
+        <span key={identification._key}>
+          <span className="survey-identification-proxy" title={answersList}>
+            {@props.task.choices[identification.choice].label}
+            {' '}
+            <button type="button" className="survey-identification-remove" title="Remove" onClick={@handleRemove.bind this, i}>&times;</button>
+          </span>
+          {' '}
+        </span>}
+    </div>
+
+  handleRemove: (index) ->
+    @props.annotation.value.splice index, 1
+    @props.classification.update 'annotations'

--- a/app/classifier/tasks/flexible-survey/annotation-view.cjsx
+++ b/app/classifier/tasks/flexible-survey/annotation-view.cjsx
@@ -13,6 +13,7 @@ module.exports = React.createClass
       {for identification, i in @props.annotation.value
         identification._key ?= Math.random()
 
+        #TODO: ARB: what is happening here
         answersByQuestion = @props.task.questionsOrder.map (questionID) =>
           if questionID of identification.answers
             answerLabels = [].concat(identification.answers[questionID]).map (answerID) =>

--- a/app/classifier/tasks/flexible-survey/annotation-view.cjsx
+++ b/app/classifier/tasks/flexible-survey/annotation-view.cjsx
@@ -13,7 +13,6 @@ module.exports = React.createClass
       {for identification, i in @props.annotation.value
         identification._key ?= Math.random()
 
-        #TODO: ARB: what is happening here
         answersByQuestion = @props.task.questionsOrder.map (questionID) =>
           if questionID of identification.answers
             answerLabels = [].concat(identification.answers[questionID]).map (answerID) =>

--- a/app/classifier/tasks/flexible-survey/choice.cjsx
+++ b/app/classifier/tasks/flexible-survey/choice.cjsx
@@ -1,7 +1,7 @@
 React = require 'react'
 TriggeredModalForm = require 'modal-form/triggered'
 {Markdown} = require 'markdownz'
-Utility = require 'utility'
+Utility = require './utility'
 
 ImageFlipper = React.createClass
   displayName: 'ImageFlipper'

--- a/app/classifier/tasks/flexible-survey/choice.cjsx
+++ b/app/classifier/tasks/flexible-survey/choice.cjsx
@@ -1,0 +1,153 @@
+React = require 'react'
+TriggeredModalForm = require 'modal-form/triggered'
+{Markdown} = require 'markdownz'
+
+ImageFlipper = React.createClass
+  displayName: 'ImageFlipper'
+
+  getDefaultProps: ->
+    images: []
+
+  getInitialState: ->
+    frame: 0
+
+  PRELOAD_STYLE:
+    height: 0
+    overflow: 'hidden'
+    position: 'fixed'
+    right: 0
+    width: 0
+
+  render: ->
+    <span className="survey-task-image-flipper">
+      {@renderPreload()}
+      <img src={@props.images[@state.frame]} className="survey-task-image-flipper-image" />
+      <span className="survey-task-image-flipper-pips">
+        {unless @props.images.length is 1
+          for index in [0...@props.images.length]
+            <span key={@props.images[index]}>
+              <button type="button" className="survey-task-image-flipper-pip" disabled={index is @state.frame} onClick={@handleFrameChange.bind this, index}>{index + 1}</button>
+              {' '}
+            </span>}
+      </span>
+    </span>
+
+  renderPreload: ->
+    <div style={@PRELOAD_STYLE}>
+      {for image in @props.images
+        <img src={image} key={image} />}
+    </div>
+
+  handleFrameChange: (frame) ->
+    @setState {frame}
+
+module.exports = React.createClass
+  displayName: 'Choice'
+
+  getDefaultProps: ->
+    task: null
+    choiceID: ''
+    onSwitch: Function.prototype
+    onConfirm: Function.prototype
+    onCancel: Function.prototype
+
+  getInitialState: ->
+    answers: {}
+
+  allFilledIn: ->
+    unless @props.task.choices[@props.choiceID].noQuestions
+      for questionID in @props.task.questionsOrder
+        question = @props.task.questions[questionID]
+        if question.required
+          answer = @state.answers[questionID]
+          if (not answer?) or (question.multiple and answer.length is 0)
+            return false
+    true
+
+  render: ->
+    choice = @props.task.choices[@props.choiceID]
+    <div className="survey-task-choice">
+      {unless choice.images.length is 0
+        <ImageFlipper images={@props.task.images[filename] for filename in choice.images} />}
+      <div className="survey-task-choice-content">
+        <div className="survey-task-choice-label">{choice.label}</div>
+        <div className="survey-task-choice-description">{choice.description}</div>
+
+        {unless choice.confusionsOrder.length is 0
+          <div className="survey-task-choice-confusions">
+            Often confused with
+            {' '}
+            {for otherChoiceID in choice.confusionsOrder
+              otherChoice = @props.task.choices[otherChoiceID]
+              <span key={otherChoiceID}>
+                <TriggeredModalForm className="survey-task-confusions-modal" trigger={
+                  <span className="survey-task-choice-confusion">
+                    {otherChoice.label}
+                  </span>
+                } style={maxWidth: '60ch'}>
+                  <ImageFlipper images={@props.task.images[filename] for filename in otherChoice.images} />
+                  <Markdown content={choice.confusions[otherChoiceID]} />
+                  <div className="survey-task-choice-confusion-buttons" style={textAlign: 'center'}>
+                    <button type="submit" className="major-button identfiy">Dismiss</button>
+                    {' '}
+                    <button type="button" className="standard-button cancel" onClick={@props.onSwitch.bind null, otherChoiceID}>I think it’s this</button>
+                  </div>
+                </TriggeredModalForm>
+                {' '}
+              </span>}
+          </div>}
+
+        <hr />
+
+        {unless choice.noQuestions
+          for questionID in @props.task.questionsOrder
+            question = @props.task.questions[questionID]
+            inputType = if question.multiple
+              'checkbox'
+            else
+              'radio'
+            <div key={questionID} className="survey-task-choice-question" data-multiple={question.multiple || null}>
+              <div className="survey-task-choice-question-label">{question.label}</div>
+              {for answerID in question.answersOrder
+                answer = question.answers[answerID]
+                isChecked = if question.multiple
+                  answerID in (@state.answers[questionID] ? [])
+                else
+                  answerID is @state.answers[questionID]
+                <span key={answerID}>
+                  <label className="survey-task-choice-answer" data-checked={isChecked || null}>
+                    <input type={inputType} checked={isChecked} onChange={@handleAnswer.bind this, questionID, answerID} />
+                    {answer.label}
+                  </label>
+                  {' '}
+                </span>}
+            </div>}
+
+        {unless choice.noQuestions or @props.task.questionsOrder.lengths is 0
+          <hr />}
+      </div>
+      <div style={textAlign: 'center'}>
+        <button type="button" className="minor-button" onClick={@props.onCancel}>Cancel</button>
+        {' '}
+        <button type="button" className="standard-button" disabled={not @allFilledIn()} onClick={@handleIdentification}>
+          <strong>Identify</strong>
+        </button>
+      </div>
+    </div>
+
+  handleAnswer: (questionID, answerID, e) ->
+    if @props.task.questions[questionID].multiple
+      @state.answers[questionID] ?= []
+      if e.target.checked
+        @state.answers[questionID].push answerID
+      else
+        @state.answers[questionID].splice @state.answers[questionID].indexOf(answerID), 1
+    else
+      @state.answers[questionID] = if e.target.checked
+        answerID
+      else
+        null
+    @setState answers: @state.answers
+
+  handleIdentification: ->
+    @props.onConfirm @props.choiceID, @state.answers

--- a/app/classifier/tasks/flexible-survey/choice.cjsx
+++ b/app/classifier/tasks/flexible-survey/choice.cjsx
@@ -123,7 +123,7 @@ module.exports = React.createClass
                 </span>}
             </div>}
 
-        {unless choice.noQuestions or Utility.getQuestionIDs(@props.task, @props.choiceID).lengths is 0
+        {unless choice.noQuestions or Utility.getQuestionIDs(@props.task, @props.choiceID).length is 0
           <hr />}
       </div>
       <div style={textAlign: 'center'}>

--- a/app/classifier/tasks/flexible-survey/choice.cjsx
+++ b/app/classifier/tasks/flexible-survey/choice.cjsx
@@ -1,6 +1,7 @@
 React = require 'react'
 TriggeredModalForm = require 'modal-form/triggered'
 {Markdown} = require 'markdownz'
+Utility = require 'utility'
 
 ImageFlipper = React.createClass
   displayName: 'ImageFlipper'
@@ -42,7 +43,7 @@ ImageFlipper = React.createClass
     @setState {frame}
 
 module.exports = React.createClass
-  displayName: 'Choice'
+  displayName: 'FlexibleChoice'
 
   getDefaultProps: ->
     task: null
@@ -55,13 +56,12 @@ module.exports = React.createClass
     answers: {}
 
   allFilledIn: ->
-    unless @props.task.choices[@props.choiceID].noQuestions
-      for questionID in @props.task.questionsOrder
-        question = @props.task.questions[questionID]
-        if question.required
-          answer = @state.answers[questionID]
-          if (not answer?) or (question.multiple and answer.length is 0)
-            return false
+    for questionID in Utility.getQuestionIDs(@props.task, @props.choiceID)
+      question = @props.task.questions[questionID]
+      if question.required
+        answer = @state.answers[questionID]
+        if (not answer?) or (question.multiple and answer.length is 0)
+          return false
     true
 
   render: ->
@@ -100,7 +100,7 @@ module.exports = React.createClass
         <hr />
 
         {unless choice.noQuestions
-          for questionID in @props.task.questionsOrder
+          for questionID in Utility.getQuestionIDs(@props.task, @props.choiceID)
             question = @props.task.questions[questionID]
             inputType = if question.multiple
               'checkbox'
@@ -123,7 +123,7 @@ module.exports = React.createClass
                 </span>}
             </div>}
 
-        {unless choice.noQuestions or @props.task.questionsOrder.lengths is 0
+        {unless choice.noQuestions or Utility.getQuestionIDs(@props.task, @props.choiceID).lengths is 0
           <hr />}
       </div>
       <div style={textAlign: 'center'}>

--- a/app/classifier/tasks/flexible-survey/chooser.cjsx
+++ b/app/classifier/tasks/flexible-survey/chooser.cjsx
@@ -1,0 +1,109 @@
+React = require 'react'
+TriggeredModalForm = require 'modal-form/triggered'
+
+THUMBNAIL_BREAKPOINTS = [Infinity, 40, 20, 10, 5, 0]
+
+module.exports = React.createClass
+  displayName: 'Chooser'
+
+  getDefaultProps: ->
+    task: null
+    filters: {}
+    onFilter: Function.prototype
+    onChoose: Function.prototype
+
+  getFilteredChoices: ->
+    for choiceID in @props.task.choicesOrder
+      choice = @props.task.choices[choiceID]
+      rejected = false
+      for characteristicID, valueID of @props.filters
+        if valueID not in choice.characteristics[characteristicID]
+          rejected = true
+          break
+      if rejected
+        continue
+      else
+        choiceID
+
+  render: ->
+    filteredChoices = @getFilteredChoices()
+
+    for point in THUMBNAIL_BREAKPOINTS
+      if filteredChoices.length <= point
+        breakpoint = point
+
+    <div className="survey-task-chooser">
+      <div className="survey-task-chooser-characteristics">
+        {for characteristicID in @props.task.characteristicsOrder
+          characteristic = @props.task.characteristics[characteristicID]
+          selectedValue = characteristic.values[@props.filters[characteristicID]]
+          hasBeenAutoFocused = false
+
+          <TriggeredModalForm key={characteristicID} ref="#{characteristicID}-dropdown" className="survey-task-chooser-characteristic-menu" trigger={
+            <span className="survey-task-chooser-characteristic" data-is-active={selectedValue? || null}>
+              <span className="survey-task-chooser-characteristic-label">{selectedValue?.label ? characteristic.label}</span>
+            </span>
+          }>
+            <div className="survey-task-chooser-characteristic-menu-container">
+              {for valueID in characteristic.valuesOrder
+                value = characteristic.values[valueID]
+
+                disabled = valueID is @props.filters[characteristicID]
+                autoFocus = not disabled and not hasBeenAutoFocused
+                selected = valueID is @props.filters[characteristicID]
+
+                if autoFocus
+                  hasBeenAutoFocused = true
+
+                <button key={valueID} type="submit" title={value.label} className="survey-task-chooser-characteristic-value" disabled={disabled} data-selected={selected} autoFocus={autoFocus} onClick={@handleFilter.bind this, characteristicID, valueID}>
+                  {if value.image?
+                    <img src={@props.task.images[value.image]} alt={value.label} className="survey-task-chooser-characteristic-value-icon" />}
+                </button>}
+
+              <button type="submit" className="survey-task-chooser-characteristic-clear-button" disabled={characteristicID not of @props.filters} autoFocus={not hasBeenAutoFocused} onClick={@handleFilter.bind this, characteristicID, undefined}>
+                Clear
+              </button>
+            </div>
+            <div className="survey-task-chooser-characteristic-value-label">
+            {label = ""
+            for valueID in characteristic.valuesOrder
+              value = characteristic.values[valueID]
+
+              if valueID is @props.filters[characteristicID]
+                label = value.label
+            if label then label else "Make a selection"
+            }</div>
+          </TriggeredModalForm>}
+      </div>
+
+      <div className="survey-task-chooser-choices" data-breakpoint={breakpoint}>
+        {if filteredChoices.length is 0
+          <div>
+            <em>No matches.</em>
+          </div>
+        else
+          for choiceID, i in filteredChoices
+            choice = @props.task.choices[choiceID]
+            <button key={choiceID + i} type="button" className="survey-task-chooser-choice" onClick={@props.onChoose.bind null, choiceID}>
+              {unless choice.images.length is 0
+                <span className="survey-task-chooser-choice-thumbnail-container">
+                  <img src={@props.task.images[choice.images[0]]} alt={choice.label} className="survey-task-chooser-choice-thumbnail" />
+                </span>}
+              <span className="survey-task-chooser-choice-label">{choice.label}</span>
+            </button>}
+      </div>
+      <div style={textAlign: 'center'}>
+        Showing {filteredChoices.length} of {@props.task.choicesOrder.length}.
+        &ensp;
+        <button type="button" className="survey-task-chooser-characteristic-clear-button" disabled={Object.keys(@props.filters).length is 0} onClick={@handleClearFilters}>
+          <i className="fa fa-ban"></i> Clear filters
+        </button>
+      </div>
+    </div>
+
+  handleFilter: (characteristicID, valueID) ->
+    @props.onFilter characteristicID, valueID
+
+  handleClearFilters: ->
+    for characteristicID in @props.task.characteristicsOrder
+      @props.onFilter characteristicID, undefined

--- a/app/classifier/tasks/flexible-survey/editor-help.cjsx
+++ b/app/classifier/tasks/flexible-survey/editor-help.cjsx
@@ -102,12 +102,14 @@ module.exports =
           <th>Multiple</th>
           <th>Required</th>
           <th>Answers</th>
+          <th>Names</th>
         </tr>
         <tr className="form-label">
           <td>The question to ask</td>
           <td>Can the user select multiple answers? <code>Y</code> or <code>N</code></td>
           <td>Is an answer required? <code>Y</code> or <code>N</code></td>
           <td>The answers, <code>,</code>-separated</td>
+          <td>The choices, <code>;</code>-separated, to which this question should apply</td>
         </tr>
         <tr>
           <td>Is this an example question?</td>

--- a/app/classifier/tasks/flexible-survey/editor-help.cjsx
+++ b/app/classifier/tasks/flexible-survey/editor-help.cjsx
@@ -1,0 +1,120 @@
+React = require 'react'
+
+module.exports =
+  choices: <div className="content-container">
+    <p>User-identifiable <strong>choices</strong>, with these headers:</p>
+
+    <table className="standard-table">
+      <tbody>
+        <tr>
+          <th>Name</th>
+          <th>Description</th>
+          <th>Images</th>
+        </tr>
+        <tr className="form-label">
+          <td>The label for the choice</td>
+          <td>A short description of the choice</td>
+          <td>Representative images of the choice, <code>,</code>-separated</td>
+        </tr>
+        <tr>
+          <td>Shark</td>
+          <td>A shark is a big gray ocean monster with fins and teeth.</td>
+          <td>http://example.com/images/shark.jpg</td>
+        </tr>
+        <tr>
+          <td>Dolphin</td>
+          <td>Dolphins are intelligent marine mammals who solve crimes.</td>
+          <td>http://example.com/images/dolphin.jpg, http://example.com/images/flipper.jpg</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  images: <div className="content-container">
+    Pick some <strong>images</strong>. Make sure they have the exact same names as the ones in your other files.
+  </div>
+
+  characteristics: <div className="content-container">
+    <p><strong>Characteristics</strong> of those choices that the user can filter through, formatted like this:</p>
+
+    <table className="standard-table">
+      <tbody>
+        <tr>
+          <th>Name</th>
+          <th>Color=Orange, http://...png</th>
+          <th>Color=Gray, http://...png</th>
+          <th>Teeth=Dull, http://...png</th>
+          <th>Teeth=Pointy, http://...png</th>
+        </tr>
+        <tr className="form-label">
+          <td>Choice name</td>
+          <td colSpan="4"><code>Characteristic</code>=<code>value</code>, <code>icon URL</code>, with each row marked <code>Y</code> or <code>N</code> for that choice</td>
+        </tr>
+        <tr>
+          <td>Shark</td>
+          <td>N</td>
+          <td>Y</td>
+          <td>N</td>
+          <td>Y</td>
+        </tr>
+        <tr>
+          <td>Dolphin</td>
+          <td>Y</td>
+          <td>Y</td>
+          <td>Y</td>
+          <td>N</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  confusions: <div className="content-container">
+    <p>Commonly <strong>confused pairs</strong> of choices:</p>
+
+    <table className="standard-table">
+      <tbody>
+        <tr>
+          <th>Name</th>
+          <th>Twin</th>
+          <th>Details</th>
+        </tr>
+        <tr className="form-label">
+          <td>The name of the choice to show this pairing for</td>
+          <td>The name of the similar choice</td>
+          <td>A short explanation of how to tell the difference</td>
+        </tr>
+        <tr>
+          <td>Shark</td>
+          <td>Dolphin</td>
+          <td>A dolphin is shaped like a shark, but its tail is horizontal and it’s less terrifying.</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  questions: <div className="content-container">
+    <p><strong>Questions</strong> to ask about each identification:</p>
+
+    <table className="standard-table">
+      <tbody>
+        <tr>
+          <th>Question</th>
+          <th>Multiple</th>
+          <th>Required</th>
+          <th>Answers</th>
+        </tr>
+        <tr className="form-label">
+          <td>The question to ask</td>
+          <td>Can the user select multiple answers? <code>Y</code> or <code>N</code></td>
+          <td>Is an answer required? <code>Y</code> or <code>N</code></td>
+          <td>The answers, <code>,</code>-separated</td>
+        </tr>
+        <tr>
+          <td>Is this an example question?</td>
+          <td>Y</td>
+          <td>N</td>
+          <td>Yes, No, Maybe</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>

--- a/app/classifier/tasks/flexible-survey/editor.cjsx
+++ b/app/classifier/tasks/flexible-survey/editor.cjsx
@@ -16,7 +16,7 @@ putFile = require '../../../lib/put-file'
 Utility = require 'utility'
 
 module.exports = React.createClass
-  displayName: 'SurveyTaskEditor'
+  displayName: 'FlexibleSurveyTaskEditor'
 
   getInitialState: ->
     importErrors: []
@@ -308,20 +308,39 @@ module.exports = React.createClass
     @props.task.choices[choiceID]?.confusionsOrder.push confusionID
     @props.task.choices[choiceID]?.confusions[confusionID] = details
 
-  addQuestion: ({question, multiple, required, answers, __parsedExtra}) ->
-    unless question?
+  addQuestion: ({question, multiple, required, answers, name, __parsedExtra}) ->
+    unless question? or name?
       throw new Error 'Questions require a "question" column'
     unless answers?
       throw new Error 'Questions require a "answers" column'
-    questionID = @makeID question
-    unless questionID in @props.task.questionsOrder
+
+    choices = if name? name.split ';' else null
+    questionID = if question? @makeID question else null
+
+    # don't put it in the default questionsOrder if we've specified choices it should map to
+    unless choices? or questionID in @props.task.questionsOrder
       @props.task.questionsOrder.push questionID
+
+    # if we specified mapped choices, create those entries instead
+    if choices?
+      task.questionsMap ?= {}
+      for choice in choices
+        choiceID = @makeID choice
+        task.questionsMap[choiceID] ?= []
+        task.questionsMap[choiceID].push[questionID]
+
+    # we only can get here if the question stuff is empty and the names are not empty
+    # that means there will be no questions for this choice, so we don't need to actually
+    # store any questions or answers for this row of the csv
+    return unless questionID?
+
     @props.task.questions[questionID] =
       label: question
       multiple: @determineBoolean multiple
       required: @determineBoolean required
       answersOrder: []
       answers: {}
+
     for answer in answers.split(/\s*,\s*/).concat(__parsedExtra ? []).filter Boolean
       answerID = @makeID answer
       @props.task.questions[questionID].answersOrder.push answerID

--- a/app/classifier/tasks/flexible-survey/editor.cjsx
+++ b/app/classifier/tasks/flexible-survey/editor.cjsx
@@ -1,0 +1,366 @@
+React = require 'react'
+FileButton = require '../../../components/file-button'
+alert = require '../../../lib/alert'
+Details = require '../../../components/details'
+TriggeredModalForm = require 'modal-form/triggered'
+surveyEditorHelp = require './editor-help'
+AutoSave = require '../../../components/auto-save'
+handleInputChange = require '../../../lib/handle-input-change'
+NextTaskSelector = require '../next-task-selector'
+MediaArea = require '../../../components/media-area'
+PromiseRenderer = require '../../../components/promise-renderer'
+{Markdown} = require 'markdownz'
+Papa = require 'papaparse'
+apiClient = require '../../../api/client'
+putFile = require '../../../lib/put-file'
+
+module.exports = React.createClass
+  displayName: 'SurveyTaskEditor'
+
+  getInitialState: ->
+    importErrors: []
+    resettingMedia: false
+
+  getDefaultProps: ->
+    workflow: null
+    task: null
+    taskPrefix: ''
+
+  render: ->
+    window.editingSurveyTask = @props.task
+
+    <div className="workflow-task-editor">
+      <p><span className="form-label">Import task data</span></p>
+      <div className="columns-container" style={marginBottom: '0.2em'}>
+        <FileButton className="major-button column" accept=".csv, .tsv" multiple onSelect={@handleFiles.bind this, @addChoice}>Add choices CSV</FileButton>
+        <TriggeredModalForm trigger={
+          <span className="secret-button">
+            <i className="fa fa-question-circle"></i>
+          </span>
+        }>
+          {surveyEditorHelp.choices}
+        </TriggeredModalForm>
+      </div>
+      <div className="columns-container" style={marginBottom: '0.2em'}>
+        <FileButton className="major-button column" accept=".csv, .tsv" multiple onSelect={@handleFiles.bind this, @addCharacteristics}>Add characteristics CSV</FileButton>
+        <TriggeredModalForm trigger={
+          <span className="secret-button">
+            <i className="fa fa-question-circle"></i>
+          </span>
+        }>
+          {surveyEditorHelp.characteristics}
+        </TriggeredModalForm>
+      </div>
+      <div className="columns-container" style={marginBottom: '0.2em'}>
+        <FileButton className="major-button column" accept=".csv, .tsv" multiple onSelect={@handleFiles.bind this, @addConfusion}>Add confused pairs CSV</FileButton>
+        <TriggeredModalForm trigger={
+          <span className="secret-button">
+            <i className="fa fa-question-circle"></i>
+          </span>
+        }>
+          {surveyEditorHelp.confusions}
+        </TriggeredModalForm>
+      </div>
+      <div className="columns-container" style={marginBottom: '0.2em'}>
+        <FileButton className="major-button column" multiple onSelect={@handleFiles.bind this, @addQuestion}>Add questions CSV</FileButton>
+        <TriggeredModalForm trigger={
+          <span className="secret-button">
+            <i className="fa fa-question-circle"></i>
+          </span>
+        }>
+          {surveyEditorHelp.questions}
+        </TriggeredModalForm>
+      </div>
+
+      <hr />
+
+      {unless @state.importErrors.length is 0
+        <div>
+          <p className="form-label">Import errors</p>
+          {for {error, file, row}, i in @state.importErrors
+            <p key={i}>
+              <strong>{error.message}</strong>
+              <br />
+              <span className="form-help">
+                {if file?
+                  <span>{file?.name} </span>}
+                {if row? or error.row?
+                  <span>Row {(row ? error.row) + 1} </span>}
+              </span>
+            </p>}
+          <hr />
+        </div>}
+
+      <div>
+        <span className="form-label">Survey images</span>{' '}
+        <AutoSave resource={@props.workflow}>
+          <button type="button" disabled={@state.resettingMedia} onClick={@resetMedia}>Delete all</button>
+          {if @state.resettingMedia
+            <i className="fa fa-spinner fa-spin"></i>}
+        </AutoSave>
+      </div>
+
+      <MediaArea
+        resource={@props.workflow}
+        metadata={prefix: @props.taskPrefix}
+        style={maxHeight: '90vh'}
+        onAdd={@handleImageAdd}
+        onDelete={@handleImageDelete}
+      />
+
+      <hr />
+
+      <p>
+        <AutoSave resource={@props.workflow}>
+          <span className="form-label">Next task</span>
+          <br />
+          <NextTaskSelector workflow={@props.workflow} name="#{@props.taskPrefix}.next" value={@props.task.next ? ''} onChange={handleInputChange.bind @props.workflow} />
+        </AutoSave>
+      </p>
+
+      <hr />
+
+      <div>
+        <span className="form-label">Survey data</span>{' '}
+        <AutoSave resource={@props.workflow}>
+          <button type="button" onClick={@resetTask}>Delete all</button>
+        </AutoSave>
+      </div>
+
+      {for choiceID in @props.task.choicesOrder
+        choice = @props.task.choices[choiceID]
+        <Details key={choiceID} className="survey-task-editor-choice" summary={
+          <strong>{choice.label}</strong>
+        }>
+          <Markdown content={choice.description} />
+          <p>
+            {for characteristicID in @props.task.characteristicsOrder when choice.characteristics[characteristicID]?.length isnt 0
+              characteristic = @props.task.characteristics[characteristicID]
+              <div key={characteristicID}>
+                <small>
+                  {characteristic.label}:{' '}
+                  {valueLabels = for valueID in characteristic.valuesOrder when valueID in choice.characteristics[characteristicID]
+                    value = characteristic.values[valueID]
+                    value.label
+                  valueLabels.join ', '}
+                </small>
+              </div>}
+            {unless choice.confusionsOrder.length is 0
+              <div>
+                <small>
+                  Confused with:{' '}
+                  {twinLabels = for twinID in choice.confusionsOrder
+                    twin = @props.task.choices[twinID]
+                    twin?.label ? '(Unknown choice)'
+                  twinLabels.join ', '}
+                </small>
+              </div>}
+          </p>
+        </Details>}
+
+      <hr />
+
+      {unless @props.task.questionsOrder.length is 0
+        <div>
+          <Details summary="Questions">
+            {for questionID in @props.task.questionsOrder
+              question = @props.task.questions[questionID]
+              <p>
+                <strong>{question.label}</strong>:{' '}
+                {if question.multiple
+                  'Any of'
+                else
+                  'One of'}{' '}
+                {(question.answers[answerID].label for answerID in question.answersOrder).join ', '}{' '}
+                {if question.required
+                  '(Required)'}
+                </p>}
+          </Details>
+          <hr />
+        </div>}
+
+      <Details summary={<small>Raw task data</small>}>
+        <pre style={fontSize: '10px', whiteSpace: 'pre-wrap'}>{JSON.stringify @props.task, null, 2}</pre>
+      </Details>
+    </div>
+
+  handleFiles: (forEachRow, e) ->
+    @setState
+      importErrors: []
+    Array::slice.call(e.target.files).forEach (file) =>
+      @readFile file
+        .then @parseFileContent
+        .then (rows) =>
+          Promise.all rows.map (row, i) =>
+            try
+              forEachRow row
+            catch error
+              @handleImportError error, file, i
+        .catch (error) =>
+          throw error
+          @handleImportError error, file
+        .then =>
+          @props.workflow.update('tasks').save()
+
+  readFile: (file) ->
+    new Promise (resolve) ->
+      reader = new FileReader
+      reader.onload = (e) =>
+        resolve e.target.result
+      reader.onerror = (error) =>
+        @handleImportError error, file
+      reader.readAsText file
+
+  parseFileContent: (content) ->
+    {errors, data} = Papa?.parse content.trim(), header: true
+
+    cleanRows = for row in data
+      clean = {}
+      for key, value of row
+        cleanKey = key.trim()
+        cleanValue = value.trim?()
+
+        if key.indexOf('=') is -1
+          cleanKey = cleanKey.toLowerCase().replace /\s+/g, '_'
+        else
+          cleanValue = @determineBoolean cleanValue
+
+        clean[cleanKey] = cleanValue
+      clean
+
+    for error in errors
+      @handleImportError error
+
+    cleanRows
+
+  determineBoolean: (value) ->
+    # TODO: Iterate on this as we see more cases.
+    value?.charAt(0).toUpperCase() in ['T', 'X', 'Y', '1']
+
+  makeID: (string) ->
+    string.replace(/[aeiouy\W]/gi, '').toUpperCase()
+
+  ensureChoice: (name) ->
+    choiceID = @makeID name
+    unless choiceID in @props.task.choicesOrder
+      @props.task.choicesOrder.push choiceID
+    @props.task.choices[choiceID] ?=
+      label: name
+      description: ''
+      noQuestions: false
+      image: []
+      characteristics: {}
+      confusionsOrder: []
+      confusions: {}
+    @props.task.choices[choiceID]
+
+  addChoice: ({name, description, no_questions, images, __parsedExtra}) ->
+    unless name?
+      throw new Error 'Choices require a "name" column.'
+    choice = @ensureChoice name
+    choice.label = name
+    if description?
+      choice.description = description
+    if no_questions?
+      choice.noQuestions = @determineBoolean no_questions
+    if images?
+      images = images.split(/\s*,\s*/).concat(__parsedExtra ? []).filter Boolean
+      choice.images = images
+
+  addCharacteristics: (row) ->
+    unless row.name?
+      throw new Error 'Characteristics require a "name" column.'
+    @ensureChoice row.name
+    for charKeyVal, isSet of row when charKeyVal isnt 'name'
+      [characteristicLabel, valueLabelAndIcon] = charKeyVal.replace('=', '__SPLIT_ONCE__').split /\s*__SPLIT_ONCE__\s*/
+      [valueLabel, valueIcon] = valueLabelAndIcon.split /\s*,\s*/
+      if characteristicLabel is '' or valueLabel is ''
+        throw new Error 'Characteristics column headers should be formatted like "Color=Blue","Color=Red".'
+      characteristicID = @makeID characteristicLabel
+      valueID = @makeID valueLabel
+      unless characteristicID in @props.task.characteristicsOrder
+        @props.task.characteristicsOrder.push characteristicID
+        @props.task.characteristics[characteristicID] =
+          label: ''
+          valuesOrder: []
+          values: {}
+      @props.task.characteristics[characteristicID].label = characteristicLabel
+      unless valueID in @props.task.characteristics[characteristicID].valuesOrder
+        @props.task.characteristics[characteristicID].valuesOrder.push valueID
+        @props.task.characteristics[characteristicID].values[valueID] =
+          label: valueLabel
+      @props.task.characteristics[characteristicID].values[valueID].image = valueIcon
+      for choiceID, choice of @props.task.choices
+        choice.characteristics[characteristicID] ?= []
+      if isSet
+        choiceID = @makeID row.name
+        @props.task.choices[choiceID]?.characteristics[characteristicID].push valueID
+
+  addConfusion: ({name, twin, details}) ->
+    unless name?
+      throw new Error 'Confused pairs require a "name" column.'
+    unless twin?
+      throw new Error 'Confused pairs require a "twin" column.'
+    @ensureChoice name
+    choiceID = @makeID name
+    confusionID = @makeID twin
+    @props.task.choices[choiceID]?.confusionsOrder.push confusionID
+    @props.task.choices[choiceID]?.confusions[confusionID] = details
+
+  addQuestion: ({question, multiple, required, answers, __parsedExtra}) ->
+    unless question?
+      throw new Error 'Questions require a "question" column'
+    unless answers?
+      throw new Error 'Questions require a "answers" column'
+    questionID = @makeID question
+    unless questionID in @props.task.questionsOrder
+      @props.task.questionsOrder.push questionID
+    @props.task.questions[questionID] =
+      label: question
+      multiple: @determineBoolean multiple
+      required: @determineBoolean required
+      answersOrder: []
+      answers: {}
+    for answer in answers.split(/\s*,\s*/).concat(__parsedExtra ? []).filter Boolean
+      answerID = @makeID answer
+      @props.task.questions[questionID].answersOrder.push answerID
+      @props.task.questions[questionID].answers[answerID] =
+        label: answer
+
+  handleImageAdd: (media) ->
+    @props.task.images[media.metadata.filename] = media.src
+    @props.workflow.update('tasks').save()
+
+  handleImageDelete: (media) ->
+    delete @props.task.images[media.metadata.filename]
+    @props.workflow.update('tasks').save()
+
+  resetTask: (e) ->
+    if e.shiftKey or confirm 'Really delete all the data from this task?'
+      Object.assign @props.task,
+        characteristicsOrder: []
+        characteristics: {}
+        choicesOrder: []
+        choices: {}
+        questionsOrder: []
+        questions: {}
+      @props.workflow.update 'tasks'
+
+  resetMedia: (e) ->
+    if e.shiftKey or confirm 'Really delete all the images from this task? This might take a while...'
+      @setState resettingMedia: true
+      errors = 0
+      massDelete = @props.workflow.get('attached_images', page_size: 200).then (workflowImages) =>
+        taskImages = workflowImages.filter (image) =>
+          image.metadata.prefix is @props.taskPrefix
+        Promise.all taskImages.map (image) =>
+          image.delete().catch =>
+            errors += 1
+      massDelete.then =>
+        @setState resettingMedia: false
+        if errors isnt 0
+          alert "There were #{errors} errors deleting all those resources. Try again to get the rest."
+
+  handleImportError: (error, file, row) ->
+    @state.importErrors.push {error, file, row}
+    @setState importErrors: @state.importErrors

--- a/app/classifier/tasks/flexible-survey/editor.cjsx
+++ b/app/classifier/tasks/flexible-survey/editor.cjsx
@@ -315,11 +315,11 @@ module.exports = React.createClass
       throw new Error 'Questions require a "answers" column'
 
     choices = null
-    questionId = null
-    if(name?)
+    questionID = null
+    if(!!name)
       choices = name.split(/\s*;s*/)
-    if(question?)
-      questionId = @makeID question
+    if(!!question)
+      questionID = @makeID question
 
     # don't put it in the default questionsOrder if we've specified choices it should map to
     unless choices? or questionID in @props.task.questionsOrder
@@ -327,11 +327,12 @@ module.exports = React.createClass
 
     # if we specified mapped choices, create those entries instead
     if choices?
-      task.questionsMap ?= {}
+      @props.task.questionsMap ?= {}
       for choice in choices
+        continue unless !!choice
         choiceID = @makeID choice
-        task.questionsMap[choiceID] ?= []
-        task.questionsMap[choiceID].push[questionID]
+        @props.task.questionsMap[choiceID] ?= []
+        @props.task.questionsMap[choiceID].push questionID if questionID?
 
     # we only can get here if the question stuff is empty and the names are not empty
     # that means there will be no questions for this choice, so we don't need to actually

--- a/app/classifier/tasks/flexible-survey/editor.cjsx
+++ b/app/classifier/tasks/flexible-survey/editor.cjsx
@@ -341,7 +341,7 @@ module.exports = React.createClass
       answersOrder: []
       answers: {}
 
-    for answer in answers.split(/\s*,\s*/).concat(__parsedExtra ? []).filter Boolean
+    for answer in answers.split(/;/).concat(__parsedExtra ? []).filter Boolean
       answerID = @makeID answer
       @props.task.questions[questionID].answersOrder.push answerID
       @props.task.questions[questionID].answers[answerID] =

--- a/app/classifier/tasks/flexible-survey/editor.cjsx
+++ b/app/classifier/tasks/flexible-survey/editor.cjsx
@@ -13,6 +13,7 @@ PromiseRenderer = require '../../../components/promise-renderer'
 Papa = require 'papaparse'
 apiClient = require '../../../api/client'
 putFile = require '../../../lib/put-file'
+Utility = require 'utility'
 
 module.exports = React.createClass
   displayName: 'SurveyTaskEditor'

--- a/app/classifier/tasks/flexible-survey/editor.cjsx
+++ b/app/classifier/tasks/flexible-survey/editor.cjsx
@@ -13,7 +13,7 @@ PromiseRenderer = require '../../../components/promise-renderer'
 Papa = require 'papaparse'
 apiClient = require '../../../api/client'
 putFile = require '../../../lib/put-file'
-Utility = require 'utility'
+Utility = require './utility'
 
 module.exports = React.createClass
   displayName: 'FlexibleSurveyTaskEditor'
@@ -314,8 +314,12 @@ module.exports = React.createClass
     unless answers?
       throw new Error 'Questions require a "answers" column'
 
-    choices = if name? name.split ';' else null
-    questionID = if question? @makeID question else null
+    choices = null
+    questionId = null
+    if(name?)
+      choices = name.split(/\s*;s*/)
+    if(question?)
+      questionId = @makeID question
 
     # don't put it in the default questionsOrder if we've specified choices it should map to
     unless choices? or questionID in @props.task.questionsOrder

--- a/app/classifier/tasks/flexible-survey/index.cjsx
+++ b/app/classifier/tasks/flexible-survey/index.cjsx
@@ -1,0 +1,103 @@
+React = require 'react'
+Editor = require './editor'
+Summary = require './summary'
+Chooser = require './chooser'
+Choice = require './choice'
+AnnotationView = require './annotation-view'
+
+module.exports = React.createClass
+  displayName: 'SurveyTask'
+
+  statics:
+    Editor: Editor
+    Summary: Summary
+    AfterSubject: AnnotationView
+
+    getDefaultTask: ->
+      type: 'survey'
+      characteristicsOrder: []
+      characteristics: {}
+      choicesOrder: []
+      choices: {}
+      questionsOrder: []
+      questions: {}
+      images: {}
+
+    getTaskText: (task) ->
+      "Survey of #{task.choicesOrder.length} choices"
+
+    getDefaultAnnotation: ->
+      value: []
+
+    isAnnotationComplete: (task, annotation) ->
+      # Booleans compare to numbers as expected: true = 1, false = 0.
+      annotation.value.length >= (task.required ? 0) and not annotation._choiceInProgress
+
+    testAnnotationQuality: (unknown, knownGood) ->
+      # NOTE: Currently only choices (not answers) are compared.
+      unknownChoices = unknown.value.map ({choice}) ->
+        choice
+      knownGoodChoices = knownGood.value.map ({choice}) ->
+        choice
+      total = 0
+      matches = 0
+      unknownChoices.forEach (choice) ->
+        total += 1
+        if choice in knownGoodChoices
+          matches += 1
+      knownGoodChoices.forEach (choice) ->
+        total += 1
+        if choice in unknownChoices
+          matches += 1
+      if total is 0
+        1
+      else
+        matches / total
+
+  getDefaultProps: ->
+    task: null
+    annotation: null
+    onChange: Function.prototype
+
+  getInitialState: ->
+    filters: {}
+    selectedChoiceID: ''
+
+  render: ->
+    <div className="survey-task">
+      {if @state.selectedChoiceID is ''
+        <Chooser task={@props.task} filters={@state.filters} onFilter={@handleFilter} onChoose={@handleChoice} />
+      else
+        <Choice task={@props.task} choiceID={@state.selectedChoiceID} onSwitch={@handleChoice} onCancel={@clearSelection} onConfirm={@handleAnnotation} />}
+    </div>
+
+  handleFilter: (characteristicID, valueID) ->
+    setTimeout =>
+      if valueID?
+        @state.filters[characteristicID] = valueID
+      else
+        delete @state.filters[characteristicID]
+      @setState filters: @state.filters
+
+  handleChoice: (choiceID) ->
+    @props.annotation._choiceInProgress = true
+    @setState selectedChoiceID: choiceID
+    @props.onChange()
+
+  clearFilters: ->
+    @setState filters: {}
+
+  clearSelection: ->
+    @props.annotation._choiceInProgress = false
+    @setState selectedChoiceID: ''
+    @props.onChange()
+
+  handleAnnotation: (choice, answers, e) ->
+    filters = JSON.parse JSON.stringify @state.filters
+
+    @props.annotation.value ?= []
+    @props.annotation.value.push {choice, answers, filters}
+    @props.onChange e
+
+    @clearFilters()
+    @clearSelection()

--- a/app/classifier/tasks/flexible-survey/index.cjsx
+++ b/app/classifier/tasks/flexible-survey/index.cjsx
@@ -14,7 +14,7 @@ module.exports = React.createClass
     AfterSubject: AnnotationView
 
     getDefaultTask: ->
-      type: 'survey'
+      type: 'flexibleSurvey'
       characteristicsOrder: []
       characteristics: {}
       choicesOrder: []

--- a/app/classifier/tasks/flexible-survey/index.cjsx
+++ b/app/classifier/tasks/flexible-survey/index.cjsx
@@ -6,7 +6,7 @@ Choice = require './choice'
 AnnotationView = require './annotation-view'
 
 module.exports = React.createClass
-  displayName: 'SurveyTask'
+  displayName: 'FlexibleSurveyTask'
 
   statics:
     Editor: Editor
@@ -24,7 +24,7 @@ module.exports = React.createClass
       images: {}
 
     getTaskText: (task) ->
-      "Survey of #{task.choicesOrder.length} choices"
+      "Flexible survey of #{task.choicesOrder.length} choices"
 
     getDefaultAnnotation: ->
       value: []

--- a/app/classifier/tasks/flexible-survey/summary.cjsx
+++ b/app/classifier/tasks/flexible-survey/summary.cjsx
@@ -1,7 +1,8 @@
 React = require 'react'
+Utility = require 'utility'
 
 module.exports = React.createClass
-  displayName: 'SurveySummary'
+  displayName: 'FlexibleSurveySummary'
 
   getDefaultProps: ->
     task: null
@@ -27,7 +28,7 @@ module.exports = React.createClass
         {if @state.expanded
           choiceSummaries = for identification in @props.annotation.value
             choice = @props.task.choices[identification.choice]
-            allAnswers = for questionID in @props.task.questionsOrder when questionID of identification.answers
+            allAnswers = for questionID in Utility.getQuestionIDs(@props.task, identification.choice) when questionID of identification.answers
               answerLabels = for answerID in [].concat identification.answers[questionID]
                 @props.task.questions[questionID].answers[answerID].label
               answerLabels.join ', '

--- a/app/classifier/tasks/flexible-survey/summary.cjsx
+++ b/app/classifier/tasks/flexible-survey/summary.cjsx
@@ -1,5 +1,5 @@
 React = require 'react'
-Utility = require 'utility'
+Utility = require './utility'
 
 module.exports = React.createClass
   displayName: 'FlexibleSurveySummary'

--- a/app/classifier/tasks/flexible-survey/summary.cjsx
+++ b/app/classifier/tasks/flexible-survey/summary.cjsx
@@ -1,0 +1,42 @@
+React = require 'react'
+
+module.exports = React.createClass
+  displayName: 'SurveySummary'
+
+  getDefaultProps: ->
+    task: null
+    annotation: null
+    expanded: false
+
+  getInitialState: ->
+    expanded: @props.expanded
+
+  render: ->
+    <div className="classification-task-summary">
+      <div className="question">
+        Survey of {@props.task.choicesOrder.length}
+        {if @state.expanded
+          <button type="button" className="toggle-more" onClick={@setState.bind this, expanded: false, null}>Less</button>
+        else
+          <button type="button" className="toggle-more" onClick={@setState.bind this, expanded: true, null}>More</button>}
+      </div>
+      <div className="answers">
+        <div className="answer">
+          {@props.annotation.value.length} identifications
+        </div>
+        {if @state.expanded
+          choiceSummaries = for identification in @props.annotation.value
+            choice = @props.task.choices[identification.choice]
+            allAnswers = for questionID in @props.task.questionsOrder when questionID of identification.answers
+              answerLabels = for answerID in [].concat identification.answers[questionID]
+                @props.task.questions[questionID].answers[answerID].label
+              answerLabels.join ', '
+
+            "#{choice.label}: #{allAnswers.join '; '}"
+
+          for choiceSummary, i in choiceSummaries
+            <div key={i} className="answer">
+              {choiceSummary}
+            </div>}
+      </div>
+    </div>

--- a/app/classifier/tasks/flexible-survey/utility.coffee
+++ b/app/classifier/tasks/flexible-survey/utility.coffee
@@ -1,0 +1,10 @@
+utility:
+  getQuestionIDs: (task, choiceID) ->
+    return [] if task.choices[choiceID].noQuestions?
+    return task.questionsOrder unless task.questionsMap? and choiceID in task.questionsMap
+    task.questionsMap[choiceID]
+  getQuestions: (task, choiceID) ->
+    @getQuestionIDs(task, choiceID).map (idx ->
+      task.questions[idx])
+
+module.exports = utility

--- a/app/classifier/tasks/flexible-survey/utility.coffee
+++ b/app/classifier/tasks/flexible-survey/utility.coffee
@@ -1,7 +1,7 @@
-module.exports = 
+module.exports =
   getQuestionIDs: (task, choiceID) ->
-    return [] if task.choices[choiceID].noQuestions?
-    return task.questionsOrder unless task.questionsMap? and choiceID in task.questionsMap
+    return [] if task.choices[choiceID].noQuestions
+    return task.questionsOrder unless task.questionsMap? and choiceID of task.questionsMap
     task.questionsMap[choiceID]
   getQuestions: (task, choiceID) ->
     @getQuestionIDs(task, choiceID).map (idx ->

--- a/app/classifier/tasks/flexible-survey/utility.coffee
+++ b/app/classifier/tasks/flexible-survey/utility.coffee
@@ -1,4 +1,4 @@
-utility:
+module.exports = 
   getQuestionIDs: (task, choiceID) ->
     return [] if task.choices[choiceID].noQuestions?
     return task.questionsOrder unless task.questionsMap? and choiceID in task.questionsMap
@@ -6,5 +6,3 @@ utility:
   getQuestions: (task, choiceID) ->
     @getQuestionIDs(task, choiceID).map (idx ->
       task.questions[idx])
-
-module.exports = utility

--- a/app/classifier/tasks/flexible-survey/utility.coffee
+++ b/app/classifier/tasks/flexible-survey/utility.coffee
@@ -4,5 +4,5 @@ module.exports =
     return task.questionsOrder unless task.questionsMap? and choiceID of task.questionsMap
     task.questionsMap[choiceID]
   getQuestions: (task, choiceID) ->
-    @getQuestionIDs(task, choiceID).map (idx ->
+    @getQuestionIDs(task, choiceID).map ((idx) ->
       task.questions[idx])

--- a/app/classifier/tasks/flexible-survey/utility.coffee
+++ b/app/classifier/tasks/flexible-survey/utility.coffee
@@ -4,5 +4,5 @@ module.exports =
     return task.questionsOrder unless task.questionsMap? and choiceID of task.questionsMap
     task.questionsMap[choiceID]
   getQuestions: (task, choiceID) ->
-    @getQuestionIDs(task, choiceID).map ((idx) ->
-      task.questions[idx])
+    @getQuestionIDs(task, choiceID).map (idx) ->
+      task.questions[idx]

--- a/app/classifier/tasks/index.coffee
+++ b/app/classifier/tasks/index.coffee
@@ -3,6 +3,7 @@ module.exports =
   multiple: require './multiple'
   drawing: require './drawing'
   survey: require './survey'
+  flexibleSurvey: require './flexible-survey'
   crop: require './crop'
   text: require './text'
 

--- a/app/components/workflow-tasks-editor.cjsx
+++ b/app/components/workflow-tasks-editor.cjsx
@@ -234,6 +234,7 @@ module.exports = React.createClass
         <button type="button" className="adder" onClick={@addNewTask.bind this, 'single'}>Question</button>
         <button type="button" className="adder" onClick={@addNewTask.bind this, 'drawing'}>Marking</button>
         <button type="button" className="adder" onClick={@addNewTask.bind this, 'survey'} disabled>Image survey</button>
+        <button type="button" className="adder" onClick={@addNewTask.bind this, 'flexibleSurvey'} disabled>Flexible Image Survey</button>
       </div>
     </div>
 

--- a/app/pages/admin/project-status.cjsx
+++ b/app/pages/admin/project-status.cjsx
@@ -11,6 +11,7 @@ handleInputChange = require '../../lib/handle-input-change'
 
 EXPERIMENTAL_FEATURES = [
   'survey'
+  'flexible-survey'
   'crop'
   'tutorial'
   'text',

--- a/app/pages/lab/workflow.cjsx
+++ b/app/pages/lab/workflow.cjsx
@@ -95,6 +95,7 @@ EditWorkflowPage = React.createClass
                         when 'multiple' then <i className="fa fa-check-square-o fa-fw"></i>
                         when 'drawing' then <i className="fa fa-pencil fa-fw"></i>
                         when 'survey' then <i className="fa fa-binoculars fa-fw"></i>
+                        when 'flexibleSurvey' then <i className="fa fa-binoculars fa-fw"></i>
                         when 'crop' then <i className="fa fa-crop fa-fw"></i>
                         when 'text' then <i className="fa fa-file-text-o fa-fw"></i>}
                       {' '}
@@ -137,6 +138,14 @@ EditWorkflowPage = React.createClass
                   {if @canUseTask(@props.project, "survey")
                     <AutoSave resource={@props.workflow}>
                       <button type="submit" className="minor-button" onClick={@addNewTask.bind this, 'survey'} title="Survey tasks: the volunteer identifies objects (usually animals) in the image(s) by filtering by their visible charactaristics, then answers questions about them.">
+                        <i className="fa fa-binoculars fa-2x"></i>
+                        <br />
+                        <small><strong>Survey</strong></small>
+                      </button>
+                    </AutoSave>}{' '}
+                  {if @canUseTask(@props.project, "flexible-survey")
+                    <AutoSave resource={@props.workflow}>
+                      <button type="submit" className="minor-button" onClick={@addNewTask.bind this, 'flexibleSurvey'} title="Flexible Survey tasks: the volunteer identifies objects (usually animals) in the image(s) by filtering by their visible charactaristics, then answers questions about them. The questions may vary based on the object they identify.">
                         <i className="fa fa-binoculars fa-2x"></i>
                         <br />
                         <small><strong>Survey</strong></small>

--- a/app/pages/lab/workflow.cjsx
+++ b/app/pages/lab/workflow.cjsx
@@ -148,7 +148,7 @@ EditWorkflowPage = React.createClass
                       <button type="submit" className="minor-button" onClick={@addNewTask.bind this, 'flexibleSurvey'} title="Flexible Survey tasks: the volunteer identifies objects (usually animals) in the image(s) by filtering by their visible charactaristics, then answers questions about them. The questions may vary based on the object they identify.">
                         <i className="fa fa-binoculars fa-2x"></i>
                         <br />
-                        <small><strong>Survey</strong></small>
+                        <small><strong>Flex Survey</strong></small>
                       </button>
                     </AutoSave>}{' '}
                   {if @canUseTask(@props.project, "crop")


### PR DESCRIPTION
This adds a new survey-related task to the system, "flexibleSurvey." FlexibleSurvey works like a regular survey, but adds the ability to specify which questions belong to which choices by the way that an additional field is filled out in the questions csv file.

It's of course silly to have two survey tasks, but it was considered too risky to modify the existing task directly because we have deployments who are consuming it.

I'm looking to merge this onto master tomorrow so that we can deploy it for WiscWildWatch

[sample spreadsheet](https://github.com/zooniverse/Panoptes-Front-End/files/69062/surveyTask-spreadsheets-inclHumanNnothing-multiQuestions-v2.xlsx)
