### PR TITLE
fix subject uploader regex for admins

### DIFF
--- a/app/pages/lab/subject-set.cjsx
+++ b/app/pages/lab/subject-set.cjsx
@@ -274,7 +274,7 @@ EditSubjectSetPage = React.createClass
   _findFilesInMetadata: (metadata) ->
     filesInMetadata = []
     for key, value of metadata
-      extensions = if isAdmin() then '\\.\\D\\w{2,3}' else "(?:#{VALID_SUBJECT_EXTENSIONS.join '|'})"
+      extensions = if isAdmin() then '\\.\\D\\w{2,4}' else "(?:#{VALID_SUBJECT_EXTENSIONS.join '|'})"
       filesInValue = value.match? ///([^#{INVALID_FILENAME_CHARS.join ''}]+#{extensions})///gi
       if filesInValue?
         filesInMetadata.push filesInValue...

--- a/app/pages/lab/subject-set.cjsx
+++ b/app/pages/lab/subject-set.cjsx
@@ -274,7 +274,7 @@ EditSubjectSetPage = React.createClass
   _findFilesInMetadata: (metadata) ->
     filesInMetadata = []
     for key, value of metadata
-      extensions = if isAdmin() then '\\.\\w{2,4}' else "(?:#{VALID_SUBJECT_EXTENSIONS.join '|'})"
+      extensions = if isAdmin() then '\\.\\D\\w{2,3}' else "(?:#{VALID_SUBJECT_EXTENSIONS.join '|'})"
       filesInValue = value.match? ///([^#{INVALID_FILENAME_CHARS.join ''}]+#{extensions})///gi
       if filesInValue?
         filesInMetadata.push filesInValue...


### PR DESCRIPTION
Fixing a bug I ran into while trying to use the subject uploader UI as an admin. Previously, if an admin tried to upload a set of subjects with metadata that included numerical values with decimal places, the regex checking for file extensions would match this metadata as a file and error that there are missing files to upload. The updated regex checks to make sure the first character in the extension is not a digit.