### PR TITLE
Ensure workflow on mount

### DIFF
--- a/app/pages/project/classify.cjsx
+++ b/app/pages/project/classify.cjsx
@@ -76,6 +76,13 @@ module.exports = React.createClass
     project: 'loadAppropriateClassification'
     query: 'loadAppropriateClassification'
 
+  componentDidMount: () ->
+    @getCurrentWorkflowID().then (id) =>
+      @getWorkflow @props.project, id
+        .then (workflow) =>
+          @setState
+            workflow: workflow
+
   loadAppropriateClassification: (_, props = @props) ->
     # To load the right classification, we'll need to know which workflow the user expects.
     # console.log 'Loading appropriate classification'
@@ -236,7 +243,7 @@ module.exports = React.createClass
 
   saveClassificationAndLoadAnotherSubject: ->
     @saveClassification()
-    @loadAnotherSubject()
+      .then @loadAnotherSubject()
 
   saveClassification: ->
     console?.info 'Completed classification', @state.classification
@@ -266,6 +273,8 @@ module.exports = React.createClass
 
       classificationsThisSession += 1
       @maybePromptToSignIn()
+
+    return savingClassification
 
   queueClassification: (classification) ->
     queue = JSON.parse localStorage.getItem FAILED_CLASSIFICATION_QUEUE_NAME


### PR DESCRIPTION
Fixes #2048. @vrooje @eatyourgreens this addresses the issue in a non-hacky way, and retains the same subject (and any unfinished classification) when returning to "classify" from any other project route (research, talk, etc).

As [mentioned](https://github.com/zooniverse/Panoptes-Front-End/issues/2048#issuecomment-166705181) the fix is pretty simple: `@state.workflow` is restored in `componentDidMount` (which is called when hopping back to the classify page). Maybe this is helpful in general too.

Also addressed is @eatyourgreens concern that the Done & Talk calls `@loadAnotherSubject` without waiting for `@saveClassification`. Would have separated these but my laptop was dying and just needed to push the changes up before it went completely (writing this on other half's Windows laptop)!