### PR TITLE
Bump history verison to allow installation

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "ejs": "~2.3.3",
     "express": "~4.13.3",
     "fast-levenshtein": "~1.0.7",
-    "history": "~1.13.1",
+    "history": "~1.17.0",
     "json-api-client": "~0.4.0",
     "lodash.intersection": "~3.2.0",
     "lodash.merge": "~2.4.1",


### PR DESCRIPTION
Something was complaining enough to prevent installation, react-router I think.

I believe this is because we prefix our dep versions with `~` instead of `^`, but I'm still not convinced that's wrong. I don't know, I could go either way at this point.