### PR TITLE
Session storage fallback

### DIFF
--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -322,7 +322,7 @@ Classifier = React.createClass
   completeClassification: ->
     @props.classification.update
       completed: true
-      'metadata.session': getSessionID().id
+      'metadata.session': getSessionID()
       'metadata.finished_at': (new Date).toISOString()
       'metadata.viewport':
         width: innerWidth

--- a/app/lib/session.coffee
+++ b/app/lib/session.coffee
@@ -1,4 +1,4 @@
-stored = sessionStorage.getItem('session_id')
+stored = sessionStorage?.getItem('session_id')
 
 generateSessionID = () ->
   sha2 = require('crypto').createHash('sha256')

--- a/app/lib/session.coffee
+++ b/app/lib/session.coffee
@@ -1,18 +1,22 @@
+stored = sessionStorage.getItem('session_id')
+
 generateSessionID = () ->
   sha2 = require('crypto').createHash('sha256')
   id = sha2.update("#{Math.random() * 10000 }#{Date.now()}#{Math.random() * 1000}").digest('hex')
   ttl = tenMinutesFromNow()
   stored = {id, ttl}
-  sessionStorage.setItem('session_id', JSON.stringify(stored))
+  try
+    sessionStorage.setItem('session_id', JSON.stringify(stored))
   stored
 
 getSessionID = () ->
-  {id, ttl} = JSON.parse(sessionStorage?.getItem('session_id'))
+  {id, ttl} = JSON.parse(sessionStorage.getItem('session_id')) ? stored
   if ttl < Date.now()
     {id} = generateSessionID()
   else
     ttl = tenMinutesFromNow()
-    sessionStorage.setItem('session_id', JSON.stringify({id, ttl}))
+    try
+      sessionStorage.setItem('session_id', JSON.stringify({id, ttl}))
   id
 
 tenMinutesFromNow = () ->

--- a/app/lib/session.coffee
+++ b/app/lib/session.coffee
@@ -3,7 +3,7 @@ stored = sessionStorage.getItem('session_id')
 generateSessionID = () ->
   sha2 = require('crypto').createHash('sha256')
   id = sha2.update("#{Math.random() * 10000 }#{Date.now()}#{Math.random() * 1000}").digest('hex')
-  ttl = tenMinutesFromNow()
+  ttl = fiveMinutesFromNow()
   stored = {id, ttl}
   try
     sessionStorage.setItem('session_id', JSON.stringify(stored))
@@ -14,12 +14,12 @@ getSessionID = () ->
   if ttl < Date.now()
     {id} = generateSessionID()
   else
-    ttl = tenMinutesFromNow()
+    ttl = fiveMinutesFromNow()
     try
       sessionStorage.setItem('session_id', JSON.stringify({id, ttl}))
   id
 
-tenMinutesFromNow = () ->
+fiveMinutesFromNow = () ->
   d = new Date()
   d.setMinutes(d.getMinutes() + 5)
   d


### PR DESCRIPTION
Closes #2058, and fixes session ID lookup (looks like classifications' metadata.session was never actually set to anything).

It'd also be super cool to remove the 90KB `crypto` module too, so let me know if `Math.random()` is good enough.