### PR TITLE
Add selection task

### DIFF
--- a/app/classifier/mock-data.coffee
+++ b/app/classifier/mock-data.coffee
@@ -39,6 +39,7 @@ workflow = apiClient.type('workflows').create
         {label: 'Multi-answer question', next: 'features'}
         {label: 'Draw stuff', next: 'draw'}
         {label: 'Survey the image', next: 'survey'}
+        {label: 'Selection', next: 'selection'}
         {label: 'We’re done here.', next: null}
       ]
 
@@ -56,6 +57,46 @@ workflow = apiClient.type('workflows').create
         **Example**: If you see a bee, then type "Bee"
       '''
       next: 'features'
+
+    selection:
+      type: 'selection'
+      required: true
+      instruction: 'Choose a date from the dropdowns'
+      help: 'Click on the menus to view the available options'
+      answersOrder: [
+        'roman', 'month', 'year'
+      ]
+      answers:
+        roman:
+          title: "Roman Numeral"
+          values: [
+            {value: '1', label: 'I'}
+            {value: '2', label: 'II'}
+            {value: '3', label: 'III'}
+          ]
+        month:
+          title: "Month"
+          values: [
+            {value: 'jan', label: 'Janurary'}
+            {value: 'feb', label: 'Feburary'}
+            {value: 'mar', label: 'March'}
+            {value: 'apr', label: 'April'}
+            {value: 'may', label: 'May'}
+            {value: 'jun', label: 'June'}
+            {value: 'jul', label: 'July'}
+            {value: 'aug', label: 'August'}
+            {value: 'sep', label: 'September'}
+            {value: 'oct', label: 'October'}
+            {value: 'nov', label: 'November'}
+            {value: 'dec', label: 'December'}
+          ]
+        year:
+          title: "Year"
+          values: [
+            {value: '1949', label: '1949'}
+            {value: '1950', label: '1950'}
+            {value: '1951', label: '1951'}
+          ]
 
     features:
       type: 'multiple'
@@ -315,3 +356,4 @@ classification = apiClient.type('classifications').create
 
 module.exports = {workflow, subject, classification}
 window?.mockClassifierData = module.exports
+

--- a/app/classifier/mock-data.coffee
+++ b/app/classifier/mock-data.coffee
@@ -70,32 +70,32 @@ workflow = apiClient.type('workflows').create
         roman:
           title: "Roman Numeral"
           values: [
-            {value: '1', label: 'I'}
-            {value: '2', label: 'II'}
-            {value: '3', label: 'III'}
+            'I'
+            'II'
+            'III'
           ]
         month:
           title: "Month"
           values: [
-            {value: 'jan', label: 'Janurary'}
-            {value: 'feb', label: 'Feburary'}
-            {value: 'mar', label: 'March'}
-            {value: 'apr', label: 'April'}
-            {value: 'may', label: 'May'}
-            {value: 'jun', label: 'June'}
-            {value: 'jul', label: 'July'}
-            {value: 'aug', label: 'August'}
-            {value: 'sep', label: 'September'}
-            {value: 'oct', label: 'October'}
-            {value: 'nov', label: 'November'}
-            {value: 'dec', label: 'December'}
+            'Janurary'
+            'Feburary'
+            'March'
+            'April'
+            'May'
+            'June'
+            'July'
+            'August'
+            'September'
+            'October'
+            'November'
+            'December'
           ]
         year:
           title: "Year"
           values: [
-            {value: '1949', label: '1949'}
-            {value: '1950', label: '1950'}
-            {value: '1951', label: '1951'}
+            '1949'
+            '1950'
+            '1951'
           ]
 
     features:

--- a/app/classifier/tasks/index.coffee
+++ b/app/classifier/tasks/index.coffee
@@ -6,5 +6,6 @@ module.exports =
   flexibleSurvey: require './flexible-survey'
   crop: require './crop'
   text: require './text'
+  selection: require './selection'
 
 window?._tasks = module.exports

--- a/app/classifier/tasks/selection/editor.cjsx
+++ b/app/classifier/tasks/selection/editor.cjsx
@@ -1,0 +1,178 @@
+React = require 'react'
+DragReorderable = require 'drag-reorderable'
+TriggeredModalForm = require 'modal-form/triggered'
+
+module?.exports = React.createClass
+  displayName: 'SelectionEditor'
+
+  getDefaultProps: ->
+    workflow: {}
+    task: {}
+
+  getInitialState: ->
+    selectBox: ''
+
+  componentWillMount: ->
+    @setDefaultAnswersOrder() if not @props.task.answersOrder.length
+
+  setDefaultAnswersOrder: ->
+    @props.task.answersOrder = Object.keys(@props.task.answers)
+    @updateTasks()
+
+  updateTasks: ->
+    @props.workflow.update('tasks')
+
+  selectedValues: ->
+    @props.task.answers[@state.selectBox]?.values
+
+  addAnswer: (answerKey, answer) ->
+    if not answer.title?
+      throw new Error('Answers must have a title key')
+
+    @props.task.answers[answerKey] = answer
+    @props.task.answersOrder = @props.task.answersOrder.concat(answerKey)
+    @updateTasks()
+
+  addAnswerValue: (answerKey, answer) ->
+    if not answer.title? and not answer.label?
+      throw new Error('Answer values must have title and label keys')
+
+    if @selectedValues().map((answer) -> answer.value).indexOf(answer.value) isnt -1
+      return window.alert('Answer values must be unique to each option')
+
+    @props.task.answers[answerKey].values?.push(answer)
+    @updateTasks()
+
+  onClickAddAnswer: (e) ->
+    @addAnswer(@refs.answerKey.value, {
+      title: @refs.answerTitle.value,
+      values: []
+    })
+    @updateTasks()
+
+    @refs.answerKey.value = ''
+    @refs.answerTitle.value = ''
+
+  onClickAddAnswerValue: (e) ->
+    newAnswerValue = {value: @refs.answerValueKey.value, label: @refs.answerValueLabel.value}
+    @addAnswerValue(@refs.selectBox.value, newAnswerValue)
+
+    @refs.answerValueKey.value = ''
+    @refs.answerValueLabel.value = ''
+
+  onClickSaveWorkflow: (e) ->
+    if window.confirm('Are you sure that you would like to save these changes?')
+      @props.workflow.save()
+
+  onChangeSelectBox: (e) ->
+    @setState({selectBox: e.target.value})
+
+  onClickDeleteSelectBox: (e) ->
+    if window.confirm('Are you sure that you would like to delete this select box?')
+      delete @props.task.answers[@refs.selectBox.value]
+      @updateTasks()
+      @props.workflow.save()
+
+  onChangeAnswersOrder: (answersOrder) ->
+    @props.task.answersOrder = answersOrder
+    @updateTasks()
+
+  onClickDeleteSelectOption: (selectItem) ->
+    {answers} = @props.task
+
+    if window.confirm('Are you sure that you would like to delete this option?')
+      answers[@state.selectBox]?.values = @selectedValues().filter (value) -> value isnt selectItem
+      @updateTasks()
+
+  render: ->
+    {answers, answersOrder} = @props.task
+    answerKeys = Object.keys(answers)
+
+    <div className="selection-editor">
+      <div className="selection">
+
+        <section>
+          <h2 className="form-label">Select Box Order</h2>
+
+          <DragReorderable
+            tag='ol'
+            items={answersOrder}
+            onChange={@onChangeAnswersOrder}
+            render={(name) ->
+              <li><i className="fa fa-reorder" title="Drag to reorder" /> {name}</li>
+            }
+          />
+        </section>
+
+        <hr />
+
+        <section>
+          <h2 className="form-label">Add a select box</h2>
+          <label>
+            Answer Key <input ref="answerKey"></input>
+          </label>
+
+          <label>
+            Title <input ref="answerTitle"></input>
+          </label>
+
+          <TriggeredModalForm trigger={<i className="fa fa-question-circle"></i>}>
+            <p><strong>Answer Keys</strong> are used as a unique identifier to store data within the classification</p>
+            <p><strong>Titles</strong> are what will be displayed as the default option within the select box</p>
+          </TriggeredModalForm>
+
+          <button type="button" onClick={@onClickAddAnswer}>+ Add Select Box</button>
+        </section>
+
+        <hr/>
+
+        <section>
+          <h2 className="form-label">Add an option to a select box</h2>
+
+          <span>Select Box </span>
+
+          <select ref="selectBox" defaultValue={@state.selectBox} onChange={@onChangeSelectBox}>
+            <option value="" disabled>Select Box</option>
+
+            {answerKeys.map (answerKey, i) =>
+              <option key={answerKey + i} value={answerKey}>{answers[answerKey].title}</option>}
+          </select>
+
+          {if @state.selectBox
+            <div>
+              <ul>
+                {@selectedValues().map (select, i) =>
+                  <li key={i}>
+                    {select.value}: {select.label}{' '}
+                    <button onClick={@onClickDeleteSelectOption.bind(this, select)} title="Delete">
+                      <i className="fa fa-close" />
+                    </button>
+                  </li>}
+              </ul>
+
+              <div className="selection-option">
+                <label>
+                  Key <input ref="answerValueKey"></input>
+                </label>{' '}
+
+                <label>
+                  Value <input ref="answerValueLabel"></input>
+                </label>
+
+                <TriggeredModalForm trigger={<i className="fa fa-question-circle"></i>}>
+                  <p><strong>Keys</strong> are used as a unique identifier to store values of the select box</p>
+                  <p><strong>Values</strong> are what will be displayed to users as options within the select box</p>
+                </TriggeredModalForm>
+              </div>
+
+              <button type="button" onClick={@onClickAddAnswerValue}><i className="fa fa-plus" /> Add Select Box Value</button>
+              <button type="button" onClick={@onClickDeleteSelectBox}><i className="fa fa-close" /> Delete Select Box</button>
+            </div>
+            }
+        </section>
+
+        <div><strong>({answerKeys.length}) Available</strong></div>
+
+        <button type="button" onClick={@onClickSaveWorkflow}><i className="fa fa-save" /> Save Workflow</button>
+      </div>
+    </div>

--- a/app/classifier/tasks/selection/editor.cjsx
+++ b/app/classifier/tasks/selection/editor.cjsx
@@ -2,6 +2,10 @@ React = require 'react'
 DragReorderable = require 'drag-reorderable'
 TriggeredModalForm = require 'modal-form/triggered'
 
+AutoSave = require '../../../components/auto-save'
+handleInputChange = require '../../../lib/handle-input-change'
+NextTaskSelector = require '../next-task-selector'
+
 module?.exports = React.createClass
   displayName: 'SelectionEditor'
 
@@ -175,4 +179,12 @@ module?.exports = React.createClass
 
         <button type="button" onClick={@onClickSaveWorkflow}><i className="fa fa-save" /> Save Workflow</button>
       </div>
+
+      <hr/>
+
+      <AutoSave resource={@props.workflow}>
+        <span className="form-label">Next task</span>
+        <br />
+        <NextTaskSelector workflow={@props.workflow} name="#{@props.taskPrefix}.next" value={@props.task.next ? ''} onChange={handleInputChange.bind @props.workflow} />
+      </AutoSave>
     </div>

--- a/app/classifier/tasks/selection/index.cjsx
+++ b/app/classifier/tasks/selection/index.cjsx
@@ -61,14 +61,17 @@ module?.exports = React.createClass
       <div className="selection-task">
 
         {selectBoxes.map (name, i) =>
-          <select key={i} defaultValue="" ref="select-#{name}" onChange={@onChangeSelect.bind(@, selectBoxes)}>
-            <option key="_title" value="" disabled>{answers[name].title}</option>
+          <div>
+            <div>{answers[name].title}</div>
+            <select key={i} defaultValue={@props.annotation.value[name] ? ""} ref="select-#{name}" onChange={@onChangeSelect.bind(@, selectBoxes)}>
+              <option key="_title" value="" disabled>--</option>
 
-            {answers[name].values.map (option, i) =>
-              <option key={i} value={option.value}>
-                {option.label}
-              </option>}
-          </select>
+              {answers[name].values.map (option, i) =>
+                <option key={i} value={option.value}>
+                  {option.label}
+                </option>}
+            </select>
+          </div>
           }
 
       </div>

--- a/app/classifier/tasks/selection/index.cjsx
+++ b/app/classifier/tasks/selection/index.cjsx
@@ -66,9 +66,9 @@ module?.exports = React.createClass
             <select key={i} defaultValue={@props.annotation.value[name] ? ""} ref="select-#{name}" onChange={@onChangeSelect.bind(@, selectBoxes)}>
               <option key="_title" value="" disabled>--</option>
 
-              {answers[name].values.map (option, i) =>
-                <option key={i} value={option.value}>
-                  {option.label}
+              {answers[name].values.map (value, i) =>
+                <option key={i} value={value}>
+                  {value}
                 </option>}
             </select>
           </div>

--- a/app/classifier/tasks/selection/index.cjsx
+++ b/app/classifier/tasks/selection/index.cjsx
@@ -1,0 +1,84 @@
+React = require 'react'
+GenericTask = require '../generic'
+SelectionTaskEditor = require './editor'
+
+Summary = React.createClass
+  displayName: 'SelectionSummary'
+
+  getDefaultProps: ->
+    task: {}
+    annotation: {}
+
+  render: ->
+    {answers} = @props.task
+
+    <div className="classification-task-summary">
+      <div className="question">{@props.task.instruction}</div>
+
+      <div className="answers">
+        {if @props.annotation.value
+          Object.keys(answers).map (key, i) =>
+            <div key={i} className="answer">
+              <i className="fa fa-arrow-circle-o-right" /> {@props.annotation?.value[key]}
+            </div>
+        }
+      </div>
+    </div>
+
+module?.exports = React.createClass
+  displayName: 'SelectionTask'
+
+  statics:
+    Editor: SelectionTaskEditor
+    Summary: Summary
+
+    getDefaultTask: ->
+      type: 'selection'
+      instruction: 'Select options from a list'
+      help: 'Click on the select box to choose an option'
+      answers: {}
+      answersOrder: []
+
+    getTaskText: (task) ->
+      task.instruction
+
+    getDefaultAnnotation: ->
+      value: {}
+
+    isAnnotationComplete: (task, annotation) ->
+      answer = (key) -> annotation.value[key]
+      answersCompleted = Object.keys(annotation.value)
+        .map(answer)
+        .filter(Boolean)
+
+      answersCompleted.length and (answersCompleted.length is Object.keys(task.answers).length)
+
+  render: ->
+    {answers, answersOrder} = @props.task
+    selectBoxes = if answersOrder.length then answersOrder else Object.keys(answers)
+
+    <GenericTask question={@props.task.instruction} help={@props.task.help} required={@props.task.required}>
+      <div className="selection-task">
+
+        {selectBoxes.map (name, i) =>
+          <select key={i} defaultValue="" ref="select-#{name}" onChange={@onChangeSelect.bind(@, selectBoxes)}>
+            <option key="_title" value="" disabled>{answers[name].title}</option>
+
+            {answers[name].values.map (option, i) =>
+              <option key={i} value={option.value}>
+                {option.label}
+              </option>}
+          </select>
+          }
+
+      </div>
+    </GenericTask>
+
+  onChangeSelect: (selectBoxes, e) ->
+    currentAnswers = selectBoxes.reduce((obj, name) =>
+      obj[name] = @refs["select-#{name}"].value
+      obj
+    , {})
+
+    @props.annotation.value = currentAnswers
+    @props.onChange()

--- a/app/pages/admin/project-status.cjsx
+++ b/app/pages/admin/project-status.cjsx
@@ -15,7 +15,8 @@ EXPERIMENTAL_FEATURES = [
   'crop'
   'tutorial'
   'text',
-  'hide classification summaries'
+  'hide classification summaries',
+  'selection'
 ]
 
 ProjectToggle = React.createClass

--- a/app/pages/lab/workflow.cjsx
+++ b/app/pages/lab/workflow.cjsx
@@ -97,6 +97,7 @@ EditWorkflowPage = React.createClass
                         when 'survey' then <i className="fa fa-binoculars fa-fw"></i>
                         when 'flexibleSurvey' then <i className="fa fa-binoculars fa-fw"></i>
                         when 'crop' then <i className="fa fa-crop fa-fw"></i>
+                        when 'selection' then <i className="fa fa-list fa-fw"></i>
                         when 'text' then <i className="fa fa-file-text-o fa-fw"></i>}
                       {' '}
                       {tasks[definition.type].getTaskText definition}
@@ -157,6 +158,15 @@ EditWorkflowPage = React.createClass
                         <i className="fa fa-crop fa-2x"></i>
                         <br />
                         <small><strong>Crop</strong></small>
+                      </button>
+                    </AutoSave>}{' '}
+
+                  {if @canUseTask(@props.project, "selection")
+                    <AutoSave resource={@props.workflow}>
+                      <button type="submit" className="minor-button" onClick={@addNewTask.bind this, 'selection'} title="Select choices from a dropdown menu">
+                        <i className="fa fa-align-justify fa-2x"></i>
+                        <br />
+                        <small><strong>Selection</strong></small>
                       </button>
                     </AutoSave>}{' '}
                 </TriggeredModalForm>
@@ -221,7 +231,7 @@ EditWorkflowPage = React.createClass
             <br />
             <small className="form-help">Import gold standard classifications to improve the quality of automatic aggregations and optionally provide classification feedback for volunteers.</small>{' '}
             <TriggeredModalForm trigger={<i className="fa fa-question-circle"></i>}>
-              <p>Gold standard classificaitons should be in the form:</p>
+              <p>Gold standard classifications should be in the form:</p>
               <pre>{EXAMPLE_GOLD_STANDARD_DATA}</pre>
             </TriggeredModalForm>
           </p>

--- a/css/classify.styl
+++ b/css/classify.styl
@@ -126,6 +126,10 @@
     stroke-width: 5
     width: 1.5em
 
+  .selection-task
+    select
+      width: 100%
+
   .drawing-tool-input
     display: none
 


### PR DESCRIPTION
- Adds a selection task: a task that contains 1 or more select menus with options
  - Code & data shape should be similiar to other tasks/editors, but let me know if I missed anything key here
- Adds an Editor for adding select boxes and options 
  - mainly just inputs for adding/deleting key-value pairs
  - also drag&drop to change up the order of the selects (`drag-reorderable` is slick :banana: btw)
- Useful for Notes From Nature panoptes port, also other projects with 2-d lists of items to choose from
- Should be quick to setup a project on dev in the lab, but also viewable on `/projects/alex-panoptes/my-project/classify`