### PR TITLE
fix busted user search by removing debounce function

### DIFF
--- a/app/components/user-search.cjsx
+++ b/app/components/user-search.cjsx
@@ -27,4 +27,5 @@ module.exports = React.createClass
       searchPromptText="Type to search Users"
       className="search standard-input"
       closeAfterClick={true}
-      asyncOptions={debounce(@searchUsers, 200)} />
+      matchProp={'label'}
+      asyncOptions={@searchUsers} />


### PR DESCRIPTION
Using debounce with react-select gives me a component that is stuck in search
<img width="1023" alt="screen shot 2015-12-31 at 15 49 18" src="https://cloud.githubusercontent.com/assets/295329/12065827/27665c62-afd6-11e5-8c27-3c15446d4fb6.png">

This is not ideal and just removes the debounce function since it breaks the react-select async component similar to what’s described here, https://github.com/JedWatson/react-select/issues/614#issuecomment-159513545. I think the debouncer just returns a busted promise or none-at all unless it meets the criteria to run. 

I'd be supper happy to see this one closed for a working throttle / debouncer that feeds nicely to react-select in the context of #1936.
