### PR TITLE
More optimizations

### DIFF
--- a/app/pages/collections.cjsx
+++ b/app/pages/collections.cjsx
@@ -52,8 +52,10 @@ List = React.createClass
 
   listCollections: ->
     query = {}
-    query.owner = @props.params.owner if @props.params?.owner?
-    query.include = 'owner'
+    if @props.params?.owner?
+      query.owner = @props.params.owner
+      query.include = 'owner'
+
     query.favorite = @props.favorite
     Object.assign query, @props.location.query
 
@@ -68,6 +70,7 @@ List = React.createClass
       heroNav={<CollectionsNav user={@props.user} />}
       heroClass="collections-hero"
       ownerName={@props.params?.owner}
+      skipOwner={!@props.params?.owner}
       imagePromise={@imagePromise}
       cardLink={@cardLink} />
 

--- a/app/pages/home.cjsx
+++ b/app/pages/home.cjsx
@@ -42,17 +42,27 @@ counterpart.registerTranslations 'en',
 FeaturedProjects = React.createClass
   displayName: "FeaturedProjects"
 
+  imagePromise: (project) ->
+    src = if project.avatar_src
+      "//#{ project.avatar_src }"
+    else
+      '/assets/simple-avatar.jpg'
+    Promise.resolve src
+
   render: ->
     <div className="featured-projects">
-      <PromiseRenderer promise={apiClient.type('projects').get(FEATURED_PRODUCT_IDS)}>{(projects) =>
+      <PromiseRenderer promise={apiClient.type('projects').get(id: FEATURED_PRODUCT_IDS, cards: true)}>{(projects) =>
         if projects?
           <div className="featured-projects-list">
           {for project in projects
             [owner, name] = project.slug.split('/')
-
-            avatarSrc = project.get('avatar').then (avatar) ->
-              avatar.src
-            <OwnedCard key={project.id} resource={project} linkTo="/projects/#{owner}/#{name}" translationObjectName="projectsPage" imagePromise={avatarSrc} />
+            <OwnedCard
+              key={project.id}
+              resource={project}
+              linkTo="/projects/#{owner}/#{name}"
+              translationObjectName="projectsPage"
+              imagePromise={@imagePromise(project)}
+              skipOwner={true} />
           }
           </div>
       }</PromiseRenderer>

--- a/app/pages/home.cjsx
+++ b/app/pages/home.cjsx
@@ -109,7 +109,7 @@ module.exports = React.createClass
             else
               <div className="recent-projects">
                 <Translate component="h5" content="home.recentProjects.altTitle" />
-                <PromiseRenderer promise={apiClient.type('projects').get(launch_approved: true, page_size: 4)}>{(projects) =>
+                <PromiseRenderer promise={apiClient.type('projects').get(launch_approved: true, page_size: 4, cards: true)}>{(projects) =>
                   <div className="recent-projects-list">
                     {projects.map (project) ->
                       <div>

--- a/app/pages/projects.cjsx
+++ b/app/pages/projects.cjsx
@@ -22,7 +22,7 @@ module.exports = React.createClass
     query = {include: 'avatar'}
 
     if !apiClient.params.admin
-      query.simple = true
+      query.cards = true
 
     apiClient.type('projects').get Object.assign {}, query, @props.location.query
 

--- a/app/talk/lib/project-linker.cjsx
+++ b/app/talk/lib/project-linker.cjsx
@@ -24,6 +24,7 @@ module?.exports = React.createClass
   loadMoreProjects: (page = 1, newProjects = [], load = 10) ->
     apiClient.type('projects').get({
       launch_approved: true,
+      cards: true
       page: page,
       page_size: 20
     })


### PR DESCRIPTION
Mainly cutting down on redundant API calls on `/`, `/about/publications`, and `/collections`.

`/collections` could probably use some server-side improvements.

`/projects` now uses the `cards=true` param for consistency.

@camallen If we merge this, then we can just settle on that serializer and remove the other.