### PR TITLE
only include launch approved projects by default

### DIFF
--- a/app/pages/projects.cjsx
+++ b/app/pages/projects.cjsx
@@ -20,9 +20,10 @@ module.exports = React.createClass
 
   listProjects: ->
     query = {include: 'avatar'}
+    query.cards = true
 
     if !apiClient.params.admin
-      query.cards = true
+      query.launch_approved = true
 
     apiClient.type('projects').get Object.assign {}, query, @props.location.query
 


### PR DESCRIPTION
and always use the cards route for pages, even when admin.