### PR TITLE
avoid the api project roles owner calls

### DIFF
--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -253,14 +253,9 @@ Classifier = React.createClass
     if @props.project?
       getUserRoles = @props.project.get 'project_roles'
         .then (projectRoles) =>
-          getProjectRoleHavers = Promise.all projectRoles.map (projectRole) =>
-            projectRole.get 'owner'
-          getProjectRoleHavers
-            .then (projectRoleHavers) =>
-              (projectRoles[i].roles for user, i in projectRoleHavers when user is @props.user)
-            .then (setsOfUserRoles) =>
-              [[], setsOfUserRoles...].reduce (set, next) =>
-                set.concat next
+          projectRoles.map (projectRole) =>
+            if @props.user.id == projectRole.links.owner.id
+              projectRole.roles
 
       <PromiseRenderer promise={getUserRoles}>{(userRoles) =>
         if isAdmin() or 'owner' in userRoles or 'collaborator' in userRoles or 'expert' in userRoles

--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -250,12 +250,11 @@ Classifier = React.createClass
     </div>
 
   renderExpertOptions: ->
-    if @props.project?
-      getUserRoles = @props.project.get 'project_roles'
+    if @props.project? && @props.user?
+      getUserRoles = @props.project.get('project_roles', user_id: @props.user.id)
         .then (projectRoles) =>
           projectRoles.map (projectRole) =>
-            if @props.user.id == projectRole.links.owner.id
-              projectRole.roles
+            projectRole.roles
 
       <PromiseRenderer promise={getUserRoles}>{(userRoles) =>
         if isAdmin() or 'owner' in userRoles or 'collaborator' in userRoles or 'expert' in userRoles


### PR DESCRIPTION
Cuts down on unnecessary api calls, especially when there are large numbers of collabs on a project. Instead just compare the logged in user id to the project_roles linked owner id to find map the roles they have. 