### PR TITLE
proper sort params for the api

### DIFF
--- a/app/pages/admin/project-status-list.cjsx
+++ b/app/pages/admin/project-status-list.cjsx
@@ -13,7 +13,7 @@ module.exports = React.createClass
   getProjects: ->
     query =
       page_size: 24
-      sort: '+updated_at'
+      sort: '-updated_at'
       include: 'avatar'
 
     Object.assign query, @props.location.query

--- a/app/pages/home.cjsx
+++ b/app/pages/home.cjsx
@@ -79,7 +79,7 @@ module.exports = React.createClass
     document.documentElement.classList.remove 'on-home-page'
 
   lastFourProjects: ->
-    @props.user.get("project_preferences", page_size: 4, sort: '+updated_at')
+    @props.user.get("project_preferences", page_size: 4, sort: '-updated_at')
 
   render: ->
     aboutItems = ['contribute', 'explore', 'collaborate', 'discover']


### PR DESCRIPTION
use the sort indexes on the api, restpack supports - for desc and nothing for asc sort orders. https://github.com/RestPack/restpack_serializer#sorting