### PR TITLE
aren't we all tired of flexible-survey yet?

### DIFF
--- a/app/classifier/tasks/flexible-survey/chooser.cjsx
+++ b/app/classifier/tasks/flexible-survey/chooser.cjsx
@@ -76,7 +76,7 @@ module.exports = React.createClass
           </TriggeredModalForm>}
       </div>
 
-      <div className="survey-task-chooser-choices" data-breakpoint={breakpoint}>
+      <div className="flex-survey-task-chooser-choices" data-breakpoint={breakpoint}>
         {if filteredChoices.length is 0
           <div>
             <em>No matches.</em>
@@ -84,7 +84,7 @@ module.exports = React.createClass
         else
           for choiceID, i in filteredChoices
             choice = @props.task.choices[choiceID]
-            <button key={choiceID + i} type="button" className="survey-task-chooser-choice" onClick={@props.onChoose.bind null, choiceID}>
+            <button key={choiceID + i} type="button" className="flex-survey-task-chooser-choice" onClick={@props.onChoose.bind null, choiceID}>
               {unless choice.images.length is 0
                 <span className="survey-task-chooser-choice-thumbnail-container">
                   <img src={@props.task.images[choice.images[0]]} alt={choice.label} className="survey-task-chooser-choice-thumbnail" />

--- a/css/flex-survey-task.styl
+++ b/css/flex-survey-task.styl
@@ -1,0 +1,25 @@
+.flex-survey-task-chooser-choices
+  background: rgba(24, 24, 24, 1)
+  border: solid 1px rgba(24, 24, 24, 1)
+  border-radius: 8px
+  display: flex
+  flex-flow: column wrap
+  height: 440px
+  padding: 4px
+  overflow: auto
+  min-width: 400px;
+
+  > *
+    margin: 0 2px 2px 0
+    position: relative
+
+.flex-survey-task-chooser-choice
+  @extends $reset-button
+  background: rgba(64, 64, 64, 1)
+  color: white
+
+  &:hover
+    background: rgba(102, 102, 102, 1)
+
+  > *
+    margin: 0.3em 0.6em

--- a/css/main.styl
+++ b/css/main.styl
@@ -34,6 +34,7 @@
 @require './classify'
 @require './tutorial'
 @require './survey-task'
+@require './flex-survey-task'
 @require "./drawing-tool"
 @require "./classification-summary"
 @require './edit-media-page'

--- a/css/survey-task.styl
+++ b/css/survey-task.styl
@@ -113,20 +113,39 @@ $survey-task-pill-button
   border: solid 1px rgba(24, 24, 24, 1)
   border-radius: 8px
   display: flex
-  flex-flow: column wrap
-  height: 440px
+  flex-wrap: wrap
   padding: 4px
-  overflow: auto
-  min-width: 400px;
 
   > *
     margin: 0 2px 2px 0
     position: relative
 
+  &[data-breakpoint="Infinity"] > *,
+  &[data-breakpoint="40"] > *
+    flex-basis: calc(33.33% - 2px)
+
+  &[data-breakpoint="20"] > *,
+  &[data-breakpoint="10"] > *
+    flex-basis: calc(50% - 2px)
+
+  &[data-breakpoint="5"] > *
+    flex-basis: calc(100% - 2px)
+
+  &[data-breakpoint="40"],
+  &[data-breakpoint="20"],
+  &[data-breakpoint="10"],
+  &[data-breakpoint="5"]
+    .survey-task-chooser-choice
+      align-items: center
+      justify-content: flex-start
+
 .survey-task-chooser-choice
   @extends $reset-button
   background: rgba(64, 64, 64, 1)
   color: white
+  display: flex
+  justify-content: center
+  width: 100%
 
   &:hover
     background: rgba(102, 102, 102, 1)


### PR DESCRIPTION
Unfortunately, Ali noticed that the style changes to re-order the items in the flexible survey task leaked out and affected the regular survey task. I don't know how high-priority this pull request is, but I've separated the style changes out into a separate file so as to un-break an existing project she said was having trouble with the new style.

The changes to chooser.cjsx pull new styles that reorder the flexbox; the new file flex-survey-task.styl implements those styles. The changes to main.styl pull in the new .styl file, and the changes to survey-task.styl simply revert the edits that were affecting both tasks.