### PR TITLE
Create project_preferences to track tutorial completion if none exists

### DIFF
--- a/app/lib/tutorial.cjsx
+++ b/app/lib/tutorial.cjsx
@@ -54,6 +54,12 @@ module.exports = React.createClass
                     now = new Date().toISOString()
                     if user?
                       user.get('project_preferences', project_id: project.id).then ([projectPreferences]) =>
+                        projectPreferences ?= apiClient.type('project_preferences').create({
+                          links: {
+                            project: '231'
+                          },
+                          preferences: {}
+                        })
                         projectPreferences.update 'preferences.tutorial_completed_at': now
                         projectPreferences.save()
                     else

--- a/app/lib/tutorial.cjsx
+++ b/app/lib/tutorial.cjsx
@@ -56,7 +56,7 @@ module.exports = React.createClass
                       user.get('project_preferences', project_id: project.id).then ([projectPreferences]) =>
                         projectPreferences ?= apiClient.type('project_preferences').create({
                           links: {
-                            project: '231'
+                            project: project.id
                           },
                           preferences: {}
                         })


### PR DESCRIPTION
I believe the issue of the tutorial popping up when it'd already been seen was due to the user's project_preferences resource not existing yet. Thanks for spotting that error @srallen!