### PR TITLE
text tool option for subTask

### DIFF
--- a/app/classifier/tasks/drawing-task-details-editor.cjsx
+++ b/app/classifier/tasks/drawing-task-details-editor.cjsx
@@ -4,6 +4,10 @@ AutoSave = require '../../components/auto-save'
 module.exports = React.createClass
   displayName: 'DrawingTaskDetailsEditor'
 
+  propTypes:
+    project: React.PropTypes.object.isRequired
+    task: React.PropTypes.object.isRequired
+
   getDefaultProps: ->
     workflow: null
     task: null
@@ -38,14 +42,35 @@ module.exports = React.createClass
       </div>
 
       <div className="commands columns-container">
+        <button type="submit" className="minor-button" onClick={@handleAddTask.bind this, 'single'} title="Question tasks: the volunteer chooses from among a list of answers but does not mark or draw on the image(s).">
+          <i className="fa fa-question-circle fa-2x"></i>
+          <br />
+          <small><strong>Question</strong></small>
+        </button>
+        {
+          if @canUseTask(@props.project, "text")
+            <button type="submit" className="minor-button" onClick={@handleAddTask.bind this, 'text'} title="Text tasks: the volunteer writes free-form text into a dialog box.">
+              <i className="fa fa-file-text-o fa-2x"></i>
+              <br />
+              <small><strong>Text</strong></small>
+            </button>
+        }
+        <br />
+
         <button type="button" className="standard-button" onClick={@props.onClose}>Close</button>
-        <button type="button" className="major-button" onClick={@handleAddTask}>Add task</button>
       </div>
     </div>
 
-  handleAddTask: ->
-    SingleChoiceTask = require './single'
-    @props.task.tools[@props.toolIndex].details.push SingleChoiceTask.getDefaultTask()
+  canUseTask: (task)->
+    task in @props.project.experimental_tools
+
+  handleAddTask: (task) ->
+    switch task
+      when 'single' 
+        TaskChoice = require './single'
+      when 'text'
+        TaskChoice = require './text'
+    @props.task.tools[@props.toolIndex].details.push TaskChoice.getDefaultTask()
     @props.workflow.update 'tasks'
     @props.workflow.save()
 

--- a/app/classifier/tasks/drawing-task-details-editor.cjsx
+++ b/app/classifier/tasks/drawing-task-details-editor.cjsx
@@ -48,7 +48,7 @@ module.exports = React.createClass
           <small><strong>Question</strong></small>
         </button>
         {
-          if @canUseTask(@props.project, "text")
+          if @canUseTask("text")
             <button type="submit" className="minor-button" onClick={@handleAddTask.bind this, 'text'} title="Text tasks: the volunteer writes free-form text into a dialog box.">
               <i className="fa fa-file-text-o fa-2x"></i>
               <br />

--- a/app/classifier/tasks/drawing-task-details-editor.cjsx
+++ b/app/classifier/tasks/drawing-task-details-editor.cjsx
@@ -1,5 +1,7 @@
 React = require 'react'
 AutoSave = require '../../components/auto-save'
+TriggeredModalForm = require 'modal-form/triggered'
+
 
 module.exports = React.createClass
   displayName: 'DrawingTaskDetailsEditor'
@@ -38,22 +40,28 @@ module.exports = React.createClass
       </div>
 
       <div className="commands columns-container">
-        <button type="submit" className="minor-button" onClick={@handleAddTask.bind this, 'single'} title="Question tasks: the volunteer chooses from among a list of answers but does not mark or draw on the image(s).">
-          <i className="fa fa-question-circle fa-2x"></i>
-          <br />
-          <small><strong>Question</strong></small>
-        </button>
-        {
-          if @canUseTask("text")
-            <button type="submit" className="minor-button" onClick={@handleAddTask.bind this, 'text'} title="Text tasks: the volunteer writes free-form text into a dialog box.">
-              <i className="fa fa-file-text-o fa-2x"></i>
-              <br />
-              <small><strong>Text</strong></small>
-            </button>
-        }
-        <br />
-
-        <button type="button" className="standard-button" onClick={@props.onClose}>Close</button>
+        <p>
+          <TriggeredModalForm trigger={
+            <span className="standard-button">
+              <i className="fa fa-plus-circle"></i>{' '}
+              Add a task
+            </span>
+          }>
+              <button type="submit" className="minor-button" onClick={@handleAddTask.bind this, 'single'} title="Question tasks: the volunteer chooses from among a list of answers but does not mark or draw on the image(s).">
+                <i className="fa fa-question-circle fa-2x"></i>
+                <br />
+                <small><strong>Question</strong></small>
+              </button>{' '}
+              {
+                if @canUseTask("text")
+                  <button type="submit" className="minor-button" onClick={@handleAddTask.bind this, 'text'} title="Text tasks: the volunteer writes free-form text into a dialog box.">
+                    <i className="fa fa-file-text-o fa-2x"></i>
+                    <br />
+                    <small><strong>Text</strong></small>
+                  </button>
+              }
+          </TriggeredModalForm>
+        </p>
       </div>
     </div>
 

--- a/app/classifier/tasks/drawing-task-details-editor.cjsx
+++ b/app/classifier/tasks/drawing-task-details-editor.cjsx
@@ -4,10 +4,6 @@ AutoSave = require '../../components/auto-save'
 module.exports = React.createClass
   displayName: 'DrawingTaskDetailsEditor'
 
-  propTypes:
-    project: React.PropTypes.object.isRequired
-    task: React.PropTypes.object.isRequired
-
   getDefaultProps: ->
     workflow: null
     task: null

--- a/app/classifier/tasks/generic-editor.cjsx
+++ b/app/classifier/tasks/generic-editor.cjsx
@@ -47,10 +47,12 @@ module.exports = React.createClass
           <small className="form-help">Add text and images for a window that pops up when volunteers click “Need some help?” You can use markdown to format this text and add images. The help text can be as long as you need, but you should try to keep it simple and avoid jargon.</small>
         </div>}
 
-      <hr />
+      {if choicesKey?
+        <hr />
 
-      <span className="form-label">Choices</span>
-      {' '}
+        <span className="form-label">Choices</span>
+      }
+      {' '} 
       {if choicesKey is 'answers'
         multipleHelp = 'Multiple Choice: Check this box if more than one answer can be selected.'
         requiredHelp = 'Check this box if this question has to be answered before proceeding. If a marking task is Required, the volunteer will not be able to move on until they have made at least 1 mark.'

--- a/app/classifier/tasks/generic-editor.cjsx
+++ b/app/classifier/tasks/generic-editor.cjsx
@@ -48,9 +48,11 @@ module.exports = React.createClass
         </div>}
 
       {if choicesKey?
-        <hr />
+        <div>
+          <hr />
 
-        <span className="form-label">Choices</span>
+          <span className="form-label">Choices</span>
+        </div>
       }
       {' '} 
       {if choicesKey is 'answers'

--- a/app/classifier/tasks/generic-editor.cjsx
+++ b/app/classifier/tasks/generic-editor.cjsx
@@ -195,6 +195,7 @@ module.exports = React.createClass
     alert (resolve) =>
       <ChangeListener target={@props.workflow}>{=>
         <DrawingTaskDetailsEditor
+          project={@props.project}
           workflow={@props.workflow}
           task={@props.task}
           toolIndex={toolIndex}

--- a/app/pages/lab/workflow.cjsx
+++ b/app/pages/lab/workflow.cjsx
@@ -268,6 +268,7 @@ EditWorkflowPage = React.createClass
                 workflow={@props.workflow}
                 task={@props.workflow.tasks[@state.selectedTaskKey]}
                 taskPrefix="tasks.#{@state.selectedTaskKey}"
+                project={@props.project}
               />
               <hr />
               <br />


### PR DESCRIPTION
This PR adds the text tool as an option when creating subTasks in the workflow editor. This option is only available for projects with the experimental text tool enabled.

@brian-c, @mcbouslog: thoughts?