### PR TITLE
Tasks now pass up updated annotation through onChange

### DIFF
--- a/app/classifier/drawing-tools/circle.cjsx
+++ b/app/classifier/drawing-tools/circle.cjsx
@@ -76,7 +76,7 @@ module.exports = React.createClass
   handleMainDrag: (e, d) ->
     @props.mark.x += d.x / @props.scale.horizontal
     @props.mark.y += d.y / @props.scale.vertical
-    @props.onChange e
+    @props.onChange @props.mark
 
   handleRadiusHandleDrag: (e, d) ->
     {x, y} = @props.getEventOffset e
@@ -84,4 +84,4 @@ module.exports = React.createClass
     angle = @constructor.getAngle @props.mark.x, @props.mark.y , x, y
     @props.mark.r = r
     @props.mark.angle = angle
-    @props.onChange e
+    @props.onChange @props.mark

--- a/app/classifier/drawing-tools/ellipse.cjsx
+++ b/app/classifier/drawing-tools/ellipse.cjsx
@@ -83,7 +83,7 @@ module.exports = React.createClass
   handleMainDrag: (e, d) ->
     @props.mark.x += d.x / @props.scale.horizontal
     @props.mark.y += d.y / @props.scale.vertical
-    @props.onChange e
+    @props.onChange @props.mark
 
   handleRadiusHandleDrag: (coord, e, d) ->
     {x, y} = @props.getEventOffset e
@@ -93,4 +93,4 @@ module.exports = React.createClass
     @props.mark.angle = angle
     if coord is 'y'
       @props.mark.angle -= 90
-    @props.onChange e
+    @props.onChange @props.mark

--- a/app/classifier/drawing-tools/line.cjsx
+++ b/app/classifier/drawing-tools/line.cjsx
@@ -54,9 +54,9 @@ module.exports = React.createClass
     for n in [1..2]
       @props.mark["x#{n}"] += d.x / @props.scale.horizontal
       @props.mark["y#{n}"] += d.y / @props.scale.vertical
-    @props.onChange e
+    @props.onChange @props.mark
 
   handleHandleDrag: (n, e, d) ->
     @props.mark["x#{n}"] += d.x / @props.scale.horizontal
     @props.mark["y#{n}"] += d.y / @props.scale.vertical
-    @props.onChange e
+    @props.onChange @props.mark

--- a/app/classifier/drawing-tools/point.cjsx
+++ b/app/classifier/drawing-tools/point.cjsx
@@ -59,4 +59,4 @@ module.exports = React.createClass
   handleDrag: (e, d) ->
     @props.mark.x += d.x / @props.scale.horizontal
     @props.mark.y += d.y / @props.scale.vertical
-    @props.onChange e
+    @props.onChange @props.mark

--- a/app/classifier/drawing-tools/poly-curve.cjsx
+++ b/app/classifier/drawing-tools/poly-curve.cjsx
@@ -173,15 +173,15 @@ module.exports = React.createClass
     document.removeEventListener 'mousemove', @handleMouseMove
 
     @props.mark.closed = true
-    @props.onChange()
+    @props.onChange @props.mark
 
   handleMainDrag: (e, d) ->
     for point in @props.mark.points
       point.x += d.x / @props.scale.horizontal
       point.y += d.y / @props.scale.vertical
-    @props.onChange e
+    @props.onChange @props.mark
 
   handleHandleDrag: (index, e, d) ->
     @props.mark.points[index].x += d.x / @props.scale.horizontal
     @props.mark.points[index].y += d.y / @props.scale.vertical
-    @props.onChange e
+    @props.onChange @props.mark

--- a/app/classifier/drawing-tools/polygon.cjsx
+++ b/app/classifier/drawing-tools/polygon.cjsx
@@ -114,15 +114,15 @@ module.exports = React.createClass
 
     @props.mark.closed = true
     @props.mark._inProgress = false
-    @props.onChange()
+    @props.onChange @props.mark
 
   handleMainDrag: (e, d) ->
     for point in @props.mark.points
       point.x += d.x / @props.scale.horizontal
       point.y += d.y / @props.scale.vertical
-    @props.onChange e
+    @props.onChange @props.mark
 
   handleHandleDrag: (index, e, d) ->
     @props.mark.points[index].x += d.x / @props.scale.horizontal
     @props.mark.points[index].y += d.y / @props.scale.vertical
-    @props.onChange e
+    @props.onChange @props.mark

--- a/app/classifier/drawing-tools/rectangle.cjsx
+++ b/app/classifier/drawing-tools/rectangle.cjsx
@@ -78,31 +78,31 @@ module.exports = React.createClass
   handleMainDrag: (e, d) ->
     @props.mark.x += d.x / @props.scale.horizontal
     @props.mark.y += d.y / @props.scale.vertical
-    @props.onChange e
+    @props.onChange @props.mark
 
   handleTopLeftDrag: (e, d) ->
     @props.mark.x += d.x / @props.scale.horizontal
     @props.mark.y += d.y / @props.scale.vertical
     @props.mark.width -= d.x / @props.scale.horizontal
     @props.mark.height -= d.y / @props.scale.vertical
-    @props.onChange e
+    @props.onChange @props.mark
 
   handleTopRightDrag: (e, d) ->
     @props.mark.y += d.y / @props.scale.vertical
     @props.mark.width += d.x / @props.scale.horizontal
     @props.mark.height -= d.y / @props.scale.vertical
-    @props.onChange e
+    @props.onChange @props.mark
 
   handleBottomRightDrag: (e, d) ->
     @props.mark.width += d.x / @props.scale.horizontal
     @props.mark.height += d.y / @props.scale.vertical
-    @props.onChange e
+    @props.onChange @props.mark
 
   handleBottomLeftDrag: (e, d) ->
     @props.mark.x += d.x / @props.scale.horizontal
     @props.mark.width -= d.x / @props.scale.horizontal
     @props.mark.height += d.y / @props.scale.vertical
-    @props.onChange e
+    @props.onChange @props.mark
 
   normalizeMark: ->
     if @props.mark.width < 0
@@ -113,4 +113,4 @@ module.exports = React.createClass
       @props.mark.y += @props.mark.height
       @props.mark.height *= -1
 
-    @props.onChange()
+    @props.onChange @props.mark

--- a/app/classifier/drawing-tools/root.cjsx
+++ b/app/classifier/drawing-tools/root.cjsx
@@ -66,7 +66,7 @@ module.exports = React.createClass
           {for detailTask, i in toolProps.details
             detailTask._key ?= Math.random()
             TaskComponent = tasks[detailTask.type]
-            <TaskComponent key={detailTask._key} task={detailTask} annotation={toolProps.mark.details[i]} onChange={toolProps.onChange} />}
+            <TaskComponent key={detailTask._key} task={detailTask} annotation={toolProps.mark.details[i]} onChange={@handleDetailsChange.bind this, i} />}
           <hr />
           <p style={textAlign: 'center'}>
             <button type="submit" className="standard-button" disabled={not detailsAreComplete}>OK</button>
@@ -76,6 +76,10 @@ module.exports = React.createClass
 
   componentDidUpdate: ->
     this.refs.detailsForm?.reposition()
+
+  handleDetailsChange: (detailIndex, annotation) ->
+    @props.tool.props.mark.details[detailIndex] = annotation
+    @props.tool.props.onChange @props.tool.props.mark
 
   handleDetailsFormClose: ->
     # TODO: Check if the details tasks are complete.

--- a/app/classifier/frame-annotator.cjsx
+++ b/app/classifier/frame-annotator.cjsx
@@ -20,6 +20,7 @@ module.exports = React.createClass
     annotation: null
     onLoad: Function.prototype
     frame: 0
+    onChange: Function.prototype
 
   getInitialState: ->
     naturalWidth: 0
@@ -73,7 +74,7 @@ module.exports = React.createClass
 
   getEventOffset: (e) ->
     scale = @getScale()
-    console?.log 'Subject scale is', JSON.stringify scale
+    # console?.log 'Subject scale is', JSON.stringify scale
     x = (e.pageX - @state.sizeRect?.left) / scale.horizontal || 0
     y = (e.pageY - @state.sizeRect?.top) / scale.vertical || 0
     {x, y}
@@ -94,21 +95,24 @@ module.exports = React.createClass
 
     if TaskComponent?
       {BeforeSubject, InsideSubject, AfterSubject} = TaskComponent
-      hookProps =
-        workflow: @props.workflow
-        task: taskDescription
-        classification: @props.classification
-        annotation: @props.annotation
-        frame: @props.frame
-        scale: @getScale()
-        naturalWidth: @props.naturalWidth
-        naturalHeight: @props.naturalHeight
-        containerRect: @state.sizeRect
-        getEventOffset: this.getEventOffset
 
-      for task, Component of tasks when Component.getSVGProps?
-        for key, value of Component.getSVGProps hookProps
-          svgProps[key] = value
+    hookProps =
+      taskTypes: tasks
+      workflow: @props.workflow
+      task: taskDescription
+      classification: @props.classification
+      annotation: @props.annotation
+      frame: @props.frame
+      scale: @getScale()
+      naturalWidth: @props.naturalWidth
+      naturalHeight: @props.naturalHeight
+      containerRect: @state.sizeRect
+      getEventOffset: this.getEventOffset
+      onChange: @props.onChange
+
+    for task, Component of tasks when Component.getSVGProps?
+      for key, value of Component.getSVGProps hookProps
+        svgProps[key] = value
 
     <div className="frame-annotator">
       <div className="subject-area">

--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -118,6 +118,7 @@ Classifier = React.createClass
           frameWrapper={FrameAnnotator}
           allowFlipbook={workflowAllowsFlipbook @props.workflow}
           allowSeparateFrames={workflowAllowsSeparateFrames @props.workflow}
+          onChange={@handleAnnotationChange.bind this, currentClassification}
         />
 
         <div className="task-area">
@@ -156,7 +157,7 @@ Classifier = React.createClass
       pointerEvents: 'none'
 
     <div className="task-container" style={disabledStyle if @state.subjectLoading}>
-      <TaskComponent task={task} annotation={annotation} onChange={@updateAnnotations.bind this, classification} />
+      <TaskComponent taskTypes={tasks} workflow={@props.workflow} task={task} annotation={annotation} onChange={@handleAnnotationChange.bind this, classification} />
 
       <hr />
 
@@ -323,14 +324,14 @@ Classifier = React.createClass
     changes["metadata.subject_dimensions.#{frameIndex}"] = {naturalWidth, naturalHeight, clientWidth, clientHeight}
     @props.classification.update changes
 
-  # This is passed as a generic change handler to the tasks
-  updateAnnotations: ->
-    @props.classification.update 'annotations'
+  handleAnnotationChange: (classification, newAnnotation) ->
+    classification.annotations[classification.annotations.length - 1] = newAnnotation
+    classification.update 'annotations'
 
   # Next (or start):
   addAnnotationForTask: (classification, taskKey) ->
     taskDescription = @props.workflow.tasks[taskKey]
-    annotation = tasks[taskDescription.type].getDefaultAnnotation()
+    annotation = tasks[taskDescription.type].getDefaultAnnotation taskDescription, @props.workflow, tasks
     annotation.task = taskKey
     classification.annotations.push annotation
     classification.update 'annotations'

--- a/app/classifier/mock-data.coffee
+++ b/app/classifier/mock-data.coffee
@@ -92,7 +92,7 @@ workflow = apiClient.type('workflows').create
       '''
       tools: [
         {type: 'point', label: 'Point', color: 'red', min: 1, max: 2}
-        {type: 'line', label: 'Line', color: 'yellow', min: 1}
+        {type: 'line', label: 'Line', color: 'yellow', min: 0}
         {type: 'rectangle', label: 'Rectangle', color: 'lime', max: 2}
         {type: 'polygon', label: 'Polygon', color: 'cyan', details: MISC_DRAWING_DETAILS}
         {type: 'circle', label: 'Circle', color: 'blue', details: MISC_DRAWING_DETAILS}
@@ -291,6 +291,9 @@ subject = apiClient.type('subjects').create
         task: 'write'
         value: 'Rhino'
       }, {
+        task: 'ask'
+        value: 0
+      }, {
         task: 'features'
         value: [0, 1]
       }, {
@@ -313,7 +316,7 @@ subject = apiClient.type('subjects').create
         value: []
       }, {
         task: 'init'
-        value: 5
+        value: 6
       }]
 
 classification = apiClient.type('classifications').create

--- a/app/classifier/mock-data.coffee
+++ b/app/classifier/mock-data.coffee
@@ -37,6 +37,7 @@ workflow = apiClient.type('workflows').create
       answers: [
         {label: 'Crop the image', next: 'crop'}
         {label: 'Enter some text', next: 'write'}
+        {label: 'Single-answer question', next: 'ask'}
         {label: 'Multi-answer question', next: 'features'}
         {label: 'Draw stuff', next: 'draw'}
         {label: 'Survey the image', next: 'survey'}
@@ -56,6 +57,18 @@ workflow = apiClient.type('workflows').create
       help: '''
         **Example**: If you see a bee, then type "Bee"
       '''
+      next: 'ask'
+
+    ask:
+      type: 'single'
+      question: 'Rhino starts with...'
+      answers: [
+        {label: 'Are'}
+        {label: 'Aitch'}
+        {label: 'Eye'}
+        {label: 'En'}
+        {label: 'Oh'}
+      ]
       next: 'features'
 
     features:

--- a/app/classifier/mock-data.coffee
+++ b/app/classifier/mock-data.coffee
@@ -63,13 +63,12 @@ workflow = apiClient.type('workflows').create
       type: 'single'
       question: 'Rhino starts with...'
       answers: [
-        {label: 'Are'}
-        {label: 'Aitch'}
-        {label: 'Eye'}
-        {label: 'En'}
-        {label: 'Oh'}
+        {label: 'Are', next: 'features'}
+        {label: 'Aitch', next: 'features'}
+        {label: 'Eye', next: 'features'}
+        {label: 'En', next: 'features'}
+        {label: 'Oh', next: 'features'}
       ]
-      next: 'features'
 
     features:
       type: 'multiple'

--- a/app/classifier/mock-data.coffee
+++ b/app/classifier/mock-data.coffee
@@ -27,6 +27,9 @@ MISC_DRAWING_DETAILS = [{
 workflow = apiClient.type('workflows').create
   id: 'MOCK_WORKFLOW_FOR_CLASSIFIER'
 
+  configuration:
+    multi_image_mode: 'flipbook_and_separate'
+
   first_task: 'init'
 
   tasks:
@@ -97,6 +100,7 @@ workflow = apiClient.type('workflows').create
         {type: 'polygon', label: 'Polygon', color: 'cyan', details: MISC_DRAWING_DETAILS}
         {type: 'circle', label: 'Circle', color: 'blue', details: MISC_DRAWING_DETAILS}
         {type: 'ellipse', label: 'Ellipse '.repeat(25), color: 'magenta', details: MISC_DRAWING_DETAILS}
+        {type: 'bezier', label: 'Bezier', color: 'orange', details: MISC_DRAWING_DETAILS}
       ]
       next: 'survey'
 

--- a/app/classifier/tasks/crop/index.cjsx
+++ b/app/classifier/tasks/crop/index.cjsx
@@ -62,6 +62,7 @@ module.exports = React.createClass
     onChange: Function.prototype
 
   render: ->
+    # The actual value is updated in the Initializer.
     <GenericTask question={@props.task.instruction} help={@props.task.help} required={@props.task.required}>
       <p>
         <button type="button" className="minor-button" disabled={not @props.annotation.value?} onClick={@handleClear}>Clear current crop</button>
@@ -69,5 +70,5 @@ module.exports = React.createClass
     </GenericTask>
 
   handleClear: ->
-    @props.annotation.value = null
-    @props.onChange()
+    newAnnotation = Object.assign {}, @props.annotation, value: null
+    @props.onChange newAnnotation

--- a/app/classifier/tasks/drawing/index.cjsx
+++ b/app/classifier/tasks/drawing/index.cjsx
@@ -114,8 +114,10 @@ module.exports = React.createClass
 
     <GenericTask question={@props.task.instruction} help={@props.task.help} answers={tools} required={@props.task.required} />
 
-  handleChange: (index, e) ->
+  handleChange: (toolIndex, e) ->
+    # This handles changing tools, not any actually drawing.
+    # The annotation value is updated by the MarkingInitializer and the individual tools themselves.
     @constructor.closeAllMarks @props.task, @props.annotation
     if e.target.checked
-      @props.annotation._toolIndex = index
-      @props.onChange? e
+      newAnnotation = Object.assign {}, @props.annotation, _toolIndex: toolIndex
+      @props.onChange newAnnotation

--- a/app/classifier/tasks/drawing/marking-initializer.cjsx
+++ b/app/classifier/tasks/drawing/marking-initializer.cjsx
@@ -44,7 +44,7 @@ module.exports = React.createClass
         frame: @props.frame
       if toolDescription.details?
         mark.details = for detailTaskDescription in toolDescription.details
-          tasks[detailTaskDescription.type].getDefaultAnnotation()
+          tasks[detailTaskDescription.type].getDefaultAnnotation detailTaskDescription, @props.workflow, tasks
 
       @props.annotation.value.push mark
 

--- a/app/classifier/tasks/drawing/markings-renderer.cjsx
+++ b/app/classifier/tasks/drawing/markings-renderer.cjsx
@@ -41,7 +41,7 @@ module.exports = React.createClass
         taskDescription = @props.workflow.tasks[annotation.task]
         if taskDescription.type is 'drawing'
           <g key={annotation._key} className="marks-for-annotation" data-disabled={isPriorAnnotation || null}>
-            {for mark in annotation.value when parseInt(mark.frame) is parseInt(@props.frame)
+            {for mark, i in annotation.value when parseInt(mark.frame) is parseInt(@props.frame)
               mark._key ?= Math.random()
               toolDescription = taskDescription.tools[mark.tool]
 
@@ -59,7 +59,7 @@ module.exports = React.createClass
                 color: toolDescription.color
 
               toolMethods =
-                onChange: @handleChange
+                onChange: @handleChange.bind this, i
                 onSelect: @handleSelect.bind this, annotation, mark
                 onDeselect: @handleDeselect
                 onDestroy: @handleDestroy.bind this, annotation, mark
@@ -69,8 +69,9 @@ module.exports = React.createClass
           </g>}
     </g>
 
-  handleChange: ->
-    @props.classification.update 'annotations'
+  handleChange: (markIndex, mark) ->
+    @props.annotation.value[markIndex] = mark
+    @props.onChange @props.annotation
 
   handleSelect: (annotation, mark) ->
     @setState selection: mark

--- a/app/classifier/tasks/flexible-survey/index.cjsx
+++ b/app/classifier/tasks/flexible-survey/index.cjsx
@@ -79,24 +79,23 @@ module.exports = React.createClass
       @setState filters: @state.filters
 
   handleChoice: (choiceID) ->
-    @props.annotation._choiceInProgress = true
     @setState selectedChoiceID: choiceID
-    @props.onChange()
+    newAnnotation = Object.assign {}, @props.annotation, _choiceInProgress: true
+    @props.onChange newAnnotation
 
   clearFilters: ->
     @setState filters: {}
 
   clearSelection: ->
-    @props.annotation._choiceInProgress = false
     @setState selectedChoiceID: ''
-    @props.onChange()
+    newAnnotation = Object.assign {}, @props.annotation, _choiceInProgress: false
+    @props.onChange newAnnotation
 
   handleAnnotation: (choice, answers, e) ->
     filters = JSON.parse JSON.stringify @state.filters
-
-    @props.annotation.value ?= []
-    @props.annotation.value.push {choice, answers, filters}
-    @props.onChange e
-
+    value = @props.annotation.value?.slice?(0) ? []
+    value.push {choice, answers, filters}
+    newAnnotation = Object.assign {}, @props.annotation, {value}
     @clearFilters()
     @clearSelection()
+    @props.onChange newAnnotation

--- a/app/classifier/tasks/multiple.cjsx
+++ b/app/classifier/tasks/multiple.cjsx
@@ -117,5 +117,5 @@ module.exports = React.createClass
         indexInValue = value.indexOf index
         value.splice indexInValue, 1
 
-    newAnnotation = Object.assign {}, @props.annotations, {value}
+    newAnnotation = Object.assign {}, @props.annotation, {value}
     @props.onChange newAnnotation

--- a/app/classifier/tasks/multiple.cjsx
+++ b/app/classifier/tasks/multiple.cjsx
@@ -107,15 +107,15 @@ module.exports = React.createClass
     <GenericTask question={@props.task.question} help={@props.task.help} answers={answers} required={@props.task.required} />
 
   handleChange: (index, e) ->
-    answers = @props.annotation.value
+    value = @props.annotation.value.slice 0
 
     if e.target.checked
-      if index not in answers
-        answers.push index
+      if index not in value
+        value.push index
     else
-      if index in answers
-        indexInAnswers = answers.indexOf index
-        answers.splice indexInAnswers, 1
+      if index in value
+        indexInValue = value.indexOf index
+        value.splice indexInValue, 1
 
-    @props.annotation.value = answers
-    @props.onChange? e
+    newAnnotation = Object.assign {}, @props.annotations, {value}
+    @props.onChange newAnnotation

--- a/app/classifier/tasks/single.cjsx
+++ b/app/classifier/tasks/single.cjsx
@@ -95,5 +95,5 @@ module.exports = React.createClass
 
   handleChange: (index, e) ->
     if e.target.checked
-      @props.annotation.value = index
-      @props.onChange? e
+      newAnnotation = Object.assign {}, @props.annotation, value: index
+      @props.onChange newAnnotation

--- a/app/classifier/tasks/survey/index.cjsx
+++ b/app/classifier/tasks/survey/index.cjsx
@@ -80,24 +80,24 @@ module.exports = React.createClass
       @setState filters: @state.filters
 
   handleChoice: (choiceID) ->
-    @props.annotation._choiceInProgress = true
     @setState selectedChoiceID: choiceID
-    @props.onChange()
+    newAnnotation = Object.assign {}, @props.annotation, _choiceInProgress: true
+    @props.onChange newAnnotation
 
   clearFilters: ->
     @setState filters: {}
 
   clearSelection: ->
-    @props.annotation._choiceInProgress = false
     @setState selectedChoiceID: ''
-    @props.onChange()
+    newAnnotation = Object.assign {}, @props.annotation, _choiceInProgress: false
+    @props.onChange newAnnotation
 
   handleAnnotation: (choice, answers, e) ->
     filters = JSON.parse JSON.stringify @state.filters
-
-    @props.annotation.value ?= []
-    @props.annotation.value.push {choice, answers, filters}
-    @props.onChange e
-
+    value = @props.annotation.value?.slice?(0) ? []
+    value.push {choice, answers, filters}
     @clearFilters()
     @clearSelection()
+    setTimeout => # Wait for filters and selection to clear.
+      newAnnotation = Object.assign {}, @props.annotation, {value}
+      @props.onChange newAnnotation

--- a/app/classifier/tasks/text/index.cjsx
+++ b/app/classifier/tasks/text/index.cjsx
@@ -65,6 +65,7 @@ module.exports = React.createClass
       </label>
     </GenericTask>
 
-  handleChange: (index, e) ->
-    @props.annotation.value = React.findDOMNode(@refs.textInput).value
-    @props.onChange? e
+  handleChange: ->
+    value = React.findDOMNode(@refs.textInput).value
+    newAnnotation = Object.assign @props.annotation, {value}
+    @props.onChange newAnnotation

--- a/app/components/frame-viewer.cjsx
+++ b/app/components/frame-viewer.cjsx
@@ -26,13 +26,14 @@ module.exports = React.createClass
     onLoad: NOOP
     classification: null
     workflow: null
+    frameWrapper: null
+    onChange: ->
 
   getInitialState: ->
     loading: true
     playing: false
     playbackRate: 1
     frameDimensions: {}
-    frameWrapper: null
 
   componentDidMount: ->
     @refs.videoScrubber?.value = 0
@@ -93,7 +94,7 @@ module.exports = React.createClass
         </div>
 
     if FrameWrapper
-      <FrameWrapper frame={frame} naturalWidth={@state.frameDimensions?.width or 0} naturalHeight={@state.frameDimensions?.height or 0} workflow={@props.workflow} subject={@props.subject} classification={@props.classification} annotation={@props.annotation} loading={@state.loading}>
+      <FrameWrapper frame={frame} naturalWidth={@state.frameDimensions?.width or 0} naturalHeight={@state.frameDimensions?.height or 0} workflow={@props.workflow} subject={@props.subject} classification={@props.classification} annotation={@props.annotation} loading={@state.loading} onChange={@props.onChange}>
         {frameDisplay}
       </FrameWrapper>
     else

--- a/app/components/subject-viewer.cjsx
+++ b/app/components/subject-viewer.cjsx
@@ -141,7 +141,7 @@ module.exports = React.createClass
     </div>
 
   renderFrame: (frame) ->
-    <FrameViewer frame={frame} project={@props.project} classification={@props.classification} subject={@props.subject} workflow={@props.workflow} classification={@props.classification} annotation={@props.annotation} onLoad={@props.onLoad} frameWrapper={@props.frameWrapper}  />
+    <FrameViewer frame={frame} project={@props.project} classification={@props.classification} subject={@props.subject} workflow={@props.workflow} classification={@props.classification} annotation={@props.annotation} onLoad={@props.onLoad} frameWrapper={@props.frameWrapper} onChange={@props.onChange} />
 
   hiddenPreloadedImages: ->
     # Render this to ensure that all a subject's location images are cached and ready to display.

--- a/app/lib/workflow-allows-flipbook.cjsx
+++ b/app/lib/workflow-allows-flipbook.cjsx
@@ -1,5 +1,5 @@
 module.exports = (workflow) ->
-  if workflow.configuration.multi_image_mode
+  if workflow.configuration?.multi_image_mode
     workflow.configuration?.multi_image_mode is 'flipbook' or workflow.configuration?.multi_image_mode is 'flipbook_and_separate'
   else
     true

--- a/app/lib/workflow-allows-separate-frames.cjsx
+++ b/app/lib/workflow-allows-separate-frames.cjsx
@@ -1,5 +1,5 @@
 module.exports = (workflow) ->
-  if workflow.configuration.multi_image_mode
+  if workflow.configuration?.multi_image_mode
     workflow.configuration?.multi_image_mode is 'separate' or workflow.configuration?.multi_image_mode is 'flipbook_and_separate'
   else
     false

--- a/app/partials/main-footer.cjsx
+++ b/app/partials/main-footer.cjsx
@@ -93,6 +93,8 @@ module.exports = React.createClass
             <Link to="/lab"><Translate content="footer.discover.projectBuilder" /></Link>
             <Link to="/lab-how-to"><Translate content="footer.discover.howToGuide" /></Link>
             <Link to="/lab-policies"><Translate content="footer.discover.projectBuilderPolicies" /></Link>
+            {if process.env isnt 'production'
+              <Link to="/dev/classifier">Dev Classifier</Link>}
           </div>
           <div className="site-map-section">
             <Translate component="h6" content="footer.about.title" />
@@ -113,7 +115,6 @@ module.exports = React.createClass
             <a href="https://twitter.com/the_zooniverse" target="_blank"><i className="fa fa-twitter"></i></a>
             <a href="https://plus.google.com/+ZooniverseOrgReal" target="_blank"><i className="fa fa-google-plus"></i></a>
           </div>
-
         </nav>
       </div>
       <div className="footer-sole">


### PR DESCRIPTION
(Changes from #2137) Tasks are now responsible for passing updated annotations up to their parent, instead of updating the annotation in place and telling the classifier that it changed.

This allows task components to be used in contexts other than as direct children of the classifier.

cc: @itsravenous