### PR TITLE
Load field guide after creation

### DIFF
--- a/app/pages/lab/field-guide/actions.js
+++ b/app/pages/lab/field-guide/actions.js
@@ -5,8 +5,8 @@ var projects = apiClient.type('projects');
 var guides = apiClient.type('field_guides');
 
 var DEFAULT_ITEM = {
-  title: 'Untitled',
-  content: 'Here’s everything you need to know about the great **Untitled**...'
+  title: 'An example',
+  content: 'Here’s everything you need to know about the great **Example**...'
 };
 
 var actions = {

--- a/app/pages/lab/field-guide/article-list.cjsx
+++ b/app/pages/lab/field-guide/article-list.cjsx
@@ -26,7 +26,12 @@ ArticleList = React.createClass
 
   render: ->
     <div>
-      <DragReorderable tag="ul" className="field-guide-editor-article-list" items={@props.articles} render={@renderArticle} onChange={@props.onReorder} />
+      {if @props.articles.length is 0
+        <div>
+          <small>No field guide entries</small>
+        </div>
+      else
+        <DragReorderable tag="ul" className="field-guide-editor-article-list" items={@props.articles} render={@renderArticle} onChange={@props.onReorder} />}
       <p style={textAlign: 'center'}>
         <button type="button" className="standard-button" onClick={@props.onAddArticle}>Add an entry</button>
       </p>

--- a/app/pages/lab/field-guide/index.cjsx
+++ b/app/pages/lab/field-guide/index.cjsx
@@ -34,8 +34,9 @@ FieldGuideEditor = React.createClass
     apiClient.type('field_guides').get project_id: project.id
       .then ([guide]) =>
         @listenTo guide
-        @fetchIcons guide
         @setState {guide}
+        if guide?
+          @fetchIcons guide
 
   listenTo: (guide) ->
     @_forceUpdate ?= @forceUpdate.bind this

--- a/app/pages/lab/field-guide/index.cjsx
+++ b/app/pages/lab/field-guide/index.cjsx
@@ -19,6 +19,7 @@ FieldGuideEditor = React.createClass
     actions: actions
 
   getInitialState: ->
+    loading: false
     guide: null
     icons: {}
     editing: null
@@ -31,10 +32,13 @@ FieldGuideEditor = React.createClass
       @loadGuide nextProps.project
 
   loadGuide: (project) ->
+    @setState loading: true
     apiClient.type('field_guides').get project_id: project.id
       .then ([guide]) =>
         @listenTo guide
-        @setState {guide}
+        @setState
+          loading: false
+          guide: guide
         if guide?
           @fetchIcons guide
 
@@ -92,20 +96,18 @@ FieldGuideEditor = React.createClass
 
       {if @state.guide?
         @renderEditor()
+      else if @state.loading
+        <p className="form-help">Loading field guide...</p>
       else
-        @renderCreator()}
-    </div>
-
-  renderCreator: ->
-    <div>
-      <p>
-        This project doesn’t have a field guide yet.{' '}
-        <button type="button" onClick={@createGuide}>Create one!</button>
-      </p>
+        <p>
+          This project doesn’t have a field guide yet.{' '}
+          <button type="button" onClick={@createGuide}>Create one!</button>
+        </p>}
     </div>
 
   renderEditor: ->
     window.editingGuide = @state.guide
+
     <div className="field-guide-editor" className="columns-container">
       <div>
         <ArticleList

--- a/app/pages/lab/field-guide/index.cjsx
+++ b/app/pages/lab/field-guide/index.cjsx
@@ -52,6 +52,11 @@ FieldGuideEditor = React.createClass
           icons[image.id] = image
         @setState {icons}
 
+  createGuide: ->
+    @props.actions.createGuide @props.project.id
+      .then =>
+        @loadGuide @props.project
+
   createArticle: ->
     @props.actions.appendItem @state.guide.id
       .then =>
@@ -94,7 +99,7 @@ FieldGuideEditor = React.createClass
     <div>
       <p>
         This project doesn’t have a field guide yet.{' '}
-        <button type="button" onClick={@props.actions.createGuide.bind null, @props.project.id}>Create one!</button>
+        <button type="button" onClick={@createGuide}>Create one!</button>
       </p>
     </div>
 

--- a/app/pages/lab/field-guide/index.cjsx
+++ b/app/pages/lab/field-guide/index.cjsx
@@ -108,7 +108,7 @@ FieldGuideEditor = React.createClass
   renderEditor: ->
     window.editingGuide = @state.guide
 
-    <div className="field-guide-editor" className="columns-container">
+    <div className="field-guide-editor columns-container">
       <div>
         <ArticleList
           articles={@state.guide.items}

--- a/css/field-guide-editor.styl
+++ b/css/field-guide-editor.styl
@@ -1,13 +1,13 @@
 .field-guide-editor
   [draggable]
+    cursor: move
     cursor: -moz-grab
     cursor: -webkit-grab
-    cursor: move
 
     [data-drag-reorderable-dragging] &
+      cursor: move
       cursor: -moz-grabbing
       cursor: -webkit-grabbing
-      cursor: move
 
 .field-guide-editor-article-list
   border: 1px solid rgba(gray, 0.3)


### PR DESCRIPTION
Fixes a bug where creating a project's field guide wouldn't actually load it until the page was reloaded. Also adds a "loading" state and cleans up some other visual bits.

For #2140