### PR TITLE
Fix SVG dimensions for videos

### DIFF
--- a/app/components/frame-viewer.cjsx
+++ b/app/components/frame-viewer.cjsx
@@ -143,10 +143,12 @@ module.exports = React.createClass
     scrubber.value = player.currentTime
 
   handleLoad: (e) ->
+    width = e.target.videoWidth ? e.target.naturalWidth
+    height = e.target.videoHeight ? e.target.naturalHeight
     @setState
       loading: false
       frameDimensions:
-        width: e.target.naturalWidth
-        height: e.target.naturalHeight
+        width: width ? 0
+        height: height ? 0
 
     @props.onLoad? arguments...


### PR DESCRIPTION
Use `offsetHeight` and `offsetWidth` when `naturalHeight` and `naturalWidth` are undefined.

Should fix the drawing surface dimensions being set to 0 for video subjects.