### PR TITLE
Started discussions preference

### DIFF
--- a/app/pages/notifications/notification.cjsx
+++ b/app/pages/notifications/notification.cjsx
@@ -3,6 +3,7 @@ CommentNotification = require './comment'
 DataRequestNotification = require './data-request'
 MessageNotification = require './message'
 ModerationNotification = require './moderation'
+StartedDiscussionNotification = require './started-discussion'
 
 module?.exports = React.createClass
   displayName: 'Notification'
@@ -22,6 +23,8 @@ module?.exports = React.createClass
         <MessageNotification {...@props} />
       when 'Moderation'
         <ModerationNotification {...@props} />
+      when 'Discussion'
+        <StartedDiscussionNotification {...@props} />
 
   render: ->
     {notification} = @props

--- a/app/pages/notifications/started-discussion.cjsx
+++ b/app/pages/notifications/started-discussion.cjsx
@@ -1,0 +1,53 @@
+React = require 'react'
+talkClient = require '../../api/talk'
+{Link} = require 'react-router'
+{Markdown} = require 'markdownz'
+Loading = require '../../components/loading-indicator'
+Comment = require '../../talk/search-result'
+
+module?.exports = React.createClass
+  displayName: 'CommentNotification'
+
+  propTypes:
+    project: React.PropTypes.object
+    user: React.PropTypes.object.isRequired
+    notification: React.PropTypes.object.isRequired
+
+  getInitialState: ->
+    discussion: null
+    comment: null
+
+  componentWillMount: ->
+    talkClient.type('discussions').get(@props.notification.source_id).then (discussion) =>
+      @setState {discussion}
+      talkClient.type('comments').get(discussion_id: discussion.id, sort: 'created_at', page_size: 1).then ([comment]) =>
+        @setState {comment}
+
+  render: ->
+    if @state.discussion
+      [owner, name] = @state.discussion.project_slug?.split('/') or []
+      slug = if @state.discussion.project_slug
+        "/projects/#{@state.discussion.project_slug}"
+      else
+        ''
+
+      <div className="talk-started-discussion talk-module">
+        <div>
+          <div className="title">
+            <Link to={"#{slug}/talk/#{@state.discussion.board_id}/#{@state.discussion.id}"} {...@props}>
+              {@props.notification.message}
+            </Link>
+          </div>
+
+          {if @state.comment
+            <Comment
+              data={@state.comment}
+              user={@props.user}
+              project={@props.project} />
+          }
+        </div>
+      </div>
+    else
+      <div className="talk-module">
+        <Loading />
+      </div>

--- a/app/pages/settings/email.cjsx
+++ b/app/pages/settings/email.cjsx
@@ -21,9 +21,10 @@ module.exports = React.createClass
       when 'mentions' then "When I'm mentioned"
       when 'group_mentions' then "When I'm mentioned by group (@admins, @team, etc)"
       when 'messages' then 'When I receive a private message'
+      when 'started_discussions' then "When a discussion is started in a board I'm following"
 
   sortPreferences: (preferences) ->
-    order = ['participating_discussions', 'followed_discussions', 'mentions', 'group_mentions', 'messages']
+    order = ['participating_discussions', 'followed_discussions', 'started_discussions', 'mentions', 'group_mentions', 'messages']
     preferences.sort (a, b) ->
       order.indexOf(a.category) > order.indexOf(b.category)
 

--- a/app/talk/board.cjsx
+++ b/app/talk/board.cjsx
@@ -4,6 +4,7 @@ ReactDOM = require 'react-dom'
 DiscussionPreview = require './discussion-preview'
 talkClient = require '../api/talk'
 CommentBox = require './comment-box'
+FollowBoard = require './follow-board'
 commentValidations = require './lib/comment-validations'
 discussionValidations = require './lib/discussion-validations'
 {getErrors} = require './lib/validations'
@@ -142,6 +143,7 @@ module?.exports = React.createClass
     <div className="talk-board">
       <h1 className="talk-page-header">{board?.title}</h1>
       <p>{board?.description}</p>
+      <FollowBoard user={@props.user} board={board} />
       {if board && @props.user?
         <div className="talk-moderation">
           <Moderation user={@props.user} section={@props.section}>

--- a/app/talk/follow-board.cjsx
+++ b/app/talk/follow-board.cjsx
@@ -1,0 +1,78 @@
+React = require 'react'
+talkClient = require '../api/talk'
+SingleSubmitButton = require '../components/single-submit-button'
+
+module?.exports = React.createClass
+  displayName: 'FollowBoard'
+
+  propTypes:
+    board: React.PropTypes.object.isRequired
+    user: React.PropTypes.object.isRequired
+
+  getInitialState: ->
+    digest: null
+
+  componentWillMount: ->
+    {board} = @props
+    @getSubscriptionFor(board.id) if board
+
+  componentWillReceiveProps: (nextProps) ->
+    boardId = nextProps.board?.id
+    @getPreferences()
+    @getSubscriptionFor(boardId) if boardId and boardId isnt @props.board?.id
+
+  toggle: (e) ->
+    e.preventDefault()
+    if @state.subscription
+      @state.subscription.update(enabled: not @state.subscription.enabled).save().then =>
+        @getSubscriptionFor @props.board.id
+    else
+      talkClient.type('subscriptions').create
+        source_id: @props.board.id
+        source_type: 'Board'
+        category: 'started_discussions'
+      .save().then =>
+        @getSubscriptionFor @props.board.id
+
+  follow: ->
+    talkClient.type('subscriptions').create
+      source_id: @props.board.id
+      source_type: 'Board'
+      category: 'started_discussions'
+    .save().then =>
+      @getSubscriptionFor @props.board.id
+
+  buttonLabel: ->
+    if @state.subscription?.enabled
+      'Unsubscribe'
+    else
+      'Subscribe'
+
+  getPreferences: ->
+    talkClient.type('subscription_preferences').get().then (preferences) =>
+      for preference in preferences
+        @setState(digest: preference.email_digest) if preference.category is 'started_discussions'
+
+  getSubscriptionFor: (id) ->
+    talkClient.type('subscriptions').get
+      source_id: id
+      source_type: 'Board'
+    .then ([subscription]) =>
+      @setState subscription: subscription, loaded: true
+
+  render: ->
+    <div className="talk-board-follow">
+      {if @props.user and @state.loaded
+        <div>
+          <SingleSubmitButton onClick={@toggle}>{@buttonLabel()}</SingleSubmitButton>
+          <p className="description">
+            {if @state.subscription?.enabled
+                "You're receiving notifications because you've subscribed to new discussions in this board"
+              else
+                "Subscribe to receive notifications for new discussions in this board"
+            }{' '}
+            {"(#{ @state.digest } email)" if @state.digest}
+          </p>
+        </div>
+      }
+    </div>

--- a/css/talk.styl
+++ b/css/talk.styl
@@ -746,6 +746,15 @@ COPY_GREY_LIGHT = #afaeae
       @extend .talk .talk-discussion-link .latest-comment-time
       font-size: 0.9em
 
+  .talk-started-discussion
+    .talk-search-result
+      margin: 0
+      padding: 0
+      border: none
+
+      .talk-comment-link
+        display: none
+
   .talk-discussion-preview
     border-bottom: none
     margin: auto

--- a/css/talk.styl
+++ b/css/talk.styl
@@ -251,6 +251,14 @@ COPY_GREY_LIGHT = #afaeae
     .talk-page-header
       text-align: left
 
+    .talk-board-follow
+      margin: 10px auto
+
+      .description
+        display: inline-block
+        margin: auto 10px
+        color: #989898
+
   .talk-board-new-discussion
     @extend .talk-module
     padding: 0px


### PR DESCRIPTION
This allows users to subscribe to new discussions on a board.

### :warning: The API for this is only deployed on staging at the moment :warning: 

We should coordinate deploys before merging.

This is currently staged at http://preview.zooniverse.org/panoptes-front-end/started_discussions-preference/

@srallen, would you mind taking a look?