### PR TITLE
Fix undefined commentsMeta after deleting a comment

### DIFF
--- a/app/talk/discussion.cjsx
+++ b/app/talk/discussion.cjsx
@@ -78,11 +78,19 @@ module?.exports = React.createClass
   setComments: (page = @props.location.query?.page) ->
     @commentsRequest(page)
       .then (comments) =>
-        commentsMeta = comments[0]?.getMeta() ? {}
-        @setState {comments, commentsMeta}, =>
-          if @shouldScrollToBottom and comments.length
-            @scrollToBottomOfDiscussion()
-            @shouldScrollToBottom = false
+        if comments.length
+          commentsMeta = comments[0]?.getMeta() ? {}
+          @setState {comments, commentsMeta}, =>
+            if @shouldScrollToBottom
+              @scrollToBottomOfDiscussion()
+              @shouldScrollToBottom = false
+        else
+          {board, owner, name} = @props.params
+          if (owner and name)
+            @history.pushState(null, "/projects/#{owner}/#{name}/talk/#{board}")
+          else
+            @history.pushState(null, "/talk/#{board}")
+          
 
   setCommentsMeta: (page = @props.location.query?.page) ->
     @commentsRequest(page).then (comments) =>

--- a/app/talk/discussion.cjsx
+++ b/app/talk/discussion.cjsx
@@ -78,7 +78,7 @@ module?.exports = React.createClass
   setComments: (page = @props.location.query?.page) ->
     @commentsRequest(page)
       .then (comments) =>
-        commentsMeta = comments[0]?.getMeta()
+        commentsMeta = comments[0]?.getMeta() ? {}
         @setState {comments, commentsMeta}, =>
           if @shouldScrollToBottom and comments.length
             @scrollToBottomOfDiscussion()
@@ -86,7 +86,7 @@ module?.exports = React.createClass
 
   setCommentsMeta: (page = @props.location.query?.page) ->
     @commentsRequest(page).then (comments) =>
-      commentsMeta = comments[0]?.getMeta()
+      commentsMeta = comments[0]?.getMeta() ? {}
       @setState {commentsMeta}
 
   scrollToBottomOfDiscussion: ->
@@ -303,7 +303,6 @@ module?.exports = React.createClass
       {if discussion and @props.user
         <FollowDiscussion user={@props.user} discussion={discussion} />
       }
-
       <Paginator page={+@state.commentsMeta.page} pageCount={@state.commentsMeta.page_count} />
 
       <div className="talk-list-content">


### PR DESCRIPTION
It was possible to set commentsMeta to undefined after deleting a post, which then prevents the discussion page from re-rendering.
Closes #2171