### PR TITLE
Talk: External image link uses invalid HTML

### DIFF
--- a/app/components/subject-viewer.cjsx
+++ b/app/components/subject-viewer.cjsx
@@ -132,8 +132,8 @@ module.exports = React.createClass
               <CollectionsManagerIcon project={@props.project} subject={@props.subject} user={@props.user} />
             </span>}
           {if type is 'image' and @props.linkToFullImage
-            <a href={src} title="Subject Image" target="_blank">
-              <button type="button"><i className="fa fa-photo" /></button>
+            <a className="button" href={src} aria-label="Subject Image" title="Subject Image" target="zooImage">
+              <i className="fa fa-photo" />
             </a>}
         </span>
       </div>

--- a/css/talk.styl
+++ b/css/talk.styl
@@ -88,6 +88,7 @@ COPY_GREY_LIGHT = #afaeae
     &:hover
       color: MAIN_HIGHLIGHT
 
+  a.button
   button:not(.link-style)
     @extend .standard-button
     @extend .talk-module


### PR DESCRIPTION
Buttons aren't valid content for link elements: just style the link as a button instead.
Set a named link target so external image link only opens one new tab then reuses it.
Add aria-label since the link element has no text content.