### PR TITLE
Add notification of moved tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,8 +65,7 @@
     "stage-branch-with-docker": "./bin/run-through-docker.sh 'npm run-script stage-branch'",
     "stage-with-docker": "./bin/run-through-docker.sh 'npm run-script stage'",
     "start": "./bin/serve.sh",
-    "test": "browserify ./test/runner.coffee --extension .coffee --extension .cjsx --transform coffee-reactify --transform envify --ignore-transform coffeeify | testling \"${TESTLING_ARGS:---pass}\" | tap-spec",
-    "test-mac": "TESTLING_ARGS=\"-x open --new -a Google\\ Chrome --args --incognito\" npm run test"
+    "test": "echo 'Integration tests have moved to the panoptes-client library.'"
   },
   "browserify": {
     "transform": [


### PR DESCRIPTION
The last deploy was mysteriously broken (`process.env.NODE_ENV` was replaced with `"production"` like usual, but the new panoptes-client lib didn't pick it up).

The `npm test` failed, so maybe things got sorta half deployed?

This keeps the tests from failing (they've actually been moved to the panoptes-client lib).

Will investigate running dependencies' tests from the app.