### PR TITLE
Ensure SVG stretches over original subject size when cropping. Fixes #2180

### DIFF
--- a/app/components/frame-viewer.cjsx
+++ b/app/components/frame-viewer.cjsx
@@ -12,14 +12,6 @@ generateRadioRef = (name, subject, frame) =>
 module.exports = React.createClass
   displayName: 'FrameViewer'
 
-  statics:
-    overlayStyle:
-      height: '100%'
-      left: 0
-      position: 'absolute'
-      top: 0
-      width: '100%'
-
   getDefaultProps: ->
     subject: null
     frame: 0

--- a/app/components/subject-viewer.cjsx
+++ b/app/components/subject-viewer.cjsx
@@ -23,14 +23,6 @@ CONTAINER_STYLE = display: 'flex', flexWrap: 'wrap', position: 'relative'
 module.exports = React.createClass
   displayName: 'SubjectViewer'
 
-  statics:
-    overlayStyle:
-      height: '100%'
-      left: 0
-      position: 'absolute'
-      top: 0
-      width: '100%'
-
   getDefaultProps: ->
     subject: null
     user: null

--- a/css/frame-annotator.styl
+++ b/css/frame-annotator.styl
@@ -6,5 +6,5 @@
     position: absolute
     left: 0
     top: 0
-    right: 0
-    bottom: 0
+    width: 100%
+    height: 100%


### PR DESCRIPTION
When I did the multi frame stuff, I migrated the SVG-stretching styles from the component to CSS, and absentmindedly switched from `top: 0; left: 0; width: 100%; height: 100%` to `top: 0; left: 0; bottom: 0; right: 0;`. I had no idea there was any difference, but you learn something new every day.