### PR TITLE
Better handling of empty field guides

### DIFF
--- a/app/components/field-guide.cjsx
+++ b/app/components/field-guide.cjsx
@@ -36,7 +36,7 @@ module.exports = React.createClass
   renderItem: ({icon, title, content, items}) ->
     <div className="field-guide-item">
       <header>
-        {if icon?
+        {if @props.icons[icon]?
           <div className="field-guide-item-icon-container">
             <CroppedImage className="field-guide-item-icon" src={@props.icons[icon].src} aspectRatio={1} width="6em" height="6em" />
           </div>}

--- a/app/pages/lab/field-guide/actions.js
+++ b/app/pages/lab/field-guide/actions.js
@@ -5,8 +5,8 @@ var projects = apiClient.type('projects');
 var guides = apiClient.type('field_guides');
 
 var DEFAULT_ITEM = {
-  title: 'Untitled',
-  content: 'Here’s everything you need to know about the great **Untitled**...'
+  title: 'An example',
+  content: 'Here’s everything you need to know about the great **Example**...'
 };
 
 var actions = {

--- a/app/pages/lab/field-guide/article-list.cjsx
+++ b/app/pages/lab/field-guide/article-list.cjsx
@@ -26,7 +26,12 @@ ArticleList = React.createClass
 
   render: ->
     <div>
-      <DragReorderable tag="ul" className="field-guide-editor-article-list" items={@props.articles} render={@renderArticle} onChange={@props.onReorder} />
+      {if @props.articles.length is 0
+        <div>
+          <small>No field guide entries</small>
+        </div>
+      else
+        <DragReorderable tag="ul" className="field-guide-editor-article-list" items={@props.articles} render={@renderArticle} onChange={@props.onReorder} />}
       <p style={textAlign: 'center'}>
         <button type="button" className="standard-button" onClick={@props.onAddArticle}>Add an entry</button>
       </p>

--- a/app/pages/lab/field-guide/article-list.cjsx
+++ b/app/pages/lab/field-guide/article-list.cjsx
@@ -8,7 +8,6 @@ ArticleList = React.createClass
     icons: {}
     onReorder: ->
     onSelectArticle: ->
-    onAddArticle: ->
     onRemoveArticle: ->
 
   renderArticle: (article, i) ->
@@ -25,16 +24,6 @@ ArticleList = React.createClass
     </li>
 
   render: ->
-    <div>
-      {if @props.articles.length is 0
-        <div>
-          <small>No field guide entries</small>
-        </div>
-      else
-        <DragReorderable tag="ul" className="field-guide-editor-article-list" items={@props.articles} render={@renderArticle} onChange={@props.onReorder} />}
-      <p style={textAlign: 'center'}>
-        <button type="button" className="standard-button" onClick={@props.onAddArticle}>Add an entry</button>
-      </p>
-    </div>
+    <DragReorderable tag="ul" className="field-guide-editor-article-list" items={@props.articles} render={@renderArticle} onChange={@props.onReorder} />
 
 module.exports = ArticleList

--- a/app/pages/lab/field-guide/index.cjsx
+++ b/app/pages/lab/field-guide/index.cjsx
@@ -118,6 +118,9 @@ FieldGuideEditor = React.createClass
           onRemoveArticle={@props.actions.removeItem.bind null, @state.guide.id}
           onSelectArticle={@editArticle}
         />
+        <p style={textAlign: 'center'}>
+          <button type="button" className="standard-button" onClick={@createArticle}>Add an entry</button>
+        </p>
       </div>
 
       <div className="form-help">

--- a/app/pages/lab/field-guide/index.cjsx
+++ b/app/pages/lab/field-guide/index.cjsx
@@ -62,7 +62,14 @@ FieldGuideEditor = React.createClass
       .then =>
         @loadGuide @props.project
 
+  deleteGuide: (guide) ->
+    if guide.items.length is 0 or confirm "Really delete this field guide and its #{guide.items.length} items?"
+      @props.actions.deleteGuide guide.id
+        .then =>
+          @loadGuide @props.project
+
   createArticle: ->
+    # TODO: Allow creation of article before writing to server.
     @props.actions.appendItem @state.guide.id
       .then =>
         @editArticle @state.guide.items.length - 1
@@ -105,19 +112,29 @@ FieldGuideEditor = React.createClass
         </p>}
     </div>
 
+  renderEmpty: ->
+    <p className="form-help">
+      Nothing in this guide.{' '}
+      <small>
+        <button type="button" className="minor-button" onClick={@deleteGuide.bind this, @state.guide}>Delete it</button>
+      </small>
+    </p>
+
   renderEditor: ->
     window.editingGuide = @state.guide
 
     <div className="field-guide-editor columns-container">
       <div>
-        <ArticleList
-          articles={@state.guide.items}
-          icons={@state.icons}
-          onReorder={@props.actions.replaceItems.bind null, @state.guide.id}
-          onAddArticle={@createArticle}
-          onRemoveArticle={@props.actions.removeItem.bind null, @state.guide.id}
-          onSelectArticle={@editArticle}
-        />
+        {if @state.guide.items.length is 0
+          @renderEmpty()
+        else
+          <ArticleList
+            articles={@state.guide.items}
+            icons={@state.icons}
+            onReorder={@props.actions.replaceItems.bind null, @state.guide.id}
+            onRemoveArticle={@props.actions.removeItem.bind null, @state.guide.id}
+            onSelectArticle={@editArticle}
+          />}
         <p style={textAlign: 'center'}>
           <button type="button" className="standard-button" onClick={@createArticle}>Add an entry</button>
         </p>

--- a/app/pages/lab/field-guide/index.cjsx
+++ b/app/pages/lab/field-guide/index.cjsx
@@ -34,8 +34,9 @@ FieldGuideEditor = React.createClass
     apiClient.type('field_guides').get project_id: project.id
       .then ([guide]) =>
         @listenTo guide
-        @fetchIcons guide
         @setState {guide}
+        if guide?
+          @fetchIcons guide
 
   listenTo: (guide) ->
     @_forceUpdate ?= @forceUpdate.bind this

--- a/app/pages/lab/field-guide/index.cjsx
+++ b/app/pages/lab/field-guide/index.cjsx
@@ -19,6 +19,7 @@ FieldGuideEditor = React.createClass
     actions: actions
 
   getInitialState: ->
+    loading: false
     guide: null
     icons: {}
     editing: null
@@ -31,10 +32,13 @@ FieldGuideEditor = React.createClass
       @loadGuide nextProps.project
 
   loadGuide: (project) ->
+    @setState loading: true
     apiClient.type('field_guides').get project_id: project.id
       .then ([guide]) =>
         @listenTo guide
-        @setState {guide}
+        @setState
+          loading: false
+          guide: guide
         if guide?
           @fetchIcons guide
 
@@ -92,20 +96,18 @@ FieldGuideEditor = React.createClass
 
       {if @state.guide?
         @renderEditor()
+      else if @state.loading
+        <p className="form-help">Loading field guide...</p>
       else
-        @renderCreator()}
-    </div>
-
-  renderCreator: ->
-    <div>
-      <p>
-        This project doesn’t have a field guide yet.{' '}
-        <button type="button" onClick={@createGuide}>Create one!</button>
-      </p>
+        <p>
+          This project doesn’t have a field guide yet.{' '}
+          <button type="button" onClick={@createGuide}>Create one!</button>
+        </p>}
     </div>
 
   renderEditor: ->
     window.editingGuide = @state.guide
+
     <div className="field-guide-editor" className="columns-container">
       <div>
         <ArticleList

--- a/app/pages/lab/field-guide/index.cjsx
+++ b/app/pages/lab/field-guide/index.cjsx
@@ -52,6 +52,11 @@ FieldGuideEditor = React.createClass
           icons[image.id] = image
         @setState {icons}
 
+  createGuide: ->
+    @props.actions.createGuide @props.project.id
+      .then =>
+        @loadGuide @props.project
+
   createArticle: ->
     @props.actions.appendItem @state.guide.id
       .then =>
@@ -94,7 +99,7 @@ FieldGuideEditor = React.createClass
     <div>
       <p>
         This project doesn’t have a field guide yet.{' '}
-        <button type="button" onClick={@props.actions.createGuide.bind null, @props.project.id}>Create one!</button>
+        <button type="button" onClick={@createGuide}>Create one!</button>
       </p>
     </div>
 

--- a/app/pages/lab/field-guide/index.cjsx
+++ b/app/pages/lab/field-guide/index.cjsx
@@ -108,7 +108,7 @@ FieldGuideEditor = React.createClass
   renderEditor: ->
     window.editingGuide = @state.guide
 
-    <div className="field-guide-editor" className="columns-container">
+    <div className="field-guide-editor columns-container">
       <div>
         <ArticleList
           articles={@state.guide.items}

--- a/app/pages/project/potential-field-guide.cjsx
+++ b/app/pages/project/potential-field-guide.cjsx
@@ -37,7 +37,7 @@ module.exports = React.createClass
     @setState revealed: not @state.revealed
 
   render: ->
-    if @state.guide?
+    if @state.guide? and @state.guide.items.length isnt 0
       <Pullout className="field-guide-pullout" side="right" open={@state.revealed}>
         <button type="button" className="field-guide-pullout-toggle" onClick={@toggleFieldGuide}>
           <strong>Field guide</strong>

--- a/css/field-guide-editor.styl
+++ b/css/field-guide-editor.styl
@@ -1,13 +1,13 @@
 .field-guide-editor
   [draggable]
+    cursor: move
     cursor: -moz-grab
     cursor: -webkit-grab
-    cursor: move
 
     [data-drag-reorderable-dragging] &
+      cursor: move
       cursor: -moz-grabbing
       cursor: -webkit-grabbing
-      cursor: move
 
 .field-guide-editor-article-list
   border: 1px solid rgba(gray, 0.3)


### PR DESCRIPTION
To merge after #2148.

This prevents existing field guides from showing up if they have no items and allows fully deleting a field guide with no items.

I'm not sure the user should have to think about the difference between having a field guide with no items  and not having a field guide at all. Might be worth revisiting in the future.