### PR TITLE
pan & zoom feature for images

### DIFF
--- a/app/classifier/frame-annotator.cjsx
+++ b/app/classifier/frame-annotator.cjsx
@@ -135,7 +135,7 @@ module.exports = React.createClass
           <rect ref="sizeRect" width={@props.naturalWidth} height={@props.naturalHeight} fill="rgba(0, 0, 0, 0.01)" fillOpacity="0.01" stroke="none" />
           {if type is 'image'
             <Draggable onDrag={@props.panByDrag} disabled={@props.disabled}>
-              <SVGImage src={src} width={@props.naturalWidth} height={@props.naturalHeight} />
+              <SVGImage className={"pan-active" if @props.panEnabled} src={src} width={@props.naturalWidth} height={@props.naturalHeight} />
             </Draggable>
           }
 

--- a/app/classifier/frame-annotator.cjsx
+++ b/app/classifier/frame-annotator.cjsx
@@ -133,10 +133,11 @@ module.exports = React.createClass
           <BeforeSubject {...hookProps} />}
         <svg style=svgStyle viewBox={createdViewBox} {...svgProps}>
           <rect ref="sizeRect" width={@props.naturalWidth} height={@props.naturalHeight} fill="rgba(0, 0, 0, 0.01)" fillOpacity="0.01" stroke="none" />
-
           {if type is 'image'
-            <SVGImage src={src} width={@props.naturalWidth} height={@props.naturalHeight} />}
-
+            <Draggable onDrag={@props.panByDrag} disabled={@props.disabled}>
+              <SVGImage src={src} width={@props.naturalWidth} height={@props.naturalHeight} />
+            </Draggable>
+          }
           {if InsideSubject?
             <InsideSubject {...hookProps} />}
 

--- a/app/classifier/frame-annotator.cjsx
+++ b/app/classifier/frame-annotator.cjsx
@@ -138,7 +138,8 @@ module.exports = React.createClass
               <SVGImage src={src} width={@props.naturalWidth} height={@props.naturalHeight} />
             </Draggable>
           }
-          {if InsideSubject?
+
+          {if InsideSubject? && !@props.panEnabled
             <InsideSubject {...hookProps} />}
 
           {for anyTaskName, {PersistInsideSubject} of tasks when PersistInsideSubject?

--- a/app/classifier/frame-annotator.cjsx
+++ b/app/classifier/frame-annotator.cjsx
@@ -90,41 +90,12 @@ module.exports = React.createClass
   toggleWarning: ->
     @setState showWarning: not @state.showWarning
 
-  zoom: (change) ->
-    newNaturalWidth = @state.naturalWidth * change;
-    newNaturalHeight = @state.naturalHeight * change;
-    
-    newNaturalX = @state.naturalX - (newNaturalWidth - @state.naturalWidth)/2;
-    newNaturalY = @state.naturalY - (newNaturalHeight - @state.naturalHeight)/2;
-    
-    @setState
-      naturalWidth: newNaturalWidth, 
-      naturalHeight: newNaturalHeight,
-      naturalX: newNaturalX,
-      naturalY:newNaturalY
-
-  zoomReset: ->
-    @setState
-      naturalWidth: @props.naturalWidth, 
-      naturalHeight: @props.naturalHeight,
-      naturalX: 0,
-      naturalY: 0
-
-  panHorizontal:(direction) ->
-    return if this.state.naturalX == 0 || this.state.naturalY == 0   
-    @setState
-      naturalX: @state.naturalX * direction
-
-  panVertical:(direction)->
-    @setState
-      naturalY: @state.naturalY * direction
-
   render: ->    
     taskDescription = @props.workflow.tasks[@props.annotation?.task]
     TaskComponent = tasks[taskDescription?.type]
     {type, format, src} = getSubjectLocation @props.subject, @props.frame
     
-    createdViewBox = "#{@state.naturalX} #{@state.naturalY} #{@state.naturalWidth} #{@state.naturalHeight}"
+    createdViewBox = "#{@props.viewBoxDimensions.x} #{@props.viewBoxDimensions.y} #{@props.viewBoxDimensions.width} #{@props.viewBoxDimensions.height}"
     
     svgStyle = {}
     if type is 'image' and not @props.loading
@@ -173,15 +144,6 @@ module.exports = React.createClass
             <PersistInsideSubject key={anyTaskName} {...hookProps} />}
         </svg>
         {@props.children}
-        <span>
-          <button className={ "fa fa-arrow-circle-left" + if @state.naturalHeight == @props.naturalHeight then " disabled" else "" } onClick={ @panHorizontal.bind(this, .7) }> </button>
-          <button className={ "fa fa-arrow-circle-up" + if @state.naturalHeight == @props.naturalHeight then " disabled" else "" } onClick={@panVertical.bind(this, .7)}> </button>
-          <button className={ "fa fa-arrow-circle-down" + if @state.naturalWidth == @props.naturalWidth then " disabled" else ""} onClick={@panVertical.bind(this, 1.3)}> </button>
-          <button className={ "fa fa-arrow-circle-right" + if @state.naturalX == 0 then " disabled" else "" } onClick={@panHorizontal.bind(this, 1.3)}> </button>
-          <button className="zoom-out fa fa-minus-circle" onClick={ @zoom.bind(this, 1.1) }></button>
-          <button className="zoom-in fa fa-plus-circle" onClick={ @zoom.bind(this,.9) } ></button>
-          <button className="reset" onClick={ this.zoomReset } >Reset</button>
-        </span>
         {if @state.alreadySeen
           <button type="button" className="warning-banner" onClick={@toggleWarning}>
             Already seen!

--- a/app/classifier/frame-annotator.cjsx
+++ b/app/classifier/frame-annotator.cjsx
@@ -23,10 +23,6 @@ module.exports = React.createClass
     onChange: Function.prototype
 
   getInitialState: ->
-    naturalWidth: @props.naturalWidth
-    naturalHeight: @props.naturalHeight
-    naturalX: 0,
-    naturalY: 0
     showWarning: false
     sizeRect: null
     alreadySeen: false

--- a/app/classifier/frame-annotator.cjsx
+++ b/app/classifier/frame-annotator.cjsx
@@ -23,8 +23,11 @@ module.exports = React.createClass
     onChange: Function.prototype
 
   getInitialState: ->
-    naturalWidth: 0
-    naturalHeight: 0
+    console.log "--> getInitialState::@props.naturalWidth", @props.naturalWidth
+    naturalWidth: @props.naturalWidth
+    naturalHeight: @props.naturalHeight
+    naturalX: 0,
+    naturalY: 0
     showWarning: false
     sizeRect: null
     alreadySeen: false
@@ -47,6 +50,10 @@ module.exports = React.createClass
   componentWillReceiveProps: (nextProps) ->
     if nextProps.annotation isnt @props.annotation
       @handleAnnotationChange @props.annotation, nextProps.annotation
+    @setState
+      naturalWidth: nextProps.naturalWidth
+      naturalHeight: nextProps.naturalHeight
+
 
   handleAnnotationChange: (oldAnnotation, currentAnnotation) ->
     if oldAnnotation?
@@ -84,11 +91,42 @@ module.exports = React.createClass
   toggleWarning: ->
     @setState showWarning: not @state.showWarning
 
-  render: ->
+  zoom: (change) ->
+    newNaturalWidth = @state.naturalWidth * change;
+    newNaturalHeight = @state.naturalHeight * change;
+    
+    newNaturalX = @state.naturalX - (newNaturalWidth - @state.naturalWidth)/2;
+    newNaturalY = @state.naturalY - (newNaturalHeight - @state.naturalHeight)/2;
+    
+    @setState
+      naturalWidth: newNaturalWidth, 
+      naturalHeight: newNaturalHeight,
+      naturalX: newNaturalX,
+      naturalY:newNaturalY
+
+  zoomReset: ->
+    @setState
+      naturalWidth: @props.naturalWidth, 
+      naturalHeight: @props.naturalHeight,
+      naturalX: 0,
+      naturalY: 0
+
+  panHorizontal:(direction) ->
+    return if this.state.naturalX == 0 || this.state.naturalY == 0   
+    @setState
+      naturalX: @state.naturalX * direction
+
+  panVertical:(direction)->
+    @setState
+      naturalY: @state.naturalY * direction
+
+  render: ->    
     taskDescription = @props.workflow.tasks[@props.annotation?.task]
     TaskComponent = tasks[taskDescription?.type]
     {type, format, src} = getSubjectLocation @props.subject, @props.frame
-
+    
+    createdViewBox = "#{@state.naturalX} #{@state.naturalY} #{@state.naturalWidth} #{@state.naturalHeight}"
+    
     svgStyle = {}
     if type is 'image' and not @props.loading
       # Images are rendered again within the SVG itself.
@@ -123,8 +161,7 @@ module.exports = React.createClass
       <div className="subject-area">
         {if BeforeSubject?
           <BeforeSubject {...hookProps} />}
-
-        <svg className="subject" style=svgStyle viewBox="0 0 #{@props.naturalWidth} #{@props.naturalHeight}" {...svgProps}>
+        <svg style=svgStyle viewBox={createdViewBox} {...svgProps}>
           <rect ref="sizeRect" width={@props.naturalWidth} height={@props.naturalHeight} fill="rgba(0, 0, 0, 0.01)" fillOpacity="0.01" stroke="none" />
 
           {if type is 'image'
@@ -137,7 +174,15 @@ module.exports = React.createClass
             <PersistInsideSubject key={anyTaskName} {...hookProps} />}
         </svg>
         {@props.children}
-
+        <span>
+          <button className="pan-left fa fa-arrow-circle-left" onClick={ @panHorizontal.bind(this, .7) }> </button>
+          <button className="pan-left fa fa-arrow-circle-up" onClick={@panVertical.bind(this, .7)}> </button>
+          <button className="pan-left fa fa-arrow-circle-down" onClick={@panVertical.bind(this, 1.3)}> </button>
+          <button className="pan-left fa fa-arrow-circle-right" onClick={@panHorizontal.bind(this, 1.3)}> </button>
+          <button className="zoom-out" onClick={ @zoom.bind(this, 1.1) }>-</button>
+          <button className="zoom-in" onClick={ @zoom.bind(this,.9) } >+</button>
+          <button className="reset" onClick={ this.zoomReset } >Reset</button>
+        </span>
         {if @state.alreadySeen
           <button type="button" className="warning-banner" onClick={@toggleWarning}>
             Already seen!

--- a/app/classifier/frame-annotator.cjsx
+++ b/app/classifier/frame-annotator.cjsx
@@ -23,7 +23,6 @@ module.exports = React.createClass
     onChange: Function.prototype
 
   getInitialState: ->
-    console.log "--> getInitialState::@props.naturalWidth", @props.naturalWidth
     naturalWidth: @props.naturalWidth
     naturalHeight: @props.naturalHeight
     naturalX: 0,
@@ -175,12 +174,12 @@ module.exports = React.createClass
         </svg>
         {@props.children}
         <span>
-          <button className="pan-left fa fa-arrow-circle-left" onClick={ @panHorizontal.bind(this, .7) }> </button>
-          <button className="pan-left fa fa-arrow-circle-up" onClick={@panVertical.bind(this, .7)}> </button>
-          <button className="pan-left fa fa-arrow-circle-down" onClick={@panVertical.bind(this, 1.3)}> </button>
-          <button className="pan-left fa fa-arrow-circle-right" onClick={@panHorizontal.bind(this, 1.3)}> </button>
-          <button className="zoom-out" onClick={ @zoom.bind(this, 1.1) }>-</button>
-          <button className="zoom-in" onClick={ @zoom.bind(this,.9) } >+</button>
+          <button className={ "fa fa-arrow-circle-left" + if @state.naturalHeight == @props.naturalHeight then " disabled" else "" } onClick={ @panHorizontal.bind(this, .7) }> </button>
+          <button className={ "fa fa-arrow-circle-up" + if @state.naturalHeight == @props.naturalHeight then " disabled" else "" } onClick={@panVertical.bind(this, .7)}> </button>
+          <button className={ "fa fa-arrow-circle-down" + if @state.naturalWidth == @props.naturalWidth then " disabled" else ""} onClick={@panVertical.bind(this, 1.3)}> </button>
+          <button className={ "fa fa-arrow-circle-right" + if @state.naturalX == 0 then " disabled" else "" } onClick={@panHorizontal.bind(this, 1.3)}> </button>
+          <button className="zoom-out fa fa-minus-circle" onClick={ @zoom.bind(this, 1.1) }></button>
+          <button className="zoom-in fa fa-plus-circle" onClick={ @zoom.bind(this,.9) } ></button>
           <button className="reset" onClick={ this.zoomReset } >Reset</button>
         </span>
         {if @state.alreadySeen

--- a/app/components/frame-viewer.cjsx
+++ b/app/components/frame-viewer.cjsx
@@ -48,6 +48,7 @@ module.exports = React.createClass
     subject = @props.subject
     frame = @props.frame
     {type, format, src} = getSubjectLocation @props.subject, @props.frame
+    console.log "TYPE", type
     FrameWrapper = @props.frameWrapper
     frameDisplay = switch type
       when 'image'
@@ -58,12 +59,6 @@ module.exports = React.createClass
             <div className="loading-cover" style={@constructor.overlayStyle} >
               <LoadingIndicator />
             </div>}
-          <div>
-            <button className={if @state.panEnabled then "toggle fa fa-arrows active" else "toggle fa fa-arrows"} title={"pan"} onClick={@togglePan} ></button>
-            <button className="zoom-out fa fa-minus" onClick={ @zoom.bind(this, 1.1 ) } />
-            <button className="zoom-in fa fa-plus" onClick={ @zoom.bind(this, .9) } />
-            <button className="reset" onClick={ this.zoomReset } >Reset</button>
-          </div>
         </div>
       when 'video'
         <div className="subject-video-frame">
@@ -103,9 +98,19 @@ module.exports = React.createClass
         </div>
 
     if FrameWrapper
-      <FrameWrapper frame={frame} naturalWidth={@state.frameDimensions?.width or 0} naturalHeight={@state.frameDimensions?.height or 0} panByDrag={@panByDrag} viewBoxDimensions={@state.viewBoxDimensions or "0 0 0 0"} workflow={@props.workflow} subject={@props.subject} classification={@props.classification} annotation={@props.annotation} loading={@state.loading} onChange={@props.onChange} panEnabled={@state.panEnabled} >
-        {frameDisplay}
-      </FrameWrapper>
+      <div>
+        <FrameWrapper frame={frame} naturalWidth={@state.frameDimensions?.width or 0} naturalHeight={@state.frameDimensions?.height or 0} panByDrag={@panByDrag} viewBoxDimensions={@state.viewBoxDimensions or "0 0 0 0"} workflow={@props.workflow} subject={@props.subject} classification={@props.classification} annotation={@props.annotation} loading={@state.loading} onChange={@props.onChange} panEnabled={@state.panEnabled} >
+          {frameDisplay}
+        </FrameWrapper>
+        <div>
+          <button className={if @state.panEnabled then "toggle fa fa-arrows active" else "toggle fa fa-arrows"} title={"pan"} onClick={@togglePan} ></button>
+          <button className="zoom-out fa fa-minus" onClick={ @zoom.bind(this, 1.1 ) } />
+          <button className="zoom-in fa fa-plus" onClick={ @zoom.bind(this, .9) } />
+          <button className="reset" onClick={ this.zoomReset } >Reset</button>
+        </div>
+      </div>
+
+
     else
       frameDisplay
 

--- a/app/components/frame-viewer.cjsx
+++ b/app/components/frame-viewer.cjsx
@@ -212,23 +212,35 @@ module.exports = React.createClass
     keypress = e.which
     switch keypress
       # left
-      when 37 then @panHorizontal( .7)
+      when 37
+        e.preventDefault()
+        @panHorizontal(-20)
       # up
-      when 38 then @panVertical(1.3)
+      when 38 
+        e.preventDefault()
+        @panVertical(-20) 
       # right
-      when 39 then @panHorizontal(1.3)
+      when 39 
+        e.preventDefault()
+        @panHorizontal(20) 
       # down
-      when 40 then @panVertical(.7)
+      when 40 
+        e.preventDefault()
+        @panVertical(20) 
       # zoom out
-      when 187 then @zoom(1.1)
+      when 187 
+        e.preventDefault()
+        @zoom(.9) 
       # zoom in 
-      when 189 then @zoom(.9)
+      when 189 
+        e.preventDefault()
+        @zoom(1.1) 
 
 
   panHorizontal:(direction) ->
     @setState
       viewBoxDimensions:
-        x: @state.viewBoxDimensions.x * direction
+        x: @state.viewBoxDimensions.x + direction
         y: @state.viewBoxDimensions.y
         width: @state.viewBoxDimensions.width
         height: @state.viewBoxDimensions.height
@@ -237,6 +249,6 @@ module.exports = React.createClass
     @setState
       viewBoxDimensions:
         x: @state.viewBoxDimensions.x 
-        y: @state.viewBoxDimensions.y * direction
+        y: @state.viewBoxDimensions.y + direction
         width: @state.viewBoxDimensions.width
         height: @state.viewBoxDimensions.height

--- a/app/components/frame-viewer.cjsx
+++ b/app/components/frame-viewer.cjsx
@@ -103,7 +103,7 @@ module.exports = React.createClass
         </div>
 
     if FrameWrapper
-      <FrameWrapper frame={frame} naturalWidth={@state.frameDimensions?.width or 0} naturalHeight={@state.frameDimensions?.height or 0} panByDrag={@panByDrag} viewBoxDimensions={@state.viewBoxDimensions or "0 0 0 0"} workflow={@props.workflow} subject={@props.subject} classification={@props.classification} annotation={@props.annotation} loading={@state.loading} onChange={@props.onChange}>
+      <FrameWrapper frame={frame} naturalWidth={@state.frameDimensions?.width or 0} naturalHeight={@state.frameDimensions?.height or 0} panByDrag={@panByDrag} viewBoxDimensions={@state.viewBoxDimensions or "0 0 0 0"} workflow={@props.workflow} subject={@props.subject} classification={@props.classification} annotation={@props.annotation} loading={@state.loading} onChange={@props.onChange} panEnabled={@state.panEnabled} >
         {frameDisplay}
       </FrameWrapper>
     else

--- a/app/components/frame-viewer.cjsx
+++ b/app/components/frame-viewer.cjsx
@@ -39,16 +39,13 @@ module.exports = React.createClass
     @refs.videoScrubber?.value = 0
     addEventListener "keydown", @frameKeyPan
 
-
   componentDidUpdate: ->
     @refs.videoPlayer?.playbackRate = @state.playbackRate
-
 
   render: () ->
     subject = @props.subject
     frame = @props.frame
     {type, format, src} = getSubjectLocation @props.subject, @props.frame
-    console.log "TYPE", type
     FrameWrapper = @props.frameWrapper
     frameDisplay = switch type
       when 'image'

--- a/app/components/frame-viewer.cjsx
+++ b/app/components/frame-viewer.cjsx
@@ -58,12 +58,12 @@ module.exports = React.createClass
             <div className="loading-cover" style={@constructor.overlayStyle} >
               <LoadingIndicator />
             </div>}
-          <span>
-            <button className={if @state.panEnabled then "fa fa-arrows" else "fa fa-pencil"} onClick={@togglePan}/>
+          <div>
+            <button className={if @state.panEnabled then "toggle fa fa-arrows active" else "toggle fa fa-arrows"} title={"pan"} onClick={@togglePan} ></button>
             <button className="zoom-out fa fa-minus" onClick={ @zoom.bind(this, 1.1 ) } />
             <button className="zoom-in fa fa-plus" onClick={ @zoom.bind(this, .9) } />
             <button className="reset" onClick={ this.zoomReset } >Reset</button>
-          </span>
+          </div>
         </div>
       when 'video'
         <div className="subject-video-frame">

--- a/app/components/frame-viewer.cjsx
+++ b/app/components/frame-viewer.cjsx
@@ -102,12 +102,14 @@ module.exports = React.createClass
         <FrameWrapper frame={frame} naturalWidth={@state.frameDimensions?.width or 0} naturalHeight={@state.frameDimensions?.height or 0} panByDrag={@panByDrag} viewBoxDimensions={@state.viewBoxDimensions or "0 0 0 0"} workflow={@props.workflow} subject={@props.subject} classification={@props.classification} annotation={@props.annotation} loading={@state.loading} onChange={@props.onChange} panEnabled={@state.panEnabled} >
           {frameDisplay}
         </FrameWrapper>
-        <div>
-          <button className={if @state.panEnabled then "toggle fa fa-arrows active" else "toggle fa fa-arrows"} title={"pan"} onClick={@togglePan} ></button>
-          <button className="zoom-out fa fa-minus" onClick={ @zoom.bind(this, 1.1 ) } />
-          <button className="zoom-in fa fa-plus" onClick={ @zoom.bind(this, .9) } />
-          <button className="reset" onClick={ this.zoomReset } >Reset</button>
-        </div>
+        {if ( @props.project? &&'pan and zoom' in @props.project?.experimental_tools) || window.location.pathname == "/dev/classifier"
+          <div>
+            <button className={if @state.panEnabled then "toggle fa fa-arrows active" else "toggle fa fa-arrows"} title={"pan"} onClick={@togglePan} ></button>
+            <button className="zoom-out fa fa-minus" onClick={ @zoom.bind(this, 1.1 ) } />
+            <button className="zoom-in fa fa-plus" onClick={ @zoom.bind(this, .9) } />
+            <button className="reset" onClick={ this.zoomReset } >Reset</button>
+          </div>}
+        
       </div>
 
 

--- a/app/components/frame-viewer.cjsx
+++ b/app/components/frame-viewer.cjsx
@@ -102,7 +102,7 @@ module.exports = React.createClass
         <FrameWrapper frame={frame} naturalWidth={@state.frameDimensions?.width or 0} naturalHeight={@state.frameDimensions?.height or 0} panByDrag={@panByDrag} viewBoxDimensions={@state.viewBoxDimensions or "0 0 0 0"} workflow={@props.workflow} subject={@props.subject} classification={@props.classification} annotation={@props.annotation} loading={@state.loading} onChange={@props.onChange} panEnabled={@state.panEnabled} >
           {frameDisplay}
         </FrameWrapper>
-        {if ( @props.project? &&'pan and zoom' in @props.project?.experimental_tools) || window.location.pathname == "/dev/classifier"
+        {if ( @props.project? &&'pan and zoom' in @props.project?.experimental_tools)
           <div>
             <button className={if @state.panEnabled then "toggle fa fa-arrows active" else "toggle fa fa-arrows"} title={"pan"} onClick={@togglePan} ></button>
             <button className="zoom-out fa fa-minus" onClick={ @zoom.bind(this, 1.1 ) } />

--- a/app/components/frame-viewer.cjsx
+++ b/app/components/frame-viewer.cjsx
@@ -99,9 +99,10 @@ module.exports = React.createClass
         <FrameWrapper frame={frame} naturalWidth={@state.frameDimensions?.width or 0} naturalHeight={@state.frameDimensions?.height or 0} panByDrag={@panByDrag} viewBoxDimensions={@state.viewBoxDimensions or "0 0 0 0"} workflow={@props.workflow} subject={@props.subject} classification={@props.classification} annotation={@props.annotation} loading={@state.loading} onChange={@props.onChange} panEnabled={@state.panEnabled} >
           {frameDisplay}
         </FrameWrapper>
-        {if ( @props.project? &&'pan and zoom' in @props.project?.experimental_tools)
+        {if ( @props.project? && 'pan and zoom' in @props.project?.experimental_tools)
           <div>
-            <button className={if @state.panEnabled then "toggle fa fa-arrows active" else "toggle fa fa-arrows"} title={"pan"} onClick={@togglePan} ></button>
+            <button className={"fa fa-mouse-pointer"} />
+            <button className={if @state.panEnabled then "toggle fa fa-arrows active" else "toggle fa fa-mouse-pointer"} title={"pan"} onClick={@togglePan} ></button>
             <button className="zoom-out fa fa-minus" onClick={ @zoom.bind(this, 1.1 ) } />
             <button className="zoom-in fa fa-plus" onClick={ @zoom.bind(this, .9) } />
             <button className="reset" onClick={ this.zoomReset } >Reset</button>

--- a/app/components/frame-viewer.cjsx
+++ b/app/components/frame-viewer.cjsx
@@ -104,23 +104,23 @@ module.exports = React.createClass
         </FrameWrapper>
         {if ( @props.project? && 'pan and zoom' in @props.project?.experimental_tools)
           <div className="pan-zoom-controls" >
-            <span className="draw-pan-toggle" >
-              <span onClick={@togglePan} className={if @state.panEnabled then "" else "active"} >
+            <div className="draw-pan-toggle" >
+              <div onClick={@togglePan} className={if @state.panEnabled then "" else "active"} >
                 <button title={"draw"} className={"fa fa-mouse-pointer"} title={"annotate"} onClick={@togglePanOff}/>
-              </span>
-              <span className={if @state.panEnabled then "active" else ""}>
+              </div>
+              <div className={if @state.panEnabled then "active" else ""}>
                 <button title={"pan"} className={"fa fa-arrows"} title={"pan"} onClick={@togglePanOn}/>
-              </span>
-            </span>
-            <span>
+              </div>
+            </div>
+            <div>
               <button title={"zoom out"} className="zoom-out fa fa-minus" onClick={ @zoom.bind(this, 1.1 ) } />
-            </span>
-            <span>
+            </div>
+            <div>
               <button title={"zoom in"} className="zoom-in fa fa-plus" onMouseDown={@zoom.bind(this, .9)} onMouseUp={@toggleZoom} />
-            </span>
-            <span>
+            </div>
+            <div>
               <button title={"rest zoom levels"} className="reset fa fa-refresh" onClick={ this.zoomReset } ></button>
-            </span>
+            </div>
           </div>}
         
       </div>
@@ -233,7 +233,7 @@ module.exports = React.createClass
 
   panByDrag: (e, d) ->
     return if @state.panEnabled == false
-    
+
     maximumX = (@state.frameDimensions.width - @state.viewBoxDimensions.width) + 20
     minumumX = -20
     changedX = @state.viewBoxDimensions.x -= d.x
@@ -270,11 +270,11 @@ module.exports = React.createClass
         e.preventDefault()
         @panVertical(20) 
       # zoom out
-      when 187 #61
+      when 187
         e.preventDefault()
         @zoom(.9) 
       # zoom in 
-      when 189 #45
+      when 189
         @setState zooming: true
         e.preventDefault()
         @zoom(1.1) 

--- a/app/components/frame-viewer.cjsx
+++ b/app/components/frame-viewer.cjsx
@@ -101,7 +101,6 @@ module.exports = React.createClass
         </FrameWrapper>
         {if ( @props.project? && 'pan and zoom' in @props.project?.experimental_tools)
           <div>
-            <button className={"fa fa-mouse-pointer"} />
             <button className={if @state.panEnabled then "toggle fa fa-arrows active" else "toggle fa fa-mouse-pointer"} title={"pan"} onClick={@togglePan} ></button>
             <button className="zoom-out fa fa-minus" onClick={ @zoom.bind(this, 1.1 ) } />
             <button className="zoom-in fa fa-plus" onClick={ @zoom.bind(this, .9) } />

--- a/app/components/frame-viewer.cjsx
+++ b/app/components/frame-viewer.cjsx
@@ -26,6 +26,12 @@ module.exports = React.createClass
     playing: false
     playbackRate: 1
     frameDimensions: {}
+    viewBoxDimensions: {
+      x: 0,
+      y: 0,
+      width: 0
+      height: 0
+    }
 
   componentDidMount: ->
     @refs.videoScrubber?.value = 0
@@ -47,6 +53,15 @@ module.exports = React.createClass
             <div className="loading-cover" style={@constructor.overlayStyle}>
               <LoadingIndicator />
             </div>}
+          <span>
+            <button className={ "fa fa-arrow-circle-left" + if @state.viewBoxDimensions.x == 0 then " disabled" else "" } onClick={ @panHorizontal.bind(this, .7) }> </button>
+            <button className={ "fa fa-arrow-circle-up" + if @state.viewBoxDimensions.height == @state.frameDimensions.height then " disabled" else "" } onClick={@panVertical.bind(this, .7)}> </button>
+            <button className={ "fa fa-arrow-circle-down" + if @state.viewBoxDimensions.width == @state.frameDimensions.width then " disabled" else ""} onClick={@panVertical.bind(this, 1.3)}> </button>
+            <button className={ "fa fa-arrow-circle-right" + if @state.viewBoxDimensions.x == 0 then " disabled" else "" } onClick={@panHorizontal.bind(this, 1.3)}> </button>
+            <button className="zoom-out fa fa-minus-circle" onClick={ @zoom.bind(this, 1.1 ) }></button>
+            <button className="zoom-in fa fa-plus-circle" onClick={ @zoom.bind(this, .9) } ></button>
+            <button className="reset" onClick={ this.zoomReset } >Reset</button>
+          </span>
         </div>
       when 'video'
         <div className="subject-video-frame">
@@ -86,7 +101,7 @@ module.exports = React.createClass
         </div>
 
     if FrameWrapper
-      <FrameWrapper frame={frame} naturalWidth={@state.frameDimensions?.width or 0} naturalHeight={@state.frameDimensions?.height or 0} workflow={@props.workflow} subject={@props.subject} classification={@props.classification} annotation={@props.annotation} loading={@state.loading} onChange={@props.onChange}>
+      <FrameWrapper frame={frame} naturalWidth={@state.frameDimensions?.width or 0} naturalHeight={@state.frameDimensions?.height or 0} viewBoxDimensions={@state.viewBoxDimensions or "0 0 0 0"} workflow={@props.workflow} subject={@props.subject} classification={@props.classification} annotation={@props.annotation} loading={@state.loading} onChange={@props.onChange}>
         {frameDisplay}
       </FrameWrapper>
     else
@@ -144,4 +159,48 @@ module.exports = React.createClass
         width: width ? 0
         height: height ? 0
 
+      viewBoxDimensions:
+        width: width ? 0
+        height: height ? 0
+        x: 0
+        y: 0
+
     @props.onLoad? e, @props.frame
+
+  zoom: (change) ->
+    newNaturalWidth = @state.viewBoxDimensions.width * change
+    newNaturalHeight = @state.viewBoxDimensions.height * change
+    
+    newNaturalX = @state.viewBoxDimensions.x - (newNaturalWidth - @state.viewBoxDimensions.width)/2
+    newNaturalY = @state.viewBoxDimensions.y - (newNaturalHeight - @state.viewBoxDimensions.height)/2
+    
+    @setState
+      viewBoxDimensions:
+        width: newNaturalWidth,
+        height: newNaturalHeight,
+        x: newNaturalX,
+        y: newNaturalY
+
+  zoomReset: ->
+    @setState
+      viewBoxDimensions:
+        width: @state.frameDimensions.width, 
+        height: @state.frameDimensions.height,
+        x: 0,
+        y: 0
+
+  panHorizontal:(direction) ->
+    @setState
+      viewBoxDimensions:
+        x: @state.viewBoxDimensions.x * direction
+        y: @state.viewBoxDimensions.y
+        width: @state.viewBoxDimensions.width
+        height: @state.viewBoxDimensions.height
+
+  panVertical:(direction)->
+    @setState
+      viewBoxDimensions:
+        x: @state.viewBoxDimensions.x 
+        y: @state.viewBoxDimensions.y * direction
+        width: @state.viewBoxDimensions.width
+        height: @state.viewBoxDimensions.height

--- a/app/components/frame-viewer.cjsx
+++ b/app/components/frame-viewer.cjsx
@@ -233,13 +233,19 @@ module.exports = React.createClass
 
   panByDrag: (e, d) ->
     return if @state.panEnabled == false
-    minX = @state.frameDimensions.width - @state.viewBoxDimensions.width
-    minY = @state.frameDimensions.height - @state.viewBoxDimensions.height
+    
+    maximumX = (@state.frameDimensions.width - @state.viewBoxDimensions.width) + 20
+    minumumX = -20
+    changedX = @state.viewBoxDimensions.x -= d.x
+
+    maximumY = (@state.frameDimensions.height - @state.viewBoxDimensions.height) + 20
+    minimumY = -20
+    changedY = @state.viewBoxDimensions.y -= d.y
 
     @setState
       viewBoxDimensions:
-        x: Math.max(0, Math.min(@state.viewBoxDimensions.x -= d.x, minX))
-        y: Math.max(0, Math.min(@state.viewBoxDimensions.y -= d.y, minY))
+        x: Math.max(minumumX, Math.min(changedX, maximumX))
+        y: Math.max(minimumY, Math.min(changedY, maximumY))
         width: @state.viewBoxDimensions.width
         height: @state.viewBoxDimensions.height
 
@@ -275,19 +281,23 @@ module.exports = React.createClass
 
 
   panHorizontal:(direction) ->
-    minX = @state.frameDimensions.width - @state.viewBoxDimensions.width
+    maximumX = (@state.frameDimensions.width - @state.viewBoxDimensions.width) + 20
+    minumumX = -20
+    changedX = @state.viewBoxDimensions.x + direction
     @setState
       viewBoxDimensions:
-        x: Math.max(0, Math.min(@state.viewBoxDimensions.x + direction, minX))
+        x: Math.max(minumumX, Math.min(changedX, maximumX))
         y: @state.viewBoxDimensions.y
         width: @state.viewBoxDimensions.width
         height: @state.viewBoxDimensions.height
 
   panVertical:(direction)->
-    minY = @state.frameDimensions.height - @state.viewBoxDimensions.height
+    maximumY = (@state.frameDimensions.height - @state.viewBoxDimensions.height) + 20
+    minimumY = -20
+    changedY = @state.viewBoxDimensions.y + direction
     @setState
       viewBoxDimensions:
         x: @state.viewBoxDimensions.x 
-        y: Math.max(0, Math.min(@state.viewBoxDimensions.y + direction, minY))
+        y: Math.max(minimumY, Math.min(changedY, maximumY))
         width: @state.viewBoxDimensions.width
         height: @state.viewBoxDimensions.height

--- a/app/components/frame-viewer.cjsx
+++ b/app/components/frame-viewer.cjsx
@@ -37,10 +37,13 @@ module.exports = React.createClass
 
   componentDidMount: ->
     @refs.videoScrubber?.value = 0
-    addEventListener "keypress", @frameKeyPan
+    addEventListener "keydown", @frameKeyPan
 
   componentDidUpdate: ->
     @refs.videoPlayer?.playbackRate = @state.playbackRate
+
+  componentWillUnmount: ->
+    removeEventListener "keydown", @frameKeyPan
 
   render: () ->
     subject = @props.subject
@@ -203,13 +206,7 @@ module.exports = React.createClass
           height: newNaturalHeight,
           x: newNaturalX,
           y: newNaturalY
-        , =>
-          console.log "Pressed Zoom"
-          # setTimeout(function(){ debugger; }, 3000);
-          # setTimeout console.log "time", 0000
-          # debugger
           
-
   zoomReset: ->
     @setState
       viewBoxDimensions:
@@ -220,7 +217,6 @@ module.exports = React.createClass
 
 
   toggleZoom: ->
-    console.log "toggleZoom"
     @setState zooming: !@state.zooming
 
   togglePanOn: ->
@@ -248,9 +244,6 @@ module.exports = React.createClass
         height: @state.viewBoxDimensions.height
 
   frameKeyPan: (e)->
-    console.log "frameKeyPan()"
-    console.log "---> keypress", e.which
-    console.log "---> @state.panEnabled", @state.panEnabled
     return if @state.panEnabled == false
     keypress = e.which
     switch keypress
@@ -271,11 +264,11 @@ module.exports = React.createClass
         e.preventDefault()
         @panVertical(20) 
       # zoom out
-      when 61 #187 
+      when 187 #61
         e.preventDefault()
         @zoom(.9) 
       # zoom in 
-      when 45 #189 
+      when 189 #45
         @setState zooming: true
         e.preventDefault()
         @zoom(1.1) 

--- a/app/components/frame-viewer.cjsx
+++ b/app/components/frame-viewer.cjsx
@@ -101,10 +101,17 @@ module.exports = React.createClass
         </FrameWrapper>
         {if ( @props.project? && 'pan and zoom' in @props.project?.experimental_tools)
           <div>
-            <button className={if @state.panEnabled then "toggle fa fa-arrows active" else "toggle fa fa-mouse-pointer"} title={"pan"} onClick={@togglePan} ></button>
+            <span className="draw-pan-toggle" >
+              <span onClick={@togglePan} className={if @state.panEnabled then "" else "active"} >
+                <button className={"fa fa-mouse-pointer"} title={"annotate"} onClick={@togglePan}/>
+              </span>
+              <span className={if @state.panEnabled then "active" else ""}>
+                <button className={"fa fa-arrows"} title={"pan"} onClick={@togglePan}/>
+              </span>
+            </span>
             <button className="zoom-out fa fa-minus" onClick={ @zoom.bind(this, 1.1 ) } />
             <button className="zoom-in fa fa-plus" onClick={ @zoom.bind(this, .9) } />
-            <button className="reset" onClick={ this.zoomReset } >Reset</button>
+            <button className="reset fa fa-refresh" onClick={ this.zoomReset } ></button>
           </div>}
         
       </div>

--- a/app/components/frame-viewer.cjsx
+++ b/app/components/frame-viewer.cjsx
@@ -52,7 +52,6 @@ module.exports = React.createClass
     removeEventListener "keyup", @stopZoom
 
   render: () ->
-    console.log "frameDimensions", @state.frameDimensions
     subject = @props.subject
     frame = @props.frame
     {type, format, src} = getSubjectLocation @props.subject, @props.frame

--- a/app/components/subject-viewer.cjsx
+++ b/app/components/subject-viewer.cjsx
@@ -101,7 +101,7 @@ module.exports = React.createClass
     <div className={rootClass} style={ROOT_STYLE if @props.defaultStyle}>
       {if type is 'image'
         @hiddenPreloadedImages()}
-      <div className="subject-container" style={CONTAINER_STYLE}>
+      <div className="subject-container" style={CONTAINER_STYLE} >
         {mainDisplay}
         {@props.children}
       </div>

--- a/app/components/subject-viewer.cjsx
+++ b/app/components/subject-viewer.cjsx
@@ -131,6 +131,8 @@ module.exports = React.createClass
       </div>
     </div>
 
+  
+
   renderFrame: (frame, props = {}) ->
     <FrameViewer {...@props} {...props} frame={frame} />
 
@@ -174,6 +176,7 @@ module.exports = React.createClass
   handleFrameChange: (frame) ->
     @setState {frame}
     @props.onFrameChange frame
+
 
   showMetadata: ->
     # TODO: Sticky popup.

--- a/app/pages/admin/project-status.cjsx
+++ b/app/pages/admin/project-status.cjsx
@@ -17,6 +17,7 @@ EXPERIMENTAL_FEATURES = [
   'tutorial'
   'field guide'
   'hide classification summaries'
+  'pan and zoom'
 ]
 
 ProjectToggle = React.createClass

--- a/app/pages/dev-classifier/index.cjsx
+++ b/app/pages/dev-classifier/index.cjsx
@@ -51,6 +51,7 @@ ClassificationViewer = React.createClass
 DevClassifierPage = React.createClass
   getDefaultProps: ->
     classification: mockData.classification
+    project: mockData.project
 
   reload: ->
     workflow = @props.classification._workflow
@@ -63,7 +64,7 @@ DevClassifierPage = React.createClass
 
   render: ->
     <div className="content-container">
-      <Classifier classification={@props.classification} onClickNext={@reload} />
+      <Classifier project={@props.project} classification={@props.classification} onClickNext={@reload} />
       <hr />
       <ClassificationViewer classification={@props.classification} />
     </div>

--- a/app/pages/dev-classifier/mock-data.coffee
+++ b/app/pages/dev-classifier/mock-data.coffee
@@ -337,19 +337,21 @@ subject = apiClient.type('subjects').create
         value: 6
       }]
 
+project = apiClient.type('project').create
+  id: 'MOCK_PROJECT_FOR_CLASSIFIER'
+  title: "The Dev Classifier"
+  experimental_tools: ['pan and zoom']
+
 classification = apiClient.type('classifications').create
   annotations: []
   metadata: {}
   links:
-    project: 'NO_PROJECT'
+    project: project.id
     workflow: workflow.id
     subjects: [subject.id]
   _workflow: workflow # TEMP
   _subjects: [subject] # TEMP
 
-project = 
-  title: "The Dev Classifier"
-  experimental_tools: ['pan and zoom']
 
 module.exports = {workflow, subject, classification, project}
 window?.mockClassifierData = module.exports

--- a/app/pages/dev-classifier/mock-data.coffee
+++ b/app/pages/dev-classifier/mock-data.coffee
@@ -347,5 +347,9 @@ classification = apiClient.type('classifications').create
   _workflow: workflow # TEMP
   _subjects: [subject] # TEMP
 
-module.exports = {workflow, subject, classification}
+project = 
+  title: "The Dev Classifier"
+  experimental_tools: ['pan and zoom']
+
+module.exports = {workflow, subject, classification, project}
 window?.mockClassifierData = module.exports

--- a/bin/postinstall.sh
+++ b/bin/postinstall.sh
@@ -3,7 +3,7 @@
 set -e
 
 FALLBACK_POLYFILLS_URL="https://cdn.polyfill.io/v1/polyfill.min.js?features=default,es6,Promise,fetch&flags=gated&ua=(MSIE%209.0)"
-FONT_AWESOME_URL="https://github.com/FortAwesome/Font-Awesome/blob/8027c940b6/assets/font-awesome-4.2.0.zip?raw=true"
+FONT_AWESOME_URL="https://fortawesome.github.io/Font-Awesome/assets/font-awesome-4.5.0.zip"
 
 curl "$FALLBACK_POLYFILLS_URL" > ./public/fallback-polyfills.js
 

--- a/css/frame-annotator.styl
+++ b/css/frame-annotator.styl
@@ -9,3 +9,6 @@
     width: 100%
     height: 100%
     overflow: hidden
+    
+  button.disabled
+    color: #ADABAB;

--- a/css/subject.styl
+++ b/css/subject.styl
@@ -40,6 +40,12 @@
   .subject-container
     > *
       max-width: 100%;
+      
+    button.toggle
+      &.active
+        background-color: #43BBFD
+        color: black
+        border none
 
   // Multi-image layouts
   &:not(.subject-viewer--flipbook)

--- a/css/subject.styl
+++ b/css/subject.styl
@@ -66,11 +66,15 @@
         button
           background-color: transparent
           border:none
+          
       button
         background-color: #f9f9f9
         border: solid 1px #989898
         -webkit-border-radius: 0.2em
         border-radius: 0.2em
+        &.disabled
+          background-color: #bbc0c0
+          color: #575959 
 
   // Multi-image layouts
   &:not(.subject-viewer--flipbook)

--- a/css/subject.styl
+++ b/css/subject.styl
@@ -40,16 +40,23 @@
   .subject-container
     > *
       max-width: 100%
+    
+    .frame-annotator
+      
+      display inline-block      
+        
     image.pan-active
       cursor all-scroll
     .pan-zoom-controls
-      span
-        padding 3px
+      display inline-block
+      float left
+      background: grey;
+      border-radius: .1em;
       .draw-pan-toggle
         background-color: #F9F9F9
         border: solid 1px #989898
         border-radius: .2em
-        span
+        div
           border-radius: .1em
           transition: background-color .5s
           &.active

--- a/css/subject.styl
+++ b/css/subject.styl
@@ -39,13 +39,29 @@
 
   .subject-container
     > *
-      max-width: 100%;
+      max-width: 100%
       
-    button.toggle
-      &.active
-        background-color: #43BBFD
-        color: black
-        border none
+    span.draw-pan-toggle
+      background-color: #F9F9F9
+      border: solid .1px #989898
+      border-radius: .2em
+      span
+        // margin: .2em
+        border-radius: .1em
+        transition: background-color .5s
+        &.active
+          background-color: #43BBFD
+          color: black
+          border none
+      button
+        background-color: transparent
+        border:none
+    button
+      background-color: #f9f9f9
+      border: solid 1px #989898
+      -webkit-border-radius: 0.2em
+      border-radius: 0.2em
+      vertical-align: bottom
 
   // Multi-image layouts
   &:not(.subject-viewer--flipbook)

--- a/css/subject.styl
+++ b/css/subject.styl
@@ -44,29 +44,26 @@
       cursor all-scroll
     .pan-zoom-controls
       span
-        margin: 0.05em;
-    
-    span.draw-pan-toggle
-      background-color: #F9F9F9
-      border: solid .1px #989898
-      border-radius: .2em
-      span
-        // margin: .2em
-        border-radius: .1em
-        transition: background-color .5s
-        &.active
-          background-color: #43BBFD
-          color: black
-          border none
+        padding 3px
+      .draw-pan-toggle
+        background-color: #F9F9F9
+        border: solid 1px #989898
+        border-radius: .2em
+        span
+          border-radius: .1em
+          transition: background-color .5s
+          &.active
+            background-color: #43BBFD
+            color: black
+            border none
+        button
+          background-color: transparent
+          border:none
       button
-        background-color: transparent
-        border:none
-    button
-      background-color: #f9f9f9
-      border: solid 1px #989898
-      -webkit-border-radius: 0.2em
-      border-radius: 0.2em
-      vertical-align: bottom
+        background-color: #f9f9f9
+        border: solid 1px #989898
+        -webkit-border-radius: 0.2em
+        border-radius: 0.2em
 
   // Multi-image layouts
   &:not(.subject-viewer--flipbook)

--- a/css/subject.styl
+++ b/css/subject.styl
@@ -40,7 +40,12 @@
   .subject-container
     > *
       max-width: 100%
-      
+    image.pan-active
+      cursor all-scroll
+    .pan-zoom-controls
+      span
+        margin: 0.05em;
+    
     span.draw-pan-toggle
       background-color: #F9F9F9
       border: solid .1px #989898

--- a/css/subject.styl
+++ b/css/subject.styl
@@ -42,14 +42,15 @@
       max-width: 100%
     
     .frame-annotator
+      display: inline-block      
+      width: 90%
       
-      display inline-block      
-        
     image.pan-active
-      cursor all-scroll
+      cursor: all-scroll
     .pan-zoom-controls
-      display inline-block
-      float left
+      display: inline-block
+      width: 9%
+      float: left
       background: grey;
       border-radius: .1em;
       .draw-pan-toggle
@@ -62,7 +63,7 @@
           &.active
             background-color: #43BBFD
             color: black
-            border none
+            border: none
         button
           background-color: transparent
           border:none

--- a/css/subject.styl
+++ b/css/subject.styl
@@ -51,6 +51,7 @@
       display: inline-block
       width: 9%
       float: left
+      text-align: center
       background: grey;
       border-radius: .1em;
       .draw-pan-toggle

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -6,8 +6,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <base href="<%= process.env.DEPLOY_SUBDIR === undefined ? '/' : '/' + process.env.DEPLOY_SUBDIR + '/' %>" />
     <title>Zooniverse</title>
-    <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" />
-    <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Montserrat&amp;text=ZOONIVERSE" />
+    <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css" />
+    <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Montserrat&amp;text=ZOONIVERSE">
     <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Open+Sans:400,400italic,700,700italic" />
     <link rel="stylesheet" href="./<%= process.env.OUT_CSS %>" />
     <meta name="google-site-verification" content="bcDZuAlk550Gho9TJsiyHFj_PzVXVkkVvGB13YWFtUo" />


### PR DESCRIPTION
This PR address Issue #2130 by introducing a pan and zoom feature for images in the subject-viewer. An admin will need to opt-in to this feature on a project-by-project basis. 

**WIP:**
- [x] viewable in dev/classifier
- [x] scroll wheel to zoom in/out
- [x] keyboard event listeners available when the pan control is activated
- [x] add limits to prevent moving off the image
- [x] continuous zoom on button press