### PR TITLE
Highlight the current line of the lab projects list on hover

### DIFF
--- a/css/lab.styl
+++ b/css/lab.styl
@@ -9,8 +9,17 @@
   > li
     display: block
 
+    &:first-child:hover
+      margin-top: -2px
+
     &:not(:first-child)
       border-top: 1px solid rgba(gray, 0.2)
+
+    &:hover
+      border-top: 2px solid rgba(0,0,0,.2)
+      border-bottom: 2px solid rgba(0,0,0,.2)
+      margin-top: -1px
+      margin-bottom: -2px
 
 .lab-index-project-row
   display: flex


### PR DESCRIPTION
I love the new lab screen (#2188) but one thing I noticed is that on a large screen, the edit & view buttons are a LONG way from the text they correspond to, which makes the grid a little hard to use.

I suggest a small CSS tweak like this to highlight the current line as you hover.

![screenshot 2016-02-11 13 33 52](https://cloud.githubusercontent.com/assets/1473244/12980404/34d8d676-d0d4-11e5-9266-f78939d8f89a.png)

Deployed it at https://preview.zooniverse.org/panoptes-front-end/lab-page-tweak/?env=production (then click Build a Project)

We might also consider making the project name and icon itself clickable (left click to edit, hold down to popup a menu that offers you Edit or View) - (i'm thinking in particular of touch screen users)
