### PR TITLE
FrameViewer should pass frame up on load

### DIFF
--- a/app/components/frame-viewer.cjsx
+++ b/app/components/frame-viewer.cjsx
@@ -144,4 +144,4 @@ module.exports = React.createClass
         width: width ? 0
         height: height ? 0
 
-    @props.onLoad? arguments...
+    @props.onLoad? e, @props.frame


### PR DESCRIPTION
Fixes zooniverse/Panoptes#1670. The frame wasn't being passed up to the classifier on load, which broke recording the image dimensions in the classification.