### PR TITLE
Move pfe-base back into main Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,18 @@
-FROM zooniverse/pfe-base
+FROM ubuntu:14.04
 
-WORKDIR /src/
+ENV DEBIAN_FRONTEND noninteractive
+
+WORKDIR /src
+
+RUN apt-get update && \
+    apt-get install -y curl libfreetype6 libfontconfig1 git ruby unzip flex \
+                       bison && \
+    curl https://deb.nodesource.com/setup_4.x | bash - && \
+    apt-get install -y nodejs && apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN curl -L https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 \
+    | tar -xvj -C / --strip-components 1 --wildcards "*/bin/phantomjs"
 
 ADD . /src/
 


### PR DESCRIPTION
There's finally a binary version of phantomjs, which was the only reason
we separated these before.

@brian-c I'm assuming phantomjs 2.1 is OK (we were previously using 2.0)