### PR TITLE
Don't fetch field guide images unless the guide exists

### DIFF
--- a/app/pages/project/potential-field-guide.cjsx
+++ b/app/pages/project/potential-field-guide.cjsx
@@ -27,7 +27,7 @@ module.exports = React.createClass
     apiClient.type('field_guides').get project_id: project.id
       .then ([guide]) =>
         @setState {guide}
-        guide.get('attached_images').then (images) =>
+        guide?.get('attached_images')?.then (images) =>
           icons = {}
           for image in images
             icons[image.id] = image


### PR DESCRIPTION
Just stumbled across this when trying to track down a different bug