### PR TITLE
fix _choiceInProgress

### DIFF
--- a/app/classifier/tasks/flexible-survey/index.cjsx
+++ b/app/classifier/tasks/flexible-survey/index.cjsx
@@ -80,7 +80,7 @@ module.exports = React.createClass
 
   handleChoice: (choiceID) ->
     @setState selectedChoiceID: choiceID
-    newAnnotation = Object.assign {}, @props.annotation, _choiceInProgress: true
+    newAnnotation = Object.assign {}, @props.annotation, _choiceInProgress: false
     @props.onChange newAnnotation
 
   clearFilters: ->


### PR DESCRIPTION
when we're initializing a new choice, it shouldn't be immediately marked as InProgress or else we'll never be allowed to complete the task

this basically completely breaks the task as nobody is ever able to complete the classification