### PR TITLE
transparent underlay style for subTask

### DIFF
--- a/app/classifier/drawing-tools/root.cjsx
+++ b/app/classifier/drawing-tools/root.cjsx
@@ -10,7 +10,7 @@ SEMI_MODAL_FORM_STYLE =
 
 SEMI_MODAL_UNDERLAY_STYLE =
   pointerEvents: 'none'
-  backgroundColor: 'rgba(0, 0, 0, 0.3)'
+  backgroundColor: 'rgba(0, 0, 0, 0)'
 
 module.exports = React.createClass
   displayName: 'DrawingToolRoot'


### PR DESCRIPTION
In master, the subTask modal is render with a non-transparent underlay. This PR proposes to make that underlay transparent in order to give participants the clearest and most consistent view of a subject during a subTask. 

Example with non-transparent underlay:
![screen shot 2016-03-01 at 1 03 29 pm](https://cloud.githubusercontent.com/assets/7684729/13438345/4cad694a-dfae-11e5-9e33-348c00e135e2.png)

Example with transparent underlay:
![screen shot 2016-03-01 at 1 02 47 pm](https://cloud.githubusercontent.com/assets/7684729/13438346/4e189e1c-dfae-11e5-97f6-55cc0a4d4a14.png)


This PR will not change the underlay style for the "Need some help" modals.