### PR TITLE
Stop the subject SVG from filling its parent

### DIFF
--- a/css/frame-annotator.styl
+++ b/css/frame-annotator.styl
@@ -6,6 +6,4 @@
     position: absolute
     left: 0
     top: 0
-    width: 100%
-    height: 100%
     overflow: hidden


### PR DESCRIPTION
Fixes #2262.

Not sure what the intention was to have the SVG grow as big as it can. In general it should maintain the proportions of the subject image. If I've broken something unknowingly here, let me know.

(Seems I can't assign this to @itsravenous. Mind taking a look Tom? Thanks!)