### PR TITLE
Fix: dev/classifier images don't load over HTTPS

### DIFF
--- a/app/pages/dev-classifier/mock-data.coffee
+++ b/app/pages/dev-classifier/mock-data.coffee
@@ -283,9 +283,9 @@ subject = apiClient.type('subjects').create
   id: 'MOCK_SUBJECT_FOR_CLASSIFIER'
 
   locations: [
-    {'image/jpeg': if navigator?.onLine then 'http://lorempixel.com/320/240/animals/1' else BLANK_IMAGE}
-    {'image/jpeg': if navigator?.onLine then 'http://lorempixel.com/320/240/animals/2' else BLANK_IMAGE}
-    {'image/jpeg': if navigator?.onLine then 'http://lorempixel.com/320/240/animals/3' else BLANK_IMAGE}
+    {'image/jpeg': if navigator?.onLine then '//lorempixel.com/320/240/animals/1' else BLANK_IMAGE}
+    {'image/jpeg': if navigator?.onLine then '//lorempixel.com/320/240/animals/2' else BLANK_IMAGE}
+    {'image/jpeg': if navigator?.onLine then '//lorempixel.com/320/240/animals/3' else BLANK_IMAGE}
   ]
 
   metadata:


### PR DESCRIPTION
Quick fix for Mixed Content warnings that stop the example images from loading.