### PR TITLE
Fix default images

### DIFF
--- a/app/classifier/tasks/survey/chooser.cjsx
+++ b/app/classifier/tasks/survey/chooser.cjsx
@@ -85,7 +85,7 @@ module.exports = React.createClass
           for choiceID, i in filteredChoices
             choice = @props.task.choices[choiceID]
             <button key={choiceID + i} type="button" className="survey-task-chooser-choice" onClick={@props.onChoose.bind null, choiceID}>
-              {unless choice.images.length is 0
+              {if choice.images?.length > 0
                 <span className="survey-task-chooser-choice-thumbnail-container">
                   <img src={@props.task.images[choice.images[0]]} alt={choice.label} className="survey-task-chooser-choice-thumbnail" />
                 </span>}

--- a/app/classifier/tasks/survey/editor.cjsx
+++ b/app/classifier/tasks/survey/editor.cjsx
@@ -250,7 +250,7 @@ module.exports = React.createClass
       label: name
       description: ''
       noQuestions: false
-      image: []
+      images: []
       characteristics: {}
       confusionsOrder: []
       confusions: {}


### PR DESCRIPTION
Choices were being created with an `image` property instead of `images`. This would break if no images were specified to override it.

Closes #2267.