### PR TITLE
Subject viewer styling

### DIFF
--- a/app/classifier/frame-annotator.cjsx
+++ b/app/classifier/frame-annotator.cjsx
@@ -127,7 +127,7 @@ module.exports = React.createClass
       <div className="subject-area">
         {if BeforeSubject?
           <BeforeSubject {...hookProps} />}
-        <svg style=svgStyle viewBox={createdViewBox} {...svgProps}>
+        <svg className="subject" style=svgStyle viewBox={createdViewBox} {...svgProps}>
           <rect ref="sizeRect" width={@props.naturalWidth} height={@props.naturalHeight} fill="rgba(0, 0, 0, 0.01)" fillOpacity="0.01" stroke="none" />
           {if type is 'image'
             <Draggable onDrag={@props.panByDrag} disabled={@props.disabled}>

--- a/css/subject.styl
+++ b/css/subject.styl
@@ -40,17 +40,15 @@
   .subject-container
     > *
       max-width: 100%
+      display: flex
     
-    .frame-annotator
-      display: inline-block      
-      width: 90%
+    .frame-annotator   
+      flex: 9
       
     image.pan-active
       cursor: all-scroll
     .pan-zoom-controls
-      display: inline-block
-      width: 9%
-      float: left
+      flex: 1
       text-align: center
       background: grey;
       border-radius: .1em;


### PR DESCRIPTION
Changes pan-and-zoom to use flexbox.
Restores `subject` class on SVG marking surface.
Fixes #2285