### PR TITLE
Adjust Margins on Tutorial Modal

### DIFF
--- a/css/tutorial.styl
+++ b/css/tutorial.styl
@@ -4,8 +4,8 @@
   padding: 0 0 1.5em
 
   @media screen and (max-width: 400px)
-    margin-left: 0vh
-    margin-top: 5vh
+    margin-left: 0em
+    margin-top: 1.75em
 
 .tutorial-steps
   display: flex

--- a/css/tutorial.styl
+++ b/css/tutorial.styl
@@ -2,6 +2,8 @@
   border-radius: 8px
   max-width: 400px
   padding: 0 0 1.5em
+  margin-left: 0px !important
+  margin-top: 28px !important
 
 .tutorial-steps
   display: flex

--- a/css/tutorial.styl
+++ b/css/tutorial.styl
@@ -2,8 +2,10 @@
   border-radius: 8px
   max-width: 400px
   padding: 0 0 1.5em
-  margin-left: 0px !important
-  margin-top: 28px !important
+
+  @media screen and (max-width: 400px)
+    margin-left: 0vh
+    margin-top: 5vh
 
 .tutorial-steps
   display: flex


### PR DESCRIPTION
Close issue #2100 

Default left margin caused the tutorial modal to be pushed too far to the right on small screens. Increasing the top margin pushed the modal down far enough to reveal the close button.