### PR TITLE
Prevent images from overlapping the frame in Firefox

### DIFF
--- a/css/frame-annotator.styl
+++ b/css/frame-annotator.styl
@@ -1,6 +1,7 @@
 .frame-annotator
   // Layout
   position: relative; // Contain absolutely-positioned children
+  max-width: 100%;
 
   svg
     position: absolute


### PR DESCRIPTION
This fixes #2285. Tested in Chrome & Firefox & Safari. Also checked Pan & Zoom tool still aligned correctly in Dev Classifier