### PR TITLE
Explicit flex prop on child items. Fixes subject viewer in IE 11

### DIFF
--- a/css/classify.styl
+++ b/css/classify.styl
@@ -18,6 +18,9 @@
 .classifier
   display: flex
   justify-content: center
+  
+  > *
+    flex: 1 1 auto
 
   @media (max-width: 900px) // This is between iPad landscape and portrait.
     flex-wrap: wrap
@@ -35,6 +38,7 @@
     max-width: 100%
     > *
       display: flex
+      flex: 1 1 auto
 
   .subject
     border-radius: 5px


### PR DESCRIPTION
Got notified by WWW team that the subjects in the classifier weren't displaying at all in IE. Explicitly stating the `flex` prop on the child items fixes this. Tested in Chrome, Firefox, Safari, IE 11, and iOS Safari and this doesn't seem to break anything. 

I looked in MS Edge, but it appears to have some other issues that I'll have to take a look at later. 