### PR TITLE
Pan Zoom Revisions: Scale drawn marks when zooming

### DIFF
--- a/app/classifier/frame-annotator.cjsx
+++ b/app/classifier/frame-annotator.cjsx
@@ -34,8 +34,8 @@ module.exports = React.createClass
     @setState alreadySeen: @props.subject.already_seen or seenThisSession.check @props.workflow, @props.subject
 
   componentDidUpdate: (prevProps, prevState)->
-    # If size of the frame image has changed, update our sizing information (used for scaling/translating annotations)
-    if @props.naturalWidth isnt prevProps.naturalWidth or @props.naturalHeight isnt prevProps.naturalHeight
+    # If size of the frame image or viewBoxDimensions has changed, update our sizing information (used for scaling/translating annotations)
+    if @props.naturalWidth isnt prevProps.naturalWidth or @props.naturalHeight isnt prevProps.naturalHeight or @props.viewBoxDimensions isnt prevProps.viewBoxDimensions
       setTimeout =>
         @updateSize()
 
@@ -45,20 +45,13 @@ module.exports = React.createClass
   componentWillReceiveProps: (nextProps) ->
     if nextProps.annotation isnt @props.annotation
       @handleAnnotationChange @props.annotation, nextProps.annotation
-    @setState
-      naturalWidth: nextProps.naturalWidth
-      naturalHeight: nextProps.naturalHeight
-
 
   handleAnnotationChange: (oldAnnotation, currentAnnotation) ->
     if oldAnnotation?
-      # console.log 'Old annotation was', oldAnnotation
       lastTask = @props.workflow.tasks[oldAnnotation.task]
       LastTaskComponent = tasks[lastTask.type]
       if LastTaskComponent.onLeaveAnnotation?
         LastTaskComponent.onLeaveAnnotation lastTask, oldAnnotation
-    # if currentAnnotation?
-    #   console.log 'Annotation is now', currentAnnotation
     setTimeout => # Wait a tick for the annotation to load.
       @updateSize()
 
@@ -78,7 +71,6 @@ module.exports = React.createClass
 
   getEventOffset: (e) ->
     scale = @getScale()
-    # console?.log 'Subject scale is', JSON.stringify scale
     x = (e.pageX - @state.sizeRect?.left) / scale.horizontal || 0
     y = (e.pageY - @state.sizeRect?.top) / scale.vertical || 0
     {x, y}

--- a/app/components/frame-viewer.cjsx
+++ b/app/components/frame-viewer.cjsx
@@ -150,8 +150,8 @@ module.exports = React.createClass
       clearTimeout @state.zoomingTimeoutId
 
   zoom: (change) ->
-    return if !@state.zooming
     @clearZoomingTimeout()
+    return if !@state.zooming
     newNaturalWidth = @state.viewBoxDimensions.width * change
     newNaturalHeight = @state.viewBoxDimensions.height * change
   

--- a/app/components/frame-viewer.cjsx
+++ b/app/components/frame-viewer.cjsx
@@ -78,13 +78,13 @@ module.exports = React.createClass
               </div>
             </div>
             <div>
-              <button title={"zoom out"} className={"zoom-out fa fa-minus" + if @canZoomOut() then " disabled" else "" } onMouseDown={ @continuousZoom.bind(this, 1.1 ) } onMouseUp={@stopZoom} />
+              <button title={"zoom out"} className={"zoom-out fa fa-minus" + if @cannotZoomOut() then " disabled" else "" } onMouseDown={ @continuousZoom.bind(this, 1.1 ) } onMouseUp={@stopZoom} />
             </div>
             <div>
               <button title={"zoom in"} className="zoom-in fa fa-plus" onMouseDown={@continuousZoom.bind(this, .9)} onMouseUp={@stopZoom} />
             </div>
             <div>
-              <button title={"rest zoom levels"} className={"reset fa fa-refresh" + if @canZoomOut() then " disabled" else ""} onClick={ this.zoomReset } ></button>
+              <button title={"rest zoom levels"} className={"reset fa fa-refresh" + if @cannotZoomOut() then " disabled" else ""} onClick={ this.zoomReset } ></button>
             </div>
           </div>}
         
@@ -111,7 +111,7 @@ module.exports = React.createClass
 
     @props.onLoad? e, @props.frame
 
-  canZoomOut: ->
+  cannotZoomOut: ->
     return @state.frameDimensions.width == @state.viewBoxDimensions.width && @state.frameDimensions.height == @state.viewBoxDimensions.height      
 
   continuousZoom: (change) ->

--- a/app/components/frame-viewer.cjsx
+++ b/app/components/frame-viewer.cjsx
@@ -133,6 +133,7 @@ module.exports = React.createClass
     return @state.frameDimensions.width == @state.viewBoxDimensions.width && @state.frameDimensions.height == @state.viewBoxDimensions.height      
 
   continuousZoom: (change) ->
+    @clearZoomingTimeout()
     return if change == 0
     @setState zooming: true, =>
       zoomNow = =>


### PR DESCRIPTION
This PR:
- scales drawn marks correctly when zooming in on a subject
- removes some unnecessary state variables, methods, and setTimeout calls.

I think the next step is to move pan & zoom into its own component, but this PR will fix the above issues in the meantime.