### PR TITLE
Video player

### DIFF
--- a/app/components/frame-viewer.cjsx
+++ b/app/components/frame-viewer.cjsx
@@ -97,17 +97,6 @@ module.exports = React.createClass
     else
       frameDisplay
 
-  setPlaying: ( playing) ->
-    if playing
-      @nextFrame()
-      @_playingInterval = setInterval @nextFrame, @props.playFrameDuration
-
-      autoStopDelay = @props.subject.locations.length * @props.playFrameDuration * @props.playIterations
-      @_autoStop = setTimeout @setPlaying.bind(this, false), autoStopDelay
-    else
-      clearInterval @_playingInterval
-      clearTimeout @_autoStop
-
   handleLoad: (e) ->
     width = e.target.videoWidth ? e.target.naturalWidth
     height = e.target.videoHeight ? e.target.naturalHeight
@@ -145,8 +134,8 @@ module.exports = React.createClass
     newNaturalWidth = @state.viewBoxDimensions.width * change
     newNaturalHeight = @state.viewBoxDimensions.height * change
   
-    newNaturalX = @state.viewBoxDimensions.x - (newNaturalWidth - @state.viewBoxDimensions.width)/2
-    newNaturalY = @state.viewBoxDimensions.y - (newNaturalHeight - @state.viewBoxDimensions.height)/2
+    newNaturalX = @state.viewBoxDimensions.x - (newNaturalWidth - @state.viewBoxDimensions.width) / 2
+    newNaturalY = @state.viewBoxDimensions.y - (newNaturalHeight - @state.viewBoxDimensions.height) / 2
 
     if (newNaturalWidth > @state.frameDimensions.width) || (newNaturalHeight * change > @state.frameDimensions.height)
       @zoomReset()

--- a/app/components/frame-viewer.cjsx
+++ b/app/components/frame-viewer.cjsx
@@ -58,7 +58,7 @@ module.exports = React.createClass
             </div>}
         </div>
       when 'video'
-        <VideoPlayer src={src} type={type} format={format} onLoad={@handleLoad}>
+        <VideoPlayer src={src} type={type} format={format} frame={@props.frame} onLoad={@handleLoad}>
         {if @state.loading
           <div className="loading-cover" style={@constructor.overlayStyle}>
             <LoadingIndicator />

--- a/app/components/frame-viewer.cjsx
+++ b/app/components/frame-viewer.cjsx
@@ -1,13 +1,10 @@
 React = require 'react'
 LoadingIndicator = require '../components/loading-indicator'
 getSubjectLocation = require '../lib/get-subject-location'
+VideoPlayer = require './video-player'
 
 SUBJECT_STYLE = display: 'block'
 NOOP = Function.prototype
-
-# Generates a standard ref for a radio button, based on the subject and frame, to avoid conflicts with radios in other viewers on the page
-generateRadioRef = (name, subject, frame) =>
-  'subject'+subject.id+'_frame'+frame+'_'+name
 
 module.exports = React.createClass
   displayName: 'FrameViewer'
@@ -23,8 +20,6 @@ module.exports = React.createClass
 
   getInitialState: ->
     loading: true
-    playing: false
-    playbackRate: 1
     frameDimensions: {}
     viewBoxDimensions: {
       x: 0,
@@ -37,14 +32,10 @@ module.exports = React.createClass
     zoomingTimeoutId: 0
 
   componentDidMount: ->
-    @refs.videoScrubber?.value = 0
     addEventListener "keydown", @frameKeyPan
     addEventListener "mousewheel", @frameKeyPan
     addEventListener "mouseup", @stopZoom
     addEventListener "keyup", @stopZoom
-
-  componentDidUpdate: ->
-    @refs.videoPlayer?.playbackRate = @state.playbackRate
 
   componentWillUnmount: ->
     removeEventListener "keydown", @frameKeyPan
@@ -67,41 +58,12 @@ module.exports = React.createClass
             </div>}
         </div>
       when 'video'
-        <div className="subject-video-frame">
-          <video ref="videoPlayer" src={src} type={"#{type}/#{format}"} preload="auto" onCanPlay={@handleLoad} onEnded={@endVideo} onTimeUpdate={@updateScrubber}>
-            Your browser does not support the video format. Please upgrade your browser.
-          </video>
-          <span className="subject-video-controls">
-            <span className="subject-frame-play-controls">
-              {if @state.playing
-                <button type="button" className="secret-button" aria-label="Pause" onClick={@playVideo.bind this, false}>
-                  <i className="fa fa-pause fa-fw"></i>
-                </button>
-              else
-                <button type="button" className="secret-button" aria-label="Play" onClick={@playVideo.bind this, true}>
-                  <i className="fa fa-play fa-fw"></i>
-                </button>}
-            </span>
-            <input type="range" className="video-scrubber" ref="videoScrubber" min="0" step="any" onChange={@seekVideo} />
-            <span className="video-speed">
-            Speed:
-              {for rate, i in [0.25, 0.5, 1]
-                ref = generateRadioRef 'rate', subject, frame
-                <label key="rate-#{i}" className="secret-button">
-                  <input type="radio" name={ref} ref={ref} value={rate} checked={rate == @state.playbackRate} onChange={@setPlayRate} />
-                  <span>
-                    {rate}&times;
-                  </span>
-                </label>
-              }
-            </span>
-          </span>
-
-          {if @state.loading
-            <div className="loading-cover" style={@constructor.overlayStyle}>
-              <LoadingIndicator />
-            </div>}
-        </div>
+        <VideoPlayer src={src} type={type} format={format} onLoad={@handleLoad}>
+        {if @state.loading
+          <div className="loading-cover" style={@constructor.overlayStyle}>
+            <LoadingIndicator />
+          </div>}
+        </VideoPlayer>
 
     if FrameWrapper
       <div>
@@ -145,38 +107,6 @@ module.exports = React.createClass
     else
       clearInterval @_playingInterval
       clearTimeout @_autoStop
-
-  playVideo: (playing) ->
-    player = @refs.videoPlayer
-    return unless player?
-
-    @setState
-      playing: playing
-
-    if playing
-      player.play()
-    else
-      player.pause()
-
-  setPlayRate: (e) ->
-    @setState
-      playbackRate: parseFloat e.target.value
-
-  seekVideo: () ->
-    player = @refs.videoPlayer
-    scrubber = @refs.videoScrubber
-    time = scrubber.value
-    player.currentTime = time
-
-  endVideo: () ->
-    @setState
-      playing: false
-
-  updateScrubber: () ->
-    player = @refs.videoPlayer
-    scrubber = @refs.videoScrubber
-    scrubber.setAttribute 'max', player.duration unless scrubber.getAttribute 'max'
-    scrubber.value = player.currentTime
 
   handleLoad: (e) ->
     width = e.target.videoWidth ? e.target.naturalWidth

--- a/app/components/subject-viewer.cjsx
+++ b/app/components/subject-viewer.cjsx
@@ -41,7 +41,6 @@ module.exports = React.createClass
     loading: true
     playing: false
     frame: @props.frame ? 0
-    playbackRate: 1
     frameDimensions: {}
     inFlipbookMode: @props.allowFlipbook
 
@@ -50,12 +49,6 @@ module.exports = React.createClass
     if typeof nextProps.allowFlipbook is 'boolean'
       this.setState
         inFlipbookMode: allowFlipbook
-
-  componentDidMount: ->
-    @refs.videoScrubber?.value = 0
-
-  componentDidUpdate: ->
-    @refs.videoPlayer?.playbackRate = @state.playbackRate
 
   render: ->
     rootClass = 'subject-viewer'

--- a/app/components/video-player.cjsx
+++ b/app/components/video-player.cjsx
@@ -67,7 +67,7 @@ module.exports = React.createClass
         Speed:
           {for rate, i in [0.25, 0.5, 1]
             <label key="rate-#{i}" className="secret-button">
-              <input type="radio" name="playRate" value={rate} checked={rate == @state.playbackRate} onChange={@setPlayRate} />
+              <input type="radio" name="playRate#{@props.frame}" value={rate} checked={rate == @state.playbackRate} onChange={@setPlayRate} />
               <span>
                 {rate}&times;
               </span>

--- a/app/components/video-player.cjsx
+++ b/app/components/video-player.cjsx
@@ -1,0 +1,79 @@
+React = require 'react'
+
+module.exports = React.createClass
+  
+  displayName: "VideoPlayer"
+  
+  getInitialState: ->
+    playing: false
+    playbackRate: 1
+  
+  componentDidMount: ->
+    @refs.videoScrubber?.value = 0
+
+  componentDidUpdate: ->
+    @refs.videoPlayer?.playbackRate = @state.playbackRate
+
+  playVideo: (playing) ->
+    player = @refs.videoPlayer
+    return unless player?
+
+    @setState
+      playing: playing
+
+    if playing
+      player.play()
+    else
+      player.pause()
+
+  setPlayRate: (e) ->
+    @setState
+      playbackRate: parseFloat e.target.value
+
+  seekVideo: () ->
+    player = @refs.videoPlayer
+    scrubber = @refs.videoScrubber
+    time = scrubber.value
+    player.currentTime = time
+  
+  endVideo: () ->
+    @setState
+      playing: false
+
+  updateScrubber: () ->
+    player = @refs.videoPlayer
+    scrubber = @refs.videoScrubber
+    scrubber.setAttribute 'max', player.duration unless scrubber.getAttribute 'max'
+    scrubber.value = player.currentTime
+  
+  render: ->
+    <div className="subject-video-frame">
+      <video className="subject" ref="videoPlayer" src={@props.src} type={"#{@props.type}/#{@props.format}"} preload="auto" onCanPlay={@props.onLoad} onEnded={@endVideo} onTimeUpdate={@updateScrubber}>
+        Your browser does not support the video format. Please upgrade your browser.
+      </video>
+      <span className="subject-video-controls">
+        <span className="subject-frame-play-controls">
+          {if @state.playing
+            <button type="button" className="secret-button" aria-label="Pause" onClick={@playVideo.bind this, false}>
+              <i className="fa fa-pause fa-fw"></i>
+            </button>
+          else
+            <button type="button" className="secret-button" aria-label="Play" onClick={@playVideo.bind this, true}>
+              <i className="fa fa-play fa-fw"></i>
+            </button>}
+        </span>
+        <input type="range" className="video-scrubber" ref="videoScrubber" min="0" step="any" onChange={@seekVideo} />
+        <span className="video-speed">
+        Speed:
+          {for rate, i in [0.25, 0.5, 1]
+            <label key="rate-#{i}" className="secret-button">
+              <input type="radio" name="playRate" value={rate} checked={rate == @state.playbackRate} onChange={@setPlayRate} />
+              <span>
+                {rate}&times;
+              </span>
+            </label>
+          }
+        </span>
+      </span>
+      {@props.children}
+    </div>


### PR DESCRIPTION
Work towards #2144 

Moves the video player into its own component and tidies up the flipbook code for subjects with multiple images.

Might affect projects that use video or projects that use the flipbook slideshow for subject images, or projects that use pan-and-zoom.