### PR TITLE
Auto delete out-of-bounds marks

### DIFF
--- a/app/classifier/drawing-tools/circle.cjsx
+++ b/app/classifier/drawing-tools/circle.cjsx
@@ -3,6 +3,7 @@ EllipseTool = require './ellipse'
 DrawingToolRoot = require './root'
 DragHandle = require './drag-handle'
 Draggable = require '../../lib/draggable'
+deleteIfOutOfBounds = require './delete-if-out-of-bounds'
 DeleteButton = require './delete-button'
 
 MINIMUM_RADIUS = 5
@@ -62,7 +63,7 @@ module.exports = React.createClass
       {if @props.selected
         <line x1="0" y1="0" x2={@props.mark.r} y2="0" strokeWidth={GUIDE_WIDTH / ((@props.scale.horizontal + @props.scale.vertical) / 2)} strokeDasharray={GUIDE_DASH} />}
 
-      <Draggable onDrag={@handleMainDrag} disabled={@props.disabled}>
+      <Draggable onDrag={@handleMainDrag} onEnd={deleteIfOutOfBounds.bind null, this} disabled={@props.disabled}>
         <ellipse rx={@props.mark.r} ry={@props.mark.r} />
       </Draggable>
 

--- a/app/classifier/drawing-tools/delete-button.cjsx
+++ b/app/classifier/drawing-tools/delete-button.cjsx
@@ -12,8 +12,6 @@ CROSS_PATH = "
   L 0 #{RADIUS * 0.7 }
 "
 
-DESTROY_TRANSITION_DURATION = 300
-
 module.exports = React.createClass
   displayName: 'DeleteButton'
 
@@ -21,6 +19,7 @@ module.exports = React.createClass
     x: 0
     y: 0
     rotate: 0
+    destroyTransitionDuration: 300
 
   render: ->
     transform = "
@@ -36,4 +35,4 @@ module.exports = React.createClass
 
   destroyTool: ->
     @props.tool.setState destroying: true, =>
-      setTimeout @props.tool.props.onDestroy, DESTROY_TRANSITION_DURATION
+      setTimeout @props.tool.props.onDestroy, @props.destroyTransitionDuration

--- a/app/classifier/drawing-tools/delete-if-out-of-bounds.coffee
+++ b/app/classifier/drawing-tools/delete-if-out-of-bounds.coffee
@@ -1,12 +1,5 @@
 ReactDOM = require 'react-dom'
-DeleteButton = require './delete-button'
-
-isInBounds = ({top, left, width, height}, bounds) ->
-  goodTop = top < bounds.top + bounds.height
-  goodRight = left + width > bounds.left
-  goodBottom = top + height > bounds.top
-  goodLeft = left < bounds.left + bounds.width
-  goodTop and goodRight and goodBottom and goodLeft
+isInBounds = require '../../lib/is-in-bounds'
 
 deleteIfOutOfBounds = (tool) ->
   domNode = ReactDOM.findDOMNode tool

--- a/app/classifier/drawing-tools/delete-if-out-of-bounds.coffee
+++ b/app/classifier/drawing-tools/delete-if-out-of-bounds.coffee
@@ -1,0 +1,18 @@
+ReactDOM = require 'react-dom'
+DeleteButton = require './delete-button'
+
+isInBounds = ({top, left, width, height}, bounds) ->
+  goodTop = top < bounds.top + bounds.height
+  goodRight = left + width > bounds.left
+  goodBottom = top + height > bounds.top
+  goodLeft = left < bounds.left + bounds.width
+  goodTop and goodRight and goodBottom and goodLeft
+
+deleteIfOutOfBounds = (tool) ->
+  domNode = ReactDOM.findDOMNode tool
+  boundingBox = domNode.getBoundingClientRect()
+  outOfBounds = not isInBounds boundingBox, tool.props.containerRect
+  if outOfBounds
+    tool.props.onDestroy()
+
+module.exports = deleteIfOutOfBounds

--- a/app/classifier/drawing-tools/delete-if-out-of-bounds.coffee
+++ b/app/classifier/drawing-tools/delete-if-out-of-bounds.coffee
@@ -3,7 +3,11 @@ isInBounds = require '../../lib/is-in-bounds'
 
 deleteIfOutOfBounds = (tool) ->
   domNode = ReactDOM.findDOMNode tool
-  boundingBox = domNode.getBoundingClientRect()
+  boundingBox = do ->
+    {left, top, width, height} = domNode.getBoundingClientRect()
+    left += pageXOffset
+    top += pageYOffset
+    {left, top, width, height}
   outOfBounds = not isInBounds boundingBox, tool.props.containerRect
   if outOfBounds
     tool.props.onDestroy()

--- a/app/classifier/drawing-tools/ellipse.cjsx
+++ b/app/classifier/drawing-tools/ellipse.cjsx
@@ -2,6 +2,7 @@ React = require 'react'
 DrawingToolRoot = require './root'
 DragHandle = require './drag-handle'
 Draggable = require '../../lib/draggable'
+deleteIfOutOfBounds = require './delete-if-out-of-bounds'
 DeleteButton = require './delete-button'
 
 DEFAULT_SQUASH = 1 / 2
@@ -68,7 +69,7 @@ module.exports = React.createClass
           <line x1="0" y1="0" x2="0" y2={-1 * @props.mark.ry} strokeWidth={guideWidth} strokeDasharray={GUIDE_DASH} />
         </g>}
 
-      <Draggable onDrag={@handleMainDrag} disabled={@props.disabled}>
+      <Draggable onDrag={@handleMainDrag} onEnd={deleteIfOutOfBounds.bind null, this} disabled={@props.disabled}>
         <ellipse rx={@props.mark.rx} ry={@props.mark.ry} />
       </Draggable>
 

--- a/app/classifier/drawing-tools/line.cjsx
+++ b/app/classifier/drawing-tools/line.cjsx
@@ -1,6 +1,7 @@
 React = require 'react'
 DrawingToolRoot = require './root'
 Draggable = require '../../lib/draggable'
+deleteIfOutOfBounds = require './delete-if-out-of-bounds'
 DeleteButton = require './delete-button'
 DragHandle = require './drag-handle'
 
@@ -38,7 +39,7 @@ module.exports = React.createClass
     <DrawingToolRoot tool={this}>
       <line {...points} />
 
-      <Draggable onDrag={@handleStrokeDrag} disabled={@props.disabled}>
+      <Draggable onDrag={@handleStrokeDrag} onEnd={deleteIfOutOfBounds.bind null, this} disabled={@props.disabled}>
         <line {...points} strokeWidth={GRAB_STROKE_WIDTH / ((@props.scale.horizontal + @props.scale.vertical) / 2)} strokeOpacity="0" />
       </Draggable>
 

--- a/app/classifier/drawing-tools/point.cjsx
+++ b/app/classifier/drawing-tools/point.cjsx
@@ -1,5 +1,6 @@
 React = require 'react'
 DrawingToolRoot = require './root'
+deleteIfOutOfBounds = require './delete-if-out-of-bounds'
 Draggable = require '../../lib/draggable'
 DeleteButton = require './delete-button'
 
@@ -48,7 +49,7 @@ module.exports = React.createClass
       <line x1="0" y1={crosshairSpace * selectedRadius} x2="0" y2={selectedRadius} strokeWidth={crosshairWidth} />
       <line x1={crosshairSpace * selectedRadius} y1="0" x2={selectedRadius} y2="0" strokeWidth={crosshairWidth} />
 
-      <Draggable onDrag={@handleDrag} disabled={@props.disabled}>
+      <Draggable onDrag={@handleDrag} onEnd={deleteIfOutOfBounds.bind null, this} disabled={@props.disabled}>
         <circle r={radius} />
       </Draggable>
 

--- a/app/classifier/drawing-tools/point.cjsx
+++ b/app/classifier/drawing-tools/point.cjsx
@@ -3,6 +3,7 @@ DrawingToolRoot = require './root'
 deleteIfOutOfBounds = require './delete-if-out-of-bounds'
 Draggable = require '../../lib/draggable'
 DeleteButton = require './delete-button'
+isInBounds = require '../../lib/is-in-bounds'
 
 RADIUS = 10
 SELECTED_RADIUS = 20
@@ -22,6 +23,14 @@ module.exports = React.createClass
 
     initMove: ({x, y}) ->
       {x, y}
+
+    initValid: (mark, {containerRect}) ->
+      markRect =
+        top: containerRect.top + mark.y
+        left: containerRect.left + mark.y
+        width: 1
+        height: 1
+      isInBounds markRect, containerRect
 
     initRelease: ->
       _inProgress: false

--- a/app/classifier/drawing-tools/point.cjsx
+++ b/app/classifier/drawing-tools/point.cjsx
@@ -24,10 +24,10 @@ module.exports = React.createClass
     initMove: ({x, y}) ->
       {x, y}
 
-    initValid: (mark, {containerRect}) ->
+    initValid: (mark, {containerRect, scale}) ->
       markRect =
-        top: containerRect.top + mark.y
-        left: containerRect.left + mark.y
+        left: containerRect.left + (mark.x * scale.vertical)
+        top: containerRect.top + (mark.y * scale.horizontal)
         width: 1
         height: 1
       isInBounds markRect, containerRect

--- a/app/classifier/drawing-tools/poly-curve.cjsx
+++ b/app/classifier/drawing-tools/poly-curve.cjsx
@@ -2,6 +2,7 @@ React = require 'react'
 DrawingToolRoot = require './root'
 DragHandle = require './drag-handle'
 Draggable = require '../../lib/draggable'
+deleteIfOutOfBounds = require './delete-if-out-of-bounds'
 DeleteButton = require './delete-button'
 
 FINISHER_RADIUS = 8
@@ -119,7 +120,7 @@ module.exports = React.createClass
       svgPathGuide = "M#{lastEnd.x} #{lastEnd.y} Q #{controlPoint.x} #{controlPoint.y} #{newPoint.x} #{newPoint.y}"
 
     <DrawingToolRoot tool={this}>
-      <Draggable onDrag={@handleMainDrag} disabled={@props.disabled}>
+      <Draggable onDrag={@handleMainDrag} onEnd={deleteIfOutOfBounds.bind null, this} disabled={@props.disabled}>
         <path d={svgPath} fill={'none' unless @props.mark.closed} />
       </Draggable>
 

--- a/app/classifier/drawing-tools/polygon.cjsx
+++ b/app/classifier/drawing-tools/polygon.cjsx
@@ -2,6 +2,7 @@ React = require 'react'
 DrawingToolRoot = require './root'
 DragHandle = require './drag-handle'
 Draggable = require '../../lib/draggable'
+deleteIfOutOfBounds = require './delete-if-out-of-bounds'
 DeleteButton = require './delete-button'
 
 FINISHER_RADIUS = 8
@@ -68,7 +69,7 @@ module.exports = React.createClass
       y: (firstPoint.y + ((DELETE_BUTTON_WEIGHT - 1) * secondPoint.y)) / DELETE_BUTTON_WEIGHT
 
     <DrawingToolRoot tool={this}>
-      <Draggable onDrag={@handleMainDrag} disabled={@props.disabled}>
+      <Draggable onDrag={@handleMainDrag} onEnd={deleteIfOutOfBounds.bind null, this} disabled={@props.disabled}>
         <polyline points={points} fill={'none' unless @props.mark.closed} />
       </Draggable>
 

--- a/app/classifier/drawing-tools/rectangle.cjsx
+++ b/app/classifier/drawing-tools/rectangle.cjsx
@@ -2,6 +2,7 @@ React = require 'react'
 DrawingToolRoot = require './root'
 DragHandle = require './drag-handle'
 Draggable = require '../../lib/draggable'
+deleteIfOutOfBounds = require './delete-if-out-of-bounds'
 DeleteButton = require './delete-button'
 
 MINIMUM_SIZE = 5
@@ -60,7 +61,7 @@ module.exports = React.createClass
     ].join '\n'
 
     <DrawingToolRoot tool={this}>
-      <Draggable onDrag={@handleMainDrag} disabled={@props.disabled}>
+      <Draggable onDrag={@handleMainDrag} onEnd={deleteIfOutOfBounds.bind null, this} disabled={@props.disabled}>
         <polyline points={points} />
       </Draggable>
 

--- a/app/classifier/tasks/drawing/marking-initializer.cjsx
+++ b/app/classifier/tasks/drawing/marking-initializer.cjsx
@@ -89,7 +89,7 @@ module.exports = React.createClass
     @props.classification.update 'annotations'
 
     if MarkComponent.initValid?
-      unless MarkComponent.initValid mark
+      unless MarkComponent.initValid mark, @props
         @destroyMark @props.annotation, mark
 
   destroyMark: (annotation, mark) ->

--- a/app/lib/is-in-bounds.coffee
+++ b/app/lib/is-in-bounds.coffee
@@ -1,0 +1,8 @@
+isInBounds = (rect, bounds) ->
+  goodTop = rect.top < bounds.top + bounds.height
+  goodRight = rect.left + rect.width > bounds.left
+  goodBottom = rect.top + rect.height > bounds.top
+  goodLeft = rect.left < bounds.left + bounds.width
+  goodTop and goodRight and goodBottom and goodLeft
+
+module.exports = isInBounds

--- a/app/lib/is-in-bounds.coffee
+++ b/app/lib/is-in-bounds.coffee
@@ -1,8 +1,8 @@
 isInBounds = (rect, bounds) ->
-  goodTop = rect.top < bounds.top + bounds.height
-  goodRight = rect.left + rect.width > bounds.left
-  goodBottom = rect.top + rect.height > bounds.top
-  goodLeft = rect.left < bounds.left + bounds.width
-  goodTop and goodRight and goodBottom and goodLeft
+  notBeyondLeft = rect.left + rect.width > bounds.left
+  notBeyondRight = rect.left < bounds.left + bounds.width
+  notBeyondTop = rect.top + rect.height > bounds.top
+  notBeyondBottom = rect.top < bounds.top + bounds.height
+  notBeyondLeft and notBeyondRight and notBeyondTop and notBeyondBottom
 
 module.exports = isInBounds

--- a/app/lib/is-in-bounds.coffee
+++ b/app/lib/is-in-bounds.coffee
@@ -1,8 +1,8 @@
-isInBounds = (rect, bounds) ->
-  notBeyondLeft = rect.left + rect.width > bounds.left
-  notBeyondRight = rect.left < bounds.left + bounds.width
-  notBeyondTop = rect.top + rect.height > bounds.top
-  notBeyondBottom = rect.top < bounds.top + bounds.height
+isInBounds = (object, bounds) ->
+  notBeyondLeft = object.left + object.width > bounds.left
+  notBeyondRight = object.left < bounds.left + bounds.width
+  notBeyondTop = object.top + object.height > bounds.top
+  notBeyondBottom = object.top < bounds.top + bounds.height
   notBeyondLeft and notBeyondRight and notBeyondTop and notBeyondBottom
 
 module.exports = isInBounds


### PR DESCRIPTION
This adds a check after the "main" drag of each drawing tool to see if the its element's bounding box has left the bounds of the subject image. If so, its associated mark is deleted from the annotation.

The same behavior is added to the `initValid` check of the point tool, which is the only tool that can be _initialized_ out of bounds.

Closes #2125.