### PR TITLE
Feature detect IE11 and only apply flex prop when detected

### DIFF
--- a/app/components/subject-viewer.cjsx
+++ b/app/components/subject-viewer.cjsx
@@ -5,6 +5,7 @@ alert = require '../lib/alert'
 getSubjectLocation = require '../lib/get-subject-location'
 CollectionsManagerIcon = require '../collections/manager-icon'
 FrameViewer = require './frame-viewer'
+classnames = require 'classnames'
 
 NOOP = Function.prototype
 
@@ -17,7 +18,6 @@ subjectHasMixedLocationTypes = (subject) ->
         allTypes.push type
   allTypes.length > 1
 
-ROOT_STYLE = display: 'block'
 CONTAINER_STYLE = display: 'flex', flexWrap: 'wrap', position: 'relative'
 
 module.exports = React.createClass
@@ -51,9 +51,13 @@ module.exports = React.createClass
         inFlipbookMode: allowFlipbook
 
   render: ->
-    rootClass = 'subject-viewer'
-    if @props.workflow?.configuration?.multi_image_layout then rootClass += ' subject-viewer--layout-' + @props.workflow.configuration?.multi_image_layout
-    if @state.inFlipbookMode then rootClass += ' subject-viewer--flipbook'
+    rootClasses = classnames('subject-viewer', { 
+      'default-root-style': @props.defaultStyle
+      'subject-viewer--flipbook': @state.inFlipbookMode 
+      "subject-viewer--layout-#{@props.workflow.configuration?.multi_image_layout}": @props.workflow?.configuration?.multi_image_layout
+    })
+    # Feature detect IE11 and apply flex prop. Revisit or remove when IE11 is no longer supported.
+    rootStyle = flex: "1 1 auto" if "ActiveXObject" in window or window.ActiveXObject isnt undefined
     mainDisplay = ''
     {type, format, src} = getSubjectLocation @props.subject, @state.frame
     if @state.inFlipbookMode
@@ -91,7 +95,7 @@ module.exports = React.createClass
               </span>}
           </span>
 
-    <div className={rootClass} style={ROOT_STYLE if @props.defaultStyle}>
+    <div className={rootClasses} style={rootStyle}>
       {if type is 'image'
         @hiddenPreloadedImages()}
       <div className="subject-container" style={CONTAINER_STYLE} >

--- a/css/classify.styl
+++ b/css/classify.styl
@@ -18,9 +18,6 @@
 .classifier
   display: flex
   justify-content: center
-  
-  > *
-    flex: 1 1 auto
 
   @media (max-width: 900px) // This is between iPad landscape and portrait.
     flex-wrap: wrap
@@ -38,7 +35,7 @@
     max-width: 100%
     > *
       display: flex
-      flex: 1 1 auto
+      flex: 1 1 auto // Fix for IE 11. Revisit or remove when IE11 is no longer supported.
 
   .subject
     border-radius: 5px

--- a/css/subject.styl
+++ b/css/subject.styl
@@ -1,6 +1,9 @@
 .subject-viewer
   min-width: 0
   max-width: 100%
+  
+  .default-root-style
+    display: block
 
   .subject-frame-pips
     .subject-frame-pip


### PR DESCRIPTION
Fixed #2329 by feature detecting for IE11 and only applying `flex: 1 1 auto` to the subject viewer when it is IE11. Flex-grow must be set to 1 for the subject viewer to display correctly in IE11. I tried out ideas with setting max-width to the parent element or possibly setting max-width of the viewer to the naturalWidth of the subject image, but both of those didn't entirely solve the issue or had unintended consequences.

Deployed as a feature branch: https://preview.zooniverse.org/panoptes-front-end/fix-2329
@alexbfree or @eatyourgreens care to take to look to make sure I'm not inadvertently breaking something somewhere. I checked chrome, FF, IE11, safari, and iOS safari and it looked alright to me. IE11 will still possibly have the black background behind subjects with large viewports, but here's hoping our IE support days will be behind us soon :weary:  