### PR TITLE
Make sure the background behind text is really dark

### DIFF
--- a/css/project-page.styl
+++ b/css/project-page.styl
@@ -140,6 +140,9 @@
   font-size: .75em
   color: #CDCDCD
 
+.project-text-content
+  background: rgba(0,0,0,0.8)
+  padding: 1.5em 3vw
 
 .project-metadata
   padding: 1.5em 3vw


### PR DESCRIPTION
Main goal for this is to enhance readability of text and the make images stand out better. I know we're working towards a larger redesign, but perhaps we can take this small step in the meantime?

/cc @aliburchard @alexbfree @jwbmartin 

# Before

![screenshot_05](https://cloud.githubusercontent.com/assets/277/13950495/2f955fb8-f023-11e5-9062-ce116e5f1e22.png)

# After

![screenshot_06](https://cloud.githubusercontent.com/assets/277/13950498/32fbfbd0-f023-11e5-9ed8-3657502ba5bc.png)
