### PR TITLE
Fix the title and numbering for recent Planet Hunters paper. 

### DIFF
--- a/app/pages/about/publications-page.cjsx
+++ b/app/pages/about/publications-page.cjsx
@@ -147,10 +147,12 @@ publicationCategories =
     },
     {slug: "zooniverse/planet-hunters"
     publications: [
-      {citation: "Planet Hunters. IX. KIC 8462852 – Where’s the flux?, Boyajian+ 2016."
-      href: "http://mnras.oxfordjournals.org/content/457/4/3988.full.pdf"},
+      {citation: "Planet Hunters X: Searching for Nearby Neighbors of 75 Planet and Eclipsing Binary Candidates from the K2 Kepler extended mission, Schmitt+ 2016."
+      href: "http://arxiv.org/pdf/1603.06945v1.pdf"},
       {citation: "Planet Hunters. VIII. Characterization of 41 Long-Period Exoplanet Candidates from Kepler Archival Data, Wang+ 2015."
       href: "http://arxiv.org/pdf/1512.02559v2.pdf"},
+      {citation: "Planet Hunters. IX. KIC 8462852 – Where’s the flux?, Boyajian+ 2015."
+      href: "http://mnras.oxfordjournals.org/content/457/4/3988.full.pdf"},
       {citation: "GALEX J194419.33+491257.0: An unusually active SU UMa-type dwarf nova with a very short orbital period in the Kepler data, Kato & Osaki 2014."
       href: "http://adsabs.harvard.edu/doi/10.1093/pasj/psu025"},
       {citation: "Planet Hunters. VI. An Independent Characterization of KOI-351 and Several Long Period Planet Candidates from the Kepler Archival Data, Schmitt+ 2014."

--- a/app/pages/about/publications-page.cjsx
+++ b/app/pages/about/publications-page.cjsx
@@ -147,10 +147,10 @@ publicationCategories =
     },
     {slug: "zooniverse/planet-hunters"
     publications: [
+      {citation: "Planet Hunters. IX. KIC 8462852 – Where’s the flux?, Boyajian+ 2016."
+      href: "http://mnras.oxfordjournals.org/content/457/4/3988.full.pdf"},
       {citation: "Planet Hunters. VIII. Characterization of 41 Long-Period Exoplanet Candidates from Kepler Archival Data, Wang+ 2015."
       href: "http://arxiv.org/pdf/1512.02559v2.pdf"},
-      {citation: "Planet Hunters. X. KIC 8462852 – Where’s the flux?, Boyajian+ 2015."
-      href: "http://arxiv.org/pdf/1509.03622v1.pdf"},
       {citation: "GALEX J194419.33+491257.0: An unusually active SU UMa-type dwarf nova with a very short orbital period in the Kepler data, Kato & Osaki 2014."
       href: "http://adsabs.harvard.edu/doi/10.1093/pasj/psu025"},
       {citation: "Planet Hunters. VI. An Independent Characterization of KOI-351 and Several Long Period Planet Candidates from the Kepler Archival Data, Schmitt+ 2014."


### PR DESCRIPTION
Boyajian+15 was initially submitted to the arXiv as "Planet Hunters X", when it should have been "Planet Hunters IX" (only the ninth in the series). I also changed the link to point to the correct MNRAS version of the paper (which is open access), rather than the arXiv preprint. 