### PR TITLE
"Quick fix" to improve readability

### DIFF
--- a/css/project-page.styl
+++ b/css/project-page.styl
@@ -140,6 +140,22 @@
   font-size: .75em
   color: #CDCDCD
 
+.project-text-content
+  background: rgba(255,255,255,0.85)
+  padding: 1.5em 3vw
+  color: #000000
+  border-radius: 3px
+
+  .project-role
+    color: #ffffff
+    background-color: #555555
+    padding: 0.1em 0.4em
+
+    &.owner
+      background-color: #1277fd
+
+  img
+    padding: 5px 0
 
 .project-metadata
   padding: 1.5em 3vw


### PR DESCRIPTION
Based on https://github.com/zooniverse/Panoptes-Front-End/pull/2331, which this PR replaces

Key features:

* White background (85% opacity) and black text on all project pages
* Small padding (5px) above and below embedded images
* Change owner/collaborator to tags to be readable on white background (slight increase to padding, change colours)

I have reviewed this with all project pages on all published-to-the-homepage public project builder projects, all seem readable.

## Before (FAQ with images)

![screenshot 2016-04-01 17 56 15](https://cloud.githubusercontent.com/assets/1473244/14214137/418671e0-f833-11e5-84eb-e2285870445a.png)

## After (FAQ with images)

![screenshot 2016-04-01 17 56 47](https://cloud.githubusercontent.com/assets/1473244/14214150/504f8c8e-f833-11e5-8013-9f1be23ca463.png)

## Before (Research Page with Team Role markers)

![screenshot 2016-04-01 17 56 24](https://cloud.githubusercontent.com/assets/1473244/14214164/6012b98e-f833-11e5-8ebf-39ac7367af45.png)

## After (Research Page with Team Role markers)

![screenshot 2016-04-01 17 56 58](https://cloud.githubusercontent.com/assets/1473244/14214170/6c0c81d4-f833-11e5-8f78-0bac148190b9.png)

(Happy to change colours of role markers if anyone has better suggestions!)

