### PR TITLE
Make links on the white page contents slightly darker.

### DIFF
--- a/css/project-page.styl
+++ b/css/project-page.styl
@@ -152,7 +152,10 @@
     padding: 0.1em 0.4em
 
     &.owner
-      background-color: #1277fd
+      background-color: #0072ff
+
+  a
+    color: #0072ff
 
 .project-metadata
   padding: 1.5em 3vw


### PR DESCRIPTION
Following up on #2374 I found the links slightly to light. I've switched them over to the same colour as the owner tag in the sidebar.

## Before:

![image](https://cloud.githubusercontent.com/assets/277/14250734/b11b115a-fa77-11e5-962b-97e232ceca4c.png)

## After:

![image](https://cloud.githubusercontent.com/assets/277/14250757/be222bcc-fa77-11e5-86d3-04aa1564f1f1.png)
