### PR TITLE
Use local mirror of PhantomJS package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && \
     apt-get install -y nodejs && apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN curl -L https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 \
+RUN curl -L https://static.zooniverse.org/phantomjs-2.1.1-linux-x86_64.tar.bz2 \
     | tar -xvj -C / --strip-components 1 --wildcards "*/bin/phantomjs"
 
 ADD . /src/


### PR DESCRIPTION
because BitBucket is unreliable