### PR TITLE
darker text color for home page description

### DIFF
--- a/css/project-page.styl
+++ b/css/project-page.styl
@@ -121,13 +121,13 @@
       font-weight: 700
       line-height: 2.5em
       font-size: 15px
-      color: #5a5a5a
+      color: #404040
       text-align: center
       max-width: 800px
       margin: 0 auto 1em
 
    .markdown
-      color: #989898
+      color: #646464
       line-height: 1.4em
       text-align: center
       max-width: 800px


### PR DESCRIPTION
This PR darkens the color of the home-page-description text to increase readability. @jwbmartin, thoughts?

Original text color:
<img width="788" alt="original_lighter_grey" src="https://cloud.githubusercontent.com/assets/7684729/14329875/2f50e554-fc03-11e5-95e2-88a9dcae60af.png">

Proposed text color:
<img width="765" alt="proposed_darker_grey" src="https://cloud.githubusercontent.com/assets/7684729/14329879/36de0216-fc03-11e5-9d9f-2389eab57d5e.png">

 