### PR TITLE
Workflow tutorials

### DIFF
--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -40,11 +40,13 @@ Classifier = React.createClass
   componentDidMount: ->
     @loadSubject @props.subject
     @prepareToClassify @props.classification
-    Tutorial.startIfNecessary @props.user, @props.project
+    {workflow, project, user} = @props
+    Tutorial.startIfNecessary {workflow, project, user}
 
   componentWillReceiveProps: (nextProps) ->
     if nextProps.project isnt @props.project or nextProps.user isnt @props.user
-      Tutorial.startIfNecessary nextProps.user, nextProps.project
+      {workflow, project, user} = nextProps
+      Tutorial.startIfNecessary {workflow, project, user}
     if nextProps.subject isnt @props.subject
       @loadSubject subject
     if nextProps.classification isnt @props.classification
@@ -178,7 +180,7 @@ Classifier = React.createClass
       <p>
         <small>
           <strong>
-            <TutorialButton className="minor-button" user={@props.user} project={@props.project} title="Project tutorial" aria-label="Show the project tutorial" style={marginTop: '2em'}>
+            <TutorialButton className="minor-button" user={@props.user} workflow={@props.workflow} project={@props.project} title="Project tutorial" aria-label="Show the project tutorial" style={marginTop: '2em'}>
               Show the project tutorial
             </TutorialButton>
           </strong>

--- a/app/classifier/tutorial-button.cjsx
+++ b/app/classifier/tutorial-button.cjsx
@@ -4,27 +4,28 @@ Tutorial = require '../lib/tutorial'
 
 module.exports = React.createClass
   getDefaultProps: ->
-    user: null
+    workflow: null
     project: null
+    user: null
 
   getInitialState: ->
     tutorial: null
 
   componentDidMount: ->
-    @fetchTutorialFor @props.project
+    @fetchTutorialFor @props.workflow, @props.project
 
   componentWillReceiveProps: (nextProps) ->
-    unless nextProps.project is @props.project
-      @fetchTutorialFor nextProps.project
+    unless nextProps.workflow is @props.workflow and nextProps.project is @props.project
+      @fetchTutorialFor nextProps.workflow, nextProps.project
 
-  fetchTutorialFor: (project) ->
-    apiClient.type('tutorials').get project_id: project.id
-      .then ([tutorial]) =>
-        @setState {tutorial}
+  fetchTutorialFor: (workflow, project) ->
+    @setState tutorial: null
+    Tutorial.find({workflow, project}).then (tutorial) =>
+      @setState {tutorial}
 
   render: ->
-    if @state.tutorial? and @state.tutorial.steps.length isnt 0
-      <button type="button" {...@props} onClick={Tutorial.start.bind(Tutorial, @props.user, @props.project)}>
+    if @state.tutorial?.steps.length > 0
+      <button type="button" {...@props} onClick={Tutorial.start.bind(Tutorial, @state.tutorial, @props.user)}>
         {@props.children}
       </button>
     else


### PR DESCRIPTION
Tutorials are now looked up by workflow first and fall back to lookup by project. (@marten, just to confirm:  getting `/tutorials?workflow_id=123` and `/tutorials?project_id=234` will both work and will continue to in the future, correct?)

Completed tutorials are now recorded by tutorial ID instead of project ID.

Related to zooniverse/Panoptes#1747. That deploy and this merge should probably be at the same time.