### PR TITLE
Fix survey chooser buttons in Firefox

### DIFF
--- a/app/classifier/tasks/survey/chooser.cjsx
+++ b/app/classifier/tasks/survey/chooser.cjsx
@@ -102,11 +102,13 @@ module.exports = React.createClass
         else
           for choiceID, i in sortedFilteredChoices
             choice = @props.task.choices[choiceID]
-            <button key={choiceID + i} type="button" className="survey-task-chooser-choice" onClick={@props.onChoose.bind null, choiceID}>
-              {if choice.images?.length > 0
-                thumbnailSrc = @props.task.images[choice.images[0]]
-                <span className="survey-task-chooser-choice-thumbnail" role="presentation" style={backgroundImage: "url('#{thumbnailSrc}')"}></span>}
-              <span className="survey-task-chooser-choice-label">{choice.label}</span>
+            <button key={choiceID + i} type="button" className="survey-task-chooser-choice-button" onClick={@props.onChoose.bind null, choiceID}>
+              <div className="survey-task-chooser-choice">
+                {if choice.images?.length > 0
+                  thumbnailSrc = @props.task.images[choice.images[0]]
+                  <span className="survey-task-chooser-choice-thumbnail" role="presentation" style={backgroundImage: "url('#{thumbnailSrc}')"}></span>}
+                <span className="survey-task-chooser-choice-label">{choice.label}</span>
+              </div>
             </button>}
       </div>
       <div style={textAlign: 'center'}>

--- a/css/common.styl
+++ b/css/common.styl
@@ -29,6 +29,20 @@ background-stripes(color1, color2, size)
   to
     background-position: 1em 0
 
+/* Globally prevent Firefox from affecting buttons' dimensions. */
+@css {
+  button::-moz-focus-inner {
+    border: 0;
+    padding: 0;
+  }
+
+  @-moz-document url-prefix() {
+    button:focus {
+      outline: 1px dotted;
+    }
+  }
+}
+
 $reset-button
   background: transparent
   border: 0

--- a/css/survey-task.styl
+++ b/css/survey-task.styl
@@ -115,11 +115,10 @@ $survey-task-pill-button
   border-radius: 8px
   display: flex
   flex-wrap: wrap
-  padding: 4px
+  padding: 3px
 
   > *
-    margin: 0 2px 2px 0
-    position: relative
+    margin: 1px
 
   &[data-columns="3"] > *
     flex-basis: calc(33.33% - 2px)
@@ -130,17 +129,14 @@ $survey-task-pill-button
   &[data-columns="1"] > *
     flex-basis: calc(100% - 2px)
 
-  .survey-task-chooser-choice
-    align-items: center
-    justify-content: flex-start
+.survey-task-chooser-choice-button
+  @extends $reset-button
 
 .survey-task-chooser-choice
-  @extends $reset-button
+  align-items: center
   background: rgba(64, 64, 64, 1)
   color: white
   display: flex
-  justify-content: center
-  width: 100%
 
   &:hover
     background: rgba(102, 102, 102, 1)
@@ -175,7 +171,7 @@ $survey-task-pill-button
 .survey-task-chooser-choice-label
   display: inline-block
 
-  [data-breakpoint="5"] &
+  [data-columns="1"] &
     font-size: 1.5em
 
 .survey-task-chooser-characteristic-clear-button


### PR DESCRIPTION
Firefox apparently [cannot display buttons as flex at all](https://bugzilla.mozilla.org/show_bug.cgi?id=984869).

Also finally found a decent solution to removing Firefox's focus ring padding from buttons.

Closes #2401.