### PR TITLE
resolves frozen subTask editor - fixes #2422

### DIFF
--- a/app/classifier/tasks/generic-editor.cjsx
+++ b/app/classifier/tasks/generic-editor.cjsx
@@ -57,7 +57,7 @@ module.exports = React.createClass
         </div>}
       {' '}
 
-      {if 'hide previous marks' in @props.project.experimental_tools
+      {if @props.project and 'hide previous marks' in @props.project.experimental_tools
         <label className="pill-button">
           <AutoSave resource={@props.workflow}>
             <input type="checkbox" checked={@props.task.enableHidePrevMarks} onChange={@toggleHidePrevMarksEnabled} />{' '}


### PR DESCRIPTION
The `<GenericTaskEditor />` editor needs to check for a `@props.project` before checking if `'hide previous marks' in @props.project.experimental_tools`, otherwise the subTask editor freezes as documented in Issue #2422.