### PR TITLE
Fix projects page filters

### DIFF
--- a/app/components/project-card-list.cjsx
+++ b/app/components/project-card-list.cjsx
@@ -239,7 +239,8 @@ ProjectFilteringInterface = React.createClass
         @setState loading: false
 
   handleDisciplineChange: (discipline) ->
-    this.props.onChangeQuery {discipline}
+    page = 1
+    this.props.onChangeQuery {discipline, page}
 
   handleSortChange: (sort) ->
     page = 1

--- a/app/pages/projects.cjsx
+++ b/app/pages/projects.cjsx
@@ -42,6 +42,7 @@ ProjectsPage = React.createClass
       if value is ''
         delete query[key]
     newLocation = Object.assign {}, @props.location, {query}
+    newLocation.search = ""
     @props.history.replace newLocation
 
   render: ->


### PR DESCRIPTION
Resets the page to 1 when discipline changes.
Resets the discipline filter for All Disciplines.
Fixes #2419
Fixes #2372