### PR TITLE
Change default sort order to launch date.

### DIFF
--- a/app/components/project-card-list.cjsx
+++ b/app/components/project-card-list.cjsx
@@ -186,7 +186,7 @@ ProjectFilteringInterface = React.createClass
   getDefaultProps: ->
     discipline: ''
     page: 1
-    sort: 'display_name'
+    sort: '-launch_date'
 
     # To separate the API from the UI (and present the user with more friendly query terms):
     SORT_QUERY_VALUES:


### PR DESCRIPTION
In light of emerging consensus on #2424, set sort order to launch date for now. Will leave ticket open in case we change it.