### PR TITLE
[project page branch] Rename "Astronomy" category to "Space"

### DIFF
--- a/app/components/disciplines.cjsx
+++ b/app/components/disciplines.cjsx
@@ -1,7 +1,6 @@
 module.exports =
   DISCIPLINES:   [
     {value: 'arts', label: 'Arts'},
-    {value: 'astronomy', label: 'Astronomy'},
     {value: 'biology', label: 'Biology'},
     {value: 'climate', label: 'Climate'},
     {value: 'history', label: 'History'},
@@ -11,5 +10,6 @@ module.exports =
     {value: 'medicine', label: 'Medicine'},
     {value: 'nature', label: 'Nature'},
     {value: 'physics', label: 'Physics'},
-    {value: 'social science', label: 'Social Science'}
+    {value: 'social science', label: 'Social Science'},
+    {value: 'astronomy', label: 'Space'}
   ]


### PR DESCRIPTION
... so that it encompasses "Planetary Science" too. Per @mschwamb's suggestion in https://github.com/zooniverse/Panoptes-Front-End/issues/2373 - @mrniaboc and I both agreed it is a good idea - and Space is what it used to be called on old Zoo home.