### PR TITLE
Fix issues with talk moderations

### DIFF
--- a/app/pages/profile/comment-link.cjsx
+++ b/app/pages/profile/comment-link.cjsx
@@ -51,20 +51,23 @@ module?.exports = React.createClass
   render: ->
     <div className="profile-feed-comment-link">
       <header>
-        <span className="comment-timestamp"title={moment(@props.comment.created_at).toISOString()}>
+        <span className="comment-timestamp" title={moment(@props.comment.created_at).toISOString()}>
           {moment(@props.comment.created_at).fromNow()}
-        </span>{' '}
-        in{' '}
-        <a href={@state.href}>
-          {if @state.project? and @state.owner
-            <span>
-              <strong className="comment-project" title="#{@state.owner.display_name}/#{@state.project.display_name}">{@state.project.display_name}</strong>
+        </span>
+        {if @state.board?.id and @state.discussion?.id
+          <span>
+            {' '}in{' '}
+            <a href={@state.href}>
+              {if @state.project? and @state.owner
+                <span>
+                  <strong className="comment-project" title="#{@state.owner.display_name}/#{@state.project.display_name}">{@state.project.display_name}</strong>
+                  ➞
+                </span>}
+              <strong className="comment-board">{@state.board?.title}</strong>
               ➞
-            </span>}
-          <strong className="comment-board">{@state.board?.title}</strong>
-          ➞
-          <strong className="comment-discussion">{@state.discussion?.title}</strong>
-        </a>
+              <strong className="comment-discussion">{@state.discussion?.title}</strong>
+            </a>
+          </span>}
       </header>
 
       <Markdown className="comment-body" content={@props.comment.body} />

--- a/app/talk/moderation/actions.cjsx
+++ b/app/talk/moderation/actions.cjsx
@@ -1,0 +1,96 @@
+React = require 'react'
+{Link} = require 'react-router'
+moment = require 'moment'
+apiClient = require 'panoptes-client/lib/api-client'
+Loading = require '../../components/loading-indicator'
+
+actionTaken =
+  destroy: 'Deleted'
+  destroyed: 'Deleted'
+  open: 'Opened'
+  opened: 'Opened'
+  close: 'Deleted'
+  closed: 'Deleted'
+  ignore: 'Ignored'
+  ignored: 'Ignored'
+  watch: 'Watched'
+  watched: 'Watched'
+
+module?.exports = React.createClass
+  displayName: 'ModerationActions'
+
+  propTypes:
+    moderation: React.PropTypes.object.isRequired
+    comment: React.PropTypes.object.isRequired
+    user: React.PropTypes.object.isRequired
+    updateModeration: React.PropTypes.func.isRequired
+
+  getInitialState: ->
+    actions: null
+
+  componentDidMount: ->
+    if @props.moderation.actions.length is 0
+      @setState actions: []
+    else
+      Promise.all(@props.moderation.actions.map (action) =>
+        apiClient.type('users').get(action.user_id.toString()).then (user) =>
+          Object.assign { }, action, {user}
+      ).then (actions) =>
+        @setState {actions}
+
+  confirmDelete: ->
+    window.confirm 'Are you sure that you want to delete the reported comment?'
+
+  updateModeration: (action) ->
+    =>
+      return if action is 'destroy' and not @confirmDelete()
+      message = @refs.message.value ? null
+      @refs.message.value = ''
+      @props.updateModeration @props.moderation, action, message
+
+  availableActions: ->
+    @props.comment.moderatable_actions.filter (action) =>
+      (@props.moderation.state.indexOf(action) is -1) and action isnt 'report'
+
+  actionButtons: ->
+    @availableActions().map (action) =>
+      label = if action is 'destroy' then 'delete' else action
+      <button
+        key={"action-#{@props.comment.id}-#{action}"}
+        className="moderations-#{action}"
+        onClick={@updateModeration(action)}>
+          {label}
+      </button>
+
+  render: ->
+    {moderation} = @props
+    <div className="moderations-actions-buttons">
+      <p>
+        Status: <strong>
+          {actionTaken[moderation.state] ? moderation.state}
+        </strong> {moment(moderation.created_at).fromNow()}
+      </p>
+
+      {if @state.actions
+        <div>
+          {for action in @state.actions
+            <div key={"moderation-#{moderation.id}-action-#{action.action}"}>
+              {actionTaken[action.action] ? action.action} by <Link to="/users/#{action.user.login}">{action.user.display_name}</Link>
+              {if action.message
+                <div>
+                  <i className="fa fa-quote-left"/> {action.message} <i className="fa fa-quote-right"/>
+                </div>}
+            </div>}
+        </div>
+      else
+        <Loading />}
+
+      {if moderation.state isnt 'closed'
+        <div>
+          <div className="textarea-container">
+            <textarea ref="message" placeholder="Optional message" />
+          </div>
+
+          {@actionButtons()}
+        </div>}
+    </div>

--- a/app/talk/moderation/comment.cjsx
+++ b/app/talk/moderation/comment.cjsx
@@ -1,0 +1,48 @@
+React = require 'react'
+{Link} = require 'react-router'
+talkClient = require 'panoptes-client/lib/talk-client'
+Loading = require '../../components/loading-indicator'
+CommentLink = require '../../pages/profile/comment-link'
+ModerationReports = require './reports'
+ModerationActions = require './actions'
+
+module?.exports = React.createClass
+  displayName: 'ModerationComment'
+
+  propTypes:
+    moderation: React.PropTypes.object.isRequired
+    user: React.PropTypes.object.isRequired
+    updateModeration: React.PropTypes.func.isRequired
+
+  getInitialState: ->
+    comment: null
+
+  getComment: ->
+    if @props.moderation.destroyed_target
+      Promise.resolve @props.moderation.destroyed_target
+    else
+      talkClient.type('comments').get @props.moderation.target_id
+
+  componentDidMount: ->
+    @getComment().then (comment) =>
+      @setState {comment}
+
+  render: ->
+    <div className="talk-module">
+      {if @state.comment
+        <div key={"comment-#{@state.comment.id}"}>
+          <h1>Comment {@state.comment.id} Reports</h1>
+          <ModerationReports reports={@props.moderation.reports} />
+
+          <span>Reported comment by:{' '}
+            <Link to="/users/#{@state.comment.user_login}">
+              {@state.comment.user_display_name or @state.comment.user_login}
+            </Link>:
+          </span>
+
+          <CommentLink comment={@state.comment} />
+          <ModerationActions {...@props} comment={@state.comment} />
+        </div>
+      else
+        <Loading />}
+    </div>

--- a/app/talk/moderation/reports.cjsx
+++ b/app/talk/moderation/reports.cjsx
@@ -1,0 +1,31 @@
+React = require 'react'
+{Link} = require 'react-router'
+apiClient = require 'panoptes-client/lib/api-client'
+Loading = require '../../components/loading-indicator'
+
+module?.exports = React.createClass
+  displayName: 'ModerationActions'
+
+  propTypes:
+    reports: React.PropTypes.array.isRequired
+
+  getInitialState: ->
+    reports: null
+
+  componentDidMount: ->
+    Promise.all(@props.reports.map (report) =>
+      apiClient.type('users').get(report.user_id.toString()).then (user) =>
+        Object.assign { }, report, {user}
+    ).then (reports) =>
+      @setState {reports}
+
+  render: ->
+    <ul>
+      {if @state.reports
+        for report, i in @state.reports
+          <li key={"report-#{i}"}>
+            <Link to="/users/#{report.user.login}">{report.user.display_name}</Link>: {report.message}
+          </li>
+      else
+        <Loading />}
+    </ul>

--- a/app/talk/moderations.cjsx
+++ b/app/talk/moderations.cjsx
@@ -1,33 +1,12 @@
 React = require 'react'
-ReactDOM = require 'react-dom'
 talkClient = require 'panoptes-client/lib/talk-client'
-apiClient = require 'panoptes-client/lib/api-client'
 auth = require 'panoptes-client/lib/auth'
-PromiseRenderer = require '../components/promise-renderer'
-ChangeListener = require '../components/change-listener'
-{Markdown} = require 'markdownz'
-CommentLink = require '../pages/profile/comment-link'
 Paginator = require './lib/paginator'
 Loading = require '../components/loading-indicator'
-{Link} = require 'react-router'
-PAGE_SIZE = require('./config').moderationsPageSize
+page_size = require('./config').moderationsPageSize
 {History} = require 'react-router'
-merge = require 'lodash.merge'
-projectSection = require './lib/project-section'
-userIsModerator = require './lib/user-is-moderator'
-moment = require 'moment'
-
-actionTaken =
-  destroy: 'Deleted'
-  destroyed: 'Deleted'
-  open: 'Opened'
-  opened: 'Opened'
-  close: 'Deleted'
-  closed: 'Deleted'
-  ignore: 'Ignored'
-  ignored: 'Ignored'
-  watch: 'Watched'
-  watched: 'Watched'
+updateQueryParams = require './lib/update-query-params'
+ModerationComment = require './moderation/comment'
 
 module?.exports = React.createClass
   displayName: 'TalkModerations'
@@ -40,27 +19,27 @@ module?.exports = React.createClass
     loading: true
 
   getDefaultProps: ->
-    location: query: page: 1
+    foo: 'bar'
+    location:
+      query:
+        page: 1
+        state: 'opened'
 
   componentDidMount: ->
     @props.location.query.state or= 'opened'
-    @setModerations(@props.location.query.page)
+    @setModerations()
 
   componentWillReceiveProps: (nextProps) ->
-    @setModerations(nextProps.location.query.page)
+    @setModerations nextProps.location.query
 
-  setModerations: (page) ->
+  setModerations: ({page, state} = { }) ->
+    page or= @props.location.query.page
+    state or= @props.location.query.state
+    section = @props.section
+
     @setState loading: true
-    @setModerationsForSection(page, @props.section)
-
-  setModerationsForSection: (page, section) ->
-    moderationParams = merge {},
-      {page: page, page_size: PAGE_SIZE, state: @props.location.query.state},
-      if section then {section} else {}
-
-    delete moderationParams.state if moderationParams.state is 'all'
-    auth.checkCurrent().then (user) => if user?
-      talkClient.type('moderations').get(moderationParams)
+    auth.checkCurrent().then (user) =>
+      talkClient.type('moderations').get({section, state, page, page_size})
         .then (moderations) =>
           moderationsMeta = moderations[0]?.getMeta()
           @setState {user, moderations, moderationsMeta, loading: false}
@@ -68,153 +47,52 @@ module?.exports = React.createClass
           @setState {loading: false}
           throw new Error(e)
 
-  updateModeration: (moderation, action) ->
-    if ['destroy', 'ignore', 'watch', 'open'].indexOf(action) is -1
-      throw new Error("Moderation update action must be one of ['destroy', 'ignore', 'watch', 'open']")
-
-    textarea = ReactDOM.findDOMNode(@).querySelector('.textarea-container textarea')
-    message = textarea.value ? null
-
-    updateParams =
-      actions: [{
-        user_id: @state.user.id
-        action: action
-        message: message
-        }]
-
-    moderation.update(updateParams).save()
-      .then (updatedModeration) =>
-        textarea.value = ''
-        @setModerations()
-
-  report: (report, i) ->
-    <div key={"report-#{i}"}>
-      <PromiseRenderer promise={apiClient.type('users').get(report.user_id.toString())}>{(user) =>
-        <li>
-          <Link to="/users/#{user.login}">{user.display_name}</Link>: {report.message}
-        </li>
-      }</PromiseRenderer>
-    </div>
-
-  comment: (comment, moderation) ->
-    <div key={"comment-#{comment.id}"}>
-      <h1>Comment {comment.id} Reports</h1>
-      <ul>{moderation.reports.map(@report)}</ul>
-
-      <span>Reported comment by:{' '}
-        <Link to="/users/#{comment.user_login}">
-          {comment.user_display_name}
-        </Link>:
-      </span>
-
-      <CommentLink comment={comment} />
-
-      <div className="moderations-actions-buttons">
-        <p>Status: <strong>{actionTaken[moderation.state] ? moderation.state}</strong> {moment(moderation.created_at).fromNow()}</p>
-
-        {if moderation.actions.length
-          <div>
-            {moderation.actions.map(@action)}
-          </div>
-          }
-
-        {if moderation.state isnt 'closed'
-          <div className="textarea-container">
-            <textarea placeholder="Optional message" />
-          </div>
-          }
-
-        {if moderation.state isnt 'closed'
-          comment.moderatable_actions
-            .filter (action) =>
-              (moderation.state.indexOf(action) is -1) and (action isnt 'report')
-            .map (action) =>
-              if action is 'destroy'
-                <button key={"action-#{comment.id}-#{action}"} className="moderations-#{action}" onClick={=>
-                  if window.confirm("Are you sure that you want to delete the reported comment?")
-                    @updateModeration(moderation, action)
-                }>Delete</button>
-              else
-                <button key={"action-#{comment.id}-#{action}"} className="moderations-#{action}" onClick={=> @updateModeration(moderation, action)}>{action}</button>
-          }
-      </div>
-    </div>
-
-  action: (action, i) ->
-    <PromiseRenderer promise={apiClient.type('users').get(action.user_id.toString())}>{(user) =>
-      <div>
-        {actionTaken[action.action] ? action.action} by <Link to="/users/#{user.login}">{user.display_name}</Link>
-        {if action.message
-          <div><i className="fa fa-quote-left"/> {action.message} <i className="fa fa-quote-right"/></div>
-          }
-      </div>
-    }</PromiseRenderer>
-
-  moderatedComment: (moderation) ->
-    if moderation.destroyed_target
-      Promise.resolve moderation.destroyed_target
-    else
-      talkClient.type('comments').get moderation.target_id
-
-  moderation: (moderation, i) ->
-    <div key={"moderation-#{moderation.id}"} className="talk-module">
-      <PromiseRenderer promise={@moderatedComment moderation}>{(comment) =>
-        <div>
-          {@comment(comment, moderation)}
-        </div>
-      }</PromiseRenderer>
-    </div>
+  updateModeration: (moderation, action, message) ->
+    user_id = @state.user.id
+    moderation.update(actions: [{user_id, action, message}]).save().then =>
+      @setModerations()
 
   filterByAction: (action) ->
-    {owner, name} = @props.params
-    if (owner and name)
-      @history.pushState(null, "/projects/#{owner}/#{name}/talk/moderations?state=#{action}")
-    else
-      @history.pushState(null, "/talk/moderations?state=#{action}")
+    updateQueryParams @history, state: action
+
+  nameOf: (action) ->
+    switch action
+      when 'closed' then 'deleted'
+      when 'all' then 'all reports'
+      else
+        action
 
   render: ->
-    {moderations} = @state
-    {owner, name} = @props.params
+    return <p>You must be logged in to view this page</p> unless @props.user
+    state = @props.location.query.state
 
-    if @props.user?
-      roles = talkClient.type('roles').get(user_id: @props.user.id, page_size: 100)
-      <PromiseRenderer promise={roles}>{(roles) =>
-        if userIsModerator(@props.user, roles, @props.section)
-          <div className="talk moderations">
-            <section>
-              <button
-                key='all-reports'
-                onClick={=> @filterByAction('all')}
-                className={if @props.location.query.state is 'all' then 'active' else ''}>
-                All reports
-              </button>
+    <div className="talk moderations">
+      <section>
+        {['all', 'opened', 'ignored', 'closed'].map (action) =>
+          <button
+            key={action}
+            onClick={=> @filterByAction(action)}
+            className={if state is action then 'active' else ''}>
+            {@nameOf(action)}
+          </button>}
+      </section>
 
-              {['opened', 'ignored', 'closed'].map (action) =>
-                <button
-                  key={action}
-                  onClick={=> @filterByAction(action)}
-                  className={if @props.location.query.state is action then 'active' else ''}>
-                  {actionTaken[action] ? action}
-                </button>
-                }
-            </section>
+      <div>
+        {if @state.loading
+           <Loading />
+        else if @state.moderations.length > 0
+          <div>
+            {for moderation in @state.moderations
+              <ModerationComment {...@props}
+                key={"moderation-#{moderation.id}"}
+                moderation={moderation}
+                updateModeration={@updateModeration} />}
 
-            {if @state.loading
-               <Loading />
-             else if moderations?.length > 0
-               <div>{moderations?.map(@moderation)}</div>
-             else
-               <p>There are not currently any reports that require moderation.</p>
-               }
-
-            {if +@state.moderationsMeta?.page_count > 1
-              <Paginator
-                page={@state.moderationsMeta.page}
-                pageCount={@state.moderationsMeta.page_count} />
-              }
+            <Paginator
+              page={+@state.moderationsMeta.page}
+              pageCount={+@state.moderationsMeta.page_count} />
           </div>
         else
-          <p>You must be a moderator to view this page</p>
-      }</PromiseRenderer>
-    else
-      <p>You must be logged in to view this page</p>
+          <p>There are not currently any {@nameOf(state) unless state is 'all'} moderations.</p>}
+      </div>
+    </div>

--- a/css/moderations.styl
+++ b/css/moderations.styl
@@ -30,7 +30,7 @@ hover-button(color)
       textarea
         display: inline
 
-    > button
+    button
       color: white
       text-transform: capitalize
 


### PR DESCRIPTION
This closes #2166 and also closes #2167.

I also tried to cleanup code sprawl by extracting components to isolate state.

The change to pages/profile/comment-link are to prevent linking to deleted boards or discussions as mentioned in #2167.

Feedback welcome.