### PR TITLE
Scroll the filmstrip by animating scrollLeft

### DIFF
--- a/app/components/filmstrip.cjsx
+++ b/app/components/filmstrip.cjsx
@@ -13,9 +13,6 @@ module.exports = React.createClass
   getDefaultProps: ->
     filterCards: DISCIPLINES
 
-  getInitialState: ->
-    scrollPos: 0
-
   scrollLeft: ->
     @adjustPos(-@props.increment)
 
@@ -44,31 +41,38 @@ module.exports = React.createClass
     return list.join ' '
 
   adjustPos: (increment) ->
-    @innerwidth = @strip.getBoundingClientRect().width
-    @viewportwidth = @viewport.getBoundingClientRect().width
 
-    newPos = @state.scrollPos - increment
-    offset = @viewportwidth - @innerwidth
+    oldPos = @refs.viewport.scrollLeft
+    newPos = oldPos + increment
 
     if(increment < 0)
-      newPos = Math.min(newPos, 0)
+      newPos = Math.max(newPos, 0)
 
     if(increment > 0)
-      newPos = Math.max(newPos, offset)
+      newPos = Math.min(newPos, @refs.strip.clientWidth)
 
-    @setState scrollPos: newPos
+    increment = (newPos - oldPos) / 10
+    i = 0
+
+    scroll = =>
+      @refs.viewport.scrollLeft += increment
+      i++
+      setTimeout scroll, 20 if i < 10
+    
+    scroll()
 
   componentDidMount: ->
-    @strip = @refs.strip
-    @viewport = @refs.viewport
-    @refs.filmstrip.style.height = @strip.clientHeight + 'px'
-    @refs.viewport.style.paddingBottom = @viewport.offsetHeight - @viewport.clientHeight + 'px'
-    
+    strip = @refs.strip
+    viewport = @refs.viewport
+    @refs.filmstrip.style.height = strip.clientHeight + 'px'
+    @refs.viewport.style.paddingBottom = viewport.offsetHeight - viewport.clientHeight + 'px'
+
+       
 
   render: -> <div className='filmstrip filmstrip--disciplines' ref='filmstrip'>
       <button className='filmstrip__nav-btn' onClick={@scrollLeft} role="presentation" aria-hidden="true" aria-label="Scroll Left"><i className="fa fa-chevron-left"></i></button>
       <div className='filmstrip__viewport' ref='viewport'>
-        <div className='filmstrip__strip' ref='strip' style={left: @state.scrollPos}>
+        <div className='filmstrip__strip' ref='strip'>
             <ul>
               <li>
                 <button className={@calculateClasses('all')} onClick={@selectFilter.bind this, ''} >

--- a/css/filmstrip.styl
+++ b/css/filmstrip.styl
@@ -31,21 +31,13 @@
   height: 100%
   overflow-x: auto
   overflow-y: hidden
-  position: relative
   width: 100%
 
 .filmstrip__strip
-  position: absolute
-  top: 0
-  left: 0
   white-space: nowrap
   display: flex
   margin-left: -0.28em
 
-  -webkit-transition-property: left
-  transition-property: left
-  transition-duration: 0.4s
-  transition-timing-function: ease
   ul
     padding: 0
     list-style-type: none


### PR DESCRIPTION
Tidy up the filmstrip component.
Remove absolute positioning and animated transition from filmstrip CSS.
Fixes #2433 but adds horizontal scrollbars to the filmstrip.