### PR TITLE
setting up context

### DIFF
--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -390,6 +390,9 @@ Classifier = React.createClass
 module.exports = React.createClass
   displayName: 'ClassifierWrapper'
 
+  contextTypes:
+    updateSubject: React.PropTypes.func
+
   getDefaultProps: ->
     user: null
     classification: {}
@@ -414,6 +417,9 @@ module.exports = React.createClass
 
     unless nextProps.classification is @props.classification
       @loadClassification nextProps.classification
+
+  componentWillUpdate: (nextProps, nextState) ->
+    @context.updateSubject nextState.subject if nextState.subject isnt @state.subject
 
   loadClassification: (classification) ->
     @setState

--- a/app/pages/project/classify.cjsx
+++ b/app/pages/project/classify.cjsx
@@ -63,6 +63,7 @@ module.exports = React.createClass
 
   contextTypes:
     updateWorkflow: React.PropTypes.func
+    updateClassification: React.PropTypes.func
 
   getDefaultProps: ->
     query: null
@@ -86,6 +87,7 @@ module.exports = React.createClass
 
   componentWillUpdate: (nextProps, nextState) ->
     @context.updateWorkflow nextState.workflow if nextState.workflow isnt @state.workflow
+    @context.updateClassification nextState.classification if nextState.classification isnt @state.classification
 
   loadAppropriateClassification: (_, props = @props) ->
     # To load the right classification, we'll need to know which workflow the user expects.

--- a/app/pages/project/classify.cjsx
+++ b/app/pages/project/classify.cjsx
@@ -61,6 +61,9 @@ module.exports = React.createClass
 
   title: 'Classify'
 
+  contextTypes:
+    updateWorkflow: React.PropTypes.func
+
   getDefaultProps: ->
     query: null
     project: null
@@ -80,6 +83,9 @@ module.exports = React.createClass
   componentDidMount: () ->
     @getCurrentWorkflow().then (workflow) =>
       @setState {workflow}
+
+  componentWillUpdate: (nextProps, nextState) ->
+    @context.updateWorkflow nextState.workflow if nextState.workflow isnt @state.workflow
 
   loadAppropriateClassification: (_, props = @props) ->
     # To load the right classification, we'll need to know which workflow the user expects.

--- a/app/pages/project/index.cjsx
+++ b/app/pages/project/index.cjsx
@@ -173,7 +173,7 @@ module.exports = React.createClass
     'user': 'fetchProject'
 
   componentWillUpdate: (nextProps, nextState) ->
-    @context.updateProject nextState.project unless @state.project == nextState.project
+    @context.updateProject nextState.project if nextState.project isnt @state.project
 
   fetchProject: (_, props = @props) ->
     @setState error: false

--- a/app/pages/project/index.cjsx
+++ b/app/pages/project/index.cjsx
@@ -154,6 +154,9 @@ module.exports = React.createClass
   displayName: 'ProjectPageWrapper'
   mixins: [TitleMixin, HandlePropChanges]
 
+  contextTypes:
+    updateProject: React.PropTypes.func
+
   title: ->
     @state.project?.display_name ? '(Loading)'
 
@@ -168,6 +171,9 @@ module.exports = React.createClass
     'params.owner': 'fetchProject'
     'params.name': 'fetchProject'
     'user': 'fetchProject'
+
+  componentWillUpdate: (nextProps, nextState) ->
+    @context.updateProject nextState.project unless @state.project == nextState.project
 
   fetchProject: (_, props = @props) ->
     @setState error: false

--- a/app/partials/app.cjsx
+++ b/app/partials/app.cjsx
@@ -8,9 +8,46 @@ MainFooter = require './main-footer'
 module.exports = React.createClass
   displayName: 'PanoptesApp'
 
+  childContextTypes:
+    user: React.PropTypes.object
+    project: React.PropTypes.object
+    subject: React.PropTypes.object
+    workflow: React.PropTypes.object
+    updateUser: React.PropTypes.func
+    updateProject: React.PropTypes.func
+    updateSubject: React.PropTypes.func
+    updateWorkflow: React.PropTypes.func
+
+  getChildContext: ->
+    user: @state.user
+    project: @state.project
+    updateUser: @updateUser
+    updateProject: @updateProject
+    updateSubject: @updateSubject
+    updateWorkflow: @updateWorkflow
+
+
   getInitialState: ->
     user: null
+    project: null
+    subject: null
     initialLoadComplete: false
+
+  updateProject: (project) ->
+    @setState project: project
+
+  updateUser: (user) ->
+    @setState user: user
+
+  updateSubject: (subject) ->
+    @setState subject: subject
+
+  updateWorkflow: (workflow) ->
+    @setState workflow: workflow
+
+  componentDidMount: ->
+  updateSubject: (subject) ->
+    @setState subject: subject
 
   componentDidMount: ->
     auth.listen 'change', @handleAuthChange

--- a/app/partials/app.cjsx
+++ b/app/partials/app.cjsx
@@ -13,19 +13,26 @@ module.exports = React.createClass
     project: React.PropTypes.object
     subject: React.PropTypes.object
     workflow: React.PropTypes.object
+    classification: React.PropTypes.object
+
     updateUser: React.PropTypes.func
     updateProject: React.PropTypes.func
     updateSubject: React.PropTypes.func
     updateWorkflow: React.PropTypes.func
+    updateClassification: React.PropTypes.func
 
   getChildContext: ->
     user: @state.user
     project: @state.project
+    subject: @state.subject
+    workflow: @state.workflow
+    classification: @state.classification
+
     updateUser: @updateUser
     updateProject: @updateProject
     updateSubject: @updateSubject
     updateWorkflow: @updateWorkflow
-
+    updateClassification: @updateClassification
 
   getInitialState: ->
     user: null
@@ -44,6 +51,9 @@ module.exports = React.createClass
 
   updateWorkflow: (workflow) ->
     @setState workflow: workflow
+
+  updateClassification: (classification) ->
+    @setState classification: classification
 
   componentDidMount: ->
   updateSubject: (subject) ->

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "sort-into-columns": "~1.0.0",
     "sugar-client": "~1.0.1",
     "swipe-js-iso": "~2.0.1",
-    "test-shape-closeness": "0.0.1"
+    "test-shape-closeness": "0.0.1",
+    "zooniverse-geordi-client": "~1.3.6"
   },
   "devDependencies": {
     "browserify": "~11.0.1",


### PR DESCRIPTION
user, project, workflow, and subject are now exposed to the context by the PanoptesApp object; the child components that are responsible for them use callbacks (also exposed on the context) to keep these values in sync

this means that anywhere in the application can inspect these values by adding

contextTypes:
  user: React.PropTypes.object

and then looking at the value @context.user

this way all of these things will be available for all of our logging.