### PR TITLE
Fix overlapping filmstrip list items in Safari

### DIFF
--- a/css/disciplines-slider.styl
+++ b/css/disciplines-slider.styl
@@ -1,5 +1,10 @@
 .filmstrip--disciplines ul
-  display: flex;
+
+  li
+    display: inline-block
+    line-height: 4em
+    margin: .28em
+    vertical-align: middle
 
   .filmstrip--disciplines__discipline-card
     background-color: white
@@ -8,7 +13,7 @@
     color: #006DFF
     font-size:25px
     height: 4em
-    margin: 0.28em
+    line-height: 1.2
     min-width: 100px
     padding: .2em .5em .5em
     text-align: center


### PR DESCRIPTION
Removes flex from the list.
Displays the list items as inline blocks.
Uses line-height hack to centre buttons vertically.