### PR TITLE
Add default OG tags

### DIFF
--- a/views/index.ejs
+++ b/views/index.ejs
@@ -11,6 +11,13 @@
     <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Open+Sans:400,400italic,700,700italic" />
     <link rel="stylesheet" href="/<%= process.env.OUT_CSS %>" />
     <meta name="google-site-verification" content="bcDZuAlk550Gho9TJsiyHFj_PzVXVkkVvGB13YWFtUo" />
+
+    <!-- Facebook OG tags -->
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="Zooniverse" />
+    <meta property="og:description" content="The Zooniverse is the world’s largest and most popular platform for people-powered research." />
+    <meta property="og:image" content="https://zooniverse-static.s3.amazonaws.com/assets/opengraph.jpg" />
+
   </head>
 
   <body>


### PR DESCRIPTION
@alexbfree Adds some default open graph tags so sharing links on FB is slightly richer. 

Ref #2107 

<img width="483" alt="screen shot 2016-04-20 at 16 08 38" src="https://cloud.githubusercontent.com/assets/2725841/14679555/4f120dc2-0712-11e6-958e-948624310f49.png">
