### PR TITLE
render favorites button unless workflow configuration states otherwise

### DIFF
--- a/app/components/subject-viewer.cjsx
+++ b/app/components/subject-viewer.cjsx
@@ -117,7 +117,8 @@ module.exports = React.createClass
             <button type="button" aria-label="Metadata" title="Metadata" className="metadata-toggle" onClick={@showMetadata}><i className="fa fa-info-circle fa-fw"></i></button>}
           {if @props.subject? and @props.user? and @props.project?
             <span>
-              <FavoritesButton project={@props.project} subject={@props.subject} user={@props.user} />
+              {unless @props.workflow.configuration.disable_favorites
+                <FavoritesButton project={@props.project} subject={@props.subject} user={@props.user} />}
               <CollectionsManagerIcon project={@props.project} subject={@props.subject} user={@props.user} />
             </span>}
           {if type is 'image' and @props.linkToFullImage


### PR DESCRIPTION
Checks `workflow.configuration.disable_favorites` and renders the Fav button only if the value isn't `true`