### PR TITLE
name each drawing input

### DIFF
--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -303,7 +303,7 @@ Classifier = React.createClass
         {if @props.owner? and @props.project?
           [ownerName, name] = @props.project.slug.split('/')
           <Link onClick={@props.onClickNext} to="/projects/#{ownerName}/#{name}/talk/subjects/#{@props.subject.id}" className="talk standard-button">Talk</Link>}
-        <button type="button" className="continue major-button" onClick={@props.onClickNext}>Next</button>
+        <button type="button" autoFocus={true} className="continue major-button" onClick={@props.onClickNext}>Next</button>
         {@renderExpertOptions()}
       </nav>
     </div>

--- a/app/classifier/tasks/combo/index.cjsx
+++ b/app/classifier/tasks/combo/index.cjsx
@@ -115,7 +115,7 @@ ComboTask = React.createClass
                 <strong>This task might not work as part of a combo at this time.</strong>
               </small>
             </div>}
-          <TaskComponent {...@props} task={taskDescription} annotation={annotation} onChange={@handleChange.bind this, i} />
+          <TaskComponent {...@props} autoFocus={i is 0} task={taskDescription} annotation={annotation} onChange={@handleChange.bind this, i} />
         </div>}
     </div>
 

--- a/app/classifier/tasks/drawing/index.cjsx
+++ b/app/classifier/tasks/drawing/index.cjsx
@@ -91,25 +91,27 @@ module.exports = React.createClass
     tools = for tool, i in @props.task.tools
       tool._key ?= Math.random()
       count = (true for mark in @props.annotation.value when mark.tool is i).length
-      <label key={tool._key} className="minor-button answer-button #{if i is (@props.annotation._toolIndex ? 0) then 'active' else ''}">
-        <div className="answer-button-icon-container">
-          <input type="radio" className="drawing-tool-button-input" checked={i is (@props.annotation._toolIndex ? 0)} onChange={@handleChange.bind this, i} />
-          <span className="drawing-tool-button-icon" style={color: tool.color}>{icons[tool.type]}</span>
-        </div>
+      <label key={tool._key} >
+        <input name={i} autoFocus={@props.autoFocus and i is 0} type="radio" className="drawing-tool-button-input" checked={i is (@props.annotation._toolIndex ? 0)} onChange={@handleChange.bind this, i} />
+        <div className="minor-button answer-button #{if i is (@props.annotation._toolIndex ? 0) then 'active' else ''}">
+          <div className="answer-button-icon-container">
+            <span className="drawing-tool-button-icon" style={color: tool.color}>{icons[tool.type]}</span>
+          </div>
 
-        <div className="answer-button-label-container">
-          <Markdown className="answer-button-label">{tool.label}</Markdown>
-          <div className="answer-button-status">
-            {count + ' '}
-            {if tool.min? or tool.max?
-              'of '}
-            {if tool.min?
-              <span style={color: 'red' if count < tool.min}>{tool.min} required</span>}
-            {if tool.min? and tool.max?
-              ', '}
-            {if tool.max?
-              <span style={color: 'orange' if count is tool.max}>{tool.max} maximum</span>}
-            {' '}drawn
+          <div className="answer-button-label-container">
+            <Markdown className="answer-button-label">{tool.label}</Markdown>
+            <div className="answer-button-status">
+              {count + ' '}
+              {if tool.min? or tool.max?
+                'of '}
+              {if tool.min?
+                <span style={color: 'red' if count < tool.min}>{tool.min} required</span>}
+              {if tool.min? and tool.max?
+                ', '}
+              {if tool.max?
+                <span style={color: 'orange' if count is tool.max}>{tool.max} maximum</span>}
+              {' '}drawn
+            </div>
           </div>
         </div>
       </label>

--- a/app/classifier/tasks/multiple.cjsx
+++ b/app/classifier/tasks/multiple.cjsx
@@ -97,7 +97,7 @@ module.exports = React.createClass
       answer._key ?= Math.random()
       <label key={answer._key} className="minor-button answer-button #{if i in @props.annotation.value then 'active' else ''}">
         <div className="answer-button-icon-container">
-          <input autoFocus={true if @props.autoFocus and i is 0} type="checkbox" checked={i in @props.annotation.value} onChange={@handleChange.bind this, i} />
+          <input autoFocus={@props.autoFocus and i is 0} type="checkbox" checked={i in @props.annotation.value} onChange={@handleChange.bind this, i} />
         </div>
         <div className="answer-button-label-container">
           <Markdown className="answer-button-label">{answer.label}</Markdown>

--- a/app/classifier/tasks/single.cjsx
+++ b/app/classifier/tasks/single.cjsx
@@ -85,7 +85,7 @@ module.exports = React.createClass
       answer._key ?= Math.random()
       <label key={answer._key} className="minor-button answer-button #{if i is @props.annotation.value then 'active' else ''}">
         <div className="answer-button-icon-container">
-          <input type="radio" autoFocus={ true if i is 0 and @props.autoFocus } checked={i is @props.annotation.value} onChange={@handleChange.bind this, i} />
+          <input type="radio" autoFocus={ @props.autoFocus and i is 0 } checked={i is @props.annotation.value} onChange={@handleChange.bind this, i} />
         </div>
         <div className="answer-button-label-container">
           <Markdown className="answer-button-label">{answer.label}</Markdown>

--- a/app/classifier/tasks/text/index.cjsx
+++ b/app/classifier/tasks/text/index.cjsx
@@ -61,7 +61,7 @@ module.exports = React.createClass
   render: ->
     <GenericTask question={@props.task.instruction} help={@props.task.help} required={@props.task.required}>
       <label className="answer">
-        <textarea autoFocus={if @props.autoFocus == true then true} className="standard-input full" rows="5" ref="textInput" value={@props.annotation.value} onChange={@handleChange} />
+        <textarea autoFocus={@props.autoFocus} className="standard-input full" rows="5" ref="textInput" value={@props.annotation.value} onChange={@handleChange} />
       </label>
     </GenericTask>
 

--- a/css/classify.styl
+++ b/css/classify.styl
@@ -175,6 +175,5 @@
   .drawing-tool-button-input
     opacity: 0.01
     position: absolute
-    &:focus
-      background: lighten(#424242, 95%)
-      
+    &:focus + *:not(.active)
+      background: lighten(#424242, 95%)      


### PR DESCRIPTION
This PR:
-  places a unique name on each drawing tool input, so that a user can tab through the drawing tools 
- cleaned up some of the autoFocus evaluations on other tools. 
- adds autoFocus to the Next button of the Classification Summary