### PR TITLE
Remove erroneous top margin

### DIFF
--- a/css/classify.styl
+++ b/css/classify.styl
@@ -150,7 +150,7 @@
 
       > :last-child
         margin-bottom: 0
-        
+
     .answer-button-icon-container
       align-self: flex-start
       flex-shrink: 0

--- a/css/classify.styl
+++ b/css/classify.styl
@@ -125,7 +125,7 @@
     margin-top: 2em
 
   .markdown:first-child
-    p:first-child
+    :first-child
       margin-top: 0
 
   // Only show the "required" warning when a task is outside the normal flow.

--- a/css/classify.styl
+++ b/css/classify.styl
@@ -146,7 +146,11 @@
 
       > :last-child
         margin-bottom: 0
-
+      
+    &:first-child
+      p:first-child
+        margin-top: 0
+        
     .answer-button-icon-container
       align-self: flex-start
       flex-shrink: 0

--- a/css/classify.styl
+++ b/css/classify.styl
@@ -124,6 +124,10 @@
   & + .workflow-task
     margin-top: 2em
 
+  .markdown:first-child
+    p:first-child
+      margin-top: 0
+
   // Only show the "required" warning when a task is outside the normal flow.
   .classifier > .task-area & .required-task-warning
     display: none
@@ -146,10 +150,6 @@
 
       > :last-child
         margin-bottom: 0
-      
-    &:first-child
-      p:first-child
-        margin-top: 0
         
     .answer-button-icon-container
       align-self: flex-start


### PR DESCRIPTION
The first question on all workflows on all projects isn't properly aligning with the top of the subject viewer. This should fix most cases.