### PR TITLE
Less obnoxious sign-in suggestion

### DIFF
--- a/app/collections/favorites-button.cjsx
+++ b/app/collections/favorites-button.cjsx
@@ -87,13 +87,14 @@ module?.exports = React.createClass
   render: ->
     <PromiseRenderer promise={@state.favoritedPromise}>{(favorited) =>
       <button
-        className="favorites-button"
+        className="favorites-button #{@props.className ? ''}"
         type="button"
         title={if favorited then 'Unfavorite' else 'Favorite'}
         onClick={@toggleFavorite}>
         <i className="
           fa fa-heart#{if favorited then '' else '-o'}
           #{if favorited then 'favorited' else ''}
+          fa-fw
         " />
       </button>
     }</PromiseRenderer>

--- a/app/collections/manager-icon.cjsx
+++ b/app/collections/manager-icon.cjsx
@@ -21,10 +21,10 @@ module?.exports = React.createClass
 
   render: ->
     <button
-      className="collections-manager-icon"
+      className="collections-manager-icon #{@props.className ? ''}"
       title="Collect"
       onClick={@open}>
-      <i className="fa fa-list" />
+      <i className="fa fa-list fa-fw" />
 
       {if @state.open
         <Dialog tag="div" closeButton={true} onCancel={@close}>

--- a/app/components/subject-viewer.cjsx
+++ b/app/components/subject-viewer.cjsx
@@ -7,6 +7,7 @@ CollectionsManagerIcon = require '../collections/manager-icon'
 FrameViewer = require './frame-viewer'
 classnames = require 'classnames'
 FlagSubjectButton = require './flag-subject-button'
+SignInPrompt = require '../partials/sign-in-prompt'
 
 NOOP = Function.prototype
 
@@ -51,6 +52,12 @@ module.exports = React.createClass
       this.setState
         inFlipbookMode: allowFlipbook
 
+  promptToSignIn: ->
+    alert (resolve) ->
+      <SignInPrompt onChoose={resolve}>
+        <p>Sign in to help us make the most out of your hard work.</p>
+      </SignInPrompt>
+
   render: ->
     rootClasses = classnames('subject-viewer', {
       'default-root-style': @props.defaultStyle
@@ -65,7 +72,6 @@ module.exports = React.createClass
       mainDisplay = @renderFrame @state.frame
     else
       mainDisplay = (@renderFrame frame, {key: "frame-#{frame}"} for frame of @props.subject.locations)
-
 
     tools = switch type
       when 'image'
@@ -122,14 +128,21 @@ module.exports = React.createClass
                 <i className="fa fa-info-circle fa-fw"></i>
               </button>{' '}
             </span>}
-          {if @props.subject? and @props.user? and @props.project?
-            <span>
-              {unless @props.workflow?.configuration?.disable_favorites
-                <span>
-                  <FavoritesButton className="secret-button" project={@props.project} subject={@props.subject} user={@props.user} />{' '}
-                </span>}
-              <CollectionsManagerIcon className="secret-button" project={@props.project} subject={@props.subject} user={@props.user} />
-            </span>}
+          {if @props.project? and @props.subject?
+            if  @props.user?
+              <span>
+                {unless @props.workflow?.configuration?.disable_favorites
+                  <span>
+                    <FavoritesButton className="secret-button" project={@props.project} subject={@props.subject} user={@props.user} />{' '}
+                  </span>}
+                <CollectionsManagerIcon className="secret-button" project={@props.project} subject={@props.subject} user={@props.user} />
+              </span>
+            else
+              <span>
+                <button type="button" className="secret-button" onClick={@promptToSignIn}>
+                  <small>You should sign in!</small>
+                </button>
+              </span>}
           {if type is 'image' and @props.linkToFullImage
             <a className="button" href={src} aria-label="Subject Image" title="Subject Image" target="zooImage">
               <i className="fa fa-photo" />
@@ -137,8 +150,6 @@ module.exports = React.createClass
         </span>
       </div>
     </div>
-
-
 
   renderFrame: (frame, props = {}) ->
     <FrameViewer {...@props} {...props} frame={frame} />
@@ -183,7 +194,6 @@ module.exports = React.createClass
   handleFrameChange: (frame) ->
     @setState {frame}
     @props.onFrameChange frame
-
 
   showMetadata: ->
     # TODO: Sticky popup.

--- a/app/components/subject-viewer.cjsx
+++ b/app/components/subject-viewer.cjsx
@@ -71,13 +71,13 @@ module.exports = React.createClass
       when 'image'
         if not @state.inFlipbookMode or @props.subject?.locations.length < 2 or subjectHasMixedLocationTypes @props.subject
           if @props.allowFlipbook and @props.allowSeparateFrames
-            <button aria-label="Toggle flipbook mode" title="Toggle flipbook mode" className="flipbook-toggle" onClick={@toggleInFlipbookMode}>
+            <button className="secret-button" aria-label="Toggle flipbook mode" title="Toggle flipbook mode" onClick={@toggleInFlipbookMode}>
               <i className={"fa fa-fw " + if @state.inFlipbookMode then "fa-th-large" else "fa-film"}></i>
             </button>
         else
           <span className="tools">
             {if @props.allowFlipbook and @props.allowSeparateFrames
-              <button aria-label="Toggle flipbook mode" title="Toggle flipbook mode" className="flipbook-toggle" onClick={@toggleInFlipbookMode}>
+              <button className="secret-button" aria-label="Toggle flipbook mode" title="Toggle flipbook mode" onClick={@toggleInFlipbookMode}>
                 <i className={"fa fa-fw " + if @state.inFlipbookMode then "fa-th-large" else "fa-film"}></i>
               </button>}
 
@@ -117,12 +117,18 @@ module.exports = React.createClass
           {if @props.workflow?.configuration?.enable_subject_flags
             <FlagSubjectButton classification={@props.classification} />}
           {if @props.subject?.metadata?
-            <button type="button" aria-label="Metadata" title="Metadata" className="metadata-toggle" onClick={@showMetadata}><i className="fa fa-info-circle fa-fw"></i></button>}
+            <span>
+              <button type="button" className="secret-button" aria-label="Metadata" title="Metadata" onClick={@showMetadata}>
+                <i className="fa fa-info-circle fa-fw"></i>
+              </button>{' '}
+            </span>}
           {if @props.subject? and @props.user? and @props.project?
             <span>
               {unless @props.workflow?.configuration?.disable_favorites
-                <FavoritesButton project={@props.project} subject={@props.subject} user={@props.user} />}
-              <CollectionsManagerIcon project={@props.project} subject={@props.subject} user={@props.user} />
+                <span>
+                  <FavoritesButton className="secret-button" project={@props.project} subject={@props.subject} user={@props.user} />{' '}
+                </span>}
+              <CollectionsManagerIcon className="secret-button" project={@props.project} subject={@props.subject} user={@props.user} />
             </span>}
           {if type is 'image' and @props.linkToFullImage
             <a className="button" href={src} aria-label="Subject Image" title="Subject Image" target="zooImage">

--- a/app/components/subject-viewer.cjsx
+++ b/app/components/subject-viewer.cjsx
@@ -25,6 +25,8 @@ CONTAINER_STYLE = display: 'flex', flexWrap: 'wrap', position: 'relative'
 module.exports = React.createClass
   displayName: 'SubjectViewer'
 
+  signInAttentionTimeout: NaN
+
   getDefaultProps: ->
     subject: null
     user: null
@@ -46,11 +48,10 @@ module.exports = React.createClass
     frameDimensions: {}
     inFlipbookMode: @props.allowFlipbook
 
-  willReceiveProps: (nextProps) ->
-    # The default state for subjects is flipbook if allowed
-    if typeof nextProps.allowFlipbook is 'boolean'
-      this.setState
-        inFlipbookMode: allowFlipbook
+  componentWillReceiveProps: (nextProps) ->
+    unless nextProps.subject is @props.subject
+      clearTimeout @signInAttentionTimeout
+      @setState loading: true
 
   promptToSignIn: ->
     alert (resolve) ->
@@ -139,7 +140,7 @@ module.exports = React.createClass
               </span>
             else
               <span>
-                <button type="button" className="secret-button" onClick={@promptToSignIn}>
+                <button type="button" className="secret-button #{if @state.loading then 'get-attention'}" onClick={@promptToSignIn}>
                   <small>You should sign in!</small>
                 </button>
               </span>}
@@ -151,8 +152,12 @@ module.exports = React.createClass
       </div>
     </div>
 
+  handleFrameLoad: ->
+    @props.onLoad? arguments...
+    @signInAttentionTimeout = setTimeout (=> @setState loading: false), 3000
+
   renderFrame: (frame, props = {}) ->
-    <FrameViewer {...@props} {...props} frame={frame} />
+    <FrameViewer {...@props} {...props} frame={frame} onLoad={@handleFrameLoad} />
 
   hiddenPreloadedImages: ->
     # Render this to ensure that all a subject's location images are cached and ready to display.

--- a/app/pages/dev-classifier/index.cjsx
+++ b/app/pages/dev-classifier/index.cjsx
@@ -72,7 +72,7 @@ DevClassifierPage = React.createClass
 
   render: ->
     <div className="content-container">
-      <Classifier project={@props.project} classification={@props.classification} onClickNext={@reload} />
+      <Classifier user={@props.user}  project={@props.project} classification={@props.classification} onClickNext={@reload} />
       <hr />
       <ClassificationViewer classification={@props.classification} />
     </div>

--- a/app/pages/project/classify.cjsx
+++ b/app/pages/project/classify.cjsx
@@ -10,22 +10,14 @@ counterpart = require 'counterpart'
 FinishedBanner = require './finished-banner'
 Classifier = require '../../classifier'
 alert = require '../../lib/alert'
-SignInPrompt = require '../../partials/sign-in-prompt'
 seenThisSession = require '../../lib/seen-this-session'
 
 FAILED_CLASSIFICATION_QUEUE_NAME = 'failed-classifications'
-
-PROMPT_TO_SIGN_IN_AFTER = [5, 10, 25, 50, 100, 250, 500]
 
 SKIP_CELLECT = location?.search.match(/\Wcellect=0(?:\W|$)/)?
 
 if SKIP_CELLECT
   console?.warn 'Intelligent subject selection disabled'
-
-classificationsThisSession = 0
-
-auth.listen ->
-  classificationsThisSession = 0
 
 # Map each project ID to a promise of its last randomly-selected workflow ID.
 # This is to maintain the same random workflow for each project when none is specified by the user.
@@ -270,9 +262,6 @@ module.exports = React.createClass
         console?.warn 'Failed to save classification:', error
         @queueClassification classification
 
-      classificationsThisSession += 1
-      @maybePromptToSignIn()
-
     return savingClassification
 
   queueClassification: (classification) ->
@@ -302,13 +291,6 @@ module.exports = React.createClass
               console?.error 'Failed to update classification queue:', error
           .catch (error) =>
             console?.error 'Failed to save a queued classification:', error
-
-  maybePromptToSignIn: ->
-    if classificationsThisSession in PROMPT_TO_SIGN_IN_AFTER and not @props.user?
-      alert (resolve) =>
-        <SignInPrompt project={@props.project} onChoose={resolve}>
-          <p><strong>You’ve done {classificationsThisSession} classifications, but you’re not signed in!</strong></p>
-        </SignInPrompt>
 
   loadAnotherSubject: ->
     @getCurrentWorkflow(@props).then (workflow) =>

--- a/css/classify.styl
+++ b/css/classify.styl
@@ -1,3 +1,16 @@
+@keyframes be-slightly-annoying
+  0%
+    transform: rotate(0);
+  25%
+    transform: rotate(2deg);
+  75%
+    transform: rotate(-2deg);
+  100%
+    transform: rotate(0);
+
+.get-attention
+  animation: be-slightly-annoying 0.3s infinite
+
 .pulsar-hunters-feedback
   background: #666
   box-shadow: 0 1px 3px rgba(black, 0.5)


### PR DESCRIPTION
This removes the "You should sign in" pop-up between _n_ classifications and replaces it with a button under the subject. When the subject changes, the button jiggles tantalizingly for a couple seconds.

![jiggle](https://cloud.githubusercontent.com/assets/464389/14993893/a2f40f1a-1132-11e6-8e26-609d6bce820d.gif)

Right?

In the process, I cleaned up the look of all the under-subject buttons by removing default system style and fixing icon widths.

Also removed a `willReceiveProps` method in the SubjectViewer that was broken and never called anyway. Probably a typo (it would've been `componentWillReceiveProps`).