### PR TITLE
[WIP] Text task prev answers access

### DIFF
--- a/app/classifier/tasks/generic-editor.cjsx
+++ b/app/classifier/tasks/generic-editor.cjsx
@@ -48,6 +48,11 @@ module.exports = React.createClass
             <MarkdownEditor name="#{@props.taskPrefix}.help" onHelp={-> alert <MarkdownHelp/>} value={@props.task.help ? ""} rows="7" className="full" onChange={handleChange} />
           </AutoSave>
           <small className="form-help">Add text and images for a window that pops up when volunteers click “Need some help?” You can use markdown to format this text and add images. The help text can be as long as you need, but you should try to keep it simple and avoid jargon.</small>
+          {if @props.task.type is 'text'
+            <div>
+              <br />
+              <small className="form-help">For text tasks consider adding the help message "Use Ctrl-M to cycle through previous answers provided and Ctrl-K to clear previous answers."</small>
+            </div>}
         </div>}
 
       {if choicesKey?
@@ -58,12 +63,15 @@ module.exports = React.createClass
       {' '}
 
       {if @props.project and 'hide previous marks' in @props.project.experimental_tools
-        <label className="pill-button">
-          <AutoSave resource={@props.workflow}>
-            <input type="checkbox" checked={@props.task.enableHidePrevMarks} onChange={@toggleHidePrevMarksEnabled} />{' '}
-            Allow hiding marks
-          </AutoSave>
-        </label>}
+        <div>
+        <hr />
+          <label className="pill-button">
+            <AutoSave resource={@props.workflow}>
+              <input type="checkbox" checked={@props.task.enableHidePrevMarks} onChange={@toggleHidePrevMarksEnabled} />{' '}
+              Allow hiding marks
+            </AutoSave>
+          </label>
+        </div>}
 
       {if isAQuestion
         multipleHelp = 'Multiple Choice: Check this box if more than one answer can be selected.'
@@ -122,7 +130,7 @@ module.exports = React.createClass
                             for toolKey of drawingTools
                               <option key={toolKey} value={toolKey}>{toolKey}</option>
                           else
-                            for toolKey of drawingTools 
+                            for toolKey of drawingTools
                               <option key={toolKey} value={toolKey}>{toolKey}</option> unless toolKey is "column"}
                         </select>
                       </AutoSave>

--- a/app/classifier/tasks/text/index.cjsx
+++ b/app/classifier/tasks/text/index.cjsx
@@ -81,7 +81,7 @@ module.exports = React.createClass
     </GenericTask>
 
   handleChange: ->
-    value = React.findDOMNode(@refs.textInput).value
+    value = @refs.textInput.value
     newAnnotation = Object.assign @props.annotation, {value}
     @props.onChange newAnnotation
 
@@ -100,7 +100,7 @@ module.exports = React.createClass
     if (e.keyCode is key.M) and (not e.target.value or (prevAnswers.indexOf e.target.value.trim()) isnt -1)
       @props.annotation.value = prevAnswers[@state.prevAnswerIndex]
       @setState prevAnswerIndex: (@state.prevAnswerIndex + 1) %% prevAnswers.length
-    # clears current answer from previous answers in local storage
+    # clears current answer from previous answers in local storage and textarea
     if e.keyCode is key.K
       answer = e.target.value.trim()
       unless (prevAnswers.indexOf answer) is -1

--- a/app/classifier/tasks/text/index.cjsx
+++ b/app/classifier/tasks/text/index.cjsx
@@ -6,6 +6,10 @@ levenshtein = require 'fast-levenshtein'
 
 NOOP = Function.prototype
 
+key =
+  K: 75
+  M: 77
+
 Summary = React.createClass
   displayName: 'TextSummary'
 
@@ -58,10 +62,21 @@ module.exports = React.createClass
     annotation: null
     onChange: NOOP
 
+  getInitialState: ->
+    prevAnswerIndex: 0
+
   render: ->
     <GenericTask question={@props.task.instruction} help={@props.task.help} required={@props.task.required}>
       <label className="answer">
-        <textarea className="standard-input full" rows="5" ref="textInput" value={@props.annotation.value} onChange={@handleChange} />
+        <textarea
+          className="standard-input full"
+          rows="5"
+          ref="textInput"
+          value={@props.annotation.value}
+          onChange={@handleChange}
+          onBlur={@handleBlur.bind(@, @props.task.instruction)}
+          onKeyDown={@handleKeyDown.bind(@, @props.task.instruction)}
+        />
       </label>
     </GenericTask>
 
@@ -69,3 +84,34 @@ module.exports = React.createClass
     value = React.findDOMNode(@refs.textInput).value
     newAnnotation = Object.assign @props.annotation, {value}
     @props.onChange newAnnotation
+
+  handleBlur: (question, e) ->
+    answer = e.target.value.trim()
+    prevAnswers = @getPreviousAnswers(question) or []
+    if answer and ((prevAnswers.indexOf answer) is -1)
+      prevAnswers.unshift answer
+      @setPreviousAnswers(prevAnswers, question)
+
+  handleKeyDown: (question, e) ->
+    return unless e.ctrlKey and (e.keyCode is key.M or e.keyCode is key.K)
+    prevAnswers = @getPreviousAnswers(question)
+    return unless prevAnswers.length
+    # accesses previous answers from local storage
+    if (e.keyCode is key.M) and (not e.target.value or (prevAnswers.indexOf e.target.value.trim()) isnt -1)
+      @props.annotation.value = prevAnswers[@state.prevAnswerIndex]
+      @setState prevAnswerIndex: (@state.prevAnswerIndex + 1) %% prevAnswers.length
+    # clears current answer from previous answers in local storage
+    if e.keyCode is key.K
+      answer = e.target.value.trim()
+      unless (prevAnswers.indexOf answer) is -1
+        e.target.value = ''
+        @setState prevAnswerIndex: 0
+        prevAnswers.splice (prevAnswers.indexOf answer), 1
+        @setPreviousAnswers(prevAnswers, question)
+        @handleChange(e)
+
+  getPreviousAnswers: (question) ->
+    JSON.parse localStorage.getItem "#{window.location.pathname}-#{question}"
+
+  setPreviousAnswers: (prevAnswers, question) ->
+    localStorage.setItem "#{window.location.pathname}-#{question}", JSON.stringify prevAnswers


### PR DESCRIPTION
per Notes from Nature conversion, legacy version includes Ctrl-M shortcut key combination to access previous answer provided for text tasks (which include annotating scientific name, location, habitat, collector and collector number). Often a collection of subjects will have the same scientific name or collector, so this feature makes annotating that attribute significantly easier, increasing volunteer participation and satisfaction.

this Pull Request adds the following functionality to the **text task**:

1. Ctrl-M recalls most recent answer provided (from local storage), pressing again cycles through in chronological order (from most recent to least recent, then back to most recent)
2. Ctrl-K clears answer shown (from local storage) and from being accessed in the future
3. answers are stored to local storage associated with a key defined as `"#{window.location.pathname}-#{question}"`, thereby preventing a volunteer from pressing Ctrl-M in a Scientific Name field and provided Collector names previously provided

[branch staged for testing](https://text-task-prev-answers.pfe-preview.zooniverse.org)

eventually shortcut keys (and how we note what shortcut keys are available) will be improved site-wide, and this text task functionality will be included in those improvements.