### PR TITLE
A more pleasant project-status admin page

### DIFF
--- a/app/pages/admin/project-status.cjsx
+++ b/app/pages/admin/project-status.cjsx
@@ -106,7 +106,7 @@ ProjectExperimentalFeatures = React.createClass
       <AutoSave resource={@props.project}>
         <div className="project-status__section--table">
           {EXPERIMENTAL_FEATURES.map (task) =>
-            <label key={task}>
+            <label key={task} className="project-status__section--table--row">
               <input type="checkbox" name={task} checked={@setting(task)} onChange={@updateTasks.bind @, task} />
               {task.charAt(0).toUpperCase() + task.slice(1)}
             </label>}
@@ -156,8 +156,8 @@ VersionList = React.createClass
   render: ->
     <PromiseRenderer promise={@props.project.get 'versions'}>{ (versions) =>
       vs = versions.sort()
+      <h4>Recent Status Changes</h4>
       <ul className="project-status__section--list">
-        <h4>Recent Status Changes</h4>
         {vs.map (version) =>
           key = Object.keys(version.changeset)[0]
           from = version.changeset[key][0].toString()

--- a/app/pages/admin/project-status.cjsx
+++ b/app/pages/admin/project-status.cjsx
@@ -104,9 +104,9 @@ ProjectExperimentalFeatures = React.createClass
     <div className="project-status__section">
       <h4>Experimental Features</h4>
       <AutoSave resource={@props.project}>
-        <div className="project-status__section--table">
+        <div className="project-status__section-table">
           {EXPERIMENTAL_FEATURES.map (task) =>
-            <label key={task} className="project-status__section--table--row">
+            <label key={task} className="project-status__section-table-row">
               <input type="checkbox" name={task} checked={@setting(task)} onChange={@updateTasks.bind @, task} />
               {task.charAt(0).toUpperCase() + task.slice(1)}
             </label>}
@@ -157,7 +157,7 @@ VersionList = React.createClass
     <PromiseRenderer promise={@props.project.get 'versions'}>{ (versions) =>
       vs = versions.sort()
       <h4>Recent Status Changes</h4>
-      <ul className="project-status__section--list">
+      <ul className="project-status__section-list">
         {vs.map (version) =>
           key = Object.keys(version.changeset)[0]
           from = version.changeset[key][0].toString()
@@ -181,7 +181,7 @@ ProjectStatus = React.createClass
         <ProjectIcon project={@props.project} />
         <div className="project-status__section">
           <h4>Visibility Settings</h4>
-          <ul className="project-status__section--list">
+          <ul className="project-status__section-list">
             <li>Private: <ProjectToggle project={@props.project} field="private" trueLabel="Private" falseLabel="Public" /></li>
             <li>Live: <ProjectToggle project={@props.project} field="live" trueLabel="Live" falseLabel="Development" /></li>
             <li>Beta Requested: <ProjectToggle project={@props.project} field="beta_requested" /></li>
@@ -199,7 +199,7 @@ ProjectStatus = React.createClass
               <div className="workflow-status-list">No workflows found</div>
             else
               <div className="workflow-status-list">
-                <ul className="project-status__section--list">
+                <ul className="project-status__section-list">
                   {workflows.map (workflow) =>
                     <li key={workflow.id}>
                       <WorkflowToggle workflow={workflow} project={@props.project} field="active" />

--- a/app/pages/admin/project-status.cjsx
+++ b/app/pages/admin/project-status.cjsx
@@ -101,13 +101,16 @@ ProjectExperimentalFeatures = React.createClass
     @props.project.update({experimental_tools: tools})
 
   render: ->
-    <div>
+    <div className="project-status__section">
+      <h4>Experimental Features</h4>
       <AutoSave resource={@props.project}>
-        {EXPERIMENTAL_FEATURES.map (task) =>
-          <label key={task}>
-            <input type="checkbox" name={task} checked={@setting(task)} onChange={@updateTasks.bind @, task} />
-            {task.charAt(0).toUpperCase() + task.slice(1)}
-          </label>}
+        <div className="project-status__section--table">
+          {EXPERIMENTAL_FEATURES.map (task) =>
+            <label key={task}>
+              <input type="checkbox" name={task} checked={@setting(task)} onChange={@updateTasks.bind @, task} />
+              {task.charAt(0).toUpperCase() + task.slice(1)}
+            </label>}
+          </div>
       </AutoSave>
     </div>
 
@@ -136,7 +139,8 @@ ProjectRedirectToggle = React.createClass
       "Invalid URL - must be in https?://format"
 
   render: ->
-    <div>
+    <div className="project-status__section">
+      <h4>Project Redirect</h4>
       <AutoSave resource={@props.project}>
         <input type="text" name="redirect" ref="redirectUrl" value={@props.project.redirect} placeholder="External redirect" onBlur={@updateRedirect} onChange={handleInputChange.bind @props.project} />
         <span>{ @validUrlMessage() }</span>
@@ -152,7 +156,8 @@ VersionList = React.createClass
   render: ->
     <PromiseRenderer promise={@props.project.get 'versions'}>{ (versions) =>
       vs = versions.sort()
-      <ul className="project-status-changes">
+      <ul className="project-status__section--list">
+        <h4>Recent Status Changes</h4>
         {vs.map (version) =>
           key = Object.keys(version.changeset)[0]
           from = version.changeset[key][0].toString()
@@ -174,36 +179,39 @@ ProjectStatus = React.createClass
     <ChangeListener target={@props.project}>{ =>
       <div className="project-status">
         <ProjectIcon project={@props.project} />
-        <h4>Visibility Settings</h4>
-        <ul>
-          <li>Private: <ProjectToggle project={@props.project} field="private" trueLabel="Private" falseLabel="Public" /></li>
-          <li>Live: <ProjectToggle project={@props.project} field="live" trueLabel="Live" falseLabel="Development" /></li>
-          <li>Beta Requested: <ProjectToggle project={@props.project} field="beta_requested" /></li>
-          <li>Beta Approved: <ProjectToggle project={@props.project} field="beta_approved" /></li>
-          <li>Launch Requested: <ProjectToggle project={@props.project} field="launch_requested" /></li>
-          <li>Launch Approved: <ProjectToggle project={@props.project} field="launch_approved" /></li>
-        </ul>
-        <h4>Project Redirect</h4>
+        <div className="project-status__section">
+          <h4>Visibility Settings</h4>
+          <ul className="project-status__section--list">
+            <li>Private: <ProjectToggle project={@props.project} field="private" trueLabel="Private" falseLabel="Public" /></li>
+            <li>Live: <ProjectToggle project={@props.project} field="live" trueLabel="Live" falseLabel="Development" /></li>
+            <li>Beta Requested: <ProjectToggle project={@props.project} field="beta_requested" /></li>
+            <li>Beta Approved: <ProjectToggle project={@props.project} field="beta_approved" /></li>
+            <li>Launch Requested: <ProjectToggle project={@props.project} field="launch_requested" /></li>
+            <li>Launch Approved: <ProjectToggle project={@props.project} field="launch_approved" /></li>
+          </ul>
+        </div>
         <ProjectRedirectToggle project={@props.project} />
-        <h4>Experimental Features</h4>
         <ProjectExperimentalFeatures project={@props.project} />
-        <h4>Workflow Settings</h4>
-        <PromiseRenderer promise={@props.project.get('workflows')}>{(workflows) =>
-          if workflows.length is 0
-            <div className="workflow-status-list">No workflows found</div>
-          else
-            <div className="workflow-status-list">
-              <ul>
-                {workflows.map (workflow) =>
-                  <li key={workflow.id}>
-                    <WorkflowToggle workflow={workflow} project={@props.project} field="active" />
-                  </li>}
-              </ul>
-           </div>
-        }</PromiseRenderer>
+        <div className="project-status__section">
+          <h4>Workflow Settings</h4>
+          <PromiseRenderer promise={@props.project.get('workflows')}>{(workflows) =>
+            if workflows.length is 0
+              <div className="workflow-status-list">No workflows found</div>
+            else
+              <div className="workflow-status-list">
+                <ul className="project-status__section--list">
+                  {workflows.map (workflow) =>
+                    <li key={workflow.id}>
+                      <WorkflowToggle workflow={workflow} project={@props.project} field="active" />
+                    </li>}
+                </ul>
+             </div>
+          }</PromiseRenderer>
+        </div>
         <hr />
-        <h4>Recent Status Changes</h4>
-        <VersionList project={@props.project} />
+        <div className="project-status__section">
+          <VersionList project={@props.project} />
+        </div>
       </div>
     }</ChangeListener>
 

--- a/css/admin-page.styl
+++ b/css/admin-page.styl
@@ -1,13 +1,13 @@
 .admin-page
   .project-status
-    .project-status__section
+    &__section
       margin: 1em 0
       
-      .project-status__section--list
+      &--list
         margin: 0 0 1em 0
 
-      .project-status__section--table
+      &--table
         display: table
         
-        label
+        &--row
           display: table-row

--- a/css/admin-page.styl
+++ b/css/admin-page.styl
@@ -3,11 +3,11 @@
     &__section
       margin: 1em 0
       
-      &--list
+      &-list
         margin: 0 0 1em 0
 
-      &--table
+      &-table
         display: table
         
-        &--row
+        &-row
           display: table-row

--- a/css/admin-page.styl
+++ b/css/admin-page.styl
@@ -1,0 +1,13 @@
+.admin-page
+  .project-status
+    .project-status__section
+      margin: 1em 0
+      
+      .project-status__section--list
+        margin: 0 0 1em 0
+
+      .project-status__section--table
+        display: table
+        
+        label
+          display: table-row

--- a/css/main.styl
+++ b/css/main.styl
@@ -47,6 +47,7 @@
 @require "./field-guide-editor"
 @require "./project-modal-editor"
 @require "./best-practices-page"
+@require "./admin-page"
 
 @require "./user-profile"
 @require "./profile-feed-comment-link"


### PR DESCRIPTION
Adds an `admin-page` stylus file with a few styles for the project status admin page and some better markup. Started to use BEM here too. The experimental feature list is getting unwieldily; this makes it a bit more pleasant to look at.