### PR TITLE
Allow collections manager dialog overflow

### DIFF
--- a/app/collections/manager-icon.cjsx
+++ b/app/collections/manager-icon.cjsx
@@ -13,15 +13,21 @@ module?.exports = React.createClass
   getInitialState: ->
     open: false
 
+  open: ->
+    @setState {open: true}
+
+  close: ->
+    @setState {open: false}
+
   render: ->
     <button
       className="collections-manager-icon"
       title="Collect"
-      onClick={@setState.bind this, {open: true}, null}>
+      onClick={@open}>
       <i className="fa fa-list" />
 
       {if @state.open
-        <Dialog tag="div">
-          <CollectionsManager user={@props.user} project={@props.project} subject={@props.subject} onSuccess={@setState.bind this, {open: false}, null} />
+        <Dialog tag="div" closeButton={true} onCancel={@close}>
+          <CollectionsManager user={@props.user} project={@props.project} subject={@props.subject} onSuccess={@close} />
         </Dialog>}
     </button>

--- a/app/collections/manager-icon.cjsx
+++ b/app/collections/manager-icon.cjsx
@@ -1,6 +1,6 @@
 React = require 'react'
 CollectionsManager = require './manager'
-alert = require '../lib/alert'
+Dialog = require 'modal-form/dialog'
 
 # Shows an icon to logged-in users that pops up a collections manager
 module?.exports = React.createClass
@@ -10,16 +10,18 @@ module?.exports = React.createClass
     subject: React.PropTypes.object
     user: React.PropTypes.object
 
-  toggleCollectionsManagerPopup: ->
-    alert (resolve) =>
-      <div className="content-container">
-        <CollectionsManager user={@props.user} project={@props.project} subject={@props.subject} onSuccess={resolve} />
-      </div>
+  getInitialState: ->
+    open: false
 
   render: ->
     <button
       className="collections-manager-icon"
       title="Collect"
-      onClick={@toggleCollectionsManagerPopup}>
+      onClick={@setState.bind this, {open: true}, null}>
       <i className="fa fa-list" />
+
+      {if @state.open
+        <Dialog tag="div">
+          <CollectionsManager user={@props.user} project={@props.project} subject={@props.subject} onSuccess={@setState.bind this, {open: false}, null} />
+        </Dialog>}
     </button>

--- a/css/dialog.styl
+++ b/css/dialog.styl
@@ -55,7 +55,7 @@
         position: fixed
 
 .dialog-content
-  overflow: auto
+  overflow: visible
   max-width: 800px
   width: 100%
 


### PR DESCRIPTION
Extending #2522, this switches to modal-form Dialog component to allow the collections dropdown to extend beyond the dialog bounds.

Closes #2522, which closes #2056.