### PR TITLE
Clean up display of owned cards (collections, favourites etc)

### DIFF
--- a/app/components/owned-card-list.cjsx
+++ b/app/components/owned-card-list.cjsx
@@ -55,7 +55,7 @@ module.exports = React.createClass
                   count = meta.count
                   <Translate pageStart={pageStart} pageEnd={pageEnd} count={count} content="#{@props.translationObjectName}.countMessage" component="p" />}
               </div>
-              <div className="card-list">
+              <div className="owned-card-list">
                 {for resource in ownedResources
                    <OwnedCard
                      key={resource.id}

--- a/app/components/project-card-list.cjsx
+++ b/app/components/project-card-list.cjsx
@@ -56,7 +56,7 @@ ProjectCard = React.createClass
       to: if project.redirect then project.redirect else '/projects/' + project.slug
 
     <FlexibleLink {...linkProps}>
-      <div className="card" ref="ownedCard">
+      <div className="project-card" ref="ownedCard">
         <svg className="card-space-maker" viewBox="0 0 2 1" width="100%"></svg>
         <div className="details">
           <div className="name"><span>{project.display_name}</span></div>
@@ -79,7 +79,7 @@ ProjectCardList = React.createClass
     document.documentElement.classList.remove 'on-secondary-page'
 
   render: ->
-    <div className="card-list">
+    <div className="project-card-list">
       {@props.projects.map (project) =>
         <div key={project.id}>
           <ProjectCard project={project} />

--- a/app/partials/owned-card.cjsx
+++ b/app/partials/owned-card.cjsx
@@ -54,7 +54,7 @@ module.exports = React.createClass
         name: name
 
     <FlexibleLink {...linkProps}>
-      <div className="card" ref="ownedCard">
+      <div className="owned-card" ref="ownedCard">
         <svg className="card-space-maker" viewBox="0 0 2 1" width="100%"></svg>
         <div className="details">
           <div className="name"><span>{@props.resource.display_name}</span></div>

--- a/css/owned-card.styl
+++ b/css/owned-card.styl
@@ -1,4 +1,5 @@
-.card-list
+.owned-card-list,
+.project-card-list
   display: flex
   flex-direction: row
   flex-wrap: wrap
@@ -11,7 +12,8 @@
   position: relative
   font-size: 14px
 
-.card
+.owned-card,
+.project-card
   background-position: 50% 0
   background-size: cover
   display: inline-block
@@ -31,7 +33,6 @@
     color: FOREGROUND
     display: flex
     flex-direction: column
-    height: 175px
     padding: 20px
     text-align: left
 
@@ -55,6 +56,10 @@
 
     &:hover
       background: lighten(COBOLT_BLUE, 20%)
+
+.owned-card
+  .name
+    margin-bottom: 1em
 
 .project-card
   height: 270px


### PR DESCRIPTION
When project cards and owned cards were separated, the CSS was not cleanly split and still shared the same CSS class. Possibly because of this, or for another reason, owned cards are wrongly stretched vertically to 175px. This change separates out the CSS classes to avoid accidental collisions like this in future, and stops the 175px height from applying to owned cards

Also adding some space below collection titles as the text was too close to the button.

Changes owned cards from this
![screenshot 2016-05-04 11 54 58](https://cloud.githubusercontent.com/assets/1473244/15012246/11b2fd28-11ef-11e6-8e5f-561fe5fe5dc1.png)

to this
![screenshot 2016-05-04 11 54 24](https://cloud.githubusercontent.com/assets/1473244/15012251/19d24356-11ef-11e6-94ba-7acf6daa6b0d.png)

