### PR TITLE
manage, edit and create workflows in Project Builder rgdless if project live

### DIFF
--- a/app/components/workflow-toggle.cjsx
+++ b/app/components/workflow-toggle.cjsx
@@ -1,0 +1,29 @@
+React = require 'react'
+SetToggle = require '../lib/set-toggle'
+
+module.exports = React.createClass
+  displayName: "WorkflowToggle"
+
+  mixins: [SetToggle]
+
+  getDefaultProps: ->
+    workflow: null
+    project: null
+    field: null
+
+  getInitialState: ->
+    error: null
+    setting: {}
+
+  setterProperty: 'workflow'
+
+  render: ->
+    workflow = @props.workflow
+    setting = workflow[@props.field]
+    <span>
+      { workflow.id } - { workflow.display_name}:
+      <label style={whiteSpace: 'nowrap'}>
+        <input type="checkbox" name={@props.field} value={setting} checked={setting} onChange={@set.bind this, @props.field, not setting} />
+        Active
+      </label>
+    </span>

--- a/app/pages/admin/project-status.cjsx
+++ b/app/pages/admin/project-status.cjsx
@@ -57,33 +57,6 @@ ProjectToggle = React.createClass
       </label>
     </span>
 
-# WorkflowToggle = React.createClass
-#   displayName: "WorkflowToggle"
-#
-#   mixins: [SetToggle]
-#
-#   getDefaultProps: ->
-#     workflow: null
-#     project: null
-#     field: null
-#
-#   getInitialState: ->
-#     error: null
-#     setting: {}
-#
-#   setterProperty: 'workflow'
-#
-#   render: ->
-#     workflow = @props.workflow
-#     setting = workflow[@props.field]
-#     <span>
-#       { workflow.id } - { workflow.display_name}:
-#       <label style={whiteSpace: 'nowrap'}>
-#         <input type="checkbox" name={@props.field} value={setting} checked={setting} onChange={@set.bind this, @props.field, not setting} />
-#         Active
-#       </label>
-#     </span>
-
 ProjectExperimentalFeatures = React.createClass
   displayName: "ProjectExperimentalFeatures"
 

--- a/app/pages/admin/project-status.cjsx
+++ b/app/pages/admin/project-status.cjsx
@@ -8,6 +8,7 @@ ChangeListener = require '../../components/change-listener'
 ProjectIcon = require '../../components/project-icon'
 AutoSave = require '../../components/auto-save'
 handleInputChange = require '../../lib/handle-input-change'
+WorkflowToggle = require '../../components/workflow-toggle'
 
 EXPERIMENTAL_FEATURES = [
   'survey'
@@ -56,32 +57,32 @@ ProjectToggle = React.createClass
       </label>
     </span>
 
-WorkflowToggle = React.createClass
-  displayName: "WorkflowToggle"
-
-  mixins: [SetToggle]
-
-  getDefaultProps: ->
-    workflow: null
-    project: null
-    field: null
-
-  getInitialState: ->
-    error: null
-    setting: {}
-
-  setterProperty: 'workflow'
-
-  render: ->
-    workflow = @props.workflow
-    setting = workflow[@props.field]
-    <span>
-      { workflow.id } - { workflow.display_name}:
-      <label style={whiteSpace: 'nowrap'}>
-        <input type="checkbox" name={@props.field} value={setting} checked={setting} onChange={@set.bind this, @props.field, not setting} />
-        Active
-      </label>
-    </span>
+# WorkflowToggle = React.createClass
+#   displayName: "WorkflowToggle"
+#
+#   mixins: [SetToggle]
+#
+#   getDefaultProps: ->
+#     workflow: null
+#     project: null
+#     field: null
+#
+#   getInitialState: ->
+#     error: null
+#     setting: {}
+#
+#   setterProperty: 'workflow'
+#
+#   render: ->
+#     workflow = @props.workflow
+#     setting = workflow[@props.field]
+#     <span>
+#       { workflow.id } - { workflow.display_name}:
+#       <label style={whiteSpace: 'nowrap'}>
+#         <input type="checkbox" name={@props.field} value={setting} checked={setting} onChange={@set.bind this, @props.field, not setting} />
+#         Active
+#       </label>
+#     </span>
 
 ProjectExperimentalFeatures = React.createClass
   displayName: "ProjectExperimentalFeatures"

--- a/app/pages/lab/project.cjsx
+++ b/app/pages/lab/project.cjsx
@@ -102,7 +102,7 @@ EditProjectPage = React.createClass
                   <ChangeListener key={workflow.id} target={workflow} eventName="save" handler={renderWorkflowListItem.bind this, workflow} />}
 
                 <li className="nav-list-item">
-                  <button type="button" onClick={@showCreateWorkflow} disabled={@props.project.live or @state.workflowCreationInProgress} title="A workflow is the sequence of tasks that you’re asking volunteers to perform.">
+                  <button type="button" onClick={@showCreateWorkflow} disabled={@state.workflowCreationInProgress} title="A workflow is the sequence of tasks that you’re asking volunteers to perform.">
                     New workflow{' '}
                     <LoadingIndicator off={not @state.workflowCreationInProgress} />
                   </button>
@@ -113,7 +113,7 @@ EditProjectPage = React.createClass
 
           {if @state.workflowCreationInProgress
             <ModalFormDialog tag="div">
-              <WorkflowCreateForm onSubmit={@props.workflowActions.createWorkflowForProject} onCancel={@hideCreateWorkflow} onSuccess={@handleWorkflowCreation}  projectID={@props.project.id} />
+              <WorkflowCreateForm onSubmit={@props.workflowActions.createWorkflowForProject} onCancel={@hideCreateWorkflow} onSuccess={@handleWorkflowCreation}  projectID={@props.project.id} workflowActiveStatus={not @props.project.live} />
             </ModalFormDialog>}
 
           <li>

--- a/app/pages/lab/visibility.cjsx
+++ b/app/pages/lab/visibility.cjsx
@@ -1,5 +1,33 @@
 React = require 'react'
+PromiseRenderer = require '../../components/promise-renderer'
 SetToggle = require '../../lib/set-toggle'
+
+WorkflowToggle = React.createClass
+  displayName: "WorkflowToggle"
+
+  mixins: [SetToggle]
+
+  getDefaultProps: ->
+    workflow: null
+    project: null
+    field: null
+
+  getInitialState: ->
+    error: null
+    setting: {}
+
+  setterProperty: 'workflow'
+
+  render: ->
+    workflow = @props.workflow
+    setting = workflow[@props.field]
+    <span>
+      { workflow.id } - { workflow.display_name}:
+      <label style={whiteSpace: 'nowrap'}>
+        <input type="checkbox" name={@props.field} value={setting} checked={setting} onChange={@set.bind this, @props.field, not setting} />
+        Active
+      </label>
+    </span>
 
 module.exports = React.createClass
   displayName: 'EditProjectVisibility'
@@ -123,4 +151,21 @@ module.exports = React.createClass
 
         </div>
       </div>
+
+      <hr/>
+
+      <p className="form-label">Workflow Settings</p>
+      <PromiseRenderer promise={@props.project.get('workflows')}>{(workflows) =>
+        if workflows.length is 0
+          <div className="workflow-status-list">No workflows found</div>
+        else
+          <div className="workflow-status-list">
+            <ul>
+            {workflows.map (workflow) =>
+              <li key={workflow.id}>
+                <WorkflowToggle workflow={workflow} project={@props.project} field="active" />
+              </li>}
+            </ul>
+          </div>
+      }</PromiseRenderer>
     </div>

--- a/app/pages/lab/visibility.cjsx
+++ b/app/pages/lab/visibility.cjsx
@@ -1,33 +1,7 @@
 React = require 'react'
+WorkflowToggle = require '../../components/workflow-toggle'
 PromiseRenderer = require '../../components/promise-renderer'
 SetToggle = require '../../lib/set-toggle'
-
-WorkflowToggle = React.createClass
-  displayName: "WorkflowToggle"
-
-  mixins: [SetToggle]
-
-  getDefaultProps: ->
-    workflow: null
-    project: null
-    field: null
-
-  getInitialState: ->
-    error: null
-    setting: {}
-
-  setterProperty: 'workflow'
-
-  render: ->
-    workflow = @props.workflow
-    setting = workflow[@props.field]
-    <span>
-      { workflow.id } - { workflow.display_name}:
-      <label style={whiteSpace: 'nowrap'}>
-        <input type="checkbox" name={@props.field} value={setting} checked={setting} onChange={@set.bind this, @props.field, not setting} />
-        Active
-      </label>
-    </span>
 
 module.exports = React.createClass
   displayName: 'EditProjectVisibility'

--- a/app/pages/lab/visibility.cjsx
+++ b/app/pages/lab/visibility.cjsx
@@ -57,7 +57,7 @@ module.exports = React.createClass
         Live
       </label>
 
-      <p className="form-help">Workflows can be edited during development, and subjects will never retire. In a live project, workflows are locked and can no longer be edited, and classifications count toward subject retirement.</p>
+      <p className="form-help">All workflows can be edited during development, and subjects will never retire. In a live project, active workflows are locked and can no longer be edited, and classifications count toward subject retirement.</p>
 
       <div style={looksDisabled if @props.project.private or not @props.project.live}>
         <hr />
@@ -142,4 +142,5 @@ module.exports = React.createClass
             </ul>
           </div>
       }</PromiseRenderer>
+      <p className="form-help">In a live project active workflows are available to volunteers and cannot be edited. Inactive workflows can be edited if a project is live or in development.</p>
     </div>

--- a/app/pages/lab/workflow-create-form.cjsx
+++ b/app/pages/lab/workflow-create-form.cjsx
@@ -9,6 +9,7 @@ WorkflowCreateForm = React.createClass
     onSuccess: ->
     projectID: ''
     workflowToClone: null
+    workflowActiveStatus: false
 
   getInitialState: ->
     busy: false
@@ -35,6 +36,7 @@ WorkflowCreateForm = React.createClass
       first_task: workflowToClone?.first_task ? 'init'
       configuration: workflowToClone?.configuration ? {}
       retirement: workflowToClone?.retirement ? {}
+      active: @props.workflowActiveStatus ? false
 
     awaitSubmission = @props.onSubmit(@props.projectID, newWorkflow)
 

--- a/app/pages/lab/workflow.cjsx
+++ b/app/pages/lab/workflow.cjsx
@@ -217,9 +217,10 @@ EditWorkflowPage = React.createClass
             <hr />
 
             <p>
-              <small className="form-help">Version {@props.workflow.version}</small>
+              <small className="form-help">Version {@props.workflow.version} - Status: <span className={if @props.workflow.active then "color-label green" else "color-label red"}>{if @props.workflow.active then "Active" else "Inactive"}</span></small>
             </p>
             <p className="form-help"><small>Version indicates which version of the workflow you are on. Every time you save changes to a workflow, you create a new version. Big changes, like adding or deleting questions, will change the version by a whole number: 1.0 to 2.0, etc. Smaller changes, like modifying the help text, will change the version by a decimal, e.g. 2.0 to 2.1. The version is tracked with each classification in case you need it when analyzing your data.</small></p>
+            <p className="form-help"><small>Status indicates whether a workflow is active or inactive. Active workflows are available to volunteers and classifications count toward subject retirement. Workflow status can be managed under the Visibility section within the Project Builder.</small></p>
           </div>
 
           <hr />

--- a/app/pages/lab/workflow.cjsx
+++ b/app/pages/lab/workflow.cjsx
@@ -88,18 +88,18 @@ EditWorkflowPage = React.createClass
 
     <div className="edit-workflow-page">
       <h3>{@props.workflow.display_name} #{@props.workflow.id}{' '}
-        <button onClick={@showCreateWorkflow} disabled={@props.project.live or @state.workflowCreationInProgress} title="Copy workflow">
+        <button onClick={@showCreateWorkflow} disabled={@state.workflowCreationInProgress} title="Copy workflow">
           <i className="fa fa-copy"/>
         </button>
       </h3>
       {if @state.workflowCreationInProgress
         <ModalFormDialog tag="div">
-          <WorkflowCreateForm onSubmit={@props.workflowActions.createWorkflowForProject} onCancel={@hideCreateWorkflow} onSuccess={@handleWorkflowCreation}  projectID={@props.project.id} workflowToClone={@props.workflow} />
+          <WorkflowCreateForm onSubmit={@props.workflowActions.createWorkflowForProject} onCancel={@hideCreateWorkflow} onSuccess={@handleWorkflowCreation}  projectID={@props.project.id} workflowToClone={@props.workflow} workflowActiveStatus={not @props.project.live} />
         </ModalFormDialog>}
       <p className="form-help">A workflow is the sequence of tasks that you’re asking volunteers to perform. For example, you might want to ask volunteers to answer questions about your images, or to mark features in your images, or both.</p>
-      {if @props.project.live
-        <p className="form-help warning"><strong>You cannot edit a project’s workflows once it’s gone live.</strong></p>}
-      <div className="columns-container" style={disabledStyle if @props.project.live}>
+      {if @props.project.live and @props.workflow.active
+        <p className="form-help warning"><strong>You cannot edit an active workflow if the project is live.</strong></p>}
+      <div className="columns-container" style={disabledStyle if @props.project.live and @props.workflow.active}>
         <div className="column">
           <div>
             <AutoSave tag="label" resource={@props.workflow}>


### PR DESCRIPTION
1) adds same workflow active/inactive management currently in admin settings of a project to Visibility section within Project Builder
2) allows editing of inactive workflows
3) allows creation or copying (within project) of new workflows, which are set as active if project in development (current setup) or inactive if project live.

a new workflow active status is set within the workflow-create-form.cjsx. i believe it's duplicative to set the workflowActiveStatus prop's default to false ([line 12](https://github.com/mcbouslog/Panoptes-Front-End/blob/467d8c28c147b39587febd6bd7bae5c8eef24ca7/app/pages/lab/workflow-create-form.cjsx#L12)) and set the active property to false if the prop is undefined ([line 39](https://github.com/mcbouslog/Panoptes-Front-End/blob/467d8c28c147b39587febd6bd7bae5c8eef24ca7/app/pages/lab/workflow-create-form.cjsx#L39)), but maybe it's worth it to make sure a workflow isn't unintentionally added as active?

also, i considered removing the workflow management from admin project settings, but because all admins have quick access to all projects' admin settings, but only collaborators have access to the Project Builder, Visibility section, i thought ok to leave in both places so an admin unassociated with a project can quickly manage workflows if need be, without being added as a project collaborator.

per Laura's suggestion, mentioning @aliburchard and @camallen who may be interested in this?

branch staged for review [here](https://edit-inactive-workflows.pfe-preview.zooniverse.org)