### PR TITLE
Update tool label styling

### DIFF
--- a/css/classify.styl
+++ b/css/classify.styl
@@ -148,9 +148,9 @@
         margin-bottom: 0
 
     .answer-button-icon-container
-      align-self: flex-start
+      align-self: center
       flex-shrink: 0
-      height: 1em // Overflow is okay!
+      height: 1.5em
 
     .answer-button-label-container
       align-items: baseline


### PR DESCRIPTION
Fix from @itsravenous. Follows on from #2535. Vertically centers the svg rectangle not just the text.
(the 1.5em matches the height of the svg el within so this should work on all projects regardless of image height and label height)

![screenshot from 2016-05-06 12-52-48](https://cloud.githubusercontent.com/assets/1473244/15072476/e0382906-138a-11e6-8670-81b3866d486c.png)
