### PR TITLE
Big cleanup of the root project page

### DIFF
--- a/app/pages/project/index.cjsx
+++ b/app/pages/project/index.cjsx
@@ -1,16 +1,24 @@
 counterpart = require 'counterpart'
 React = require 'react'
-ChangeListener = require '../../components/change-listener'
-PromiseRenderer = require '../../components/promise-renderer'
 Translate = require 'react-translate-component'
-{Link} = require 'react-router'
+{IndexLink, Link} = require 'react-router'
 {Markdown} = require 'markdownz'
-TitleMixin = require '../../lib/title-mixin'
-HandlePropChanges = require '../../lib/handle-prop-changes'
-apiClient = window.api = require 'panoptes-client/lib/api-client'
-{sugarClient} = require 'panoptes-client/lib/sugar'
-LoadingIndicator = require '../../components/loading-indicator'
 PotentialFieldGuide = require './potential-field-guide'
+TitleMixin = require '../../lib/title-mixin'
+apiClient = require 'panoptes-client/lib/api-client'
+{sugarClient} = require 'panoptes-client/lib/sugar'
+
+counterpart.registerTranslations 'en',
+  project:
+    loading: 'Loading project'
+    disclaimer: "This project has been built using the Zooniverse Project Builder but is not yet an official Zooniverse project. Queries and issues relating to this project directed at the Zooniverse Team may not receive any response."
+    nav:
+      research: 'Research'
+      results: 'Results'
+      classify: 'Classify'
+      faq: 'FAQ'
+      education: 'Education'
+      talk: 'Talk'
 
 SOCIAL_ICONS =
   'bitbucket.com/': 'bitbucket'
@@ -27,164 +35,222 @@ SOCIAL_ICONS =
   'youtu.be/': 'youtube'
   'youtube.com/': 'youtube'
 
-counterpart.registerTranslations 'en',
-  project:
-    loading: 'Loading project'
-    disclaimer: "This project has been built using the Zooniverse Project Builder but is not yet an official Zooniverse project. Queries and issues relating to this project directed at the Zooniverse Team may not receive any response."
-    nav:
-      research: 'Research'
-      results: 'Results'
-      classify: 'Classify'
-      faq: 'FAQ'
-      education: 'Education'
-      talk: 'Talk'
-
-ProjectAvatar = React.createClass
-  displayName: 'ProjectAvatar'
-
-  render: ->
-    <PromiseRenderer promise={@props.project.get 'avatar'} then={(avatar) =>
-      <img src={avatar.src} className="avatar" />
-    } catch={null} />
 
 ProjectPage = React.createClass
-  displayName: 'ProjectPage'
-
   getDefaultProps: ->
     project: null
+    owner: null
+
+  getInitialState: ->
+    background: null
+    avatar: null
+    pages: []
 
   componentDidMount: ->
-    sugarClient.subscribeTo "project-#{ @props.project.id }"
     document.documentElement.classList.add 'on-project-page'
+    @fetchInfo @props.project
+    @updateSugarSubscription @props.project
 
   componentWillUnmount: ->
-    sugarClient.unsubscribeFrom "project-#{ @props.project.id }"
     document.documentElement.classList.remove 'on-project-page'
+    @updateSugarSubscription null
 
-  getPageTitles: (page) ->
-    page.filter((page) -> page.content isnt '' and page.content?)
-      .reduce(((accum, page) -> accum[page.url_key] = page.title; accum), {})
+  componentWillReceiveProps: (nextProps) ->
+    if nextProps.project isnt @props.project
+      @fetchInfo nextProps.project
+      @updateSugarSubscription nextProps.project
 
-  redirect_classify_link: (redirect) ->
+  fetchInfo: (project) ->
+    @setState
+      background: null
+      avatar: null
+      pages: []
+
+    project.get 'background'
+      .catch =>
+        null
+      .then (background) =>
+        @setState {background}
+
+    project.get 'avatar'
+      .catch =>
+        null
+      .then (avatar) =>
+        @setState {avatar}
+
+    project.get 'pages'
+      .catch =>
+        []
+      .then (pages) =>
+        @setState {pages}
+
+  _lastSugarSubscribedID: null
+
+  updateSugarSubscription: (project) ->
+    if @_lastSugarSubscribedID?
+      sugarClient.unsubscribeFrom "project-#{@_lastSugarSubscribedID}"
+    if project?
+      sugarClient.subscribeTo "project-#{project.id}"
+
+  redirectClassifyLink: (redirect) ->
     "#{redirect.replace(/\/?#?\/+$/, "")}/#/classify"
 
   render: ->
-    <ChangeListener target={@props.project}>{=>
-      <PromiseRenderer promise={@props.project.get 'owner'}>{(owner) =>
-        [ownerName, name] = @props.project.slug.split('/')
-        projectPath = "/projects/#{ownerName}/#{name}"
+    projectPath = "/projects/#{@props.project.slug}"
 
-        <div className="project-page">
-          <PromiseRenderer promise={@props.project.get 'background'} then={(background) =>
-            <div className="project-background" style={backgroundImage: "url('#{background.src}')"}></div>
-          } catch={null} />
+    pages = [{}, @state.pages...].reduce (map, page) =>
+      map[page.url_key] = page
+      map
 
-          <nav className="project-nav tabbed-content-tabs">
-            {if @props.project.redirect
-              <a target="_blank" href={@props.project.redirect} className="tabbed-content-tab">
-                <ProjectAvatar project={@props.project} />
-                Visit {@props.project.title}
-              </a>
-            else
-              <Link to="#{projectPath}/home" activeClassName="active" className="tabbed-content-tab">
-                <ProjectAvatar project={@props.project} />
-                {@props.project.display_name}
-              </Link>}
-            {unless @props.project.redirect
-              <Link to="#{projectPath}/research" activeClassName="active" className="tabbed-content-tab">
-                <Translate content="project.nav.research" />
-              </Link>}
-            {if @props.project.redirect
-              <a target="_blank" href={@redirect_classify_link(@props.project.redirect)} className="tabbed-content-tab">
-                <Translate content="project.nav.classify" />
-              </a>
-            else
-              <Link to="#{projectPath}/classify" activeClassName="active" className="classify tabbed-content-tab">
-                <Translate content="project.nav.classify" />
-              </Link>}
-            {unless @props.project.redirect
-              <PromiseRenderer promise={@props.project.get 'pages'}>{(pages) =>
-                pageTitles = @getPageTitles(pages)
-                <span>
-                  {if pageTitles.results
-                    <Link to="#{projectPath}/results" activeClassName="active"className="tabbed-content-tab">
-                      {pageTitles.results}
-                    </Link>}
-                  {if pageTitles.faq
-                    <Link to="#{projectPath}/faq" activeClassName="active" className="tabbed-content-tab">
-                      {pageTitles.faq}
-                    </Link>}
-                  {if pageTitles.education
-                    <Link to="#{projectPath}/education" activeClassName="active" className="tabbed-content-tab">
-                      {pageTitles.education}
-                    </Link>}
-                </span>
-              }</PromiseRenderer>}
-            <Link to="#{projectPath}/talk" activeClassName="active" className="tabbed-content-tab">
-              <Translate content="project.nav.talk" />
-            </Link>
-            {for link, i in @props.project.urls
-              link._key ?= Math.random()
-              {label} = link
-              unless label
-                for pattern, icon of SOCIAL_ICONS
-                  if link.url.indexOf(pattern) isnt -1
-                    socialIcon = icon
-                socialIcon ?= 'globe'
-                label = <i className="fa fa-#{socialIcon} fa-fw fa-2x"></i>
-              <a key={link._key} href={link.url} className="tabbed-content-tab" target="#{@props.project.id}-#{i}">{label}</a>}
-          </nav>
+    <div className="project-page">
+      {if @state.background?
+        <div className="project-background" style={backgroundImage: "url('#{@state.background.src}')"}></div>}
 
-          {if @props.project.configuration?.announcement
-            <div className="informational project-announcement-banner">
-              <Markdown>{@props.project.configuration.announcement}</Markdown>
-            </div>}
+      <nav className="project-nav tabbed-content-tabs">
+        {if @props.project.redirect
+          <a href={@props.project.redirect} className="tabbed-content-tab" target="_blank">
+            {if @state.avatar?
+              <img src={@state.avatar.src} className="avatar" />}
+            Visit {@props.project.display_name}
+          </a>
+        else
+          <IndexLink to="#{projectPath}" activeClassName="active" className="tabbed-content-tab">
+            {if @state.avatar?
+              <img src={@state.avatar.src} className="avatar" />}
+            {@props.project.display_name}
+          </IndexLink>}
 
-          {React.cloneElement(@props.children, {owner: owner, project: @props.project, user: @props.user})}
+        {unless @props.project.redirect
+          <Link to="#{projectPath}/research" activeClassName="active" className="tabbed-content-tab">
+            <Translate content="project.nav.research" />
+          </Link>}
 
-          {unless @props.project.launch_approved or @props.project.beta_approved
-            <Translate className="project-disclaimer" content="project.disclaimer" component="p" />}
+        {if @props.project.redirect
+          <a href={@redirectClassifyLink(@props.project.redirect)} className="tabbed-content-tab" target="_blank">
+            <Translate content="project.nav.classify" />
+          </a>
+        else
+          <Link to="#{projectPath}/classify" activeClassName="active" className="classify tabbed-content-tab">
+            <Translate content="project.nav.classify" />
+          </Link>}
 
-          <PotentialFieldGuide project={@props.project} />
-        </div>
-      }</PromiseRenderer>
-    }</ChangeListener>
+        {if !!pages.results?.content
+          <Link to="#{projectPath}/results" activeClassName="active"className="tabbed-content-tab">
+            {pages.results.title}
+          </Link>}
 
-module.exports = React.createClass
-  displayName: 'ProjectPageWrapper'
-  mixins: [TitleMixin, HandlePropChanges]
+        {if !!pages.faq?.content
+          <Link to="#{projectPath}/faq" activeClassName="active" className="tabbed-content-tab">
+            {pages.faq.title}
+          </Link>}
+
+        {if !!pages.education?.content
+          <Link to="#{projectPath}/education" activeClassName="active" className="tabbed-content-tab">
+            {pages.education.title}
+          </Link>}
+
+        <Link to="#{projectPath}/talk" activeClassName="active" className="tabbed-content-tab">
+          <Translate content="project.nav.talk" />
+        </Link>
+
+        {@props.project.urls.map ({label, url}, i) =>
+          unless !!label
+            for pattern, icon of SOCIAL_ICONS
+              if url.indexOf(pattern) isnt -1
+                iconForLabel = icon
+            iconForLabel ?= 'globe'
+            label = <i className="fa fa-#{iconForLabel} fa-fw fa-2x"></i>
+          <a key={i} href={url} className="tabbed-content-tab" target="#{@props.project.id}#{url}">{label}</a>}
+      </nav>
+
+      {if !!@props.project.configuration?.announcement
+        <div className="informational project-announcement-banner">
+          <Markdown>{@props.project.configuration.announcement}</Markdown>
+        </div>}
+
+      {React.cloneElement @props.children, user: @props.user, project: @props.project, owner: @props.owner}
+
+      {unless @props.project.launch_approved or @props.project.beta_approved
+        <Translate component="p" className="project-disclaimer" content="project.disclaimer" />}
+
+      <PotentialFieldGuide project={@props.project} />
+    </div>
+
+
+ProjectPageController = React.createClass
+  displayName: 'ProjectPageController'
+
+  mixins: [TitleMixin]
 
   title: ->
     @state.project?.display_name ? '(Loading)'
 
   getDefaultProps: ->
-    params: null
+    params: {}
     user: null
 
   getInitialState: ->
+    loading: false
+    error: null
     project: null
+    owner: null
 
-  propChangeHandlers:
-    'params.owner': 'fetchProject'
-    'params.name': 'fetchProject'
-    'user': 'fetchProject'
+  componentDidMount: ->
+    @fetchProject @props.params.owner, @props.params.name
 
-  fetchProject: (_, props = @props) ->
-    @setState error: false
-    query =
-      slug: props.params.owner + '/' + props.params.name
+  componentWillReceiveProps: (nextProps) ->
+    {owner, name} = nextProps.params
+    pathChanged = owner isnt @props.params.owner or name isnt @props.params.name
+    userChanged = nextProps.user isnt @props.user
+
+    if pathChanged or userChanged
+      @fetchProject owner, name
+
+  fetchProject: (owner, name) ->
+    @setState
+      loading: true
+      error: null
+      project: null
+      owner: null
+
+    query = slug: owner + '/' + name
 
     apiClient.type('projects').get query
       .then ([project]) =>
-        @setState { project }
-      .catch =>
-        @setState error: true
+        @setState {project}
+        project.get 'owner'
+      .then (owner) =>
+        @setState {owner}
+      .catch (error) =>
+        @setState {error}
+      .then =>
+        @setState loading: false
 
   render: ->
-    <div className="project-page-wrapper">
-      {if @state.error
-        <p>There was an error retrieving the project.</p>}
+    slug = @props.params.owner + '/' + @props.params.name
 
-      {if @state.project? && !@state.error
-        <ProjectPage {...@props} project={@state.project} />}
+    <div className="project-page-wrapper">
+      {if @state.loading
+        <div>
+          <p>
+            Loading{' '}
+            <strong>{slug}</strong>...
+          </p>
+        </div>}
+
+      {if @state.error?
+        <div>
+          <p>
+            There was an error retrieving the project{' '}
+            <strong>{slug}</strong>.
+          </p>
+          <p>
+            <code>{@state.error.stack}</code>
+          </p>
+        </div>}
+
+      {if @state.project? and @state.owner?
+        <ProjectPage {...@props} project={@state.project} owner={@state.owner} />}
     </div>
+
+module.exports = ProjectPageController

--- a/app/router.cjsx
+++ b/app/router.cjsx
@@ -2,16 +2,22 @@ Router = {IndexRoute, Route, Redirect} = require 'react-router'
 React = require 'react'
 
 # <Redirect from="home" to="/" /> doesn't work.
-ROOT_REDIRECT = React.createClass
+ONE_UP_REDIRECT = React.createClass
   componentDidMount: ->
-    @props.history.replace '/'
+    givenPathSegments = @props.location.pathname.split '/'
+    givenPathSegments.pop()
+    pathOneLevelUp = givenPathSegments.join '/'
+    @props.history.replace
+      pathname: pathOneLevelUp,
+      query: @props.location.query
+
   render: ->
     null
 
 module.exports =
   <Route path="/" component={require './partials/app'}>
     <IndexRoute component={require './pages/home'} />
-    <Route path="home" component={ROOT_REDIRECT} />
+    <Route path="home" component={ONE_UP_REDIRECT} />
 
     <Route path="about" component={require './pages/about'} ignoreScrollBehavior>
       <IndexRoute component={require './pages/about/about-home'} />
@@ -50,7 +56,7 @@ module.exports =
     <Route path="projects" component={require './pages/projects'} />
     <Route path="projects/:owner/:name" component={require './pages/project'}>
       <IndexRoute component={require './pages/project/home'} />
-      <Route path="home" component={require './pages/project/home'} />
+      <Route path="home" component={ONE_UP_REDIRECT} />
       <Route path="research" component={require './pages/project/research'} />
       <Route path="results" component={require './pages/project/results'} />
       <Route path="classify" component={require './pages/project/classify'} />


### PR DESCRIPTION
Just realized this branch is totally named wrong, sorry. This is a refactor of the root project page. It removes any `ChangeListener` and `PromiseRenderer` components and makes accessing resources more explicit.

Also set up a redirect for /projects/owner/name**/home** back to /projects/owner/name, so there's only a single URL per page. Feels kinda hacky but I just could not get react-router to behave.

Just FYI @srallen, this is in preparation for my change for storing the last selected workflow as a state on the project root page.