### PR TITLE
Remove any markdown from tool labels when summarising classification

### DIFF
--- a/app/classifier/tasks/drawing/summary.cjsx
+++ b/app/classifier/tasks/drawing/summary.cjsx
@@ -11,6 +11,7 @@ module.exports = React.createClass
     expanded: false
 
   stripMarkdownFromLabel: (label) ->
+    label = label.replace /\!\[[^\]]*\]\([^)]*\)/g, ""
     remark.process(label)
 
   getInitialState: ->

--- a/app/classifier/tasks/drawing/summary.cjsx
+++ b/app/classifier/tasks/drawing/summary.cjsx
@@ -1,4 +1,6 @@
 React = require 'react'
+strip = require 'strip-markdown'
+remark = (require 'remark').use(strip)
 
 module.exports = React.createClass
   displayName: 'DrawingSummary'
@@ -7,6 +9,9 @@ module.exports = React.createClass
     task: null
     annotation: null
     expanded: false
+
+  stripMarkdownFromLabel: (label) ->
+    remark.process(label)
 
   getInitialState: ->
     expanded: @props.expanded
@@ -31,7 +36,7 @@ module.exports = React.createClass
         toolMarks = (mark for mark in @props.annotation.value when mark.tool is i)
         if @state.expanded or toolMarks.length isnt 0
           <div key={tool._key} className="answer">
-            {tool.type} <strong>{tool.label}</strong> ({[].concat toolMarks.length})
+            <strong>{@stripMarkdownFromLabel(tool.label)}</strong> ({[].concat toolMarks.length} {tool.type}s marked)
             {if @state.expanded
               for mark, i in toolMarks
                 mark._key ?= Math.random()

--- a/app/classifier/tasks/drawing/summary.cjsx
+++ b/app/classifier/tasks/drawing/summary.cjsx
@@ -10,6 +10,9 @@ module.exports = React.createClass
     annotation: null
     expanded: false
 
+  getCorrectSingularOrPluralOfDrawingType: (type, number) ->
+    if number>1 then "#{type}s" else type
+
   stripMarkdownFromLabel: (label) ->
     label = label.replace /\!\[[^\]]*\]\([^)]*\)/g, ""
     remark.process(label)
@@ -37,7 +40,7 @@ module.exports = React.createClass
         toolMarks = (mark for mark in @props.annotation.value when mark.tool is i)
         if @state.expanded or toolMarks.length isnt 0
           <div key={tool._key} className="answer">
-            <strong>{@stripMarkdownFromLabel(tool.label)}</strong> ({[].concat toolMarks.length} {tool.type}s marked)
+            <strong>{@stripMarkdownFromLabel(tool.label)}</strong> ({[].concat toolMarks.length} {@getCorrectSingularOrPluralOfDrawingType(tool.type,toolMarks.length)} marked)
             {if @state.expanded
               for mark, i in toolMarks
                 mark._key ?= Math.random()

--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
     "react-select": "~0.9.1",
     "react-swipe": "~3.0.0",
     "react-translate-component": "~0.10.0",
+    "remark": "~4.2.2",
     "sort-into-columns": "~1.0.0",
+    "strip-markdown": "~0.3.1",
     "sugar-client": "~1.0.1",
     "swipe-js-iso": "~2.0.1",
     "test-shape-closeness": "0.0.1"


### PR DESCRIPTION
Fixes https://github.com/zooniverse/Panoptes-Front-End/issues/2536 and improves classification summary for drawing tasks. 