### PR TITLE
removes autoFocus on first answer for single and multiple answer tasks

### DIFF
--- a/app/classifier/tasks/multiple.cjsx
+++ b/app/classifier/tasks/multiple.cjsx
@@ -97,7 +97,7 @@ module.exports = React.createClass
       answer._key ?= Math.random()
       <label key={answer._key} className="minor-button answer-button #{if i in @props.annotation.value then 'active' else ''}">
         <div className="answer-button-icon-container">
-          <input autoFocus={@props.autoFocus and i is 0} type="checkbox" checked={i in @props.annotation.value} onChange={@handleChange.bind this, i} />
+          <input type="checkbox" checked={i in @props.annotation.value} onChange={@handleChange.bind this, i} />
         </div>
         <div className="answer-button-label-container">
           <Markdown className="answer-button-label">{answer.label}</Markdown>

--- a/app/classifier/tasks/single.cjsx
+++ b/app/classifier/tasks/single.cjsx
@@ -85,7 +85,7 @@ module.exports = React.createClass
       answer._key ?= Math.random()
       <label key={answer._key} className="minor-button answer-button #{if i is @props.annotation.value then 'active' else ''}">
         <div className="answer-button-icon-container">
-          <input type="radio" autoFocus={ @props.autoFocus and i is 0 } checked={i is @props.annotation.value} onChange={@handleChange.bind this, i} />
+          <input type="radio" checked={i is @props.annotation.value} onChange={@handleChange.bind this, i} />
         </div>
         <div className="answer-button-label-container">
           <Markdown className="answer-button-label">{answer.label}</Markdown>


### PR DESCRIPTION
This PR address Issue #2563 by removing the autoFocus attribute from the `<SingleChoiceTask />` and the `<MultipleChoiceTask />`.

Examples:
- [Sample workflows with multiple task types](https://limit-autofocus-fix-2563.pfe-preview.zooniverse.org/projects/markb-panoptes/focus-testing-project)

The 'Next' button,  not the 'Talk' button, is still focused at the end of the classification. Does that also need to be changed?

CC: @eatyourgreens, @alexbfree, @aliburchard, @mschwamb 