### PR TITLE
Store workflow in prefs

### DIFF
--- a/app/pages/project/home.cjsx
+++ b/app/pages/project/home.cjsx
@@ -28,9 +28,11 @@ module.exports = React.createClass
   getInitialState: ->
     workflows: []
 
-  render: ->
-    [owner, name] = @props.project.slug.split('/')
+  handleWorkflowSelection: (workflow) ->
+    @props.onChangePreferences 'preferences.selected_workflow', workflow?.id
+    undefined # Don't prevent default Link behavior.
 
+  render: ->
     <div className="project-home-page">
       <div className="call-to-action-container content-container">
         <FinishedBanner project={@props.project} />
@@ -45,12 +47,18 @@ module.exports = React.createClass
             <small>at {@props.project.redirect}</small>
           </a>
         else if @props.project.configuration?.user_chooses_workflow
-          for workflow in @state.workflows
-            <Link to={"/projects/#{owner}/#{name}/classify?workflow=#{workflow.id}"} key={workflow.id} className="call-to-action standard-button">
+          @state.workflows.map (workflow) =>
+            <Link
+              to={"/projects/#{@props.project.slug}/classify"}
+              query={workflow: workflow.id}
+              key={workflow.id + Math.random()}
+              className="call-to-action standard-button"
+              onMouseDown={@handleWorkflowSelection.bind this, workflow}
+            >
               {workflow.display_name}
             </Link>
         else
-          <Link to={"/projects/#{owner}/#{name}/classify"} className="call-to-action standard-button">
+          <Link to={"/projects/#{@props.project.slug}/classify"} className="call-to-action standard-button">
             Get started!
           </Link>}
       </div>

--- a/app/pages/project/home.cjsx
+++ b/app/pages/project/home.cjsx
@@ -53,7 +53,7 @@ module.exports = React.createClass
               query={workflow: workflow.id}
               key={workflow.id + Math.random()}
               className="call-to-action standard-button"
-              onMouseDown={@handleWorkflowSelection.bind this, workflow}
+              onClick={@handleWorkflowSelection.bind this, workflow}
             >
               {workflow.display_name}
             </Link>

--- a/app/pages/project/index.cjsx
+++ b/app/pages/project/index.cjsx
@@ -99,7 +99,7 @@ ProjectPage = React.createClass
   render: ->
     projectPath = "/projects/#{@props.project.slug}"
 
-    currentWorkflow = @props.preferences?.preferences.selected_workflow ? @props.project.configuration.default_workflow
+    currentWorkflow = @props.preferences?.preferences.selected_workflow ? @props.project.configuration?.default_workflow
 
     pages = [{}, @state.pages...].reduce (map, page) =>
       map[page.url_key] = page

--- a/app/pages/project/index.cjsx
+++ b/app/pages/project/index.cjsx
@@ -40,6 +40,7 @@ ProjectPage = React.createClass
   getDefaultProps: ->
     project: null
     owner: null
+    preferences: null
 
   getInitialState: ->
     background: null
@@ -168,7 +169,12 @@ ProjectPage = React.createClass
           <Markdown>{@props.project.configuration.announcement}</Markdown>
         </div>}
 
-      {React.cloneElement @props.children, user: @props.user, project: @props.project, owner: @props.owner}
+      {React.cloneElement @props.children,
+        user: @props.user
+        project: @props.project
+        owner: @props.owner
+        preferences: @props.preferences
+        onChangePreferences: @props.onChangePreferences}
 
       {unless @props.project.launch_approved or @props.project.beta_approved
         <Translate component="p" className="project-disclaimer" content="project.disclaimer" />}
@@ -194,9 +200,15 @@ ProjectPageController = React.createClass
     error: null
     project: null
     owner: null
+    preferences: null
+
+  _listenedToPreferences: null
+
+  _boundForceUpdate: null
 
   componentDidMount: ->
-    @fetchProject @props.params.owner, @props.params.name
+    @_boundForceUpdate = @forceUpdate.bind this
+    @fetchProjectData @props.params.owner, @props.params.name, @props.user
 
   componentWillReceiveProps: (nextProps) ->
     {owner, name} = nextProps.params
@@ -204,27 +216,58 @@ ProjectPageController = React.createClass
     userChanged = nextProps.user isnt @props.user
 
     if pathChanged or userChanged
-      @fetchProject owner, name
+      @fetchProjectData owner, name, nextProps.user
 
-  fetchProject: (owner, name) ->
+  fetchProjectData: (owner, name, user) ->
+    @listenToPreferences null
     @setState
       loading: true
       error: null
       project: null
       owner: null
+      preferences: null
 
     query = slug: owner + '/' + name
 
     apiClient.type('projects').get query
       .then ([project]) =>
         @setState {project}
-        project.get 'owner'
-      .then (owner) =>
-        @setState {owner}
+
+        awaitOwner = project.get 'owner'
+          .then (owner) =>
+            @setState {owner}
+
+        awaitPreferences = user?.get 'project_preferences', project_id: project.id
+          .then ([preferences]) =>
+            preferences ? newPreferences = apiClient.type('project_preferences').create({
+              links: {
+                project: project.id
+              },
+              preferences: {}
+            }).save()
+          .then (preferences) =>
+            @listenToPreferences preferences
+            @setState {preferences}
+
+        Promise.all [awaitOwner, awaitPreferences]
+
       .catch (error) =>
         @setState {error}
+
       .then =>
         @setState loading: false
+
+  listenToPreferences: (preferences) ->
+    @_listenedToPreferences?.stopListening 'change', @_boundForceUpdate
+    preferences?.listen 'change', @_boundForceUpdate
+
+  handlePreferencesChange: (key, value) ->
+    changes = {}
+    changes[key] = value
+    if @state.preferences?
+      @state.preferences.update(changes).save()
+    else
+      console.log 'TODO: Store guest preferences'
 
   render: ->
     slug = @props.params.owner + '/' + @props.params.name
@@ -241,7 +284,7 @@ ProjectPageController = React.createClass
       {if @state.error?
         <div>
           <p>
-            There was an error retrieving the project{' '}
+            There was an error retrieving project{' '}
             <strong>{slug}</strong>.
           </p>
           <p>
@@ -250,7 +293,13 @@ ProjectPageController = React.createClass
         </div>}
 
       {if @state.project? and @state.owner?
-        <ProjectPage {...@props} project={@state.project} owner={@state.owner} />}
+        <ProjectPage
+          {...@props}
+          project={@state.project}
+          owner={@state.owner}
+          preferences={@state.preferences}
+          onChangePreferences={@handlePreferencesChange}
+        />}
     </div>
 
 module.exports = ProjectPageController

--- a/app/pages/project/index.cjsx
+++ b/app/pages/project/index.cjsx
@@ -99,6 +99,8 @@ ProjectPage = React.createClass
   render: ->
     projectPath = "/projects/#{@props.project.slug}"
 
+    currentWorkflow = @props.preferences?.preferences.selected_workflow ? @props.project.configuration.default_workflow
+
     pages = [{}, @state.pages...].reduce (map, page) =>
       map[page.url_key] = page
       map
@@ -131,7 +133,7 @@ ProjectPage = React.createClass
             <Translate content="project.nav.classify" />
           </a>
         else
-          <Link to="#{projectPath}/classify" activeClassName="active" className="classify tabbed-content-tab">
+          <Link to="#{projectPath}/classify" query={workflow: currentWorkflow} activeClassName="active" className="classify tabbed-content-tab">
             <Translate content="project.nav.classify" />
           </Link>}
 


### PR DESCRIPTION
~~WIP for~~ Closes #2565.

The user's workflow selection from the project landing page is now stored in their project preferences and passed into the "Classify" link in the project nav. Not-signed-in users get a temporary project preferences resource that's thrown out when they switch projects or reload the page.

~~I want to play with it a little more, but~~ I think this is just about ready. Any thoughts @mrniaboc? @srallen, is this something you can work with for #2534?