### PR TITLE
Subject uploader regex update

### DIFF
--- a/app/pages/lab/subject-set.cjsx
+++ b/app/pages/lab/subject-set.cjsx
@@ -275,7 +275,7 @@ EditSubjectSetPage = React.createClass
     filesInMetadata = []
     for key, value of metadata
       extensions = if isAdmin() then '\\.\\D\\w{2,4}' else "(?:#{'\\'.concat VALID_SUBJECT_EXTENSIONS.join '|\\'})"
-      filesInValue = value.match? ///([^#{INVALID_FILENAME_CHARS.join ''}]+#{extensions})///gi
+      filesInValue = value.match? ///([^#{INVALID_FILENAME_CHARS.join '\\'}]+#{extensions})///gi
       if filesInValue?
         filesInMetadata.push filesInValue...
     filesInMetadata

--- a/app/pages/lab/subject-set.cjsx
+++ b/app/pages/lab/subject-set.cjsx
@@ -274,8 +274,8 @@ EditSubjectSetPage = React.createClass
   _findFilesInMetadata: (metadata) ->
     filesInMetadata = []
     for key, value of metadata
-      extensions = if isAdmin() then '\\.\\D\\w{2,4}' else "(?:#{'\\'.concat VALID_SUBJECT_EXTENSIONS.join '|\\'})"
-      filesInValue = value.match? ///([^#{INVALID_FILENAME_CHARS.join '\\'}]+#{extensions})///gi
+      extensions = if isAdmin() then '\\.\\D\\w{2,4}' else "(?:#{'\\'+VALID_SUBJECT_EXTENSIONS.join '|\\'})"
+      filesInValue = value.match? ///([^#{'\\'+INVALID_FILENAME_CHARS.join '\\'}]+#{extensions})///gi
       if filesInValue?
         filesInMetadata.push filesInValue...
     filesInMetadata

--- a/app/pages/lab/subject-set.cjsx
+++ b/app/pages/lab/subject-set.cjsx
@@ -274,7 +274,7 @@ EditSubjectSetPage = React.createClass
   _findFilesInMetadata: (metadata) ->
     filesInMetadata = []
     for key, value of metadata
-      extensions = if isAdmin() then '\\.\\D\\w{2,4}' else "(?:#{VALID_SUBJECT_EXTENSIONS.join '|'})"
+      extensions = if isAdmin() then '\\.\\D\\w{2,4}' else "(?:#{'\\'.concat VALID_SUBJECT_EXTENSIONS.join '|\\'})"
       filesInValue = value.match? ///([^#{INVALID_FILENAME_CHARS.join ''}]+#{extensions})///gi
       if filesInValue?
         filesInMetadata.push filesInValue...


### PR DESCRIPTION
Important note: this issue and solution applies to non-Admin users on PFE, please disable Admin access when testing.

The NfN team had an issue while trying to upload a manifest file that included the following metadata:
`http://bisque.iplantcollaborative.org/image_service/image/00-uCGZDUoynWLhtoRqMKanoQ?resize=4000&format=jpeg`.
The subject uploader within Project Builder wanted to interpret `00-7Uj9yBZYiBPzSstLjMTpo7?resize=4000&format=jpeg` as a filename.

So on inspection of the related code it appears our intent of filtering certain extensions (line 18, VAR_SUBJECT_EXTENSIONS) or characters (line 19, INVALID_FILENAME_CHARS) wasn't behaving as intended, or more specifically once the filters made their way to the regex on lines 277 and 278 they weren't being interpreted literally, so `.jpeg` was interpreted within regex with the leading period as the regex wildcard, not literally filter for `.jpeg` but just look for `jpeg` (without the period). And the `\\` was interpreted as to take the literal of the next item.

I think the solution (thanks to @srallen for help!) is to add the `\\`'s as noted so our filters are interpreted literally within the regex. However, regex is not a strength of mine, so please take a look and let me know if there's a better way.

I've attached the NfN manifest and images for testing.
[d0a48b68-fde7-46cd-a97d-3a1db3de6821.tar.gz](https://github.com/zooniverse/Panoptes-Front-End/files/261585/d0a48b68-fde7-46cd-a97d-3a1db3de6821.tar.gz)
