### PR TITLE
Mini-course and workflow tutorials

### DIFF
--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -20,7 +20,6 @@ WorldWideTelescope = require './world_wide_telescope'
 MiniCourse = require '../lib/mini-course'
 MiniCourseButton = require './mini-course-button'
 
-
 PULSAR_HUNTERS_SLUG = 'zooniverse/pulsar-hunters'
 
 Classifier = React.createClass

--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -220,7 +220,7 @@ Classifier = React.createClass
       <p>
         <small>
           <strong>
-            <MiniCourseButton className="minor-button" user={@props.user} project={@props.project} title="Project Mini-course" aria-label="Show the project mini-course" style={marginTop: '2em'}>
+            <MiniCourseButton className="minor-button" user={@props.user} project={@props.project} workflow={@props.workflow} title="Project Mini-course" aria-label="Show the project mini-course" style={marginTop: '2em'}>
               Restart the project mini-course
             </MiniCourseButton>
           </strong>

--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -17,6 +17,9 @@ Tutorial = require '../lib/tutorial'
 workflowAllowsFlipbook = require '../lib/workflow-allows-flipbook'
 workflowAllowsSeparateFrames = require '../lib/workflow-allows-separate-frames'
 WorldWideTelescope = require './world_wide_telescope'
+MiniCourse = require '../lib/mini-course'
+MiniCourseButton = require './mini-course-button'
+
 
 PULSAR_HUNTERS_SLUG = 'zooniverse/pulsar-hunters'
 
@@ -209,6 +212,16 @@ Classifier = React.createClass
             <TutorialButton className="minor-button" user={@props.user} project={@props.project} title="Project tutorial" aria-label="Show the project tutorial" style={marginTop: '2em'}>
               Show the project tutorial
             </TutorialButton>
+          </strong>
+        </small>
+      </p>
+
+      <p>
+        <small>
+          <strong>
+            <MiniCourseButton className="minor-button" user={@props.user} project={@props.project} title="Project Mini-course" aria-label="Show the project mini-course" style={marginTop: '2em'}>
+              Restart the project mini-course
+            </MiniCourseButton>
           </strong>
         </small>
       </p>

--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -44,11 +44,13 @@ Classifier = React.createClass
   componentDidMount: ->
     @loadSubject @props.subject
     @prepareToClassify @props.classification
-    Tutorial.startIfNecessary @props.user, @props.project
+    {workflow, project, user} = @props
+    Tutorial.startIfNecessary {workflow, project, user}
 
   componentWillReceiveProps: (nextProps) ->
     if nextProps.project isnt @props.project or nextProps.user isnt @props.user
-      Tutorial.startIfNecessary nextProps.user, nextProps.project
+      {workflow, project, user} = nextProps
+      Tutorial.startIfNecessary {workflow, project, user}
     if nextProps.subject isnt @props.subject
       @loadSubject subject
     if nextProps.classification isnt @props.classification
@@ -209,7 +211,7 @@ Classifier = React.createClass
       <p>
         <small>
           <strong>
-            <TutorialButton className="minor-button" user={@props.user} project={@props.project} title="Project tutorial" aria-label="Show the project tutorial" style={marginTop: '2em'}>
+            <TutorialButton className="minor-button" user={@props.user} workflow={@props.workflow} project={@props.project} title="Project tutorial" aria-label="Show the project tutorial" style={marginTop: '2em'}>
               Show the project tutorial
             </TutorialButton>
           </strong>

--- a/app/classifier/mini-course-button.cjsx
+++ b/app/classifier/mini-course-button.cjsx
@@ -11,20 +11,20 @@ module.exports = React.createClass
     minicourse: null
 
   componentDidMount: ->
-    @fetchMiniCourseFor @props.project
+    @fetchMiniCourseFor @props.workflow, @props.project
 
   componentWillReceiveProps: (nextProps) ->
-    unless nextProps.project is @props.project
-      @fetchMiniCourseFor nextProps.project
+    unless nextProps.workflow is @props.workflow and nextProps.project is @props.project
+      @fetchMiniCourseFor nextProps.workflow, nextProps.project
 
-  fetchMiniCourseFor: (project) ->
-    apiClient.type('minicourses').get project_id: project.id
-      .then ([minicourse]) =>
-        @setState {minicourse}
+  fetchMiniCourseFor: (workflow, project) ->
+    @setState minicourse: null
+    MiniCourse.find({workflow, project}).then (minicourse) =>
+      @setState {minicourse}
 
   render: ->
-    if @state.minicourse? and @state.minicourse.steps.length isnt 0
-      <button type="button" {...@props} onClick={MiniCourse.start.bind(MiniCourse, @props.user, @props.project)}>
+    if @state.minicourse?.steps.length > 0
+      <button type="button" {...@props} onClick={MiniCourse.start.bind(MiniCourse, @state.minicourse, @props.user)}>
         {@props.children}
       </button>
     else

--- a/app/classifier/mini-course-button.cjsx
+++ b/app/classifier/mini-course-button.cjsx
@@ -3,6 +3,8 @@ apiClient = require 'panoptes-client/lib/api-client'
 MiniCourse = require '../lib/mini-course'
 
 module.exports = React.createClass
+  displayName: 'MiniCourseButton'
+  
   getDefaultProps: ->
     user: null
     project: null

--- a/app/classifier/mini-course-button.cjsx
+++ b/app/classifier/mini-course-button.cjsx
@@ -25,7 +25,7 @@ module.exports = React.createClass
       @setState {minicourse}
 
   render: ->
-    if @state.minicourse?.steps.length > 0
+    if @state.minicourse?.steps.length > 0 and @props.user?
       <button type="button" {...@props} onClick={MiniCourse.restart.bind(MiniCourse, @state.minicourse, @props.project, @props.user)}>
         {@props.children}
       </button>

--- a/app/classifier/mini-course-button.cjsx
+++ b/app/classifier/mini-course-button.cjsx
@@ -26,7 +26,7 @@ module.exports = React.createClass
 
   render: ->
     if @state.minicourse?.steps.length > 0
-      <button type="button" {...@props} onClick={MiniCourse.start.bind(MiniCourse, @state.minicourse, @props.user)}>
+      <button type="button" {...@props} onClick={MiniCourse.restart.bind(MiniCourse, @state.minicourse, @props.project, @props.user)}>
         {@props.children}
       </button>
     else

--- a/app/classifier/mini-course-button.cjsx
+++ b/app/classifier/mini-course-button.cjsx
@@ -1,0 +1,31 @@
+React = require 'react'
+apiClient = require 'panoptes-client/lib/api-client'
+MiniCourse = require '../lib/mini-course'
+
+module.exports = React.createClass
+  getDefaultProps: ->
+    user: null
+    project: null
+
+  getInitialState: ->
+    minicourse: null
+
+  componentDidMount: ->
+    @fetchMiniCourseFor @props.project
+
+  componentWillReceiveProps: (nextProps) ->
+    unless nextProps.project is @props.project
+      @fetchMiniCourseFor nextProps.project
+
+  fetchMiniCourseFor: (project) ->
+    apiClient.type('minicourses').get project_id: project.id
+      .then ([minicourse]) =>
+        @setState {minicourse}
+
+  render: ->
+    if @state.minicourse? and @state.minicourse.steps.length isnt 0
+      <button type="button" {...@props} onClick={MiniCourse.start.bind(MiniCourse, @props.user, @props.project)}>
+        {@props.children}
+      </button>
+    else
+      null

--- a/app/classifier/tutorial-button.cjsx
+++ b/app/classifier/tutorial-button.cjsx
@@ -4,27 +4,28 @@ Tutorial = require '../lib/tutorial'
 
 module.exports = React.createClass
   getDefaultProps: ->
-    user: null
+    workflow: null
     project: null
+    user: null
 
   getInitialState: ->
     tutorial: null
 
   componentDidMount: ->
-    @fetchTutorialFor @props.project
+    @fetchTutorialFor @props.workflow, @props.project
 
   componentWillReceiveProps: (nextProps) ->
-    unless nextProps.project is @props.project
-      @fetchTutorialFor nextProps.project
+    unless nextProps.workflow is @props.workflow and nextProps.project is @props.project
+      @fetchTutorialFor nextProps.workflow, nextProps.project
 
-  fetchTutorialFor: (project) ->
-    apiClient.type('tutorials').get project_id: project.id
-      .then ([tutorial]) =>
-        @setState {tutorial}
+  fetchTutorialFor: (workflow, project) ->
+    @setState tutorial: null
+    Tutorial.find({workflow, project}).then (tutorial) =>
+      @setState {tutorial}
 
   render: ->
-    if @state.tutorial? and @state.tutorial.steps.length isnt 0
-      <button type="button" {...@props} onClick={Tutorial.start.bind(Tutorial, @props.user, @props.project)}>
+    if @state.tutorial?.steps.length > 0
+      <button type="button" {...@props} onClick={Tutorial.start.bind(Tutorial, @state.tutorial, @props.user)}>
         {@props.children}
       </button>
     else

--- a/app/components/step-through.cjsx
+++ b/app/components/step-through.cjsx
@@ -2,6 +2,8 @@ React = require 'react'
 ReactSwipe = require 'react-swipe'
 
 module.exports = React.createClass
+  displayName: 'StepThrough'
+  
   propTypes:
     defaultStep: React.PropTypes.number
 

--- a/app/lib/mini-course.cjsx
+++ b/app/lib/mini-course.cjsx
@@ -175,7 +175,7 @@ module.exports = React.createClass
   handleProjectPreferencesOnUnmount: ->
     if @state.slideToStart is @props.minicourse.steps.length - 1
       now = new Date().toISOString()
-      completedThisSession[@props.minicourse.id] = now
+      minicoursesCompletedThisSession[@props.minicourse.id] = now
 
       @state.projectPreferences.update "preferences.minicourses.completed_at.id_#{@props.minicourse.id}": now
       @state.projectPreferences.save()

--- a/app/lib/mini-course.cjsx
+++ b/app/lib/mini-course.cjsx
@@ -1,0 +1,124 @@
+React = require 'react'
+Dialog = require 'modal-form/dialog'
+StepThrough = require '../components/step-through'
+MediaCard = require '../components/media-card'
+{Markdown} = require 'markdownz'
+apiClient = require 'panoptes-client/lib/api-client'
+
+completedThisSession = {}
+window?.tutorialsCompletedThisSession = completedThisSession
+
+DEFAULT_PREFERENCES = { 'preferences.opt_out': false, 'preferences.slide_last_seen': 0 }
+
+module.exports = React.createClass
+  displayName: 'MiniCourse'
+
+  statics:
+    checkIfCompleted: (projectPreferences) ->
+      getCompletedAt = if completedThisSession[project.id]?
+        Promise.resolve new Date completedThisSession[project.id]
+      else if projectPreferences?
+        new Date projectPreferences?.preferences?.mini_course_completed_at
+      else
+        Promise.resolve null
+
+      getCompletedAt.then (completedAt) =>
+        if isNaN completedAt?.valueOf()
+          false
+        else
+          # TODO: Check if the completion date is greater than the minicourse's modified_at date.
+          # Return `null` to mean "Completed, but not with the most recent version".
+          true
+
+    start: (user, project) ->
+      apiClient.type('minicourses').get project_id: project.id
+        .then ([minicourse]) =>
+          if minicourse? and minicourse.steps.length isnt 0
+            minicourse.get 'attached_images'
+              .catch =>
+                []
+              .then (mediaResources) =>
+                mediaByID = {}
+                for mediaResource in mediaResources
+                  mediaByID[mediaResource.id] = mediaResource
+
+                MiniCourseComponent = this
+                Dialog.alert(<MiniCourseComponent steps={minicourse.steps} media={mediaByID} />, {
+                  className: 'tutorial-dialog', #reusing tutorial styling
+                  required: true,
+                  closeButton: true
+                })
+                  .catch =>
+                    null # We don't really care if the user canceled or completed the tutorial.
+                  .then =>
+                    # now = new Date().toISOString()
+                    # completedThisSession[project.id] = now
+                    if user?
+                      user.get('project_preferences', project_id: project.id).then ([projectPreferences]) =>
+                        if projectPreferences.preferences.opt_out # user is restarting via mini-course button
+                          projectPreferences.update DEFAULT_PREFERENCES
+                          projectPreferences.save()
+                        else
+                          projectPreferences ?= apiClient.type('project_preferences').create({
+                            links: {
+                              project: project.id
+                            },
+                            preferences: {}
+                          })
+                          projectPreferences.update DEFAULT_PREFERENCES
+                          # projectPreferences.update 'preferences.mini_course_completed_at': now
+                          projectPreferences.save()
+
+    fetchUserPreferences: (user, project) ->
+      user.get('project_preferences', project_id: project.id).then ([projectPreferences]) =>
+        projectPreferences
+      .catch =>
+        null
+
+    startIfNecessary: (user, project) ->
+      projectPreferences = fetchUserPreferences user, project
+      @checkIfCompleted projectPreferences
+        .then (completed) =>
+          if completed is false
+            @start user, project unless projectPreferences.preferences.opt_out
+
+  propTypes:
+    steps: React.PropTypes.arrayOf React.PropTypes.shape
+      media: React.PropTypes.string
+      content: React.PropTypes.string
+
+  getDefaultProps: ->
+    steps: []
+    media: {}
+
+  getInitialState: ->
+    projectPreferences: null
+
+  componentDidMount: ->
+    @setState projectPreferences: @fetchUserPreferences
+
+  componentWillUnmount: ->
+    if @state.projectPreferences.preferences.slide_last_seen < @props.steps.length
+      nextSlideIndex = @state.projectPreferences.preferences.slide_last_seen + 1
+    @state.projectPreferences.update 'preferences.slide_last_seen': nextSlideIndex
+    @state.projectPreferences.save()
+  
+  render: ->
+    <StepThrough ref="stepThrough" className="tutorial-steps" defaultStep={@state.projectPreferences?.slide_last_seen}>
+      {for step, i in @props.steps
+        step._key ?= Math.random()
+        <MediaCard key={step._key} className="tutorial-step" src={@props.media[step.media]?.src}>
+          <Markdown>{step.content}</Markdown>
+          <hr />
+          <p style={textAlign: 'center'}>
+            <button type="button" className="standard-button" onClick={@handleOptOut}>Opt Out</button>
+          </p>
+        </MediaCard>}
+    </StepThrough>
+
+  handleNextClick: ->
+    @refs.stepThrough.goNext()
+
+  handleOptOut: ->
+    @state.projectPreferences.update 'preferences.out_out': true
+    @state.projectPreferences.save()

--- a/app/lib/mini-course.cjsx
+++ b/app/lib/mini-course.cjsx
@@ -26,18 +26,6 @@ module.exports = React.createClass
       else
         Promise.resolve()
 
-      # Wait for the workflow tutorial, but if nothing comes back, check for a project tutorial.
-      awaitMiniCourseInGeneral = awaitMiniCourseForWorkflow.then (miniCourseForWorkflow) ->
-        if miniCourseForWorkflow?
-          miniCourseForWorkflow
-        else if project?
-          apiClient.type('tutorials').get project_id: project.id, kind: "mini-course"
-            .then ([minicourse]) =>
-              minicourse
-        else
-          # There's no workflow tutorial and no project given.
-          Promise.resolve()
-
     start: (minicourse, user) ->
       MiniCourseComponent = this
       if minicourse.steps.length isnt 0

--- a/app/lib/mini-course.cjsx
+++ b/app/lib/mini-course.cjsx
@@ -8,29 +8,27 @@ apiClient = require 'panoptes-client/lib/api-client'
 completedThisSession = {}
 window?.tutorialsCompletedThisSession = completedThisSession
 
-DEFAULT_PREFERENCES = { 'preferences.opt_out': false, 'preferences.slide_last_seen': 0 }
-
 module.exports = React.createClass
   displayName: 'MiniCourse'
 
   statics:
     find: ({workflow, project}) ->
       # Prefer fetching the tutorial for the workflow, if a workflow is given.
-      awaitTutorialForWorkflow = if workflow?
-        apiClient.type('tutorials').get workflow_id: workflow.id
-          .then ([tutorial]) ->
-            tutorial
+      awaitMiniCourseForWorkflow = if workflow?
+        apiClient.type('tutorials').get workflow_id: workflow.id, kind: "mini-course"
+          .then ([minicourse]) ->
+            minicourse
       else
         Promise.resolve()
 
       # Wait for the workflow tutorial, but if nothing comes back, check for a project tutorial.
-      awaitTutorialInGeneral = awaitTutorialForWorkflow.then (tutorialForWorkflow) ->
-        if tutorialForWorkflow?
-          tutorialForWorkflow
+      awaitMiniCourseInGeneral = awaitMiniCourseForWorkflow.then (miniCourseForWorkflow) ->
+        if miniCourseForWorkflow?
+          miniCourseForWorkflow
         else if project?
           apiClient.type('tutorials').get project_id: project.id
-            .then ([tutorial]) =>
-              tutorial
+            .then ([minicourse]) =>
+              minicourse
         else
           # There's no workflow tutorial and no project given.
           Promise.resolve()
@@ -51,57 +49,63 @@ module.exports = React.createClass
           # Return `null` to mean "Completed, but not with the most recent version".
           true
 
-    start: (user, project) ->
-      apiClient.type('tutorials').get project_id: project.id
-        .then ([tutorial]) =>
-          if tutorial? and tutorial.steps.length isnt 0
-            tutorial.get 'attached_images'
-              .catch =>
-                []
-              .then (mediaResources) =>
-                mediaByID = {}
-                for mediaResource in mediaResources
-                  mediaByID[mediaResource.id] = mediaResource
+    start: (minicourse, user) ->
+      MiniCourseComponent = this
+      preferences = null
 
-                MiniCourseComponent = this
-                Dialog.alert(<MiniCourseComponent steps={tutorial.steps} media={mediaByID} />, {
-                  className: 'tutorial-dialog', #reusing tutorial styling
-                  required: true,
-                  closeButton: true
-                })
-                  .catch =>
-                    null # We don't really care if the user canceled or completed the tutorial.
-                  .then =>
-                    # now = new Date().toISOString()
-                    # completedThisSession[project.id] = now
-                    if user?
-                      user.get('project_preferences', project_id: project.id).then ([projectPreferences]) =>
-                        if projectPreferences.preferences.opt_out # user is restarting via mini-course button
-                          projectPreferences.update DEFAULT_PREFERENCES
-                          projectPreferences.save()
-                        else
-                          projectPreferences ?= apiClient.type('project_preferences').create({
-                            links: {
-                              project: project.id
-                            },
-                            preferences: {}
-                          })
-                          projectPreferences.update DEFAULT_PREFERENCES
-                          # projectPreferences.update 'preferences.mini_course_completed_at': now
-                          projectPreferences.save()
+      if user?
+        minicourse.get('project').then (project) ->
+          user.get('project_preferences', project_id: project.id).then ([projectPreferences]) ->
+            preferences = projectPreferences
 
-    fetchUserPreferences: (user, project) ->
-      user.get('project_preferences', project_id: project.id).then ([projectPreferences]) =>
-        projectPreferences
-      .catch =>
-        null
+      if minicourse.steps.length isnt 0
+        awaitMiniCourseMedia = minicourse.get 'attached_images'
+          .catch ->
+            # Checking for attached images throws if there are none.
+            []
+          .then (mediaResources) ->
+            mediaByID = {}
+            for mediaResource in mediaResources
+              mediaByID[mediaResource.id] = mediaResource
+            mediaByID
 
-    startIfNecessary: (user, project) ->
-      projectPreferences = fetchUserPreferences user, project
-      @checkIfCompleted projectPreferences
-        .then (completed) =>
-          if completed is false
-            @start user, project unless projectPreferences.preferences.opt_out
+        awaitMiniCourseMedia.then (mediaByID) =>
+          Dialog.alert(<MiniCourseComponent id={minicourse.id} projectPreferences={preferences} steps={minicourse.steps} media={mediaByID} />, {
+            className: 'tutorial-dialog', #reusing tutorial styling
+            required: true,
+            closeButton: true
+          })
+            .catch =>
+              null # We don't really care if the user canceled or completed the tutorial.
+            .then =>
+              @markPreferences preferences, minicourse, user
+
+
+    markPreferences: (projectPreferences, minicourse, user) -> 
+      defaultPreferences = { "preferences.minicourse_opt_out.#{minicourse.id}": false, "preferences.slide_last_seen.#{minicourse.id}": 0 }
+      
+      if user?
+        if projectPreferences.preferences.minicourse_opt_out?[minicourse.id] # user is restarting via mini-course button
+          projectPreferences.update defaultPreferences
+          projectPreferences.save()
+        else
+          projectPreferences ?= apiClient.type('project_preferences').create({
+            links: {
+              project: project.id
+            },
+            preferences: {}
+          })
+          projectPreferences.update defaultPreferences
+          # projectPreferences.update 'preferences.mini_course_completed_at': now
+          projectPreferences.save()
+
+    startIfNecessary: ({workflow, project, user}) ->
+      @find({workflow, project}).then (minicourse) =>
+        if minicourse?
+          @checkIfCompleted(tutorial, user).then (completed) =>
+            console.log {completed}
+            unless completed
+              @start minicourse, user unless projectPreferences.preferences.minicourse_opt_out["#{minicourse.id}"]
 
   propTypes:
     steps: React.PropTypes.arrayOf React.PropTypes.shape
@@ -112,20 +116,14 @@ module.exports = React.createClass
     steps: []
     media: {}
 
-  getInitialState: ->
-    projectPreferences: null
-
-  componentDidMount: ->
-    @setState projectPreferences: @fetchUserPreferences
-
   componentWillUnmount: ->
-    if @state.projectPreferences.preferences.slide_last_seen < @props.steps.length
-      nextSlideIndex = @state.projectPreferences.preferences.slide_last_seen + 1
-    @state.projectPreferences.update 'preferences.slide_last_seen': nextSlideIndex
-    @state.projectPreferences.save()
+    if @props.projectPreferences.preferences.slide_last_seen[@props.id] < @props.steps.length
+      nextSlideIndex = @props.projectPreferences.preferences.slide_last_seen[@props.id] + 1
+    @props.projectPreferences.update "preferences.slide_last_seen.#{@props.id}": nextSlideIndex
+    @props.projectPreferences.save()
   
   render: ->
-    <StepThrough ref="stepThrough" className="tutorial-steps" defaultStep={@state.projectPreferences?.slide_last_seen}>
+    <StepThrough ref="stepThrough" className="tutorial-steps" defaultStep={@props.projectPreferences?.slide_last_seen[@props.id] || 0}>
       {for step, i in @props.steps
         step._key ?= Math.random()
         <MediaCard key={step._key} className="tutorial-step" src={@props.media[step.media]?.src}>
@@ -141,5 +139,5 @@ module.exports = React.createClass
     @refs.stepThrough.goNext()
 
   handleOptOut: ->
-    @state.projectPreferences.update 'preferences.out_out': true
-    @state.projectPreferences.save()
+    @props.projectPreferences.update "preferences.minicourse_out_out.#{@props.id}": true
+    @props.projectPreferences.save()

--- a/app/lib/mini-course.cjsx
+++ b/app/lib/mini-course.cjsx
@@ -9,8 +9,6 @@ apiClient = require 'panoptes-client/lib/api-client'
 completedThisSession = {}
 window?.minicoursesCompletedThisSession = completedThisSession
 
-MINI_COURSE_LAST_SLIDE_SEEN = 0
-
 module.exports = React.createClass
   displayName: 'MiniCourse'
 
@@ -114,16 +112,14 @@ module.exports = React.createClass
         # projectPreferences.save()
         if projectPreferences.preferences.minicourses?
           console.log('projectPreferences')
-          if projectPreferences.preferences.minicourses.opt_out["id_#{@props.minicourse.id}"] # user is restarting via mini-course button
+          # user is restarting via mini-course button
+          if projectPreferences.preferences.minicourses.opt_out["id_#{@props.minicourse.id}"] or projectPreferences.preferences.minicourses.slide_last_seen["id_#{@props.minicourse.id}"] >= @props.minicourse.steps.length 
             console.log('defaultPreferences', defaultPreferences)
             projectPreferences.update defaultPreferences
             projectPreferences.save()
               .then =>
                 slideToStart = 0
                 @setState {slideToStart: slideToStart, projectPreferences: projectPreferences}
-          else if projectPreferences.preferences.minicourses.slide_last_seen["id_#{@props.minicourse.id}"] >= @props.minicourse.steps.length
-            slideToStart = 0
-            @setState {slideToStart: slideToStart, projectPreferences: projectPreferences}
           else
             slideToStart = projectPreferences.preferences.minicourses.slide_last_seen["id_#{@props.minicourse.id}"]
             @setState {slideToStart: slideToStart, projectPreferences: projectPreferences}

--- a/app/lib/mini-course.cjsx
+++ b/app/lib/mini-course.cjsx
@@ -18,25 +18,12 @@ module.exports = React.createClass
   statics:
     find: ({workflow, project}) ->
       # Prefer fetching the tutorial for the workflow, if a workflow is given.
-      awaitMiniCourseForWorkflow = if workflow?
+      if workflow?
         apiClient.type('tutorials').get workflow_id: workflow.id, kind: "mini-course"
           .then ([minicourse]) ->
             minicourse
       else
         Promise.resolve()
-
-      # Wait for the workflow tutorial, but if nothing comes back, check for a project tutorial.
-      # Take this out once workflow linking works:
-      awaitMiniCourseInGeneral = awaitMiniCourseForWorkflow.then (miniCourseForWorkflow) ->
-        if miniCourseForWorkflow?
-          miniCourseForWorkflow
-        else if project?
-          apiClient.type('tutorials').get project_id: project.id, kind: "mini-course"
-            .then ([minicourse]) =>
-              minicourse
-        else
-          # There's no workflow tutorial and no project given.
-          Promise.resolve()
 
     start: (minicourse, user) ->
       MiniCourseComponent = this

--- a/app/lib/mini-course.cjsx
+++ b/app/lib/mini-course.cjsx
@@ -9,9 +9,8 @@ apiClient = require 'panoptes-client/lib/api-client'
 minicoursesCompletedThisSession = {}
 window?.minicoursesCompletedThisSession = minicoursesCompletedThisSession
 
-# Note: the logic to handle a non-logged in user is currently commented out.
-# This logic may be added at a later date, but for now 
-# will move forward with the mini-course working only for signed in users.
+# Note: We may add logic to handle non-signed-in users.
+# For now, will move forward with the mini-course working only for signed-in users.
 
 module.exports = React.createClass
   displayName: 'MiniCourse'
@@ -27,6 +26,7 @@ module.exports = React.createClass
         Promise.resolve()
 
       # Wait for the workflow tutorial, but if nothing comes back, check for a project tutorial.
+      # Take this out once workflow linking works:
       awaitMiniCourseInGeneral = awaitMiniCourseForWorkflow.then (miniCourseForWorkflow) ->
         if miniCourseForWorkflow?
           miniCourseForWorkflow
@@ -81,10 +81,6 @@ module.exports = React.createClass
               # Create default preferences if they don't exist
               @createProjectPreferences(projectPreferences, minicourse.id, project.id).then =>
                 @start minicourse, user
-      # else
-      #   sessionStorage.setItem 'minicourse_slide_to_start', 0
-
-      #   @start minicourse, user
 
     startIfNecessary: ({workflow, project, user}) ->
       if user?
@@ -92,11 +88,8 @@ module.exports = React.createClass
           if minicourse?
             @checkIfCompleted(minicourse, project, user).then (completed) =>
               unless completed
-                # if user?
                 user.get('project_preferences', project_id: project.id).then ([projectPreferences]) =>
-                  @start minicourse, user unless projectPreferences.preferences.minicourses?.opt_out["id_#{minicourse.id}"]
-                # else
-                #   @start minicourse, user 
+                  @start minicourse, user unless projectPreferences.preferences.minicourses?.opt_out["id_#{minicourse.id}"] 
 
     checkIfCompleted: (minicourse, project, user) ->
       if user?
@@ -106,8 +99,6 @@ module.exports = React.createClass
           .then ([projectPreferences]) =>
             window.prefs = projectPreferences
             projectPreferences?.preferences?.minicourses?.completed_at?["id_#{minicourse.id}"]?
-      # else
-      #   Promise.resolve minicoursesCompletedThisSession[minicourse.id]?
 
     handleOptOut: (project, user, minicourseID) ->
       if user?
@@ -153,17 +144,10 @@ module.exports = React.createClass
           # Create default preferences
           newProjectPreferences = @createProjectPreferences(projectPreferences, @props.minicourse.id, @props.project.id)
           @setState { projectPreferences: newProjectPreferences }
-    # else
-    #   if sessionStorage.getItem('minicourse_slide_to_start')?
-    #     @refs.stepThrough.goTo sessionStorage.getItem('minicourse_slide_to_start')
   
   componentWillUnmount: ->
     if @state.projectPreferences?
       @handleProjectPreferencesOnUnmount()
-    # else
-      # now = new Date().toISOString()
-      # minicoursesCompletedThisSession[@props.minicourse.id] = now
-      # sessionStorage.setItem('minicourse_slide_to_start', @state.slideToStart + 1)
   
   render: ->
     <StepThrough ref="stepThrough" className="tutorial-steps">
@@ -173,8 +157,7 @@ module.exports = React.createClass
           <Markdown>{step.content}</Markdown>
           <hr />
           <p>
-            <button type="button" className="standard-button">Close</button>{' '}
-            {<button type="submit" className="minor-button">Opt Out</button> if @props.user?}
+            <button type="submit" className="minor-button">Opt Out</button> 
           </p>
         </MediaCard>}
     </StepThrough>
@@ -184,7 +167,6 @@ module.exports = React.createClass
       now = new Date().toISOString()
       minicoursesCompletedThisSession[@props.minicourse.id] = now
 
-      # if @props.user?
       @state.projectPreferences.update "preferences.minicourses.completed_at.id_#{@props.minicourse.id}": now
       @state.projectPreferences.save()
     else

--- a/app/lib/mini-course.cjsx
+++ b/app/lib/mini-course.cjsx
@@ -160,10 +160,10 @@ module.exports = React.createClass
   componentWillUnmount: ->
     if @state.projectPreferences?
       @handleProjectPreferencesOnUnmount()
-    else
-      now = new Date().toISOString()
-      minicoursesCompletedThisSession[@props.minicourse.id] = now
-      sessionStorage.setItem('minicourse_slide_to_start', @state.slideToStart + 1)
+    # else
+      # now = new Date().toISOString()
+      # minicoursesCompletedThisSession[@props.minicourse.id] = now
+      # sessionStorage.setItem('minicourse_slide_to_start', @state.slideToStart + 1)
   
   render: ->
     <StepThrough ref="stepThrough" className="tutorial-steps">

--- a/app/lib/mini-course.cjsx
+++ b/app/lib/mini-course.cjsx
@@ -6,8 +6,8 @@ MediaCard = require '../components/media-card'
 {Markdown} = require 'markdownz'
 apiClient = require 'panoptes-client/lib/api-client'
 
-completedThisSession = {}
-window?.minicoursesCompletedThisSession = completedThisSession
+minicoursesCompletedThisSession = {}
+window?.minicoursesCompletedThisSession = minicoursesCompletedThisSession
 
 module.exports = React.createClass
   displayName: 'MiniCourse'
@@ -99,18 +99,13 @@ module.exports = React.createClass
             window.prefs = projectPreferences
             projectPreferences?.preferences?.minicourses?.completed_at?["id_#{minicourse.id}"]?
       else
-        Promise.resolve completedThisSession[minicourse.id]?
+        Promise.resolve minicoursesCompletedThisSession[minicourse.id]?
 
     handleOptOut: (project, user, minicourseID) ->
       if user?
         user.get('project_preferences', project_id: project.id).then ([projectPreferences]) =>
           projectPreferences.update "preferences.minicourses.opt_out.id_#{minicourseID}": true
           projectPreferences.save()
-
-  # propTypes:
-  #   steps: React.PropTypes.arrayOf React.PropTypes.shape
-  #     media: React.PropTypes.string
-  #     content: React.PropTypes.string
 
   getDefaultProps: ->
     media: {}
@@ -156,6 +151,8 @@ module.exports = React.createClass
     if @state.projectPreferences?
       @handleProjectPreferencesOnUnmount()
     else
+      now = new Date().toISOString()
+      minicoursesCompletedThisSession[@props.minicourse.id] = now
       sessionStorage.setItem('minicourse_slide_to_start', @state.slideToStart + 1)
   
   render: ->
@@ -177,8 +174,9 @@ module.exports = React.createClass
       now = new Date().toISOString()
       minicoursesCompletedThisSession[@props.minicourse.id] = now
 
-      @state.projectPreferences.update "preferences.minicourses.completed_at.id_#{@props.minicourse.id}": now
-      @state.projectPreferences.save()
+      if @props.user?
+        @state.projectPreferences.update "preferences.minicourses.completed_at.id_#{@props.minicourse.id}": now
+        @state.projectPreferences.save()
     else
       nextSlide = @state.projectPreferences.preferences.minicourses.slide_to_start["id_#{@props.minicourse.id}"] + 1
       

--- a/app/lib/tutorial.cjsx
+++ b/app/lib/tutorial.cjsx
@@ -17,21 +17,10 @@ module.exports = React.createClass
       awaitTutorialForWorkflow = if workflow?
         apiClient.type('tutorials').get workflow_id: workflow.id
           .then ([tutorial]) ->
-            tutorial
+            # Backwards compatibility with null kind values. We assume these are tutorials.
+            tutorial if tutorial?.kind isnt 'mini-course'
       else
         Promise.resolve()
-
-      # Wait for the workflow tutorial, but if nothing comes back, check for a project tutorial.
-      awaitTutorialInGeneral = awaitTutorialForWorkflow.then (tutorialForWorkflow) ->
-        if tutorialForWorkflow?
-          tutorialForWorkflow
-        else if project?
-          apiClient.type('tutorials').get project_id: project.id
-            .then ([tutorial]) =>
-              tutorial
-        else
-          # There's no workflow tutorial and no project given.
-          Promise.resolve()
 
     startIfNecessary: ({workflow, project, user}) ->
       @find({workflow, project}).then (tutorial) =>

--- a/app/lib/tutorial.cjsx
+++ b/app/lib/tutorial.cjsx
@@ -18,21 +18,20 @@ module.exports = React.createClass
         apiClient.type('tutorials').get workflow_id: workflow.id
           .then ([tutorial]) ->
             # Backwards compatibility for null kind values. We assume these are standard tutorials.
-            tutorial if tutorial?.kind isnt 'mini-course'
+            tutorial if tutorial?.kind is 'tutorial' or tutorial?.kind is null
       else
         Promise.resolve()
 
       # Wait for the workflow tutorial, but if nothing comes back, check for a project tutorial.
-      # Keeping this check for now, but we should eventually take this out:
+      # Keeping this fetch for now, but we should eventually take this out:
       awaitTutorialInGeneral = awaitTutorialForWorkflow.then (tutorialForWorkflow) ->
         if tutorialForWorkflow?
           tutorialForWorkflow
         else if project?
           apiClient.type('tutorials').get project_id: project.id
             .then ([tutorial]) =>
-              console.log('tutorial', tutorial)
               # Backwards compatibility for null kind values. We assume these are standard tutorials.
-              tutorial if tutorial.kind isnt 'mini-course'
+              tutorial if tutorial?.kind is 'tutorial' or tutorial?.kind is null
         else
           # There's no workflow tutorial and no project given.
           Promise.resolve()

--- a/app/lib/tutorial.cjsx
+++ b/app/lib/tutorial.cjsx
@@ -40,7 +40,6 @@ module.exports = React.createClass
       @find({workflow, project}).then (tutorial) =>
         if tutorial?
           @checkIfCompleted(tutorial, user).then (completed) =>
-            console.log {completed}
             unless completed
               @start tutorial, user
 

--- a/app/pages/lab/mini-course.cjsx
+++ b/app/pages/lab/mini-course.cjsx
@@ -11,6 +11,6 @@ module.exports = React.createClass
         <p><strong>Work in progress.</strong></p>
       </div>
       <div>
-        <ProjectModalEditor project={@props.project} type="minicourses" />
+        <ProjectModalEditor project={@props.project} kind="mini-course" />
       </div>
     </div>

--- a/app/pages/lab/tutorial.cjsx
+++ b/app/pages/lab/tutorial.cjsx
@@ -13,6 +13,6 @@ module.exports = React.createClass
         <p>However, it's also important to keep this as short as possible so volunteers can get started classifying as soon as possible!</p>
       </div>
       <div>
-        <ProjectModalEditor project={@props.project} type="tutorials" />
+        <ProjectModalEditor project={@props.project} kind="tutorial" />
       </div>
     </div>

--- a/app/pages/lab/tutorial.cjsx
+++ b/app/pages/lab/tutorial.cjsx
@@ -11,6 +11,7 @@ module.exports = React.createClass
         <p>The project tutorial is a step-by-step introduction to the project's interface.</p>
         <p>This is the place to give the volunteers a preview of the data they'll be working with and of the steps they'll be taking to make classifications. It's also a good place to mention any common "gotchas" users might face.</p>
         <p>However, it's also important to keep this as short as possible so volunteers can get started classifying as soon as possible!</p>
+        <p>Tutorials can be linked to workflows on the workflow editor page.</p>
       </div>
       <div>
         <ProjectModalEditor project={@props.project} kind="tutorial" />

--- a/app/pages/project/classify.cjsx
+++ b/app/pages/project/classify.cjsx
@@ -315,9 +315,7 @@ module.exports = React.createClass
 
   maybeLaunchMiniCourse: ->
     if classificationsThisSession % PROMPT_MINI_COURSE_EVERY is 0
-      apiClient.type('minicourses').get project_id: @props.project.id
-        .then([minicourse]) =>
-          MiniCourse.startIfNecessary.bind(MiniCourse, @props.user, @props.project)
+      MiniCourse.startIfNecessary {workflow: @state.workflow, project: @props.project, user: @props.user}
           
 # For debugging:
 window.currentWorkflowForProject = currentWorkflowForProject

--- a/app/pages/project/classify.cjsx
+++ b/app/pages/project/classify.cjsx
@@ -317,7 +317,7 @@ module.exports = React.createClass
     if classificationsThisSession % PROMPT_MINI_COURSE_EVERY is 0
       apiClient.type('minicourses').get project_id: @props.project.id
         .then([minicourse]) =>
-          MiniCourse.start.bind(MiniCourse, @props.user, @props.project)
+          MiniCourse.startIfNecessary.bind(MiniCourse, @props.user, @props.project)
           
 # For debugging:
 window.currentWorkflowForProject = currentWorkflowForProject

--- a/app/pages/project/classify.cjsx
+++ b/app/pages/project/classify.cjsx
@@ -15,7 +15,7 @@ MiniCourse = require '../../lib/mini-course'
 
 FAILED_CLASSIFICATION_QUEUE_NAME = 'failed-classifications'
 
-PROMPT_MINI_COURSE_EVERY = 6
+PROMPT_MINI_COURSE_EVERY = 2
 
 SKIP_CELLECT = location?.search.match(/\Wcellect=0(?:\W|$)/)?
 

--- a/app/pages/project/classify.cjsx
+++ b/app/pages/project/classify.cjsx
@@ -317,7 +317,11 @@ module.exports = React.createClass
     if classificationsThisSession % PROMPT_MINI_COURSE_EVERY is 0
       apiClient.type('minicourses').get project_id: @props.project.id
         .then([minicourse]) =>
+<<<<<<< HEAD
           MiniCourse.startIfNecessary.bind(MiniCourse, @props.user, @props.project)
+=======
+          MiniCourse.start.bind(MiniCourse, @props.user, @props.project)
+>>>>>>> Start of mini-course
           
 # For debugging:
 window.currentWorkflowForProject = currentWorkflowForProject

--- a/app/pages/project/classify.cjsx
+++ b/app/pages/project/classify.cjsx
@@ -15,7 +15,7 @@ MiniCourse = require '../../lib/mini-course'
 
 FAILED_CLASSIFICATION_QUEUE_NAME = 'failed-classifications'
 
-PROMPT_MINI_COURSE_EVERY = 5
+PROMPT_MINI_COURSE_EVERY = 6
 
 SKIP_CELLECT = location?.search.match(/\Wcellect=0(?:\W|$)/)?
 

--- a/app/pages/project/classify.cjsx
+++ b/app/pages/project/classify.cjsx
@@ -317,11 +317,7 @@ module.exports = React.createClass
     if classificationsThisSession % PROMPT_MINI_COURSE_EVERY is 0
       apiClient.type('minicourses').get project_id: @props.project.id
         .then([minicourse]) =>
-<<<<<<< HEAD
           MiniCourse.startIfNecessary.bind(MiniCourse, @props.user, @props.project)
-=======
-          MiniCourse.start.bind(MiniCourse, @props.user, @props.project)
->>>>>>> Start of mini-course
           
 # For debugging:
 window.currentWorkflowForProject = currentWorkflowForProject

--- a/app/partials/project-modal-editor.cjsx
+++ b/app/partials/project-modal-editor.cjsx
@@ -68,7 +68,10 @@ ProjectModalEditor = React.createClass
 
   render: ->
     <div className="project-modal-editor">
-      <p className="form-label">{@props.kind} #{@props.projectModal.id}</p>
+      <div className="project-modal-header">
+        <p className="form-label">{@props.kind} #{@props.projectModal.id}</p>
+        <p><button className="pill-button" onClick={@props.onProjectModalDelete}>Delete {@props.kind}</button></p>
+      </div>
       {if @props.projectModal.steps.length is 0
         <p>This {@props.kind} has no steps.</p>
       else
@@ -136,8 +139,21 @@ ProjectModalEditorController = React.createClass
         onMediaSelect={@handleStepMediaChange}
         onMediaClear={@handleStepMediaClear}
         onStepChange={@handleStepChange}
+        onProjectModalDelete={@handleProjectModalDelete}
       />
     </div>
+
+  deleteProjectModal: ->
+    @props.projectModal.delete()
+      .then =>
+        @props.onDelete()
+
+  handleProjectModalDelete: ->
+    if @props.projectModal.steps.length > 0
+      for step, index in @props.projectModal.steps
+        @handleStepRemove(index)
+    else
+      @deleteProjectModal()
 
   handleStepAdd: ->
     @props.projectModal.steps.push
@@ -154,9 +170,7 @@ ProjectModalEditorController = React.createClass
     @props.projectModal.update changes
 
     if @props.projectModal.steps.length is 0
-      @props.projectModal.delete()
-        .then =>
-          @props.onDelete()
+      @deleteProjectModal()
     else
       @props.projectModal.save()
 

--- a/app/partials/project-modal-editor.cjsx
+++ b/app/partials/project-modal-editor.cjsx
@@ -153,7 +153,7 @@ ProjectModalEditorController = React.createClass
     apiClient.post @props.projectModal._getURL('attached_images'), payload
       .then (media) =>
         media = [].concat(media)[0]
-        putFile media.src, file, {'Content-Type': file.type}
+        putFile media.src, file
           .then =>
             changes = {}
             changes["steps.#{index}.media"] = media.id

--- a/app/partials/project-modal-editor.cjsx
+++ b/app/partials/project-modal-editor.cjsx
@@ -229,7 +229,6 @@ ProjectModalCreator = React.createClass
       kind: @props.kind
       links:
         project: @props.project.id
-        workflows: @props.project.links.workflows
         
     @setState error: null
     apiClient.type('tutorials').create(projectModalData).save()

--- a/app/partials/project-modal-editor.cjsx
+++ b/app/partials/project-modal-editor.cjsx
@@ -229,11 +229,11 @@ ProjectModalCreator = React.createClass
       kind: @props.kind
       links:
         project: @props.project.id
-
+        workflows: @props.project.links.workflows
+        
     @setState error: null
     apiClient.type('tutorials').create(projectModalData).save()
       .then (createdProjectModal) =>
-        createdProjectModal.addLink 'workflows', @props.project.links.workflows
         @props.onCreate createdProjectModal
       .catch (error) =>
         @setState {error}

--- a/app/partials/project-modal-editor.cjsx
+++ b/app/partials/project-modal-editor.cjsx
@@ -233,6 +233,7 @@ ProjectModalCreator = React.createClass
     @setState error: null
     apiClient.type('tutorials').create(projectModalData).save()
       .then (createdProjectModal) =>
+        createdProjectModal.addLink 'workflows', @props.project.links.workflows
         @props.onCreate createdProjectModal
       .catch (error) =>
         @setState {error}
@@ -269,7 +270,12 @@ ProjectModalEditorFetcher = React.createClass
       projectModals: null
     apiClient.type('tutorials').get project_id: project.id
       .then (projectModals) =>
-        @setState {projectModals}
+        filteredProjectModals = 
+          if @props.kind is "tutorial"
+            projectModal for projectModal in projectModals when projectModal.kind is @props.kind or projectModal.kind is null
+          else if @props.kind is "mini-course"
+            projectModal for projectModal in projectModals when projectModal.kind is @props.kind
+        @setState {projectModals: filteredProjectModals}
       .catch (error) =>
         @setState {error}
       .then =>
@@ -284,7 +290,6 @@ ProjectModalEditorFetcher = React.createClass
       window?.editingProjectModals = @state.projectModals
       <div>
         {for projectModal in @state.projectModals
-          if projectModal.kind is @props.kind or projectModal.kind is null
             <ProjectModalEditorController
               key={projectModal.id}
               project={@props.project}

--- a/app/partials/project-modal-editor.cjsx
+++ b/app/partials/project-modal-editor.cjsx
@@ -52,7 +52,7 @@ ProjectModalEditor = React.createClass
   getDefaultProps: ->
     projectModal: null
     media: null
-    type: null
+    kind: null
 
     onStepAdd: ->
       console.log 'ProjectModalEditor onStepAdd', arguments
@@ -67,9 +67,10 @@ ProjectModalEditor = React.createClass
       console.log 'ProjectModalEditor onChange', arguments
 
   render: ->
-    <div style={maxWidth: '50ch'}>
+    <div className="project-modal-editor">
+      <p className="form-label">{@props.kind} #{@props.projectModal.id}</p>
       {if @props.projectModal.steps.length is 0
-        <p>This tutorial has no steps.</p>
+        <p>This {@props.kind} has no steps.</p>
       else
         for step, i in @props.projectModal.steps
           step._key ?= Math.random()
@@ -88,15 +89,16 @@ ProjectModalEditor = React.createClass
     </div>
 
 ProjectModalEditorController = React.createClass
+  displayName: 'ProjectModalEditorController'
+
+  getInitialState: ->
+    media: {}
+
   getDefaultProps: ->
     project: null
     projectModal: null
-    media: {}
     delayBeforeSave: 5000
-    type: null
-
-    onChangeMedia: ->
-      console.log 'ProjectModalEditorController onChangeMedia', arguments
+    kind: null
 
     onDelete: ->
       console.log 'ProjectModalEditorController onDelete', arguments
@@ -104,21 +106,38 @@ ProjectModalEditorController = React.createClass
   componentDidMount: ->
     @_boundForceUpdate = @forceUpdate.bind this
     @props.projectModal.listen @_boundForceUpdate
+    @fetchMediaFor(@props.projectModal)
 
   componentWillUnmount: ->
     @props.projectModal.stopListening @_boundForceUpdate
 
+  fetchMediaFor: (projectModal) ->
+    if projectModal?
+      projectModal.get 'attached_images', {} # Prevent caching.
+        .catch =>
+          [] # We get an an error if there're no attached images.
+        .then (mediaResources) =>
+          media = {}
+          for mediaResource in mediaResources
+            media[mediaResource.id] = mediaResource
+          @setState {media}
+    else
+      @setState media: {}
+
   render: ->
-    <ProjectModalEditor
-      projectModal={@props.projectModal}
-      media={@props.media}
-      type={@props.type}
-      onStepAdd={@handleStepAdd}
-      onStepRemove={@handleStepRemove}
-      onMediaSelect={@handleStepMediaChange}
-      onMediaClear={@handleStepMediaClear}
-      onStepChange={@handleStepChange}
-    />
+    <div>
+      <hr />
+      <ProjectModalEditor
+        projectModal={@props.projectModal}
+        media={@state.media}
+        kind={@props.kind}
+        onStepAdd={@handleStepAdd}
+        onStepRemove={@handleStepRemove}
+        onMediaSelect={@handleStepMediaChange}
+        onMediaClear={@handleStepMediaClear}
+        onStepChange={@handleStepChange}
+      />
+    </div>
 
   handleStepAdd: ->
     @props.projectModal.steps.push
@@ -153,19 +172,19 @@ ProjectModalEditorController = React.createClass
     apiClient.post @props.projectModal._getURL('attached_images'), payload
       .then (media) =>
         media = [].concat(media)[0]
-        putFile media.src, file
+        putFile media.src, file, {'Content-Type': file.type}
           .then =>
             changes = {}
             changes["steps.#{index}.media"] = media.id
             @props.projectModal.update changes
             @props.projectModal.save()
               .then =>
-                @props.onChangeMedia()
+                @fetchMediaFor @props.projectModal
       .catch (error) =>
         console.error error
 
   handleStepMediaClear: (index) ->
-    @props.media[@props.projectModal.steps[index].media]?.delete()
+    @state.media[@props.projectModal.steps[index].media]?.delete()
     changes = {}
     changes["steps.#{index}.media"] = undefined
     @props.projectModal.update changes
@@ -186,7 +205,7 @@ ProjectModalEditorController = React.createClass
 ProjectModalCreator = React.createClass
   getDefaultProps: ->
     project: null
-    type: null
+    kind: null
 
     onCreate: ->
       console.log 'ProjectModalCreator onCreate', arguments
@@ -196,24 +215,23 @@ ProjectModalCreator = React.createClass
 
   render: ->
     <div>
-      <p>This project doesn’t have a tutorial.</p>
       {if @state.error?
           <p>{@state.error.toString()}</p>}
       <p>
-        <button type="button" onClick={@handleCreateClick}>Build one</button>
+        <button type="button" onClick={@handleCreateClick}>Build a {@props.kind}</button>
       </p>
     </div>
 
   handleCreateClick: ->
-    projectModalType = @props.type
     projectModalData =
       steps: []
       language: 'en'
+      kind: @props.kind
       links:
         project: @props.project.id
 
     @setState error: null
-    apiClient.type(projectModalType).create(projectModalData).save()
+    apiClient.type('tutorials').create(projectModalData).save()
       .then (createdProjectModal) =>
         @props.onCreate createdProjectModal
       .catch (error) =>
@@ -222,18 +240,18 @@ ProjectModalCreator = React.createClass
 ProjectModalEditorFetcher = React.createClass
   getDefaultProps: ->
     project: null
-    type: null
+    kind: null
 
   getInitialState: ->
     loading: false
     error: null
-    projectModal: null
+    projectModals: null
     media: {}
 
   componentDidMount: ->
     @_boundForceUpdate = @forceUpdate.bind this
     @props.project.listen @_boundForceUpdate
-    @fetchProjectModalFor @props.project
+    @fetchProjectModalsFor @props.project
 
   componentWillUnmount: ->
     @props.project.stopListening @_boundForceUpdate
@@ -242,57 +260,46 @@ ProjectModalEditorFetcher = React.createClass
     unless nextProps.project is @props.project
       @props.project.stopListening @_boundForceUpdate
       nextProps.project.listen @_boundForceUpdate
-      @fetchProjectModalFor nextProps.project
+      @fetchProjectModalsFor nextProps.project
 
-  fetchProjectModalFor: (project) ->
+  fetchProjectModalsFor: (project) ->
     @setState
       loading: true
       error: null
-      projectModal: null
-    apiClient.type(@props.type).get project_id: project.id
-      .then ([projectModal]) =>
-        @setState {projectModal}
-        @fetchMediaFor projectModal
+      projectModals: null
+    apiClient.type('tutorials').get project_id: project.id
+      .then (projectModals) =>
+        @setState {projectModals}
       .catch (error) =>
         @setState {error}
       .then =>
         @setState loading: false
-
-  fetchMediaFor: (projectModal) ->
-    if projectModal?
-      projectModal.get 'attached_images', {} # Prevent caching.
-        .catch =>
-          [] # We get an an error if there're no attached images.
-        .then (mediaResources) =>
-          media = {}
-          for mediaResource in mediaResources
-            media[mediaResource.id] = mediaResource
-          @setState {media}
-    else
-      @setState media: {}
 
   render: ->
     if @state.loading
       <p>Loading...</p>
     else if @state.error?
       <p>{@state.error.toString()}</p>
-    else if @state.projectModal?
-      window?.editingProjectModal = @state.projectModal
-      <ProjectModalEditorController
-        project={@props.project}
-        projectModal={@state.projectModal}
-        media={@state.media}
-        type={@props.type}
-        onChangeMedia={@handleChangeToMedia}
-        onDelete={@handleProjectModalCreateOrDelete}
-      />
+    else if @state.projectModals?
+      window?.editingProjectModals = @state.projectModals
+      <div>
+        {for projectModal in @state.projectModals
+          if projectModal.kind is @props.kind or projectModal.kind is null
+            <ProjectModalEditorController
+              key={projectModal.id}
+              project={@props.project}
+              projectModal={projectModal}
+              media={@state.media}
+              kind={@props.kind}
+              onDelete={@handleProjectModalCreateOrDelete}
+            />}
+        <hr />
+        <ProjectModalCreator project={@props.project} kind={@props.kind} onCreate={@handleProjectModalCreateOrDelete} />
+      </div>
     else
-      <ProjectModalCreator project={@props.project} type={@props.type} onCreate={@handleProjectModalCreateOrDelete} />
-
-  handleChangeToMedia: ->
-    @fetchMediaFor @state.projectModal
+      <ProjectModalCreator project={@props.project} kind={@props.kind} onCreate={@handleProjectModalCreateOrDelete} />
 
   handleProjectModalCreateOrDelete: ->
-    @fetchProjectModalFor @props.project
+    @fetchProjectModalsFor @props.project
 
 module.exports = ProjectModalEditorFetcher

--- a/css/main.styl
+++ b/css/main.styl
@@ -37,6 +37,7 @@
 @require './classify'
 @require './field-guide'
 @require './tutorial'
+@require './mini-course-dialog'
 @require './disciplines-slider'
 @require './survey-task'
 @require "./drawing-tool"

--- a/css/mini-course-dialog.styl
+++ b/css/mini-course-dialog.styl
@@ -1,0 +1,3 @@
+.mini-course-dialog
+  .step-through-controls
+    display: none

--- a/css/project-modal-editor.styl
+++ b/css/project-modal-editor.styl
@@ -1,6 +1,11 @@
 .project-modal-editor
   max-width: 50ch
 
+  .project-modal-header
+    align-items: center
+    display: flex
+    justify-content: space-between
+
 .project-modal-step-editor
   border: 1px solid rgba(gray, 0.5)
   margin: 1em 0

--- a/css/project-modal-editor.styl
+++ b/css/project-modal-editor.styl
@@ -1,3 +1,6 @@
+.project-modal-editor
+  max-width: 50ch
+
 .project-modal-step-editor
   border: 1px solid rgba(gray, 0.5)
   margin: 1em 0

--- a/css/tutorial.styl
+++ b/css/tutorial.styl
@@ -26,6 +26,8 @@
     @extends .content-container
 
 .media-card-media
+  border-top-left-radius: 8px
+  border-top-right-radius: 8px
   display: block
   max-width: 100%
 

--- a/css/workflow-editor.styl
+++ b/css/workflow-editor.styl
@@ -81,3 +81,10 @@
     
   .column
     max-width: 500px
+    
+.workflow-task-editor-link-tutorials-form
+  display: table
+  
+  label
+    display: table-row
+    text-transform: capitalize

--- a/css/workflow-editor.styl
+++ b/css/workflow-editor.styl
@@ -82,8 +82,9 @@
   .column
     max-width: 500px
     
-.workflow-task-editor-link-tutorials-form
+.workflow-link-tutorials-form
   display: table
+  margin: 1em 0
   
   label
     display: table-row


### PR DESCRIPTION
Apologies for the size of this PR. This superceded #2399 and brings in the workflow tutorial functionality as well as mini-courses

- Mini-course pops up every X number of classifications and uses similar logic to the old sign-in prompt on the `classify` project page. Currently the mini-course pops up every 2 classifications until it is complete for easy testing.
- Mini-course has its own view in `lib` with it logic to track the which slide to start on, whether or not someone has opted out, and when the mini-course is completed. Sometime in the future, some logic may be added to have the mini-course pop up to non-signed-in users, but that was punted for later. This is why there are many `if user?` type checks
- Project builders can create multiple tutorials or mini-courses if those have been enabled by admin and linking to tutorials is done on the workflow editor page. Only one tutorial of a kind can be linked to a workflow
- I would prefer if we only fetched tutorials by workflow id, however, I left in the logic to fetch by either workflow or project since I'm not sure if the tutorial has been enabled for projects in the last month or so that this was being worked on. 
- Improved UI and styling will come in a later PR for the mini-course. Still getting feedback from folks about that, but I wanted to get the functionality done. Notes for Nature need the workflow tutorial feature next week sometime. @trouille when does this need to be in place for NfN next week?

Mini-courses and workflow tutorials can be tested at: https://mini-course.pfe-preview.zooniverse.org/projects/srallen086/srallen-testing/classify
You must be signed-in for the mini-course to work. Let me know if you want me to add you as a collaborator on the test project.