### PR TITLE
Adds username and tag autocompletion to talk

### DIFF
--- a/app/talk/comment-box.cjsx
+++ b/app/talk/comment-box.cjsx
@@ -8,6 +8,7 @@ Loading = require '../components/loading-indicator'
 SingleSubmitButton = require '../components/single-submit-button'
 alert = require '../lib/alert'
 {Markdown, MarkdownEditor} = require 'markdownz'
+Suggester = require './suggester'
 
 module?.exports = React.createClass
   displayName: 'Commentbox'
@@ -76,61 +77,64 @@ module?.exports = React.createClass
     feedback = @renderFeedback()
     loader = if @state.loading then <Loading />
 
-    <div className="talk-comment-box">
-
-      {if @props.reply
-        <div className="talk-comment-reply">
-          <div style={color: '#afaeae'}>
-            In reply to {@props.reply.comment.user_display_name}'s comment:
+    <div className="talk-comment-container">
+      <div className="talk-comment-box">
+        {if @props.reply
+          <div className="talk-comment-reply">
+            <div style={color: '#afaeae'}>
+              In reply to {@props.reply.comment.user_display_name}'s comment:
+            </div>
+            <Markdown project={@props.project}>{@props.reply.comment.body}</Markdown>
+            <button type="button" onClick={@props.onClickClearReply}><i className="fa fa-close" /> Clear Reply</button>
           </div>
-          <Markdown project={@props.project}>{@props.reply.comment.body}</Markdown>
-          <button type="button" onClick={@props.onClickClearReply}><i className="fa fa-close" /> Clear Reply</button>
-        </div>
-        }
+          }
 
-      <h1>{@props.header}</h1>
+        <h1>{@props.header}</h1>
 
-      {if @state.subject
-        <img className="talk-comment-focus-image" src={getSubjectLocation(@state.subject).src} />}
+        {if @state.subject
+          <img className="talk-comment-focus-image" src={getSubjectLocation(@state.subject).src} />}
 
-      <form className="talk-comment-form" onSubmit={@onSubmitComment}>
+        <form className="talk-comment-form" onSubmit={@onSubmitComment}>
+          <Suggester {...@props} input={@state.content} onSelect={@onInputChange}>
+            <MarkdownEditor previewing={@state.loading} placeholder={@props.placeholder} project={@props.project} className="full" value={@state.content} onChange={@onInputChange} onHelp={-> alert <MarkdownHelp talk={true} title={<h1>Guide to commenting in Talk</h1>}/> }/>
+          </Suggester>
 
-        <MarkdownEditor previewing={@state.loading} placeholder={@props.placeholder} project={@props.project} className="full" value={@state.content} onChange={@onInputChange} onHelp={-> alert <MarkdownHelp talk={true} title={<h1>Guide to commenting in Talk</h1>}/> }/>
-        <section>
-          <button
-            type="button"
-            className="talk-comment-image-select-button #{if @state.showing is 'image-selector' then 'active' else ''}"
-            onClick={@onImageSelectClick}>
-            Linked Image
-            {if @state.showing is 'image-selector' then <span>&nbsp;<i className="fa fa-close" /></span>}
-          </button>
-
-        <SingleSubmitButton type="submit" onClick={@onSubmitComment} className='talk-comment-submit-button'>{@props.submit}</SingleSubmitButton>
-          {if @props.onCancelClick
+          <section>
             <button
               type="button"
-              className="button talk-comment-submit-button"
-              onClick={@props.onCancelClick}>
-             Cancel
-            </button>}
-        </section>
+              className="talk-comment-image-select-button #{if @state.showing is 'image-selector' then 'active' else ''}"
+              onClick={@onImageSelectClick}>
+              Linked Image
+              {if @state.showing is 'image-selector' then <span>&nbsp;<i className="fa fa-close" /></span>}
+            </button>
 
-        {feedback}
+          <SingleSubmitButton type="submit" onClick={@onSubmitComment} className='talk-comment-submit-button'>{@props.submit}</SingleSubmitButton>
+            {if @props.onCancelClick
+              <button
+                type="button"
+                className="button talk-comment-submit-button"
+                onClick={@props.onCancelClick}>
+               Cancel
+              </button>}
+          </section>
 
-        <div className="submit-error">
-          {validationErrors}
-          {@state.error ? null}
+          {feedback}
+
+          <div className="submit-error">
+            {validationErrors}
+            {@state.error ? null}
+          </div>
+        </form>
+
+        <div className="talk-comment-children">
+          {switch @state.showing
+            when 'image-selector'
+              <CommentImageSelector
+                onSelectImage={@onSelectImage}
+                onClearImageClick={@onClearImageClick}
+                user={@props.user} />}
         </div>
-      </form>
 
-      <div className="talk-comment-children">
-        {switch @state.showing
-          when 'image-selector'
-            <CommentImageSelector
-              onSelectImage={@onSelectImage}
-              onClearImageClick={@onClearImageClick}
-              user={@props.user} />}
+        {loader}
       </div>
-
-      {loader}
     </div>

--- a/app/talk/lib/get-caret-position.cjsx
+++ b/app/talk/lib/get-caret-position.cjsx
@@ -1,0 +1,95 @@
+textProperties = [
+  'direction'
+  'boxSizing'
+  'width'
+  'height'
+  'overflowX'
+  'overflowY'
+  'borderTopWidth'
+  'borderRightWidth'
+  'borderBottomWidth'
+  'borderLeftWidth'
+  'borderStyle'
+  'paddingTop'
+  'paddingRight'
+  'paddingBottom'
+  'paddingLeft'
+  'fontStyle'
+  'fontVariant'
+  'fontWeight'
+  'fontStretch'
+  'fontSize'
+  'fontSizeAdjust'
+  'lineHeight'
+  'fontFamily'
+  'textAlign'
+  'textTransform'
+  'textIndent'
+  'letterSpacing'
+  'wordSpacing'
+  'tabSize'
+  'MozTabSize'
+]
+
+getStyleOf = (element) ->
+  if window.getComputedStyle
+    getComputedStyle element
+  else
+    element.currentStyle
+
+# Creates a div to mimic the textarea
+mimic = (element) ->
+  reactId = element.getAttribute 'data-reactid'
+  id = "mimic-textarea#{reactId}".replace(/\./g, '-')
+  div = document.querySelector "##{id}"
+
+  unless div
+    div = document.createElement 'div'
+    div.id = id
+    document.body.appendChild div
+
+  div
+
+# Copy textarea properties to the div
+# Returns the computed properties of the textarea
+copyTextProps = ({from, to}) ->
+  textAreaProps = getStyleOf from
+  Object.assign to.style, whiteSpace: 'pre-wrap', position: 'absolute', visibility: 'hidden'
+  to.style[prop] = textAreaProps[prop] for prop in textProperties
+  textAreaProps
+
+# Copy the textarea contents to the div
+# Returns a span at the position of the caret
+copyText = ({from, to, at}) ->
+  to.textContent = from.value.substring 0, at
+  caretSpan = document.createElement 'span'
+
+  # Mark the position of the caret in the div with a span
+  caretSpan.textContent = from.value.substring(at) or '&nbsp;'
+  to.appendChild caretSpan
+
+# Find the relative bounds of the textarea
+getBounds = ({from, container, containing}) ->
+  top: from.offsetTop + parseInt container['borderTopWidth']
+  bottom: parseInt container.height
+  left: from.offsetLeft + parseInt container['borderLeftWidth']
+  right: parseInt(container.width) - containing.getBoundingClientRect().width
+
+# Constrain the position to the textarea
+constrainedPositionIn = (bounds) ->
+  top: Math.min(bounds.top, bounds.bottom)
+  left: Math.min(bounds.left, bounds.right)
+
+# Offset the position from the nearest relative parent
+relativePosition = ({from, within}) ->
+  relativeParent = within.offsetParent
+  top: relativeParent.offsetTop + within.offsetTop + from.top
+  left: relativeParent.offsetLeft + within.offsetLeft + from.left
+
+# Returns the {top, left} of the caret position within a textarea
+module?.exports = (textArea, popupElement, caretPosition) ->
+  div = mimic textArea
+  textAreaProps = copyTextProps from: textArea, to: div
+  caretSpan = copyText from: textArea, to: div, at: caretPosition
+  bounds = getBounds from: caretSpan, container: textAreaProps, containing: popupElement
+  relativePosition from: constrainedPositionIn(bounds), within: textArea

--- a/app/talk/suggester.cjsx
+++ b/app/talk/suggester.cjsx
@@ -1,0 +1,177 @@
+React = require 'react'
+ReactDOM = require 'react-dom'
+talkClient = require 'panoptes-client/lib/talk-client'
+Loading = require '../components/loading-indicator'
+getCaretPosition = require './lib/get-caret-position'
+
+module?.exports = React.createClass
+  displayName: 'Suggester'
+
+  propTypes:
+    input: React.PropTypes.string.isRequired
+    onSelect: React.PropTypes.func
+
+  getDefaultProps: ->
+    onSelect: ->
+
+  getInitialState: ->
+    data: []
+    loading: false
+    open: false
+    kind: null
+    pendingSearch: null
+    lastSearch: null
+
+  componentDidMount: ->
+    textArea = ReactDOM.findDOMNode(@).querySelector 'textarea'
+    @setState textArea: textArea
+    textArea.addEventListener 'click', @handleInput
+
+  componentWillUnmount: ->
+    @state.textArea.removeEventListener 'click', @handleInput
+    mimic.remove() for mimic in document.querySelectorAll('[id^="mimic-textarea-"]')
+
+  componentWillReceiveProps: (nextProps) ->
+    @handleInput() if @state.textArea
+
+  show: (kind) ->
+    return if @state.open
+    @reposition()
+    @refs.suggestions.style.display = 'block'
+    @setState open: true, kind: kind, data: []
+
+  reposition: ->
+    position = getCaretPosition @state.textArea, @refs.suggestions, @state.textArea.selectionEnd
+    @refs.suggestions.style.top = "#{position.top}px"
+    @refs.suggestions.style.left = "#{position.left}px"
+
+  hide: ->
+    return unless @state.open
+    @refs.suggestions.style.display = 'none'
+    @setState @getInitialState()
+
+  defer: (search) ->
+    if @state.loading or @debounce()
+      @setState pendingSearch: search
+      true
+
+  debounce: ->
+    timeSince = Date.now() - @state.lastSearch
+    tooSoon = timeSince < 300
+
+    if tooSoon
+      setTimeout =>
+        if pendingSearch = @state.pendingSearch
+          @setState pendingSearch: null
+          @searchFor pendingSearch
+      , 300 - timeSince
+
+    tooSoon
+
+  getTags: (search) ->
+    section = if @props.project then "project-#{@props.project.id}" else 'zooniverse'
+    @get 'tags/autocomplete', {search, section}
+
+  getUsers: (search) ->
+    @get 'users/autocomplete', {search}
+
+  get: (resource, params) ->
+    return if @defer params.search
+    @setState loading: true, lastSearch: new Date()
+    talkClient.type(resource).get(params).then @handleResults
+
+  handleResults: (results) ->
+    if pendingSearch = @state.pendingSearch
+      @setState data: results, loading: false, pendingSearch: null
+      @searchFor pendingSearch
+    else
+      @setState data: results, loading: false
+
+  searchFor: (search = '', kind) ->
+    search = search.toLowerCase().replace /[@#]+/g, ''
+    kind or= @state.kind
+    @show kind
+
+    if kind is 'usernames'
+      @getUsers search
+    else if kind is 'tags'
+      @getTags search
+
+  lastWord: ->
+    words = @state.textArea.value.substr(0, @state.textArea.selectionEnd).split /\s/m
+    words[words.length - 1]
+
+  currentTrigger: ->
+    if @state.kind is 'usernames'
+      '@'
+    else if @state.kind is 'tags'
+      '#'
+
+  title: ->
+    if @state.kind is 'usernames'
+      'Mention a user'
+    else if @state.kind is 'tags'
+      'Use a tag'
+
+  handleInput: ->
+    lastWord = @lastWord()
+    @reposition() if @state.open
+    @hide() if lastWord.match(/^(\@|\#)/)?[1] isnt @currentTrigger()
+
+    if lastWord.match(/^\@/)
+      @searchFor lastWord, 'usernames'
+    else if lastWord.match(/^\#/)
+      @searchFor lastWord, 'tags'
+
+  moveCaretTo: (position) ->
+    @state.textArea.focus()
+
+    if @state.textArea.setSelectionRange
+      @state.textArea.setSelectionRange position, position
+    else if @state.textArea.createTextRange
+      range = @state.textArea.createTextRange()
+      range.collapse true
+      range.moveEnd 'character', position
+      range.moveStart 'character', position
+      range.select()
+
+  choose: (value) ->
+    lastWord = @lastWord()
+    endingPosition = @state.textArea.selectionEnd
+    startingPosition = endingPosition - lastWord.length
+    beginning = @state.textArea.value.substr 0, startingPosition
+    ending = @state.textArea.value.substr endingPosition, @state.textArea.value.length
+    @state.textArea.value = "#{beginning}#{value} #{ending.replace(/^ /, '')}"
+    @moveCaretTo startingPosition + value.length + 1
+    @hide()
+
+    # Pass a fake input change event
+    @props.onSelect target: @state.textArea
+
+  render: ->
+    <div className="suggester">
+      {@props.children}
+      <div ref="suggestions" className={"suggestions suggest-#{@state.kind}"}>
+        <p className="title">
+          {@title()}
+          <span className={"loading #{if @state.loading or @state.pendingSearch then 'shown' else ''}"}>
+            <Loading />
+          </span>
+        </p>
+        <ul>
+          {for datum, i in @state.data
+            if @state.kind is 'tags'
+              <li className="tag"
+                key={"tag-#{i}"}
+                onClick={@choose.bind @, "##{datum.name}"}>
+                {datum.name}
+              </li>
+            else if @state.kind is 'usernames'
+              <li className="user"
+                key={"username-#{i}"}
+                onClick={@choose.bind @, "@#{datum.login}"}>
+                @{datum.login} <small>{datum.display_name}</small>
+              </li>}
+        </ul>
+      </div>
+    </div>

--- a/css/talk.styl
+++ b/css/talk.styl
@@ -570,6 +570,9 @@ COPY_GREY_LIGHT = #afaeae
     color: green
     text-decoration: italic
 
+  .talk-comment-container
+    position: relative
+
   .talk-comment-box
     @extend .talk-module
     width: 100%
@@ -766,3 +769,58 @@ COPY_GREY_LIGHT = #afaeae
 
     &:hover
       text-decoration: underline
+
+.talk .suggester
+  .suggestions
+    @extend .talk-module
+    position: absolute
+    display: none
+    z-index: 2
+    background-color: #FFFFFF
+    border: 1px solid TALK_BORDER
+    border-radius: TALK_BORDER_RADIUS
+    box-shadow: 0 0 5px rgba(0, 0, 0, 0.1)
+    margin-top: 1.5em
+    padding: 0
+
+    .title
+      margin: 0
+      padding: 5px 10px
+      font-size: 1em
+      line-height: 1em
+      text-align: center
+      background-color: TALK_BACKGROUND
+      border-bottom: 1px solid TALK_BORDER
+
+      .loading
+        margin-left: 10px
+        transition: opacity 300ms ease
+        opacity: 0
+
+        &.shown
+          opacity: 1
+
+    ul
+      list-style: none outside none
+      margin: 0
+      padding: 0
+
+      li
+        padding: 5px 10px
+        border-bottom: 1px solid TALK_BORDER
+        cursor: pointer
+
+        small
+          font-weight: normal
+          color: COPY_GREY_MID
+
+        &.user
+          font-weight: bold
+
+        &:hover
+          background-color: SECOND_HIGHLIGHT
+          color: #FFFFFF
+
+          small
+            color: #FFFFFF
+


### PR DESCRIPTION
This closes #1884

Usernames are autocompleted by login or display name with priority based on
  1. Frequently mentioned users
  2. Frequently messaged users
  3. Group names (e.g. moderator, researcher, admin)
  4. All users

By default it will show top results from priorities 1 - 3.

Tags are autocompleted by name (trigram fuzzy searching) with priority based on
  1. Similar suggested tags
    - Separate PR ~~in the works~~  in #2582 for managing suggested tags.
  2. Similarity scaled by the number of unique user usages

By default it will show the suggested tags.

The changes to comment-box are just wrapping the component in a relatively positioned container and adding the suggester.  [Cleaner diff here](https://github.com/zooniverse/Panoptes-Front-End/pull/2580/files?w=0#diff-3a7c3905094f87ae89efe8121197052a)

Also, the username completion will be pretty slow until zooniverse/panoptes#1800 is merged.