### PR TITLE
Only fetch workflow tutorials

### DIFF
--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -44,12 +44,12 @@ Classifier = React.createClass
     @loadSubject @props.subject
     @prepareToClassify @props.classification
     {workflow, project, user} = @props
-    Tutorial.startIfNecessary {workflow, project, user}
+    Tutorial.startIfNecessary {workflow, user}
 
   componentWillReceiveProps: (nextProps) ->
     if nextProps.project isnt @props.project or nextProps.user isnt @props.user
       {workflow, project, user} = nextProps
-      Tutorial.startIfNecessary {workflow, project, user}
+      Tutorial.startIfNecessary {workflow, user}
     if nextProps.subject isnt @props.subject
       @loadSubject subject
     if nextProps.classification isnt @props.classification

--- a/app/classifier/mini-course-button.cjsx
+++ b/app/classifier/mini-course-button.cjsx
@@ -13,15 +13,15 @@ module.exports = React.createClass
     minicourse: null
 
   componentDidMount: ->
-    @fetchMiniCourseFor @props.workflow, @props.project
+    @fetchMiniCourseFor @props.workflow
 
   componentWillReceiveProps: (nextProps) ->
     unless nextProps.workflow is @props.workflow and nextProps.project is @props.project
-      @fetchMiniCourseFor nextProps.workflow, nextProps.project
+      @fetchMiniCourseFor nextProps.workflow
 
-  fetchMiniCourseFor: (workflow, project) ->
+  fetchMiniCourseFor: (workflow) ->
     @setState minicourse: null
-    MiniCourse.find({workflow, project}).then (minicourse) =>
+    MiniCourse.find({workflow}).then (minicourse) =>
       @setState {minicourse}
 
   render: ->

--- a/app/classifier/tutorial-button.cjsx
+++ b/app/classifier/tutorial-button.cjsx
@@ -12,15 +12,15 @@ module.exports = React.createClass
     tutorial: null
 
   componentDidMount: ->
-    @fetchTutorialFor @props.workflow, @props.project
+    @fetchTutorialFor @props.workflow
 
   componentWillReceiveProps: (nextProps) ->
     unless nextProps.workflow is @props.workflow and nextProps.project is @props.project
-      @fetchTutorialFor nextProps.workflow, nextProps.project
+      @fetchTutorialFor nextProps.workflow
 
-  fetchTutorialFor: (workflow, project) ->
+  fetchTutorialFor: (workflow) ->
     @setState tutorial: null
-    Tutorial.find({workflow, project}).then (tutorial) =>
+    Tutorial.find({workflow}).then (tutorial) =>
       @setState {tutorial}
 
   render: ->

--- a/app/lib/mini-course.cjsx
+++ b/app/lib/mini-course.cjsx
@@ -16,7 +16,7 @@ module.exports = React.createClass
   displayName: 'MiniCourse'
 
   statics:
-    find: ({workflow, project}) ->
+    find: ({workflow}) ->
       # Prefer fetching the tutorial for the workflow, if a workflow is given.
       if workflow?
         apiClient.type('tutorials').get workflow_id: workflow.id, kind: "mini-course"
@@ -71,7 +71,7 @@ module.exports = React.createClass
 
     startIfNecessary: ({workflow, project, user}) ->
       if user?
-        @find({workflow, project}).then (minicourse) =>
+        @find({workflow}).then (minicourse) =>
           if minicourse?
             @checkIfCompleted(minicourse, project, user).then (completed) =>
               unless completed

--- a/app/lib/tutorial.cjsx
+++ b/app/lib/tutorial.cjsx
@@ -22,20 +22,6 @@ module.exports = React.createClass
       else
         Promise.resolve()
 
-      # Wait for the workflow tutorial, but if nothing comes back, check for a project tutorial.
-      # Keeping this fetch for now, but we should eventually take this out:
-      awaitTutorialInGeneral = awaitTutorialForWorkflow.then (tutorialForWorkflow) ->
-        if tutorialForWorkflow?
-          tutorialForWorkflow
-        else if project?
-          apiClient.type('tutorials').get project_id: project.id
-            .then ([tutorial]) =>
-              # Backwards compatibility for null kind values. We assume these are standard tutorials.
-              tutorial if tutorial?.kind is 'tutorial' or tutorial?.kind is null
-        else
-          # There's no workflow tutorial and no project given.
-          Promise.resolve()
-
     startIfNecessary: ({workflow, project, user}) ->
       @find({workflow, project}).then (tutorial) =>
         if tutorial?

--- a/app/lib/tutorial.cjsx
+++ b/app/lib/tutorial.cjsx
@@ -12,18 +12,20 @@ module.exports = React.createClass
   displayName: 'Tutorial'
 
   statics:
-    find: ({workflow, project}) ->
+    find: ({workflow}) ->
       # Prefer fetching the tutorial for the workflow, if a workflow is given.
-      awaitTutorialForWorkflow = if workflow?
+      if workflow?
         apiClient.type('tutorials').get workflow_id: workflow.id
-          .then ([tutorial]) ->
+          .then (tutorials) ->
             # Backwards compatibility for null kind values. We assume these are standard tutorials.
-            tutorial if tutorial?.kind is 'tutorial' or tutorial?.kind is null
+            onlyStandardTutorials = tutorials.filter (tutorial) ->
+              tutorial.kind in ['tutorial', null]
+            onlyStandardTutorials[0]
       else
         Promise.resolve()
 
-    startIfNecessary: ({workflow, project, user}) ->
-      @find({workflow, project}).then (tutorial) =>
+    startIfNecessary: ({workflow, user}) ->
+      @find({workflow}).then (tutorial) =>
         if tutorial?
           @checkIfCompleted(tutorial, user).then (completed) =>
             unless completed

--- a/app/pages/lab/tutorial.cjsx
+++ b/app/pages/lab/tutorial.cjsx
@@ -11,7 +11,7 @@ module.exports = React.createClass
         <p>The project tutorial is a step-by-step introduction to the project's interface.</p>
         <p>This is the place to give the volunteers a preview of the data they'll be working with and of the steps they'll be taking to make classifications. It's also a good place to mention any common "gotchas" users might face.</p>
         <p>However, it's also important to keep this as short as possible so volunteers can get started classifying as soon as possible!</p>
-        <p>Tutorials can be linked to workflows on the workflow editor page.</p>
+        <p><strong>Tutorials should be linked to a workflow on its workflow editor page to pop up for your project.</strong></p>
       </div>
       <div>
         <ProjectModalEditor project={@props.project} kind="tutorial" />


### PR DESCRIPTION
Now that workflow tutorials are in production and Marten reran the rake task yesterday to link all of the pre-existing tutorials, we can now remove the fallback call to fetch tutorials by project id only. This prevents the possible scenario of a project builder creating two tutorials, but since they are unlinked to a workflow, we don't know which they intended to have pop up. The call to fetch by project id will just fetch the first one in the response array. I also bolded the instructions on the editor to go to the workflow editor for linking.