### PR TITLE
Cleans up errors in Talk

### DIFF
--- a/app/talk/active-users.cjsx
+++ b/app/talk/active-users.cjsx
@@ -51,7 +51,7 @@ module?.exports = React.createClass
 
   userIdsOnPage: (ids, page) ->
     offset = (page - 1) * @state.perPage
-    ids.slice offset, offset + @state.perPage
+    [].concat(ids).slice offset, offset + @state.perPage
 
   getActiveUserIds: ->
     sugarApiClient.get '/active_users', channel: @props.section

--- a/app/talk/popular-tags.cjsx
+++ b/app/talk/popular-tags.cjsx
@@ -25,9 +25,9 @@ module?.exports = React.createClass
   tag: (talkTag, i) ->
     tag = talkTag.name
     if @props.project
-      <div key={talkTag.id} className="truncated"><Link to="/projects/#{@props.project.slug}/talk/tags/#{tag}">#{tag}</Link>{' '}</div>
+      <div key={"#{talkTag.id}-#{i}"} className="truncated"><Link to="/projects/#{@props.project.slug}/talk/tags/#{tag}">#{tag}</Link>{' '}</div>
     else
-      <div key={talkTag.id} className="truncated"><Link to="/talk/search/?query=#{tag}">#{tag}</Link>{' '}</div>
+      <div key={"#{talkTag.id}-#{i}"} className="truncated"><Link to="/talk/search/?query=#{tag}">#{tag}</Link>{' '}</div>
 
   render: ->
     <div className="talk-popular-tags">


### PR DESCRIPTION
As mentioned in #2580.  Fixes duplicate key errors in popular tags and traps the oddly intermittent bug in `ActiveUsers#userIdsOnPage`