### PR TITLE
Add project context to subject page comments

### DIFF
--- a/app/subjects/comment-list.cjsx
+++ b/app/subjects/comment-list.cjsx
@@ -40,7 +40,7 @@ module?.exports = React.createClass
         <h2>Comments:</h2>
         <div>
           {for comment in @state.comments
-            <Comment key={"comment-#{comment.id}"} data={comment} locked={true} linked={true} />}
+            <Comment {...@props} key={"comment-#{comment.id}"} data={comment} locked={true} linked={true} hideFocus={true} />}
         </div>
 
         {if +@state.meta.page_count > 1

--- a/app/talk/comment.cjsx
+++ b/app/talk/comment.cjsx
@@ -37,11 +37,13 @@ module?.exports = React.createClass
     index: React.PropTypes.number # The index of the comment in a discussion
     locked: React.PropTypes.bool  # disable action buttons
     linked: React.PropTypes.bool
+    hideFocus: React.PropTypes.bool # Control visibility of focus (default: false)
 
   getDefaultProps: ->
     active: false
     locked: false
     linked: false
+    hideFocus: false
 
   getInitialState: ->
     editing: false
@@ -128,12 +130,14 @@ module?.exports = React.createClass
     </div>
 
   # Render the focus if the comment has a focus AND
+  #   - @props.hideFocus isn't true
   #   - it's not in a discussion (recents) OR
   #   - it's a focused discussion and this is the first comment OR
   #   - it's not a focused discussion OR
   #   - it's a focused discussion and this comment's focus is different
   shouldShowFocus: ->
     return false unless @props.data.focus_id
+    return false if @props.hideFocus
 
     notInDiscussion = not @props.index
     isFirstSubjectComment = @props.index is 0 and @props.data.discussion_focus_id


### PR DESCRIPTION
This is something of a temporary fix.  If subjects are actually used from multiple project contexts, this becomes a bit funky unless we maintain the project path in the route.

This fixes #2366.  It triages some of #2253.