### PR TITLE
Transcription Metadata Tags

### DIFF
--- a/app/classifier/tasks/drawing-task-details-editor.cjsx
+++ b/app/classifier/tasks/drawing-task-details-editor.cjsx
@@ -1,6 +1,7 @@
 React = require 'react'
 AutoSave = require '../../components/auto-save'
 TriggeredModalForm = require 'modal-form/triggered'
+TextTaskEditor = require './text/editor'
 
 
 module.exports = React.createClass
@@ -25,14 +26,26 @@ module.exports = React.createClass
           for subtask, i in @props.details
             subtask._key ?= Math.random()
             <div key={subtask._key} className="drawing-task-details-editor-subtask-wrapper">
-              <GenericTaskEditor
-                workflow={@props.workflow}
-                task={subtask}
-                taskPrefix="#{@props.toolPath}.details.#{i}"
-                isSubtask={true}
-                onChange={@handleSubtaskChange.bind this, i}
-                onDelete={@handleSubtaskDelete.bind this, i}
-              />
+              {
+                if subtask.type is 'text'
+                  <TextTaskEditor 
+                    workflow={@props.workflow}
+                    task={subtask}
+                    taskPrefix="#{@props.toolPath}.details.#{i}"
+                    isSubtask={true}
+                    onChange={@handleSubtaskChange.bind this, i}
+                    onDelete={@handleSubtaskDelete.bind this, i}
+                  />
+                else                
+                  <GenericTaskEditor
+                    workflow={@props.workflow}
+                    task={subtask}
+                    taskPrefix="#{@props.toolPath}.details.#{i}"
+                    isSubtask={true}
+                    onChange={@handleSubtaskChange.bind this, i}
+                    onDelete={@handleSubtaskDelete.bind this, i}
+                  />
+              }
               <AutoSave resource={@props.workflow}>
                 <button type="button" className="subtask-delete" aria-label="Remove subtask" title="Remove subtask" onClick={@handleSubtaskDelete.bind this, i}>&times;</button>
               </AutoSave>

--- a/app/classifier/tasks/text/editor.cjsx
+++ b/app/classifier/tasks/text/editor.cjsx
@@ -50,15 +50,16 @@ module?.exports = React.createClass
           <small className="form-help">Describe the task, or ask the question, in a way that is clear to a non-expert. You can use markdown to format this text.</small><br />
         </div>
         <br/>
-        <div>
-          <AutoSave resource={@props.workflow}>
-            <span className="form-label">Help text</span>
-            <br />
-            <MarkdownEditor name="#{@props.taskPrefix}.help" value={@props.task.help ? ""} rows="4" className="full" onChange={handleChange} onHelp={-> alert <MarkdownHelp/>} />
-          </AutoSave>
-          <small className="form-help">Add text and images for a help window.</small>
-        </div>
-        <hr/>
+        {unless @props.isSubtask
+          <div>
+            <AutoSave resource={@props.workflow}>
+              <span className="form-label">Help text</span>
+              <br />
+              <MarkdownEditor name="#{@props.taskPrefix}.help" value={@props.task.help ? ""} rows="4" className="full" onChange={handleChange} onHelp={-> alert <MarkdownHelp/>} />
+            </AutoSave>
+            <small className="form-help">Add text and images for a help window.</small>
+          </div>
+          <hr/>}
       </section>
       <section>
         <span className="form-label">Metadata Tags</span> <br/>
@@ -79,9 +80,10 @@ module?.exports = React.createClass
             </label>
       </section>
       <hr/>
-      <AutoSave resource={@props.workflow}>
-        <span className="form-label">Next task</span>
-        <br />
-        <NextTaskSelector workflow={@props.workflow} name="#{@props.taskPrefix}.next" value={@props.task.next ? ''} onChange={handleInputChange.bind @props.workflow} />
-      </AutoSave>
+      {unless @props.isSubtask
+        <AutoSave resource={@props.workflow}>
+          <span className="form-label">Next task</span>
+          <br />
+          <NextTaskSelector workflow={@props.workflow} name="#{@props.taskPrefix}.next" value={@props.task.next ? ''} onChange={handleInputChange.bind @props.workflow} />
+        </AutoSave>}
     </div>

--- a/app/classifier/tasks/text/editor.cjsx
+++ b/app/classifier/tasks/text/editor.cjsx
@@ -1,0 +1,82 @@
+React = require 'react'
+alert = require '../../../lib/alert'
+AutoSave = require '../../../components/auto-save'
+handleInputChange = require '../../../lib/handle-input-change'
+{MarkdownEditor} = require 'markdownz'
+MarkdownHelp = require '../../../partials/markdown-help'
+
+
+
+module?.exports = React.createClass
+  displayName: 'TextTaskEditor'
+
+  getDefaultProps: ->
+    workflow: {}
+    task: {}
+
+  tagExists:(tag) ->
+    if @props.task.text_tags
+      @props.task.text_tags.indexOf(tag) > -1
+
+  updateTags:(e)->
+    value = e.target.value
+    checked = e.target.checked
+    if @props.task.text_tags
+      # the tag does not current exist and the input is checked
+      if @props.task.text_tags.indexOf(value) is -1 and checked
+        @props.task.text_tags.push(value)
+        @props.onChange @props.task
+      else if !checked
+        removalIndex = @props.task.text_tags.indexOf(value)
+        @props.task.text_tags.splice(removalIndex,1);
+        @props.onChange @props.task
+    else 
+      @props.task.text_tags = []
+      @props.task.text_tags.push(value) if checked
+      @props.onChange @props.task
+
+
+  render: ->
+    handleChange = handleInputChange.bind @props.workflow
+
+
+    <div className="text-editor" >
+      <section>
+        <div>
+          <AutoSave resource={@props.workflow}>
+            <span className="form-label">Main text</span>
+            <br />
+            <textarea name="#{@props.taskPrefix}.instruction" value={@props.task.instruction} className="standard-input full" onChange={handleChange} />
+          </AutoSave>
+          <small className="form-help">Describe the task, or ask the question, in a way that is clear to a non-expert. You can use markdown to format this text.</small><br />
+        </div>
+        <br/>
+        <div>
+          <AutoSave resource={@props.workflow}>
+            <span className="form-label">Help text</span>
+            <br />
+            <MarkdownEditor name="#{@props.taskPrefix}.help" value={@props.task.help ? ""} rows="4" className="full" onChange={handleChange} onHelp={-> alert <MarkdownHelp/>} />
+          </AutoSave>
+          <small className="form-help">Add text and images for a help window.</small>
+        </div>
+        <hr/>
+      </section>
+      <section>
+        <span className="form-label">Metadata Tags</span> <br/>
+          <small className="form-help">Volunteers can attach the following tags to highlighted portions of their transcription.</small><br/>
+            <label>
+              <input type="checkbox" value="deletion" checked={@tagExists('deletion')} onChange={@updateTags} />
+              {"Deletion"}
+            </label>
+            <br/>
+            <label>
+              <input type="checkbox" value="insertion" checked={@tagExists('insertion')} onChange={@updateTags} />
+              {"Insertion"}
+            </label>
+            <br/>
+            <label>
+              <input type="checkbox" value="unclear" checked={@tagExists('unclear')} onChange={@updateTags} />
+              {"Unclear"}
+            </label>
+      </section>
+    </div>

--- a/app/classifier/tasks/text/editor.cjsx
+++ b/app/classifier/tasks/text/editor.cjsx
@@ -4,8 +4,7 @@ AutoSave = require '../../../components/auto-save'
 handleInputChange = require '../../../lib/handle-input-change'
 {MarkdownEditor} = require 'markdownz'
 MarkdownHelp = require '../../../partials/markdown-help'
-
-
+NextTaskSelector = require '../next-task-selector'
 
 module?.exports = React.createClass
   displayName: 'TextTaskEditor'
@@ -79,4 +78,10 @@ module?.exports = React.createClass
               {"Unclear"}
             </label>
       </section>
+      <hr/>
+      <AutoSave resource={@props.workflow}>
+        <span className="form-label">Next task</span>
+        <br />
+        <NextTaskSelector workflow={@props.workflow} name="#{@props.taskPrefix}.next" value={@props.task.next ? ''} onChange={handleInputChange.bind @props.workflow} />
+      </AutoSave>
     </div>

--- a/app/classifier/tasks/text/editor.cjsx
+++ b/app/classifier/tasks/text/editor.cjsx
@@ -26,6 +26,7 @@ module?.exports = React.createClass
     else if !checked
       removalIndex = text_tags.indexOf(value)
       text_tags.splice(removalIndex,1);
+    @props.task.text_tags = text_tags
     @props.onChange @props.task
 
 

--- a/app/classifier/tasks/text/editor.cjsx
+++ b/app/classifier/tasks/text/editor.cjsx
@@ -20,23 +20,18 @@ module?.exports = React.createClass
   updateTags:(e)->
     value = e.target.value
     checked = e.target.checked
-    if @props.task.text_tags
-      # the tag does not current exist and the input is checked
-      if @props.task.text_tags.indexOf(value) is -1 and checked
-        @props.task.text_tags.push(value)
-        @props.onChange @props.task
-      else if !checked
-        removalIndex = @props.task.text_tags.indexOf(value)
-        @props.task.text_tags.splice(removalIndex,1);
-        @props.onChange @props.task
-    else 
-      @props.task.text_tags = []
-      @props.task.text_tags.push(value) if checked
-      @props.onChange @props.task
+    text_tags = @props.task.text_tags ? []
+    if text_tags.indexOf(value) is -1 and checked
+      text_tags.push(value)
+    else if !checked
+      removalIndex = text_tags.indexOf(value)
+      text_tags.splice(removalIndex,1);
+    @props.onChange @props.task
 
 
   render: ->
     handleChange = handleInputChange.bind @props.workflow
+    requiredHelp = 'Check this box if this question has to be answered before proceeding. If a marking task is Required, the volunteer will not be able to move on until they have made at least 1 mark.'
 
     <div className="text-editor" >
       <section>
@@ -58,6 +53,16 @@ module?.exports = React.createClass
             </AutoSave>
             <small className="form-help">Add text and images for a help window.</small>
           </div>}
+        <span>
+          <label className="pill-button" title={requiredHelp}>
+            <AutoSave resource={@props.workflow}>
+              <input type="checkbox" name="#{@props.taskPrefix}.required" checked={@props.task.required} onChange={handleChange} />{' '}
+              Required
+            </AutoSave>
+          </label>
+          {' '}
+        </span>
+        <br />
         <span className="form-label">Metadata Tags</span> <br/>
           <small className="form-help">Volunteers can attach the following tags to highlighted portions of their transcription.</small><br/>
             <label>

--- a/app/classifier/tasks/text/editor.cjsx
+++ b/app/classifier/tasks/text/editor.cjsx
@@ -59,9 +59,7 @@ module?.exports = React.createClass
             </AutoSave>
             <small className="form-help">Add text and images for a help window.</small>
           </div>
-          <hr/>}
-      </section>
-      <section>
+          <br/>}
         <span className="form-label">Metadata Tags</span> <br/>
           <small className="form-help">Volunteers can attach the following tags to highlighted portions of their transcription.</small><br/>
             <label>

--- a/app/classifier/tasks/text/editor.cjsx
+++ b/app/classifier/tasks/text/editor.cjsx
@@ -38,7 +38,6 @@ module?.exports = React.createClass
   render: ->
     handleChange = handleInputChange.bind @props.workflow
 
-
     <div className="text-editor" >
       <section>
         <div>
@@ -58,8 +57,7 @@ module?.exports = React.createClass
               <MarkdownEditor name="#{@props.taskPrefix}.help" value={@props.task.help ? ""} rows="4" className="full" onChange={handleChange} onHelp={-> alert <MarkdownHelp/>} />
             </AutoSave>
             <small className="form-help">Add text and images for a help window.</small>
-          </div>
-          <br/>}
+          </div>}
         <span className="form-label">Metadata Tags</span> <br/>
           <small className="form-help">Volunteers can attach the following tags to highlighted portions of their transcription.</small><br/>
             <label>

--- a/app/classifier/tasks/text/index.cjsx
+++ b/app/classifier/tasks/text/index.cjsx
@@ -59,12 +59,6 @@ module.exports = React.createClass
     annotation: null
     onChange: NOOP
 
-  getInitialState: ->
-    currentTextAreaValue: ""
-
-  componentWillReceiveProps: (nextProps) ->
-    console.log "nextProps", nextProps
-
   render: ->
     <GenericTask question={@props.task.instruction} help={@props.task.help} required={@props.task.required}>
       <label className="answer">

--- a/app/classifier/tasks/text/index.cjsx
+++ b/app/classifier/tasks/text/index.cjsx
@@ -73,7 +73,8 @@ module.exports = React.createClass
       {if @props.task.text_tags 
           <div className="transcription-metadata-tags">
             {for tag, i in @props.task.text_tags
-              <button className="standard-button text-tag" key={i} value={tag} onClick={@setTagSelection} >{tag}</button>}
+              <input type="button" className="standard-button text-tag" key={i} value={tag} onClick={@setTagSelection} />}
+
           </div>}
     </GenericTask>
 

--- a/app/classifier/tasks/text/index.cjsx
+++ b/app/classifier/tasks/text/index.cjsx
@@ -74,7 +74,6 @@ module.exports = React.createClass
           <div className="transcription-metadata-tags">
             {for tag, i in @props.task.text_tags
               <input type="button" className="standard-button text-tag" key={i} value={tag} onClick={@setTagSelection} />}
-
           </div>}
     </GenericTask>
 

--- a/app/classifier/tasks/text/index.cjsx
+++ b/app/classifier/tasks/text/index.cjsx
@@ -1,6 +1,7 @@
 React = require 'react'
 {Markdown} = require 'markdownz'
 GenericTask = require '../generic'
+TextTaskEditor = require './editor'
 GenericTaskEditor = require '../generic-editor'
 levenshtein = require 'fast-levenshtein'
 
@@ -31,7 +32,7 @@ module.exports = React.createClass
   displayName: 'TextTask'
 
   statics:
-    Editor: GenericTaskEditor
+    Editor: TextTaskEditor
     Summary: Summary
 
     getDefaultTask: ->

--- a/app/classifier/tasks/text/index.cjsx
+++ b/app/classifier/tasks/text/index.cjsx
@@ -59,14 +59,46 @@ module.exports = React.createClass
     annotation: null
     onChange: NOOP
 
+  getInitialState: ->
+    currentTextAreaValue: ""
+
+  componentWillReceiveProps: (nextProps) ->
+    console.log "nextProps", nextProps
+
   render: ->
     <GenericTask question={@props.task.instruction} help={@props.task.help} required={@props.task.required}>
       <label className="answer">
         <textarea autoFocus={@props.autoFocus} className="standard-input full" rows="5" ref="textInput" value={@props.annotation.value} onChange={@handleChange} />
       </label>
+      {if @props.task.text_tags 
+          <div className="transcription-metadata-tags">
+            {for tag, i in @props.task.text_tags
+              <button className="standard-button text-tag" key={i} value={tag} onClick={@setTagSelection} >{tag}</button>}
+          </div>}
     </GenericTask>
 
   handleChange: ->
-    value = React.findDOMNode(@refs.textInput).value
+    value = @refs.textInput.value
     newAnnotation = Object.assign @props.annotation, {value}
     @props.onChange newAnnotation
+
+  setTagSelection: (e) ->
+    textTag = e.target.value
+    startTag = '[' + textTag + ']'
+    endTag = '[/' + textTag + ']'
+    textArea = this.refs.textInput
+    textAreaValue = textArea.value
+    selectionStart = textArea.selectionStart
+    selectionEnd = textArea.selectionEnd
+    textBefore = textAreaValue.substring(0, selectionStart)
+    if selectionStart is selectionEnd
+      textAfter = textAreaValue.substring(selectionStart, textAreaValue.length)
+      value = textBefore + startTag + endTag + textAfter
+      newAnnotation = Object.assign @props.annotation, {value}
+      @props.onChange newAnnotation
+    else
+      textInBetween = textAreaValue.substring(selectionStart, selectionEnd)
+      textAfter = textAreaValue.substring(selectionEnd, textAreaValue.length)
+      value = textBefore + startTag + textInBetween + endTag + textAfter
+      newAnnotation = Object.assign @props.annotation, {value}
+      @props.onChange newAnnotation

--- a/app/classifier/tasks/text/index.cjsx
+++ b/app/classifier/tasks/text/index.cjsx
@@ -2,7 +2,6 @@ React = require 'react'
 {Markdown} = require 'markdownz'
 GenericTask = require '../generic'
 TextTaskEditor = require './editor'
-GenericTaskEditor = require '../generic-editor'
 levenshtein = require 'fast-levenshtein'
 
 NOOP = Function.prototype
@@ -88,11 +87,9 @@ module.exports = React.createClass
     if selectionStart is selectionEnd
       textAfter = textAreaValue.substring(selectionStart, textAreaValue.length)
       value = textBefore + startTag + endTag + textAfter
-      newAnnotation = Object.assign @props.annotation, {value}
-      @props.onChange newAnnotation
     else
       textInBetween = textAreaValue.substring(selectionStart, selectionEnd)
       textAfter = textAreaValue.substring(selectionEnd, textAreaValue.length)
       value = textBefore + startTag + textInBetween + endTag + textAfter
-      newAnnotation = Object.assign @props.annotation, {value}
-      @props.onChange newAnnotation
+    newAnnotation = Object.assign @props.annotation, {value}
+    @props.onChange newAnnotation

--- a/css/main.styl
+++ b/css/main.styl
@@ -41,6 +41,7 @@
 @require './survey-task'
 @require "./drawing-tool"
 @require "./dropdown-task"
+@require "./text-task"
 @require "./classification-summary"
 @require './edit-media-page'
 @require "./lab"

--- a/css/text-task.styl
+++ b/css/text-task.styl
@@ -5,7 +5,6 @@
   flex-direction: row
   justify-content: center
   
-  
   .text-tag
     background-color: #989898
     margin: .1em

--- a/css/text-task.styl
+++ b/css/text-task.styl
@@ -5,5 +5,9 @@
   flex-direction: row
   justify-content: center
   
+  
   .text-tag
+    background-color: #989898
     margin: .1em
+    &:hover
+      background-color: #CCC

--- a/css/text-task.styl
+++ b/css/text-task.styl
@@ -1,0 +1,9 @@
+.transcription-metadata-tags
+  align-content: space-around
+  align-items: center
+  display: flex
+  flex-direction: row
+  justify-content: center
+  
+  .text-tag
+    margin: .1em


### PR DESCRIPTION
Fixes Issue #2576. 

This PR introduces text tagging functionality for transcriptions, similar to the text tagging feature in [AnnoTate](https://anno.tate.org.uk/#/). Find the staging branch with sample workflow [here](https://transcription-metadata-tags.pfe-preview.zooniverse.org/projects/markb-panoptes/focus-testing-project/classify?workflow=2359).

A volunteer should be able to 1) highlight a portion of their transcription, 2) click the input associated with the desired tag, which surrounds the selection text with the metadata tag.

In the project builder, any project with access to the text tool has access to the three metadata tags. In a future iteration, the project builders will be able to create there own tags, instead of choosing between "Insertion", "Deletion", and "Unclear". The tags are stored on the task object as an array of strings under the key `text_task`.
<img width="250" alt="text tag editor interface" src="https://cloud.githubusercontent.com/assets/7684729/15339099/62fcf31a-1c48-11e6-920d-dc666a34ec27.png">