### PR TITLE
add hover and focus labels for bar graphs

### DIFF
--- a/app/pages/project/stats/charts.cjsx
+++ b/app/pages/project/stats/charts.cjsx
@@ -124,7 +124,17 @@ Graph = React.createClass
         if data.index % numberBars
           data.element.attr({style: "display: none"})
     else if data.type == 'bar'
-      data.element.attr({style: "stroke-width: #{100 / length}%"})
+      data.element.attr(
+        style: "stroke-width: #{100 / length}%"
+        focusable: true
+        tabindex: 0
+      )
+      data.group.elem('text', {
+          x: data.x1
+          y: 15
+          class: "ct-label ct-tooltip"
+        }
+      ).text(data.series[data.index])
 
   onDrawSmall: (data) ->
     if data.type == 'bar'

--- a/css/project-stats-page.styl
+++ b/css/project-stats-page.styl
@@ -7,6 +7,9 @@ zoo-orange = #f78d27
       .ct-bar, .ct-slice-donut
         // stroke-width: 4.5%
         stroke: zoo-blue
+        &:hover + .ct-tooltip
+        &:focus + .ct-tooltip
+          fill: #000
     .ct-series-b
       .ct-bar, .ct-slice-donut
         stroke-width: 4.5%
@@ -14,6 +17,11 @@ zoo-orange = #f78d27
   .progress-label, .ct-label.ct-vertical, .ct-label.ct-horizontal
     color: #000
     fill: #000
+  .ct-tooltip
+    text-anchor: middle
+    color: #000
+    fill: rgba(0,0,0,0)
+    font-size: 1rem
 
 .ct-chart-bar
   .ct-label.ct-horizontal.ct-end

--- a/css/project-stats-page.styl
+++ b/css/project-stats-page.styl
@@ -5,11 +5,10 @@ zoo-orange = #f78d27
 .ct-chart
     .ct-series-a
       .ct-bar, .ct-slice-donut
-        // stroke-width: 4.5%
         stroke: zoo-blue
         &:hover + .ct-tooltip
         &:focus + .ct-tooltip
-          fill: #000
+          fill: zoo-blue
     .ct-series-b
       .ct-bar, .ct-slice-donut
         stroke-width: 4.5%
@@ -19,8 +18,7 @@ zoo-orange = #f78d27
     fill: #000
   .ct-tooltip
     text-anchor: middle
-    color: #000
-    fill: rgba(0,0,0,0)
+    fill: alpha(zoo-blue, 0)
     font-size: 1rem
 
 .ct-chart-bar

--- a/css/project-stats-page.styl
+++ b/css/project-stats-page.styl
@@ -20,6 +20,7 @@ zoo-orange = #f78d27
     text-anchor: middle
     fill: alpha(zoo-blue, 0)
     font-size: 1rem
+    font-weight: bold
 
 .ct-chart-bar
   .ct-label.ct-horizontal.ct-end


### PR DESCRIPTION
Closes https://github.com/zooniverse/Panoptes-Front-End/issues/2587

Adds on-focus and on-hover labels to the bar charts on the stats page.  The labels are displayed along the top to make sure no bars are drawn over the top of them.

@eatyourgreens if you have time could you take a look at this.