### PR TITLE
dropdown bug fixes

### DIFF
--- a/app/classifier/tasks/dropdown/dropdown-dialog.cjsx
+++ b/app/classifier/tasks/dropdown/dropdown-dialog.cjsx
@@ -198,7 +198,7 @@ DropdownDialog = React.createClass
               <select onChange={@onChangeConditionalAnswer.bind(@, condition)}>
                 <option value="">none selected</option>
                 {condition.options[@getOptionsKey(condition)]?.map (option) =>
-                  <option key={option.value} value={option.value} label={option.label}></option>}
+                  <option key={option.value} value={option.value}>{option.label}</option>}
               </select>
             </div>
           }

--- a/app/classifier/tasks/dropdown/index.cjsx
+++ b/app/classifier/tasks/dropdown/index.cjsx
@@ -118,10 +118,13 @@ module?.exports = React.createClass
     select.options[optionsKey]
 
   getDisabledAttribute: (i) ->
-    select = @props.task.selects[i]
+    {selects} = @props.task
+    select = selects[i]
+    condition = selects.filter (filterSelect) => filterSelect.id is select.condition
+    conditionIndex = selects.indexOf(condition[0])
     optionsKeys = @state.optionsKeys
 
-    if select.condition? and not optionsKeys[select.condition]
+    if select.condition? and not @props.annotation.value[conditionIndex]
       return true
     if select.condition? and select.allowCreate is false and not select.options[optionsKeys[select.condition]]?.length
       return true
@@ -143,13 +146,16 @@ module?.exports = React.createClass
       <div>
         {selectKeys.map (i) =>
           options = @getOptions(i)
+          disabled = @getDisabledAttribute(i)
           <div key={Math.random()}>
-            <div>{selects[i].title}</div>
+            {if selects[i].title isnt @props.task.instruction
+              <div>{selects[i].title}</div>}
             <Select
               options={options}
               onChange={@onChangeSelect.bind(@, i)}
               value={@props.annotation.value[i]?.value}
-              disabled={@getDisabledAttribute(i)}
+              disabled={disabled}
+              placeholder={if disabled then "N/A"}
               allowCreate={selects[i].allowCreate}
               noResultsText={if not options?.length then null}
               addLabelText="Press enter for {label}..."


### PR DESCRIPTION
fixes the following issues:

1. in editor dialog - options for upstream conditional answers not showing labels
2. showing task title and dropdown label when the same
3. improperly keeping conditional dropdown disabled when custom answer provided and allow create enabled
4. adding placeholder text for when dropdown is purposefully disabled

closes #2544 