### PR TITLE
Fix comment editing

### DIFF
--- a/app/talk/lib/get-caret-position.cjsx
+++ b/app/talk/lib/get-caret-position.cjsx
@@ -38,9 +38,8 @@ getStyleOf = (element) ->
     element.currentStyle
 
 # Creates a div to mimic the textarea
-mimic = (element) ->
-  reactId = element.getAttribute 'data-reactid'
-  id = "mimic-textarea#{reactId}".replace(/\./g, '-')
+mimic = (element, id) ->
+  id = "mimic-textarea#{id}"
   div = document.querySelector "##{id}"
 
   unless div
@@ -87,8 +86,8 @@ relativePosition = ({from, within}) ->
   left: relativeParent.offsetLeft + within.offsetLeft + from.left
 
 # Returns the {top, left} of the caret position within a textarea
-module?.exports = (textArea, popupElement, caretPosition) ->
-  div = mimic textArea
+module?.exports = (id, textArea, popupElement, caretPosition) ->
+  div = mimic textArea, id
   textAreaProps = copyTextProps from: textArea, to: div
   caretSpan = copyText from: textArea, to: div, at: caretPosition
   bounds = getBounds from: caretSpan, container: textAreaProps, containing: popupElement

--- a/app/talk/suggester.cjsx
+++ b/app/talk/suggester.cjsx
@@ -21,10 +21,11 @@ module?.exports = React.createClass
     kind: null
     pendingSearch: null
     lastSearch: null
+    id: null
 
   componentDidMount: ->
     textArea = ReactDOM.findDOMNode(@).querySelector 'textarea'
-    @setState textArea: textArea
+    @setState textArea: textArea, id: Date.now().toString(16)
     textArea.addEventListener 'click', @handleInput
 
   componentWillUnmount: ->
@@ -41,7 +42,7 @@ module?.exports = React.createClass
     @setState open: true, kind: kind, data: []
 
   reposition: ->
-    position = getCaretPosition @state.textArea, @refs.suggestions, @state.textArea.selectionEnd
+    position = getCaretPosition @state.id, @state.textArea, @refs.suggestions, @state.textArea.selectionEnd
     @refs.suggestions.style.top = "#{position.top}px"
     @refs.suggestions.style.left = "#{position.left}px"
 


### PR DESCRIPTION
`document.querySelector` was breaking in cases where textarea-mimic-div ids contained non alphanumeric characters.  One of these cases was triggered by editing a comment.

This closes #2618 