### PR TITLE
warning onFocus or hover for task back button

### DIFF
--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -39,6 +39,7 @@ Classifier = React.createClass
     classificationQuality: NaN
     showingExpertClassification: false
     selectedExpertAnnotation: -1
+    backButtonWarning: false
 
   componentDidMount: ->
     @loadSubject @props.subject
@@ -190,7 +191,7 @@ Classifier = React.createClass
 
       <nav className="task-nav">
         {if Object.keys(@props.workflow.tasks).length > 1
-          <button type="button" className="back minor-button" disabled={onFirstAnnotation} onClick={@destroyCurrentAnnotation}>Back</button>}
+          <button type="button" className="back minor-button" disabled={onFirstAnnotation} onClick={@destroyCurrentAnnotation} onMouseEnter={@warningToggleOn} onFocus={@warningToggleOn} onMouseLeave={@warningToggleOff} onBlur={@warningToggleOff}>Back</button>}
         {if not nextTaskKey and @props.workflow.configuration?.hide_classification_summaries and @props.owner? and @props.project?
           [ownerName, name] = @props.project.slug.split('/')
           <Link onClick={@completeClassification} to="/projects/#{ownerName}/#{name}/talk/subjects/#{@props.subject.id}" className="talk standard-button" style={if waitingForAnswer then disabledStyle}>Done &amp; Talk</Link>}
@@ -206,6 +207,7 @@ Classifier = React.createClass
           </button>}
         {@renderExpertOptions()}
       </nav>
+      { @renderBackButtonWarning() if @state.backButtonWarning }
 
       <p>
         <small>
@@ -413,6 +415,15 @@ Classifier = React.createClass
 
   toggleExpertClassification: (value) ->
     @setState showingExpertClassification: value
+
+  warningToggleOn: ->
+    @setState backButtonWarning: true
+
+  warningToggleOff: ->
+    @setState backButtonWarning: false 
+
+  renderBackButtonWarning: ->
+    <p className={"back-button-warning"} >{"Going back will delete all annotations for the current task."}</p>
 
 module.exports = React.createClass
   displayName: 'ClassifierWrapper'

--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -423,7 +423,7 @@ Classifier = React.createClass
     @setState backButtonWarning: false 
 
   renderBackButtonWarning: ->
-    <p className="back-button-warning" >Going back will delete all annotations for the current task.</p>
+    <p className="back-button-warning" >Going back will clear your work for the current task.</p>
 
 module.exports = React.createClass
   displayName: 'ClassifierWrapper'

--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -423,7 +423,7 @@ Classifier = React.createClass
     @setState backButtonWarning: false 
 
   renderBackButtonWarning: ->
-    <p className={"back-button-warning"} >{"Going back will delete all annotations for the current task."}</p>
+    <p className="back-button-warning" >Going back will delete all annotations for the current task.</p>
 
 module.exports = React.createClass
   displayName: 'ClassifierWrapper'

--- a/css/classify.styl
+++ b/css/classify.styl
@@ -132,6 +132,13 @@
 
     > :not(:first-child)
       margin-left: 0.5em
+  
+  .back-button-warning
+    background-color: #686868
+    border-radius: .3em
+    margin-top: 1em
+    padding: .5em
+    text-align: center;
 
 .workflow-task
   & + .workflow-task


### PR DESCRIPTION
Fixes Issue #2611. This PR warns users that pressing the back button deletes the annotations for the current task. The warning will only show when a user hovers over or focuses the back button. See it in action [here](https://back-button-warning.pfe-preview.zooniverse.org/).

<img width="250" alt="screen shot 2016-05-19 at 2 47 56 pm" src="https://cloud.githubusercontent.com/assets/7684729/15407621/7cbed2ca-1dd1-11e6-8a71-9a9192d796e0.png">

@mrniaboc, @aliburchard: If merged, this PR will introduce a slight change to the classify interface. What messaging would need to happen for the project builder? Also, opinions about copy?