### PR TITLE
Focus Style for Main Buttons

### DIFF
--- a/css/buttons.styl
+++ b/css/buttons.styl
@@ -9,10 +9,8 @@
   padding: 0.4em 1.4em
   text-align: center
 
+  &:focus,
   &:hover
-    background: lighten(MAIN_HIGHLIGHT, 20%)
-
-  &:focus
     background: lighten(MAIN_HIGHLIGHT, 20%)
 
   &:disabled
@@ -27,21 +25,18 @@
   background: SECOND_HIGHLIGHT
   font-weight: bold
 
+  &:focus,
   &:hover
     background: lighten(SECOND_HIGHLIGHT, 20%)
   
-  &:focus
-    background: lighten(SECOND_HIGHLIGHT, 20%)
 
 .minor-button
   @extends .standard-button
   color: FOREGROUND
   background: lighten(#424242, 90%)
 
+  &:focus,
   &:hover
-    background: lighten(#424242, 95%)
-  
-  &:focus
     background: lighten(#424242, 95%)
 
   &.active
@@ -69,10 +64,8 @@
     font-size: 14px
     padding: 1em
 
+    &:focus,
     &:hover
-      background: lighten(COBOLT_BLUE, 20%)
-    
-    &:focus
       background: lighten(COBOLT_BLUE, 20%)
 
     &:disabled
@@ -110,11 +103,8 @@
   color: COBOLT_BLUE
   position: static // position: relative inherited from $reset-button was causing inconsistent rendering in chrome
 
+  &:focus,
   &:hover
-    background: COBOLT_BLUE
-    color: white
-  
-  &:focus
     background: COBOLT_BLUE
     color: white
     

--- a/css/buttons.styl
+++ b/css/buttons.styl
@@ -12,6 +12,9 @@
   &:hover
     background: lighten(MAIN_HIGHLIGHT, 20%)
 
+  &:focus
+    background: lighten(MAIN_HIGHLIGHT, 20%)
+
   &:disabled
     pointer-events: none
 
@@ -26,6 +29,9 @@
 
   &:hover
     background: lighten(SECOND_HIGHLIGHT, 20%)
+  
+  &:focus
+    background: lighten(SECOND_HIGHLIGHT, 20%)
 
 .minor-button
   @extends .standard-button
@@ -33,6 +39,9 @@
   background: lighten(#424242, 90%)
 
   &:hover
+    background: lighten(#424242, 95%)
+  
+  &:focus
     background: lighten(#424242, 95%)
 
   &.active
@@ -61,6 +70,9 @@
     padding: 1em
 
     &:hover
+      background: lighten(COBOLT_BLUE, 20%)
+    
+    &:focus
       background: lighten(COBOLT_BLUE, 20%)
 
     &:disabled
@@ -101,3 +113,8 @@
   &:hover
     background: COBOLT_BLUE
     color: white
+  
+  &:focus
+    background: COBOLT_BLUE
+    color: white
+    

--- a/css/project-page.styl
+++ b/css/project-page.styl
@@ -13,6 +13,9 @@
 
     &:hover
       background: lighten(#424242, 20%)
+    
+    &:focus
+      background: lighten(#424242, 20%)
 
     &.active
       background: MAIN_HIGHLIGHT

--- a/css/project-page.styl
+++ b/css/project-page.styl
@@ -11,10 +11,8 @@
     color: white
     background: #424242
 
+    &:focus,
     &:hover
-      background: lighten(#424242, 20%)
-    
-    &:focus
       background: lighten(#424242, 20%)
 
     &.active


### PR DESCRIPTION
This PR extends the styling for :hover to :focus for buttons specified in `buttons.styl`. Related to, but not dependent on PR #2621. 