### PR TITLE
Allow workflow reordering

### DIFF
--- a/app/lib/get-workflows-in-order.coffee
+++ b/app/lib/get-workflows-in-order.coffee
@@ -1,5 +1,4 @@
 getWorkflowsInOrder = (project, query) ->
-  console.log {project}
   order = project.configuration?.workflow_order ? []
 
   project.get('workflows', query).then (workflows) ->

--- a/app/lib/get-workflows-in-order.coffee
+++ b/app/lib/get-workflows-in-order.coffee
@@ -1,8 +1,8 @@
-getWorkflowsInOrder = (project) ->
+getWorkflowsInOrder = (project, query) ->
   console.log {project}
   order = project.configuration?.workflow_order ? []
 
-  project.get('workflows').then (workflows) ->
+  project.get('workflows', query).then (workflows) ->
     workflowsByID = {}
     workflows.forEach (workflow) ->
       workflowsByID[workflow.id] = workflow

--- a/app/lib/get-workflows-in-order.coffee
+++ b/app/lib/get-workflows-in-order.coffee
@@ -1,0 +1,23 @@
+getWorkflowsInOrder = (project) ->
+  console.log {project}
+  order = project.configuration?.workflow_order ? []
+
+  project.get('workflows').then (workflows) ->
+    workflowsByID = {}
+    workflows.forEach (workflow) ->
+      workflowsByID[workflow.id] = workflow
+
+    workflowsInOrder = order.map (workflowID) ->
+      workflowsByID[workflowID]
+
+    # Filter out any workflows that appear in the order but do not actually exist.
+    workflowsInOrder = workflowsInOrder.filter Boolean
+
+    # Append any workflows that exist but do not appear in the order.
+    workflows.forEach (workflow) ->
+      if workflow not in workflowsInOrder
+        workflowsInOrder.push workflow
+
+    workflowsInOrder
+
+module.exports = getWorkflowsInOrder

--- a/app/pages/lab/project.cjsx
+++ b/app/pages/lab/project.cjsx
@@ -97,7 +97,11 @@ EditProjectPage = React.createClass
             <PromiseRenderer promise={getWorkflowsInOrder @props.project}>{(workflows) =>
               renderWorkflowListItem = (workflow) =>
                 <li key={workflow.id}>
-                  <Link to={@labPath "/workflow/#{workflow.id}"} className="nav-list-item" activeClassName="active">{workflow.display_name}</Link>
+                  <Link to={@labPath "/workflow/#{workflow.id}"} className="nav-list-item" activeClassName="active">
+                    {workflow.display_name}
+                    {if workflow.id is @props.project.configuration?.default_workflow
+                      <span title="Default workflow">{' '}*{' '}</span>}
+                  </Link>
                 </li>
 
               renderWorkflowListItemListener = (workflow) =>

--- a/app/pages/lab/project.cjsx
+++ b/app/pages/lab/project.cjsx
@@ -99,7 +99,11 @@ EditProjectPage = React.createClass
                 <li key={workflow.id}>
                   <Link to={@labPath "/workflow/#{workflow.id}"} className="nav-list-item" activeClassName="active">{workflow.display_name}</Link>
                 </li>
-              <DragReorderable tag="ul" className="nav-list" items={workflows} render={renderWorkflowListItem} onChange={@handleWorkflowReorder} />
+
+              renderWorkflowListItemListener = (workflow) =>
+                <ChangeListener key={workflow.id} target={workflow} eventName="save" handler={renderWorkflowListItem.bind null, workflow} />
+
+              <DragReorderable tag="ul" className="nav-list" items={workflows} render={renderWorkflowListItemListener} onChange={@handleWorkflowReorder} />
             }</PromiseRenderer>
 
             <div className="nav-list-item">

--- a/app/pages/lab/project.cjsx
+++ b/app/pages/lab/project.cjsx
@@ -96,16 +96,16 @@ EditProjectPage = React.createClass
             <div className="nav-list-header">Workflows</div>
             <PromiseRenderer promise={getWorkflowsInOrder @props.project}>{(workflows) =>
               renderWorkflowListItem = (workflow) =>
-                <li key={workflow.id}>
-                  <Link to={@labPath "/workflow/#{workflow.id}"} className="nav-list-item" activeClassName="active">
-                    {workflow.display_name}
-                    {if workflow.id is @props.project.configuration?.default_workflow
-                      <span title="Default workflow">{' '}*{' '}</span>}
-                  </Link>
-                </li>
+                <Link to={@labPath "/workflow/#{workflow.id}"} className="nav-list-item" activeClassName="active">
+                  {workflow.display_name}
+                  {if workflow.id is @props.project.configuration?.default_workflow
+                    <span title="Default workflow">{' '}*{' '}</span>}
+                </Link>
 
               renderWorkflowListItemListener = (workflow) =>
-                <ChangeListener key={workflow.id} target={workflow} eventName="save" handler={renderWorkflowListItem.bind null, workflow} />
+                <li key={workflow.id}>
+                  <ChangeListener target={workflow} eventName="save" handler={renderWorkflowListItem.bind null, workflow} />
+                </li>
 
               <DragReorderable tag="ul" className="nav-list" items={workflows} render={renderWorkflowListItemListener} onChange={@handleWorkflowReorder} />
             }</PromiseRenderer>

--- a/app/pages/project/home.cjsx
+++ b/app/pages/project/home.cjsx
@@ -5,6 +5,7 @@ PromiseToSetState = require '../../lib/promise-to-set-state'
 PromiseRenderer = require '../../components/promise-renderer'
 FinishedBanner = require './finished-banner'
 ProjectMetadata = require './metadata'
+getWorkflowsInOrder = require '../../lib/get-workflows-in-order'
 {Link} = require 'react-router'
 
 module.exports = React.createClass
@@ -18,7 +19,7 @@ module.exports = React.createClass
       if project._workflows?
         @setState workflows: project._workflows
       else
-        workflows = project.get 'workflows', active: true
+        workflows = getWorkflowsInOrder project, active: true
 
         workflows.then (workflows) =>
           project._workflows = workflows

--- a/css/nav-list.styl
+++ b/css/nav-list.styl
@@ -9,6 +9,10 @@
     border: 1px solid rgba(gray, 0.8)
     border-radius: 3px
 
+  &.drag-reorderable
+    > [draggable]
+      border-left: 1ch solid rgba(gray, 0.2)
+
 .nav-list-header
   @extends $generic-heading
   margin: 0.2em 1vw


### PR DESCRIPTION
Allows setting workflow order in the project builder and displays workflows in that order on the project home page.

@camallen I'm storing this order on the project configuration. There's no way to store it in the project's workflow links, correct?

Closes #2510.