### PR TITLE
Bump modal-form

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lodash.pick": "~3.1.0",
     "lodash.uniq": "~3.2.2",
     "markdownz": "~4.1.2",
-    "modal-form": "~2.3.0",
+    "modal-form": "~2.4.0",
     "moment": "~2.9.0",
     "panoptes-client": "~2.5.0",
     "papaparse": "mholt/PapaParse#cada171",


### PR DESCRIPTION
Bump to modal-form 2.4.0, which takes overflow into account when determining target dimensions.