### PR TITLE
update focus and when image pan-able

### DIFF
--- a/app/components/frame-viewer.cjsx
+++ b/app/components/frame-viewer.cjsx
@@ -75,30 +75,38 @@ module.exports = React.createClass
           <div className="pan-zoom-controls" >
             <div className="draw-pan-toggle" >
               <div className={if @state.panEnabled then "" else "active"} >
-                <button title={"draw"} className={"fa fa-mouse-pointer"} title={"annotate"} onClick={@togglePanOff}/>
+                <button title={"draw"} title={"annotate"} className={"fa fa-mouse-pointer"} onClick={@togglePanOff}/>
               </div>
               <div className={if @state.panEnabled then "active" else ""}>
-                <button title={"pan"} className={"fa fa-arrows"} title={"pan"} onClick={@togglePanOn}/>
+                <button title={"pan"} ref="pan" className={"fa fa-arrows"} onClick={@handleFocus.bind(this, "pan")} onFocus={@togglePanOn} onBlur={@togglePanOff}/>
               </div>
             </div>
             <div>
               <button
                 title={ "zoom out" }
+                ref="zoomOut"
                 className={"zoom-out fa fa-minus" + if @cannotZoomOut() then " disabled" else "" }
                 onMouseDown={ @continuousZoom.bind(this, 1.1 ) }
                 onMouseUp={@stopZoom}
                 onKeyDown={@keyDownZoomButton.bind(this,1.1)}
                 onKeyUp={@stopZoom}
+                onFocus={@togglePanOn}
+                onBlur={@togglePanOff}
+                onClick={@handleFocus.bind(this, "zoomOut")}
               />
             </div>
             <div>
               <button
                 title={ "zoom in" }
+                ref="zoomIn"
                 className={ "zoom-in fa fa-plus" }
                 onMouseDown={@continuousZoom.bind(this, .9)}
                 onMouseUp={@stopZoom}
                 onKeyDown={@keyDownZoomButton.bind(this,.9)}
                 onKeyUp={@stopZoom}
+                onFocus={@togglePanOn}
+                onBlur={@togglePanOff}
+                onClick={@handleFocus.bind(this, "zoomIn")}
               />
             </div>
             <div>
@@ -128,6 +136,10 @@ module.exports = React.createClass
         y: 0
 
     @props.onLoad? e, @props.frame
+
+  handleFocus: (ref) ->
+    @refs[ref].focus()
+    @togglePanOn()
 
   cannotZoomOut: ->
     return @state.frameDimensions.width == @state.viewBoxDimensions.width && @state.frameDimensions.height == @state.viewBoxDimensions.height
@@ -191,15 +203,13 @@ module.exports = React.createClass
 
   togglePanOn: ->
     unless @state.panEnabled
-      @setState panEnabled: true, =>
-        this.refs.subjectImage.focus()
+      @setState panEnabled: true
 
   togglePanOff: ->
     @setState panEnabled: false
 
   toggleKeyPanZoom: ->
-    @setState keyPanZoomEnabled: !@state.keyPanZoomEnabled, =>
-      if @state.panEnabled then this.refs.subjectImage.focus()
+    @setState keyPanZoomEnabled: !@state.keyPanZoomEnabled
 
   panByDrag: (e, d) ->
     return unless @state.panEnabled

--- a/app/components/frame-viewer.cjsx
+++ b/app/components/frame-viewer.cjsx
@@ -51,7 +51,7 @@ module.exports = React.createClass
     frameDisplay = switch type
       when 'image'
         <div className="subject-image-frame" >
-          <img ref="subjectImage" className={"subject pan-active"} src={src} style={SUBJECT_STYLE} onLoad={@handleLoad} tabIndex={0} onFocus={@togglePanOn} onBlur={@togglePanOff}/>
+          <img ref="subjectImage" className="subject pan-active" src={src} style={SUBJECT_STYLE} onLoad={@handleLoad} tabIndex={0} onFocus={@togglePanOn} onBlur={@togglePanOff}/>
 
           {if @state.loading
             <div className="loading-cover" style={@constructor.overlayStyle} >
@@ -75,15 +75,15 @@ module.exports = React.createClass
           <div className="pan-zoom-controls" >
             <div className="draw-pan-toggle" >
               <div className={if @state.panEnabled then "" else "active"} >
-                <button title={"draw"} title={"annotate"} className={"fa fa-mouse-pointer"} onClick={@togglePanOff}/>
+                <button title="annotate" className="fa fa-mouse-pointer" onClick={@togglePanOff}/>
               </div>
               <div className={if @state.panEnabled then "active" else ""}>
-                <button title={"pan"} ref="pan" className={"fa fa-arrows"} onClick={@handleFocus.bind(this, "pan")} onFocus={@togglePanOn} onBlur={@togglePanOff}/>
+                <button title="pan" ref="pan" className="fa fa-arrows" onClick={@handleFocus.bind(this, "pan")} onFocus={@togglePanOn} onBlur={@togglePanOff}/>
               </div>
             </div>
             <div>
               <button
-                title={ "zoom out" }
+                title="zoom out"
                 ref="zoomOut"
                 className={"zoom-out fa fa-minus" + if @cannotZoomOut() then " disabled" else "" }
                 onMouseDown={ @continuousZoom.bind(this, 1.1 ) }
@@ -97,9 +97,9 @@ module.exports = React.createClass
             </div>
             <div>
               <button
-                title={ "zoom in" }
+                title="zoom in"
                 ref="zoomIn"
-                className={ "zoom-in fa fa-plus" }
+                className="zoom-in fa fa-plus"
                 onMouseDown={@continuousZoom.bind(this, .9)}
                 onMouseUp={@stopZoom}
                 onKeyDown={@keyDownZoomButton.bind(this,.9)}
@@ -110,7 +110,7 @@ module.exports = React.createClass
               />
             </div>
             <div>
-              <button title={"reset zoom levels"} className={"reset fa fa-refresh" + if @cannotZoomOut() then " disabled" else ""} onClick={ this.zoomReset } ></button>
+              <button title="reset zoom levels" className={"reset fa fa-refresh" + if @cannotZoomOut() then " disabled" else ""} onClick={ this.zoomReset } ></button>
             </div>
           </div>}
 


### PR DESCRIPTION
addresses focus and when pan-able, keeping the following use cases in mind:

1. keyboard only - tab to pan & zoom controls to pan or zoom (or attempt to >:( on Safari) then tab away. once tabbed away from pan & zoom controls pan-able should be disabled.
2. mouse with drag and wheel - click cross-arrows so can pan & zoom, drag label to center, mousewheel to zoom in, maybe drag a bit more to re-center. once clicked away from pan & zoom controls pan-able should be disabled.
3. mouse with drag and click +/- buttons - click cross-arrows so can pan & zoom, drag label to center, click + button to zoom in (either hold down or click multiple times), maybe drag a bit more to re-center. once clicked away from pan & zoom controls pan-able should be disabled.

[branch staged here](https://pan-zoom-focus.pfe-preview.zooniverse.org/)

@simensta @eatyourgreens 

oh the draw button has two `title`'s, i just scooted together, i doubt hurting anything but just wanted to see if intentional or should get rid of one?