### PR TITLE
Reorder tutorial slides

### DIFF
--- a/app/partials/project-modal-editor.cjsx
+++ b/app/partials/project-modal-editor.cjsx
@@ -5,7 +5,6 @@ FileButton = require '../components/file-button'
 {MarkdownEditor} = (require 'markdownz').default
 debounce = require 'debounce'
 DragReorderable = require 'drag-reorderable'
-CroppedImage = require '../components/cropped-image'
 classnames = require 'classnames'
 
 ProjectModalStepEditor = React.createClass

--- a/app/partials/project-modal-editor.cjsx
+++ b/app/partials/project-modal-editor.cjsx
@@ -83,18 +83,21 @@ ProjectModalEditor = React.createClass
     for step, index in stepsInNewOrder
       stepReorderedIndex = index if @props.projectModal.steps[@state.stepToEdit].content is step.content
 
+    for step, i in @props.projectModal.steps
+      step._key = null
+      
     @props.onStepOrderChange stepsInNewOrder
     @setState stepToEdit: stepReorderedIndex
 
   renderStepList: (step, i) ->
-    step._key ?= Math.random()
+    step._key ?= i+1
     buttonClasses = classnames 
       "selected": @state.stepToEdit is i
       "project-modal-step-list-item-button": true
 
     <li key={step._key} className="project-modal-step-list-item">
       <button type="button" className={buttonClasses} onClick={@onClick.bind null, i}>
-        <span className="project-modal-step-list-item-button-title">Step #{i+1}</span>
+        <span className="project-modal-step-list-item-button-title">Step #{step._key}</span>
       </button>
       <button type="button" className="project-modal-step-list-item-remove-button" title="Remove this step" onClick={@handleStepRemove.bind null, i}>
         <i className="fa fa-trash-o fa-fw"></i>

--- a/app/partials/project-modal-editor.cjsx
+++ b/app/partials/project-modal-editor.cjsx
@@ -82,22 +82,23 @@ ProjectModalEditor = React.createClass
 
     for step, index in stepsInNewOrder
       stepReorderedIndex = index if @props.projectModal.steps[@state.stepToEdit].content is step.content
-
-    for step, i in @props.projectModal.steps
-      step._key = null
       
     @props.onStepOrderChange stepsInNewOrder
     @setState stepToEdit: stepReorderedIndex
 
+  handleStepAdd: ->
+    @props.onStepAdd()
+    @setState stepToEdit: @props.projectModal.steps.length - 1
+
   renderStepList: (step, i) ->
-    step._key ?= i+1
+    step._key ?= Math.random()
     buttonClasses = classnames 
       "selected": @state.stepToEdit is i
       "project-modal-step-list-item-button": true
 
     <li key={step._key} className="project-modal-step-list-item">
       <button type="button" className={buttonClasses} onClick={@onClick.bind null, i}>
-        <span className="project-modal-step-list-item-button-title">Step #{step._key}</span>
+        <span className="project-modal-step-list-item-button-title">Step #{i + 1}</span>
       </button>
       <button type="button" className="project-modal-step-list-item-remove-button" title="Remove this step" onClick={@handleStepRemove.bind null, i}>
         <i className="fa fa-trash-o fa-fw"></i>
@@ -124,7 +125,7 @@ ProjectModalEditor = React.createClass
           />
         </div>}
       <div>
-        <button type="button" onClick={@props.onStepAdd}>Add a step</button>
+        <button type="button" onClick={@handleStepAdd}>Add a step</button>
       </div>
     </div>
 
@@ -188,8 +189,11 @@ ProjectModalEditorController = React.createClass
 
   handleProjectModalDelete: ->
     if @props.projectModal.steps.length > 0
-      for step, index in @props.projectModal.steps
-        @handleStepRemove(index)
+      for step in @props.projectModal.steps
+        # Always pass in first index into step remove, because step deletion changes length
+        # i.e. index 3 will be undefined in an originally 4 item length array after first is deleted
+        # but iterate through the length of the original step array.
+        @handleStepRemove(0)
     else
       @deleteProjectModal()
 

--- a/css/project-modal-editor.styl
+++ b/css/project-modal-editor.styl
@@ -8,22 +8,57 @@
 
 .project-modal-step-editor-container
   display: flex
+  flex-wrap: wrap
   
   .project-modal-step-list
-    flex: 1 1 50%
+    border: 1px solid rgba(gray,0.3)
+    flex: 1 1 auto
     list-style: none
+    margin: 1em 0.5em 1em 0
+    max-width: 50ch
     padding: 0
     
-    li
-      display: flex
+    > :not(:first-child)
+      border-top: 1px solid rgba(gray, 0.2)
       
-      &.selected
-        background-color: lightgray
+    .project-modal-step-list-item
+      display: flex
+      border-left: 1em solid rgba(gray, 0.1) // Drag handle
+      
+      .project-modal-step-list-item-button
+        @extends $reset-button
+        align-items: center
+        display: flex
+        flex-grow: 1
+        padding: 0.5em 1em
+        text-align: left
+
+        &:hover, &:focus
+          background: rgba(MAIN_HIGHLIGHT, 0.2)
+
+        &:active, &.selected
+          background: MAIN_HIGHLIGHT
+          color: white
+          
+          .project-modal-step-list-item-button-title
+            font-weight: bold
+            
+      .project-modal-step-list-item-remove-button
+        @extends $reset-button
+        padding: 0.5em 1em
+
+        &:hover
+          background: rgba(red, 0.2)
+
+        &:active
+          background: red
+          color: white
+          
 
 .project-modal-step-editor
   border: 1px solid rgba(gray, 0.5)
-  flex: 1 1 50%
-  margin: 1em 0
+  flex: 1 1 auto
+  margin: 1em 0 1em 0.5em
   max-width: 50ch
   padding: 0.5em 1em
   position: relative
@@ -32,3 +67,4 @@
     position: absolute
     right: 0
     top: 0
+      

--- a/css/project-modal-editor.styl
+++ b/css/project-modal-editor.styl
@@ -1,14 +1,30 @@
 .project-modal-editor
-  max-width: 50ch
+  width: 100%
 
   .project-modal-header
     align-items: center
     display: flex
     justify-content: space-between
 
+.project-modal-step-editor-container
+  display: flex
+  
+  .project-modal-step-list
+    flex: 1 1 50%
+    list-style: none
+    padding: 0
+    
+    li
+      display: flex
+      
+      &.selected
+        background-color: lightgray
+
 .project-modal-step-editor
   border: 1px solid rgba(gray, 0.5)
+  flex: 1 1 50%
   margin: 1em 0
+  max-width: 50ch
   padding: 0.5em 1em
   position: relative
 

--- a/css/project-modal-editor.styl
+++ b/css/project-modal-editor.styl
@@ -10,6 +10,10 @@
   display: flex
   flex-wrap: wrap
   
+  .drag-reorderable [data-being-dragged]
+    opacity: 0.5
+    outline: 2px dashed lightgray
+
   .project-modal-step-list
     border: 1px solid rgba(gray,0.3)
     flex: 1 1 auto


### PR DESCRIPTION
Closes #2629. This adds `drag-reorderable` to the project modal editor that handles the tutorial and mini-course editing interface. This also makes the UI a bit more consistent with the field guide editor. 

Staged at https://reorder-tutorial-slides.pfe-preview.zooniverse.org/