### PR TITLE
Add labels for stats date range

### DIFF
--- a/app/pages/project/stats/charts.cjsx
+++ b/app/pages/project/stats/charts.cjsx
@@ -46,8 +46,8 @@ Graph = React.createClass
         onlyInteger: true
     optionsSmall:
       axisX:
-        offset: 0
-        showLabel: false
+        offset: 90
+        #showLabel: false
         showGrid: false
       axisY:
         offset: 0
@@ -137,6 +137,10 @@ Graph = React.createClass
       ).text(data.series[data.index])
 
   onDrawSmall: (data) ->
+    if data.type == 'label'
+      if data.axis.units.dir == 'horizontal'
+        if ([@state.minIdx, @state.maxIdx].indexOf(data.index) < 0)          
+          data.element.attr({style: "display: none"})
     if data.type == 'bar'
       style = "stroke-width: #{100 / @state.data.labels.length}%"
       if (data.index >= @state.minIdx & data.index <= @state.maxIdx)

--- a/css/project-stats-page.styl
+++ b/css/project-stats-page.styl
@@ -22,18 +22,19 @@ zoo-orange = #f78d27
     font-size: 1rem
     font-weight: bold
 
-.ct-chart-bar
-  .ct-label.ct-horizontal.ct-end
-    display: block
-    overflow: hidden
-    text-overflow: ellipsis
-    white-space: nowrap
-    transform: rotate(-90deg) translateY(-6px)
-    transform-origin: 100% 0
-    text-align: right
-    max-height: 1.5em
-    min-width: 100px
-    max-width: 100px
+.ct-major-tenth
+  .ct-chart-bar
+    .ct-label.ct-horizontal.ct-end
+      display: block
+      overflow: hidden
+      text-overflow: ellipsis
+      white-space: nowrap
+      transform: rotate(-90deg) translateY(-6px)
+      transform-origin: 100% 0
+      text-align: right
+      max-height: 1.5em
+      min-width: 100px
+      max-width: 100px
 
 .ct-slice-donut
   cursor: auto

--- a/css/project-stats-page.styl
+++ b/css/project-stats-page.styl
@@ -22,6 +22,12 @@ zoo-orange = #f78d27
     font-size: 1rem
     font-weight: bold
 
+.ct-labels-range
+  .ct-label-range
+    font-size: 0.75rem
+  .ct-label-range-last
+    text-align: right
+
 .ct-major-tenth
   .ct-chart-bar
     .ct-label.ct-horizontal.ct-end
@@ -38,6 +44,11 @@ zoo-orange = #f78d27
 
 .ct-slice-donut
   cursor: auto
+  
+.date-range
+  margin: .5em 0
+  .date-reset
+    float: right
   
 .flex-wrapper
   padding: 5px  


### PR DESCRIPTION
Addresses both #2592 and #2588 by adding a label showing the currently selected date range, labels for the min and max dates, and a reset button for the range.  The preview can be found [here](https://stats-range-labels.pfe-preview.zooniverse.org/projects/?env=production)

@alexbfree could you take a look when you get a chance.