### PR TITLE
Publication page open access

### DIFF
--- a/app/pages/about/publications-page.cjsx
+++ b/app/pages/about/publications-page.cjsx
@@ -152,7 +152,8 @@ publicationCategories =
       {citation: "Planet Hunters. VIII. Characterization of 41 Long-Period Exoplanet Candidates from Kepler Archival Data, Wang+ 2015."
       href: "http://arxiv.org/pdf/1512.02559v2.pdf"},
       {citation: "Planet Hunters. IX. KIC 8462852 – Where’s the flux?, Boyajian+ 2015."
-      href: "http://mnras.oxfordjournals.org/content/457/4/3988.full.pdf"},
+      href: "http://mnras.oxfordjournals.org/content/457/4/3988.full.pdf"
+      openAccess: "http://arxiv.org/pdf/1509.03622v1.pdf"},
       {citation: "GALEX J194419.33+491257.0: An unusually active SU UMa-type dwarf nova with a very short orbital period in the Kepler data, Kato & Osaki 2014."
       href: "http://adsabs.harvard.edu/doi/10.1093/pasj/psu025"},
       {citation: "Planet Hunters. VI. An Independent Characterization of KOI-351 and Several Long Period Planet Candidates from the Kepler Archival Data, Schmitt+ 2014."
@@ -367,7 +368,8 @@ module.exports = React.createClass
                         <div className="citation">
                           <p>
                             <cite>{publication.citation}</cite><br />
-                            {if publication.href? then <a href={publication.href} target="_blank">Available here.</a>}
+                            {if publication.href? then <a href={publication.href} target="_blank">View publication.</a>}{' '}
+                            {if publication.openAccess then <a href={publication.openAccess} target="_blank">View open access version.</a>}
                           </p>
                         </div>
                       </li>}

--- a/app/pages/about/publications-page.cjsx
+++ b/app/pages/about/publications-page.cjsx
@@ -369,7 +369,7 @@ module.exports = React.createClass
                           <p>
                             <cite>{publication.citation}</cite><br />
                             {if publication.href? then <a href={publication.href} target="_blank">View publication.</a>}{' '}
-                            {if publication.openAccess then <a href={publication.openAccess} target="_blank">View open access version.</a>}
+                            {if publication.openAccess? then <a href={publication.openAccess} target="_blank">View open access version.</a>}
                           </p>
                         </div>
                       </li>}


### PR DESCRIPTION
Closes #1850. Adds a `openAccess` property to the publications object and displays it next to the original href. Staged at: https://publication-page-open-access.pfe-preview.zooniverse.org/about/publications

@willettk, @mrniaboc is this ok? This supercedes #2511 