### PR TITLE
Makes hot-reload optional

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,6 +3,11 @@
   "env": {
     "development": {
       "plugins": [
+        ["transform-react-jsx"]
+      ]
+    },
+    "hot-reload": {
+      "plugins": [
         ["react-transform", {
           "transforms": [{
             "transform": "react-transform-hmr",

--- a/dev-server.js
+++ b/dev-server.js
@@ -18,7 +18,10 @@ const middleware = webpackMiddleware(compiler, {
 });
 
 app.use(middleware);
-app.use(webpackHotMiddleware(compiler));
+
+if (process.env.BABEL_ENV === 'hot-reload') {
+  app.use(webpackHotMiddleware(compiler));
+}
 
 app.use(express.static(path.join(__dirname, 'dist')));
 app.use(function(req,res,next){
@@ -31,6 +34,5 @@ app.listen(port, 'localhost', function onStart(err) {
     console.log(err);
   }
   console.info('==> 🌎 Listening on port %s. Open up http://localhost:%s/ in your browser.', port, port);
-  console.info('==> 🕓 Please wait for webpack to finish processing your application code.')
-  console.info('==> 🕓 Message will read "webpack: bundle is now VALID."')
+  console.info('==> 🕓 Please wait for webpack to finish processing your application code.');
 });

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
 
     "_build": "export HEAD_COMMIT=$(git rev-parse --short HEAD); check-engines && rimraf dist; webpack --config ./webpack.build.js --progress --profile --colors",
     "serve-static": "export NODE_ENV=staging; check-engines && npm run _build && node ./static-server.js",
+    "serve-hot": "export BABEL_ENV=hot-reload; npm start",
 
     "_publish": "publisssh ./dist \"zooniverse-static/$PATH_ROOT/$SUBDIR\" $PUBLISH_FLAGS",
     "_log-staging-url": "echo \"Staged at https://$SUBDIR.pfe-preview.zooniverse.org/\"",

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -5,10 +5,9 @@ var webpack = require('webpack');
 var HtmlWebpackPlugin = require('html-webpack-plugin');
 var CopyWebpackPlugin = require('copy-webpack-plugin');
 
-module.exports = {
+var config = {
   devtool: 'eval-source-map',
   entry: [
-    'webpack-hot-middleware/client?reload=true',
     path.join(__dirname, 'app/main.cjsx')
   ],
   output: {
@@ -29,9 +28,7 @@ module.exports = {
       template: 'views/index.ejs',
       inject: 'body',
       filename: 'index.html'
-    }),
-    new webpack.HotModuleReplacementPlugin(),
-    // new webpack.NoErrorsPlugin(),
+    })
   ],
   resolve: {
     extensions: ['', '.js', '.jsx', '.cjsx', '.coffee', '.styl', '.css'],
@@ -74,3 +71,10 @@ module.exports = {
     fs: "empty"
   }
 };
+
+if (process.env.BABEL_ENV === 'hot-reload') {
+  config.entry.unshift('webpack-hot-middleware/client?reload=true');
+  config.plugins.push(new webpack.HotModuleReplacementPlugin());
+}
+
+module.exports = config;


### PR DESCRIPTION
Yay, a contentious PR!

Since it's really just down to developer preference, this allows hot-reloading to be optionally enabled.

`npm start` to serve without it and `npm run start-dev` to serve with it.  Happy to flip those around or rename based on preference.

cc/d everybody assigned from #2656.