### PR TITLE
remove browserfy workaround from stats page now that webpack is used

### DIFF
--- a/app/pages/project/stats/charts.cjsx
+++ b/app/pages/project/stats/charts.cjsx
@@ -1,10 +1,6 @@
 React = require 'react'
 ChartistGraph = require 'react-chartist'
 moment = require 'moment'
-
-# hack to make browserify and rc-slider play nice when using window shim
-document.createElement ?= (input) ->
-  style: {}
 Rcslider = require 'rc-slider'
 
 Progress = React.createClass


### PR DESCRIPTION
This just removes a workaround that is no longer needed since the move to webpack.