### PR TITLE
dropdown - add list of options, disable if conditions not selected

### DIFF
--- a/app/classifier/tasks/dropdown/dropdown-dialog.cjsx
+++ b/app/classifier/tasks/dropdown/dropdown-dialog.cjsx
@@ -1,12 +1,16 @@
 React = require 'react'
 ReactDOM = require 'react-dom'
 DragReorderable = require 'drag-reorderable'
+TriggeredModalForm = require 'modal-form/triggered'
+dropdownEditorHelp = require './editor-help'
 months = require './presets/months'
 countries = require './presets/countries' # value = ISO 3166-1 numeric code
 statesUSA = require './presets/states-USA' # value = two-letter postal abbreviation, does not duplicate with Canada
 provincesCanada = require './presets/provinces-Canada' # value = two-letter postal abbreviation, does not duplicate with USA
 statesMexico = require './presets/states-Mexico' # value = three-letter ISO 3166-2 abbreviation
 # IMPORTANT: before adding preset options, confirm values are not duplicated in existing presets
+
+alertCount = 0
 
 DropdownDialog = React.createClass
 
@@ -33,13 +37,17 @@ DropdownDialog = React.createClass
         conditionalSelect = @props.selects.filter (select) => select.id is conditionalSelect[0].condition
       conditionalSelects.reverse()
       @setState conditionalSelects: conditionalSelects
+      optionsKeys = {}
+      for select in conditionalSelects
+        optionsKeys[select.id] = null
+      @setState optionsKeys: optionsKeys
 
   handleOptionsKeys: (select, value) ->
     optionsKeys = @state.optionsKeys
-    if not select.condition?
-      optionsKeys[select.id] = value
-    else if value is null or value is ''
+    if value is null or value is ""
       optionsKeys[select.id] = null
+    else if not select.condition?
+      optionsKeys[select.id] = value
     else
       optionsKeys[select.id] = "#{optionsKeys[select.condition]};#{value}"
     @setState optionsKeys: optionsKeys
@@ -58,22 +66,29 @@ DropdownDialog = React.createClass
     select.allowCreate = @refs.allowCreate.checked
     @setState editSelect: select
 
-  onChangeConditionalAnswer: (select, e) ->
+  onChangeConditionalAnswer: (select, index, e) ->
     @handleOptionsKeys(select, e.target.value)
-    for select in @props.related
-      @handleOptionsKeys(select, null)
+    if @state.conditionalSelects.length and index isnt (@state.conditionalSelects.length - 1)
+      for otherIndex in [(index + 1)..(@state.conditionalSelects.length - 1)]
+        @handleOptionsKeys(@state.conditionalSelects[otherIndex], null)
 
   addOption: (optionLabel) ->
+    addOption: (optionLabel) ->
     if not optionLabel
-      return window.alert('Please provide an option')
+      alertCount++
+      return window.alert('Please provide an option.')
 
     if @getOptionsByProp("label")?.indexOf(optionLabel) isnt -1
-      return window.alert('Options must be unique within each dropdown')
+      alertCount++
+      return window.alert('Options must be unique within each dropdown.')
 
     select = @state.editSelect
 
     if select.condition? and not @state.optionsKeys[select.condition]
-      return window.alert('Please select an answer to the related conditional dropdown(s) to associate the new option to')
+      alertCount++
+      return window.alert('Please select an answer to the related conditional dropdown(s) to associate the new option to.')
+
+    alertCount = 0
 
     optionsKey = @getOptionsKey(select)
 
@@ -83,10 +98,6 @@ DropdownDialog = React.createClass
       select.options["#{optionsKey}"] = [{value: "#{Math.random().toString(16).split('.')[1]}", label: "#{optionLabel}"}]
 
     @setState editSelect: select
-
-  onClickAddOption: ->
-    @addOption @refs.optionInput.value
-    @refs.optionInput.value = ''
 
   onReorder: (newOptions) ->
     select = @state.editSelect
@@ -141,6 +152,16 @@ DropdownDialog = React.createClass
 
     return select
 
+  handleAdd: ->
+    optionsArray = @refs.optionInput.value.split(/\n|,/)
+
+    for option in optionsArray
+      if alertCount < 3
+        @addOption option
+
+    alertCount = 0
+    @refs.optionInput.value = ""
+
   save: (e) ->
     if not @state.editSelect.title
       return window.alert('Dropdowns must have a Title.')
@@ -159,6 +180,13 @@ DropdownDialog = React.createClass
   cancel: ->
     @props.onCancel()
 
+  checkConditions: ->
+    if @props.initialSelect.condition?
+      disable = Object.keys(@state.optionsKeys).some (key) =>
+        @state.optionsKeys[key] is null
+      return disable
+    return false
+
   renderOption: (option) ->
     <li key={option.value}>
       <span><i className="fa fa-bars" />{' '}</span>
@@ -169,6 +197,10 @@ DropdownDialog = React.createClass
     </li>
 
   render: ->
+    disabledStyle =
+      opacity: 0.4
+      pointerEvents: 'none'
+
     select = @state.editSelect
     <div className="dropdown-editor">
       <p>
@@ -181,10 +213,10 @@ DropdownDialog = React.createClass
           <span>Dependent on {@state.conditionalSelects[@state.conditionalSelects.length - 1]?.title}</span>}
       </p>
 
-      <label className="pill-button">
+      <label className="pill-button" title={dropdownEditorHelp.required}>
         Required <input type="checkbox" ref="required" checked={select.required} onChange={@editSelect}></input>
       </label>{' '}
-      <label className="pill-button">
+      <label className="pill-button" title={dropdownEditorHelp.allowCreate}>
         Allow Create <input type="checkbox" ref="allowCreate" checked={select.allowCreate} onChange={@editSelect}></input>
       </label>
       <br />
@@ -193,9 +225,9 @@ DropdownDialog = React.createClass
         <div>
           <br />
           <h2 className="form-label">Options For</h2>
-          {@state.conditionalSelects.map (condition) =>
+          {@state.conditionalSelects.map (condition, index) =>
             <div key={condition.id}>
-              <select onChange={@onChangeConditionalAnswer.bind(@, condition)}>
+              <select onChange={@onChangeConditionalAnswer.bind(@, condition, index)}>
                 <option value="">none selected</option>
                 {condition.options[@getOptionsKey(condition)]?.map (option) =>
                   <option key={option.value} value={option.value}>{option.label}</option>}
@@ -219,9 +251,25 @@ DropdownDialog = React.createClass
           render={@renderOption}
           onChange={@onReorder}
         />
+      </div>
 
-        <input ref="optionInput"></input>{' '}
-        <button type="button" onClick={@onClickAddOption}><i className="fa fa-plus"/> Add Option</button>
+      <div>
+        <p>
+          <span className="form-label">Add Option(s){' '}</span>
+          <TriggeredModalForm trigger={
+            <span className="secret-button">
+              <i className="fa fa-question-circle"></i>
+            </span>
+          }>{dropdownEditorHelp.options}
+          </TriggeredModalForm>
+        </p>
+        {if @checkConditions()
+          <p className="form-help warning">Please select Options For above</p>}
+        <div style={disabledStyle if @checkConditions()}>
+          <textarea ref="optionInput"/>
+          <br />
+          <button type="button" onClick={@handleAdd}><i className="fa fa-plus"/> Add</button>
+        </div>
       </div>
 
       <br />

--- a/app/classifier/tasks/dropdown/dropdown-dialog.cjsx
+++ b/app/classifier/tasks/dropdown/dropdown-dialog.cjsx
@@ -10,8 +10,6 @@ provincesCanada = require './presets/provinces-Canada' # value = two-letter post
 statesMexico = require './presets/states-Mexico' # value = three-letter ISO 3166-2 abbreviation
 # IMPORTANT: before adding preset options, confirm values are not duplicated in existing presets
 
-alertCount = 0
-
 DropdownDialog = React.createClass
 
   getDefaultProps: ->
@@ -73,24 +71,15 @@ DropdownDialog = React.createClass
         @handleOptionsKeys(@state.conditionalSelects[otherIndex], null)
 
   addOption: (optionLabel) ->
-    addOption: (optionLabel) ->
     if not optionLabel
-      alertCount++
-      return window.alert('Please provide an option.')
-
-    if @getOptionsByProp("label")?.indexOf(optionLabel) isnt -1
-      alertCount++
-      return window.alert('Options must be unique within each dropdown.')
+      return
 
     select = @state.editSelect
-
-    if select.condition? and not @state.optionsKeys[select.condition]
-      alertCount++
-      return window.alert('Please select an answer to the related conditional dropdown(s) to associate the new option to.')
-
-    alertCount = 0
-
     optionsKey = @getOptionsKey(select)
+
+    if @getOptionsByProp("label")?.indexOf(optionLabel) isnt -1
+      dupIndex = @getOptionsByProp("label")?.indexOf(optionLabel)
+      select.options[optionsKey]?.splice(dupIndex, 1)
 
     if select.options[optionsKey]?
       select.options[optionsKey].push {value: "#{Math.random().toString(16).split('.')[1]}", label: "#{optionLabel}"}
@@ -121,10 +110,6 @@ DropdownDialog = React.createClass
 
   handlePresetApply: ->
     select = @state.editSelect
-
-    if select.condition? and not @state.optionsKeys[select.condition]
-      return window.alert('Please select an answer to the related conditional dropdown(s) to associate the new option to')
-
     optionsKey = @getOptionsKey(select)
     preset = @state.presetValue
 
@@ -153,13 +138,11 @@ DropdownDialog = React.createClass
     return select
 
   handleAdd: ->
-    optionsArray = @refs.optionInput.value.split(/\n|,/)
+    optionsArray = @refs.optionInput.value.split(/\n/)
 
     for option in optionsArray
-      if alertCount < 3
-        @addOption option
+      @addOption option
 
-    alertCount = 0
     @refs.optionInput.value = ""
 
   save: (e) ->
@@ -274,7 +257,7 @@ DropdownDialog = React.createClass
 
       <br />
 
-      <div>
+      <div style={disabledStyle if @checkConditions()}>
         <h2 className="form-label">Presets</h2>
         <select value={@state.presetValue} onChange={@handlePresetChange}>
           <option value="">none selected</option>

--- a/app/classifier/tasks/dropdown/dropdown-dialog.cjsx
+++ b/app/classifier/tasks/dropdown/dropdown-dialog.cjsx
@@ -239,7 +239,7 @@ DropdownDialog = React.createClass
       <div>
         <p>
           <span className="form-label">Add Option(s){' '}</span>
-          <TriggeredModalForm trigger={
+          <TriggeredModalForm className="dropdown-help" trigger={
             <span className="secret-button">
               <i className="fa fa-question-circle"></i>
             </span>

--- a/app/classifier/tasks/dropdown/editor-help.cjsx
+++ b/app/classifier/tasks/dropdown/editor-help.cjsx
@@ -6,34 +6,7 @@ module.exports =
   allowCreate: "Check this box to allow a volunteer to type an unique answer, not provided as an option."
 
   options: <div className="content-container">
-    <p>Add an option label individually <strong>OR</strong> copy and paste a list of option labels, <em>NO</em> header, and click the 'Add' button. Labels can be copied directly from file types CSV, TXT, XLS(X) or others. An example of a list that could be copied then pasted into the input is as follows:</p>
+    <p>Add an option label individually <strong>OR</strong> copy and paste a list of option labels, <em>NO</em> header, and click the 'Add' button. An example of a list of option labels is as follows:</p>
 
-    <table className="standard-table">
-      <tbody>
-        <tr>
-          <td>Mercury</td>
-        </tr>
-        <tr>
-          <td>Venus</td>
-        </tr>
-        <tr>
-          <td>Earth</td>
-        </tr>
-        <tr>
-          <td>Mars</td>
-        </tr>
-        <tr>
-          <td>Jupiter</td>
-        </tr>
-        <tr>
-          <td>Saturn</td>
-        </tr>
-        <tr>
-          <td>Uranus</td>
-        </tr>
-        <tr>
-          <td>Neptune</td>
-        </tr>
-      </tbody>
-    </table>
+    <textarea readOnly rows="5" value={"Mercury\nVenus\nEarth\nMars\nJupiter\nSaturn\nUranus\nNeptune"} />
   </div>

--- a/app/classifier/tasks/dropdown/editor-help.cjsx
+++ b/app/classifier/tasks/dropdown/editor-help.cjsx
@@ -1,0 +1,39 @@
+React = require 'react'
+
+module.exports =
+  required: "Check this box if an option has to be provided before proceeding."
+
+  allowCreate: "Check this box to allow a volunteer to type an unique answer, not provided as an option."
+
+  options: <div className="content-container">
+    <p>Add an option label individually <strong>OR</strong> copy and paste a list of option labels, <em>NO</em> header or blank rows, and click the 'Add' button. Labels can be seperated by line breaks or commas, and copied directly from file types CSV, TXT, XLS(X) or others. An example of a list that could be copied then pasted into the input is as follows:</p>
+
+    <table className="standard-table">
+      <tbody>
+        <tr>
+          <td>Mercury</td>
+        </tr>
+        <tr>
+          <td>Venus</td>
+        </tr>
+        <tr>
+          <td>Earth</td>
+        </tr>
+        <tr>
+          <td>Mars</td>
+        </tr>
+        <tr>
+          <td>Jupiter</td>
+        </tr>
+        <tr>
+          <td>Saturn</td>
+        </tr>
+        <tr>
+          <td>Uranus</td>
+        </tr>
+        <tr>
+          <td>Neptune</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>

--- a/app/classifier/tasks/dropdown/editor-help.cjsx
+++ b/app/classifier/tasks/dropdown/editor-help.cjsx
@@ -6,7 +6,7 @@ module.exports =
   allowCreate: "Check this box to allow a volunteer to type an unique answer, not provided as an option."
 
   options: <div className="content-container">
-    <p>Add an option label individually <strong>OR</strong> copy and paste a list of option labels, <em>NO</em> header or blank rows, and click the 'Add' button. Labels can be seperated by line breaks or commas, and copied directly from file types CSV, TXT, XLS(X) or others. An example of a list that could be copied then pasted into the input is as follows:</p>
+    <p>Add an option label individually <strong>OR</strong> copy and paste a list of option labels, <em>NO</em> header, and click the 'Add' button. Labels can be copied directly from file types CSV, TXT, XLS(X) or others. An example of a list that could be copied then pasted into the input is as follows:</p>
 
     <table className="standard-table">
       <tbody>

--- a/css/dropdown-task.styl
+++ b/css/dropdown-task.styl
@@ -59,4 +59,4 @@
     color: white
 
 .dropdown-options-list
-    list-style-type: none
+  list-style-type: none

--- a/css/dropdown-task.styl
+++ b/css/dropdown-task.styl
@@ -60,3 +60,7 @@
 
 .dropdown-options-list
   list-style-type: none
+
+.dropdown-help
+  .modal-form
+    max-width: 50%


### PR DESCRIPTION
Closes #2385 

[Staged branch here](https://dropdown-handle-lists.pfe-preview.zooniverse.org/).

Adds:

1. Ability to copy and paste a list of option labels into textarea option add input. Will work from file types CSV, TXT, and XLS.
2. Disabling of option add input and button if Options For not selected.