### PR TITLE
Fixes #1780

### DIFF
--- a/app/pages/lab/project.cjsx
+++ b/app/pages/lab/project.cjsx
@@ -10,7 +10,7 @@ Router = require 'react-router'
 ModalFormDialog = require 'modal-form/dialog'
 WorkflowCreateForm = require './workflow-create-form'
 workflowActions = require './actions/workflow'
-isAdmin = require '../lib/is-admin'
+isAdmin = require '../../lib/is-admin'
 
 DEFAULT_SUBJECT_SET_NAME = 'Untitled subject set'
 DELETE_CONFIRMATION_PHRASE = 'I AM DELETING THIS PROJECT'

--- a/app/pages/lab/project.cjsx
+++ b/app/pages/lab/project.cjsx
@@ -10,6 +10,7 @@ Router = require 'react-router'
 ModalFormDialog = require 'modal-form/dialog'
 WorkflowCreateForm = require './workflow-create-form'
 workflowActions = require './actions/workflow'
+isAdmin = require '../lib/is-admin'
 
 DEFAULT_SUBJECT_SET_NAME = 'Untitled subject set'
 DELETE_CONFIRMATION_PHRASE = 'I AM DELETING THIS PROJECT'
@@ -252,7 +253,7 @@ module.exports = React.createClass
           <p className="form-help">Loading project</p>
         </div>
       } then={([project, owners]) =>
-        if @props.user in owners or @props.user.admin
+        if @props.user in owners or isAdmin()
           <EditProjectPage {...@props} project={project} />
         else
           <div className="content-container">

--- a/app/pages/lab/project.cjsx
+++ b/app/pages/lab/project.cjsx
@@ -252,7 +252,7 @@ module.exports = React.createClass
           <p className="form-help">Loading project</p>
         </div>
       } then={([project, owners]) =>
-        if @props.user in owners
+        if @props.user in owners or @props.user.admin
           <EditProjectPage {...@props} project={project} />
         else
           <div className="content-container">


### PR DESCRIPTION
Allow admins access to project builder on all projects.

Deployed to https://allow-admins-into-project-builder-on-all-projects.pfe-preview.zooniverse.org/ for testing. Add the production environment parameter to test on production projects.

To test, go into admin mode, then add a project ID to the end of 
`https://allow-admins-into-project-builder-on-all-projects.pfe-preview.zooniverse.org/lab/`

Usecases and background in https://github.com/zooniverse/rfc/issues/4