### PR TITLE
[ready for merge if approved] Ensure preservation of project context

### DIFF
--- a/app/collections/preview.cjsx
+++ b/app/collections/preview.cjsx
@@ -30,7 +30,7 @@ module?.exports = React.createClass
 
   render: ->
     [owner, name] = @props.collection.slug.split('/')
-    collectionLink = ContextualLinks.prefixLinkIfNeeded(@props,"/collections/#{owner}/#{name}")
+    collectionLink = ContextualLinks.prefixLinkIfNeeded @props,"/collections/#{owner}/#{name}"
 
     <div className="collection-preview">
       <div className="collection">
@@ -40,7 +40,7 @@ module?.exports = React.createClass
           </Link>
           {' '}by{' '}
           {if @state.owner
-            ownerProfileLink = ContextualLinks.prefixLinkIfNeeded(@props,"/users/#{@state.owner.login}")
+            ownerProfileLink = ContextualLinks.prefixLinkIfNeeded @props, "/users/#{@state.owner.login}"
             <Link className="user-profile-link" to="#{ownerProfileLink}">
               <Avatar user={@state.owner} />{' '}{@state.owner.display_name}
             </Link>}

--- a/app/collections/preview.cjsx
+++ b/app/collections/preview.cjsx
@@ -5,6 +5,7 @@ Loading = require '../components/loading-indicator'
 Thumbnail = require '../components/thumbnail'
 Avatar = require '../partials/avatar'
 getSubjectLocation = require '../lib/get-subject-location'
+ContextualLinks = require '../lib/contextual-links'
 
 module?.exports = React.createClass
   displayName: 'CollectionPreview'
@@ -29,16 +30,18 @@ module?.exports = React.createClass
 
   render: ->
     [owner, name] = @props.collection.slug.split('/')
+    collectionLink = ContextualLinks.prefixLinkIfNeeded(@props,"/collections/#{owner}/#{name}")
 
     <div className="collection-preview">
       <div className="collection">
         <p className="title">
-          <Link to="/collections/#{owner}/#{name}">
+          <Link to="#{collectionLink}">
             {@props.collection.display_name}
           </Link>
           {' '}by{' '}
           {if @state.owner
-            <Link className="user-profile-link" to="/users/#{@state.owner.login}">
+            ownerProfileLink = ContextualLinks.prefixLinkIfNeeded(@props,"/users/#{@state.owner.login}")
+            <Link className="user-profile-link" to="#{ownerProfileLink}">
               <Avatar user={@state.owner} />{' '}{@state.owner.display_name}
             </Link>}
         </p>

--- a/app/collections/show.cjsx
+++ b/app/collections/show.cjsx
@@ -16,7 +16,8 @@ counterpart.registerTranslations 'en',
   collectionPage:
     settings: 'Settings'
     collaborators: 'Collaborators'
-    backToCollections: 'Back to Collections'
+    collectionsLink: '%(user)s\'s\u00a0Collections'
+    userLink: '%(user)s\'s\u00a0Profile'
   collectionsPageWrapper:
     error: 'There was an error retrieving this collection.'
 
@@ -44,6 +45,7 @@ CollectionPage = React.createClass
       params = {owner: ownerName, name: name}
 
       isOwner = @props.user?.id is owner.id
+      nonBreakableOwnerName =  owner.display_name.replace /\ /g, "\u00a0"
       <div className="collections-page">
         <nav className="collection-nav tabbed-content-tabs">
           <IndexLink to="#{@getProjectContextForLinkPrefix()}/collections/#{ownerName}/#{name}" activeClassName="active" className="tabbed-content-tab">
@@ -61,8 +63,11 @@ CollectionPage = React.createClass
               <Translate content="collectionPage.collaborators" />
             </Link>}
 
-          <Link to="#{@getProjectContextForLinkPrefix()}/collections" activeClassName="active" className="tabbed-content-tab">
-            <Translate content="collectionPage.backToCollections" />
+          <Link to="#{@getProjectContextForLinkPrefix()}/collections/#{ownerName}" activeClassName="active" className="tabbed-content-tab">
+            <Translate content="collectionPage.collectionsLink" user="#{nonBreakableOwnerName}" />
+          </Link>
+          <Link to="#{@getProjectContextForLinkPrefix()}/users/#{ownerName}" activeClassName="active" className="tabbed-content-tab">
+            <Translate content="collectionPage.userLink" user="#{nonBreakableOwnerName}" />
           </Link>
         </nav>
         <div className="collection-container talk">

--- a/app/collections/show.cjsx
+++ b/app/collections/show.cjsx
@@ -37,9 +37,9 @@ CollectionPage = React.createClass
 
   getCollectionsLink: (ownerName) ->
     if @props.collection.favorite?
-      ContextualLinks.prefixLinkIfNeeded(@props,"/favorites/#{ownerName}")
+      ContextualLinks.prefixLinkIfNeeded @props, "/favorites/#{ownerName}"
     else
-      ContextualLinks.prefixLinkIfNeeded(@props,"/collections/#{ownerName}")
+      ContextualLinks.prefixLinkIfNeeded @props, "/collections/#{ownerName}"
 
   getCollectionsLinkMessageKey: ->
     if @props.collection.favorite?
@@ -52,13 +52,13 @@ CollectionPage = React.createClass
       [ownerName, name] = @props.collection.slug.split('/')
       params = {owner: ownerName, name: name}
 
-      collectionLink = ContextualLinks.prefixLinkIfNeeded(@props,"/collections/#{ownerName}/#{name}")
+      collectionLink = ContextualLinks.prefixLinkIfNeeded @props, "/collections/#{ownerName}/#{name}"
 
       isOwner = @props.user?.id is owner.id
       if isOwner
-        settingsLink = ContextualLinks.prefixLinkIfNeeded(@props,"/collections/#{ownerName}/#{name}/settings")
-        collabLink = ContextualLinks.prefixLinkIfNeeded(@props,"/collections/#{ownerName}/#{name}/collaborators")
-      profileLink = ContextualLinks.prefixLinkIfNeeded(@props,"/users/#{ownerName}")
+        settingsLink = ContextualLinks.prefixLinkIfNeeded @props, "/collections/#{ownerName}/#{name}/settings"
+        collabLink = ContextualLinks.prefixLinkIfNeeded @props, "/collections/#{ownerName}/#{name}/collaborators"
+      profileLink = ContextualLinks.prefixLinkIfNeeded @props, "/users/#{ownerName}"
       nonBreakableOwnerName =  owner.display_name.replace /\ /g, "\u00a0"
       <div className="collections-page">
         <nav className="collection-nav tabbed-content-tabs">

--- a/app/collections/show.cjsx
+++ b/app/collections/show.cjsx
@@ -36,13 +36,13 @@ CollectionPage = React.createClass
     document.documentElement.classList.remove 'on-collection-page'
 
   getCollectionsLink: (ownerName) ->
-    if @props.collection.favorite?
+    if @props.collection.favorite
       ContextualLinks.prefixLinkIfNeeded @props, "/favorites/#{ownerName}"
     else
       ContextualLinks.prefixLinkIfNeeded @props, "/collections/#{ownerName}"
 
   getCollectionsLinkMessageKey: ->
-    if @props.collection.favorite?
+    if @props.collection.favorite
       "collectionPage.favoritesLink"
     else
       "collectionPage.collectionsLink"

--- a/app/components/owned-card-list.cjsx
+++ b/app/components/owned-card-list.cjsx
@@ -48,7 +48,6 @@ module.exports = React.createClass
       "#{@props.translationObjectName}.title.generic"
 
   getOwnerForTitle: ->
-    console.log 'filter is ',@props.filter
     if @props.filter? and "owner" of @props.filter
       return @props.nonBreakableOwnerName
 

--- a/app/components/owned-card-list.cjsx
+++ b/app/components/owned-card-list.cjsx
@@ -27,6 +27,8 @@ module.exports = React.createClass
     document.documentElement.classList.remove 'on-secondary-page'
 
   getMessageKeyToUseForTitle: ->
+    console.log @props.filter
+    console.log @props.filter?, "project_ids" of @props.filter, "owner" of @props.filter, @viewingOwnCollections
     if @props.filter?
       if "project_ids" of @props.filter
         if "owner" of @props.filter
@@ -48,6 +50,7 @@ module.exports = React.createClass
       "#{@props.translationObjectName}.title.generic"
 
   getOwnerForTitle: ->
+    console.log "nbo",@props.nonBreakableOwnerName
     if @props.filter? and "owner" of @props.filter
       return @props.nonBreakableOwnerName
 

--- a/app/components/owned-card-list.cjsx
+++ b/app/components/owned-card-list.cjsx
@@ -36,13 +36,19 @@ module.exports = React.createClass
     {location} = @props
 
     <div className="secondary-page all-resources-page">
-      <section className={"hero #{@props.heroClass}"}>
-        <div className="hero-container">
+      {if @props.project?
+        <div className="hero-with-context">
           <Translate component="h1" user={@userForTitle()} content={"#{@props.translationObjectName}.title"} />
-          {if @props.heroNav?
-            @props.heroNav}
         </div>
-      </section>
+      else
+        <section className={"hero #{@props.heroClass}"}>
+          <div className="hero-container">
+            <Translate component="h1" user={@userForTitle()} content={"#{@props.translationObjectName}.title"} />
+            {if @props.heroNav?
+              @props.heroNav}
+          </div>
+        </section>}
+
       <section className="resources-container">
         <PromiseRenderer promise={@props.listPromise}>{(ownedResources) =>
           if ownedResources?.length > 0

--- a/app/components/owned-card-list.cjsx
+++ b/app/components/owned-card-list.cjsx
@@ -26,11 +26,35 @@ module.exports = React.createClass
   componentWillUnmount: ->
     document.documentElement.classList.remove 'on-secondary-page'
 
-  userForTitle: ->
-    if @props.ownerName
-      "#{@props.ownerName}'s"
+  getMessageKeyToUseForTitle: ->
+    if @props.filter?
+      if "project_ids" of @props.filter
+        if "owner" of @props.filter
+          if @viewingOwnCollections
+            "#{@props.translationObjectName}.title.project.ownedBySelf"
+          else
+            "#{@props.translationObjectName}.title.project.ownedByOther"
+        else
+          "#{@props.translationObjectName}.title.project.allOwners"
+      else
+        if "owner" of @props.filter
+          if @viewingOwnCollections
+            "#{@props.translationObjectName}.title.allProjects.ownedBySelf"
+          else
+            "#{@props.translationObjectName}.title.allProjects.ownedByOther"
+        else
+          "#{@props.translationObjectName}.title.allProjects.allOwners"
     else
-      'All'
+      "#{@props.translationObjectName}.title.generic"
+
+  getOwnerForTitle: ->
+    console.log 'filter is ',@props.filter
+    if @props.filter? and "owner" of @props.filter
+      return @props.nonBreakableOwnerName
+
+  getProjectForTitle: ->
+    if @props.filter? and "project_ids" of @props.filter
+      return @props.nonBreakableProjectName
 
   getPageClasses: ->
     classes = 'secondary-page all-resources-page'
@@ -44,7 +68,7 @@ module.exports = React.createClass
     <div className={@getPageClasses()}>
       <section className={"hero #{@props.heroClass}"}>
         <div className="hero-container">
-          <Translate component="h1" user={@userForTitle()} content={"#{@props.translationObjectName}.title"} />
+          <Translate component="h1" owner={@getOwnerForTitle()} project={@getProjectForTitle()} content={"#{@getMessageKeyToUseForTitle()}"} />
           {if @props.heroNav?
             @props.heroNav}
         </div>

--- a/app/components/owned-card-list.cjsx
+++ b/app/components/owned-card-list.cjsx
@@ -32,23 +32,23 @@ module.exports = React.createClass
     else
       'All'
 
+  getPageClasses: ->
+    classes = 'secondary-page all-resources-page'
+    if @props.project?
+      classes += ' has-project-context'
+    classes
+
   render: ->
     {location} = @props
 
-    <div className="secondary-page all-resources-page">
-      {if @props.project?
-        <div className="hero-with-context">
+    <div className={@getPageClasses()}>
+      <section className={"hero #{@props.heroClass}"}>
+        <div className="hero-container">
           <Translate component="h1" user={@userForTitle()} content={"#{@props.translationObjectName}.title"} />
+          {if @props.heroNav?
+            @props.heroNav}
         </div>
-      else
-        <section className={"hero #{@props.heroClass}"}>
-          <div className="hero-container">
-            <Translate component="h1" user={@userForTitle()} content={"#{@props.translationObjectName}.title"} />
-            {if @props.heroNav?
-              @props.heroNav}
-          </div>
-        </section>}
-
+      </section>
       <section className="resources-container">
         <PromiseRenderer promise={@props.listPromise}>{(ownedResources) =>
           if ownedResources?.length > 0

--- a/app/components/owned-card-list.cjsx
+++ b/app/components/owned-card-list.cjsx
@@ -5,6 +5,7 @@ Translate = require 'react-translate-component'
 apiClient = require 'panoptes-client/lib/api-client'
 PromiseRenderer = require '../components/promise-renderer'
 OwnedCard = require '../partials/owned-card'
+ContextualLinks = require '../lib/contextual-links'
 {Link} = require 'react-router'
 
 module.exports = React.createClass
@@ -46,13 +47,23 @@ module.exports = React.createClass
         <PromiseRenderer promise={@props.listPromise}>{(ownedResources) =>
           if ownedResources?.length > 0
             meta = ownedResources[0].getMeta()
+            classNames = "resource-results-counter"
+            if meta and @props.removeProjectContextLink?
+              classNames += " remove-project-context-link-follows"
             <div>
-              <div className="resource-results-counter">
+              <div className={classNames}>
                 {if meta
                   pageStart = meta.page * meta.page_size - meta.page_size + 1
                   pageEnd = Math.min(meta.page * meta.page_size, meta.count)
                   count = meta.count
                   <Translate pageStart={pageStart} pageEnd={pageEnd} count={count} content="#{@props.translationObjectName}.countMessage" component="p" />}
+                {if @props.removeProjectContextLink?
+                  link = @props.removeProjectContextLink
+                  <p className="remove-project-context-link">
+                    <Link key="#{link.key}" to="#{link.to}" title="#{link.message.hoverText}" activeClassName="active">
+                      <Translate content="#{link.message.messageKey}" projectDisplayName={link.message.project?.displayName} collectionOwnerName={link.message.user?.displayName} />
+                    </Link>
+                  </p>}
               </div>
               <div className="owned-card-list">
                 {for resource in ownedResources
@@ -62,7 +73,7 @@ module.exports = React.createClass
                      imagePromise={@props.imagePromise(resource)}
                      linkTo={@props.cardLink(resource)}
                      translationObjectName={@props.translationObjectName}
-                     skipOwner={@props.skipOwner} />}
+                     skipOwner={!ContextualLinks.shouldShowCollectionOwner(@props)} />}
               </div>
               <nav>
                 {if meta

--- a/app/components/owned-card-list.cjsx
+++ b/app/components/owned-card-list.cjsx
@@ -27,25 +27,29 @@ module.exports = React.createClass
     document.documentElement.classList.remove 'on-secondary-page'
 
   getMessageKeyToUseForTitle: ->
+    if @props.favorite
+      base = "favorites"
+    else
+      base = "collections"
     if @props.filter?
       if "project_ids" of @props.filter
         if "owner" of @props.filter
           if @viewingOwnCollections
-            "#{@props.translationObjectName}.title.collections.project.ownedBySelf"
+            "#{@props.translationObjectName}.title.#{base}.project.ownedBySelf"
           else
-            "#{@props.translationObjectName}.title.collections.project.ownedByOther"
+            "#{@props.translationObjectName}.title.#{base}.project.ownedByOther"
         else
-          "#{@props.translationObjectName}.title.collections.project.allOwners"
+          "#{@props.translationObjectName}.title.#{base}.project.allOwners"
       else
         if "owner" of @props.filter
           if @viewingOwnCollections
-            "#{@props.translationObjectName}.title.collections.allProjects.ownedBySelf"
+            "#{@props.translationObjectName}.title.#{base}.allProjects.ownedBySelf"
           else
-            "#{@props.translationObjectName}.title.collections.allProjects.ownedByOther"
+            "#{@props.translationObjectName}.title.#{base}.allProjects.ownedByOther"
         else
-          "#{@props.translationObjectName}.title.collections.allProjects.allOwners"
+          "#{@props.translationObjectName}.title.#{base}.allProjects.allOwners"
     else
-      "#{@props.translationObjectName}.title.collections.generic"
+      "#{@props.translationObjectName}.title.#{base}.generic"
 
   getOwnerForTitle: ->
     if @props.filter? and "owner" of @props.filter
@@ -63,7 +67,6 @@ module.exports = React.createClass
 
   render: ->
     {location} = @props
-
     <div className={@getPageClasses()}>
       <section className={"hero #{@props.heroClass}"}>
         <div className="hero-container">
@@ -111,9 +114,9 @@ module.exports = React.createClass
               </nav>
             </div>
           else if ownedResources?.length is 0
-            <Translate content="#{@props.translationObjectName}.notFoundMessage" component="div" />
+            <Translate content="#{@props.translationObjectName}.notFoundMessage" component="div" className="error"/>
           else
-            <Translate content="#{@props.translationObjectName}.loadMessage" component="div" />
+            <Translate content="#{@props.translationObjectName}.loadMessage" component="div" className="loading"/>
         }</PromiseRenderer>
       </section>
     </div>

--- a/app/components/owned-card-list.cjsx
+++ b/app/components/owned-card-list.cjsx
@@ -39,11 +39,13 @@ module.exports = React.createClass
       <section className={"hero #{@props.heroClass}"}>
         <div className="hero-container">
           <Translate component="h1" collectionOwnerName={@props.titleMessageObject.user?.displayName} projectDisplayName={@props.titleMessageObject.project?.displayName} content={"#{@props.titleMessageObject.messageKey}"} />
-          {if @props.heroNav?
+          {if @props.heroNav? and !@props.project?
             @props.heroNav}
         </div>
       </section>
       <section className="resources-container">
+        {if @props.heroNav? and @props.project?
+            @props.heroNav}
         <PromiseRenderer promise={@props.listPromise}>{(ownedResources) =>
           if ownedResources?.length > 0
             meta = ownedResources[0].getMeta()

--- a/app/components/owned-card-list.cjsx
+++ b/app/components/owned-card-list.cjsx
@@ -37,7 +37,7 @@ module.exports = React.createClass
     <div className={@getPageClasses()}>
       <section className={"hero #{@props.heroClass}"}>
         <div className="hero-container">
-          <Translate component="h1" collectionOwnerName={@props.unbreakableCollectionOwnerName} projectDisplayName={@props.unbreakableProjectDisplayName} content={"#{@props.titleMessageKey}"} />
+          <Translate component="h1" collectionOwnerName={@props.titleMessageObject.user?.displayName} projectDisplayName={@props.titleMessageObject.project?.displayName} content={"#{@props.titleMessageObject.messageKey}"} />
           {if @props.heroNav?
             @props.heroNav}
         </div>

--- a/app/components/owned-card-list.cjsx
+++ b/app/components/owned-card-list.cjsx
@@ -26,39 +26,6 @@ module.exports = React.createClass
   componentWillUnmount: ->
     document.documentElement.classList.remove 'on-secondary-page'
 
-  getMessageKeyToUseForTitle: ->
-    if @props.favorite
-      base = "favorites"
-    else
-      base = "collections"
-    if @props.filter?
-      if "project_ids" of @props.filter
-        if "owner" of @props.filter
-          if @viewingOwnCollections
-            "#{@props.translationObjectName}.title.#{base}.project.ownedBySelf"
-          else
-            "#{@props.translationObjectName}.title.#{base}.project.ownedByOther"
-        else
-          "#{@props.translationObjectName}.title.#{base}.project.allOwners"
-      else
-        if "owner" of @props.filter
-          if @viewingOwnCollections
-            "#{@props.translationObjectName}.title.#{base}.allProjects.ownedBySelf"
-          else
-            "#{@props.translationObjectName}.title.#{base}.allProjects.ownedByOther"
-        else
-          "#{@props.translationObjectName}.title.#{base}.allProjects.allOwners"
-    else
-      "#{@props.translationObjectName}.title.#{base}.generic"
-
-  getOwnerForTitle: ->
-    if @props.filter? and "owner" of @props.filter
-      return @props.nonBreakableOwnerName
-
-  getProjectForTitle: ->
-    if @props.filter? and "project_ids" of @props.filter
-      return @props.nonBreakableProjectName
-
   getPageClasses: ->
     classes = 'secondary-page all-resources-page'
     if @props.project?
@@ -70,7 +37,7 @@ module.exports = React.createClass
     <div className={@getPageClasses()}>
       <section className={"hero #{@props.heroClass}"}>
         <div className="hero-container">
-          <Translate component="h1" owner={@getOwnerForTitle()} project={@getProjectForTitle()} content={"#{@getMessageKeyToUseForTitle()}"} />
+          <Translate component="h1" collectionOwnerName={@props.unbreakableCollectionOwnerName} projectDisplayName={@props.unbreakableProjectDisplayName} content={"#{@props.titleMessageKey}"} />
           {if @props.heroNav?
             @props.heroNav}
         </div>

--- a/app/components/owned-card-list.cjsx
+++ b/app/components/owned-card-list.cjsx
@@ -27,30 +27,27 @@ module.exports = React.createClass
     document.documentElement.classList.remove 'on-secondary-page'
 
   getMessageKeyToUseForTitle: ->
-    console.log @props.filter
-    console.log @props.filter?, "project_ids" of @props.filter, "owner" of @props.filter, @viewingOwnCollections
     if @props.filter?
       if "project_ids" of @props.filter
         if "owner" of @props.filter
           if @viewingOwnCollections
-            "#{@props.translationObjectName}.title.project.ownedBySelf"
+            "#{@props.translationObjectName}.title.collections.project.ownedBySelf"
           else
-            "#{@props.translationObjectName}.title.project.ownedByOther"
+            "#{@props.translationObjectName}.title.collections.project.ownedByOther"
         else
-          "#{@props.translationObjectName}.title.project.allOwners"
+          "#{@props.translationObjectName}.title.collections.project.allOwners"
       else
         if "owner" of @props.filter
           if @viewingOwnCollections
-            "#{@props.translationObjectName}.title.allProjects.ownedBySelf"
+            "#{@props.translationObjectName}.title.collections.allProjects.ownedBySelf"
           else
-            "#{@props.translationObjectName}.title.allProjects.ownedByOther"
+            "#{@props.translationObjectName}.title.collections.allProjects.ownedByOther"
         else
-          "#{@props.translationObjectName}.title.allProjects.allOwners"
+          "#{@props.translationObjectName}.title.collections.allProjects.allOwners"
     else
-      "#{@props.translationObjectName}.title.generic"
+      "#{@props.translationObjectName}.title.collections.generic"
 
   getOwnerForTitle: ->
-    console.log "nbo",@props.nonBreakableOwnerName
     if @props.filter? and "owner" of @props.filter
       return @props.nonBreakableOwnerName
 

--- a/app/lib/contextual-links.coffee
+++ b/app/lib/contextual-links.coffee
@@ -414,19 +414,14 @@ module.exports =
     baseType = @getCurrentBaseType(props)
     filterType = @getCurrentFilterType(props)
     title = @getMessageWithData(props, contextUserLogin, context, filterType, baseType, perspective, true)
-    console.log 'context',context
     crossUsersContextualLinks = @getContextualLinksAcrossUsers(props,contextUserLogin)
     crossUsersContextualLinks.sort @sortForCollectionsAndFavorites
-    console.log 'broad',crossUsersContextualLinks
     thisUserContextualLinks = @getContextualLinksForThisUser(props,contextUserLogin)
     thisUserContextualLinks.sort @sortForCollectionsAndFavorites
-    console.log 'user',thisUserContextualLinks
     selfContextualLinks = @getContextualLinksForSelf(props)
     selfContextualLinks.sort @sortForCollectionsAndFavorites
-    console.log 'self',selfContextualLinks
     zooniverseLinks = @getZooniverseLinksForThisBaseType(props, contextUserLogin)
     zooniverseLinks.sort @sortForCollectionsAndFavorites
-    console.log 'zoo',zooniverseLinks
     orderedLinks = crossUsersContextualLinks.concat thisUserContextualLinks, selfContextualLinks, zooniverseLinks
 
     return {

--- a/app/lib/contextual-links.coffee
+++ b/app/lib/contextual-links.coffee
@@ -258,7 +258,7 @@ module.exports =
         displayName: @makeTextUnbreakable(props.project.display_name)
       }
     if currentContext?.includes('project') and !desiredFilterType?.includes('project')
-      message.messageKey = "link.removeProjectContext"
+      message.messageKey = "removeProjectContext." + message.messageKey
       message.hoverText += " on zooniverse.org"
     message.isATitle = title
     return message
@@ -376,8 +376,9 @@ module.exports =
         links.push @getLink(props,contextUserLogin,currentContext,desiredFilterType,@getOppositeBaseType(currentBaseType),"self",false)
     return links
 
-  # A "To the Zooniverse!" project context removal link that will view the same user & baseType in a non-project context
-  getZooniverseLinksForThisBaseType: (props,
+  # A project context removal link that will view the same user & baseType in a non-project context
+  # If not in project context, return null
+  getRemoveProjectContextLink: (props,
     contextUserLogin=@getContextUserLogin(props),
     currentContext=@getCurrentContext(props,contextUserLogin),
     currentFilterType=@getCurrentFilterType(props),
@@ -385,11 +386,11 @@ module.exports =
     currentPerspective=@getCurrentPerspective(props),
     desiredFilterType=@removeProjectFromFilterType(currentFilterType)) ->
 
-    zooniverseLinks = []
     if currentContext.includes("project")
       # if in project context, add "remove project context" link
-      zooniverseLinks.push @getLink(props,contextUserLogin,currentContext,desiredFilterType,currentBaseType,currentPerspective,false)
-    return zooniverseLinks
+      return @getLink(props,contextUserLogin,currentContext,desiredFilterType,currentBaseType,currentPerspective,false)
+    else
+      return null
 
   removeProjectFromFilterType: (filterType) ->
     filterType = "user" if filterType == "user-and-project"
@@ -419,12 +420,16 @@ module.exports =
     thisUserContextualLinks.sort @sortForCollectionsAndFavorites
     selfContextualLinks = @getContextualLinksForSelf(props)
     selfContextualLinks.sort @sortForCollectionsAndFavorites
-    zooniverseLinks = @getZooniverseLinksForThisBaseType(props, contextUserLogin)
-    zooniverseLinks.sort @sortForCollectionsAndFavorites
-    orderedLinks = crossUsersContextualLinks.concat thisUserContextualLinks, selfContextualLinks, zooniverseLinks
+    orderedLinks = crossUsersContextualLinks.concat thisUserContextualLinks, selfContextualLinks
 
     return {
       title: title
       links: orderedLinks
     }
 
+  shouldShowCollectionOwner: (props,
+    contextUserLogin=@getContextUserLogin(props),
+    currentContext=@getCurrentContext(props,contextUserLogin)) ->
+    console.log 'should show determined ',!currentContext.includes("user")
+    return !currentContext.includes("user")
+    

--- a/app/lib/contextual-links.coffee
+++ b/app/lib/contextual-links.coffee
@@ -246,7 +246,7 @@ module.exports =
     message = {}
     message.messageKey = @getMessageKey(props,currentContext,desiredBaseType,desiredFilterType,currentPerspective,title)
     message.hoverText = "View #{@getFilterSummary(props,desiredFilterType,desiredBaseType,currentPerspective)}"
-    if desiredFilterType.includes("user")
+    if desiredFilterType.includes("user") or desiredBaseType=="users"
       message.user = {
         login: @makeTextUnbreakable(contextUserLogin)
         displayName: @makeTextUnbreakable(contextUserLogin) # in future we should get the actual display name

--- a/app/lib/contextual-links.coffee
+++ b/app/lib/contextual-links.coffee
@@ -1,17 +1,388 @@
+# When it comes to "context", there are actually a few different related concepts, which are explained here:
+#
+#  - Base Type   : When looking at user data, we can look at one of two types of set: collections or favorites (which are actually collections under the covers, but have special routes)
+#
+#  - Context     : Pages such as collections, recents, favorites and user profiles can be viewed either in a "zoo-wide" context (@props.project? will be false)
+#                  or in the context of a specific project.
+#                  In a project context, the user can be in the context of a particular user, or all users.
+#                  This gives four possible contexts at any given time: user, project, user + project or everything (zoo-wide, a.k.a. "all").
+#                  When we change context, we don't necessarily change what data is shown, just how it is referred to or presented.
+#
+#  - Filter      : The filter will determine which collections, favorites or recents are actually shown.
+#                  This usually corresponds to the context - but doesn't have to.
+#                  We can filter by project, by user, or by user + project, or have no filter in affect.
+#                  when we change the filter, we modify the query and actually change what data is shown.
+#
+#  - Perspective : Pages such as collections, recents and favorites can be viewed in one of three perspectives:
+#                  - viewing your *own* collections, viewing those of other users while logged in,
+#                  or viewing those of any users while logged out
+#                  When we change perspective, we don't change what content is shown, just how it is referred to or presented.
+#                  (Caveat: Privacy settings may cause different content to be visible depending on who we are - but this is handled
+#                   entirely by the API and is ignored in the front-end except for marking when a collection is Private)
+#
+# Here is a guide to the various contextual URL routes we are supporting:
+#
+#   /projects/project_owner/project_name/collections/collection_owner     -> All collection_owner's collections for project_name
+#   /projects/project_owner/project_name/collections/                     -> All collections for project_name
+#   /collections/collection_owner                                         -> All collections by collection owner
+#   /collections/                                                         -> All collections for all users
+#   /projects/project_owner/project_name/favorites/collection_owner       -> All collection_owner's favorites for project_name
+#   /projects/project_owner/project_name/favorites/                       -> All favorites collections for project_name
+#   /favorites/collection_owner                                           -> All collections owner's favorites
+#   /favorites/                                                           -> All favorites for all users
+#   /users/user_name                                                      -> The profile for user_name, in general Zooniverse context
+#   /projects/project_owner/project_name/users/user_name                  -> The profile for user_name, in the context of project_name
+#   /projects/project_owner/project_name/talk/recents/user_name           -> All recent comments for user_name made to the Talk of project_name
+#   /projects/project_owner/project_name/talk/recents                     -> All recent comments for all users and made to the Talk of project_name
+#   /talk/recents/user_name                                               -> All recent comments made by user_name to all projects
+#   /talk/recents/board_id                                                -> All recent comments on board_id made by user_name
+#   /talk/recents/                                                        -> All recent comments for all users and all projects
+#
+
+
 module.exports =
+
+  
+  #  In general, when we are in a user context, that could be the user who we're logged in as or the user whose content 
+  # we're viewing. Therefore we can deduce this from props 
+  # This method will return the login name of the user whose context we are in
+  # This comes from the collection, if present, otherwise from the logged in user if there is one.
+  # TODO UPDATE THIS FOR TALK RECENTS AND USER PROFILES
+  getContextUserLogin: (props) ->
+    if props.favorite
+      if props.params?.favorites_owner?
+        return props.params.favorites_owner
+      else
+        if props.user?
+          return props.user.login
+        else
+          return props.params.owner
+    else
+      if props.params?.collection_owner?
+        return props.params.collection_owner
+      else
+        if props.user?
+          return props.user.login
+        else
+          return props.params.owner
+  
+  # to discourage navigation links from ending up with a line break on small screens, we can swap all spaces for &nbsp;
+  makeTextUnbreakable: (text) ->
+    text.replace /\ /g, "\u00a0"
+    
   # ensures that a link will stay in the project context if we are in the context of a project
-  prefixLinkIfNeeded: (props,link) ->
+  prefixLinkIfNeeded: (props,url) ->
     if props.project?
       # keeps project in context
-      link = "/projects/#{props.project.slug}" + link
-    return link
+      url = "/projects/#{props.project.slug}" + url
+    return url
 
-  # generate a link to the current page, but forcing any project context to be removed
+  # determines current user/project/user+project filters in effect from the URL.
+  # returns the correct format for directly attaching to the query.
+  getFiltersFromPath: (props) ->
+    #TODO CHECK THIS AGAINST NEW URL SCHEMES
+    #TODO UPDATE ROUTES PER NEW URL SCHEMES
+    filters = {}
+    pathParts = props.location.pathname.split('/')
+    [firstPart, ..., lastPart] = pathParts
+    if firstPart == "projects" and pathParts.length < 6 and lastPart != "all"
+      filters["project_ids"] = @props.project.id
+    if firstPart == "collections" and pathParts.length == 2 and pathParts[1] != "" and pathParts[1] != "all"
+      filters["owner"] = pathParts[1]
+    if firstPart == "favorites" and pathParts.length == 2 and pathParts[1] != "" and pathParts[1] != ""
+      filters["owner"] = pathParts[1]
+    if pathParts.length>4 and pathParts[3] == "collections" and pathParts[4] != "" and pathParts[4] != "all"
+      filters["owner"] = pathParts[4]
+    if pathParts.length>4 and pathParts[3] == "favorites" and pathParts[4] != "" and pathParts[4] != "all"
+      filters["owner"] = pathParts[4]
+    return filters
+
+  # dashes not allowed in message keys, so we map the name. (We keep dashes so we can do things like context.includes("user"). )
+  convertFilterTypeForUseInMessageKey: (filterType) ->
+    if filterType == "user-and-project"
+      return "userAndProject"
+    else
+      return filterType
+
+  viewingAUsersCollectionsOrFavorites: (props) ->
+    pathParts = props.location.pathname.split('/')
+    [first, ..., penultimate, last] = pathParts
+    return last!="" and (penultimate == "collections" or penultimate == "favorites")
+
+  viewingAUserProfile: (props) ->
+    pathParts = props.location.pathname.split('/')
+    [first, ..., penultimate, last] = pathParts
+    return penultimate == "users"
+
+  viewingRecents: (props) ->
+    pathParts = props.location.pathname.split('/')
+    [first, ..., penultimate, last] = pathParts
+    return last == "recents" or penultimate == "recents"
+
+  # determine current context according to whether we are in a project and whether we are focussed on a user
+  getCurrentContext: (props, contextUserLogin=@getContextUserLogin(props)) ->
+    if props.project?
+      if @viewingAUsersCollectionsOrFavorites(props)
+        "user-and-project"
+      else
+        "project"
+    else
+      if @viewingAUsersCollectionsOrFavorites(props)
+        "user"
+      else
+        "all"
+
+  # determine current perspective
+  getCurrentPerspective: (props) ->
+    context=@getCurrentContext(props)
+    contextUserLogin=@getContextUserLogin(props)
+    if props.user?
+      currentUserLogin = props.user.login
+    if context.includes("user")
+      if currentUserLogin? and contextUserLogin==currentUserLogin
+        "self"
+      else
+        "other"
+    else
+      null
+
+  # determine what type of page we are viewing
+  getCurrentBaseType: (props) ->
+    if @viewingAUserProfile(props)
+      "users"
+    else if @viewingRecents(props)
+      "talk/recents"
+    else if props.favorite
+      "favorites"
+    else
+      "collections"
+
+  # determine what filter(s) are in effect - user, project, user-and-project or none ("all")
+  getCurrentFilterType: (props, filter = @getFiltersFromPath(props)) ->
+    if filter?
+      if "project_ids" of filter
+        if "owner" of filter
+          "user-and-project"
+        else
+          "project"
+      else
+        if "owner" of filter
+          "user"
+        else
+          "all"
+    else
+      "all"
+
+  # get a link that is the non-project-specific version of current page    
   getRemoveProjectContextLink: (props) ->
     pathParts = props.location.pathname.split('/')
-    [first, ..., last] = pathParts
+    [first, ...] = pathParts
     if first == "projects"
-      if last == "all"
-        return pathParts[3...-1].join("/")
+      return pathParts[3...].join("/")
+      
+  # construct a message key for a link or title
+  getMessageKey: (props,desiredBaseType,desiredFilterType,currentPerspective,title=false) ->
+    messageKey = ""
+    
+    if props.translationObjectName?
+      messageKey += "#{props.translationObjectName}."
+    
+    if title
+      messageKey += "title"
+    else
+      messageKey += "link"
+      
+    messageKey += ".#{desiredBaseType}.#{@convertFilterTypeForUseInMessageKey(desiredFilterType)}"
+    
+    if currentPerspective?
+      messageKey += ".#{currentPerspective}"
+    else
+      messageKey += ".other"
+    messageKey
+
+  # get message object with needed data for inserts
+  getMessageWithData: (props,
+    contextUserLogin=@getContextUserLogin(props),
+    currentContext=@getCurrentContext(props,contextUserLogin),
+    desiredFilterType=@getCurrentFilterType(props),
+    desiredBaseType=@getCurrentBaseType(props),
+    currentPerspective=@getCurrentPerspective(props),
+    title=false) ->
+
+    message = {}
+    message.messageKey = @getMessageKey(props,desiredBaseType,desiredFilterType,currentPerspective,title)
+    if desiredFilterType.includes("user")
+      message.user = {
+        login: @makeTextUnbreakable(contextUserLogin)
+        displayName: @makeTextUnbreakable(contextUserLogin) #TODO get actual display name
+      }
+    if desiredFilterType.includes("project")
+      message.project = {
+        id: props.project.id
+        slug: props.project.slug
+        displayName: @makeTextUnbreakable(props.project.display_name)
+      }
+    message.isATitle = title
+    return message
+
+  # used by the following method
+  getUniqueId: (length=8) ->
+    id = ""
+    id += Math.random().toString(36).substr(2) while id.length < length
+    id.substr 0, length
+
+  # every link in react needs a unique ID. This creates one.
+  generateUniqueKeyForLinkInstance: (url) ->
+    tokenizedURL =  url.replace /\//g, "_"
+    return "link_#{tokenizedURL}_#{@getUniqueId()}"
+
+  # construct a URL for a link to specified base type with specified filter
+  getURL: (props, desiredBaseType, desiredFilterType) ->
+    url = "/#{desiredBaseType}/"
+    if desiredFilterType.includes("project")
+      url = @prefixLinkIfNeeded(props,url)
+    if desiredFilterType.includes("user")
+      url += "#{@getContextUserLogin(props)}/"
+    return url
+
+  # returns a new filter type, adding in a user filter to whatever is currently present
+  getFilterTypeWithUserFilterAdded: (currentFilterType) ->
+    if currentFilterType=="project"
+      return "user-and-project"
+    else if currentFilterType=="all"
+      return "user"
+    else
+      return currentFilterType
+
+  # get an object with all the necessary information to render a link
+  getLink: (props,
+    contextUserLogin=@getContextUserLogin(props),
+    currentContext=@getCurrentContext(props,contextUserLogin),
+    desiredFilterType=@getCurrentFilterType(props),
+    desiredBaseType=@getCurrentBaseType(props),
+    currentPerspective=@getCurrentPerspective(props),
+    title = false) ->
+
+    url = @getURL(props,desiredBaseType,desiredFilterType)
+
+    if desiredFilterType=="all" or desiredFilterType=="project"
+      linkType="IndexLink"
+    else
+      linkType="Link"
+      
+    return {
+      message: @getMessageWithData(props,contextUserLogin,currentContext,desiredFilterType,desiredBaseType,currentPerspective,title)
+      to: url
+      type: linkType
+      key: @generateUniqueKeyForLinkInstance(url)
+      baseType: desiredBaseType
+    }
+
+  getOppositeBaseType: (baseType) ->
+    if baseType=="collections"
+      return "favorites"
+    else if baseType=="favorites"
+      return "collections"
+    else
+      return baseType
+
+  # links to "all collections", "all favorites", "all project collections", "all project favorites" etc.
+  getContextualLinksAcrossUsers: (props,
+    contextUserLogin=@getContextUserLogin(props),
+    currentContext=@getCurrentContext(props,contextUserLogin),
+    currentFilterType=@getCurrentFilterType(props),
+    currentBaseType=@getCurrentBaseType(props),
+    currentPerspective=@getCurrentPerspective(props)) ->
+
+    links = []
+    if currentContext.includes("project")
+      desiredFilterType="project"
+    else
+      desiredFilterType="all"
+    links.push @getLink(props,contextUserLogin,currentContext,desiredFilterType,currentBaseType,currentPerspective,false)
+    return links
+
+  # links to "user's collections", "user's favorites", "user's project collections", "user's project favorites" etc.
+  getContextualLinksForThisUser: (props,
+    contextUserLogin=@getContextUserLogin(props),
+    currentContext=@getCurrentContext(props,contextUserLogin),
+    currentFilterType=@getCurrentFilterType(props),
+    currentBaseType=@getCurrentBaseType(props),
+    currentPerspective=@getCurrentPerspective(props)) ->
+    links = []
+    if currentContext.includes("user")
+      links.push @getLink(props,contextUserLogin,currentContext,currentFilterType,currentBaseType,currentPerspective,false)
+      links.push @getLink(props,contextUserLogin,currentContext,currentFilterType,@getOppositeBaseType(currentBaseType),currentPerspective,false)
+    return links
+
+  # links to "my collections", "my favorites", etc. (if not already covered in getContextualLinksForThisUser)
+  getContextualLinksForSelf: (props,
+    contextUserLogin=@getContextUserLogin(props),
+    currentContext=@getCurrentContext(props,contextUserLogin),
+    currentFilterType=@getCurrentFilterType(props),
+    currentBaseType=@getCurrentBaseType(props),
+    currentPerspective=@getCurrentPerspective(props)) ->
+
+    links = []
+    if currentContext.includes("user") and (props.user?) and currentPerspective!="self"
+      links.push @getLink(props,props.user.login,currentContext,currentFilterType,currentBaseType,currentPerspective,false)
+      links.push @getLink(props,props.user.login,currentContext,currentFilterType,@getOppositeBaseType(currentBaseType),currentPerspective,false)
+    return links
+
+  # A "To the Zooniverse!" project context removal link that will view the same user & baseType in a non-project context
+  getZooniverseLinksForThisBaseType: (props,
+    contextUserLogin=@getContextUserLogin(props),
+    currentContext=@getCurrentContext(props,contextUserLogin),
+    currentFilterType=@getCurrentFilterType(props),
+    currentBaseType=@getCurrentBaseType(props),
+    currentPerspective=@getCurrentPerspective(props),
+    desiredFilterType=@removeProjectFromFilterType(currentFilterType)) ->
+
+    zooniverseLinks = []
+    if currentContext.includes("project")
+      # if in project context, add "remove project context" link
+      zooniverseLinks.push @getLink(props,contextUserLogin,currentContext,desiredFilterType,currentBaseType,currentPerspective,false)
+    return zooniverseLinks
+
+  removeProjectFromFilterType: (filterType) ->
+    filterType = "user" if filterType == "user-and-project"
+    filterType = "all" if filterType == "project"
+    return filterType
+
+  # sort function that always puts collections before favorites, and leaves everything else untouched.
+  sortForCollectionsAndFavorites: (linkA,linkB) ->
+    if linkA.baseType == "collections"
+        return -1
+      else if linkA.baseType == "favorites"
+        return 1
       else
-        return pathParts[3...].join("/")
+        return 0
+
+  # get a title and list of links for a navigation bar, according to the current context, perspective, base type and filter
+  getContextualTitleAndNavLinks: (props) ->
+    contextUserLogin=@getContextUserLogin(props)
+    context = @getCurrentContext(props, contextUserLogin)
+    perspective = @getCurrentPerspective(props)
+    baseType = @getCurrentBaseType(props)
+    filterType = @getCurrentFilterType(props)
+    title = @getMessageWithData(props, contextUserLogin, context, filterType, baseType, perspective, true)
+
+    crossUsersContextualLinks = @getContextualLinksAcrossUsers(props,contextUserLogin)
+    crossUsersContextualLinks.sort @sortForCollectionsAndFavorites
+    console.log "broad",crossUsersContextualLinks
+    thisUserContextualLinks = @getContextualLinksForThisUser(props,contextUserLogin)
+    thisUserContextualLinks.sort @sortForCollectionsAndFavorites
+    console.log "user",thisUserContextualLinks
+    selfContextualLinks = @getContextualLinksForThisUser(props,contextUserLogin)
+    selfContextualLinks.sort @sortForCollectionsAndFavorites
+    console.log "self",selfContextualLinks
+    zooniverseLinks = @getZooniverseLinksForThisBaseType(props, contextUserLogin)
+    zooniverseLinks.sort @sortForCollectionsAndFavorites
+    console.log "zoo",zooniverseLinks
+    orderedLinks = crossUsersContextualLinks.concat thisUserContextualLinks, selfContextualLinks, zooniverseLinks
+
+    return {
+      title: title
+      links: orderedLinks
+    }
+

--- a/app/lib/contextual-links.coffee
+++ b/app/lib/contextual-links.coffee
@@ -430,6 +430,5 @@ module.exports =
   shouldShowCollectionOwner: (props,
     contextUserLogin=@getContextUserLogin(props),
     currentContext=@getCurrentContext(props,contextUserLogin)) ->
-    console.log 'should show determined ',!currentContext.includes("user")
     return !currentContext.includes("user")
     

--- a/app/lib/contextual-links.coffee
+++ b/app/lib/contextual-links.coffee
@@ -1,0 +1,17 @@
+module.exports =
+  # ensures that a link will stay in the project context if we are in the context of a project
+  prefixLinkIfNeeded: (props,link) ->
+    if props.project?
+      # keeps project in context
+      link = "/projects/#{props.project.slug}" + link
+    return link
+
+  # generate a link to the current page, but forcing any project context to be removed
+  getRemoveProjectContextLink: (props) ->
+    pathParts = props.location.pathname.split('/')
+    [first, ..., last] = pathParts
+    if first == "projects"
+      if last == "all"
+        return pathParts[3...-1].join("/")
+      else
+        return pathParts[3...].join("/")

--- a/app/lib/contextual-links.coffee
+++ b/app/lib/contextual-links.coffee
@@ -49,22 +49,16 @@ module.exports =
   # This comes from the collection, if present, otherwise from the logged in user if there is one.
   # TODO UPDATE THIS FOR TALK RECENTS AND USER PROFILES
   getContextUserLogin: (props) ->
-    if props.favorite
-      if props.params?.favorites_owner?
-        return props.params.favorites_owner
-      else
-        if props.user?
-          return props.user.login
-        else
-          return props.params.owner
+    if props.favorite and props.params?.favorites_owner?
+      return props.params.favorites_owner
+    else if !props.favorite and props.params?.collection_owner?
+      return props.params.collection_owner
+    else if !props.project? and props.params?.owner?
+      return props.params.owner
+    else if props.user?
+      return props.user.login
     else
-      if props.params?.collection_owner?
-        return props.params.collection_owner
-      else
-        if props.user?
-          return props.user.login
-        else
-          return props.params.owner
+      return props.params.owner # which may be null
   
   # to discourage navigation links from ending up with a line break on small screens, we can swap all spaces for &nbsp;
   makeTextUnbreakable: (text) ->
@@ -83,10 +77,11 @@ module.exports =
     #TODO CHECK THIS AGAINST NEW URL SCHEMES
     #TODO UPDATE ROUTES PER NEW URL SCHEMES
     filters = {}
-    pathParts = props.location.pathname.split('/')
+    pathParts = @safelyGetPath(props)
     [firstPart, ..., lastPart] = pathParts
+
     if firstPart == "projects" and pathParts.length < 6 and lastPart != "all"
-      filters["project_ids"] = @props.project.id
+      filters["project_ids"] = props.project.id
     if firstPart == "collections" and pathParts.length == 2 and pathParts[1] != "" and pathParts[1] != "all"
       filters["owner"] = pathParts[1]
     if firstPart == "favorites" and pathParts.length == 2 and pathParts[1] != "" and pathParts[1] != ""
@@ -95,6 +90,7 @@ module.exports =
       filters["owner"] = pathParts[4]
     if pathParts.length>4 and pathParts[3] == "favorites" and pathParts[4] != "" and pathParts[4] != "all"
       filters["owner"] = pathParts[4]
+
     return filters
 
   # dashes not allowed in message keys, so we map the name. (We keep dashes so we can do things like context.includes("user"). )
@@ -104,19 +100,24 @@ module.exports =
     else
       return filterType
 
-  viewingAUsersCollectionsOrFavorites: (props) ->
+  # get the path, ensuring the last element is never an empty string    
+  safelyGetPath: (props) ->
     pathParts = props.location.pathname.split('/')
-    [first, ..., penultimate, last] = pathParts
+    [firstPart, ..., lastPart] = pathParts
+    if lastPart==""
+      pathParts=pathParts.slice 0, -1
+    pathParts
+
+  viewingAUsersCollectionsOrFavorites: (props) ->
+    [first, ..., penultimate, last] = @safelyGetPath(props)
     return last!="" and (penultimate == "collections" or penultimate == "favorites")
 
   viewingAUserProfile: (props) ->
-    pathParts = props.location.pathname.split('/')
-    [first, ..., penultimate, last] = pathParts
+    [first, ..., penultimate, last] = @safelyGetPath(props)
     return penultimate == "users"
 
   viewingRecents: (props) ->
-    pathParts = props.location.pathname.split('/')
-    [first, ..., penultimate, last] = pathParts
+    [first, ..., penultimate, last] = @safelyGetPath(props)
     return last == "recents" or penultimate == "recents"
 
   # determine current context according to whether we are in a project and whether we are focussed on a user
@@ -134,17 +135,11 @@ module.exports =
 
   # determine current perspective
   getCurrentPerspective: (props) ->
-    context=@getCurrentContext(props)
     contextUserLogin=@getContextUserLogin(props)
-    if props.user?
-      currentUserLogin = props.user.login
-    if context.includes("user")
-      if currentUserLogin? and contextUserLogin==currentUserLogin
-        "self"
-      else
-        "other"
+    if props.user?.login? and contextUserLogin==props.user.login
+      "self"
     else
-      null
+      "other"
 
   # determine what type of page we are viewing
   getCurrentBaseType: (props) ->
@@ -175,7 +170,7 @@ module.exports =
 
   # get a link that is the non-project-specific version of current page    
   getRemoveProjectContextLink: (props) ->
-    pathParts = props.location.pathname.split('/')
+    pathParts = @safelyGetPath(props)
     [first, ...] = pathParts
     if first == "projects"
       return pathParts[3...].join("/")
@@ -200,6 +195,32 @@ module.exports =
       messageKey += ".other"
     messageKey
 
+  # string summarizing what we would actually be filtering on for the desired filter
+  getFilterSummary: (props,
+    desiredFilterType=@getCurrentFilterType(props,contextUserLogin),
+    desiredBaseType=@getCurrentBaseType(props),
+    currentPerspective=@getCurrentPerspective(props)) ->
+
+    if desiredFilterType.includes("user")
+      if currentPerspective=='self'
+        summaryString="all my"
+      else
+        summaryString="all this user\'s"
+    else
+      summaryString="all"
+
+    if desiredBaseType=="collections" or desiredBaseType=="favorites"
+      summaryString += " #{desiredBaseType}"
+    else if desiredBaseType=="recents"
+      summaryString += " recent comments"
+    else
+      summaryString += " [#{desiredBaseType}]" # TODO check this
+
+    if desiredFilterType.includes("project")
+      summaryString += " within this project"
+
+    return summaryString
+
   # get message object with needed data for inserts
   getMessageWithData: (props,
     contextUserLogin=@getContextUserLogin(props),
@@ -211,6 +232,7 @@ module.exports =
 
     message = {}
     message.messageKey = @getMessageKey(props,desiredBaseType,desiredFilterType,currentPerspective,title)
+    message.hoverText = "View #{@getFilterSummary(props,desiredFilterType,desiredBaseType,currentPerspective)}"
     if desiredFilterType.includes("user")
       message.user = {
         login: @makeTextUnbreakable(contextUserLogin)
@@ -222,6 +244,9 @@ module.exports =
         slug: props.project.slug
         displayName: @makeTextUnbreakable(props.project.display_name)
       }
+    if currentContext?.includes('project') and !desiredFilterType?.includes('project')
+      message.messageKey = "link.removeProjectContext"
+      message.hoverText += " on zooniverse.org"
     message.isATitle = title
     return message
 
@@ -237,22 +262,22 @@ module.exports =
     return "link_#{tokenizedURL}_#{@getUniqueId()}"
 
   # construct a URL for a link to specified base type with specified filter
-  getURL: (props, desiredBaseType, desiredFilterType) ->
+  getURL: (props, desiredUserLogin, desiredBaseType, desiredFilterType) ->
     url = "/#{desiredBaseType}/"
     if desiredFilterType.includes("project")
       url = @prefixLinkIfNeeded(props,url)
     if desiredFilterType.includes("user")
-      url += "#{@getContextUserLogin(props)}/"
+      url += "#{desiredUserLogin}/"
     return url
 
-  # returns a new filter type, adding in a user filter to whatever is currently present
-  getFilterTypeWithUserFilterAdded: (currentFilterType) ->
-    if currentFilterType=="project"
+  # returns a new filter type or context, adding in a user filter to whatever is currently present
+  addUserToFilterOrContext: (currentValue) ->
+    if currentValue=="project"
       return "user-and-project"
-    else if currentFilterType=="all"
+    else if currentValue=="all"
       return "user"
     else
-      return currentFilterType
+      return currentValue
 
   # get an object with all the necessary information to render a link
   getLink: (props,
@@ -263,7 +288,7 @@ module.exports =
     currentPerspective=@getCurrentPerspective(props),
     title = false) ->
 
-    url = @getURL(props,desiredBaseType,desiredFilterType)
+    url = @getURL(props,contextUserLogin,desiredBaseType,desiredFilterType)
 
     if desiredFilterType=="all" or desiredFilterType=="project"
       linkType="IndexLink"
@@ -300,6 +325,9 @@ module.exports =
     else
       desiredFilterType="all"
     links.push @getLink(props,contextUserLogin,currentContext,desiredFilterType,currentBaseType,currentPerspective,false)
+    if !props.user?
+      # if not logged in, there's room for a link to the other baseType.
+      links.push @getLink(props,contextUserLogin,currentContext,currentFilterType,@getOppositeBaseType(currentBaseType),currentPerspective,false)
     return links
 
   # links to "user's collections", "user's favorites", "user's project collections", "user's project favorites" etc.
@@ -315,18 +343,23 @@ module.exports =
       links.push @getLink(props,contextUserLogin,currentContext,currentFilterType,@getOppositeBaseType(currentBaseType),currentPerspective,false)
     return links
 
+  getSelfIfAvailable: (props) ->
+    if props.user?
+      return props.user.login
+
   # links to "my collections", "my favorites", etc. (if not already covered in getContextualLinksForThisUser)
   getContextualLinksForSelf: (props,
-    contextUserLogin=@getContextUserLogin(props),
+    contextUserLogin=@getSelfIfAvailable(props)
     currentContext=@getCurrentContext(props,contextUserLogin),
     currentFilterType=@getCurrentFilterType(props),
     currentBaseType=@getCurrentBaseType(props),
     currentPerspective=@getCurrentPerspective(props)) ->
 
     links = []
-    if currentContext.includes("user") and (props.user?) and currentPerspective!="self"
-      links.push @getLink(props,props.user.login,currentContext,currentFilterType,currentBaseType,currentPerspective,false)
-      links.push @getLink(props,props.user.login,currentContext,currentFilterType,@getOppositeBaseType(currentBaseType),currentPerspective,false)
+    if props.user? and not (currentContext=="user" or (currentContext=="user-and-project" and currentPerspective=="self"))
+      desiredFilterType = @addUserToFilterOrContext(currentFilterType)
+      links.push @getLink(props,contextUserLogin,currentContext,desiredFilterType,currentBaseType,"self",false)
+      links.push @getLink(props,contextUserLogin,currentContext,desiredFilterType,@getOppositeBaseType(currentBaseType),"self",false)
     return links
 
   # A "To the Zooniverse!" project context removal link that will view the same user & baseType in a non-project context
@@ -366,19 +399,19 @@ module.exports =
     baseType = @getCurrentBaseType(props)
     filterType = @getCurrentFilterType(props)
     title = @getMessageWithData(props, contextUserLogin, context, filterType, baseType, perspective, true)
-
+    console.log 'context',context
     crossUsersContextualLinks = @getContextualLinksAcrossUsers(props,contextUserLogin)
     crossUsersContextualLinks.sort @sortForCollectionsAndFavorites
-    console.log "broad",crossUsersContextualLinks
+    console.log 'broad',crossUsersContextualLinks
     thisUserContextualLinks = @getContextualLinksForThisUser(props,contextUserLogin)
     thisUserContextualLinks.sort @sortForCollectionsAndFavorites
-    console.log "user",thisUserContextualLinks
-    selfContextualLinks = @getContextualLinksForThisUser(props,contextUserLogin)
+    console.log 'user',thisUserContextualLinks
+    selfContextualLinks = @getContextualLinksForSelf(props)
     selfContextualLinks.sort @sortForCollectionsAndFavorites
-    console.log "self",selfContextualLinks
+    console.log 'self',selfContextualLinks
     zooniverseLinks = @getZooniverseLinksForThisBaseType(props, contextUserLogin)
     zooniverseLinks.sort @sortForCollectionsAndFavorites
-    console.log "zoo",zooniverseLinks
+    console.log 'zoo',zooniverseLinks
     orderedLinks = crossUsersContextualLinks.concat thisUserContextualLinks, selfContextualLinks, zooniverseLinks
 
     return {

--- a/app/lib/contextual-links.coffee
+++ b/app/lib/contextual-links.coffee
@@ -47,7 +47,7 @@ module.exports =
   # we're viewing. Therefore we can deduce this from props 
   # This method will return the login name of the user whose context we are in
   # This comes from the collection, if present, otherwise from the logged in user if there is one.
-  # TODO UPDATE THIS FOR TALK RECENTS AND USER PROFILES
+
   getContextUserLogin: (props) ->
     if props.favorite and props.params?.favorites_owner?
       return props.params.favorites_owner
@@ -74,8 +74,6 @@ module.exports =
   # determines current user/project/user+project filters in effect from the URL.
   # returns the correct format for directly attaching to the query.
   getFiltersFromPath: (props) ->
-    #TODO CHECK THIS AGAINST NEW URL SCHEMES
-    #TODO UPDATE ROUTES PER NEW URL SCHEMES
     filters = {}
     pathParts = @safelyGetPath(props)
     [firstPart, ..., lastPart] = pathParts
@@ -215,23 +213,24 @@ module.exports =
     desiredBaseType=@getCurrentBaseType(props),
     currentPerspective=@getCurrentPerspective(props)) ->
 
-    if desiredFilterType.includes("user")
-      if currentPerspective=='self'
-        summaryString="all my"
+    if desiredBaseType=="users"
+      summaryString = "this user's profile"
+    else
+      if desiredFilterType.includes("user")
+        if currentPerspective=='self'
+          summaryString="all my"
+        else
+          summaryString="all this user\'s"
       else
-        summaryString="all this user\'s"
-    else
-      summaryString="all"
+        summaryString="all"
 
-    if desiredBaseType=="collections" or desiredBaseType=="favorites"
-      summaryString += " #{desiredBaseType}"
-    else if desiredBaseType=="recents"
-      summaryString += " recent comments"
-    else
-      summaryString += " [#{desiredBaseType}]" # TODO check this
+      if desiredBaseType=="collections" or desiredBaseType=="favorites"
+        summaryString += " #{desiredBaseType}"
+      else if desiredBaseType=="talk/recents"
+        summaryString += " recent comments"
 
-    if desiredFilterType.includes("project")
-      summaryString += " within this project"
+      if desiredFilterType.includes("project")
+        summaryString += " within this project"
 
     return summaryString
 
@@ -250,7 +249,7 @@ module.exports =
     if desiredFilterType.includes("user")
       message.user = {
         login: @makeTextUnbreakable(contextUserLogin)
-        displayName: @makeTextUnbreakable(contextUserLogin) #TODO get actual display name
+        displayName: @makeTextUnbreakable(contextUserLogin) # in future we should get the actual display name
       }
     if desiredFilterType.includes("project")
       message.project = {

--- a/app/lib/contextual-links.coffee
+++ b/app/lib/contextual-links.coffee
@@ -246,7 +246,8 @@ module.exports =
     message = {}
     message.messageKey = @getMessageKey(props,currentContext,desiredBaseType,desiredFilterType,currentPerspective,title)
     message.hoverText = "View #{@getFilterSummary(props,desiredFilterType,desiredBaseType,currentPerspective)}"
-    if desiredFilterType.includes("user") or desiredBaseType=="users"
+
+    if desiredFilterType.includes("user") or desiredBaseType=="users" or currentContext=="project"
       message.user = {
         login: @makeTextUnbreakable(contextUserLogin)
         displayName: @makeTextUnbreakable(contextUserLogin) # in future we should get the actual display name

--- a/app/pages/collections.cjsx
+++ b/app/pages/collections.cjsx
@@ -22,9 +22,8 @@ counterpart.registerTranslations 'en',
     button: 'View Collection'
     loadMessage: 'Loading Collections'
     notFoundMessage: 'No Collections Found'
-    myCollections: 'My\u00a0Collections'
     favorites: 'My\u00a0Favorites'
-    viewOnZooniverseOrg: 'View on zooniverse.org'
+    viewOnZooniverseOrg: 'View\u00a0on\u00a0zooniverse.org'
     collections:
       project:
         allOwners: 'All\u00a0%(project)s\u00a0Collections'
@@ -79,11 +78,11 @@ CollectionsNav = React.createClass
   renderWithoutProjectContext: ->
     <nav className="hero-nav">
       <IndexLink to="/collections" activeClassName="active">
-        <Translate content="collectionsPage.all" />
+        <Translate content="collectionsPage.collections.allProjects.allOwners" />
       </IndexLink>
       {if @props.user?
         <Link to="/collections/#{@props.user.login}" activeClassName="active">
-          <Translate content="collectionsPage.myCollections" />
+          <Translate content="collectionsPage.title.allProjects.ownedBySelf" />
         </Link>}
       {if @props.user?
         <Link to="/favorites/#{@props.user.login}" activeClassName="active">
@@ -165,7 +164,9 @@ List = React.createClass
   render: ->
     if @props.project?
       @nonBreakableProjectName = @props.project.display_name.replace /\ /g, "\u00a0"
-      @nonBreakableCollectionOwnerName = @getCollectionOwnerName().replace /\ /g, "\u00a0"
+    owner = @getCollectionOwnerName()
+    if owner?
+      @nonBreakableCollectionOwnerName = owner.replace /\ /g, "\u00a0"
 
     <OwnedCardList
       {...@props}

--- a/app/pages/collections.cjsx
+++ b/app/pages/collections.cjsx
@@ -8,8 +8,16 @@ Translate = require 'react-translate-component'
 
 counterpart.registerTranslations 'en',
   collectionsPage:
-    title: '%(user)s Collections'
-    titleWithProjectContext: '%(project)s Collections'
+    title:
+      generic: 'All\u00a0Collections'
+      project:
+        ownedBySelf: 'My\u00a0%(project)s\u00a0Collections'
+        ownedByOther: '%(owner)s\'s\u00a0%(project)s\u00a0Collections'
+        allOwners: '%(project)s\u00a0Collections'
+      allProjects:
+        ownedBySelf: 'My\u00a0Collections'
+        ownedByOther: '%(owner)s\'s\u00a0Collections'
+        allOwners: 'All\u00a0Collections'
     countMessage: 'Showing %(count)s collections'
     button: 'View Collection'
     loadMessage: 'Loading Collections'
@@ -145,10 +153,13 @@ List = React.createClass
     <OwnedCardList
       {...@props}
       translationObjectName="collectionsPage"
-      listPromise={@listCollections(@getCollectionOwnerName()}
+      listPromise={@listCollections(@getCollectionOwnerName())}
       linkTo="collections"
+      filter={@getFiltersFromPath()}
       heroNav={<CollectionsNav user={@props.user} filters={@getFiltersFromPath()} nonBreakableCollectionOwnerName={@nonBreakableCollectionOwnerName} nonBreakableProjectName={@nonBreakableProjectName} project={@props.project} owner={@props.owner} viewingOwnCollections={@checkIfViewingOwnCollections()} collectionOwnerName={@getCollectionOwnerName()} />}
       heroClass="collections-hero"
+      nonBreakableOwnerName={@nonBreakableCollectionOwnerName}
+      nonBreakableProjectName={@nonBreakableProjectName}
       ownerName={@getCollectionOwnerName()}
       skipOwner={!@props.params?.owner}
       imagePromise={@imagePromise}

--- a/app/pages/collections.cjsx
+++ b/app/pages/collections.cjsx
@@ -16,33 +16,49 @@ counterpart.registerTranslations 'en',
     myCollections: 'My\u00a0Collections'
     favorites: 'My\u00a0Favorites'
     allProjectCollections: 'All\u00a0%(project)s\u00a0Collections'
-    allProjectUserCollections: 'All\u00a0%(user)s\'s\u00a0%(project)s\u00a0Collections'
-    allUserCollections: 'All\u00a0%(user)s\'s\u00a0Collections'
+    myProjectCollections: 'My\u00a0%(project)s\u00a0Collections'
+    theirProjectCollections: '%(user)s\'s\u00a0%(project)s\u00a0Collections'
+    allMyCollections: 'All\u00a0My\u00a0Collections'
+    allTheirCollections: 'All\u00a0%(user)s\'s\u00a0Collections'
     allCollections: 'All\u00a0Collections'
 
 CollectionsNav = React.createClass
   displayName: 'CollectionsNav'
 
   renderWithProjectContext: ->
+    console.log @props.nonBreakableCollectionOwnerName
+    if @props.user? and @props.user.login == @props.collectionOwnerName
+      @lookingAtOwnCollections = true
+
     <nav className="hero-nav">
-      <IndexLink to="#{@props.project.slug}/collections">
+      {if @lookingAtOwnCollections
+        <Link to="/projects/#{@props.project.slug}/collections/#{@props.user.login}" activeClassName="active">
+          <Translate content="collectionsPage.myProjectCollections" user={@props.user.login} project={@props.nonBreakableProjectName} />
+        </Link>}
+      {if @lookingAtOwnCollections
+        <Link to="/projects/#{@props.project.slug}/collections/#{@props.collectionOwnerName}/all" activeClassName="active">
+          <Translate content="collectionsPage.allMyCollections" user={@props.nonBreakableCollectionOwnerName} />
+        </Link>}
+      {if !@lookingAtOwnCollections
+        <Link to="/projects/#{@props.project.slug}/collections/#{@props.collectionOwnerName}" activeClassName="active">
+          <Translate content="collectionsPage.theirProjectCollections" user={@props.nonBreakableCollectionOwnerName} project={@props.nonBreakableProjectName} />
+        </Link>}
+      {if !@lookingAtOwnCollections
+        <Link to="/projects/#{@props.project.slug}/collections/#{@props.collectionOwnerName}/all" activeClassName="active">
+          <Translate content="collectionsPage.allTheirCollections" user={@props.nonBreakableCollectionOwnerName} project={@props.nonBreakableProjectName} />
+        </Link>}
+      <IndexLink to="/projects/#{@props.project.slug}/collections" activeClassName="active">
         <Translate content="collectionsPage.allProjectCollections" project={@props.nonBreakableProjectName} />
       </IndexLink>
-      <Link to="#{@props.project.slug}/collections/#{@props.collectionOwnerName}" activeClassName="active">
-        <Translate content="collectionsPage.allProjectUserCollections" user={@props.nonBreakableCollectionOwnerName} project={@props.nonBreakableProjectName} />
-      </Link>
-      <Link to="#{@props.project.slug}/collections/#{@props.collectionOwnerName}/all">
-        <Translate content="collectionsPage.allUserCollections" user={@props.nonBreakableCollectionOwnerName} />
-      </Link>
-      <Link to="#{@props.project.slug}/collections/all">
+      <Link to="/projects/#{@props.project.slug}/collections/all" activeClassName="active">
         <Translate content="collectionsPage.allCollections" />
       </Link>
-      {if @props.user?
-        <Link to="#{@props.project.slug}/collections/#{@props.user.login}" activeClassName="active">
+      {if @props.user? and !@lookingAtOwnCollections
+        <Link to="/projects/#{@props.project.slug}/collections/#{@props.user.login}" activeClassName="active">
           <Translate content="collectionsPage.myCollections" />
         </Link>}
       {if @props.user?
-        <Link to="#{@props.project.slug}/favorites/#{@props.user.login}" activeClassName="active">
+        <Link to="/projects/#{@props.project.slug}/favorites/#{@props.user.login}" activeClassName="active">
           <Translate content="collectionsPage.favorites" />
         </Link>}
     </nav>
@@ -52,7 +68,6 @@ CollectionsNav = React.createClass
       <IndexLink to="/collections" activeClassName="active">
         <Translate content="collectionsPage.all" />
       </IndexLink>
-
       {if @props.user?
         <Link to="/collections/#{@props.user.login}" activeClassName="active">
           <Translate content="collectionsPage.myCollections" />

--- a/app/pages/collections.cjsx
+++ b/app/pages/collections.cjsx
@@ -24,12 +24,15 @@ counterpart.registerTranslations 'en',
     notFoundMessage: 'No Collections Found'
     myCollections: 'My\u00a0Collections'
     favorites: 'My\u00a0Favorites'
-    allProjectCollections: 'All\u00a0%(project)s\u00a0Collections'
-    myProjectCollections: 'My\u00a0%(project)s\u00a0Collections'
-    theirProjectCollections: '%(user)s\'s\u00a0%(project)s\u00a0Collections'
-    allMyCollections: 'All\u00a0My\u00a0Collections'
-    allTheirCollections: 'All\u00a0%(user)s\'s\u00a0Collections'
-    allCollections: 'All\u00a0Collections'
+    collections:
+      project:
+        allOwners: 'All\u00a0%(project)s\u00a0Collections'
+        ownedBySelf: 'My\u00a0%(project)s\u00a0Collections'
+        ownedByOther: '%(user)s\'s\u00a0%(project)s\u00a0Collections'
+      allProjects:
+        allOwners: 'All\u00a0Collections'
+        ownedBySelf: 'All\u00a0My\u00a0Collections'
+        ownedByOther: 'All\u00a0%(user)s\'s\u00a0Collections'
 
 CollectionsNav = React.createClass
   displayName: 'CollectionsNav'
@@ -38,29 +41,29 @@ CollectionsNav = React.createClass
     <nav className="hero-nav">
       {if @props.viewingOwnCollections
         <Link to="/projects/#{@props.project.slug}/collections/#{@props.user.login}" activeClassName="active">
-          <Translate content="collectionsPage.myProjectCollections" user={@props.user.login} project={@props.nonBreakableProjectName} />
+          <Translate content="collectionsPage.collections.project.ownedBySelf" user={@props.user.login} project={@props.nonBreakableProjectName} />
         </Link>}
       {if @props.viewingOwnCollections
         <Link to="/projects/#{@props.project.slug}/collections/#{@props.collectionOwnerName}/all" activeClassName="active">
-          <Translate content="collectionsPage.allMyCollections" user={@props.nonBreakableCollectionOwnerName} />
+          <Translate content="collectionsPage.collections.allProjects.ownedBySelf" user={@props.nonBreakableCollectionOwnerName} />
         </Link>}
       {if !@props.viewingOwnCollections
         <Link to="/projects/#{@props.project.slug}/collections/#{@props.collectionOwnerName}" activeClassName="active">
-          <Translate content="collectionsPage.theirProjectCollections" user={@props.nonBreakableCollectionOwnerName} project={@props.nonBreakableProjectName} />
+          <Translate content="collectionsPage.collections.project.ownedByOther" user={@props.nonBreakableCollectionOwnerName} project={@props.nonBreakableProjectName} />
         </Link>}
       {if !@props.viewingOwnCollections
         <Link to="/projects/#{@props.project.slug}/collections/#{@props.collectionOwnerName}/all" activeClassName="active">
-          <Translate content="collectionsPage.allTheirCollections" user={@props.nonBreakableCollectionOwnerName} project={@props.nonBreakableProjectName} />
+          <Translate content="collectionsPage.collections.allProjects.ownedByOther" user={@props.nonBreakableCollectionOwnerName} project={@props.nonBreakableProjectName} />
         </Link>}
       <IndexLink to="/projects/#{@props.project.slug}/collections" activeClassName="active">
-        <Translate content="collectionsPage.allProjectCollections" project={@props.nonBreakableProjectName} />
+        <Translate content="collectionsPage.collections.project.allOwners" project={@props.nonBreakableProjectName} />
       </IndexLink>
       <Link to="/projects/#{@props.project.slug}/collections/all" activeClassName="active">
-        <Translate content="collectionsPage.allCollections" />
+        <Translate content="collectionsPage.collections.allProjects.allOwners" />
       </Link>
       {if @props.user? and !@props.viewingOwnCollections
         <Link to="/projects/#{@props.project.slug}/collections/#{@props.user.login}/all" activeClassName="active">
-          <Translate content="collectionsPage.myCollections" />
+          <Translate content="collectionsPage.collections.project.ownedBySelf" />
         </Link>}
       {if @props.user?
         <Link to="/projects/#{@props.project.slug}/favorites/#{@props.user.login}" activeClassName="active">

--- a/app/pages/collections.cjsx
+++ b/app/pages/collections.cjsx
@@ -9,7 +9,7 @@ Translate = require 'react-translate-component'
 counterpart.registerTranslations 'en',
   collectionsPage:
     title: '%(user)s Collections'
-    countMessage: 'Showing %(count)s found'
+    countMessage: 'Showing %(count)s collections'
     button: 'View Collection'
     loadMessage: 'Loading Collections'
     notFoundMessage: 'No Collections Found'
@@ -63,6 +63,12 @@ List = React.createClass
 
     apiClient.type('collections').get query
 
+  getCollectionOwnerName: ->
+    if @props.params?.collection_owner?
+      return @props.params.collection_owner
+    else
+      return @props.params.owner
+
   render: ->
     <OwnedCardList
       {...@props}
@@ -71,7 +77,7 @@ List = React.createClass
       linkTo="collections"
       heroNav={<CollectionsNav user={@props.user} />}
       heroClass="collections-hero"
-      ownerName={@props.params?.owner}
+      ownerName={@getCollectionOwnerName()}
       skipOwner={!@props.params?.owner}
       imagePromise={@imagePromise}
       cardLink={@cardLink} />

--- a/app/pages/collections.cjsx
+++ b/app/pages/collections.cjsx
@@ -24,6 +24,7 @@ counterpart.registerTranslations 'en',
     notFoundMessage: 'No Collections Found'
     myCollections: 'My\u00a0Collections'
     favorites: 'My\u00a0Favorites'
+    viewOnZooniverseOrg: 'View on zooniverse.org'
     collections:
       project:
         allOwners: 'All\u00a0%(project)s\u00a0Collections'
@@ -68,6 +69,10 @@ CollectionsNav = React.createClass
       {if @props.user?
         <Link to="/projects/#{@props.project.slug}/favorites/#{@props.user.login}" activeClassName="active">
           <Translate content="collectionsPage.favorites" />
+        </Link>}
+      {if @props.removeProjectContextLink?
+        <Link to="#{@props.removeProjectContextLink}">
+          <Translate content="collectionsPage.viewOnZooniverseOrg" />
         </Link>}
     </nav>
 
@@ -148,6 +153,15 @@ List = React.createClass
   checkIfViewingOwnCollections: ->
     return @props.user? and @props.user.login == @getCollectionOwnerName()
 
+  getRemoveProjectContextLink: ->
+    pathParts = @props.location.pathname.split('/')
+    [first, ..., last] = pathParts
+    if first == "projects"
+      if last == "all"
+        return pathParts[3...-1].join("/")
+      else
+        return pathParts[3...].join("/")
+
   render: ->
     if @props.project?
       @nonBreakableProjectName = @props.project.display_name.replace /\ /g, "\u00a0"
@@ -159,7 +173,7 @@ List = React.createClass
       listPromise={@listCollections(@getCollectionOwnerName())}
       linkTo="collections"
       filter={@getFiltersFromPath()}
-      heroNav={<CollectionsNav user={@props.user} filters={@getFiltersFromPath()} nonBreakableCollectionOwnerName={@nonBreakableCollectionOwnerName} nonBreakableProjectName={@nonBreakableProjectName} project={@props.project} owner={@props.owner} viewingOwnCollections={@checkIfViewingOwnCollections()} collectionOwnerName={@getCollectionOwnerName()} />}
+      heroNav={<CollectionsNav user={@props.user} filters={@getFiltersFromPath()} removeProjectContextLink={@getRemoveProjectContextLink()} nonBreakableCollectionOwnerName={@nonBreakableCollectionOwnerName} nonBreakableProjectName={@nonBreakableProjectName} project={@props.project} owner={@props.owner} viewingOwnCollections={@checkIfViewingOwnCollections()} collectionOwnerName={@getCollectionOwnerName()} />}
       heroClass="collections-hero"
       nonBreakableOwnerName={@nonBreakableCollectionOwnerName}
       nonBreakableProjectName={@nonBreakableProjectName}

--- a/app/pages/collections.cjsx
+++ b/app/pages/collections.cjsx
@@ -105,8 +105,30 @@ counterpart.registerTranslations 'en',
         other: '%(collectionOwnerName)s\'s\u00a0Favorites'
         anonymous:
           user: '%(collectionOwnerName)s\'s\u00a0Favorites'
-    removeProjectContext: 'To\u00a0the\u00a0Zooniverse!'
-
+  removeProjectContext:
+    link:
+      collections:
+        all:
+          self: 'View\u00a0Other\u00a0Zooniverse\u00a0Collections'
+          other: 'View\u00a0Other\u00a0Zooniverse\u00a0Collections'
+          anonymous:
+            project: 'View\u00a0Other\u00a0Zooniverse\u00a0Collections'
+        user:
+          self: 'View\u00a0My\u00a0Other\u00a0Zooniverse\u00a0Collections'
+          other: 'View\u00a0%(collectionOwnerName)s\'s\u00a0Other\u00a0Zooniverse\u00a0Collections'
+          anonymous:
+            userAndProject: 'View\u00a0%(collectionOwnerName)s\'s\u00a0Other\u00a0Zooniverse\u00a0Collections'
+      favorites:
+        all:
+          self: 'View\u00a0Other\u00a0Zooniverse\u00a0Favorites'
+          other: 'View\u00a0Other\u00a0Zooniverse\u00a0Favorites'
+          anonymous:
+            project: 'View\u00a0Other\u00a0Zooniverse\u00a0Favorites'
+        user:
+          self: 'View\u00a0My\u00a0Other\u00a0Zooniverse\u00a0Favorites'
+          other: 'View\u00a0%(collectionOwnerName)s\'s\u00a0Other\u00a0Zooniverse\u00a0Favorites'
+          anonymous:
+            userAndProject: 'View\u00a0%(collectionOwnerName)s\'s\u00a0Other\u00a0Zooniverse\u00a0Favorites'
 
 CollectionsNav = React.createClass
   displayName: 'CollectionsNav'
@@ -169,18 +191,20 @@ List = React.createClass
   render: ->
     titleAndNavLinks = ContextualLinks.getContextualTitleAndNavLinks(@props)
     contextUserLogin = ContextualLinks.getContextUserLogin(@props)
+    removeProjectContextLink = ContextualLinks.getRemoveProjectContextLink(@props,contextUserLogin)
     <OwnedCardList
       {...@props}
       translationObjectName = "collectionsPage"
       contextUserLogin = {contextUserLogin}
       titleAndNavLinks = {titleAndNavLinks}
       listPromise = {@listCollections()}
+      removeProjectContextLink = {removeProjectContextLink}
       linkTo = "collections"
       titleMessageObject = {titleAndNavLinks.title}
       heroNav={<CollectionsNav {...@props} contextUserLogin={contextUserLogin} titleAndNavLinks={titleAndNavLinks} />}
       heroClass = "collections-hero"
       ownerName = {contextUserLogin}
-      skipOwner = {!@props.params?.owner}
+      skipOwner = {false}
       imagePromise = {@imagePromise}
       cardLink = {@cardLink} />
 

--- a/app/pages/collections.cjsx
+++ b/app/pages/collections.cjsx
@@ -28,8 +28,8 @@ counterpart.registerTranslations 'en',
         anonymous:
           project: '%(projectDisplayName)s Collections'
       userAndProject:
-        other: '%(collectionOwnerName)s\'s %(projectDisplayName)s Collections'
-        self: '%(collectionOwnerName)s\'s %(projectDisplayName)s Collections'
+        other: '%(collectionOwnerName)s\'s Collections'
+        self: '%(collectionOwnerName)s\'s Collections'
         anonymous:
           userAndProject: '%(collectionOwnerName)s\'s Collections'
       user:
@@ -49,8 +49,8 @@ counterpart.registerTranslations 'en',
         anonymous:
           project: '%(projectDisplayName)s Favorites'
       userAndProject:
-        self: '%(collectionOwnerName)s\'s %(projectDisplayName)s Favorites'
-        other: '%(collectionOwnerName)s\'s %(projectDisplayName)s Favorites'
+        self: '%(collectionOwnerName)s\'s Favorites'
+        other: '%(collectionOwnerName)s\'s Favorites'
         anonymous:
           userAndProject: '%(collectionOwnerName)s\'s Favorites'
       user:
@@ -61,7 +61,7 @@ counterpart.registerTranslations 'en',
   link:
     collections:
       all:
-        other: 'All Collections'
+        other: 'All\u00a0Collections'
         self: 'All'
         anonymous:
           all: 'Collections'
@@ -73,18 +73,18 @@ counterpart.registerTranslations 'en',
           project: 'Collections'
           userAndProject: 'All'
       userAndProject:
-        other: '%(collectionOwnerName)s\'s Collections'
-        self: 'My Collections'
+        other: '%(collectionOwnerName)s\'s\u00a0Collections'
+        self: 'My\u00a0Collections'
         anonymous:
-          userAndProject: '%(collectionOwnerName)s\'s Collections'
+          userAndProject: '%(collectionOwnerName)s\'s\u00a0Collections'
       user:
-        self: 'My Collections'
-        other: '%(collectionOwnerName)s\'s Collections'
+        self: 'My\u00a0Collections'
+        other: '%(collectionOwnerName)s\'s\u00a0Collections'
         anonymous:
-          user: '%(collectionOwnerName)s\'s Collections'
+          user: '%(collectionOwnerName)s\'s\u00a0Collections'
     favorites:
       all:
-        other: 'All Favorites'
+        other: 'All\u00a0Favorites'
         self: 'All'
         anonymous:
           all: 'Favorites'
@@ -96,16 +96,16 @@ counterpart.registerTranslations 'en',
           project: 'Favorites'
           userAndProject: 'All'
       userAndProject:
-        other: '%(collectionOwnerName)s\'s Favorites'
+        other: '%(collectionOwnerName)s\'s\u00a0Favorites'
         self: 'My Favorites'
         anonymous:
-          userAndProject: '%(collectionOwnerName)s\'s Favorites'
+          userAndProject: '%(collectionOwnerName)s\'s\u00a0Favorites'
       user:
-        self: 'My Favorites'
-        other: '%(collectionOwnerName)s\'s Favorites'
+        self: 'My\u00a0Favorites'
+        other: '%(collectionOwnerName)s\'s\u00a0Favorites'
         anonymous:
-          user: '%(collectionOwnerName)s\'s Favorites'
-    removeProjectContext: 'To the Zooniverse!'
+          user: '%(collectionOwnerName)s\'s\u00a0Favorites'
+    removeProjectContext: 'To\u00a0the\u00a0Zooniverse!'
 
 
 CollectionsNav = React.createClass

--- a/app/pages/collections.cjsx
+++ b/app/pages/collections.cjsx
@@ -1,3 +1,22 @@
+# Since this page appears differently in different situations, here is an explanation of the varying concepts that can affect how this page appears.
+#
+#  - Base Type   : This page can deal with a base type of collections or of favorites (which are actually collections under the covers, but have special routes)
+#
+#  - Context     : This page can be viewed in a "zoo-wide" context (@props.project? will be false) or in the context of a specific project.
+#                  In a project context, it will appear within the project (project menu still visible) and project filters will be available.
+#                  Additionally, we can be in the context of a particular user, or all users. This gives four possible contexts: user, project, user + project or everything (zoo-wide, a.k.a. "all").
+#                  When we change context, we don't change what data is shown, just how it is referred to or presented.
+#
+#  - Filter      : This page can show all the collections or favorites that exist, or it can filter by project, by user, or by user + project.
+#                  Here we are talking about actually changing what data is shown when we change the filter.
+#
+#  - Perspective : This page can be used in three different perspectives - viewing your *own* collections, viewing those of other users while logged in,
+#                  or viewing those of any users while logged out
+#                  When we change perspective, we don't change what content is shown, just how it is referred to or presented.
+#                  (Caveat: Privacy settings may cause different content to be visible depending on who we are - but this is handled
+#                   entirely by the API and is ignored in the front end except for marking when a collection is Private)
+#
+
 counterpart = require 'counterpart'
 React = require 'react'
 TitleMixin = require '../lib/title-mixin'
@@ -33,86 +52,262 @@ counterpart.registerTranslations 'en',
     button: 'View Collection'
     loadMessage: 'Loading Collections'
     notFoundMessage: 'No Collections Found'
-    favorites: 'My\u00a0Favorites'
     viewOnZooniverseOrg: 'View\u00a0on\u00a0zooniverse.org'
     collections:
-      project:
-        allOwners: 'All\u00a0%(project)s\u00a0Collections'
-        ownedBySelf: 'My\u00a0%(project)s\u00a0Collections'
-        ownedByOther: '%(user)s\'s\u00a0%(project)s\u00a0Collections'
-      allProjects:
-        allOwners: 'All\u00a0Collections'
-        ownedBySelf: 'All\u00a0My\u00a0Collections'
-        ownedByOther: 'All\u00a0%(user)s\'s\u00a0Collections'
+      self:
+        all: 'All\u00a0Collections'
+        user: 'All\u00a0My\u00a0Collections'
+        project: 'All\u00a0%(projectName)s\u00a0Collections'
+        userAndProject: 'My\u00a0%(projectName)s\u00a0Collections'
+      other:
+        all: 'All\u00a0Collections'
+        user: 'All\u00a0%(collectionOwnerLogin)s\'s\u00a0Collections'
+        project: 'All\u00a0%(projectName)s\u00a0Collections'
+        userAndProject: '%(collectionOwnerLogin)s\'s\u00a0%(projectName)s\u00a0Collections'
     favorites:
-      project:
-        allOwners: 'All\u00a0%(project)s\u00a0Favorites'
-        ownedBySelf: 'My\u00a0%(project)s\u00a0Favorites'
-        ownedByOther: '%(user)s\'s\u00a0%(project)s\u00a0Favorites'
-      allProjects:
-        allOwners: 'All\u00a0Favorites'
-        ownedBySelf: 'All\u00a0My\u00a0Favorites'
-        ownedByOther: 'All\u00a0%(user)s\'s\u00a0Favorites'
+      self:
+        all: 'All\u00a0Favorites'
+        user: 'My\u00a0Favorites'
+        project: 'All\u00a0%(projectName)s\u00a0Favorites'
+        userAndProject: 'My\u00a0%(projectName)s\u00a0Favorites'
+      other:
+        all: 'All\u00a0Favorites'
+        user: 'All\u00a0%(collectionOwnerLogin)s\'s\u00a0Favorites'
+        project: 'All\u00a0%(project)s\u00a0Favorites'
+        userAndProject: '%(collectionOwnerLogin)s\'s\u00a0%(projectName)s\u00a0Favorites'
+    profile:
+      self:
+        user: 'My\u00a0Profile'
+        userAndProject: 'My\u00a0Profile'
+      other:
+        user: '%(user)s\'s\u00a0Profile'
+        userAndProject: '%(collectionOwnerLogin)s\'s\u00a0Profile'
 
 CollectionsNav = React.createClass
   displayName: 'CollectionsNav'
+  keys: {}
 
-  renderWithProjectContext: ->
-    <nav className="hero-nav">
-      {if @props.viewingOwnCollections
-        <Link to="/projects/#{@props.project.slug}/collections/#{@props.user.login}" activeClassName="active">
-          <Translate content="collectionsPage.collections.project.ownedBySelf" user={@props.user.login} project={@props.nonBreakableProjectName} />
-        </Link>}
-      {if @props.viewingOwnCollections
-        <Link to="/projects/#{@props.project.slug}/collections/#{@props.collectionOwnerName}/all" activeClassName="active">
-          <Translate content="collectionsPage.collections.allProjects.ownedBySelf" user={@props.nonBreakableCollectionOwnerName} />
-        </Link>}
-      {if !@props.viewingOwnCollections
-        <Link to="/projects/#{@props.project.slug}/collections/#{@props.collectionOwnerName}" activeClassName="active">
-          <Translate content="collectionsPage.collections.project.ownedByOther" user={@props.nonBreakableCollectionOwnerName} project={@props.nonBreakableProjectName} />
-        </Link>}
-      {if !@props.viewingOwnCollections
-        <Link to="/projects/#{@props.project.slug}/collections/#{@props.collectionOwnerName}/all" activeClassName="active">
-          <Translate content="collectionsPage.collections.allProjects.ownedByOther" user={@props.nonBreakableCollectionOwnerName} project={@props.nonBreakableProjectName} />
-        </Link>}
-      <IndexLink to="/projects/#{@props.project.slug}/collections" activeClassName="active">
-        <Translate content="collectionsPage.collections.project.allOwners" project={@props.nonBreakableProjectName} />
+  determineSituation: ->
+    if @props.project?
+      if @props.collectionOwnerName?
+        @context = "user-and-project"
+      else
+        @context = "project"
+    else
+      if @props.collectionOwnerName?
+        @context = "user"
+      else
+        @context = "all"
+    if @props.viewingOwnCollections
+      @perspective = "self"
+    else
+      @perspective = "other"
+    if @props.favorite
+      @baseType = "favorites"
+    else
+      @baseType = "collections"
+    if @props.filter?
+      if "project_ids" of @props.filter
+        if "owner" of @props.filter
+          @filterType = "user-and-project"
+        else
+          @filterType = "project"
+      else
+        if "owner" of @props.filter
+          @filterType = "user"
+        else
+          @filterType = "all"
+    else
+      @filterType = "all"
+    console.log "context:",@context,"perspective:",@perspective,"baseType:",@baseType,"filterType:",@filterType,"filter:",@props.filter
+
+  prefixLinkIfNeeded: (link) ->
+    if @context=="project"
+      # keeps project in context
+      link = "/projects/#{@props.project.slug}" + link
+    return link
+
+  suffixLinkIfNeeded: (link) ->
+    if @context == "project" and !@filterType.includes("project")
+      # need to remove project from filter, while keeping it in context
+      link = link + "/all"
+    return link
+
+  uniqueId: (length=8) ->
+    id = ""
+    id += Math.random().toString(36).substr(2) while id.length < length
+    id.substr 0, length
+
+  createLink: (to,linkType="Link") ->
+    return {
+      to: @suffixLinkIfNeeded(@prefixLinkIfNeeded(to))
+      linkType: linkType
+    }
+
+  getRemoveProjectContextLink: ->
+    pathParts = @props.location.pathname.split('/')
+    [first, ..., last] = pathParts
+    if first == "projects"
+      if last == "all"
+        return pathParts[3...-1].join("/")
+      else
+        return pathParts[3...].join("/")
+
+  # When viewing collections, we only show one favorites link - and vice versa - to limit menu options.
+  # This method will retrieve the best single link that is currently viable, for the specified baseType
+  getBestLink: (baseType, candidateLinks) ->
+    if baseType == "favorites"
+      if @context.includes("projects")
+        bestLink = candidateLinks["projects"]
+      else
+        bestLink = candidateLinks["all"]
+    else if baseType == "collections"
+      if @context == "user-and-project"
+        bestLink = candidateLinks["user-and-project"]
+      else if @context == "user"
+        bestLink = candidateLinks["user"]
+      else if @context == "project"
+        bestLink = candidateLinks["project"]
+      else
+        bestLink = candidateLinks["all"]
+    else if baseType == "recents"
+      if @context == "user-and-project"
+        bestLink = candidateLinks["user-and-project"]
+      else if @context == "user"
+        bestLink = candidateLinks["user"]
+      else if @context == "project"
+        bestLink = candidateLinks["project"]
+      else
+        bestLink = candidateLinks["all"]
+    else if baseType == "profile"
+      if @context == "user-and-project"
+        bestLink = candidateLinks["user-and-project"]
+      else
+        bestLink = candidateLinks["user"]
+    return bestLink
+
+  getCamelCase: (filterType) ->
+    if filterType == "user-and-project"
+      return "userAndProject"
+    else
+      return filterType
+
+  # figure out the nav bar, according to current baseType, context, filters and perspective
+  getLinksToShow: ->
+    # links, indexed by baseType then filterType
+    navLinks = {
+      "collections":
+        "all": @createLink("/collections", "IndexLink")
+        "user": @createLink("/collections/#{@props.collectionOwnerLogin}")
+        "project": @createLink("/collections")
+        "user-and-project": @createLink("/collections/#{@props.collectionOwnerLogin}")
+      "favorites":
+        "all": @createLink("/favorites", "IndexLink")
+        "user": @createLink("/favorites/#{@props.collectionOwnerLogin}")
+        "project": @createLink("/favorites")
+        "user-and-project": @createLink("/favorites/#{@props.collectionOwnerLogin}")
+      "profile":
+        "user": @createLink("/users/#{@props.collectionOwnerLogin}")
+        "user-and-project": @createLink("/users/#{@props.collectionOwnerLogin}")
+      "recents":
+        "all": @createLink("/talk/recents")
+        "user": @createLink("/users/#{@props.collectionOwnerLogin}")
+        "project": @createLink("/talk/recents")
+        "user-and-project": @createLink("/users/#{@props.collectionOwnerLogin}")
+    }
+
+    # now we set the message keys, according to context and perspective
+    for baseType,links of navLinks
+      for filterType, to of links
+        links[filterType]["messageKey"] = "collectionsPage.#{baseType}.#{@perspective}.#{@getCamelCase(filterType)}"
+
+    # now we have to decide which links to show, according to base type, filter, context and perspective
+    linksToShow = []
+
+    # first handle collection links
+    if @baseType == "collections"
+      candidateLinks = navLinks[@baseType]
+      linksToShow.push candidateLinks["all"]
+      if @context.includes("user")
+        linksToShow.push candidateLinks["user"]
+      if @context.includes("project")
+        linksToShow.push candidateLinks["user"]
+      if @context == "user-and-project"
+        linksToShow.push candidateLinks["user-and-project"]
+    else
+      linksToShow.push @getBestLink "collections", navLinks["collections"]
+
+    # now favorites links
+    if @baseType == "favorites"
+      candidateLinks = navLinks[@baseType]
+      if @context.includes("project")
+        linksToShow.push candidateLinks["all"]
+      if @context.includes("user")
+        linksToShow.push candidateLinks["user"]
+      if @context.includes("project")
+        linksToShow.push candidateLinks["user"]
+      if @context == "user-and-project"
+        linksToShow.push candidateLinks["user-and-project"]
+    else
+      linksToShow.push @getBestLink "favorites", navLinks["favorites"]
+
+    # now user profile
+    if @context.includes("user")
+      linksToShow.push @getBestLink "profile", navLinks["profile"]
+
+    # now recents
+    # if (viewing profile or project recents)
+    #  linksToShow.push getBestLink "profile", navLinks["profile"]
+
+    # now context removal link
+    contextRemovalLink = @createLink(@getRemoveProjectContextLink())
+    contextRemovalLink["messageKey"] = "collectionsPage.viewOnZooniverseOrg"
+    linksToShow.push contextRemovalLink
+
+    return linksToShow
+
+  makeTextUnbreakable: (text) ->
+    text.replace /\ /g, "\u00a0"
+
+  generateUniqueKeyForLinkInstance: (link) ->
+    key = link.to + "-" + @uniqueId()
+
+  generateTranslateLink: (messageKey) ->
+    if @props.project?
+      if @props.collectionOwnerName?
+        <Translate content="#{messageKey}" projectName={@makeTextUnbreakable(@props.project.display_name)} collectionOwnerLogin={@makeTextUnbreakable(@props.collectionOwnerName)} />
+      else
+        <Translate content="#{messageKey}" projectName={@makeTextUnbreakable(@props.project.display_name)} />
+    else
+      if @props.collectionOwnerName?
+        <Translate content="#{messageKey}" collectionOwnerLogin={@makeTextUnbreakable(@props.collectionOwnerName)} />
+      else
+        <Translate content="#{messageKey}" />
+
+  renderLink: (link) ->
+    key = @generateUniqueKeyForLinkInstance(link)
+    if link.linkType == "IndexLink"
+      <IndexLink key="#{key}" to="#{link.to}" activeClassName="active">
+        {@generateTranslateLink(link.messageKey)}
       </IndexLink>
-      <Link to="/projects/#{@props.project.slug}/collections/all" activeClassName="active">
-        <Translate content="collectionsPage.collections.allProjects.allOwners" />
+    else
+      <Link key="#{key}" to="#{link.to}" activeClassName="active">
+        {@generateTranslateLink(link.messageKey)}
       </Link>
-      {if @props.user? and !@props.viewingOwnCollections
-        <Link to="/projects/#{@props.project.slug}/collections/#{@props.user.login}/all" activeClassName="active">
-          <Translate content="collectionsPage.collections.project.ownedBySelf" />
-        </Link>}
-      {if @props.user?
-        <Link to="/projects/#{@props.project.slug}/favorites/#{@props.user.login}" activeClassName="active">
-          <Translate content="collectionsPage.favorites" />
-        </Link>}
-      {if @props.removeProjectContextLink?
-        <Link to="#{@props.removeProjectContextLink}">
-          <Translate content="collectionsPage.viewOnZooniverseOrg" />
-        </Link>}
+
+  renderNavBar: ->
+    <nav className="hero-nav">
+      {@renderNavLinks()}
     </nav>
 
-  renderWithoutProjectContext: ->
-    <nav className="hero-nav">
-      <IndexLink to="/collections" activeClassName="active">
-        <Translate content="collectionsPage.collections.allProjects.allOwners" />
-      </IndexLink>
-      {if @props.user?
-        <Link to="/collections/#{@props.user.login}" activeClassName="active">
-          <Translate content="collectionsPage.title.collections.allProjects.ownedBySelf" />
-        </Link>}
-      {if @props.user?
-        <Link to="/favorites/#{@props.user.login}" activeClassName="active">
-          <Translate content="collectionsPage.favorites" />
-        </Link>}
-    </nav>
+  renderNavLinks: ->
+    @determineSituation()
+    navLinks = @getLinksToShow()
+    for i, link of navLinks
+      @renderLink(link)
 
   render: ->
-    if @props.project? then @renderWithProjectContext() else @renderWithoutProjectContext()
-
+    @renderNavBar()
 
 List = React.createClass
   displayName: 'List'
@@ -146,10 +341,17 @@ List = React.createClass
 
   # return the display name of the collection owner (just login name for now)
   getCollectionOwnerName: ->
-    if @props.params?.collection_owner?
-      return @props.params.collection_owner
+    if @props.favorite
+      if @props.params?.favorites_owner?
+        return @props.params.favorites_owner
+      else
+        return @props.params.owner
     else
-      return @props.params.owner
+      if @props.params?.collection_owner?
+        return @props.params.collection_owner
+      else
+        return @props.params.owner
+
 
   getFiltersFromPath: ->
     # /projects/project_owner/project_name/collections/collection_owner/all -> All collection_owner's collections, viewed in context of project_name and collection_owner
@@ -158,6 +360,11 @@ List = React.createClass
     # /projects/project_owner/project_name/collections/                     -> All collections for project_name, viewed in context of project_name
     # /collections/collection_owner                                         -> All collections by collection owner, no context
     # /collections/                                                         -> All collections for all users
+    # /projects/project_owner/project_name/favorites/collection_owner       -> All collection_owner's favorites, viewed in context of project_name and collection_owner
+    # /projects/project_owner/project_name/favorites/                       -> All favorites collections for project_name, viewed in context of project_name
+    # /favorites/collection_owner                                           -> All collections owner's favorites, no context
+    # /favorites/                                                           -> All favorites collections for all users
+
     filters = {}
     pathParts = @props.location.pathname.split('/')
     [firstPart, ..., lastPart] = pathParts
@@ -165,40 +372,39 @@ List = React.createClass
       filters["project_ids"] = @props.project.id
     if firstPart == "collections" and pathParts.length == 2 and pathParts[1] != ""
       filters["owner"] = pathParts[1]
+    if firstPart == "favorites" and pathParts.length == 2 and pathParts[1] != ""
+      filters["owner"] = pathParts[1]
     if pathParts.length>4 and pathParts[3] == "collections" and pathParts[4] != "" and pathParts[4] != "all"
+      filters["owner"] = pathParts[4]
+    if pathParts.length>4 and pathParts[3] == "favorites" and pathParts[4] != ""
       filters["owner"] = pathParts[4]
     return filters
 
   checkIfViewingOwnCollections: ->
     return @props.user? and @props.user.login == @getCollectionOwnerName()
 
-  getRemoveProjectContextLink: ->
-    pathParts = @props.location.pathname.split('/')
-    [first, ..., last] = pathParts
-    if first == "projects"
-      if last == "all"
-        return pathParts[3...-1].join("/")
-      else
-        return pathParts[3...].join("/")
+  getHeroNavWithAppropriateParams: ->
+    if @props.params?.collection_owner? or @props.params?.favorites_owner?
+      <CollectionsNav user={@props.user} location={@props.location} filter={@getFiltersFromPath()} project={@props.project} owner={@props.owner} viewingOwnCollections={@checkIfViewingOwnCollections()} collectionOwnerName={@getCollectionOwnerName()} collectionOwnerLogin={@getCollectionOwnerName()} />
+    else
+      <CollectionsNav user={@props.user} location={@props.location} filter={@getFiltersFromPath()} project={@props.project} owner={@props.owner} viewingOwnCollections={@checkIfViewingOwnCollections()} />
 
   render: ->
-    if @props.project?
-      @nonBreakableProjectName = @props.project.display_name.replace /\ /g, "\u00a0"
-    owner = @getCollectionOwnerName()
-    if owner?
-      @nonBreakableCollectionOwnerName = owner.replace /\ /g, "\u00a0"
+    console.log "favorite", @props.favorite
+    if @props.params?.collection_owner? or @props.params?.favorites_owner?
+      collectionOwnerName = @getCollectionOwnerName()
+    else
+      collectionOwnerName = "all"
 
     <OwnedCardList
       {...@props}
       translationObjectName="collectionsPage"
-      listPromise={@listCollections(@getCollectionOwnerName())}
+      listPromise={@listCollections(collectionOwnerName)}
       linkTo="collections"
       filter={@getFiltersFromPath()}
-      heroNav={<CollectionsNav user={@props.user} filters={@getFiltersFromPath()} removeProjectContextLink={@getRemoveProjectContextLink()} nonBreakableCollectionOwnerName={@nonBreakableCollectionOwnerName} nonBreakableProjectName={@nonBreakableProjectName} project={@props.project} owner={@props.owner} viewingOwnCollections={@checkIfViewingOwnCollections()} collectionOwnerName={@getCollectionOwnerName()} />}
+      heroNav={@getHeroNavWithAppropriateParams()}
       heroClass="collections-hero"
-      nonBreakableOwnerName={@nonBreakableCollectionOwnerName}
-      nonBreakableProjectName={@nonBreakableProjectName}
-      ownerName={@getCollectionOwnerName()}
+      ownerName={collectionOwnerName}
       skipOwner={!@props.params?.owner}
       imagePromise={@imagePromise}
       cardLink={@cardLink} />

--- a/app/pages/collections.cjsx
+++ b/app/pages/collections.cjsx
@@ -24,6 +24,7 @@ apiClient = require 'panoptes-client/lib/api-client'
 OwnedCardList = require '../components/owned-card-list'
 Translate = require 'react-translate-component'
 {Link, IndexLink} = require 'react-router'
+ContextualLinks = require '../lib/contextual-links'
 
 counterpart.registerTranslations 'en',
   collectionsPage:
@@ -104,15 +105,6 @@ CollectionsNav = React.createClass
       linkType: linkType
       newFilterType: newFilterType
     }
-
-  getRemoveProjectContextLink: ->
-    pathParts = @props.location.pathname.split('/')
-    [first, ..., last] = pathParts
-    if first == "projects"
-      if last == "all"
-        return pathParts[3...-1].join("/")
-      else
-        return pathParts[3...].join("/")
 
   # When viewing collections, we only show one favorites link - and vice versa - to limit menu options.
   # This method will retrieve the best single link that is currently viable, for the specified baseType
@@ -195,7 +187,7 @@ CollectionsNav = React.createClass
 
     # now context removal link
     if @context.includes("project")
-      contextRemovalLink = @createLink(@filterType,@getRemoveProjectContextLink(),"Link",false,true)
+      contextRemovalLink = @createLink(@filterType,ContextualLinks.getRemoveProjectContextLink(@props),"Link",false,true)
       contextRemovalLink["messageKey"] = "collectionsPage.viewOnZooniverseOrg"
       linksToShow.push contextRemovalLink
 

--- a/app/pages/collections.cjsx
+++ b/app/pages/collections.cjsx
@@ -9,15 +9,26 @@ Translate = require 'react-translate-component'
 counterpart.registerTranslations 'en',
   collectionsPage:
     title:
-      generic: 'All\u00a0Collections'
-      project:
-        ownedBySelf: 'My\u00a0%(project)s\u00a0Collections'
-        ownedByOther: '%(owner)s\'s\u00a0%(project)s\u00a0Collections'
-        allOwners: '%(project)s\u00a0Collections'
-      allProjects:
-        ownedBySelf: 'My\u00a0Collections'
-        ownedByOther: '%(owner)s\'s\u00a0Collections'
-        allOwners: 'All\u00a0Collections'
+      collections:
+        generic: 'All\u00a0Collections'
+        project:
+          ownedBySelf: 'My\u00a0%(project)s\u00a0Collections'
+          ownedByOther: '%(owner)s\'s\u00a0%(project)s\u00a0Collections'
+          allOwners: '%(project)s\u00a0Collections'
+        allProjects:
+          ownedBySelf: 'My\u00a0Collections'
+          ownedByOther: '%(owner)s\'s\u00a0Collections'
+          allOwners: 'All\u00a0Collections'
+      favorites:
+        generic: 'All\u00a0Favorites'
+        project:
+          ownedBySelf: 'My\u00a0%(project)s\u00a0Favorites'
+          ownedByOther: '%(owner)s\'s\u00a0%(project)s\u00a0Favorites'
+          allOwners: '%(project)s\u00a0Favorites'
+        allProjects:
+          ownedBySelf: 'My\u00a0Favorites'
+          ownedByOther: '%(owner)s\'s\u00a0Favorites'
+          allOwners: 'All\u00a0Favorites'
     countMessage: 'Showing %(count)s collections'
     button: 'View Collection'
     loadMessage: 'Loading Collections'
@@ -33,6 +44,15 @@ counterpart.registerTranslations 'en',
         allOwners: 'All\u00a0Collections'
         ownedBySelf: 'All\u00a0My\u00a0Collections'
         ownedByOther: 'All\u00a0%(user)s\'s\u00a0Collections'
+    favorites:
+      project:
+        allOwners: 'All\u00a0%(project)s\u00a0Favorites'
+        ownedBySelf: 'My\u00a0%(project)s\u00a0Favorites'
+        ownedByOther: '%(user)s\'s\u00a0%(project)s\u00a0Favorites'
+      allProjects:
+        allOwners: 'All\u00a0Favorites'
+        ownedBySelf: 'All\u00a0My\u00a0Favorites'
+        ownedByOther: 'All\u00a0%(user)s\'s\u00a0Favorites'
 
 CollectionsNav = React.createClass
   displayName: 'CollectionsNav'
@@ -82,7 +102,7 @@ CollectionsNav = React.createClass
       </IndexLink>
       {if @props.user?
         <Link to="/collections/#{@props.user.login}" activeClassName="active">
-          <Translate content="collectionsPage.title.allProjects.ownedBySelf" />
+          <Translate content="collectionsPage.title.collections.allProjects.ownedBySelf" />
         </Link>}
       {if @props.user?
         <Link to="/favorites/#{@props.user.login}" activeClassName="active">

--- a/app/pages/collections.cjsx
+++ b/app/pages/collections.cjsx
@@ -127,7 +127,6 @@ CollectionsNav = React.createClass
         {@generateTranslateLink(link.message)}
       </Link>
 
-  # TODO add message/stats links in the middle here
   renderNavBar: ->
     <nav className="hero-nav">
       {@renderNavLinks(@props.titleAndNavLinks.links)}

--- a/app/pages/collections.cjsx
+++ b/app/pages/collections.cjsx
@@ -27,27 +27,6 @@ Translate = require 'react-translate-component'
 
 counterpart.registerTranslations 'en',
   collectionsPage:
-    title:
-      collections:
-        generic: 'All\u00a0Collections'
-        project:
-          ownedBySelf: 'My\u00a0%(project)s\u00a0Collections'
-          ownedByOther: '%(owner)s\'s\u00a0%(project)s\u00a0Collections'
-          allOwners: '%(project)s\u00a0Collections'
-        allProjects:
-          ownedBySelf: 'My\u00a0Collections'
-          ownedByOther: '%(owner)s\'s\u00a0Collections'
-          allOwners: 'All\u00a0Collections'
-      favorites:
-        generic: 'All\u00a0Favorites'
-        project:
-          ownedBySelf: 'My\u00a0%(project)s\u00a0Favorites'
-          ownedByOther: '%(owner)s\'s\u00a0%(project)s\u00a0Favorites'
-          allOwners: '%(project)s\u00a0Favorites'
-        allProjects:
-          ownedBySelf: 'My\u00a0Favorites'
-          ownedByOther: '%(owner)s\'s\u00a0Favorites'
-          allOwners: 'All\u00a0Favorites'
     countMessage: 'Showing %(count)s collections'
     button: 'View Collection'
     loadMessage: 'Loading Collections'
@@ -55,93 +34,75 @@ counterpart.registerTranslations 'en',
     viewOnZooniverseOrg: 'View\u00a0on\u00a0zooniverse.org'
     collections:
       self:
-        all: 'All\u00a0Collections'
-        user: 'All\u00a0My\u00a0Collections'
-        project: 'All\u00a0%(projectName)s\u00a0Collections'
-        userAndProject: 'My\u00a0%(projectName)s\u00a0Collections'
+        all: 'All'
+        user: 'My\u00a0Collections'
+        project: '%(projectDisplayName)s'
+        userAndProject: 'My\u00a0%(projectDisplayName)s\u00a0Collections'
       other:
-        all: 'All\u00a0Collections'
-        user: 'All\u00a0%(collectionOwnerLogin)s\'s\u00a0Collections'
-        project: 'All\u00a0%(projectName)s\u00a0Collections'
-        userAndProject: '%(collectionOwnerLogin)s\'s\u00a0%(projectName)s\u00a0Collections'
+        all: 'All'
+        user: '%(collectionOwnerName)s'
+        project: '%(projectDisplayName)s'
+        userAndProject: '%(collectionOwnerName)s in \u00a0%(projectDisplayName)s'
+      short: 'Collections'
     favorites:
       self:
-        all: 'All\u00a0Favorites'
+        all: 'All'
         user: 'My\u00a0Favorites'
-        project: 'All\u00a0%(projectName)s\u00a0Favorites'
-        userAndProject: 'My\u00a0%(projectName)s\u00a0Favorites'
+        project: '%(projectDisplayName)s'
+        userAndProject: 'My\u00a0%(projectDisplayName)s\u00a0Favorites'
       other:
-        all: 'All\u00a0Favorites'
-        user: 'All\u00a0%(collectionOwnerLogin)s\'s\u00a0Favorites'
-        project: 'All\u00a0%(project)s\u00a0Favorites'
-        userAndProject: '%(collectionOwnerLogin)s\'s\u00a0%(projectName)s\u00a0Favorites'
+        all: 'All'
+        user: '%(collectionOwnerName)s'
+        project: '%(projectDisplayName)s'
+        userAndProject: '%(collectionOwnerName)s in \u00a0%(projectDisplayName)s'
+      short: 'Favorites'
     profile:
       self:
         user: 'My\u00a0Profile'
         userAndProject: 'My\u00a0Profile'
       other:
         user: '%(user)s\'s\u00a0Profile'
-        userAndProject: '%(collectionOwnerLogin)s\'s\u00a0Profile'
+        userAndProject: '%(collectionOwnerName)s\'s\u00a0Profile'
+    title:
+      collections:
+        all: 'All\u00a0Collections'
+        user: '%(collectionOwnerName)s\'s\u00a0Collections'
+        project: '\u00a0%(projectDisplayName)s\u00a0Collections'
+        userAndProject: '%(collectionOwnerName)s\'s\u00a0%(projectDisplayName)s\u00a0Collections'
+      favorites:
+        all: 'All\u00a0Favorites'
+        user: '%(collectionOwnerName)s\'s\u00a0Favorites'
+        project: '\u00a0%(projectDisplayName)s\u00a0Favorites'
+        userAndProject: '%(collectionOwnerName)s\'s\u00a0%(projectDisplayName)s\u00a0Favorites'
 
 CollectionsNav = React.createClass
   displayName: 'CollectionsNav'
   keys: {}
 
-  determineSituation: ->
-    if @props.project?
-      if @props.collectionOwnerName?
-        @context = "user-and-project"
-      else
-        @context = "project"
-    else
-      if @props.collectionOwnerName?
-        @context = "user"
-      else
-        @context = "all"
-    if @props.viewingOwnCollections
-      @perspective = "self"
-    else
-      @perspective = "other"
-    if @props.favorite
-      @baseType = "favorites"
-    else
-      @baseType = "collections"
-    if @props.filter?
-      if "project_ids" of @props.filter
-        if "owner" of @props.filter
-          @filterType = "user-and-project"
-        else
-          @filterType = "project"
-      else
-        if "owner" of @props.filter
-          @filterType = "user"
-        else
-          @filterType = "all"
-    else
-      @filterType = "all"
-    console.log "context:",@context,"perspective:",@perspective,"baseType:",@baseType,"filterType:",@filterType,"filter:",@props.filter
-
   prefixLinkIfNeeded: (link) ->
-    if @context=="project"
+    if @context.includes("project")
       # keeps project in context
       link = "/projects/#{@props.project.slug}" + link
     return link
 
-  suffixLinkIfNeeded: (link) ->
-    if @context == "project" and !@filterType.includes("project")
+  suffixLinkIfNeeded: (link,linkShouldRemoveProjectFilter=false) ->
+    if @context.includes("project") and linkShouldRemoveProjectFilter
       # need to remove project from filter, while keeping it in context
       link = link + "/all"
     return link
 
-  uniqueId: (length=8) ->
+  getUniqueId: (length=8) ->
     id = ""
     id += Math.random().toString(36).substr(2) while id.length < length
     id.substr 0, length
 
-  createLink: (to,linkType="Link") ->
+  createLink: (newFilterType,to,linkType="Link", linkShouldRemoveProjectFilter=false, dontModifyLink=false) ->
+    if !dontModifyLink
+      to = @suffixLinkIfNeeded(@prefixLinkIfNeeded(to),linkShouldRemoveProjectFilter)
     return {
-      to: @suffixLinkIfNeeded(@prefixLinkIfNeeded(to))
+      to: to
       linkType: linkType
+      newFilterType: newFilterType
     }
 
   getRemoveProjectContextLink: ->
@@ -155,38 +116,17 @@ CollectionsNav = React.createClass
 
   # When viewing collections, we only show one favorites link - and vice versa - to limit menu options.
   # This method will retrieve the best single link that is currently viable, for the specified baseType
-  getBestLink: (baseType, candidateLinks) ->
-    if baseType == "favorites"
-      if @context.includes("projects")
-        bestLink = candidateLinks["projects"]
-      else
-        bestLink = candidateLinks["all"]
-    else if baseType == "collections"
-      if @context == "user-and-project"
-        bestLink = candidateLinks["user-and-project"]
-      else if @context == "user"
-        bestLink = candidateLinks["user"]
-      else if @context == "project"
-        bestLink = candidateLinks["project"]
-      else
-        bestLink = candidateLinks["all"]
-    else if baseType == "recents"
-      if @context == "user-and-project"
-        bestLink = candidateLinks["user-and-project"]
-      else if @context == "user"
-        bestLink = candidateLinks["user"]
-      else if @context == "project"
-        bestLink = candidateLinks["project"]
-      else
-        bestLink = candidateLinks["all"]
-    else if baseType == "profile"
-      if @context == "user-and-project"
-        bestLink = candidateLinks["user-and-project"]
-      else
-        bestLink = candidateLinks["user"]
+  # candidateLinksForThisType should be an array of links for the desired baseType, keyed by context
+  getBestLink: (baseType, candidateLinksForThisType) ->
+    switch baseType
+      when "favorites","collections","recents" then bestLink = candidateLinksForThisType[@context]
+      when "profile"
+        switch @context
+          when "user-and-project" then bestLink = candidateLinksForThisType["user-and-project"]
+          else bestLink = candidateLinksForThisType["user"]
     return bestLink
 
-  getCamelCase: (filterType) ->
+  convertFilterTypeForMessageKey: (filterType) ->
     if filterType == "user-and-project"
       return "userAndProject"
     else
@@ -194,106 +134,108 @@ CollectionsNav = React.createClass
 
   # figure out the nav bar, according to current baseType, context, filters and perspective
   getLinksToShow: ->
-    # links, indexed by baseType then filterType
-    navLinks = {
+    # candidatelinks, indexed by baseType then filterType
+    candidateLinks = {
       "collections":
-        "all": @createLink("/collections", "IndexLink")
-        "user": @createLink("/collections/#{@props.collectionOwnerLogin}")
-        "project": @createLink("/collections")
-        "user-and-project": @createLink("/collections/#{@props.collectionOwnerLogin}")
+        "all": @createLink("all","/collections", "IndexLink",true)
+        "user": @createLink("user","/collections/#{@props.contextUserLogin}","Link",true)
+        "project": @createLink("project","/collections")
+        "user-and-project": @createLink("user-and-project","/collections/#{@props.contextUserLogin}")
       "favorites":
-        "all": @createLink("/favorites", "IndexLink")
-        "user": @createLink("/favorites/#{@props.collectionOwnerLogin}")
-        "project": @createLink("/favorites")
-        "user-and-project": @createLink("/favorites/#{@props.collectionOwnerLogin}")
+        "all": @createLink("all","/favorites", "IndexLink",true)
+        "user": @createLink("user","/favorites/#{@props.contextUserLogin}","Link",true)
+        "project": @createLink("project","/favorites")
+        "user-and-project": @createLink("user-and-project","/favorites/#{@props.contextUserLogin}")
       "profile":
-        "user": @createLink("/users/#{@props.collectionOwnerLogin}")
-        "user-and-project": @createLink("/users/#{@props.collectionOwnerLogin}")
+        "user": @createLink("user","/users/#{@props.contextUserLogin}","Link",true)
+        "user-and-project": @createLink("user-and-project","/users/#{@props.contextUserLogin}")
       "recents":
-        "all": @createLink("/talk/recents")
-        "user": @createLink("/users/#{@props.collectionOwnerLogin}")
-        "project": @createLink("/talk/recents")
-        "user-and-project": @createLink("/users/#{@props.collectionOwnerLogin}")
+        "all": @createLink("all","/talk/recents")
+        "user": @createLink("user","/users/#{@props.contextUserLogin}")
+        "project": @createLink("project","/talk/recents")
+        "user-and-project": @createLink("user-and-project","/users/#{@props.contextUserLogin}")
     }
 
     # now we set the message keys, according to context and perspective
-    for baseType,links of navLinks
+    for baseType,links of candidateLinks
       for filterType, to of links
-        links[filterType]["messageKey"] = "collectionsPage.#{baseType}.#{@perspective}.#{@getCamelCase(filterType)}"
+        links[filterType]["messageKey"] = "collectionsPage.#{baseType}.#{@perspective}.#{@convertFilterTypeForMessageKey(filterType)}"
 
     # now we have to decide which links to show, according to base type, filter, context and perspective
     linksToShow = []
 
-    # first handle collection links
-    if @baseType == "collections"
-      candidateLinks = navLinks[@baseType]
-      linksToShow.push candidateLinks["all"]
-      if @context.includes("user")
-        linksToShow.push candidateLinks["user"]
-      if @context.includes("project")
-        linksToShow.push candidateLinks["user"]
-      if @context == "user-and-project"
-        linksToShow.push candidateLinks["user-and-project"]
-    else
-      linksToShow.push @getBestLink "collections", navLinks["collections"]
+    # first handle collection links, then favorites links
+    for baseType in ["collections", "favorites"]
+      if baseType == @baseType
+        linksToShow.push candidateLinks[@baseType]["all"]
+        if @context.includes("user")
+          linksToShow.push candidateLinks[@baseType]["user"]
+        if @context.includes("project")
+          linksToShow.push candidateLinks[@baseType]["project"]
+        if @context == "user-and-project"
+          linksToShow.push candidateLinks[@baseType]["user-and-project"]
 
-    # now favorites links
-    if @baseType == "favorites"
-      candidateLinks = navLinks[@baseType]
-      if @context.includes("project")
-        linksToShow.push candidateLinks["all"]
-      if @context.includes("user")
-        linksToShow.push candidateLinks["user"]
-      if @context.includes("project")
-        linksToShow.push candidateLinks["user"]
-      if @context == "user-and-project"
-        linksToShow.push candidateLinks["user-and-project"]
-    else
-      linksToShow.push @getBestLink "favorites", navLinks["favorites"]
+    # now short links to alternate baseType
+    for baseType in ["collections", "favorites"]
+      if baseType != @baseType
+        shortLink = @getBestLink baseType, candidateLinks[baseType]
+        if @context.includes("project") or (!@context.includes("project") and !@props.owner?)
+          # when we are within a project, we shorten the link to make more room - also if logged out not viewing project
+          shortLink.messageKey = "collectionsPage.#{baseType}.short"
+
+        linksToShow.push shortLink
 
     # now user profile
     if @context.includes("user")
-      linksToShow.push @getBestLink "profile", navLinks["profile"]
+      linksToShow.push @getBestLink "profile", candidateLinks["profile"]
 
     # now recents
     # if (viewing profile or project recents)
-    #  linksToShow.push getBestLink "profile", navLinks["profile"]
+    #  linksToShow.push getBestLink "recents", candidateLinks["recents"]
 
     # now context removal link
-    contextRemovalLink = @createLink(@getRemoveProjectContextLink())
-    contextRemovalLink["messageKey"] = "collectionsPage.viewOnZooniverseOrg"
-    linksToShow.push contextRemovalLink
+    if @context.includes("project")
+      contextRemovalLink = @createLink(@filterType,@getRemoveProjectContextLink(),"Link",false,true)
+      contextRemovalLink["messageKey"] = "collectionsPage.viewOnZooniverseOrg"
+      linksToShow.push contextRemovalLink
 
     return linksToShow
 
-  makeTextUnbreakable: (text) ->
-    text.replace /\ /g, "\u00a0"
-
   generateUniqueKeyForLinkInstance: (link) ->
-    key = link.to + "-" + @uniqueId()
+    link.to + "-" + @getUniqueId()
 
   generateTranslateLink: (messageKey) ->
     if @props.project?
       if @props.collectionOwnerName?
-        <Translate content="#{messageKey}" projectName={@makeTextUnbreakable(@props.project.display_name)} collectionOwnerLogin={@makeTextUnbreakable(@props.collectionOwnerName)} />
+        <Translate content="#{messageKey}" projectDisplayName={@props.unbreakableProjectDisplayName} collectionOwnerName={@props.unbreakableCollectionOwnerName} />
       else
-        <Translate content="#{messageKey}" projectName={@makeTextUnbreakable(@props.project.display_name)} />
+        <Translate content="#{messageKey}" projectDisplayName={@props.unbreakableProjectDisplayName} />
     else
       if @props.collectionOwnerName?
-        <Translate content="#{messageKey}" collectionOwnerLogin={@makeTextUnbreakable(@props.collectionOwnerName)} />
+        <Translate content="#{messageKey}" collectionOwnerName={@props.unbreakableCollectionOwnerName} />
       else
         <Translate content="#{messageKey}" />
 
   renderLink: (link) ->
     key = @generateUniqueKeyForLinkInstance(link)
     if link.linkType == "IndexLink"
-      <IndexLink key="#{key}" to="#{link.to}" activeClassName="active">
-        {@generateTranslateLink(link.messageKey)}
-      </IndexLink>
+      if link.newFilterType==@filterType
+        <IndexLink key="#{key}" to="#{link.to}" activeClassName="active">
+          {@generateTranslateLink(link.messageKey)}
+        </IndexLink>
+      else
+        <IndexLink key="#{key}" to="#{link.to}">
+          {@generateTranslateLink(link.messageKey)}
+        </IndexLink>
     else
-      <Link key="#{key}" to="#{link.to}" activeClassName="active">
-        {@generateTranslateLink(link.messageKey)}
-      </Link>
+      if link.newFilterType==@filterType
+        <Link key="#{key}" to="#{link.to}" activeClassName="active">
+          {@generateTranslateLink(link.messageKey)}
+        </Link>
+      else
+        <Link key="#{key}" to="#{link.to}">
+          {@generateTranslateLink(link.messageKey)}
+        </Link>
 
   renderNavBar: ->
     <nav className="hero-nav">
@@ -301,12 +243,15 @@ CollectionsNav = React.createClass
     </nav>
 
   renderNavLinks: ->
-    @determineSituation()
     navLinks = @getLinksToShow()
     for i, link of navLinks
       @renderLink(link)
 
   render: ->
+    @filterType = @props.situation.filterType
+    @perspective = @props.situation.perspective
+    @baseType = @props.situation.baseType
+    @context = @props.situation.context
     @renderNavBar()
 
 List = React.createClass
@@ -328,10 +273,16 @@ List = React.createClass
     else
       "/collections/#{owner}/#{name}"
 
+  convertFilterTypeForMessageKey: (filterType) ->
+    if filterType == "user-and-project"
+      return "userAndProject"
+    else
+      return filterType
+
   listCollections: (collectionOwner,project) ->
-    filters = @getFiltersFromPath()
+    filter = @getFilterFromPath()
     query = {}
-    for field, value of filters
+    for field, value of filter
       query[field] = value
 
     query.favorite = @props.favorite
@@ -339,21 +290,89 @@ List = React.createClass
 
     apiClient.type('collections').get query
 
-  # return the display name of the collection owner (just login name for now)
-  getCollectionOwnerName: ->
+  # return the display name of the user whose context we are in (just login name for now)
+  # comes from collection, if present, otherwise from the logged in user if there is one.
+  getContextUserLogin: ->
     if @props.favorite
       if @props.params?.favorites_owner?
         return @props.params.favorites_owner
       else
-        return @props.params.owner
+        if @props.user?
+          return @props.user.login
+        else
+          return @props.params.owner
     else
       if @props.params?.collection_owner?
         return @props.params.collection_owner
       else
-        return @props.params.owner
+        if @props.user?
+          return @props.user.login
+        else
+          return @props.params.owner
 
+  # determine the current situation: context, perspective, baseType and filterType
+  determineSituation: ->
+    if @props.project?
+      if @contextUserLogin? and @contextUserLogin != "all"
+        # user context comes from the collection owner
+        context = "user-and-project"
+      else
+        if @props.user?
+          # user context comes current logged in user
+          context = "user-and-project"
+        else
+          if @props.params.owner?
+            # user context comes from the URL parameter
+            context = "user-and-project"
+          else
+            context = "project"
+    else
+      if @contextUserLogin? and @contextUserLogin != "all"
+        # user context comes from the collection
+        context = "user"
+      else
+        if @props.user?
+          # user context comes current logged in user
+          context = "user"
+        else
+          if @props.params.owner?
+            # user context comes from the URL parameter
+            context = "user"
+          else
+            context = "all"
+    if @viewingOwnCollections
+      perspective = "self"
+    else
+      perspective = "other"
+    if @props.favorite
+      baseType = "favorites"
+    else
+      baseType = "collections"
+    if @filter?
+      if "project_ids" of @filter
+        if "owner" of @filter
+          filterType = "user-and-project"
+        else
+          filterType = "project"
+      else
+        if "owner" of @filter
+          filterType = "user"
+        else
+          filterType = "all"
+    else
+      filterType = "all"
+    #console.log "context",context,"baseType",baseType,"filterType",filterType,"perspective",perspective
+    return {
+      context: context
+      perspective: perspective
+      baseType: baseType
+      filterType: filterType
+    }
 
-  getFiltersFromPath: ->
+  getTitleMessageKey: ->
+    "collectionsPage.title.#{@situation.baseType}.#{@convertFilterTypeForMessageKey(@situation.filterType)}"
+
+  getFilterFromPath: ->
     # /projects/project_owner/project_name/collections/collection_owner/all -> All collection_owner's collections, viewed in context of project_name and collection_owner
     # /projects/project_owner/project_name/collections/collection_owner     -> All collection_owner's collections for project_name, viewed in context of project_name and collection_owner
     # /projects/project_owner/project_name/collections/all                  -> All collections, viewed in context of project_name
@@ -370,44 +389,78 @@ List = React.createClass
     [firstPart, ..., lastPart] = pathParts
     if firstPart == "projects" and pathParts.length < 6 and lastPart != "all"
       filters["project_ids"] = @props.project.id
-    if firstPart == "collections" and pathParts.length == 2 and pathParts[1] != ""
+    if firstPart == "collections" and pathParts.length == 2 and pathParts[1] != "" and pathParts[1] != "all"
       filters["owner"] = pathParts[1]
-    if firstPart == "favorites" and pathParts.length == 2 and pathParts[1] != ""
+    if firstPart == "favorites" and pathParts.length == 2 and pathParts[1] != "" and pathParts[1] != ""
       filters["owner"] = pathParts[1]
     if pathParts.length>4 and pathParts[3] == "collections" and pathParts[4] != "" and pathParts[4] != "all"
       filters["owner"] = pathParts[4]
-    if pathParts.length>4 and pathParts[3] == "favorites" and pathParts[4] != ""
+    if pathParts.length>4 and pathParts[3] == "favorites" and pathParts[4] != "" and pathParts[4] != "all"
       filters["owner"] = pathParts[4]
     return filters
 
-  checkIfViewingOwnCollections: ->
-    return @props.user? and @props.user.login == @getCollectionOwnerName()
+  makeTextUnbreakable: (text) ->
+    text.replace /\ /g, "\u00a0"
+
+  getUnbreakableProjectDisplayName: ->
+    if @props.project?
+      return @makeTextUnbreakable(@props.project.display_name)
+
+  getUnbreakableCollectionOwnerName: ->
+    if @contextUserLogin? and @contextUserLogin != "all"
+      return @makeTextUnbreakable(@contextUserLogin)
 
   getHeroNavWithAppropriateParams: ->
-    if @props.params?.collection_owner? or @props.params?.favorites_owner?
-      <CollectionsNav user={@props.user} location={@props.location} filter={@getFiltersFromPath()} project={@props.project} owner={@props.owner} viewingOwnCollections={@checkIfViewingOwnCollections()} collectionOwnerName={@getCollectionOwnerName()} collectionOwnerLogin={@getCollectionOwnerName()} />
+    if @props.params?.collection_owner? or @props.params?.favorites_owner? or @props.user? or @props.params.owner?
+      <CollectionsNav user={@props.user}
+                      location={@props.location}
+                      situation={@situation}
+                      unbreakableProjectDisplayName = {@unbreakableProjectDisplayName}
+                      unbreakableCollectionOwnerName = {@unbreakableCollectionOwnerName}
+                      filter={@filter}
+                      project={@props.project}
+                      owner={@props.owner}
+                      viewingOwnCollections={@viewingOwnCollections}
+                      collectionOwnerName={@contextUserLogin}
+                      contextUserLogin={@contextUserLogin} />
     else
-      <CollectionsNav user={@props.user} location={@props.location} filter={@getFiltersFromPath()} project={@props.project} owner={@props.owner} viewingOwnCollections={@checkIfViewingOwnCollections()} />
+      <CollectionsNav user={@props.user}
+                      location={@props.location}
+                      situation={@situation}
+                      unbreakableProjectDisplayName = {@unbreakableProjectDisplayName}
+                      unbreakableCollectionOwnerName = {@unbreakableCollectionOwnerName}
+                      filter={@filter}
+                      project={@props.project}
+                      owner={@props.owner}
+                      viewingOwnCollections={@viewingOwnCollections} />
 
   render: ->
-    console.log "favorite", @props.favorite
-    if @props.params?.collection_owner? or @props.params?.favorites_owner?
-      collectionOwnerName = @getCollectionOwnerName()
+    if @props.params?.collection_owner? or @props.params?.favorites_owner? or @props.user? or @props.params.owner?
+      @contextUserLogin = @getContextUserLogin()
     else
-      collectionOwnerName = "all"
+      @contextUserLogin = "all"
+    @viewingOwnCollections = @props.user? and @props.user.login == @getContextUserLogin()
+    @filter = @getFilterFromPath()
+    @situation = @determineSituation()
+    @unbreakableProjectDisplayName = @getUnbreakableProjectDisplayName()
+    @unbreakableCollectionOwnerName = @getUnbreakableCollectionOwnerName()
 
     <OwnedCardList
       {...@props}
-      translationObjectName="collectionsPage"
-      listPromise={@listCollections(collectionOwnerName)}
-      linkTo="collections"
-      filter={@getFiltersFromPath()}
-      heroNav={@getHeroNavWithAppropriateParams()}
-      heroClass="collections-hero"
-      ownerName={collectionOwnerName}
-      skipOwner={!@props.params?.owner}
-      imagePromise={@imagePromise}
-      cardLink={@cardLink} />
+      translationObjectName = "collectionsPage"
+      unbreakableProjectDisplayName = {@getUnbreakableProjectDisplayName()}
+      unbreakableCollectionOwnerName = {@getUnbreakableCollectionOwnerName()}
+      listPromise = {@listCollections(@contextUserLogin)}
+      linkTo = "collections"
+      filter = {@filter}
+      situation = {@situation}
+      titleMessageKey = {@getTitleMessageKey()}
+      heroNav = {@getHeroNavWithAppropriateParams()}
+      heroClass = "collections-hero"
+      ownerName = {@contextUserLogin}
+      skipOwner = {!@props.params?.owner}
+      imagePromise = {@imagePromise}
+      cardLink = {@cardLink} />
 
 FavoritesList = React.createClass
   displayName: 'FavoritesPage'

--- a/app/pages/collections.cjsx
+++ b/app/pages/collections.cjsx
@@ -17,13 +17,58 @@ counterpart.registerTranslations 'en',
     collections:
       all:
         self: 'All Collections'
+        other: 'All Collections'
+      project:
+        other: '%(projectDisplayName)s Collections'
+        self: '%(projectDisplayName)s Collections'
+      userAndProject:
+        other: '%(collectionOwnerName)s\'s %(projectDisplayName)s Collections'
+        self: '%(collectionOwnerName)s\'s %(projectDisplayName)s Collections'
       user:
         self: 'All %(collectionOwnerName)s\'s Collections'
+        other: 'All %(collectionOwnerName)s\'s Collections'
     favorites:
       all:
         self: 'All Favorites'
+        other: 'All Favorites'
+      project:
+        other: '%(projectDisplayName)s Favorites'
+        self: '%(projectDisplayName)s Favorites'
+      userAndProject:
+        self: '%(collectionOwnerName)s\'s %(projectDisplayName)s Favorites'
+        other: '%(collectionOwnerName)s\'s %(projectDisplayName)s Favorites'
       user:
         self: 'All %(collectionOwnerName)s\'s Favorites'
+        other: 'All %(collectionOwnerName)s\'s Favorites'
+  link:
+    collections:
+      all:
+        other: 'All Collections'
+        self: 'All'
+      project:
+        other: 'All'
+        self: 'All'
+      userAndProject:
+        other: '%(collectionOwnerName)s\'s Collections'
+        self: 'My Collections'
+      user:
+        self: 'My Collections'
+        other: '%(collectionOwnerName)s\'s Collections'
+    favorites:
+      all:
+        other: 'All Favorites'
+        self: 'All'
+      project:
+        other: 'All'
+        self: 'All'
+      userAndProject:
+        other: '%(collectionOwnerName)s\'s Favorites'
+        self: 'My Favorites'
+      user:
+        self: 'My Favorites'
+        other: '%(collectionOwnerName)s\'s Favorites'
+    removeProjectContext: 'To the Zooniverse!'
+
 
 CollectionsNav = React.createClass
   displayName: 'CollectionsNav'
@@ -36,11 +81,11 @@ CollectionsNav = React.createClass
   # render a link from a contextual-links link object
   renderLink: (link) ->
     if link.type=="IndexLink"
-      <IndexLink key="#{link.key}" to="#{link.to}" activeClassName="active">
+      <IndexLink key="#{link.key}" to="#{link.to}" title="#{link.message.hoverText}" activeClassName="active">
         {@generateTranslateLink(link.message)}
       </IndexLink>
     else
-      <Link key="#{link.key}" to="#{link.to}" activeClassName="active">
+      <Link key="#{link.key}" to="#{link.to}" title="#{link.message.hoverText}" activeClassName="active">
         {@generateTranslateLink(link.message)}
       </Link>
 

--- a/app/pages/collections.cjsx
+++ b/app/pages/collections.cjsx
@@ -9,6 +9,7 @@ Translate = require 'react-translate-component'
 counterpart.registerTranslations 'en',
   collectionsPage:
     title: '%(user)s Collections'
+    titleWithProjectContext: '%(project)s Collections'
     countMessage: 'Showing %(count)s collections'
     button: 'View Collection'
     loadMessage: 'Loading Collections'
@@ -26,24 +27,20 @@ CollectionsNav = React.createClass
   displayName: 'CollectionsNav'
 
   renderWithProjectContext: ->
-    console.log @props.nonBreakableCollectionOwnerName
-    if @props.user? and @props.user.login == @props.collectionOwnerName
-      @lookingAtOwnCollections = true
-
     <nav className="hero-nav">
-      {if @lookingAtOwnCollections
+      {if @props.viewingOwnCollections
         <Link to="/projects/#{@props.project.slug}/collections/#{@props.user.login}" activeClassName="active">
           <Translate content="collectionsPage.myProjectCollections" user={@props.user.login} project={@props.nonBreakableProjectName} />
         </Link>}
-      {if @lookingAtOwnCollections
+      {if @props.viewingOwnCollections
         <Link to="/projects/#{@props.project.slug}/collections/#{@props.collectionOwnerName}/all" activeClassName="active">
           <Translate content="collectionsPage.allMyCollections" user={@props.nonBreakableCollectionOwnerName} />
         </Link>}
-      {if !@lookingAtOwnCollections
+      {if !@props.viewingOwnCollections
         <Link to="/projects/#{@props.project.slug}/collections/#{@props.collectionOwnerName}" activeClassName="active">
           <Translate content="collectionsPage.theirProjectCollections" user={@props.nonBreakableCollectionOwnerName} project={@props.nonBreakableProjectName} />
         </Link>}
-      {if !@lookingAtOwnCollections
+      {if !@props.viewingOwnCollections
         <Link to="/projects/#{@props.project.slug}/collections/#{@props.collectionOwnerName}/all" activeClassName="active">
           <Translate content="collectionsPage.allTheirCollections" user={@props.nonBreakableCollectionOwnerName} project={@props.nonBreakableProjectName} />
         </Link>}
@@ -53,8 +50,8 @@ CollectionsNav = React.createClass
       <Link to="/projects/#{@props.project.slug}/collections/all" activeClassName="active">
         <Translate content="collectionsPage.allCollections" />
       </Link>
-      {if @props.user? and !@lookingAtOwnCollections
-        <Link to="/projects/#{@props.project.slug}/collections/#{@props.user.login}" activeClassName="active">
+      {if @props.user? and !@props.viewingOwnCollections
+        <Link to="/projects/#{@props.project.slug}/collections/#{@props.user.login}/all" activeClassName="active">
           <Translate content="collectionsPage.myCollections" />
         </Link>}
       {if @props.user?
@@ -81,6 +78,7 @@ CollectionsNav = React.createClass
   render: ->
     if @props.project? then @renderWithProjectContext() else @renderWithoutProjectContext()
 
+
 List = React.createClass
   displayName: 'List'
 
@@ -95,39 +93,61 @@ List = React.createClass
 
   cardLink: (collection) ->
     [owner, name] = collection.slug.split('/')
-    "/collections/#{owner}/#{name}"
+    if @props.project?
+      "/projects/#{@props.project.slug}/collections/#{owner}/#{name}"
+    else
+      "/collections/#{owner}/#{name}"
 
-  listCollections: (collectionOwner) ->
+  listCollections: (collectionOwner,project) ->
+    filters = @getFiltersFromPath()
     query = {}
-    if collectionOwner?
-      query.owner = collectionOwner
-      query.include = 'owner'
-    else if @props.params?.owner?
-      query.owner = @props.params.owner
-      query.include = 'owner'
+    for field, value of filters
+      query[field] = value
 
     query.favorite = @props.favorite
     Object.assign query, @props.location.query
 
     apiClient.type('collections').get query
 
+  # return the display name of the collection owner (just login name for now)
   getCollectionOwnerName: ->
     if @props.params?.collection_owner?
       return @props.params.collection_owner
     else
       return @props.params.owner
 
+  getFiltersFromPath: ->
+    # /projects/project_owner/project_name/collections/collection_owner/all -> All collection_owner's collections, viewed in context of project_name and collection_owner
+    # /projects/project_owner/project_name/collections/collection_owner     -> All collection_owner's collections for project_name, viewed in context of project_name and collection_owner
+    # /projects/project_owner/project_name/collections/all                  -> All collections, viewed in context of project_name
+    # /projects/project_owner/project_name/collections/                     -> All collections for project_name, viewed in context of project_name
+    # /collections/collection_owner                                         -> All collections by collection owner, no context
+    # /collections/                                                         -> All collections for all users
+    filters = {}
+    pathParts = @props.location.pathname.split('/')
+    [firstPart, ..., lastPart] = pathParts
+    if firstPart == "projects" and pathParts.length < 6 and lastPart != "all"
+      filters["project_ids"] = @props.project.id
+    if firstPart == "collections" and pathParts.length == 2 and pathParts[1] != ""
+      filters["owner"] = pathParts[1]
+    if pathParts.length>4 and pathParts[3] == "collections" and pathParts[4] != "" and pathParts[4] != "all"
+      filters["owner"] = pathParts[4]
+    return filters
+
+  checkIfViewingOwnCollections: ->
+    return @props.user? and @props.user.login == @getCollectionOwnerName()
+
   render: ->
     if @props.project?
       @nonBreakableProjectName = @props.project.display_name.replace /\ /g, "\u00a0"
       @nonBreakableCollectionOwnerName = @getCollectionOwnerName().replace /\ /g, "\u00a0"
-      # TODO replace with owner display name
+
     <OwnedCardList
       {...@props}
       translationObjectName="collectionsPage"
-      listPromise={@listCollections(@getCollectionOwnerName())}
+      listPromise={@listCollections(@getCollectionOwnerName()}
       linkTo="collections"
-      heroNav={<CollectionsNav user={@props.user} nonBreakableCollectionOwnerName={@nonBreakableCollectionOwnerName} nonBreakableProjectName={@nonBreakableProjectName} project={@props.project} owner={@props.owner} collectionOwnerName={@getCollectionOwnerName()} />}
+      heroNav={<CollectionsNav user={@props.user} filters={@getFiltersFromPath()} nonBreakableCollectionOwnerName={@nonBreakableCollectionOwnerName} nonBreakableProjectName={@nonBreakableProjectName} project={@props.project} owner={@props.owner} viewingOwnCollections={@checkIfViewingOwnCollections()} collectionOwnerName={@getCollectionOwnerName()} />}
       heroClass="collections-hero"
       ownerName={@getCollectionOwnerName()}
       skipOwner={!@props.params?.owner}

--- a/app/pages/collections.cjsx
+++ b/app/pages/collections.cjsx
@@ -13,60 +13,98 @@ counterpart.registerTranslations 'en',
     button: 'View Collection'
     loadMessage: 'Loading Collections'
     notFoundMessage: 'No Collections Found'
+
+  # titles/links in the format <link|title>.<baseType>.<desiredFilterType>.<currentPerspective>[.<currentContext>]
   title:
     collections:
       all:
         self: 'All Collections'
         other: 'All Collections'
+        anonymous:
+          all: 'All Collections'
       project:
         other: '%(projectDisplayName)s Collections'
         self: '%(projectDisplayName)s Collections'
+        anonymous:
+          project: '%(projectDisplayName)s Collections'
       userAndProject:
         other: '%(collectionOwnerName)s\'s %(projectDisplayName)s Collections'
         self: '%(collectionOwnerName)s\'s %(projectDisplayName)s Collections'
+        anonymous:
+          userAndProject: '%(collectionOwnerName)s\'s Collections'
       user:
         self: 'All %(collectionOwnerName)s\'s Collections'
         other: 'All %(collectionOwnerName)s\'s Collections'
+        anonymous:
+          user: 'All %(collectionOwnerName)s\'s Collections'
     favorites:
       all:
         self: 'All Favorites'
         other: 'All Favorites'
+        anonymous:
+          all: 'All Favorites'
       project:
         other: '%(projectDisplayName)s Favorites'
         self: '%(projectDisplayName)s Favorites'
+        anonymous:
+          project: '%(projectDisplayName)s Favorites'
       userAndProject:
         self: '%(collectionOwnerName)s\'s %(projectDisplayName)s Favorites'
         other: '%(collectionOwnerName)s\'s %(projectDisplayName)s Favorites'
+        anonymous:
+          userAndProject: '%(collectionOwnerName)s\'s Favorites'
       user:
         self: 'All %(collectionOwnerName)s\'s Favorites'
         other: 'All %(collectionOwnerName)s\'s Favorites'
+        anonymous:
+          user: 'All %(collectionOwnerName)s\'s Favorites'
   link:
     collections:
       all:
         other: 'All Collections'
         self: 'All'
+        anonymous:
+          all: 'Collections'
+          user: 'All'
       project:
         other: 'All'
         self: 'All'
+        anonymous:
+          project: 'Collections'
+          userAndProject: 'All'
       userAndProject:
         other: '%(collectionOwnerName)s\'s Collections'
         self: 'My Collections'
+        anonymous:
+          userAndProject: '%(collectionOwnerName)s\'s Collections'
       user:
         self: 'My Collections'
         other: '%(collectionOwnerName)s\'s Collections'
+        anonymous:
+          user: '%(collectionOwnerName)s\'s Collections'
     favorites:
       all:
         other: 'All Favorites'
         self: 'All'
+        anonymous:
+          all: 'Favorites'
+          user: 'All'
       project:
         other: 'All'
         self: 'All'
+        anonymous:
+          project: 'Favorites'
+          userAndProject: 'All'
       userAndProject:
         other: '%(collectionOwnerName)s\'s Favorites'
         self: 'My Favorites'
+        anonymous:
+          userAndProject: '%(collectionOwnerName)s\'s Favorites'
       user:
         self: 'My Favorites'
         other: '%(collectionOwnerName)s\'s Favorites'
+        anonymous:
+          user: '%(collectionOwnerName)s\'s Favorites'
     removeProjectContext: 'To the Zooniverse!'
 
 

--- a/app/pages/collections.cjsx
+++ b/app/pages/collections.cjsx
@@ -1,22 +1,3 @@
-# Since this page appears differently in different situations, here is an explanation of the varying concepts that can affect how this page appears.
-#
-#  - Base Type   : This page can deal with a base type of collections or of favorites (which are actually collections under the covers, but have special routes)
-#
-#  - Context     : This page can be viewed in a "zoo-wide" context (@props.project? will be false) or in the context of a specific project.
-#                  In a project context, it will appear within the project (project menu still visible) and project filters will be available.
-#                  Additionally, we can be in the context of a particular user, or all users. This gives four possible contexts: user, project, user + project or everything (zoo-wide, a.k.a. "all").
-#                  When we change context, we don't change what data is shown, just how it is referred to or presented.
-#
-#  - Filter      : This page can show all the collections or favorites that exist, or it can filter by project, by user, or by user + project.
-#                  Here we are talking about actually changing what data is shown when we change the filter.
-#
-#  - Perspective : This page can be used in three different perspectives - viewing your *own* collections, viewing those of other users while logged in,
-#                  or viewing those of any users while logged out
-#                  When we change perspective, we don't change what content is shown, just how it is referred to or presented.
-#                  (Caveat: Privacy settings may cause different content to be visible depending on who we are - but this is handled
-#                   entirely by the API and is ignored in the front end except for marking when a collection is Private)
-#
-
 counterpart = require 'counterpart'
 React = require 'react'
 TitleMixin = require '../lib/title-mixin'
@@ -32,218 +13,48 @@ counterpart.registerTranslations 'en',
     button: 'View Collection'
     loadMessage: 'Loading Collections'
     notFoundMessage: 'No Collections Found'
-    viewOnZooniverseOrg: 'View\u00a0on\u00a0zooniverse.org'
+  title:
     collections:
-      self:
-        all: 'All'
-        user: 'My\u00a0Collections'
-        project: '%(projectDisplayName)s'
-        userAndProject: 'My\u00a0%(projectDisplayName)s\u00a0Collections'
-      other:
-        all: 'All'
-        user: '%(collectionOwnerName)s'
-        project: '%(projectDisplayName)s'
-        userAndProject: '%(collectionOwnerName)s in \u00a0%(projectDisplayName)s'
-      short: 'Collections'
+      all:
+        self: 'All Collections'
+      user:
+        self: 'All %(collectionOwnerName)s\'s Collections'
     favorites:
-      self:
-        all: 'All'
-        user: 'My\u00a0Favorites'
-        project: '%(projectDisplayName)s'
-        userAndProject: 'My\u00a0%(projectDisplayName)s\u00a0Favorites'
-      other:
-        all: 'All'
-        user: '%(collectionOwnerName)s'
-        project: '%(projectDisplayName)s'
-        userAndProject: '%(collectionOwnerName)s in \u00a0%(projectDisplayName)s'
-      short: 'Favorites'
-    profile:
-      self:
-        user: 'My\u00a0Profile'
-        userAndProject: 'My\u00a0Profile'
-      other:
-        user: '%(user)s\'s\u00a0Profile'
-        userAndProject: '%(collectionOwnerName)s\'s\u00a0Profile'
-    title:
-      collections:
-        all: 'All\u00a0Collections'
-        user: '%(collectionOwnerName)s\'s\u00a0Collections'
-        project: '\u00a0%(projectDisplayName)s\u00a0Collections'
-        userAndProject: '%(collectionOwnerName)s\'s\u00a0%(projectDisplayName)s\u00a0Collections'
-      favorites:
-        all: 'All\u00a0Favorites'
-        user: '%(collectionOwnerName)s\'s\u00a0Favorites'
-        project: '\u00a0%(projectDisplayName)s\u00a0Favorites'
-        userAndProject: '%(collectionOwnerName)s\'s\u00a0%(projectDisplayName)s\u00a0Favorites'
+      all:
+        self: 'All Favorites'
+      user:
+        self: 'All %(collectionOwnerName)s\'s Favorites'
 
 CollectionsNav = React.createClass
   displayName: 'CollectionsNav'
   keys: {}
 
-  prefixLinkIfNeeded: (link) ->
-    if @context.includes("project")
-      # keeps project in context
-      link = "/projects/#{@props.project.slug}" + link
-    return link
+  # generate a translated message from a contextual-links message object
+  generateTranslateLink: (message) ->
+    <Translate content="#{message.messageKey}" projectDisplayName={message.project?.displayName} collectionOwnerName={message.user?.displayName} />
 
-  suffixLinkIfNeeded: (link,linkShouldRemoveProjectFilter=false) ->
-    if @context.includes("project") and linkShouldRemoveProjectFilter
-      # need to remove project from filter, while keeping it in context
-      link = link + "/all"
-    return link
-
-  getUniqueId: (length=8) ->
-    id = ""
-    id += Math.random().toString(36).substr(2) while id.length < length
-    id.substr 0, length
-
-  createLink: (newFilterType,to,linkType="Link", linkShouldRemoveProjectFilter=false, dontModifyLink=false) ->
-    if !dontModifyLink
-      to = @suffixLinkIfNeeded(@prefixLinkIfNeeded(to),linkShouldRemoveProjectFilter)
-    return {
-      to: to
-      linkType: linkType
-      newFilterType: newFilterType
-    }
-
-  # When viewing collections, we only show one favorites link - and vice versa - to limit menu options.
-  # This method will retrieve the best single link that is currently viable, for the specified baseType
-  # candidateLinksForThisType should be an array of links for the desired baseType, keyed by context
-  getBestLink: (baseType, candidateLinksForThisType) ->
-    switch baseType
-      when "favorites","collections","recents" then bestLink = candidateLinksForThisType[@context]
-      when "profile"
-        switch @context
-          when "user-and-project" then bestLink = candidateLinksForThisType["user-and-project"]
-          else bestLink = candidateLinksForThisType["user"]
-    return bestLink
-
-  convertFilterTypeForMessageKey: (filterType) ->
-    if filterType == "user-and-project"
-      return "userAndProject"
-    else
-      return filterType
-
-  # figure out the nav bar, according to current baseType, context, filters and perspective
-  getLinksToShow: ->
-    # candidatelinks, indexed by baseType then filterType
-    candidateLinks = {
-      "collections":
-        "all": @createLink("all","/collections", "IndexLink",true)
-        "user": @createLink("user","/collections/#{@props.contextUserLogin}","Link",true)
-        "project": @createLink("project","/collections")
-        "user-and-project": @createLink("user-and-project","/collections/#{@props.contextUserLogin}")
-      "favorites":
-        "all": @createLink("all","/favorites", "IndexLink",true)
-        "user": @createLink("user","/favorites/#{@props.contextUserLogin}","Link",true)
-        "project": @createLink("project","/favorites")
-        "user-and-project": @createLink("user-and-project","/favorites/#{@props.contextUserLogin}")
-      "profile":
-        "user": @createLink("user","/users/#{@props.contextUserLogin}","Link",true)
-        "user-and-project": @createLink("user-and-project","/users/#{@props.contextUserLogin}")
-      "recents":
-        "all": @createLink("all","/talk/recents")
-        "user": @createLink("user","/users/#{@props.contextUserLogin}")
-        "project": @createLink("project","/talk/recents")
-        "user-and-project": @createLink("user-and-project","/users/#{@props.contextUserLogin}")
-    }
-
-    # now we set the message keys, according to context and perspective
-    for baseType,links of candidateLinks
-      for filterType, to of links
-        links[filterType]["messageKey"] = "collectionsPage.#{baseType}.#{@perspective}.#{@convertFilterTypeForMessageKey(filterType)}"
-
-    # now we have to decide which links to show, according to base type, filter, context and perspective
-    linksToShow = []
-
-    # first handle collection links, then favorites links
-    for baseType in ["collections", "favorites"]
-      if baseType == @baseType
-        linksToShow.push candidateLinks[@baseType]["all"]
-        if @context.includes("user")
-          linksToShow.push candidateLinks[@baseType]["user"]
-        if @context.includes("project")
-          linksToShow.push candidateLinks[@baseType]["project"]
-        if @context == "user-and-project"
-          linksToShow.push candidateLinks[@baseType]["user-and-project"]
-
-    # now short links to alternate baseType
-    for baseType in ["collections", "favorites"]
-      if baseType != @baseType
-        shortLink = @getBestLink baseType, candidateLinks[baseType]
-        if @context.includes("project") or (!@context.includes("project") and !@props.owner?)
-          # when we are within a project, we shorten the link to make more room - also if logged out not viewing project
-          shortLink.messageKey = "collectionsPage.#{baseType}.short"
-
-        linksToShow.push shortLink
-
-    # now user profile
-    if @context.includes("user")
-      linksToShow.push @getBestLink "profile", candidateLinks["profile"]
-
-    # now recents
-    # if (viewing profile or project recents)
-    #  linksToShow.push getBestLink "recents", candidateLinks["recents"]
-
-    # now context removal link
-    if @context.includes("project")
-      contextRemovalLink = @createLink(@filterType,ContextualLinks.getRemoveProjectContextLink(@props),"Link",false,true)
-      contextRemovalLink["messageKey"] = "collectionsPage.viewOnZooniverseOrg"
-      linksToShow.push contextRemovalLink
-
-    return linksToShow
-
-  generateUniqueKeyForLinkInstance: (link) ->
-    link.to + "-" + @getUniqueId()
-
-  generateTranslateLink: (messageKey) ->
-    if @props.project?
-      if @props.collectionOwnerName?
-        <Translate content="#{messageKey}" projectDisplayName={@props.unbreakableProjectDisplayName} collectionOwnerName={@props.unbreakableCollectionOwnerName} />
-      else
-        <Translate content="#{messageKey}" projectDisplayName={@props.unbreakableProjectDisplayName} />
-    else
-      if @props.collectionOwnerName?
-        <Translate content="#{messageKey}" collectionOwnerName={@props.unbreakableCollectionOwnerName} />
-      else
-        <Translate content="#{messageKey}" />
-
+  # render a link from a contextual-links link object
   renderLink: (link) ->
-    key = @generateUniqueKeyForLinkInstance(link)
-    if link.linkType == "IndexLink"
-      if link.newFilterType==@filterType
-        <IndexLink key="#{key}" to="#{link.to}" activeClassName="active">
-          {@generateTranslateLink(link.messageKey)}
-        </IndexLink>
-      else
-        <IndexLink key="#{key}" to="#{link.to}">
-          {@generateTranslateLink(link.messageKey)}
-        </IndexLink>
+    if link.type=="IndexLink"
+      <IndexLink key="#{link.key}" to="#{link.to}" activeClassName="active">
+        {@generateTranslateLink(link.message)}
+      </IndexLink>
     else
-      if link.newFilterType==@filterType
-        <Link key="#{key}" to="#{link.to}" activeClassName="active">
-          {@generateTranslateLink(link.messageKey)}
-        </Link>
-      else
-        <Link key="#{key}" to="#{link.to}">
-          {@generateTranslateLink(link.messageKey)}
-        </Link>
+      <Link key="#{link.key}" to="#{link.to}" activeClassName="active">
+        {@generateTranslateLink(link.message)}
+      </Link>
 
+  # TODO add message/stats links in the middle here
   renderNavBar: ->
     <nav className="hero-nav">
-      {@renderNavLinks()}
+      {@renderNavLinks(@props.titleAndNavLinks.links)}
     </nav>
 
-  renderNavLinks: ->
-    navLinks = @getLinksToShow()
-    for i, link of navLinks
+  renderNavLinks: (links) ->
+    for i, link of links
       @renderLink(link)
 
   render: ->
-    @filterType = @props.situation.filterType
-    @perspective = @props.situation.perspective
-    @baseType = @props.situation.baseType
-    @context = @props.situation.context
     @renderNavBar()
 
 List = React.createClass
@@ -260,21 +71,12 @@ List = React.createClass
 
   cardLink: (collection) ->
     [owner, name] = collection.slug.split('/')
-    if @props.project?
-      "/projects/#{@props.project.slug}/collections/#{owner}/#{name}"
-    else
-      "/collections/#{owner}/#{name}"
+    ContextualLinks.prefixLinkIfNeeded(@props,"/collections/#{owner}/#{name}")
 
-  convertFilterTypeForMessageKey: (filterType) ->
-    if filterType == "user-and-project"
-      return "userAndProject"
-    else
-      return filterType
-
-  listCollections: (collectionOwner,project) ->
-    filter = @getFilterFromPath()
+  listCollections: ->
+    filters = ContextualLinks.getFiltersFromPath(@props)
     query = {}
-    for field, value of filter
+    for field, value of filters
       query[field] = value
 
     query.favorite = @props.favorite
@@ -282,174 +84,20 @@ List = React.createClass
 
     apiClient.type('collections').get query
 
-  # return the display name of the user whose context we are in (just login name for now)
-  # comes from collection, if present, otherwise from the logged in user if there is one.
-  getContextUserLogin: ->
-    if @props.favorite
-      if @props.params?.favorites_owner?
-        return @props.params.favorites_owner
-      else
-        if @props.user?
-          return @props.user.login
-        else
-          return @props.params.owner
-    else
-      if @props.params?.collection_owner?
-        return @props.params.collection_owner
-      else
-        if @props.user?
-          return @props.user.login
-        else
-          return @props.params.owner
-
-  # determine the current situation: context, perspective, baseType and filterType
-  determineSituation: ->
-    if @props.project?
-      if @contextUserLogin? and @contextUserLogin != "all"
-        # user context comes from the collection owner
-        context = "user-and-project"
-      else
-        if @props.user?
-          # user context comes current logged in user
-          context = "user-and-project"
-        else
-          if @props.params.owner?
-            # user context comes from the URL parameter
-            context = "user-and-project"
-          else
-            context = "project"
-    else
-      if @contextUserLogin? and @contextUserLogin != "all"
-        # user context comes from the collection
-        context = "user"
-      else
-        if @props.user?
-          # user context comes current logged in user
-          context = "user"
-        else
-          if @props.params.owner?
-            # user context comes from the URL parameter
-            context = "user"
-          else
-            context = "all"
-    if @viewingOwnCollections
-      perspective = "self"
-    else
-      perspective = "other"
-    if @props.favorite
-      baseType = "favorites"
-    else
-      baseType = "collections"
-    if @filter?
-      if "project_ids" of @filter
-        if "owner" of @filter
-          filterType = "user-and-project"
-        else
-          filterType = "project"
-      else
-        if "owner" of @filter
-          filterType = "user"
-        else
-          filterType = "all"
-    else
-      filterType = "all"
-    #console.log "context",context,"baseType",baseType,"filterType",filterType,"perspective",perspective
-    return {
-      context: context
-      perspective: perspective
-      baseType: baseType
-      filterType: filterType
-    }
-
-  getTitleMessageKey: ->
-    "collectionsPage.title.#{@situation.baseType}.#{@convertFilterTypeForMessageKey(@situation.filterType)}"
-
-  getFilterFromPath: ->
-    # /projects/project_owner/project_name/collections/collection_owner/all -> All collection_owner's collections, viewed in context of project_name and collection_owner
-    # /projects/project_owner/project_name/collections/collection_owner     -> All collection_owner's collections for project_name, viewed in context of project_name and collection_owner
-    # /projects/project_owner/project_name/collections/all                  -> All collections, viewed in context of project_name
-    # /projects/project_owner/project_name/collections/                     -> All collections for project_name, viewed in context of project_name
-    # /collections/collection_owner                                         -> All collections by collection owner, no context
-    # /collections/                                                         -> All collections for all users
-    # /projects/project_owner/project_name/favorites/collection_owner       -> All collection_owner's favorites, viewed in context of project_name and collection_owner
-    # /projects/project_owner/project_name/favorites/                       -> All favorites collections for project_name, viewed in context of project_name
-    # /favorites/collection_owner                                           -> All collections owner's favorites, no context
-    # /favorites/                                                           -> All favorites collections for all users
-
-    filters = {}
-    pathParts = @props.location.pathname.split('/')
-    [firstPart, ..., lastPart] = pathParts
-    if firstPart == "projects" and pathParts.length < 6 and lastPart != "all"
-      filters["project_ids"] = @props.project.id
-    if firstPart == "collections" and pathParts.length == 2 and pathParts[1] != "" and pathParts[1] != "all"
-      filters["owner"] = pathParts[1]
-    if firstPart == "favorites" and pathParts.length == 2 and pathParts[1] != "" and pathParts[1] != ""
-      filters["owner"] = pathParts[1]
-    if pathParts.length>4 and pathParts[3] == "collections" and pathParts[4] != "" and pathParts[4] != "all"
-      filters["owner"] = pathParts[4]
-    if pathParts.length>4 and pathParts[3] == "favorites" and pathParts[4] != "" and pathParts[4] != "all"
-      filters["owner"] = pathParts[4]
-    return filters
-
-  makeTextUnbreakable: (text) ->
-    text.replace /\ /g, "\u00a0"
-
-  getUnbreakableProjectDisplayName: ->
-    if @props.project?
-      return @makeTextUnbreakable(@props.project.display_name)
-
-  getUnbreakableCollectionOwnerName: ->
-    if @contextUserLogin? and @contextUserLogin != "all"
-      return @makeTextUnbreakable(@contextUserLogin)
-
-  getHeroNavWithAppropriateParams: ->
-    if @props.params?.collection_owner? or @props.params?.favorites_owner? or @props.user? or @props.params.owner?
-      <CollectionsNav user={@props.user}
-                      location={@props.location}
-                      situation={@situation}
-                      unbreakableProjectDisplayName = {@unbreakableProjectDisplayName}
-                      unbreakableCollectionOwnerName = {@unbreakableCollectionOwnerName}
-                      filter={@filter}
-                      project={@props.project}
-                      owner={@props.owner}
-                      viewingOwnCollections={@viewingOwnCollections}
-                      collectionOwnerName={@contextUserLogin}
-                      contextUserLogin={@contextUserLogin} />
-    else
-      <CollectionsNav user={@props.user}
-                      location={@props.location}
-                      situation={@situation}
-                      unbreakableProjectDisplayName = {@unbreakableProjectDisplayName}
-                      unbreakableCollectionOwnerName = {@unbreakableCollectionOwnerName}
-                      filter={@filter}
-                      project={@props.project}
-                      owner={@props.owner}
-                      viewingOwnCollections={@viewingOwnCollections} />
-
   render: ->
-    if @props.params?.collection_owner? or @props.params?.favorites_owner? or @props.user? or @props.params.owner?
-      @contextUserLogin = @getContextUserLogin()
-    else
-      @contextUserLogin = "all"
-    @viewingOwnCollections = @props.user? and @props.user.login == @getContextUserLogin()
-    @filter = @getFilterFromPath()
-    @situation = @determineSituation()
-    @unbreakableProjectDisplayName = @getUnbreakableProjectDisplayName()
-    @unbreakableCollectionOwnerName = @getUnbreakableCollectionOwnerName()
-
+    titleAndNavLinks = ContextualLinks.getContextualTitleAndNavLinks(@props)
+    contextUserLogin = ContextualLinks.getContextUserLogin(@props)
     <OwnedCardList
       {...@props}
       translationObjectName = "collectionsPage"
-      unbreakableProjectDisplayName = {@getUnbreakableProjectDisplayName()}
-      unbreakableCollectionOwnerName = {@getUnbreakableCollectionOwnerName()}
-      listPromise = {@listCollections(@contextUserLogin)}
+      contextUserLogin = {contextUserLogin}
+      titleAndNavLinks = {titleAndNavLinks}
+      listPromise = {@listCollections()}
       linkTo = "collections"
-      filter = {@filter}
-      situation = {@situation}
-      titleMessageKey = {@getTitleMessageKey()}
-      heroNav = {@getHeroNavWithAppropriateParams()}
+      titleMessageObject = {titleAndNavLinks.title}
+      heroNav={<CollectionsNav {...@props} contextUserLogin={contextUserLogin} titleAndNavLinks={titleAndNavLinks} />}
       heroClass = "collections-hero"
-      ownerName = {@contextUserLogin}
+      ownerName = {contextUserLogin}
       skipOwner = {!@props.params?.owner}
       imagePromise = {@imagePromise}
       cardLink = {@cardLink} />

--- a/app/pages/collections.cjsx
+++ b/app/pages/collections.cjsx
@@ -140,12 +140,15 @@ CollectionsNav = React.createClass
 
   # render a link from a contextual-links link object
   renderLink: (link) ->
+    className = ""
+    if @props.project?
+      className += " about-tabs"
     if link.type=="IndexLink"
-      <IndexLink key="#{link.key}" to="#{link.to}" title="#{link.message.hoverText}" activeClassName="active">
+      <IndexLink key="#{link.key}" to="#{link.to}" className={className} title="#{link.message.hoverText}" activeClassName="active">
         {@generateTranslateLink(link.message)}
       </IndexLink>
     else
-      <Link key="#{link.key}" to="#{link.to}" title="#{link.message.hoverText}" activeClassName="active">
+      <Link key="#{link.key}" to="#{link.to}" className={className} title="#{link.message.hoverText}" activeClassName="active">
         {@generateTranslateLink(link.message)}
       </Link>
 

--- a/app/pages/home.cjsx
+++ b/app/pages/home.cjsx
@@ -9,6 +9,7 @@ OwnedCard = require '../partials/owned-card'
 FEATURED_PRODUCT_IDS = require '../lib/featured-projects'
 {Markdown} = (require 'markdownz').default
 ProjectIcon = require '../components/project-icon'
+ContextualLinks = require '../lib/contextual-links'
 
 counterpart.registerTranslations 'en',
   home:
@@ -90,6 +91,7 @@ module.exports = React.createClass
         {if @props.user
           <PromiseRenderer promise={@lastFourProjects()}>{(projectPreferences) =>
             if projectPreferences.length > 0
+              link = ContextualLinks.prefixLinkIfNeeded @props, "/users/#{@props.user.login}/stats"
               <div className="recent-projects">
                 <Translate component="h5" content="home.recentProjects.title" />
                 <div className="recent-projects-list">
@@ -104,7 +106,7 @@ module.exports = React.createClass
                         null
                     } />}
                 </div>
-                <Link to="/users/#{@props.user.login}/stats" className="call-to-action standard-button x-large"><Translate content="home.recentProjects.button" /></Link>
+                <Link to="#{link}" className="call-to-action standard-button x-large"><Translate content="home.recentProjects.button" /></Link>
               </div>
             else
               <div className="recent-projects">

--- a/app/pages/notifications/message.cjsx
+++ b/app/pages/notifications/message.cjsx
@@ -5,6 +5,7 @@ moment = require 'moment'
 talkClient = require 'panoptes-client/lib/talk-client'
 Loading = require '../../components/loading-indicator'
 Avatar = require '../../partials/avatar'
+ContextualLinks = require '../../lib/contextual-links'
 
 module?.exports = React.createClass
   displayName: 'MessageNotification'
@@ -28,6 +29,7 @@ module?.exports = React.createClass
   render: ->
     notification = @props.notification
     if @state.message
+      link = ContextualLinks.prefixLinkIfNeeded @props, "/users/#{@state.messageUser.login}"
       <div className="conversation-message talk-module">
         <Link to="/inbox/#{notification.source.conversation_id}" {...@props} className="message-link">
           {notification.message}{' '}
@@ -37,7 +39,7 @@ module?.exports = React.createClass
         <Markdown>{@state.message.body}</Markdown>
 
         <div className="bottom">
-          <Link className="user-profile-link" to="/users/#{@state.messageUser.login}">
+          <Link className="user-profile-link" to="#{link}">
             <Avatar user={@state.messageUser} />{' '}{@state.messageUser.display_name}
           </Link>{' '}
           <Link to={"/inbox/#{notification.source.conversation_id}"} {...@props} className="time-ago">

--- a/app/pages/notifications/moderation.cjsx
+++ b/app/pages/notifications/moderation.cjsx
@@ -6,6 +6,7 @@ talkClient = require 'panoptes-client/lib/talk-client'
 apiClient = require 'panoptes-client/lib/api-client'
 Loading = require '../../components/loading-indicator'
 Avatar = require '../../partials/avatar'
+ContextualLinks = require '../../lib/contextual-links'
 
 module?.exports = React.createClass
   displayName: 'ModerationNotification'
@@ -54,9 +55,10 @@ module?.exports = React.createClass
         <p>Reports:</p>
         <ul>
           {for report, i in @state.reports
+            link = ContextualLinks.prefixLinkIfNeeded @props, "/users/#{report.user.login}"
             <div key={"#{ @state.moderation.id }-report-#{ i }"}>
               <li>
-                <Link className="user-profile-link" to="/users/#{report.user.login}">
+                <Link className="user-profile-link" to="#{link}">
                   <Avatar user={report.user} />{' '}{report.user.display_name}
                 </Link>
                 {': '}
@@ -67,7 +69,8 @@ module?.exports = React.createClass
 
         <div className="bottom">
           {if @state.commentUser
-            <Link className="user-profile-link" to="/users/@state.commentUser.login">
+            link = ContextualLinks.prefixLinkIfNeeded @props, "/users/#{@state.commentUser.login}"
+            <Link className="user-profile-link" to="#{link}">
               <Avatar user={@state.commentUser} />{' '}{@state.commentUser.display_name}
             </Link>}
 

--- a/app/pages/profile/comment-link.cjsx
+++ b/app/pages/profile/comment-link.cjsx
@@ -60,11 +60,14 @@ module?.exports = React.createClass
             <a href={@state.href}>
               {if @state.project? and @state.owner
                 <span>
-                  <strong className="comment-project" title="#{@state.owner.display_name}/#{@state.project.display_name}">{@state.project.display_name}</strong>
-                  ➞
+                  {if !@state.project?
+                    <span>
+                      <strong className="comment-project" title="#{@state.owner.display_name}/#{@state.project.display_name}">{@state.project.display_name}</strong>
+                      <span>&nbsp;➞&nbsp;</span>
+                    </span>}
                 </span>}
               <strong className="comment-board">{@state.board?.title}</strong>
-              ➞
+              <span>&nbsp;➞&nbsp;</span>
               <strong className="comment-discussion">{@state.discussion?.title}</strong>
             </a>
           </span>}

--- a/app/pages/profile/feed.cjsx
+++ b/app/pages/profile/feed.cjsx
@@ -31,7 +31,10 @@ module.exports = React.createClass
       comments: null
       error: null
     }, =>
-      talkClient.type('comments').get({user_id: user.id, page: page, sort: '-created_at'})
+      criteria = {user_id: user.id, page: page, sort: '-created_at'}
+      if @props.project?
+        criteria.project_id = @props.project.id
+      talkClient.type('comments').get(criteria)
         .catch (error) =>
           @setState({error})
         .then (comments) =>

--- a/app/pages/profile/index.cjsx
+++ b/app/pages/profile/index.cjsx
@@ -20,7 +20,7 @@ counterpart.registerTranslations 'en',
       moderation: "Moderation"
       stats: "Your stats"
       settings: "Settings"
-      removeProjectContextLink: "To the Zooniverse!"
+      removeProjectContextLink: 'View\u00a0%(collectionOwnerName)s\'s\u00a0Zooniverse.org\u00a0Profile'
 
 UserProfilePage = React.createClass
   displayName: 'UserProfilePage'
@@ -69,27 +69,30 @@ UserProfilePage = React.createClass
 
   renderNavLinks: ->
     linksForNav = @getLinksForNav()
+    className = ""
+    if @props.project?
+      className += " about-tabs"
     <span>
-      <IndexLink to="#{linksForNav.recents}" activeClassName="active">
+      <IndexLink to="#{linksForNav.recents}" className={className} activeClassName="active">
         <Translate content="profile.nav.comments" />
       </IndexLink>
-      <Link to="#{linksForNav.collections}" activeClassName="active">
+      <Link to="#{linksForNav.collections}" className={className} activeClassName="active">
         <Translate content="profile.nav.collections" />
       </Link>
-      <Link to="#{linksForNav.favorites}" activeClassName="active">
+      <Link to="#{linksForNav.favorites}" className={className} activeClassName="active">
         <Translate content="profile.nav.favorites" />
       </Link>
       {if @props.user is @props.profileUser
-        <Link to="#{linksForNav.stats}" activeClassName="active">
+        <Link to="#{linksForNav.stats}" className={className} activeClassName="active">
           <Translate content="profile.nav.stats" />
         </Link>
       else
-        <Link to="#{linksForNav.message}" activeClassName="active">
+        <Link to="#{linksForNav.message}" className={className} activeClassName="active">
           <Translate content="profile.nav.message" />
         </Link>}
       {if @props.project?
-        <Link to="#{linksForNav.removeProjectContextLink}" activeClassName="active">
-          <Translate content="profile.nav.removeProjectContextLink" />
+        <Link to="#{linksForNav.removeProjectContextLink.to}" className={className} activeClassName="active">
+          <Translate content="profile.nav.removeProjectContextLink" collectionOwnerName={linksForNav.removeProjectContextLink.message.user?.displayName} />
         </Link>}
     </span>
 
@@ -98,18 +101,27 @@ UserProfilePage = React.createClass
     if @state.profileHeader?
       headerStyle = backgroundImage: "url(#{@state.profileHeader.src})"
 
+    classNames = "user-profile-content"
+    if @props.project?
+      classNames += " project-text-content in-project-context talk"
+
     <div className="#{@getPageClasses()}">
       <section className="hero user-profile-hero" style={headerStyle}>
         <div className="overlay"></div>
         <div className="hero-container">
           <h1>{@props.profileUser.display_name}</h1>
-          <nav className="hero-nav">
-            {@renderNavLinks()}
-          </nav>
+          {if !@props.project?
+            <nav className="hero-nav">
+              {@renderNavLinks()}
+            </nav>}
         </div>
       </section>
 
-      <section className="user-profile-content">
+      <section className={classNames}>
+        {if @props.project?
+          <nav className="hero-nav">
+            {@renderNavLinks()}
+        </nav>}
         {React.cloneElement(@props.children, @props)}
       </section>
     </div>

--- a/app/pages/profile/index.cjsx
+++ b/app/pages/profile/index.cjsx
@@ -20,7 +20,7 @@ counterpart.registerTranslations 'en',
       moderation: "Moderation"
       stats: "Your stats"
       settings: "Settings"
-      viewOnZooniverseOrg: "View on zooniverse.org"
+      removeProjectContextLink: "To the Zooniverse!"
 
 UserProfilePage = React.createClass
   displayName: 'UserProfilePage'
@@ -57,20 +57,14 @@ UserProfilePage = React.createClass
       classes += ' has-project-context'
     classes
 
-  getRemoveProjectContextLink: ->
-    pathParts = @props.location.pathname.split('/')
-    [first, ...] = pathParts
-    if first == "projects"
-      return pathParts[3...].join("/")
-
   getLinksForNav: ->
     return {
-      recents: ContextualLinks.prefixLinkIfNeeded(@props, "/users/#{@props.profileUser.login}")
-      collections: ContextualLinks.prefixLinkIfNeeded(@props, "/collections/#{@props.profileUser.login}")
-      favorites:  ContextualLinks.prefixLinkIfNeeded(@props, "/favorites/#{@props.profileUser.login}")
-      stats: ContextualLinks.prefixLinkIfNeeded(@props, "/users/#{@props.profileUser.login}/stats")
-      message: ContextualLinks.prefixLinkIfNeeded(@props, "/users/#{@props.profileUser.login}/message")
-      viewOnZooniverseOrg: ContextualLinks.getRemoveProjectContextLink(@props)
+      recents: ContextualLinks.prefixLinkIfNeeded @props, "/users/#{@props.profileUser.login}"
+      collections: ContextualLinks.prefixLinkIfNeeded @props, "/collections/#{@props.profileUser.login}"
+      favorites:  ContextualLinks.prefixLinkIfNeeded @props, "/favorites/#{@props.profileUser.login}"
+      stats: ContextualLinks.prefixLinkIfNeeded @props, "/users/#{@props.profileUser.login}/stats"
+      message: ContextualLinks.prefixLinkIfNeeded @props, "/users/#{@props.profileUser.login}/message"
+      removeProjectContextLink: ContextualLinks.getRemoveProjectContextLink @props
     }
 
   renderNavLinks: ->
@@ -94,8 +88,8 @@ UserProfilePage = React.createClass
           <Translate content="profile.nav.message" />
         </Link>}
       {if @props.project?
-        <Link to="#{linksForNav.viewOnZooniverseOrg}" activeClassName="active">
-          <Translate content="profile.nav.viewOnZooniverseOrg" />
+        <Link to="#{linksForNav.removeProjectContextLink}" activeClassName="active">
+          <Translate content="profile.nav.removeProjectContextLink" />
         </Link>}
     </span>
 

--- a/app/pages/profile/index.cjsx
+++ b/app/pages/profile/index.cjsx
@@ -6,6 +6,7 @@ apiClient = require 'panoptes-client/lib/api-client'
 Translate = require 'react-translate-component'
 {Link, IndexLink} = require 'react-router'
 talkClient = require 'panoptes-client/lib/talk-client'
+ContextualLinks = require '../../lib/contextual-links'
 
 counterpart.registerTranslations 'en',
   profile:
@@ -19,6 +20,7 @@ counterpart.registerTranslations 'en',
       moderation: "Moderation"
       stats: "Your stats"
       settings: "Settings"
+      viewOnZooniverseOrg: "View on zooniverse.org"
 
 UserProfilePage = React.createClass
   displayName: 'UserProfilePage'
@@ -49,39 +51,66 @@ UserProfilePage = React.createClass
       .then ([profileHeader]) =>
         @setState({profileHeader})
 
+  getPageClasses: ->
+    classes = 'secondary-page user-profile'
+    if @props.project?
+      classes += ' has-project-context'
+    classes
+
+  getRemoveProjectContextLink: ->
+    pathParts = @props.location.pathname.split('/')
+    [first, ...] = pathParts
+    if first == "projects"
+      return pathParts[3...].join("/")
+
+  getLinksForNav: ->
+    return {
+      recents: ContextualLinks.prefixLinkIfNeeded(@props, "/users/#{@props.profileUser.login}")
+      collections: ContextualLinks.prefixLinkIfNeeded(@props, "/collections/#{@props.profileUser.login}")
+      favorites:  ContextualLinks.prefixLinkIfNeeded(@props, "/favorites/#{@props.profileUser.login}")
+      stats: ContextualLinks.prefixLinkIfNeeded(@props, "/users/#{@props.profileUser.login}/stats")
+      message: ContextualLinks.prefixLinkIfNeeded(@props, "/users/#{@props.profileUser.login}/message")
+      viewOnZooniverseOrg: ContextualLinks.getRemoveProjectContextLink(@props)
+    }
+
+  renderNavLinks: ->
+    linksForNav = @getLinksForNav()
+    <span>
+      <IndexLink to="#{linksForNav.recents}" activeClassName="active">
+        <Translate content="profile.nav.comments" />
+      </IndexLink>
+      <Link to="#{linksForNav.collections}" activeClassName="active">
+        <Translate content="profile.nav.collections" />
+      </Link>
+      <Link to="#{linksForNav.favorites}" activeClassName="active">
+        <Translate content="profile.nav.favorites" />
+      </Link>
+      {if @props.user is @props.profileUser
+        <Link to="#{linksForNav.stats}" activeClassName="active">
+          <Translate content="profile.nav.stats" />
+        </Link>
+      else
+        <Link to="#{linksForNav.message}" activeClassName="active">
+          <Translate content="profile.nav.message" />
+        </Link>}
+      {if @props.project?
+        <Link to="#{linksForNav.viewOnZooniverseOrg}" activeClassName="active">
+          <Translate content="profile.nav.viewOnZooniverseOrg" />
+        </Link>}
+    </span>
+
   render: ->
+
     if @state.profileHeader?
       headerStyle = backgroundImage: "url(#{@state.profileHeader.src})"
 
-    <div className="secondary-page user-profile">
+    <div className="#{@getPageClasses()}">
       <section className="hero user-profile-hero" style={headerStyle}>
         <div className="overlay"></div>
         <div className="hero-container">
           <h1>{@props.profileUser.display_name}</h1>
           <nav className="hero-nav">
-            <IndexLink to="/users/#{@props.profileUser.login}" activeClassName="active">
-              <Translate content="profile.nav.comments" />
-            </IndexLink>
-            {' '}
-            <Link to="/collections/#{@props.profileUser.login}" activeClassName="active">
-              <Translate content="profile.nav.collections" />
-            </Link>
-            {' '}
-            <Link to="/favorites/#{@props.profileUser.login}" activeClassName="active">
-              <Translate content="profile.nav.favorites" />
-            </Link>
-            {' '}
-
-            <span>
-              {if @props.user is @props.profileUser
-                <Link to="/users/#{@props.profileUser.login}/stats" activeClassName="active">
-                  <Translate content="profile.nav.stats" />
-                </Link>
-              else
-                <Link to="/users/#{@props.profileUser.login}/message" activeClassName="active">
-                  <Translate content="profile.nav.message" />
-                </Link>}
-            </span>
+            {@renderNavLinks()}
           </nav>
         </div>
       </section>

--- a/app/pages/project/index.cjsx
+++ b/app/pages/project/index.cjsx
@@ -16,6 +16,7 @@ counterpart.registerTranslations 'en',
       about: 'About'
       classify: 'Classify'
       talk: 'Talk'
+      collections: 'Collect'
 
 SOCIAL_ICONS =
   'bitbucket.com/': 'bitbucket'
@@ -31,7 +32,6 @@ SOCIAL_ICONS =
   'wordpress.com/': 'wordpress'
   'youtu.be/': 'youtube'
   'youtube.com/': 'youtube'
-
 
 ProjectPage = React.createClass
   getDefaultProps: ->
@@ -136,6 +136,10 @@ ProjectPage = React.createClass
 
         <Link to="#{projectPath}/talk" activeClassName="active" className="tabbed-content-tab">
           <Translate content="project.nav.talk" />
+        </Link>
+
+        <Link to="#{projectPath}/collections" activeClassName="active" className="tabbed-content-tab">
+          <Translate content="project.nav.collections" />
         </Link>
 
         {@props.project.urls.map ({label, url}, i) =>

--- a/app/partials/avatar.cjsx
+++ b/app/partials/avatar.cjsx
@@ -42,4 +42,4 @@ module?.exports = React.createClass
     @setState src: DEFAULT_AVATAR
 
   render: ->
-    <img src={@state.src} onError={@handleError} alt="User avatar" className="avatar" data-loading={@state.loading || null} />
+    <img src={@state.src} onError={@handleError} title="#{@props.user.display_name}" alt="User avatar for #{@props.user.display_name}" className="avatar" data-loading={@state.loading || null} />

--- a/app/partials/owned-card.cjsx
+++ b/app/partials/owned-card.cjsx
@@ -59,7 +59,6 @@ module.exports = React.createClass
         <svg className="card-space-maker" viewBox="0 0 2 1" width="100%"></svg>
         <div className="details">
           <div className="name"><span>{@props.resource.display_name}</span></div>
-          {console.log 'skip is ',@props.skipOwner}
           {if !@props.skipOwner
             <PromiseRenderer promise={@props.resource.get('owner')} {...@props}>{ (owner) ->
               <div className="owner">{owner?.display_name ? 'LOADING'}</div>

--- a/app/partials/owned-card.cjsx
+++ b/app/partials/owned-card.cjsx
@@ -4,6 +4,7 @@ PromiseRenderer = require '../components/promise-renderer'
 apiClient = require 'panoptes-client/lib/api-client'
 counterpart = require 'counterpart'
 Translate = require 'react-translate-component'
+ContextualLinks = require '../lib/contextual-links'
 
 FlexibleLink = React.createClass
   displayName: 'FlexibleLink'
@@ -58,10 +59,10 @@ module.exports = React.createClass
         <svg className="card-space-maker" viewBox="0 0 2 1" width="100%"></svg>
         <div className="details">
           <div className="name"><span>{@props.resource.display_name}</span></div>
+          {console.log 'skip is ',@props.skipOwner}
           {if !@props.skipOwner
-            <PromiseRenderer promise={@props.resource.get('owner')}>{ (owner) ->
-              if document.location.hash is "/collections"
-                <div className="owner">{owner?.display_name ? 'LOADING'}</div>
+            <PromiseRenderer promise={@props.resource.get('owner')} {...@props}>{ (owner) ->
+              <div className="owner">{owner?.display_name ? 'LOADING'}</div>
             }</PromiseRenderer>}
           {<div className="description">{@props.resource.description}</div> if @props.resource.description?}
           {<div className="private"><i className="fa fa-lock"></i> Private</div> if @props.resource.private}

--- a/app/router.cjsx
+++ b/app/router.cjsx
@@ -87,6 +87,8 @@ module.exports =
       <Route path="collections" component={require('./pages/collections').CollectionsList}>
         <IndexRoute component={require './pages/collections'}.CollectionsList} />
         <Route path=":collection_owner" component={require('./pages/collections').CollectionsList} />
+        <Route path=":collection_owner/all" component={require('./pages/collections').CollectionsList} />
+        <Route path="all" component={require('./pages/collections').CollectionsList} />
       </Route>
       <Route path="faq" component={require './pages/project/faq'} />
       <Route path="education" component={require './pages/project/education'} />

--- a/app/router.cjsx
+++ b/app/router.cjsx
@@ -90,13 +90,20 @@ module.exports =
         <Route path=":collection_owner" component={require('./pages/collections').CollectionsList} />
       </Route>
       <Route path="collections/:collection_owner/:collection_name" component={require './collections/show'}>
+        <IndexRoute component={require './collections/show-list'} />
         <Route path="settings" component={require './collections/settings'} />
         <Route path="collaborators" component={require './collections/collaborators'} />
         <Route path="talk" component={require './collections/show-list'} />
       </Route>
       <Route path="favorites" component={require('./pages/collections').FavoritesList}>
         <Route path="all" component={require('./pages/collections').FavoritesList} />
+        <Route path=":favorites_owner/all" component={require('./pages/collections').FavoritesList} />
         <Route path=":favorites_owner" component={require('./pages/collections').FavoritesList} />
+      </Route>
+      <Route path="users/:name" component={require './pages/profile'}>
+        <IndexRoute component={require './pages/profile/feed'} />
+        <Route path="message" component={require './pages/profile/private-message'} />
+        <Route path="stats" component={require './pages/profile/stats'} />
       </Route>
       <Route path="faq" component={require './pages/project/faq'} />
       <Route path="education" component={require './pages/project/education'} />

--- a/app/router.cjsx
+++ b/app/router.cjsx
@@ -83,6 +83,13 @@ module.exports =
         <Route path=":board" component={require './talk/board'} />
         <Route path=":board/:discussion" component={require './talk/discussion'} />
       </Route>
+
+      <Route path="collections" component={require('./pages/collections').CollectionsList}>
+        <IndexRoute component={require './pages/collections'}.CollectionsList} />
+        <Route path=":owner" component={require('./pages/collections').CollectionsList} />
+      </Route>
+      <Route path="faq" component={require './pages/project/faq'} />
+      <Route path="education" component={require './pages/project/education'} />
       <Route path="stats" component={require './pages/project/stats'} />
     </Route>
 

--- a/app/router.cjsx
+++ b/app/router.cjsx
@@ -86,7 +86,7 @@ module.exports =
 
       <Route path="collections" component={require('./pages/collections').CollectionsList}>
         <IndexRoute component={require './pages/collections'}.CollectionsList} />
-        <Route path=":owner" component={require('./pages/collections').CollectionsList} />
+        <Route path=":collection_owner" component={require('./pages/collections').CollectionsList} />
       </Route>
       <Route path="faq" component={require './pages/project/faq'} />
       <Route path="education" component={require './pages/project/education'} />

--- a/app/router.cjsx
+++ b/app/router.cjsx
@@ -86,9 +86,9 @@ module.exports =
 
       <Route path="collections" component={require('./pages/collections').CollectionsList}>
         <IndexRoute component={require './pages/collections'}.CollectionsList} />
+        <Route path="all" component={require('./pages/collections').CollectionsList} />
         <Route path=":collection_owner" component={require('./pages/collections').CollectionsList} />
         <Route path=":collection_owner/all" component={require('./pages/collections').CollectionsList} />
-        <Route path="all" component={require('./pages/collections').CollectionsList} />
       </Route>
       <Route path="faq" component={require './pages/project/faq'} />
       <Route path="education" component={require './pages/project/education'} />

--- a/app/router.cjsx
+++ b/app/router.cjsx
@@ -86,8 +86,8 @@ module.exports =
 
       <Route path="collections" component={require('./pages/collections').CollectionsList}>
         <Route path="all" component={require('./pages/collections').CollectionsList} />
-        <Route path=":collection_owner" component={require('./pages/collections').CollectionsList} />
         <Route path=":collection_owner/all" component={require('./pages/collections').CollectionsList} />
+        <Route path=":collection_owner" component={require('./pages/collections').CollectionsList} />
       </Route>
       <Route path="collections/:collection_owner/:collection_name" component={require './collections/show'}>
         <Route path="settings" component={require './collections/settings'} />
@@ -95,6 +95,7 @@ module.exports =
         <Route path="talk" component={require './collections/show-list'} />
       </Route>
       <Route path="favorites" component={require('./pages/collections').FavoritesList}>
+        <Route path="all" component={require('./pages/collections').FavoritesList} />
         <Route path=":favorites_owner" component={require('./pages/collections').FavoritesList} />
       </Route>
       <Route path="faq" component={require './pages/project/faq'} />

--- a/app/router.cjsx
+++ b/app/router.cjsx
@@ -105,8 +105,6 @@ module.exports =
         <Route path="message" component={require './pages/profile/private-message'} />
         <Route path="stats" component={require './pages/profile/stats'} />
       </Route>
-      <Route path="faq" component={require './pages/project/faq'} />
-      <Route path="education" component={require './pages/project/education'} />
       <Route path="stats" component={require './pages/project/stats'} />
     </Route>
 

--- a/app/router.cjsx
+++ b/app/router.cjsx
@@ -90,6 +90,12 @@ module.exports =
         <Route path=":collection_owner" component={require('./pages/collections').CollectionsList} />
         <Route path=":collection_owner/all" component={require('./pages/collections').CollectionsList} />
       </Route>
+      <Route path="collections/:collection_owner/:collection_name" component={require './collections/show'}>
+        <IndexRoute component={require './collections/show-list'} />
+        <Route path="settings" component={require './collections/settings'} />
+        <Route path="collaborators" component={require './collections/collaborators'} />
+        <Route path="talk" component={require './collections/show-list'} />
+      </Route>
       <Route path="faq" component={require './pages/project/faq'} />
       <Route path="education" component={require './pages/project/education'} />
       <Route path="stats" component={require './pages/project/stats'} />

--- a/app/router.cjsx
+++ b/app/router.cjsx
@@ -85,16 +85,17 @@ module.exports =
       </Route>
 
       <Route path="collections" component={require('./pages/collections').CollectionsList}>
-        <IndexRoute component={require './pages/collections'}.CollectionsList} />
         <Route path="all" component={require('./pages/collections').CollectionsList} />
         <Route path=":collection_owner" component={require('./pages/collections').CollectionsList} />
         <Route path=":collection_owner/all" component={require('./pages/collections').CollectionsList} />
       </Route>
       <Route path="collections/:collection_owner/:collection_name" component={require './collections/show'}>
-        <IndexRoute component={require './collections/show-list'} />
         <Route path="settings" component={require './collections/settings'} />
         <Route path="collaborators" component={require './collections/collaborators'} />
         <Route path="talk" component={require './collections/show-list'} />
+      </Route>
+      <Route path="favorites" component={require('./pages/collections').FavoritesList}>
+        <Route path=":favorites_owner" component={require('./pages/collections').FavoritesList} />
       </Route>
       <Route path="faq" component={require './pages/project/faq'} />
       <Route path="education" component={require './pages/project/education'} />

--- a/app/subjects/collection-list.cjsx
+++ b/app/subjects/collection-list.cjsx
@@ -2,6 +2,7 @@ React = require 'react'
 apiClient = require 'panoptes-client/lib/api-client'
 Loading = require '../components/loading-indicator'
 CollectionPreview = require '../collections/preview'
+ContextualLinks = require '../lib/contextual-links'
 
 module?.exports = React.createClass
   displayName: 'SubjectCollectionList'
@@ -30,7 +31,7 @@ module?.exports = React.createClass
         <h2>Collections:</h2>
         <div className="subject-collection-list-container">
           {for collection in @state.collections
-            <CollectionPreview key={"collection-#{ collection.id }"} collection={collection} />}
+            <CollectionPreview project={@props.project} key={"collection-#{ collection.id }"} collection={collection} />}
         </div>
       </div>
     else

--- a/app/subjects/index.cjsx
+++ b/app/subjects/index.cjsx
@@ -60,7 +60,7 @@ module?.exports = React.createClass
           </section>
 
           <section>
-            <ActiveUsers section={@props.section} />
+            <ActiveUsers project={@props.project} section={@props.section} />
           </section>
 
           <section>

--- a/app/talk/active-users.cjsx
+++ b/app/talk/active-users.cjsx
@@ -5,6 +5,7 @@ apiClient = require 'panoptes-client/lib/api-client'
 {sugarApiClient} = require 'panoptes-client/lib/sugar'
 {Link} = require 'react-router'
 Paginator = require './lib/paginator'
+ContextualLinks = require '../lib/contextual-links'
 
 module?.exports = React.createClass
   displayName: 'ActiveUsers'
@@ -83,11 +84,13 @@ module?.exports = React.createClass
     @updateTimeout = setTimeout @update, 10000
 
   userLink: (user) ->
+    url = ContextualLinks.prefixLinkIfNeeded @props,"/users/#{user.login}"
     <li key={user.id}>
-      <Link to="/users/#{user.login}" title="#{user.display_name}'s profile">{user.display_name}</Link>
+      <Link to="#{url}" title="#{user.display_name}'s profile">{user.display_name}</Link>
     </li>
 
   render: ->
+    console.log @props
     <div className="talk-active-users">
       <h3>{@state.total} Active Participants:</h3>
       <ul>

--- a/app/talk/board.cjsx
+++ b/app/talk/board.cjsx
@@ -239,7 +239,7 @@ module?.exports = React.createClass
           </section>
 
           <section>
-            <ActiveUsers section={@props.section} />
+            <ActiveUsers project={@props.project} section={@props.section} />
           </section>
 
           <section>

--- a/app/talk/comment.cjsx
+++ b/app/talk/comment.cjsx
@@ -21,6 +21,7 @@ CommentContextIcon = require './lib/comment-context-icon'
 merge = require 'lodash.merge'
 {Markdown} = (require 'markdownz').default
 DEFAULT_AVATAR = './assets/simple-avatar.jpg'
+ContextualLinks = require '../lib/contextual-links'
 
 module?.exports = React.createClass
   displayName: 'TalkComment'
@@ -114,9 +115,10 @@ module?.exports = React.createClass
           @setState replies: [comment].concat(@state.replies)
 
   replyLine: (comment) ->
+    link = ContextualLinks.prefixLinkIfNeeded @props, "users/#{comment.user_login}"
     <div key={comment.id} className="comment-reply-line" ref="comment-reply-#{comment.id}">
       <p>
-        <Link to="/users/#{comment.user_login}">{comment.user_display_name}</Link>
+        <Link to="#{link}">{comment.user_display_name}</Link>
         {if comment.reply_id
           <span>
             {' '}in reply to <Link to="/users/#{comment.reply_user_login}">{comment.reply_user_display_name}</Link>'s{' '}
@@ -149,6 +151,7 @@ module?.exports = React.createClass
     feedback = @renderFeedback()
     activeClass = if @props.active then 'active' else ''
     isDeleted = if @props.data.is_deleted then 'deleted' else ''
+    userLink = ContextualLinks.prefixLinkIfNeeded @props,"/users/#{@props.data.user_login}"
 
     <div className="talk-comment #{activeClass} #{isDeleted}">
       <div className="talk-comment-author">
@@ -157,7 +160,7 @@ module?.exports = React.createClass
         }</PromiseRenderer>
 
         <div>
-          <Link to="/users/#{@props.data.user_login}">{@props.data.user_display_name}</Link>
+          <Link to="#{userLink}">{@props.data.user_display_name}</Link>
           <div className="user-mention-name">@{@props.data.user_login}</div>
         </div>
 
@@ -169,6 +172,7 @@ module?.exports = React.createClass
       <div className="talk-comment-body">
         <CommentContextIcon comment={@props.data}></CommentContextIcon>
         {if @props.data.reply_id
+          opLink = ContextualLinks.prefixLinkIfNeeded @props, "/users/#{@props.data.reply_user_login}"
           <div className="talk-comment-reply">
             {if @state.replies.length
               <div>
@@ -177,7 +181,7 @@ module?.exports = React.createClass
               </div>
               }
 
-            In reply to <Link to="/users/#{@props.data.reply_user_login}">{@props.data.reply_user_display_name}</Link>'s{' '}
+            In reply to <Link to="#{opLink}">{@props.data.reply_user_display_name}</Link>'s{' '}
 
             <button className="link-style" type="button" onClick={(e) => @onClickRenderReplies(e, @props.data)}>comment</button>
           </div>

--- a/app/talk/discussion.cjsx
+++ b/app/talk/discussion.cjsx
@@ -25,6 +25,7 @@ PopularTags = require './popular-tags'
 ActiveUsers = require './active-users'
 ProjectLinker = require './lib/project-linker'
 SidebarNotifications = require './lib/sidebar-notifications'
+ContextualLinks = require '../lib/contextual-links'
 
 PAGE_SIZE = talkConfig.discussionPageSize
 
@@ -331,7 +332,7 @@ module?.exports = React.createClass
           </section>
 
           <section>
-            <ActiveUsers section={@props.section} />
+            <ActiveUsers project={@props.project} section={@props.section} />
           </section>
 
           <section>
@@ -346,11 +347,12 @@ module?.exports = React.createClass
       {if discussion?.locked
         @lockedMessage()
       else if @props.user?
+        authorLink = ContextualLinks.prefixLinkIfNeeded @props, "/users/#{@props.user.login}"
         <section>
           <div className="talk-comment-author">
             <Avatar user={@props.user} />
             <p>
-              <Link to="/users/#{@props.user.login}">{@props.user.display_name}</Link>
+              <Link to="#{authorLink}">{@props.user.display_name}</Link>
             </p>
             <div className="user-mention-name">@{@props.user.login}</div>
             <PromiseRenderer promise={talkClient.type('roles').get(user_id: @props.user.id, section: ['zooniverse', discussion.section], is_shown: true, page_size: 100)}>{(roles) =>

--- a/app/talk/inbox-conversation.cjsx
+++ b/app/talk/inbox-conversation.cjsx
@@ -8,6 +8,7 @@ HandlePropChanges = require '../lib/handle-prop-changes'
 CommentBox = require './comment-box'
 {Link, History} = require 'react-router'
 {timestamp} = require './lib/time'
+ContextualLinks = require '../lib/contextual-links'
 
 module?.exports = React.createClass
   displayName: 'InboxConversation'
@@ -46,10 +47,11 @@ module?.exports = React.createClass
         @setState {messages, messagesMeta}
 
   message: (data, i) ->
+    link = ContextualLinks.prefixIfNeeded("/users/#{commentOwner.login}")
     <div className="conversation-message" key={data.id}>
       <PromiseRenderer promise={apiClient.type('users').get(data.user_id)}>{(commentOwner) =>
         <span>
-          <strong><Link to="/users/#{commentOwner.login}">{commentOwner.display_name}</Link></strong>{' '}
+          <strong><Link to="#{link}">{commentOwner.display_name}</Link></strong>{' '}
           <span>{timestamp(data.updated_at)}</span>
         </span>
       }</PromiseRenderer>
@@ -83,8 +85,9 @@ module?.exports = React.createClass
           <div>
             In this conversation:{' '}
             {@state.recipients.map (user, i) =>
+              link = ContextualLinks.prefixIfNeeded @props, "/users/#{user.login}"
               <span key={user.id}>
-                <Link to="/users/#{user.login}">
+                <Link to="#{link}">
                   {user.display_name}
                 </Link>{', ' unless i is @state.recipients.length-1}
               </span>

--- a/app/talk/inbox.cjsx
+++ b/app/talk/inbox.cjsx
@@ -10,6 +10,7 @@ talkConfig = require './config'
 {timeAgo} = require './lib/time'
 SignInPrompt = require '../partials/sign-in-prompt'
 alert = require '../lib/alert'
+ContextualLinks = require '../lib/contextual-links'
 
 PAGE_SIZE = talkConfig.inboxPageSize
 
@@ -52,8 +53,9 @@ module?.exports = React.createClass
       <PromiseRenderer promise={apiClient.type('users').get(conversation.links.users.filter (userId) => userId isnt @props.user.id)}>{(users) =>
         <div>
           {users.map (user, i) =>
+            link = ContextualLinks.prefixIfNeeded @props, "/users/#{user.login}"
             <div key={user.id}>
-              <strong><Link key={user.id} to="/users/#{user.login}">{user.display_name}</Link></strong>
+              <strong><Link key={user.id} to="#{link}">{user.display_name}</Link></strong>
                 <PromiseRenderer promise={conversation.get('messages', {page_size: 1, sort: '-created_at'})}>{(messages) =>
                   <div>{timeAgo(messages[0].updated_at)}{', ' if i isnt (users.length-1)}</div>
                 }</PromiseRenderer>

--- a/app/talk/init.cjsx
+++ b/app/talk/init.cjsx
@@ -170,7 +170,7 @@ module?.exports = React.createClass
           </section>
 
           <section>
-            <ActiveUsers section={@props.section} />
+            <ActiveUsers project={@props.project} section={@props.section} />
           </section>
 
           <section>

--- a/app/talk/latest-comment-link.cjsx
+++ b/app/talk/latest-comment-link.cjsx
@@ -8,6 +8,7 @@ PromiseRenderer = require '../components/promise-renderer'
 {Link, History} = require 'react-router'
 merge = require 'lodash.merge'
 {Markdown} = (require 'markdownz').default
+ContextualLinks = require '../lib/contextual-links'
 
 PAGE_SIZE = require('./config').discussionPageSize
 
@@ -77,7 +78,8 @@ module?.exports = React.createClass
         </div>
 
         {if @state.commentUser?
-          <Link className="user-profile-link" to="/users/#{@state.commentUser.login}">
+          commenterProfileLink = ContextualLinks.prefixLinkIfNeeded(@props,"/users/#{@state.commentUser.login}")
+          <Link className="user-profile-link" to="#{commenterProfileLink}">
             <Avatar user={@state.commentUser} />{' '}{@state.commentUser.display_name}
           </Link>}
 

--- a/app/talk/latest-comment-link.cjsx
+++ b/app/talk/latest-comment-link.cjsx
@@ -78,7 +78,7 @@ module?.exports = React.createClass
         </div>
 
         {if @state.commentUser?
-          commenterProfileLink = ContextualLinks.prefixLinkIfNeeded(@props,"/users/#{@state.commentUser.login}")
+          commenterProfileLink = ContextualLinks.prefixLinkIfNeeded @props, "/users/#{@state.commentUser.login}"
           <Link className="user-profile-link" to="#{commenterProfileLink}">
             <Avatar user={@state.commentUser} />{' '}{@state.commentUser.display_name}
           </Link>}

--- a/app/talk/moderation/actions.cjsx
+++ b/app/talk/moderation/actions.cjsx
@@ -3,6 +3,7 @@ React = require 'react'
 moment = require 'moment'
 apiClient = require 'panoptes-client/lib/api-client'
 Loading = require '../../components/loading-indicator'
+ContextualLinks = require '../../lib/contextual-links'
 
 actionTaken =
   destroy: 'Deleted'
@@ -74,8 +75,9 @@ module?.exports = React.createClass
       {if @state.actions
         <div>
           {for action in @state.actions
+            link = ContextualLinks.prefixIfNeeded(@props,"/users/#{action.user.login}")
             <div key={"moderation-#{moderation.id}-action-#{action.action}"}>
-              {actionTaken[action.action] ? action.action} by <Link to="/users/#{action.user.login}">{action.user.display_name}</Link>
+              {actionTaken[action.action] ? action.action} by <Link to="#{link}">{action.user.display_name}</Link>
               {if action.message
                 <div>
                   <i className="fa fa-quote-left"/> {action.message} <i className="fa fa-quote-right"/>

--- a/app/talk/moderation/comment.cjsx
+++ b/app/talk/moderation/comment.cjsx
@@ -5,6 +5,7 @@ Loading = require '../../components/loading-indicator'
 CommentLink = require '../../pages/profile/comment-link'
 ModerationReports = require './reports'
 ModerationActions = require './actions'
+ContextualLinks = require '../../lib/contextual-links'
 
 module?.exports = React.createClass
   displayName: 'ModerationComment'
@@ -30,6 +31,7 @@ module?.exports = React.createClass
   render: ->
     <div className="talk-module">
       {if @state.comment
+        link = ContextualLinks.prefixIfNeeded @props, "/users/#{state.comment.user-login}"
         <div key={"comment-#{@state.comment.id}"}>
           <h1>Comment {@state.comment.id} Reports</h1>
           <ModerationReports reports={@props.moderation.reports} />

--- a/app/talk/moderation/reports.cjsx
+++ b/app/talk/moderation/reports.cjsx
@@ -2,6 +2,7 @@ React = require 'react'
 {Link} = require 'react-router'
 apiClient = require 'panoptes-client/lib/api-client'
 Loading = require '../../components/loading-indicator'
+ContextualLinks = require '../../lib/contextual-links'
 
 module?.exports = React.createClass
   displayName: 'ModerationActions'
@@ -23,8 +24,9 @@ module?.exports = React.createClass
     <ul>
       {if @state.reports
         for report, i in @state.reports
+          link = ContextualLinks.prefixLinkIfNeeded @props, "/users/#{report.user.login}"
           <li key={"report-#{i}"}>
-            <Link to="/users/#{report.user.login}">{report.user.display_name}</Link>: {report.message}
+            <Link to="#{link}">{report.user.display_name}</Link>: {report.message}
           </li>
       else
         <Loading />}

--- a/app/talk/search.cjsx
+++ b/app/talk/search.cjsx
@@ -111,7 +111,7 @@ module.exports = React.createClass
               </section>
 
               <section>
-                <ActiveUsers section={@props.section} />
+                <ActiveUsers project={@props.project} section={@props.section} />
               </section>
 
               <section>

--- a/app/talk/tags.cjsx
+++ b/app/talk/tags.cjsx
@@ -93,7 +93,7 @@ module.exports = React.createClass
                 </section>
 
                 <section>
-                  <ActiveUsers section={@props.section} />
+                  <ActiveUsers project={@props.project} section={@props.section} />
                 </section>
 
                 <section>

--- a/css/owned-list-pages.styl
+++ b/css/owned-list-pages.styl
@@ -29,3 +29,10 @@
 
     .active
       border: 2px solid
+
+&.has-project-context
+  .collections-hero
+    background-image: none !important
+    background-color: transparent !important
+    padding-top: 2vw !important
+    min-height: initial !important

--- a/css/owned-list-pages.styl
+++ b/css/owned-list-pages.styl
@@ -29,14 +29,3 @@
 
     .active
       border: 2px solid
-
-&.has-project-context
-  .collections-hero
-    background-image: none !important
-    background-color: transparent !important
-    padding-top: 2vw !important
-    min-height: initial !important
-
-    .hero-container
-      margin: 0 !important
-      max-width: initial !important

--- a/css/owned-list-pages.styl
+++ b/css/owned-list-pages.styl
@@ -36,3 +36,6 @@
     background-color: transparent !important
     padding-top: 2vw !important
     min-height: initial !important
+
+    .hero-container
+      margin: 0 !important

--- a/css/owned-list-pages.styl
+++ b/css/owned-list-pages.styl
@@ -39,3 +39,4 @@
 
     .hero-container
       margin: 0 !important
+      max-width: initial !important

--- a/css/owned-list-pages.styl
+++ b/css/owned-list-pages.styl
@@ -19,6 +19,13 @@
         margin: 0
         padding: 2.33em 0
 
+    .remove-project-context-link-follows
+      p:first-child
+        padding-bottom: 0px !important
+
+      p.remove-project-context-link
+        padding-top: 5px !important
+
   .pagination
     padding: 2.33em 0
     text-align: center

--- a/css/owned-list-pages.styl
+++ b/css/owned-list-pages.styl
@@ -22,6 +22,7 @@
     .remove-project-context-link-follows
       p:first-child
         padding-bottom: 0px !important
+        padding-top: 0px !important
 
       p.remove-project-context-link
         padding-top: 5px !important

--- a/css/project-page.styl
+++ b/css/project-page.styl
@@ -161,6 +161,7 @@
   font-size: .75em
   color: #CDCDCD
 
+.collection-page-with-project-context,
 .project-text-content
   background: rgba(255,255,255,0.85)
   padding: 1.5em 3vw

--- a/css/project-page.styl
+++ b/css/project-page.styl
@@ -182,6 +182,12 @@
   a
     color: #0072ff
 
+&.in-project-context
+  nav.hero-nav
+    text-align: center
+  a
+    color: TEAL_GREEN !important
+
 .project-metadata
   padding: 1.5em 3vw
   margin: 0

--- a/css/project-page.styl
+++ b/css/project-page.styl
@@ -21,6 +21,9 @@
 .on-project-page
   background: FOREGROUND
   color: BACKGROUND
+  .error,
+  .loading
+    color: FOREGROUND
 
 .project-page
   display: flex

--- a/css/secondary-page.styl
+++ b/css/secondary-page.styl
@@ -77,6 +77,12 @@
   .content-container
     margin: 1em auto
 
+  .resources-container
+    nav.hero-nav
+      a
+        span
+          text-transform:none !important
+
 .centered-grid
   margin: 0 auto
   max-width: 960px

--- a/css/secondary-page.styl
+++ b/css/secondary-page.styl
@@ -55,6 +55,26 @@
       overflow: auto
       padding: 1em
 
+&.has-project-context
+  background-color: transparent !important
+
+  .hero
+    background-image: none !important
+    background-color: transparent !important
+    padding-top: 2vw !important
+    min-height: initial !important
+
+    .hero-container
+      margin: 0 !important
+      max-width: initial !important
+
+    .overlay
+      background-image: none !important
+      background-color: transparent !important
+
+  .content-container
+    margin: 1em auto
+
 .centered-grid
   margin: 0 auto
   max-width: 960px

--- a/css/secondary-page.styl
+++ b/css/secondary-page.styl
@@ -77,11 +77,10 @@
   .content-container
     margin: 1em auto
 
-  .resources-container
-    nav.hero-nav
-      a
-        span
-          text-transform:none !important
+  nav.hero-nav
+    a
+      span
+        text-transform:none !important
 
 .centered-grid
   margin: 0 auto

--- a/css/secondary-page.styl
+++ b/css/secondary-page.styl
@@ -68,6 +68,8 @@
       margin: 0 !important
       max-width: initial !important
 
+      h1
+        text-align: center
     .overlay
       background-image: none !important
       background-color: transparent !important


### PR DESCRIPTION
Fixes #2253.

NB This supersedes the previous approach which was overcomplicated and confusing.

## The problem(s) being solved:

- No way to view the collections/favorites specific to a project 
- Very easy to lose the fact you are "in" a project and drop back to Zoo-wide context, simply by clicking on a collection, user profile etc. This most often happens in Project Talk.

This PR can be tested on staging at https://maintain-project-context.pfe-preview.zooniverse.org/ (add `?env=production` to use on live projects)

# New Features 

This PR introduces:

## 1. A new "Collect" menu within Projects

![screenshot 2016-06-07 14 58 15 2](https://cloud.githubusercontent.com/assets/1473244/15860492/43781586-2cc1-11e6-8c95-73728cf370cf.png)

This new "Collect" menu (analogous to the Zoo-wide one) allows the user to browser all collections for a project, or just the collections/favourites within that project for a specific user.

## 2. Ability to view a user within the context of a project

![screenshot 2016-06-07 14 56 40 2](https://cloud.githubusercontent.com/assets/1473244/15860683/f43a938a-2cc1-11e6-810a-eaf68985abf0.png)

This ensures that when you click on a username in Project Talk, you remain in the context of that project.
Comments are filtered to only show those for this project, and 

## 3. Adapt all collection, favorites & user menus according to what currently makes sense

For example:
![screenshot 2016-06-07 15 15 53 2](https://cloud.githubusercontent.com/assets/1473244/15860904/cc965250-2cc2-11e6-9247-5f48228771ca.png)

The options available will carefully adapt according to:

- **Base Type** - are you looking at collections, favorites, a user profile or recent comments
- **Filter** - are you looking at the data for a user, a project, everything, or a user+project 
- **Context** - are you currently within the page/area that corresponds to a user, a project, everything, or a user+project 
- **Perspective** - are you logged out, logged in as the same user being looked at, or logged in as a different user than the one being looked at.

Key factors influencing the menu design were:

- It should always be clear what context you are in/what you are looking at
- As you click within a single menu, the options should not jump around confusingly 
- The line of menu links should never get too long - this involved shortening text and ensuring there are not too many options at any given time.
- You should be able to change focus between the whole project or a specific user without confusion.

## 4. A link that lets you explicitly step from a project to the wider Zooniverse

![screenshot 2016-06-07 14 57 57 2](https://cloud.githubusercontent.com/assets/1473244/15861129/8dcc6568-2cc3-11e6-8dad-3dce01008303.png)

This link exists on all the collection, favourite and user profile menus, and essentially means "show me everything for this user, not just on this project but on all projects".
Several different texts were considered - "Exit project", "Leave project", "View on Zooniverse.org" but @chrislintott came up with the slightly playful "To the Zooniverse!". This is a good option because it injects a bit more fun into the site, while still being clear about what it is doing. 

## 5. Menu navigation when viewing a collection

![screenshot 2016-06-07 15 23 55](https://cloud.githubusercontent.com/assets/1473244/15861238/dd70dfd6-2cc3-11e6-9d0b-704fced7bc8a.png)

As described in #2212, it's easy to hit a navigational dead end when viewing a collection. By adding a couple of contextual menu options, we are now able to ensure there is always a way back to that user's collections, or to that user's profile - keeping the project context if there is one.

## 6. Ensure that no links can accidentally take you out of a project

Now, to leave a project, you need to explicitly click "To The Zooniverse!" or go to the main Talk link in the main Zooniverse navigation. Clicking a user profile or collection within Project Talk, will never take you out of the project.

----

Note: all screenshots above are from *within* the project context, but the equivalent non-project menus for collections, favourites and user profiles have also been updated. For example:

![screenshot 2016-06-07 15 26 44](https://cloud.githubusercontent.com/assets/1473244/15861435/46c220a8-2cc4-11e6-8309-6c4236fc40e8.png)

----

Please try out this feature on staging, for example at 
https://maintain-project-context.pfe-preview.zooniverse.org/projects/alexbfree/computer-vision-serengeti/collections/?env=production
