### PR TITLE
Dynamically increase text task textarea height

### DIFF
--- a/app/classifier/tasks/text/index.cjsx
+++ b/app/classifier/tasks/text/index.cjsx
@@ -64,6 +64,7 @@ module.exports = React.createClass
 
   componentDidMount: ->
     @setState initOffsetHeight: @refs.textInput.offsetHeight
+    @updateHeight()
 
   setTagSelection: (e) ->
     textTag = e.target.value
@@ -84,10 +85,6 @@ module.exports = React.createClass
     newAnnotation = Object.assign @props.annotation, {value}
     @props.onChange newAnnotation
 
-  handleClear: (e) ->
-    if e.which is 8 or e.which is 46
-      @setState textareaHeight: @state.initOffsetHeight
-
   updateHeight: ->
     @setState textareaHeight: @refs.textInput.scrollHeight + 2
 
@@ -102,7 +99,6 @@ module.exports = React.createClass
           onChange={@handleChange}
           rows="1"
           style={height: @state.textareaHeight}
-          onKeyDown={@handleClear}
         />
       </label>
       {if @props.task.text_tags

--- a/app/classifier/tasks/text/index.cjsx
+++ b/app/classifier/tasks/text/index.cjsx
@@ -61,27 +61,6 @@ module.exports = React.createClass
   getInitialState: ->
     rows: 1
 
-  render: ->
-    <GenericTask question={@props.task.instruction} help={@props.task.help} required={@props.task.required}>
-      <label className="answer">
-        <textarea autoFocus={@props.autoFocus} className="standard-input full" rows={@state.rows} ref="textInput" value={@props.annotation.value} onChange={@handleChange} />
-      </label>
-      {if @props.task.text_tags
-          <div className="transcription-metadata-tags">
-            {for tag, i in @props.task.text_tags
-              <input type="button" className="standard-button text-tag" key={i} value={tag} onClick={@setTagSelection} />}
-          </div>}
-    </GenericTask>
-
-  handleChange: ->
-    if @refs.textInput.scrollHeight > @refs.textInput.offsetHeight
-      rows = @state.rows + 1
-      @setState rows: rows
-
-    value = @refs.textInput.value
-    newAnnotation = Object.assign @props.annotation, {value}
-    @props.onChange newAnnotation
-
   setTagSelection: (e) ->
     textTag = e.target.value
     startTag = '[' + textTag + ']'
@@ -100,3 +79,45 @@ module.exports = React.createClass
       value = textBefore + startTag + textInBetween + endTag + textAfter
     newAnnotation = Object.assign @props.annotation, {value}
     @props.onChange newAnnotation
+
+  handleResize: ->
+    scroll = @refs.textInput.scrollHeight
+    offset = @refs.textInput.offsetHeight
+    heightChange = scroll - offset + 2
+    return unless heightChange > 0
+
+    rows = @state.rows
+
+    if heightChange % 22 is 0
+      rows = rows + (heightChange / 22)
+    else
+      # Firefox increments by 7, 8, 22 or 23
+      switch heightChange
+        when 30
+          rows = rows + 2
+        when 52
+          rows = rows + 3
+        when 75
+          rows = rows + 4
+        else
+          rows = rows + 1
+
+    @setState rows: rows
+
+  render: ->
+    <GenericTask question={@props.task.instruction} help={@props.task.help} required={@props.task.required}>
+      <label className="answer">
+        <textarea autoFocus={@props.autoFocus} className="standard-input full" rows={@state.rows} ref="textInput" value={@props.annotation.value} onChange={@handleChange} />
+      </label>
+      {if @props.task.text_tags
+        <div className="transcription-metadata-tags">
+          {for tag, i in @props.task.text_tags
+            <input type="button" className="standard-button text-tag" key={i} value={tag} onClick={@setTagSelection} />}
+        </div>}
+    </GenericTask>
+
+  handleChange: ->
+    value = @refs.textInput.value
+    newAnnotation = Object.assign @props.annotation, {value}
+    @props.onChange newAnnotation
+    @handleResize()

--- a/app/classifier/tasks/text/index.cjsx
+++ b/app/classifier/tasks/text/index.cjsx
@@ -93,13 +93,13 @@ module.exports = React.createClass
       # Chrome, Safari increment rows (heightChange) by 22
       rows = rows + (heightChange / 22)
     else
-      # Firefox increments rows by 7, 8, 22 or 23, so the following handles specific noted row increases
+      # Firefox and Edge increment rows by varying amounts, so the following handles the row increases noted
       switch heightChange
-        when 30
+        when 30, 45
           rows = rows + 2
-        when 52
+        when 52, 67
           rows = rows + 3
-        when 75
+        when 75, 90
           rows = rows + 4
         else
           rows = rows + 1

--- a/app/classifier/tasks/text/index.cjsx
+++ b/app/classifier/tasks/text/index.cjsx
@@ -58,12 +58,15 @@ module.exports = React.createClass
     annotation: null
     onChange: NOOP
 
+  getInitialState: ->
+    rows: 1
+
   render: ->
     <GenericTask question={@props.task.instruction} help={@props.task.help} required={@props.task.required}>
       <label className="answer">
-        <textarea autoFocus={@props.autoFocus} className="standard-input full" rows="5" ref="textInput" value={@props.annotation.value} onChange={@handleChange} />
+        <textarea autoFocus={@props.autoFocus} className="standard-input full" rows={@state.rows} ref="textInput" value={@props.annotation.value} onChange={@handleChange} />
       </label>
-      {if @props.task.text_tags 
+      {if @props.task.text_tags
           <div className="transcription-metadata-tags">
             {for tag, i in @props.task.text_tags
               <input type="button" className="standard-button text-tag" key={i} value={tag} onClick={@setTagSelection} />}
@@ -71,6 +74,10 @@ module.exports = React.createClass
     </GenericTask>
 
   handleChange: ->
+    if @refs.textInput.scrollHeight > @refs.textInput.offsetHeight
+      rows = @state.rows + 1
+      @setState rows: rows
+
     value = @refs.textInput.value
     newAnnotation = Object.assign @props.annotation, {value}
     @props.onChange newAnnotation

--- a/app/classifier/tasks/text/index.cjsx
+++ b/app/classifier/tasks/text/index.cjsx
@@ -80,9 +80,15 @@ module.exports = React.createClass
     newAnnotation = Object.assign @props.annotation, {value}
     @props.onChange newAnnotation
 
+  handleReset: (e) ->
+    # keyCode 8 is backspace, 46 is delete
+    if e.which is 8 or e.which is 46
+      @setState rows: 1
+
   handleResize: ->
     scroll = @refs.textInput.scrollHeight
     offset = @refs.textInput.offsetHeight
+
     heightChange = scroll - offset + 2
     return unless heightChange > 0
 
@@ -107,7 +113,7 @@ module.exports = React.createClass
   render: ->
     <GenericTask question={@props.task.instruction} help={@props.task.help} required={@props.task.required}>
       <label className="answer">
-        <textarea autoFocus={@props.autoFocus} className="standard-input full" rows={@state.rows} ref="textInput" value={@props.annotation.value} onChange={@handleChange} />
+        <textarea autoFocus={@props.autoFocus} className="standard-input full" rows={@state.rows} ref="textInput" value={@props.annotation.value} onKeyDown={@handleReset} onChange={@handleChange} />
       </label>
       {if @props.task.text_tags
         <div className="transcription-metadata-tags">
@@ -118,6 +124,10 @@ module.exports = React.createClass
 
   handleChange: ->
     value = @refs.textInput.value
+
+    if @props.annotation.value?.length > value.length
+      @setState rows: 1
+    @handleResize()
+
     newAnnotation = Object.assign @props.annotation, {value}
     @props.onChange newAnnotation
-    @handleResize()

--- a/app/classifier/tasks/text/index.cjsx
+++ b/app/classifier/tasks/text/index.cjsx
@@ -113,7 +113,13 @@ module.exports = React.createClass
     </GenericTask>
 
   handleChange: ->
-    @updateHeight()
     value = @refs.textInput.value
+
+    if @props.annotation.value?.length > value.length
+      @setState textareaHeight: @state.initOffsetHeight, =>
+        @updateHeight()
+    else
+      @updateHeight()
+
     newAnnotation = Object.assign @props.annotation, {value}
     @props.onChange newAnnotation

--- a/app/classifier/tasks/text/index.cjsx
+++ b/app/classifier/tasks/text/index.cjsx
@@ -80,24 +80,20 @@ module.exports = React.createClass
     newAnnotation = Object.assign @props.annotation, {value}
     @props.onChange newAnnotation
 
-  handleReset: (e) ->
+  handleClear: (e) ->
     # keyCode 8 is backspace, 46 is delete
     if e.which is 8 or e.which is 46
       @setState rows: 1
 
   handleResize: ->
-    scroll = @refs.textInput.scrollHeight
-    offset = @refs.textInput.offsetHeight
-
-    heightChange = scroll - offset + 2
+    heightChange = @refs.textInput.scrollHeight - @refs.textInput.offsetHeight + 2
     return unless heightChange > 0
-
     rows = @state.rows
-
     if heightChange % 22 is 0
+      # Chrome, Safari increment rows (heightChange) by 22
       rows = rows + (heightChange / 22)
     else
-      # Firefox increments by 7, 8, 22 or 23
+      # Firefox increments rows by 7, 8, 22 or 23, so the following handles specific noted row increases
       switch heightChange
         when 30
           rows = rows + 2
@@ -107,13 +103,12 @@ module.exports = React.createClass
           rows = rows + 4
         else
           rows = rows + 1
-
     @setState rows: rows
 
   render: ->
     <GenericTask question={@props.task.instruction} help={@props.task.help} required={@props.task.required}>
       <label className="answer">
-        <textarea autoFocus={@props.autoFocus} className="standard-input full" rows={@state.rows} ref="textInput" value={@props.annotation.value} onKeyDown={@handleReset} onChange={@handleChange} />
+        <textarea autoFocus={@props.autoFocus} className="standard-input full" rows={@state.rows} ref="textInput" value={@props.annotation.value} onKeyDown={@handleClear} onChange={@handleChange} />
       </label>
       {if @props.task.text_tags
         <div className="transcription-metadata-tags">


### PR DESCRIPTION
update text task textarea element, row attribute, based on content typed (specifically by comparing scrollHeight to offsetHeight).

staging site here:  https://text-task-auto-height.pfe-preview.zooniverse.org.

in Firefox the textarea will only increase up to 5 rows, while other browsers (Chrome, Safari, in process of testing on Edge) will increase indefinitely.

please let me know what you think, thanks!