### PR TITLE
Option for flex on subject viewer

### DIFF
--- a/app/components/subject-viewer.cjsx
+++ b/app/components/subject-viewer.cjsx
@@ -66,7 +66,7 @@ module.exports = React.createClass
       "subject-viewer--layout-#{@props.workflow?.configuration?.multi_image_layout}": @props.workflow?.configuration?.multi_image_layout
     })
     # Feature detect IE11 and apply flex prop. Revisit or remove when IE11 is no longer supported.
-    rootStyle = flex: "1 1 auto" if "ActiveXObject" in window or window.ActiveXObject isnt undefined or @props.workflow.configuration.image_layout and 'no-max-height' in @props.workflow.configuration.image_layout
+    rootStyle = flex: "1 1 auto" if "ActiveXObject" in window or window.ActiveXObject isnt undefined or @props.workflow.configuration.image_layout and 'flex-option' in @props.workflow.configuration.image_layout
     mainDisplay = ''
     {type, format, src} = getSubjectLocation @props.subject, @state.frame
     if @state.inFlipbookMode

--- a/app/components/subject-viewer.cjsx
+++ b/app/components/subject-viewer.cjsx
@@ -66,7 +66,7 @@ module.exports = React.createClass
       "subject-viewer--layout-#{@props.workflow?.configuration?.multi_image_layout}": @props.workflow?.configuration?.multi_image_layout
     })
     # Feature detect IE11 and apply flex prop. Revisit or remove when IE11 is no longer supported.
-    rootStyle = flex: "1 1 auto" if "ActiveXObject" in window or window.ActiveXObject isnt undefined
+    rootStyle = flex: "1 1 auto" if "ActiveXObject" in window or window.ActiveXObject isnt undefined or @props.workflow.configuration.image_layout and 'no-max-height' in @props.workflow.configuration.image_layout
     mainDisplay = ''
     {type, format, src} = getSubjectLocation @props.subject, @state.frame
     if @state.inFlipbookMode


### PR DESCRIPTION
This PR uses a workflow configuration to optionally add a `flex` property to the subject viewer. The `flex` property will only be added to the subject-viewer if the `workflow.configuration.image_layout` contains `'flex-option'`. Primarily motivated by my transcription projects that are requesting more pan/zoom-able space. 

Staged [here](https://option-for-flex-on-subject-image.pfe-preview.zooniverse.org/projects/markb-panoptes/focus-testing-project/classify?workflow=2359) with an example workflow.