### PR TITLE
add holding page while stats server is being fixed

### DIFF
--- a/app/pages/project/stats/index.cjsx
+++ b/app/pages/project/stats/index.cjsx
@@ -67,4 +67,13 @@ ProjectStatsPageController = React.createClass
 
     <ProjectStatsPage {...queryProps} />
 
-module.exports = ProjectStatsPageController
+StatsHoldingPage = React.createClass
+  render: ->
+    <div className="project-text-content content-container">
+      <div className="project-stats-dashboard">
+        Project statistics are currently unavalible and we are working to fix the issue.
+      </div>
+    </div>
+
+#module.exports = ProjectStatsPageController
+module.exports = StatsHoldingPage


### PR DESCRIPTION
Adds the message "Project statistics are currently unavalible and we are working to fix the issue" as the stats page while the stats server is being fixed.