### PR TITLE
More appropriate subject image flex rules

### DIFF
--- a/app/components/subject-viewer.cjsx
+++ b/app/components/subject-viewer.cjsx
@@ -65,8 +65,7 @@ module.exports = React.createClass
       'subject-viewer--flipbook': @state.inFlipbookMode
       "subject-viewer--layout-#{@props.workflow?.configuration?.multi_image_layout}": @props.workflow?.configuration?.multi_image_layout
     })
-    # Feature detect IE11 and apply flex prop. Revisit or remove when IE11 is no longer supported.
-    rootStyle = flex: "1 1 auto" if "ActiveXObject" in window or window.ActiveXObject isnt undefined
+
     mainDisplay = ''
     {type, format, src} = getSubjectLocation @props.subject, @state.frame
     if @state.inFlipbookMode
@@ -103,7 +102,7 @@ module.exports = React.createClass
               </span>}
           </span>
 
-    <div className={rootClasses} style={rootStyle}>
+    <div className={rootClasses}>
       {if type is 'image'
         @hiddenPreloadedImages()}
       <div className="subject-container" style={CONTAINER_STYLE} >

--- a/app/components/subject-viewer.cjsx
+++ b/app/components/subject-viewer.cjsx
@@ -122,7 +122,9 @@ module.exports = React.createClass
         </span>}
         <span>
           {if @props.workflow?.configuration?.enable_subject_flags
-            <FlagSubjectButton className="secret-button" classification={@props.classification} />}
+            <span>
+              <FlagSubjectButton className="secret-button" classification={@props.classification} />{' '}
+            </span>}
           {if @props.subject?.metadata?
             <span>
               <button type="button" className="secret-button" aria-label="Metadata" title="Metadata" onClick={@showMetadata}>

--- a/app/pages/dev-classifier/mock-data.coffee
+++ b/app/pages/dev-classifier/mock-data.coffee
@@ -449,11 +449,18 @@ workflow = apiClient.type('workflows').create
 subject = apiClient.type('subjects').create
   id: 'MOCK_SUBJECT_FOR_CLASSIFIER'
 
-  locations: [
-    {'image/jpeg': if navigator?.onLine then '//lorempixel.com/320/240/animals/1' else BLANK_IMAGE}
-    {'image/jpeg': if navigator?.onLine then '//lorempixel.com/320/240/animals/2' else BLANK_IMAGE}
-    {'image/jpeg': if navigator?.onLine then '//lorempixel.com/320/240/animals/3' else BLANK_IMAGE}
-  ]
+  locations: if navigator?.onLine
+    [
+      {'image/jpeg': '//lorempixel.com/900/600/animals/1'} # Landscape
+      {'image/jpeg': '//lorempixel.com/600/900/animals/2'} # Portrait
+      {'image/jpeg': '//lorempixel.com/1900/1000/animals/3'} # Very wide
+      {'image/jpeg': '//lorempixel.com/1000/1900/animals/4'} # Very tall
+      {'image/jpeg': '//lorempixel.com/400/300/animals/4'} # Sorta small
+    ]
+  else
+    [
+      {'image/png': BLANK_IMAGE}
+    ]
 
   metadata:
     'Capture date': '5 Feb, 2015'
@@ -504,7 +511,7 @@ subject = apiClient.type('subjects').create
         value: 6
       }]
 
-project = apiClient.type('project').create
+project = apiClient.type('projects').create
   id: 'MOCK_PROJECT_FOR_CLASSIFIER'
   title: "The Dev Classifier"
   experimental_tools: ['pan and zoom']

--- a/app/pages/dev-classifier/mock-data.coffee
+++ b/app/pages/dev-classifier/mock-data.coffee
@@ -30,6 +30,7 @@ workflow = apiClient.type('workflows').create
   configuration:
     enable_subject_flags: true
     multi_image_mode: 'flipbook_and_separate'
+    multi_image_layout: 'grid3'
 
   first_task: 'init'
 

--- a/css/classify.styl
+++ b/css/classify.styl
@@ -35,20 +35,15 @@
   @media (max-width: 900px) // This is between iPad landscape and portrait.
     flex-wrap: wrap
 
-  > .subject-area
-    align-items: center
-    display: flex
-    flex-shrink: 1
-    flex-direction: column
-    margin: 0 1.5vw 1em 0
-    min-width: 0
+  > .subject-viewer
+    flex: 0 1 auto
 
   .subject-container
     color: gray
     max-width: 100%
+
     > *
       display: flex
-      flex: 1 1 auto // Fix for IE 11. Revisit or remove when IE11 is no longer supported.
 
   .subject
     border-radius: 5px
@@ -114,6 +109,7 @@
     flex: 0 0 60ch
     margin-bottom: 1em
     max-width: 100%
+
     @media (min-width: 900px)
       margin-left: 1em
 
@@ -132,7 +128,7 @@
 
     > :not(:first-child)
       margin-left: 0.5em
-  
+
   .back-button-warning
     background-color: #686868
     border-radius: .3em
@@ -200,4 +196,4 @@
     opacity: 0.01
     position: absolute
     &:focus + *:not(.active)
-      background: lighten(#424242, 95%)      
+      background: lighten(#424242, 95%)

--- a/css/subject.styl
+++ b/css/subject.styl
@@ -1,7 +1,7 @@
 .subject-viewer
   min-width: 0
   max-width: 100%
-  
+
   .default-root-style
     display: block
 
@@ -9,17 +9,17 @@
     .subject-frame-pip
       &.active
         font-weight: 700
-  
+
   video
     width: 100%
-  
+
   .subject-video-controls
     display: inline-block
     width: 30vw
-  
+
   .video-scrubber
     width: 80%
-    
+
   .video-speed
     white-space: nowrap
     display: inline-block
@@ -36,21 +36,20 @@
         left: -50px
         height: 0
         width: 0
-  
+
         &:checked + span
           color: MAIN_HIGHLIGHT
 
   .subject-container
     > *
       max-width: 100%
-    
+
     .frame-annotator
       flex: 9
-      
+
     image.pan-active
       cursor: all-scroll
     .pan-zoom-controls
-      flex: 1
       text-align: center
       background: grey;
       border-radius: .1em;
@@ -68,7 +67,7 @@
         button
           background-color: transparent
           border:none
-          
+
       button
         background-color: #f9f9f9
         border: solid 1px #989898
@@ -76,11 +75,12 @@
         border-radius: 0.2em
         &.disabled
           background-color: #bbc0c0
-          color: #575959 
+          color: #575959
 
   // Multi-image layouts
   &:not(.subject-viewer--flipbook)
     .subject-container
+      align-items: center
       justify-content: space-between
     &.subject-viewer--layout-grid2
       .subject-container > *


### PR DESCRIPTION
This replaces the IE-specific `flex: 1 1 auto` on the SubjectViewer with `flex: 0 1 auto` for all browsers. That means the element will try to be as wide as it needs to display its content (`flex-basis: auto`, shrink if there's not enough room (`flex-shrink: 1`), and (this is the change) not grow any larger than it needs (`flex-grow: 0`), which means the black bars from #2329 won't be a problem. I also removed the potential for black bars in grid view.

I've put some a few various image sizes and proportions in the dev classifier mock data to demo what each of them looks like.

Also includes a button style fix that's been buggin' me.