### PR TITLE
fix bug req dropdown cleared allow proceed

### DIFF
--- a/app/classifier/tasks/dropdown/index.cjsx
+++ b/app/classifier/tasks/dropdown/index.cjsx
@@ -79,7 +79,7 @@ module?.exports = React.createClass
 
     isAnnotationComplete: (task, annotation) ->
       task.selects.every (select, i) ->
-        not select.required or annotation.value[i]?.value?
+        not select.required or (annotation.value[i]?.value? and annotation.value[i]?.value isnt "")
 
     testAnnotationQuality: (unknown, knownGood) ->
       distance = levenshtein.get unknown.value.toLowerCase(), knownGood.value.toLowerCase()


### PR DESCRIPTION
fixes issue where if dropdown set as required, selection made, but then cleared, volunteer allowed to proceed even though they shouldn't be without providing answer to required dropdown

 - [staged branch](https://dropdown-req-clear-fix.pfe-preview.zooniverse.org/)

 - [project on staging for testing](https://pfe-preview.zooniverse.org/projects/markb-panoptes/nfn-testing) - Single Dropdown Required Workflow, Single Dropdown NOT Required Workflow or Dropdown Workflow (only country required) to help test