### PR TITLE
workflow config for large image layout

### DIFF
--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -94,7 +94,8 @@ Classifier = React.createClass
       @addAnnotationForTask classification, @props.workflow.first_task
 
   render: ->
-    classifierClassNames = if @props.workflow.configuration.image_layout and 'no-max-height' in @props.workflow.configuration.image_layout then "classifier large-image" else "classifier"
+    largeFormatImage = @props.workflow.configuration.image_layout and 'no-max-height' in @props.workflow.configuration.image_layout
+    classifierClassNames = if largeFormatImage then "classifier large-image" else "classifier"
 
     <ChangeListener target={@props.classification}>{=>
       if @state.showingExpertClassification

--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -94,6 +94,8 @@ Classifier = React.createClass
       @addAnnotationForTask classification, @props.workflow.first_task
 
   render: ->
+    classifierClassNames = if @props.workflow.configuration.image_layout and 'no-max-height' in @props.workflow.configuration.image_layout then "classifier large-image" else "classifier"
+
     <ChangeListener target={@props.classification}>{=>
       if @state.showingExpertClassification
         currentClassification = @state.expertClassification
@@ -106,7 +108,7 @@ Classifier = React.createClass
       # This is just easy access for debugging.
       window.classification = currentClassification
 
-      <div className="classifier">
+      <div className={classifierClassNames} >
         <SubjectViewer
           user={@props.user}
           project={@props.project}

--- a/app/pages/project/classify.cjsx
+++ b/app/pages/project/classify.cjsx
@@ -227,14 +227,13 @@ module.exports = React.createClass
     </div>
 
   scrollIntoView: (e) ->
-    # Auto-scroll to the middle of the classification interface on load.
+    # Auto-scroll to top of the classification interface on load.
     # It's not perfect, but it should make the location of everything more obvious.
     lineHeight = parseFloat getComputedStyle(document.body).lineHeight
     node = ReactDOM.findDOMNode(@)
-    space = (innerHeight - node.offsetHeight) / 2
-    idealScrollY = node.offsetTop - space
+    idealScrollY = node.offsetTop - lineHeight
     if Math.abs(idealScrollY - scrollY) > lineHeight
-      animatedScrollTo document.body, node.offsetTop - space, 333
+      animatedScrollTo document.body, node.offsetTop - lineHeight, 333
 
   handleDemoModeChange: (newDemoMode) ->
     sessionDemoMode = newDemoMode

--- a/css/classify.styl
+++ b/css/classify.styl
@@ -120,7 +120,7 @@
       max-height: none
     
     .task-area
-      flex: 0 0 40ch
+      flex: 0 0 45ch
       
   .task-nav
     display: flex

--- a/css/classify.styl
+++ b/css/classify.styl
@@ -50,7 +50,7 @@
     box-shadow: 0 0 0 1px gray
     max-height: 90vh
     max-width: 100%
-    user-select: none
+    user-select: none    
 
   .marking-initializer
     cursor: crosshair
@@ -113,6 +113,15 @@
     @media (min-width: 900px)
       margin-left: 1em
 
+  // for subject images that are not height contained
+  // this class name is enabled through a workflow config
+  &.large-image 
+    .subject
+      max-height: none
+    
+    .task-area
+      flex: 0 0 40ch
+      
   .task-nav
     display: flex
     margin-top: 1em


### PR DESCRIPTION
This PR creates a classifier layout that supports larger (i.e., not-height-contained) subject images and a smaller task area. This version of the classifier layout is engaged when `workflow.configuration.image_layout` contains `'no-max-height'`.

In addition, I made some adjustments to the scroll behavior for the classifier component. Instead of scrolling to the middle of the subject image, the page scrolls to just above the classifier component.

Check out the staged version with an example workflow [here](https://wrkflw-config-for-large-image-format.pfe-preview.zooniverse.org/projects/markb-panoptes/focus-testing-project/classify?reload=0&workflow=2359). 