### PR TITLE
fix text task autoheight reset

### DIFF
--- a/app/classifier/tasks/text/index.cjsx
+++ b/app/classifier/tasks/text/index.cjsx
@@ -66,6 +66,11 @@ module.exports = React.createClass
     @setState initOffsetHeight: @refs.textInput.offsetHeight
     @updateHeight()
 
+  componentWillReceiveProps: (nextProps) ->
+    if nextProps.task.instruction isnt @props.task.instruction
+      @setState textareaHeight: @state.initOffsetHeight, =>
+        @updateHeight()
+
   setTagSelection: (e) ->
     textTag = e.target.value
     startTag = '[' + textTag + ']'

--- a/app/classifier/tasks/text/index.cjsx
+++ b/app/classifier/tasks/text/index.cjsx
@@ -67,7 +67,7 @@ module.exports = React.createClass
     @updateHeight()
 
   componentWillReceiveProps: (nextProps) ->
-    if nextProps.task.instruction isnt @props.task.instruction
+    if nextProps.task isnt @props.task
       @setState textareaHeight: @state.initOffsetHeight, =>
         @updateHeight()
 


### PR DESCRIPTION
fixes issue with back to back text tasks (including within combo) where if first text task resized, second text task inherits resized height instead of reseting to default height.

 - [staged branch](https://text-task-autoheight-fix.pfe-preview.zooniverse.org/)

 - [project on staging for testing](https://pfe-preview.zooniverse.org/projects/markb-panoptes/nfn-testing) - Text Workflow to help test