### PR TITLE
Show an icon for external links

### DIFF
--- a/app/pages/about/team-page.cjsx
+++ b/app/pages/about/team-page.cjsx
@@ -417,7 +417,7 @@ module.exports = React.createClass
             <div key={teamMember} className="team-member">
               <img src={imageSrc} alt="#{details.name}" />
               <div className="team-member-details">
-                <h3>{details.name}, {details.title} {if details.twitter then <a href="http://twitter.com/#{details.twitter}" target="_blank"><i className="fa fa-twitter"></i></a> }</h3>
+                <h3>{details.name}, {details.title} {if details.twitter then <a href="http://twitter.com/#{details.twitter}" className="suppress-external-link-icon" target="_blank"><i className="fa fa-twitter"></i></a> }</h3>
                 <p>{details.bio}</p>
               </div>
             </div>

--- a/app/pages/profile/comment-link.cjsx
+++ b/app/pages/profile/comment-link.cjsx
@@ -57,7 +57,7 @@ module?.exports = React.createClass
         {if @state.board?.id and @state.discussion?.id
           <span>
             {' '}in{' '}
-            <a href={@state.href}>
+            <a className="suppress-external-link-icon" href={@state.href}>
               {if @state.project? and @state.owner
                 <span>
                   <strong className="comment-project" title="#{@state.owner.display_name}/#{@state.project.display_name}">{@state.project.display_name}</strong>

--- a/app/partials/main-footer.cjsx
+++ b/app/partials/main-footer.cjsx
@@ -112,9 +112,9 @@ module.exports = React.createClass
             <a href="http://blog.zooniverse.org/" target="_blank"><Translate content="footer.talk.blog" /></a>
           </div>
           <div className="site-map-section social-media">
-            <a href="https://www.facebook.com/therealzooniverse" target="_blank"><i className="fa fa-facebook"></i></a>
-            <a href="https://twitter.com/the_zooniverse" target="_blank"><i className="fa fa-twitter"></i></a>
-            <a href="https://plus.google.com/+ZooniverseOrgReal" target="_blank"><i className="fa fa-google-plus"></i></a>
+            <a href="https://www.facebook.com/therealzooniverse" className="suppress-external-link-icon" target="_blank"><i className="fa fa-facebook"></i></a>
+            <a href="https://twitter.com/the_zooniverse" className="suppress-external-link-icon" target="_blank"><i className="fa fa-twitter"></i></a>
+            <a href="https://plus.google.com/+ZooniverseOrgReal" className="suppress-external-link-icon" target="_blank"><i className="fa fa-google-plus"></i></a>
           </div>
         </nav>
       </div>

--- a/css/common.styl
+++ b/css/common.styl
@@ -102,7 +102,7 @@ $generic-heading
   display: block
 
 /* applying style from "fa" and "fa-external-link" conditionally rather than have to apply those classes every time */
-a[href^="http"]:after
+a[href^="http"]:not(.suppress-external-link-icon):after
   content: "\00a0\f08e"
   display: inline-block;
   font: normal normal normal 14px/1 FontAwesome;

--- a/css/common.styl
+++ b/css/common.styl
@@ -100,3 +100,13 @@ $generic-heading
 
 .approval-status
   display: block
+
+/* applying style from "fa" and "fa-external-link" conditionally rather than have to apply those classes every time */
+a[href^="http"]:after
+  content: "\00a0\f08e"
+  display: inline-block;
+  font: normal normal normal 14px/1 FontAwesome;
+  font-size: inherit;
+  text-rendering: auto;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;


### PR DESCRIPTION
We don't want to define "open in new tab" behaviour as it can and should depend on the user's preference or browser settings. We do want the behaviour of a link to be predictable. Therefore, a sensible way forward would be to ensure that any link that takes you off site is marked as an external link. Like this:

![screenshot 2016-06-16 15 13 09](https://cloud.githubusercontent.com/assets/1473244/16119861/5655802e-33d5-11e6-9ddb-4bb672a93d85.png)

or this:
![screenshot 2016-06-16 15 12 54](https://cloud.githubusercontent.com/assets/1473244/16119863/583c7db6-33d5-11e6-9a40-3123c13594f3.png)

or this:
![screenshot 2016-06-16 15 22 01](https://cloud.githubusercontent.com/assets/1473244/16120050/1f2f694c-33d6-11e6-8438-e416149b72cc.png)

This is especially useful when a menu contains a list of external and in-page links, and also when you are in a middle of a task that would be destroyed/interrupted by clicking off page (as in the second example screenshot).

The code in this PR will automatically suffix any external link with an external link icon (which is already present in our font awesome pack).

External links are identified simply as those beginning `http` (best practice would suggest any link within the site should be relatively specified and not start with `http`).

For those occasions where we do not want this to appear on specific links, we can add the `suppress-external-link-icon` class to the `<a>`'s attributes and this will ensure no icon appears.

Deployed to https://external-links.pfe-preview.zooniverse.org/?env=production for testing.

I have opted for a CSS-only solution because I think this is the best way not to miss any. Especially as project builders or Talk commenters can add their own external links.