### PR TITLE
[do not merge] Fix collection pagination (geordi logging issue)

### DIFF
--- a/app/collections/show-list.cjsx
+++ b/app/collections/show-list.cjsx
@@ -108,7 +108,7 @@ module?.exports = React.createClass
             <div className="collection-subjects-list">{subjects.map(subjectNode)}</div>
 
             <Paginator
-              collection={@props.collection}
+              data={collection:@props.collection.slug}
               page={meta.page}
               onPageChange={@onPageChange}
               pageCount={meta.page_count} />

--- a/app/collections/show-list.cjsx
+++ b/app/collections/show-list.cjsx
@@ -108,6 +108,7 @@ module?.exports = React.createClass
             <div className="collection-subjects-list">{subjects.map(subjectNode)}</div>
 
             <Paginator
+              collection={@props.collection}
               page={meta.page}
               onPageChange={@onPageChange}
               pageCount={meta.page_count} />

--- a/app/talk/lib/paginator.cjsx
+++ b/app/talk/lib/paginator.cjsx
@@ -13,6 +13,7 @@ module?.exports = React.createClass
     scrollOnChange: React.PropTypes.bool          # optional, scroll to top of page on change
     pageSelector: React.PropTypes.bool            # show page selector?
     pageKey: React.PropTypes.string               # optional name for key param (defaults to 'page')
+    data: React.PropTypes.object                  # additional data to be added to the data field when logging to Geordi
 
   getDefaultProps: ->
     page: 1
@@ -26,16 +27,12 @@ module?.exports = React.createClass
     scrollOnChange: true
     previousLabel: <span><i className="fa fa-long-arrow-left" /> Previous</span>
     nextLabel: <span>Next <i className="fa fa-long-arrow-right" /></span>
+    data: {}
 
   mixins: [History]
 
   contextTypes:
     geordi: React.PropTypes.object
-
-  addAvailableData: (data) ->
-    if @props.collection?
-      data.collection = @props.collection.slug
-    data
 
   setPage: (activePage) ->
     @props.onPageChange.call(this, activePage)
@@ -45,7 +42,7 @@ module?.exports = React.createClass
     @context.geordi?.logEvent
       type: 'change-page'
       relatedID: 'next-page'
-      data: @addAvailableData {page:@props[@props.pageKey]}
+      data: {page:@props[@props.pageKey], {...@props.data}}
     {pageCount} = @props
     page = @props[@props.pageKey]
     @props.onClickNext?()
@@ -57,7 +54,7 @@ module?.exports = React.createClass
     @context.geordi?.logEvent
       type: 'change-page'
       relatedID: 'previous-page'
-      data: @addAvailableData {page:@props[@props.pageKey]}
+      data: {page:@props[@props.pageKey], {...@props.data}}
     page = @props[@props.pageKey]
     @props.onClickPrev?()
 
@@ -68,7 +65,7 @@ module?.exports = React.createClass
     @context.geordi?.logEvent
       type: 'change-page'
       relatedID: 'select-page'
-      data: @addAvailableData {page:@refs.pageSelect.value}
+      data: {page:@refs.pageSelect.value, {...@props.data}}
     selectedPage = +@refs.pageSelect.value
     @setPage(selectedPage)
 
@@ -90,7 +87,7 @@ module?.exports = React.createClass
             @context.geordi?.logEvent
               type: 'change-page'
               relatedID: 'first-page'
-              data: @addAvailableData {page:1}
+              data: {page:1, {...@props.data}}
           }
           disabled={page is 1}>
           <i className="fa fa-fast-backward" /> First
@@ -127,7 +124,7 @@ module?.exports = React.createClass
             @context.geordi?.logEvent
               type: 'change-page'
               relatedID: 'last-page'
-              data: @addAvailableData {page:pageCount}
+              data: {page:pageCount, {...@props.data}}
           }
           disabled={page is pageCount}>
           Last <i className="fa fa-fast-forward" />

--- a/app/talk/lib/paginator.cjsx
+++ b/app/talk/lib/paginator.cjsx
@@ -32,10 +32,13 @@ module?.exports = React.createClass
   contextTypes:
     geordi: React.PropTypes.object
 
-  componentWillReceiveProps: (nextProps, nextContext) ->
-    @context.geordi?.logEvent
-      type: 'change-page'
-      relatedID: "page-#{nextProps.page}"
+  addAvailableData: (data) ->
+    if @props.collection?
+      data.collection = @props.collection.slug
+    data
+
+  componentDidMount: ->
+    @logClick = @context.geordi.makeHandler 'change-page'
 
   setPage: (activePage) ->
     @props.onPageChange.call(this, activePage)
@@ -43,8 +46,9 @@ module?.exports = React.createClass
 
   onClickNext: ->
     @context.geordi?.logEvent
-      type: 'next-page'
-      relatedID: "page-#{@props[@props.pageKey]}"
+      type: 'change-page'
+      relatedID: 'next-page'
+      data: @addAvailableData {page:@props[@props.pageKey]}
     {pageCount} = @props
     page = @props[@props.pageKey]
     @props.onClickNext?()
@@ -54,8 +58,9 @@ module?.exports = React.createClass
 
   onClickPrev: ->
     @context.geordi?.logEvent
-      type: 'previous-page'
-      relatedID: "page-#{@props[@props.pageKey]}"
+      type: 'change-page'
+      relatedID: 'previous-page'
+      data: @addAvailableData {page:@props[@props.pageKey]}
     page = @props[@props.pageKey]
     @props.onClickPrev?()
 
@@ -64,9 +69,9 @@ module?.exports = React.createClass
 
   onSelectPage: (e) ->
     @context.geordi?.logEvent
-      type: 'select-page'
-      relatedID: "page-#{@refs.pageSelect.value}"
-
+      type: 'change-page'
+      relatedID: 'select-page'
+      data: @addAvailableData {page:@refs.pageSelect.value}
     selectedPage = +@refs.pageSelect.value
     @setPage(selectedPage)
 
@@ -86,8 +91,9 @@ module?.exports = React.createClass
           onClick={=>
             @setPage(1);
             @context.geordi?.logEvent
-              type: 'first-page'
-              relatedID: 'page-1'
+              type: 'change-page'
+              relatedID: 'first-page'
+              data: @addAvailableData {page:1}
           }
           disabled={page is 1}>
           <i className="fa fa-fast-backward" /> First
@@ -122,8 +128,9 @@ module?.exports = React.createClass
           onClick={=>
             @setPage(pageCount);
             @context.geordi?.logEvent
-              type: 'last-page'
-              relatedID: "page-#{pageCount}"
+              type: 'change-page'
+              relatedID: 'last-page'
+              data: @addAvailableData {page:pageCount}
           }
           disabled={page is pageCount}>
           Last <i className="fa fa-fast-forward" />

--- a/app/talk/lib/paginator.cjsx
+++ b/app/talk/lib/paginator.cjsx
@@ -37,9 +37,6 @@ module?.exports = React.createClass
       data.collection = @props.collection.slug
     data
 
-  componentDidMount: ->
-    @logClick = @context.geordi.makeHandler 'change-page'
-
   setPage: (activePage) ->
     @props.onPageChange.call(this, activePage)
     window.scrollTo(0,0) if @props.scrollOnChange

--- a/app/talk/lib/paginator.cjsx
+++ b/app/talk/lib/paginator.cjsx
@@ -32,15 +32,19 @@ module?.exports = React.createClass
   contextTypes:
     geordi: React.PropTypes.object
 
-  componentWillReceiveProps: (nextProps, nextContext)->
-    @logClick = nextContext?.geordi?.makeHandler? 'change-page'
+  componentWillReceiveProps: (nextProps, nextContext) ->
+    @context.geordi?.logEvent
+      type: 'change-page'
+      relatedID: "page-#{nextProps.page}"
 
   setPage: (activePage) ->
     @props.onPageChange.call(this, activePage)
     window.scrollTo(0,0) if @props.scrollOnChange
 
   onClickNext: ->
-    @logClick 'next-page'
+    @context.geordi?.logEvent
+      type: 'next-page'
+      relatedID: "page-#{@props[@props.pageKey]}"
     {pageCount} = @props
     page = @props[@props.pageKey]
     @props.onClickNext?()
@@ -49,7 +53,9 @@ module?.exports = React.createClass
     @setPage(nextPage)
 
   onClickPrev: ->
-    @logClick 'previous-page'
+    @context.geordi?.logEvent
+      type: 'previous-page'
+      relatedID: "page-#{@props[@props.pageKey]}"
     page = @props[@props.pageKey]
     @props.onClickPrev?()
 
@@ -57,7 +63,10 @@ module?.exports = React.createClass
     @setPage(prevPage)
 
   onSelectPage: (e) ->
-    @logClick 'select-page'
+    @context.geordi?.logEvent
+      type: 'select-page'
+      relatedID: "page-#{@refs.pageSelect.value}"
+
     selectedPage = +@refs.pageSelect.value
     @setPage(selectedPage)
 
@@ -74,7 +83,12 @@ module?.exports = React.createClass
       {if @props.firstAndLast
         <button
           className="paginator-first"
-          onClick={=> @setPage(1); @logClick 'first-page'}
+          onClick={=>
+            @setPage(1);
+            @context.geordi?.logEvent
+              type: 'first-page'
+              relatedID: 'page-1'
+          }
           disabled={page is 1}>
           <i className="fa fa-fast-backward" /> First
         </button>}
@@ -105,7 +119,12 @@ module?.exports = React.createClass
       {if @props.firstAndLast
         <button
           className="paginator-last"
-          onClick={=> @setPage(pageCount); @logClick 'last-page'}
+          onClick={=>
+            @setPage(pageCount);
+            @context.geordi?.logEvent
+              type: 'last-page'
+              relatedID: "page-#{pageCount}"
+          }
           disabled={page is pageCount}>
           Last <i className="fa fa-fast-forward" />
         </button>}


### PR DESCRIPTION
Fixes #2713

Geordi call was breaking pagination as logClick was not in scope as willReceiveProps had not yet fired.
Changed to direct geordi.logEvent calls.
Also updated pagination logging to actually record the page number (without which the logs are fairly meaningless)
Also added logging of collection slug, without which the log has no meaningful context.