### PR TITLE
Fix components with multiple contextTypes defined

### DIFF
--- a/app/partials/account-bar.cjsx
+++ b/app/partials/account-bar.cjsx
@@ -26,12 +26,10 @@ module.exports = React.createClass
 
   contextTypes:
     router: routerShape
+    geordi: React.PropTypes.object
 
   propTypes:
     user: React.PropTypes.object.isRequired
-
-  contextTypes:
-    geordi: React.PropTypes.object
 
   componentWillReceiveProps: (nextProps, nextContext)->
     @logClick = nextContext?.geordi?.makeHandler? 'about-menu'
@@ -126,5 +124,5 @@ module.exports = React.createClass
     @logClick? 'accountMenu.signOut'
     @context.geordi?.logEvent
       type: 'logout'
-      
+
     auth.signOut()

--- a/app/partials/main-header.cjsx
+++ b/app/partials/main-header.cjsx
@@ -35,8 +35,6 @@ module.exports = React.createClass
 
   contextTypes:
     router: routerShape
-
-  contextTypes:
     geordi: React.PropTypes.object
 
   componentWillReceiveProps: (nextProps, nextContext)->


### PR DESCRIPTION
Looks like a rough merge left some components with a multiple `contextTypes` defined (and the last defined wins).

Ran [`grep -o -c contextTypes ./app/**/*.* | awk -F: '{if ($2 > 1){print $1}}'`](http://stackoverflow.com/questions/23961056/grep-files-containing-two-or-more-occurrence-of-a-specific-string) to find all cases.

Gonna merge myself real quick, but CC: @srallen.