### PR TITLE
add explicit background color for field guide tab

### DIFF
--- a/css/field-guide.styl
+++ b/css/field-guide.styl
@@ -13,7 +13,7 @@
 
 .field-guide-pullout-toggle
   @extends $reset-button
-  background: inherit
+  background: rgba(white, 0.95)
   border-radius: 0.5em 0.5em 0 0
   color: inherit
   letter-spacing: 0.1ch


### PR DESCRIPTION
Fixes #2724, _Field Guide tab transparent in IE11_.