### PR TITLE
Convert SubjectViewer dialogs to modal-form/dialog

### DIFF
--- a/app/components/subject-viewer.cjsx
+++ b/app/components/subject-viewer.cjsx
@@ -1,6 +1,6 @@
 React = require 'react'
 FavoritesButton = require '../collections/favorites-button'
-alert = require '../lib/alert'
+{alert} = require 'modal-form/dialog'
 {Markdown} = (require 'markdownz').default
 getSubjectLocation = require '../lib/get-subject-location'
 CollectionsManagerIcon = require '../collections/manager-icon'
@@ -61,10 +61,17 @@ module.exports = React.createClass
       type: logType
 
   promptToSignIn: ->
-    alert (resolve) ->
-      <SignInPrompt onChoose={resolve}>
-        <p>Sign in to help us make the most out of your hard work.</p>
-      </SignInPrompt>
+    # This is super hacky.
+    # TODO: Make a way to dismiss `alert`ed dialogs without requiring a form submission.
+    fauxSubmit = (e) ->
+      form = e.currentTarget
+      until form?.nodeName is 'FORM' or not form?
+        form = form.parentNode
+      form?.dispatchEvent new CustomEvent 'submit'
+
+    alert <SignInPrompt onChoose={fauxSubmit}>
+      <p>Sign in to help us make the most out of your hard work.</p>
+    </SignInPrompt>
 
   render: ->
     rootClasses = classnames('subject-viewer', {
@@ -227,4 +234,4 @@ module.exports = React.createClass
             </tr>}
         </tbody>
       </table>
-    </div>
+    </div>, closeButton: true

--- a/app/partials/sign-in-prompt.cjsx
+++ b/app/partials/sign-in-prompt.cjsx
@@ -29,16 +29,16 @@ module.exports = React.createClass
 
   dismiss: (e)->
     @props.contextRef?.geordi?.logEvent type: 'register-no-thanks'
-    @props.onChoose()
+    @props.onChoose e
 
-  signIn: ->
+  signIn: (e) ->
     @props.contextRef?.geordi?.logEvent type: 'register-sign-in'
-    @props.onChoose()
+    @props.onChoose e
     alert (resolve) =>
       <LoginDialog which="sign-in" project={@props.project} onSuccess={resolve} />
 
-  register: ->
+  register: (e) ->
     @props.contextRef?.geordi?.logEvent type: 'register-register'
-    @props.onChoose()
+    @props.onChoose e
     alert (resolve) =>
       <LoginDialog which="register" project={@props.project} onSuccess={resolve} />


### PR DESCRIPTION
This is pretty gross because `alert` from modal-form/dialog doesn't provide a way to close things (since it expects a form, which was a pretty fundamental design mistake). Gonna have a think about a better way to alert things.

Closes #2722.