### PR TITLE
Remove updateUser function from app context

### DIFF
--- a/app/partials/app.cjsx
+++ b/app/partials/app.cjsx
@@ -10,12 +10,10 @@ PanoptesApp = React.createClass
 
   childContextTypes:
     user: React.PropTypes.object
-    updateUser: React.PropTypes.func
     geordi: React.PropTypes.object
 
   getChildContext: ->
     user: @state.user
-    updateUser: @updateUser
     geordi: @geordiLogger
 
   getEnv: ->
@@ -25,11 +23,8 @@ PanoptesApp = React.createClass
 
   getInitialState: ->
     user: null
-    env: @getEnv()
+    env: @getEnv() # Used by Geordi.
     initialLoadComplete: false
-
-  updateUser: (user) ->
-    @setState user: user
 
   componentDidMount: ->
     auth.listen 'change', @handleAuthChange


### PR DESCRIPTION
Can't find any place where this function is used, and it seems super dangerous to expose a way to get the UI's user out of sync with the session's user. Was this left over from something else @amyrebecca?