### PR TITLE
Render while initial-loading

### DIFF
--- a/app/components/pass-context.cjsx
+++ b/app/components/pass-context.cjsx
@@ -4,10 +4,12 @@ React = require 'react'
 module.exports = React.createClass
   contextTypes:
     router: routerShape
+    user: React.PropTypes.object
     geordi: React.PropTypes.object
 
   childContextTypes:
     router: routerShape
+    user: React.PropTypes.object
     geordi: React.PropTypes.object
 
   getChildContext: ->

--- a/app/layout/account-bar.jsx
+++ b/app/layout/account-bar.jsx
@@ -26,16 +26,9 @@ counterpart.registerTranslations('en', {
 
 const AccountBar = React.createClass({
   contextTypes: {
+    user: React.PropTypes.object,
     router: routerShape,
     geordi: React.PropTypes.object,
-  },
-
-  propTypes: {
-    user: React.PropTypes.shape({
-      id: React.PropTypes.string,
-      display_name: React.PropTypes.string,
-      login: React.PropTypes.string,
-    }),
   },
 
   getInitialState() {
@@ -62,7 +55,7 @@ const AccountBar = React.createClass({
 
   lookUpUnread() {
     talkClient.type('conversations').get({
-      user_id: this.props.user.id,
+      user_id: this.context.user.id,
       unread: true,
       page_size: 1,
     }).then((conversations) => {
@@ -116,8 +109,8 @@ const AccountBar = React.createClass({
           className="site-nav__modal"
           trigger={
             <span className="site-nav__link">
-              <strong>{this.props.user.display_name}</strong>{' '}
-              <Avatar className="site-nav__user-avatar" user={this.props.user} size="2em" />
+              <strong>{this.context.user.display_name}</strong>{' '}
+              <Avatar className="site-nav__user-avatar" user={this.context.user} size="2em" />
             </span>
           }
           triggerProps={{
@@ -129,7 +122,7 @@ const AccountBar = React.createClass({
             <div ref="accountMenu" role="menu" onKeyDown={this.navigateMenu}>
               <Link
                 role="menuitem"
-                to={`/users/${this.props.user.login}`}
+                to={`/users/${this.context.user.login}`}
                 className="site-nav__link"
                 onClick={!!this.logClick ? this.logClick.bind(this, 'accountMenu.profile') : null}
               >
@@ -149,7 +142,7 @@ const AccountBar = React.createClass({
               <br />
               <Link
                 role="menuitem"
-                to={`/collections/${this.props.user.login}`}
+                to={`/collections/${this.context.user.login}`}
                 className="site-nav__link"
                 onClick={!!this.logClick ? this.logClick.bind(this, 'accountMenu.collections') : null}
               >
@@ -159,7 +152,7 @@ const AccountBar = React.createClass({
               <br />
               <Link
                 role="menuitem"
-                to={`/favorites/${this.props.user.login}`}
+                to={`/favorites/${this.context.user.login}`}
                 className="site-nav__link"
                 onClick={!!this.logClick ? this.logClick.bind(this, 'accountMenu.favorites') : null}
               >

--- a/app/layout/admin-toggle.jsx
+++ b/app/layout/admin-toggle.jsx
@@ -28,7 +28,6 @@ const AdminToggle = React.createClass({
   },
 
   render() {
-    console.log('RENDER with', apiClient.params.admin);
     return (
       <label
         className={classnames('footer-admin-toggle', {

--- a/app/layout/index.jsx
+++ b/app/layout/index.jsx
@@ -13,7 +13,6 @@ const LAYOUT_DEV_MODE = process.env.NODE_ENV !== 'production' &&
 
 const AppLayout = React.createClass({
   propTypes: {
-    user: React.PropTypes.any,
     children: React.PropTypes.node,
   },
 
@@ -101,9 +100,8 @@ const AppLayout = React.createClass({
           className={classnames('app-layout__header', {
             'app-layout__header--demoted': this.state.siteHeaderDemoted,
           })}
-          user={this.props.user}
         >
-          <SiteNav ref="mainNav" user={this.props.user} onToggle={togglePrimaryNav} />
+          <SiteNav ref="mainNav" onToggle={togglePrimaryNav} />
         </header>
 
         <div className="app-layout__not-header">
@@ -132,7 +130,7 @@ const AppLayout = React.createClass({
           </div>
 
           <footer className="app-layout__footer">
-            <SiteFooter user={this.props.user} />
+            <SiteFooter />
 
             {LAYOUT_DEV_MODE &&
               <div

--- a/app/layout/site-footer.jsx
+++ b/app/layout/site-footer.jsx
@@ -73,7 +73,7 @@ const AppFooter = React.createClass({
             </IndexLink>
             <br />
             <AdminOnly>
-              <AdminToggle user={this.props.user} />
+              <AdminToggle />
             </AdminOnly>
           </div>
 

--- a/app/layout/site-nav.jsx
+++ b/app/layout/site-nav.jsx
@@ -35,12 +35,12 @@ const SiteNav = React.createClass({
   resizeTimeout: NaN,
 
   contextTypes: {
+    user: React.PropTypes.object,
     router: routerShape,
     geordi: React.PropTypes.object,
   },
 
   propTypes: {
-    user: React.PropTypes.any,
     onToggle: React.PropTypes.func,
   },
 
@@ -223,7 +223,7 @@ const SiteNav = React.createClass({
 
         {!this.state.isMobile && this.renderLinks()}
 
-        {!!this.props.user ? <AccountBar user={this.props.user} /> : <LoginBar />}
+        {!!this.context.user ? <AccountBar /> : <LoginBar />}
 
         {!!this.props.onToggle &&
           <button

--- a/app/layout/site-nav.jsx
+++ b/app/layout/site-nav.jsx
@@ -35,6 +35,7 @@ const SiteNav = React.createClass({
   resizeTimeout: NaN,
 
   contextTypes: {
+    initialLoadComplete: React.PropTypes.bool,
     user: React.PropTypes.object,
     router: routerShape,
     geordi: React.PropTypes.object,
@@ -223,7 +224,12 @@ const SiteNav = React.createClass({
 
         {!this.state.isMobile && this.renderLinks()}
 
-        {!!this.context.user ? <AccountBar /> : <LoginBar />}
+        {!this.context.initialLoadComplete &&
+          <span className="site-nav__link">
+            <i className="fa fa-spinner fa-spin fa-fw"></i>
+          </span>}
+
+        {this.context.initialLoadComplete && (!!this.context.user ? <AccountBar /> : <LoginBar />)}
 
         {!!this.props.onToggle &&
           <button

--- a/app/partials/app.cjsx
+++ b/app/partials/app.cjsx
@@ -52,7 +52,7 @@ PanoptesApp = React.createClass
     <div className="panoptes-main">
       <IOStatus />
       {if @state.initialLoadComplete
-        <AppLayout user={@state.user}>
+        <AppLayout>
           {React.cloneElement @props.children, user: @state.user}
         </AppLayout>}
     </div>

--- a/app/partials/app.cjsx
+++ b/app/partials/app.cjsx
@@ -9,11 +9,13 @@ PanoptesApp = React.createClass
   geordiLogger: null # Maintains project and subject context for the Geordi client
 
   childContextTypes:
+    initialLoadComplete: React.PropTypes.bool
     user: React.PropTypes.object
     updateUser: React.PropTypes.func
     geordi: React.PropTypes.object
 
   getChildContext: ->
+    initialLoadComplete: @state.initialLoadComplete
     user: @state.user
     updateUser: @updateUser
     geordi: @geordiLogger
@@ -24,9 +26,9 @@ PanoptesApp = React.createClass
     @state?.env || browser_env?[1] || 'staging'
 
   getInitialState: ->
+    initialLoadComplete: false
     user: null
     env: @getEnv()
-    initialLoadComplete: false
 
   updateUser: (user) ->
     @setState user: user
@@ -45,16 +47,15 @@ PanoptesApp = React.createClass
   handleAuthChange: ->
     auth.checkCurrent().then (user) =>
       @setState
-        user: user
         initialLoadComplete: true
+        user: user
 
   render: ->
     <div className="panoptes-main">
       <IOStatus />
-      {if @state.initialLoadComplete
-        <AppLayout>
-          {React.cloneElement @props.children, user: @state.user}
-        </AppLayout>}
+      <AppLayout>
+        {React.cloneElement @props.children, user: @state.user}
+      </AppLayout>
     </div>
 
 module.exports = PanoptesApp


### PR DESCRIPTION
- Render while the initial load is happening. Show a spinner in place of the login/account area.

- Update layout-level components to use the app context's `user`.