### PR TITLE
Customizable filtering of subject-viewer metadata.  Closes #1281.

### DIFF
--- a/app/components/subject-viewer.cjsx
+++ b/app/components/subject-viewer.cjsx
@@ -43,6 +43,7 @@ module.exports = React.createClass
     frameWrapper: null
     allowFlipbook: true
     allowSeparateFrames: false
+    metadataFilters: ['#', '!']
 
   getInitialState: ->
     loading: true
@@ -235,7 +236,7 @@ module.exports = React.createClass
       <hr />
       <table className="standard-table">
         <tbody>
-          {for key, value of @props.subject?.metadata when key.charAt(0) isnt '#' and key[...2] isnt '//'
+          {for key, value of @props.subject?.metadata when key.charAt(0) not in @props.metadataFilters and key[...2] isnt '//'
             <tr key={key}>
               <th>{key}</th>
               <Markdown tag="td" content={value} inline />

--- a/app/subjects/index.cjsx
+++ b/app/subjects/index.cjsx
@@ -39,7 +39,8 @@ module.exports = React.createClass
                 subject={@state.subject}
                 user={@props.user}
                 project={@props.project}
-                linkToFullImage={true}/>
+                linkToFullImage={true}
+                metadataFilters={['#']} />
 
               <SubjectCommentList subject={@state.subject} {...@props} />
               <SubjectCollectionList subject={@state.subject} {...@props} />

--- a/app/talk/comment.cjsx
+++ b/app/talk/comment.cjsx
@@ -216,7 +216,8 @@ module.exports = React.createClass
                       subject={subject}
                       user={@props.user}
                       project={@props.project}
-                      linkToFullImage={true}/>
+                      linkToFullImage={true}
+                      metadataFilters={['#']} />
                   </div>
                 }
                 catch={null}


### PR DESCRIPTION
Currently, subject metadata keys prefixed with `#` are hidden from the user.

This expands that to a customizable list and adds `!` as a prefix that is hidden unless the subject viewer is displayed in talk.

If we come up with more conditions later on we can just expand the list