### PR TITLE
Correctly get shell environment

### DIFF
--- a/app/lib/geordi-logger.coffee
+++ b/app/lib/geordi-logger.coffee
@@ -13,9 +13,15 @@ class GeordiLogger # Make calls to the Geordi API to log user activity
   instance: =>
     @geordi = @geordi || @makeGeordi @keys?.projectToken
 
+  getEnv: ->
+    shell_env = process.env.NODE_ENV if process.env.NODE_ENV=="production"
+    reg = /\W?env=(\w+)/
+    browser_env = window?.location?.search?.match(reg)?[1]
+    shell_env || browser_env || 'staging'
+    
   makeGeordi: (projectSlug) ->
     new GeordiClient
-      env: @state?.env
+      env: @getEnv()
       projectToken: projectSlug || @keys?.projectToken
       zooUserIDGetter: () => @state.user?.id
       subjectGetter: () => @keys?.subjectID

--- a/app/lib/geordi-logger.coffee
+++ b/app/lib/geordi-logger.coffee
@@ -1,7 +1,7 @@
 GeordiClient = require 'zooniverse-geordi-client'
 
 class GeordiLogger # Make calls to the Geordi API to log user activity
-  constructor: (@state, @geordi) ->
+  constructor: (@user, @geordi) ->
 
   @tokens = ['zooHome', 'zooTalk', 'zooniverse/gravity-spy']
 
@@ -23,7 +23,7 @@ class GeordiLogger # Make calls to the Geordi API to log user activity
     new GeordiClient
       env: @getEnv()
       projectToken: projectSlug || @keys?.projectToken
-      zooUserIDGetter: () => @state.user?.id
+      zooUserIDGetter: () => @user?.id
       subjectGetter: () => @keys?.subjectID
 
   makeHandler: (defType) -> # Once defined, efficiently logs different data to same event type

--- a/app/partials/app.cjsx
+++ b/app/partials/app.cjsx
@@ -36,7 +36,8 @@ PanoptesApp = React.createClass
     auth.stopListening 'change', @handleAuthChange
 
   componentWillUpdate: (nextProps, nextState) ->
-    @geordiLogger = @geordiLogger || new GeordiLogger nextState
+    if !(@geordiLogger? && @geordiLogger.user == nextState.user)
+      @geordiLogger = new GeordiLogger nextState.user
 
   handleAuthChange: ->
     auth.checkCurrent().then (user) =>

--- a/app/partials/app.cjsx
+++ b/app/partials/app.cjsx
@@ -20,15 +20,9 @@ PanoptesApp = React.createClass
     updateUser: @updateUser
     geordi: @geordiLogger
 
-  getEnv: ->
-    reg = /\W?env=(\w+)/
-    browser_env = window?.location?.search?.match(reg)
-    @state?.env || browser_env?[1] || 'staging'
-
   getInitialState: ->
     initialLoadComplete: false
     user: null
-    env: @getEnv()
 
   updateUser: (user) ->
     @setState user: user


### PR DESCRIPTION
Fixes part of #2742 . `@state.env` wasn't being set correctly in PFE when `NODE_ENV` is set at the shell.