### PR TITLE
Ensure geordiLogger is set before mount

### DIFF
--- a/app/partials/app.cjsx
+++ b/app/partials/app.cjsx
@@ -24,9 +24,9 @@ PanoptesApp = React.createClass
     initialLoadComplete: false
     user: null
 
-  updateUser: (user) ->
-    @setState user: user
-
+  componentWillMount: ->
+    @setupGeordi(@state.user)
+  
   componentDidMount: ->
     auth.listen 'change', @handleAuthChange
     generateSessionID()
@@ -35,15 +35,15 @@ PanoptesApp = React.createClass
   componentWillUnmount: ->
     auth.stopListening 'change', @handleAuthChange
 
-  componentWillUpdate: (nextProps, nextState) ->
-    if !(@geordiLogger? && @geordiLogger.user == nextState.user)
-      @geordiLogger = new GeordiLogger nextState.user
+  setupGeordi: (user) ->
+    @geordiLogger = new GeordiLogger user
 
   handleAuthChange: ->
     auth.checkCurrent().then (user) =>
       @setState
         initialLoadComplete: true
         user: user
+      @setupGeordi(user)
 
   render: ->
     <div className="panoptes-main">

--- a/app/partials/app.cjsx
+++ b/app/partials/app.cjsx
@@ -11,13 +11,11 @@ PanoptesApp = React.createClass
   childContextTypes:
     initialLoadComplete: React.PropTypes.bool
     user: React.PropTypes.object
-    updateUser: React.PropTypes.func
     geordi: React.PropTypes.object
 
   getChildContext: ->
     initialLoadComplete: @state.initialLoadComplete
     user: @state.user
-    updateUser: @updateUser
     geordi: @geordiLogger
 
   getInitialState: ->


### PR DESCRIPTION
Possible bug fix for reported issue here: https://www.zooniverse.org/projects/adrianevans/fossil-finder/talk/49/63272?page=1

This instantiates the Geordi client in `componentWillMount` and updates it on auth change.

Also removed the extraneous `updateUser`

