### PR TITLE
update dropdown search match only at start

### DIFF
--- a/app/classifier/tasks/dropdown/index.cjsx
+++ b/app/classifier/tasks/dropdown/index.cjsx
@@ -159,6 +159,7 @@ module?.exports = React.createClass
               allowCreate={selects[i].allowCreate}
               noResultsText={if not options?.length then null}
               addLabelText="Press enter for {label}..."
+              matchPos="start"
               matchProp="label"
               ref="select-#{i}"
             />


### PR DESCRIPTION
update dropdown task to match only at start of option label when filtering, not any character in option label.

typing “N” in a list of states will filter to Nevada, Nebraska, New Hampshire..., instead of the current setup where it would search the entire label and filter to Arizona, Arkansas, California...

replaces pull request #2756 