### PR TITLE
Fix hacky sign-in prompt dialog

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lodash.pick": "~3.1.0",
     "lodash.uniq": "~3.2.2",
     "markdownz": "~4.1.2",
-    "modal-form": "~2.4.0",
+    "modal-form": "~2.4.2",
     "moment": "~2.9.0",
     "panoptes-client": "~2.5.0",
     "papaparse": "mholt/PapaParse#cada171",


### PR DESCRIPTION
This just makes showing the sign-in prompt a state of the subject viewer, removing the weird CustomEvent hack that apparently didn't work in Firefox.

Closes #2763.