### PR TITLE
Fail if dependencies aren't installed

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "babel-plugin-react-transform": "~2.0.2",
     "babel-plugin-transform-react-jsx": "~6.7.5",
     "babel-preset-es2015": "~6.6.0",
+    "check-dependencies": "~0.12.0",
     "check-engines": "~1.2.0",
     "cjsx-loader": "~3.0.0",
     "coffee-loader": "~0.7.2",
@@ -79,9 +80,9 @@
     "npm": "^2.14.7"
   },
   "scripts": {
-    "start": "export NODE_ENV=development; check-engines && babel-node ./dev-server.js",
-    "_build": "export HEAD_COMMIT=$(git rev-parse --short HEAD); check-engines && rimraf dist; webpack --config ./webpack.build.js --progress --profile --colors",
-    "serve-static": "export NODE_ENV=staging; check-engines && npm run _build && node ./static-server.js",
+    "start": "export NODE_ENV=development; check-engines && check-dependencies && babel-node ./dev-server.js",
+    "_build": "export HEAD_COMMIT=$(git rev-parse --short HEAD); check-engines && check-dependencies && rimraf dist; webpack --config ./webpack.build.js --progress --profile --colors",
+    "serve-static": "export NODE_ENV=staging; check-engines && check-dependencies && npm run _build && node ./static-server.js",
     "serve-hot": "export BABEL_ENV=hot-reload; npm start",
     "_publish": "publisssh ./dist \"zooniverse-static/$PATH_ROOT/$SUBDIR\"",
     "_log-staging-url": "echo \"Staged at https://$SUBDIR.pfe-preview.zooniverse.org/\"",


### PR DESCRIPTION
This'll just prevent us from serving/deploying with bad dependencies, like it does with bad node or npm versions.