### PR TITLE
Initially reveal the site header on the project page when not signed in

### DIFF
--- a/app/layout/index.jsx
+++ b/app/layout/index.jsx
@@ -18,6 +18,7 @@ const AppLayout = React.createClass({
 
   childContextTypes: {
     setAppHeaderVariant: React.PropTypes.func,
+    revealSiteHeader: React.PropTypes.func,
   },
 
   getInitialState() {
@@ -36,6 +37,13 @@ const AppLayout = React.createClass({
           siteHeaderDemoted: variant === 'demoted',
         });
       },
+
+      revealSiteHeader: () => {
+        this.matchWindowScale();
+        this.setState({
+          siteHeaderRevealed: true,
+        });
+      }
     };
   },
 

--- a/app/pages/project/index.cjsx
+++ b/app/pages/project/index.cjsx
@@ -36,6 +36,7 @@ SOCIAL_ICONS =
 ProjectPage = React.createClass
   contextTypes:
     setAppHeaderVariant: React.PropTypes.func
+    revealSiteHeader: React.PropTypes.func
     geordi: React.PropTypes.object
 
   getDefaultProps: ->
@@ -51,6 +52,8 @@ ProjectPage = React.createClass
 
   componentDidMount: ->
     @context.setAppHeaderVariant 'demoted'
+    unless @props.user?
+      @context.revealSiteHeader()
     document.documentElement.classList.add 'on-project-page'
     @fetchInfo @props.project
     @getSelectedWorkflow @props.project, @props.preferences


### PR DESCRIPTION
If there's no user when the project page mounts, the site header is revealed.

👍'd by @jwbmartin. Closes #2748, closes #2733.

I've also tweaked the project-not-found message, so this closes #1792.