### PR TITLE
Search for "module?.exports" and replace with "module.exports"

### DIFF
--- a/app/classifier/tasks/dropdown/editor.cjsx
+++ b/app/classifier/tasks/dropdown/editor.cjsx
@@ -11,7 +11,7 @@ MarkdownHelp = require '../../../partials/markdown-help'
 DropdownList = require './dropdown-list'
 DropdownDialog = require './dropdown-dialog'
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'DropdownEditor'
 
   getDefaultProps: ->

--- a/app/classifier/tasks/dropdown/index.cjsx
+++ b/app/classifier/tasks/dropdown/index.cjsx
@@ -48,7 +48,7 @@ Summary = React.createClass
       </div>
     </div>
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'DropdownTask'
 
   statics:

--- a/app/classifier/tasks/text/editor.cjsx
+++ b/app/classifier/tasks/text/editor.cjsx
@@ -6,7 +6,7 @@ handleInputChange = require '../../../lib/handle-input-change'
 MarkdownHelp = require '../../../partials/markdown-help'
 NextTaskSelector = require '../next-task-selector'
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'TextTaskEditor'
 
   getDefaultProps: ->

--- a/app/collections/create-form.cjsx
+++ b/app/collections/create-form.cjsx
@@ -8,7 +8,7 @@ counterpart.registerTranslations 'en',
     private: 'Private'
     submit: "Add Collection"
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'CollectionsCreateForm'
 
   getInitialState: ->

--- a/app/collections/favorites-button.cjsx
+++ b/app/collections/favorites-button.cjsx
@@ -5,7 +5,7 @@ alert = require '../lib/alert'
 SignInPrompt = require '../partials/sign-in-prompt'
 PromiseRenderer = require '../components/promise-renderer'
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'CollectionFavoritesButton'
 
   propTypes:

--- a/app/collections/get-favorites-name.cjsx
+++ b/app/collections/get-favorites-name.cjsx
@@ -1,5 +1,5 @@
 # Get the name of the favorites collection for a project
-module?.exports = (project) ->
+module.exports = (project) ->
   #--> Naming Convention: "Favorites for #{project_id}"
   #    Prevents global uniqueness validation conflict under project scope
   name = "Favorites"

--- a/app/collections/manager-icon.cjsx
+++ b/app/collections/manager-icon.cjsx
@@ -3,7 +3,7 @@ CollectionsManager = require './manager'
 Dialog = require 'modal-form/dialog'
 
 # Shows an icon to logged-in users that pops up a collections manager
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'CollectionsManagerIcon'
 
   propTypes:

--- a/app/collections/manager.cjsx
+++ b/app/collections/manager.cjsx
@@ -3,7 +3,7 @@ apiClient = require 'panoptes-client/lib/api-client'
 CollectionsCreateForm = require './create-form'
 CollectionSearch = require '../components/collection-search'
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'CollectionsManager'
 
   getInitialState: ->

--- a/app/collections/preview.cjsx
+++ b/app/collections/preview.cjsx
@@ -6,7 +6,7 @@ Thumbnail = require '../components/thumbnail'
 Avatar = require '../partials/avatar'
 getSubjectLocation = require '../lib/get-subject-location'
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'CollectionPreview'
 
   componentWillMount: ->

--- a/app/collections/show-list.cjsx
+++ b/app/collections/show-list.cjsx
@@ -17,7 +17,7 @@ counterpart.registerTranslations 'en',
     error: 'There was an error listing this collection.'
     noSubjects: 'No subjects in this collection.'
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'CollectionShowList'
   mixins: [History]
 

--- a/app/components/flag-subject-button.cjsx
+++ b/app/components/flag-subject-button.cjsx
@@ -1,6 +1,6 @@
 React = require 'react'
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'FlagSubjectButton'
 
   toggleFlag: ->

--- a/app/dashboard/line-graph/hover-box.cjsx
+++ b/app/dashboard/line-graph/hover-box.cjsx
@@ -1,6 +1,6 @@
 React = require 'react'
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'HoverBox'
 
   render: ->

--- a/app/dashboard/line-graph/legend.cjsx
+++ b/app/dashboard/line-graph/legend.cjsx
@@ -1,6 +1,6 @@
 React = require 'react'
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'LineGraphLegend'
 
   circleSize: 10

--- a/app/dashboard/line-graph/line-graph.cjsx
+++ b/app/dashboard/line-graph/line-graph.cjsx
@@ -6,7 +6,7 @@ XLabels = require './x-labels'
 YRules = require './y-rules'
 YLabels = require './y-labels'
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'LineGraph'
 
   axisColor: 'lightgrey'

--- a/app/dashboard/line-graph/line.cjsx
+++ b/app/dashboard/line-graph/line.cjsx
@@ -1,6 +1,6 @@
 React = require 'react'
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'LineGraphLine'
   borderWidth: 2
 

--- a/app/dashboard/line-graph/x-axis.cjsx
+++ b/app/dashboard/line-graph/x-axis.cjsx
@@ -1,6 +1,6 @@
 React = require 'react'
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'LineGraphXAxis'
 
   xAxisTick: (percent, i) ->

--- a/app/dashboard/line-graph/x-labels.cjsx
+++ b/app/dashboard/line-graph/x-labels.cjsx
@@ -1,6 +1,6 @@
 React = require 'react'
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'LineGraphXLabels'
 
   xAxisLabels: ->

--- a/app/dashboard/line-graph/y-labels.cjsx
+++ b/app/dashboard/line-graph/y-labels.cjsx
@@ -1,6 +1,6 @@
 React = require 'react'
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'LineGraphYLabels'
 
   yAxisLabel: (n, i) ->

--- a/app/dashboard/line-graph/y-rules.cjsx
+++ b/app/dashboard/line-graph/y-rules.cjsx
@@ -1,6 +1,6 @@
 React = require 'react'
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'LineGraphYRules'
 
   yAxisLine: (n, i) ->

--- a/app/pages/dashboard.cjsx
+++ b/app/pages/dashboard.cjsx
@@ -49,7 +49,7 @@ USER_STATS_DATA = [
   {name: "Classifications Today", value: "5"}
 ]
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'Dashboard'
 
   statsItem: (d, i) ->

--- a/app/pages/lab/talk.cjsx
+++ b/app/pages/lab/talk.cjsx
@@ -5,7 +5,7 @@ CreateBoardForm = require '../../talk/lib/create-board-form'
 projectSection = require '../../talk/lib/project-section'
 SingleSubmitButton = require '../../components/single-submit-button'
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'EditProjectTalk'
 
   getDefaultProps: ->

--- a/app/pages/notifications.cjsx
+++ b/app/pages/notifications.cjsx
@@ -5,7 +5,7 @@ ChangeListener = require '../components/change-listener'
 talkClient = require 'panoptes-client/lib/talk-client'
 Notification = require './notifications/notification'
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'NotificationsPage'
 
   propTypes:

--- a/app/pages/notifications/comment.cjsx
+++ b/app/pages/notifications/comment.cjsx
@@ -3,7 +3,7 @@ talkClient = require 'panoptes-client/lib/talk-client'
 Loading = require '../../components/loading-indicator'
 Comment = require '../../talk/search-result'
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'CommentNotification'
 
   propTypes:

--- a/app/pages/notifications/data-request.cjsx
+++ b/app/pages/notifications/data-request.cjsx
@@ -2,7 +2,7 @@ React = require 'react'
 apiClient =  require 'panoptes-client/lib/api-client'
 moment = require 'moment'
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'DataRequestNotification'
 
   propTypes:

--- a/app/pages/notifications/message.cjsx
+++ b/app/pages/notifications/message.cjsx
@@ -6,7 +6,7 @@ talkClient = require 'panoptes-client/lib/talk-client'
 Loading = require '../../components/loading-indicator'
 Avatar = require '../../partials/avatar'
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'MessageNotification'
 
   propTypes:

--- a/app/pages/notifications/moderation.cjsx
+++ b/app/pages/notifications/moderation.cjsx
@@ -7,7 +7,7 @@ apiClient = require 'panoptes-client/lib/api-client'
 Loading = require '../../components/loading-indicator'
 Avatar = require '../../partials/avatar'
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'ModerationNotification'
 
   propTypes:

--- a/app/pages/notifications/notification.cjsx
+++ b/app/pages/notifications/notification.cjsx
@@ -5,7 +5,7 @@ MessageNotification = require './message'
 ModerationNotification = require './moderation'
 StartedDiscussionNotification = require './started-discussion'
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'Notification'
 
   propTypes:

--- a/app/pages/notifications/started-discussion.cjsx
+++ b/app/pages/notifications/started-discussion.cjsx
@@ -5,7 +5,7 @@ talkClient = require 'panoptes-client/lib/talk-client'
 Loading = require '../../components/loading-indicator'
 Comment = require '../../talk/search-result'
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'CommentNotification'
 
   propTypes:

--- a/app/pages/profile/comment-link.cjsx
+++ b/app/pages/profile/comment-link.cjsx
@@ -5,7 +5,7 @@ talkClient = require 'panoptes-client/lib/talk-client'
 {Markdown} = (require 'markdownz').default
 PAGE_SIZE = require('../../talk/config').discussionPageSize
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'CommentLink'
 
   getDefaultProps: ->

--- a/app/pages/project/metadata.cjsx
+++ b/app/pages/project/metadata.cjsx
@@ -1,7 +1,7 @@
 React = require 'react'
 {Link} = require 'react-router'
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'ProjectMetadata'
 
   propTypes:

--- a/app/partials/avatar.cjsx
+++ b/app/partials/avatar.cjsx
@@ -2,7 +2,7 @@ React = require 'react'
 
 DEFAULT_AVATAR = '/assets/simple-avatar.jpg'
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'Avatar'
 
   propTypes:

--- a/app/partials/markdown-help.cjsx
+++ b/app/partials/markdown-help.cjsx
@@ -45,7 +45,7 @@ TalkMarkdownHelp = React.createClass
       </tbody>
     </table>
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'MarkdownHelp'
 
   getDefaultProps: ->

--- a/app/subjects/collection-list.cjsx
+++ b/app/subjects/collection-list.cjsx
@@ -3,7 +3,7 @@ apiClient = require 'panoptes-client/lib/api-client'
 Loading = require '../components/loading-indicator'
 CollectionPreview = require '../collections/preview'
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'SubjectCollectionList'
 
   componentWillMount: ->

--- a/app/subjects/comment-form.cjsx
+++ b/app/subjects/comment-form.cjsx
@@ -8,7 +8,7 @@ Loading = require '../components/loading-indicator'
 SignInPrompt = require '../partials/sign-in-prompt'
 alert = require '../lib/alert'
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'SubjectCommentForm'
   mixins: [History]
 

--- a/app/subjects/comment-list.cjsx
+++ b/app/subjects/comment-list.cjsx
@@ -4,7 +4,7 @@ Comment = require '../talk/comment'
 Paginator = require '../talk/lib/paginator'
 Loading = require '../components/loading-indicator'
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'SubjectCommentList'
 
   componentWillMount: ->

--- a/app/subjects/discussion-list.cjsx
+++ b/app/subjects/discussion-list.cjsx
@@ -3,7 +3,7 @@ talkClient = require 'panoptes-client/lib/talk-client'
 DiscussionPreview = require '../talk/discussion-preview'
 Loading = require '../components/loading-indicator'
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'SubjectDiscussionList'
 
   componentWillMount: ->

--- a/app/subjects/index.cjsx
+++ b/app/subjects/index.cjsx
@@ -11,7 +11,7 @@ SubjectDiscussionList = require './discussion-list'
 SubjectMentionList = require './mention-list'
 SubjectCollectionList = require './collection-list'
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'Subject'
 
   getInitialState: ->

--- a/app/subjects/mention-list.cjsx
+++ b/app/subjects/mention-list.cjsx
@@ -4,7 +4,7 @@ Comment = require '../talk/comment'
 Paginator = require '../talk/lib/paginator'
 Loading = require '../components/loading-indicator'
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'SubjectMentionList'
 
   componentWillMount: ->

--- a/app/talk/active-users.cjsx
+++ b/app/talk/active-users.cjsx
@@ -6,7 +6,7 @@ apiClient = require 'panoptes-client/lib/api-client'
 {Link} = require 'react-router'
 Paginator = require './lib/paginator'
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'ActiveUsers'
 
   contextTypes:

--- a/app/talk/add-zoo-team-form.cjsx
+++ b/app/talk/add-zoo-team-form.cjsx
@@ -3,7 +3,7 @@ UserSearch = require '../components/user-search.cjsx'
 talkClient = require 'panoptes-client/lib/talk-client'
 Feedback = require './mixins/feedback'
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'ModerationsZooniverseTeam'
   mixins: [Feedback]
 

--- a/app/talk/board-preview.cjsx
+++ b/app/talk/board-preview.cjsx
@@ -4,7 +4,7 @@ resourceCount = require './lib/resource-count'
 LatestCommentLink = require './latest-comment-link'
 merge = require 'lodash.merge'
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'TalkBoardDisplay'
 
   propTypes:

--- a/app/talk/board.cjsx
+++ b/app/talk/board.cjsx
@@ -28,7 +28,7 @@ promptToSignIn = -> alert (resolve) -> <SignInPrompt onChoose={resolve} />
 
 PAGE_SIZE = talkConfig.boardPageSize
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'TalkBoard'
   mixins: [History]
 

--- a/app/talk/breadcrumbs.cjsx
+++ b/app/talk/breadcrumbs.cjsx
@@ -4,7 +4,7 @@ talkClient = require 'panoptes-client/lib/talk-client'
 PromiseRenderer = require '../components/promise-renderer'
 merge = require 'lodash.merge'
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'TalkBreadcrumbs'
 
   crumbCatch: (e) ->

--- a/app/talk/comment-box.cjsx
+++ b/app/talk/comment-box.cjsx
@@ -10,7 +10,7 @@ alert = require '../lib/alert'
 {Markdown, MarkdownEditor} = (require 'markdownz').default
 Suggester = require './suggester'
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'Commentbox'
   mixins: [ToggleChildren, Feedback]
 

--- a/app/talk/comment-image-selector.cjsx
+++ b/app/talk/comment-image-selector.cjsx
@@ -3,7 +3,7 @@ apiClient = require 'panoptes-client/lib/api-client'
 getSubjectLocation = require '../lib/get-subject-location'
 SingleSubmitButton = require '../components/single-submit-button'
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'TalkCommentImageSelector'
 
   getInitialState: ->

--- a/app/talk/comment-link.cjsx
+++ b/app/talk/comment-link.cjsx
@@ -5,7 +5,7 @@ talkConfig = require './config'
 
 PAGE_SIZE = talkConfig.discussionPageSize
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'TalkCommentLink'
 
   propTypes:

--- a/app/talk/comment-preview.cjsx
+++ b/app/talk/comment-preview.cjsx
@@ -1,7 +1,7 @@
 React = require 'react'
 {Markdown} = (require 'markdownz').default
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'TalkCommentPreview'
 
   propTypes:

--- a/app/talk/comment-report-form.cjsx
+++ b/app/talk/comment-report-form.cjsx
@@ -2,7 +2,7 @@ React = require 'react'
 Feedback = require './mixins/feedback'
 talkClient = require 'panoptes-client/lib/talk-client'
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'TalkCommentReportForm'
 
   mixins: [Feedback]

--- a/app/talk/comment.cjsx
+++ b/app/talk/comment.cjsx
@@ -22,7 +22,7 @@ merge = require 'lodash.merge'
 {Markdown} = (require 'markdownz').default
 DEFAULT_AVATAR = '/assets/simple-avatar.jpg'
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'TalkComment'
   mixins: [ToggleChildren, Feedback]
 

--- a/app/talk/config.coffee
+++ b/app/talk/config.coffee
@@ -1,4 +1,4 @@
-module?.exports =
+module.exports =
 
   discussionPageSize: 20
 

--- a/app/talk/discussion-new-form.cjsx
+++ b/app/talk/discussion-new-form.cjsx
@@ -9,7 +9,7 @@ Loading = require '../components/loading-indicator'
 PromiseRenderer = require '../components/promise-renderer'
 projectSection = require '../talk/lib/project-section'
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'DiscussionNewForm'
 
   propTypes:

--- a/app/talk/discussion-preview.cjsx
+++ b/app/talk/discussion-preview.cjsx
@@ -9,7 +9,7 @@ apiClient = require 'panoptes-client/lib/api-client'
 talkClient = require 'panoptes-client/lib/talk-client'
 getSubjectLocation = require '../lib/get-subject-location'
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'TalkDiscussionPreview'
 
   propTypes:

--- a/app/talk/discussion.cjsx
+++ b/app/talk/discussion.cjsx
@@ -28,7 +28,7 @@ SidebarNotifications = require './lib/sidebar-notifications'
 
 PAGE_SIZE = talkConfig.discussionPageSize
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'TalkDiscussion'
   mixins: [History]
 

--- a/app/talk/follow-board.cjsx
+++ b/app/talk/follow-board.cjsx
@@ -2,7 +2,7 @@ React = require 'react'
 talkClient = require 'panoptes-client/lib/talk-client'
 SingleSubmitButton = require '../components/single-submit-button'
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'FollowBoard'
 
   propTypes:

--- a/app/talk/follow-discussion.cjsx
+++ b/app/talk/follow-discussion.cjsx
@@ -2,7 +2,7 @@ React = require 'react'
 talkClient = require 'panoptes-client/lib/talk-client'
 SingleSubmitButton = require '../components/single-submit-button'
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'FollowDiscussion'
 
   contextTypes:

--- a/app/talk/footnote.cjsx
+++ b/app/talk/footnote.cjsx
@@ -1,6 +1,6 @@
 React = require 'react'
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'TalkFootnote'
 
   render: ->

--- a/app/talk/inbox-conversation.cjsx
+++ b/app/talk/inbox-conversation.cjsx
@@ -9,7 +9,7 @@ CommentBox = require './comment-box'
 {Link, History} = require 'react-router'
 {timestamp} = require './lib/time'
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'InboxConversation'
   mixins: [HandlePropChanges, History]
 

--- a/app/talk/inbox-form.cjsx
+++ b/app/talk/inbox-form.cjsx
@@ -8,7 +8,7 @@ subjectValidations = require './lib/message-subject-validations'
 messageValidations = require './lib/message-validations'
 CommentBox = require './comment-box'
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'InboxForm'
   mixins: [History]
 

--- a/app/talk/inbox.cjsx
+++ b/app/talk/inbox.cjsx
@@ -15,7 +15,7 @@ PAGE_SIZE = talkConfig.inboxPageSize
 
 promptToSignIn = -> alert (resolve) -> <SignInPrompt onChoose={resolve} />
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'TalkInbox'
   mixins: [History]
 

--- a/app/talk/index.cjsx
+++ b/app/talk/index.cjsx
@@ -5,7 +5,7 @@ TalkSearchInput = require './search-input'
 TalkFootnote = require './footnote'
 {sugarClient} = require 'panoptes-client/lib/sugar'
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'Talk'
 
   contextTypes:

--- a/app/talk/init.cjsx
+++ b/app/talk/init.cjsx
@@ -20,7 +20,7 @@ DragReorderable = require 'drag-reorderable'
 Paginator = require './lib/paginator'
 SidebarNotifications = require './lib/sidebar-notifications'
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'TalkInit'
   mixins: [HandlePropChanges]
 

--- a/app/talk/latest-comment-link.cjsx
+++ b/app/talk/latest-comment-link.cjsx
@@ -15,7 +15,7 @@ truncate = (string = '', ending = '', length = 80) ->
   return string if string.trim().length <= length
   string.trim().slice(0, (length - ending.length)) + ending
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'TalkLatestCommentComment'
   mixins: [History]
 

--- a/app/talk/lib/comment-context-icon.cjsx
+++ b/app/talk/lib/comment-context-icon.cjsx
@@ -1,6 +1,6 @@
 React = require 'react'
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'CommentContextIcon'
 
   getInitialState: ->

--- a/app/talk/lib/comment-validations.coffee
+++ b/app/talk/lib/comment-validations.coffee
@@ -2,7 +2,7 @@
 
 MAX_LENGTH = 10000 # characters
 
-module?.exports = [
+module.exports = [
   # existence
   {
     check: (comment) -> comment.length > 0

--- a/app/talk/lib/create-board-form.cjsx
+++ b/app/talk/lib/create-board-form.cjsx
@@ -17,7 +17,7 @@ roleRankText =
     Roles rank from most private to least private in the order: <strong>{ROLES.join(' > ')}</strong>
   </span>
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'CreateBoardForm'
 
   propTypes:

--- a/app/talk/lib/create-subject-default-button.cjsx
+++ b/app/talk/lib/create-subject-default-button.cjsx
@@ -8,7 +8,7 @@ DEFAULT_BOARD_TITLE = 'Notes'            # Name of board to put subject comments
 DEFAULT_BOARD_DESCRIPTION = 'General comment threads about individual subjects'
 
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'CreateSubjectDefaultButton'
 
   propTypes:

--- a/app/talk/lib/discussion-validations.coffee
+++ b/app/talk/lib/discussion-validations.coffee
@@ -1,6 +1,6 @@
 MAX_LENGTH = 255 # characters
 
-module?.exports = [
+module.exports = [
   # existence
   {
     check: (comment) -> comment.length > 0

--- a/app/talk/lib/display-roles.cjsx
+++ b/app/talk/lib/display-roles.cjsx
@@ -33,4 +33,4 @@ DisplayRoles = React.createClass
       {uniq(@props.roles, roleDisplayName).map(@role)}
     </div>
 
-module?.exports = DisplayRoles
+module.exports = DisplayRoles

--- a/app/talk/lib/format-number.coffee
+++ b/app/talk/lib/format-number.coffee
@@ -1,4 +1,4 @@
 # Format a number as comma separated
-module?.exports = (number) ->
+module.exports = (number) ->
   return unless number?
   number.toString().replace /(\d)(?=(\d{3})+(?!\d))/g, '$1,'

--- a/app/talk/lib/get-caret-position.cjsx
+++ b/app/talk/lib/get-caret-position.cjsx
@@ -86,7 +86,7 @@ relativePosition = ({from, within}) ->
   left: relativeParent.offsetLeft + within.offsetLeft + from.left
 
 # Returns the {top, left} of the caret position within a textarea
-module?.exports = (id, textArea, popupElement, caretPosition) ->
+module.exports = (id, textArea, popupElement, caretPosition) ->
   div = mimic textArea, id
   textAreaProps = copyTextProps from: textArea, to: div
   caretSpan = copyText from: textArea, to: div, at: caretPosition

--- a/app/talk/lib/message-subject-validations.coffee
+++ b/app/talk/lib/message-subject-validations.coffee
@@ -4,7 +4,7 @@
 
 MAX_LENGTH = 256 # characters
 
-module?.exports = [
+module.exports = [
   # existence
   {
     check: (subject) -> subject.length > 0

--- a/app/talk/lib/message-validations.coffee
+++ b/app/talk/lib/message-validations.coffee
@@ -2,7 +2,7 @@
 
 MAX_LENGTH = 10000 # characters
 
-module?.exports = [
+module.exports = [
   # existence
   {
     check: (message) -> message.length > 0

--- a/app/talk/lib/moderation.cjsx
+++ b/app/talk/lib/moderation.cjsx
@@ -3,7 +3,7 @@ PromiseRenderer = require '../../components/promise-renderer'
 talkClient = require 'panoptes-client/lib/talk-client'
 userIsModerator = require './user-is-moderator'
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'Moderation'
 
   propTypes:

--- a/app/talk/lib/paginator.cjsx
+++ b/app/talk/lib/paginator.cjsx
@@ -2,7 +2,7 @@ React = require 'react'
 {History} = require 'react-router'
 updateQueryParams = require './update-query-params'
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'Paginator'
 
   propTypes:

--- a/app/talk/lib/parse-section.coffee
+++ b/app/talk/lib/parse-section.coffee
@@ -1,4 +1,4 @@
-module?.exports = (section) ->
+module.exports = (section) ->
 
   # returns the project_id of a project talk section,
   # or 'zooniverse' if section is zooniverse global talk

--- a/app/talk/lib/project-linker.cjsx
+++ b/app/talk/lib/project-linker.cjsx
@@ -3,7 +3,7 @@ talkClient = require 'panoptes-client/lib/talk-client'
 {Link} = require 'react-router'
 Loading = require '../../components/loading-indicator'
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'ProjectLinker'
 
   contextTypes:

--- a/app/talk/lib/project-section.coffee
+++ b/app/talk/lib/project-section.coffee
@@ -1,3 +1,3 @@
 # takes in a project id and returns a correctly formatted talk section for that project
 
-module?.exports = (project) -> "project-#{project.id}"
+module.exports = (project) -> "project-#{project.id}"

--- a/app/talk/lib/resource-count.coffee
+++ b/app/talk/lib/resource-count.coffee
@@ -4,5 +4,5 @@
 # and returns a string formatted "N Resource(s)"
 # trims trailing 's' if number is 1
 
-module?.exports = (count, string) ->
+module.exports = (count, string) ->
   "#{count} #{if +count is 1 then string.replace(/[Ss]$/, '') else string}"

--- a/app/talk/lib/roles.coffee
+++ b/app/talk/lib/roles.coffee
@@ -1,4 +1,4 @@
-module?.exports = [
+module.exports = [
 # Role          | Can access:
   "admin"       # admin, moderator, ream, all
   "moderator"   # moderator, team, all

--- a/app/talk/lib/sidebar-notifications.cjsx
+++ b/app/talk/lib/sidebar-notifications.cjsx
@@ -4,7 +4,7 @@ talkClient = require 'panoptes-client/lib/talk-client'
 resourceCount = require './resource-count'
 formatNumber = require './format-number'
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'SidebarNotifications'
 
   componentDidMount: ->

--- a/app/talk/lib/time.coffee
+++ b/app/talk/lib/time.coffee
@@ -1,6 +1,6 @@
 moment = require 'moment'
 
-module?.exports =
+module.exports =
   timestamp: (ts) ->
     moment(ts).format('MMMM Do YYYY, h:mm a')
 

--- a/app/talk/lib/update-query-params.cjsx
+++ b/app/talk/lib/update-query-params.cjsx
@@ -10,7 +10,7 @@ parseQuery = ->
 
   params
 
-module?.exports = (reactHistory, queryChange) ->
+module.exports = (reactHistory, queryChange) ->
   nextQuery = Object.assign { }, parseQuery(), queryChange
   nextHref = reactHistory.createHref window.location.pathname, nextQuery
   reactHistory.pushState null, nextHref

--- a/app/talk/lib/upvoted-by-current-user.coffee
+++ b/app/talk/lib/upvoted-by-current-user.coffee
@@ -1,2 +1,2 @@
-module?.exports = (user, comment) ->
+module.exports = (user, comment) ->
   user? and (Object.keys(comment.upvotes).indexOf(user.login) isnt -1)

--- a/app/talk/lib/user-is-moderator.cjsx
+++ b/app/talk/lib/user-is-moderator.cjsx
@@ -14,4 +14,4 @@ userIsModerator = (user, roles, section) -> # User response, Roles Response, Tal
 
   intersect(moderationRoles, allowedModerationRoles).length > 0
 
-module?.exports = userIsModerator
+module.exports = userIsModerator

--- a/app/talk/lib/user-is-zooniverse-admin.cjsx
+++ b/app/talk/lib/user-is-zooniverse-admin.cjsx
@@ -3,4 +3,4 @@ userIsZooniverseAdmin = (usersRoles) ->
     role.section is 'zooniverse' and role.name is 'admin'
   zooniverseAdminRoles.length > 0
 
-module?.exports = userIsZooniverseAdmin
+module.exports = userIsZooniverseAdmin

--- a/app/talk/lib/validations.coffee
+++ b/app/talk/lib/validations.coffee
@@ -2,7 +2,7 @@
 # check is a function that should be true of the input
 # error is the message if check fails
 
-module?.exports =
+module.exports =
   getErrors: (input, tests) ->
     tests.reduce (errors, validation) ->
       if not validation.check(input)

--- a/app/talk/lib/zoo-team.cjsx
+++ b/app/talk/lib/zoo-team.cjsx
@@ -3,7 +3,7 @@ PromiseRenderer = require '../../components/promise-renderer'
 talkClient = require 'panoptes-client/lib/talk-client'
 userIsZooniverseAdmin = require './user-is-zooniverse-admin'
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'ZooniverseTeam'
 
   propTypes:

--- a/app/talk/mixins/feedback.cjsx
+++ b/app/talk/mixins/feedback.cjsx
@@ -2,7 +2,7 @@
 
 React = require 'react'
 
-module?.exports =
+module.exports =
   getInitialState: ->
     feedback: null
 

--- a/app/talk/mixins/toggle-children.cjsx
+++ b/app/talk/mixins/toggle-children.cjsx
@@ -1,6 +1,6 @@
 # mixin --- toggle-children.cjsx
 
-module?.exports =
+module.exports =
   getInitialState: ->
     showing: null # string name of child component to show
 

--- a/app/talk/moderation/actions.cjsx
+++ b/app/talk/moderation/actions.cjsx
@@ -16,7 +16,7 @@ actionTaken =
   watch: 'Watched'
   watched: 'Watched'
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'ModerationActions'
 
   propTypes:

--- a/app/talk/moderation/comment.cjsx
+++ b/app/talk/moderation/comment.cjsx
@@ -6,7 +6,7 @@ CommentLink = require '../../pages/profile/comment-link'
 ModerationReports = require './reports'
 ModerationActions = require './actions'
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'ModerationComment'
 
   propTypes:

--- a/app/talk/moderation/reports.cjsx
+++ b/app/talk/moderation/reports.cjsx
@@ -3,7 +3,7 @@ React = require 'react'
 apiClient = require 'panoptes-client/lib/api-client'
 Loading = require '../../components/loading-indicator'
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'ModerationActions'
 
   propTypes:

--- a/app/talk/moderations.cjsx
+++ b/app/talk/moderations.cjsx
@@ -8,7 +8,7 @@ page_size = require('./config').moderationsPageSize
 updateQueryParams = require './lib/update-query-params'
 ModerationComment = require './moderation/comment'
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'TalkModerations'
   mixins: [History]
 

--- a/app/talk/popular-tags.cjsx
+++ b/app/talk/popular-tags.cjsx
@@ -3,7 +3,7 @@ talkClient = require 'panoptes-client/lib/talk-client'
 PromiseRenderer = require '../components/promise-renderer'
 {Link} = require 'react-router'
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'TalkPopularTags'
 
   propTypes:

--- a/app/talk/private-message-form.cjsx
+++ b/app/talk/private-message-form.cjsx
@@ -5,7 +5,7 @@ talkClient = require 'panoptes-client/lib/talk-client'
 {History} = require 'react-router'
 CommentBox = require './comment-box'
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'PrivateMessageForm'
   mixins: [History]
 

--- a/app/talk/quick-subject-comment-form.cjsx
+++ b/app/talk/quick-subject-comment-form.cjsx
@@ -18,7 +18,7 @@ defaultDiscussionTitle = (subject) ->
 
 PAGE_SIZE = talkConfig.discussionPageSize
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'TalkQuickSubjectCommentForm'
   mixins: [State, History]
 

--- a/app/talk/recents.cjsx
+++ b/app/talk/recents.cjsx
@@ -7,7 +7,7 @@ updateQueryParams = require './lib/update-query-params'
 Loading = require '../components/loading-indicator'
 talkConfig = require './config'
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'TalkRecents'
   mixins: [History]
 

--- a/app/talk/search-input.cjsx
+++ b/app/talk/search-input.cjsx
@@ -1,7 +1,7 @@
 React = require 'react'
 {History} = require 'react-router'
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'TalkSearchInput'
   mixins: [History]
 

--- a/app/talk/sticky-discussion-list.cjsx
+++ b/app/talk/sticky-discussion-list.cjsx
@@ -1,7 +1,7 @@
 React = require 'react'
 talkClient = require 'panoptes-client/lib/talk-client'
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'StickyDiscussionList'
 
   placeholder: ->

--- a/app/talk/suggester.cjsx
+++ b/app/talk/suggester.cjsx
@@ -4,7 +4,7 @@ talkClient = require 'panoptes-client/lib/talk-client'
 Loading = require '../components/loading-indicator'
 getCaretPosition = require './lib/get-caret-position'
 
-module?.exports = React.createClass
+module.exports = React.createClass
   displayName: 'Suggester'
 
   propTypes:


### PR DESCRIPTION
I just saw zooniverse/wildcam-gorongosa#223, which reminded me I've been wanting to do this for a while.

Not sure where this started, but if `module` doesn't exist for some ungodly reason, we really don't want the export to fail silently.