### PR TITLE
Stack video play controls above other elements

### DIFF
--- a/css/subject.styl
+++ b/css/subject.styl
@@ -15,6 +15,7 @@
 
   .subject-video-controls
     display: inline-block
+    position: relative
     width: 30vw
 
   .video-scrubber


### PR DESCRIPTION
Creates a new stacking context for video player controls with `position: relative`.
Should ensure that the slider control for scrubbing a video can be clicked with a mouse.