### PR TITLE
removeEventListener on unmount

### DIFF
--- a/app/layout/site-nav.jsx
+++ b/app/layout/site-nav.jsx
@@ -57,7 +57,7 @@ const SiteNav = React.createClass({
   },
 
   componentWillUnmount() {
-    addEventListener('resize', this.handleResize);
+    removeEventListener('resize', this.handleResize);
   },
 
   handleResize() {


### PR DESCRIPTION
Noticed this while looking over #2788. This should probably be `removeEventListener` on component unmount. 