### PR TITLE
Add Invert Image Tool

### DIFF
--- a/app/classifier/frame-annotator.cjsx
+++ b/app/classifier/frame-annotator.cjsx
@@ -117,7 +117,11 @@ module.exports = React.createClass
           <BeforeSubject {...hookProps} />}
         <svg className="subject" style=svgStyle viewBox={createdViewBox} {...svgProps}>
           <rect ref="sizeRect" width={@props.naturalWidth} height={@props.naturalHeight} fill="rgba(0, 0, 0, 0.01)" fillOpacity="0.01" stroke="none" />
-          {if type is 'image'
+          {if type is 'image' and @props.workflow.configuration.invert_subject?
+            <Draggable onDrag={@props.panByDrag} disabled={@props.disabled}>
+              <ModifiedImage className={"pan-active" if @props.panEnabled} src={src} subject={@props.subject} width={@props.naturalWidth} height={@props.naturalHeight}/>
+            </Draggable>
+          else if type is 'image'
             <Draggable onDrag={@props.panByDrag} disabled={@props.disabled}>
               <SVGImage className={"pan-active" if @props.panEnabled} src={src} width={@props.naturalWidth} height={@props.naturalHeight} />
             </Draggable>

--- a/app/classifier/frame-annotator.cjsx
+++ b/app/classifier/frame-annotator.cjsx
@@ -5,6 +5,7 @@ tasks = require './tasks'
 seenThisSession = require '../lib/seen-this-session'
 getSubjectLocation = require '../lib/get-subject-location'
 WarningBanner = require './warning-banner'
+ModifiedImage = require '../components/modified-image'
 
 module.exports = React.createClass
   displayName: 'FrameAnnotator'
@@ -127,6 +128,7 @@ module.exports = React.createClass
 
           {for anyTaskName, {PersistInsideSubject} of tasks when PersistInsideSubject?
             <PersistInsideSubject key={anyTaskName} {...hookProps} />}
+            <ModifiedImage src={src} width={@props.naturalWidth} height={@props.naturalHeight}/>
         </svg>
         {@props.children}
         {if @state.alreadySeen

--- a/app/classifier/frame-annotator.cjsx
+++ b/app/classifier/frame-annotator.cjsx
@@ -128,7 +128,7 @@ module.exports = React.createClass
 
           {for anyTaskName, {PersistInsideSubject} of tasks when PersistInsideSubject?
             <PersistInsideSubject key={anyTaskName} {...hookProps} />}
-            <ModifiedImage src={src} width={@props.naturalWidth} height={@props.naturalHeight}/>
+          {<ModifiedImage src={src} width={@props.naturalWidth} height={@props.naturalHeight}/> if @props.subject.invert }
         </svg>
         {@props.children}
         {if @state.alreadySeen

--- a/app/classifier/frame-annotator.cjsx
+++ b/app/classifier/frame-annotator.cjsx
@@ -117,9 +117,9 @@ module.exports = React.createClass
           <BeforeSubject {...hookProps} />}
         <svg className="subject" style=svgStyle viewBox={createdViewBox} {...svgProps}>
           <rect ref="sizeRect" width={@props.naturalWidth} height={@props.naturalHeight} fill="rgba(0, 0, 0, 0.01)" fillOpacity="0.01" stroke="none" />
-          {if type is 'image' and @props.workflow.configuration.invert_subject?
+          {if type is 'image' and @props.modification
             <Draggable onDrag={@props.panByDrag} disabled={@props.disabled}>
-              <ModifiedImage className={"pan-active" if @props.panEnabled} src={src} modified={@props.modified} width={@props.naturalWidth} height={@props.naturalHeight}/>
+              <ModifiedImage className={"pan-active" if @props.panEnabled} src={src} modification={@props.modification} width={@props.naturalWidth} height={@props.naturalHeight}/>
             </Draggable>
           else if type is 'image'
             <Draggable onDrag={@props.panByDrag} disabled={@props.disabled}>

--- a/app/classifier/frame-annotator.cjsx
+++ b/app/classifier/frame-annotator.cjsx
@@ -119,7 +119,7 @@ module.exports = React.createClass
           <rect ref="sizeRect" width={@props.naturalWidth} height={@props.naturalHeight} fill="rgba(0, 0, 0, 0.01)" fillOpacity="0.01" stroke="none" />
           {if type is 'image' and @props.workflow.configuration.invert_subject?
             <Draggable onDrag={@props.panByDrag} disabled={@props.disabled}>
-              <ModifiedImage className={"pan-active" if @props.panEnabled} src={src} subject={@props.subject} width={@props.naturalWidth} height={@props.naturalHeight}/>
+              <ModifiedImage className={"pan-active" if @props.panEnabled} src={src} modified={@props.modified} width={@props.naturalWidth} height={@props.naturalHeight}/>
             </Draggable>
           else if type is 'image'
             <Draggable onDrag={@props.panByDrag} disabled={@props.disabled}>

--- a/app/classifier/frame-annotator.cjsx
+++ b/app/classifier/frame-annotator.cjsx
@@ -132,7 +132,6 @@ module.exports = React.createClass
 
           {for anyTaskName, {PersistInsideSubject} of tasks when PersistInsideSubject?
             <PersistInsideSubject key={anyTaskName} {...hookProps} />}
-          {<ModifiedImage src={src} width={@props.naturalWidth} height={@props.naturalHeight}/> if @props.subject.invert }
         </svg>
         {@props.children}
         {if @state.alreadySeen

--- a/app/components/frame-viewer.cjsx
+++ b/app/components/frame-viewer.cjsx
@@ -68,7 +68,7 @@ module.exports = React.createClass
 
     if FrameWrapper
       <div>
-        <FrameWrapper frame={frame} naturalWidth={@state.frameDimensions?.width or 0} naturalHeight={@state.frameDimensions?.height or 0} panByDrag={@panByDrag} viewBoxDimensions={@state.viewBoxDimensions or "0 0 0 0"} workflow={@props.workflow} subject={@props.subject} classification={@props.classification} annotation={@props.annotation} loading={@state.loading} preferences={@props.preferences} onChange={@props.onChange} panEnabled={@state.panEnabled} >
+        <FrameWrapper frame={frame} naturalWidth={@state.frameDimensions?.width or 0} naturalHeight={@state.frameDimensions?.height or 0} panByDrag={@panByDrag} viewBoxDimensions={@state.viewBoxDimensions or "0 0 0 0"} workflow={@props.workflow} subject={@props.subject} classification={@props.classification} annotation={@props.annotation} loading={@state.loading} preferences={@props.preferences} modified={@props?.modified} onChange={@props.onChange} panEnabled={@state.panEnabled} >
           {frameDisplay}
         </FrameWrapper>
         {if ( @props.project? && 'pan and zoom' in @props.project?.experimental_tools)

--- a/app/components/frame-viewer.cjsx
+++ b/app/components/frame-viewer.cjsx
@@ -68,7 +68,7 @@ module.exports = React.createClass
 
     if FrameWrapper
       <div>
-        <FrameWrapper frame={frame} naturalWidth={@state.frameDimensions?.width or 0} naturalHeight={@state.frameDimensions?.height or 0} panByDrag={@panByDrag} viewBoxDimensions={@state.viewBoxDimensions or "0 0 0 0"} workflow={@props.workflow} subject={@props.subject} classification={@props.classification} annotation={@props.annotation} loading={@state.loading} preferences={@props.preferences} modified={@props?.modified} onChange={@props.onChange} panEnabled={@state.panEnabled} >
+        <FrameWrapper frame={frame} naturalWidth={@state.frameDimensions?.width or 0} naturalHeight={@state.frameDimensions?.height or 0} panByDrag={@panByDrag} viewBoxDimensions={@state.viewBoxDimensions or "0 0 0 0"} workflow={@props.workflow} subject={@props.subject} classification={@props.classification} annotation={@props.annotation} loading={@state.loading} preferences={@props.preferences} modification={@props?.modification} onChange={@props.onChange} panEnabled={@state.panEnabled} >
           {frameDisplay}
         </FrameWrapper>
         {if ( @props.project? && 'pan and zoom' in @props.project?.experimental_tools)

--- a/app/components/modified-image.cjsx
+++ b/app/components/modified-image.cjsx
@@ -1,0 +1,31 @@
+React = require 'react'
+
+STYLE = {
+    filter: "url('#svg-invert-filter')"
+}
+
+MARKUP =
+  '<svg style=\"position: fixed; right: 100%; top: 100%; visibility: hidden;\">
+    <defs>
+      <filter id=\"svg-invert-filter\">
+        <feColorMatrix in=\"SourceGraphic\" type=\"matrix\" values=\"
+              -1  0  0 0 1
+               0 -1  0 0 1
+               0  0 -1 0 1
+               0  0  0 1 0
+             \" />
+      </filter>
+    </defs>
+  </svg>'
+
+module.exports = React.createClass
+  displayName: 'ModifiedImage'
+
+  componentWillMount: ->
+    @setElements()
+
+  setElements: ->
+    document.body.insertAdjacentHTML('afterbegin', MARKUP)
+
+  render: ->
+    <image xlinkHref={@props.src} {...@props} style={STYLE} />

--- a/app/components/modified-image.cjsx
+++ b/app/components/modified-image.cjsx
@@ -5,7 +5,7 @@ STYLE = {
 }
 
 MARKUP =
-  '<svg id="svg-invert-filter" style="position: fixed; right: 100%; top: 100%; visibility: hidden;">
+  '<svg style="position: fixed; right: 100%; top: 100%; visibility: hidden;">
     <defs>
       <filter id="svg-invert-filter">
         <feComponentTransfer>
@@ -24,9 +24,7 @@ module.exports = React.createClass
     @setElements()
 
   setElements: ->
-    filter = document.getElementById('svg-invert-filter')
-    unless filter
-      document.body.insertAdjacentHTML('afterbegin', MARKUP)
+    document.body.insertAdjacentHTML('afterbegin', MARKUP)
 
   render: ->
-    <image xlinkHref={@props.src} {...@props} style={STYLE if @props?.subject} />
+    <image xlinkHref={@props.src} height={@props.height} width={@props.width} style={STYLE if @props.modified} />

--- a/app/components/modified-image.cjsx
+++ b/app/components/modified-image.cjsx
@@ -20,14 +20,10 @@ INVERT =
 module.exports = React.createClass
   displayName: 'ModifiedImage'
 
-  componentWillMount: ->
-    @setElements()
-
-  setElements: ->
-    document.body.insertAdjacentHTML('afterbegin', INVERT)
-
   filterFinder: ->
     if @props.modification.invert is true
+      unless document.getElementById('svg-invert-filter')
+        document.body.insertAdjacentHTML('afterbegin', INVERT)
       filter: FILTERS.invert
 
   render: ->

--- a/app/components/modified-image.cjsx
+++ b/app/components/modified-image.cjsx
@@ -5,15 +5,14 @@ STYLE = {
 }
 
 MARKUP =
-  '<svg style=\"position: fixed; right: 100%; top: 100%; visibility: hidden;\">
+  '<svg id="svg-invert-filter" style="position: fixed; right: 100%; top: 100%; visibility: hidden;">
     <defs>
-      <filter id=\"svg-invert-filter\">
-        <feColorMatrix in=\"SourceGraphic\" type=\"matrix\" values=\"
-              -1  0  0 0 1
-               0 -1  0 0 1
-               0  0 -1 0 1
-               0  0  0 1 0
-             \" />
+      <filter id="svg-invert-filter">
+        <feComponentTransfer>
+          <feFuncR type="table" tableValues="1 0"/>
+          <feFuncG type="table" tableValues="1 0"/>
+          <feFuncB type="table" tableValues="1 0"/>
+        </feComponentTransfer>
       </filter>
     </defs>
   </svg>'
@@ -25,7 +24,9 @@ module.exports = React.createClass
     @setElements()
 
   setElements: ->
-    document.body.insertAdjacentHTML('afterbegin', MARKUP)
+    filter = document.getElementById('svg-invert-filter')
+    unless filter
+      document.body.insertAdjacentHTML('afterbegin', MARKUP)
 
   render: ->
-    <image xlinkHref={@props.src} {...@props} style={STYLE} />
+    <image xlinkHref={@props.src} {...@props} style={STYLE if @props?.subject} />

--- a/app/components/modified-image.cjsx
+++ b/app/components/modified-image.cjsx
@@ -1,10 +1,10 @@
 React = require 'react'
 
-STYLE = {
-    filter: "url('#svg-invert-filter')"
+FILTERS = {
+    invert: "url('#svg-invert-filter')"
 }
 
-MARKUP =
+INVERT =
   '<svg style="position: fixed; right: 100%; top: 100%; visibility: hidden;">
     <defs>
       <filter id="svg-invert-filter">
@@ -24,7 +24,11 @@ module.exports = React.createClass
     @setElements()
 
   setElements: ->
-    document.body.insertAdjacentHTML('afterbegin', MARKUP)
+    document.body.insertAdjacentHTML('afterbegin', INVERT)
+
+  filterFinder: ->
+    if @props.modification.invert is true
+      filter: FILTERS.invert
 
   render: ->
-    <image xlinkHref={@props.src} height={@props.height} width={@props.width} style={STYLE if @props.modified} />
+    <image xlinkHref={@props.src} height={@props.height} width={@props.width} style={@filterFinder()} />

--- a/app/components/subject-viewer.cjsx
+++ b/app/components/subject-viewer.cjsx
@@ -126,6 +126,10 @@ module.exports = React.createClass
             </span>
         </span>}
         <span>
+          {if @props.workflow?.configuration?.invert_subject?
+            <button type="button" className="secret-button" aria-label="Invert image" title="Invert image" onClick={@toggleInvert}>
+              <i className="fa fa-adjust "></i>
+            </button>}{' '}
           {if @props.workflow?.configuration?.enable_subject_flags
             <span>
               <FlagSubjectButton className="secret-button" classification={@props.classification} />{' '}
@@ -190,6 +194,11 @@ module.exports = React.createClass
 
   toggleInFlipbookMode: () ->
     @setInFlipbookMode not @state.inFlipbookMode
+
+  toggleInvert: () ->
+    mode = not @state.imageInvert
+    @setState imageInvert: mode
+    @props.subject.invert = mode
 
   setInFlipbookMode: (inFlipbookMode) ->
     @setState {inFlipbookMode}

--- a/app/components/subject-viewer.cjsx
+++ b/app/components/subject-viewer.cjsx
@@ -174,7 +174,7 @@ module.exports = React.createClass
     @signInAttentionTimeout = setTimeout (=> @setState loading: false), 3000
 
   renderFrame: (frame, props = {}) ->
-    <FrameViewer {...@props} {...props} frame={frame} onLoad={@handleFrameLoad} />
+    <FrameViewer {...@props} {...props} frame={frame} modified={@state?.imageInvert || null} onLoad={@handleFrameLoad} />
 
   hiddenPreloadedImages: ->
     # Render this to ensure that all a subject's location images are cached and ready to display.
@@ -198,7 +198,6 @@ module.exports = React.createClass
   toggleInvert: () ->
     mode = not @state.imageInvert
     @setState imageInvert: mode
-    @props.subject.invert = mode
 
   setInFlipbookMode: (inFlipbookMode) ->
     @setState {inFlipbookMode}

--- a/app/components/subject-viewer.cjsx
+++ b/app/components/subject-viewer.cjsx
@@ -127,7 +127,7 @@ module.exports = React.createClass
         </span>}
         <span>
           {if @props.workflow?.configuration?.invert_subject?
-            <button type="button" className="secret-button" aria-label="Invert image" title="Invert image" onClick={@toggleInvert}>
+            <button type="button" className="secret-button" aria-label="Invert image" title="Invert image" onClick={@toggleModification.bind this, 'invert'}>
               <i className="fa fa-adjust "></i>
             </button>}{' '}
           {if @props.workflow?.configuration?.enable_subject_flags
@@ -174,7 +174,7 @@ module.exports = React.createClass
     @signInAttentionTimeout = setTimeout (=> @setState loading: false), 3000
 
   renderFrame: (frame, props = {}) ->
-    <FrameViewer {...@props} {...props} frame={frame} modified={@state?.imageInvert || null} onLoad={@handleFrameLoad} />
+    <FrameViewer {...@props} {...props} frame={frame} modification={@state?.modification} onLoad={@handleFrameLoad} />
 
   hiddenPreloadedImages: ->
     # Render this to ensure that all a subject's location images are cached and ready to display.
@@ -195,9 +195,15 @@ module.exports = React.createClass
   toggleInFlipbookMode: () ->
     @setInFlipbookMode not @state.inFlipbookMode
 
-  toggleInvert: () ->
-    mode = not @state.imageInvert
-    @setState imageInvert: mode
+  toggleModification: (type) ->
+    mods = @state?.modification
+    if !mods
+      mods = {}
+    if mods[type] is undefined
+      mods[type] = true
+    else
+      mods[type] = not mods[type]
+    @setState modification: mods
 
   setInFlipbookMode: (inFlipbookMode) ->
     @setState {inFlipbookMode}

--- a/app/pages/admin/project-status.cjsx
+++ b/app/pages/admin/project-status.cjsx
@@ -23,6 +23,7 @@ EXPERIMENTAL_FEATURES = [
   'hide previous marks'
   'column'
   'grid'
+  'invert'
 ]
 
 ProjectToggle = React.createClass

--- a/app/pages/lab/workflow.cjsx
+++ b/app/pages/lab/workflow.cjsx
@@ -293,6 +293,16 @@ EditWorkflowPage = React.createClass
 
           <hr />
 
+          {if 'invert' in @props.project.experimental_tools
+            <div>
+              <AutoSave tag="label" resource={@props.workflow}>
+                <input type="checkbox" name="invert_subject" checked={@props.workflow.configuration.invert_subject} onChange={@handleSetInvert} />
+                Allow Users To Flip Image Color
+              </AutoSave>
+
+              <hr />
+            </div>}
+
           <p>
             <AutoSave resource={@props.workflow}>
               Subject retirement <RetirementRulesEditor workflow={@props.workflow} />
@@ -494,6 +504,10 @@ EditWorkflowPage = React.createClass
   handleSetHideClassificationSummaries: (e) ->
     @props.workflow.update
       'configuration.hide_classification_summaries': e.target.checked
+
+  handleSetInvert: (e) ->
+    @props.workflow.update
+      'configuration.invert_subject': e.target.checked
 
   handleSetWorldWideTelescope: (e) ->
     if !@props.workflow.configuration.custom_summary


### PR DESCRIPTION
The invert tool allows users to invert the colors of an image/subject in order to more easily notice objects. This branch was tested and should be working on all browsers (IE, Safari, Firefox, Chrome). I tried to abstract the invert into a modification property to allow the `ModifiedImage` component to be more flexible with other filters in the future.

Staged branch at https://invert-tool.pfe-preview.zooniverse.org/projects/wgranger-test/invert-testing/classify 