### PR TITLE
downcase the branch name on stage deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "_publish": "publisssh ./dist \"zooniverse-static/$PATH_ROOT/$SUBDIR\"",
     "_log-staging-url": "echo \"Staged at https://$SUBDIR.pfe-preview.zooniverse.org/\"",
     "_stage": "export PATH_ROOT=preview.zooniverse.org/panoptes-front-end; npm run _build && npm run _publish && npm run _log-staging-url",
-    "stage": "export NODE_ENV=staging; export SUBDIR=$(git symbolic-ref --short HEAD); npm run _stage",
+    "stage": "export NODE_ENV=staging; export SUBDIR=$(git symbolic-ref --short HEAD | awk '{print tolower($0)}'); npm run _stage",
     "stage-with-docker": "./bin/run-through-docker.sh 'npm run stage'",
     "_deploy": "export PATH_ROOT=www.zooniverse.org; npm run _build && npm run _publish",
     "deploy": "export NODE_ENV=production; npm run _deploy",


### PR DESCRIPTION
I assume `awk`  is ok to use here. 

This PR fixes a problem i just came across where the domain name of the staged URL is case insensitive and browsers will downcast them before requesting the URL. However our static proxy takes the subdomain and uses it as an s3 bucket path which may not match the branches actual case. This PR will force the bucket path to lowercase to match the domain case via the browser.