### PR TITLE
Adjust delete button

### DIFF
--- a/app/classifier/drawing-tools/circle.cjsx
+++ b/app/classifier/drawing-tools/circle.cjsx
@@ -9,7 +9,7 @@ MINIMUM_RADIUS = 5
 GUIDE_WIDTH = 1
 GUIDE_DASH = [4, 4]
 DELETE_BUTTON_ANGLE = 45
-BUFFER = 12
+BUFFER = 18
 
 module.exports = React.createClass
   displayName: 'EllipseTool'
@@ -48,14 +48,8 @@ module.exports = React.createClass
 
   getDeletePosition: ->
     theta = (DELETE_BUTTON_ANGLE - @props.mark.angle) * (Math.PI / 180)
-    x = @props.mark.r * Math.cos theta
-    y = -1 * @props.mark.r * Math.sin theta
-    x += (BUFFER / @props.scale.horizontal) if @calculateDistance(x, @props.mark.r, y, 0) < BUFFER / @props.scale.horizontal
-    x: x
-    y: y
-
-  calculateDistance: (x1, x2, y1, y2) ->
-    Math.sqrt(Math.pow(x1 - x2, 2) + Math.pow(y1 - y2, 2))
+    x: (@props.mark.r + (BUFFER / @props.scale.horizontal)) * Math.cos theta
+    y: -1 * (@props.mark.r + (BUFFER / @props.scale.vertical)) * Math.sin theta
 
   render: ->
     positionAndRotate = "

--- a/app/classifier/drawing-tools/circle.cjsx
+++ b/app/classifier/drawing-tools/circle.cjsx
@@ -9,7 +9,7 @@ MINIMUM_RADIUS = 5
 GUIDE_WIDTH = 1
 GUIDE_DASH = [4, 4]
 DELETE_BUTTON_ANGLE = 45
-BUFFER = 18
+BUFFER = 16
 
 module.exports = React.createClass
   displayName: 'EllipseTool'

--- a/app/classifier/drawing-tools/circle.cjsx
+++ b/app/classifier/drawing-tools/circle.cjsx
@@ -9,7 +9,7 @@ MINIMUM_RADIUS = 5
 GUIDE_WIDTH = 1
 GUIDE_DASH = [4, 4]
 DELETE_BUTTON_ANGLE = 45
-BUFFER = 40
+BUFFER = 44
 
 module.exports = React.createClass
   displayName: 'EllipseTool'

--- a/app/classifier/drawing-tools/circle.cjsx
+++ b/app/classifier/drawing-tools/circle.cjsx
@@ -9,6 +9,7 @@ MINIMUM_RADIUS = 5
 GUIDE_WIDTH = 1
 GUIDE_DASH = [4, 4]
 DELETE_BUTTON_ANGLE = 45
+BUFFER = 40
 
 module.exports = React.createClass
   displayName: 'EllipseTool'
@@ -47,8 +48,14 @@ module.exports = React.createClass
 
   getDeletePosition: ->
     theta = (DELETE_BUTTON_ANGLE - @props.mark.angle) * (Math.PI / 180)
-    x: @props.mark.r * Math.cos theta
-    y: -1 * @props.mark.r * Math.sin theta
+    x = @props.mark.r * Math.cos theta
+    y = -1 * @props.mark.r * Math.sin theta
+    x += BUFFER if @calculateDistance(x, @props.mark.r, y, 0) < BUFFER
+    x: x
+    y: y
+
+  calculateDistance: (x1, x2, y1, y2) ->
+    Math.sqrt(Math.pow(x1 - x2, 2) + Math.pow(y1 - y2, 2))
 
   render: ->
     positionAndRotate = "

--- a/app/classifier/drawing-tools/circle.cjsx
+++ b/app/classifier/drawing-tools/circle.cjsx
@@ -9,7 +9,7 @@ MINIMUM_RADIUS = 5
 GUIDE_WIDTH = 1
 GUIDE_DASH = [4, 4]
 DELETE_BUTTON_ANGLE = 45
-BUFFER = 44
+BUFFER = 12
 
 module.exports = React.createClass
   displayName: 'EllipseTool'
@@ -50,7 +50,7 @@ module.exports = React.createClass
     theta = (DELETE_BUTTON_ANGLE - @props.mark.angle) * (Math.PI / 180)
     x = @props.mark.r * Math.cos theta
     y = -1 * @props.mark.r * Math.sin theta
-    x += BUFFER if @calculateDistance(x, @props.mark.r, y, 0) < BUFFER
+    x += (BUFFER / @props.scale.horizontal) if @calculateDistance(x, @props.mark.r, y, 0) < BUFFER / @props.scale.horizontal
     x: x
     y: y
 

--- a/app/classifier/drawing-tools/ellipse.cjsx
+++ b/app/classifier/drawing-tools/ellipse.cjsx
@@ -10,6 +10,7 @@ MINIMUM_RADIUS = 5
 GUIDE_WIDTH = 1
 GUIDE_DASH = [4, 4]
 DELETE_BUTTON_ANGLE = 45
+BUFFER = 40
 
 module.exports = React.createClass
   displayName: 'EllipseTool'
@@ -50,8 +51,16 @@ module.exports = React.createClass
 
   getDeletePosition: ->
     theta = (DELETE_BUTTON_ANGLE - @props.mark.angle) * (Math.PI / 180)
-    x: @props.mark.rx * Math.cos theta
-    y: -1 * @props.mark.ry * Math.sin theta
+    x = @props.mark.rx * Math.cos theta
+    y = -1 * @props.mark.ry * Math.sin theta
+    yHandle = -1 * @props.mark.ry
+    x += BUFFER if @calculateDistance(x, @props.mark.rx, y, 0) < BUFFER
+    y += BUFFER if @calculateDistance(x, 0, y, yHandle) < BUFFER
+    x: x
+    y: y
+
+  calculateDistance: (x1, x2, y1, y2) ->
+    Math.sqrt(Math.pow(x1 - x2, 2) + Math.pow(y1 - y2, 2))
 
   render: ->
     positionAndRotate = "

--- a/app/classifier/drawing-tools/ellipse.cjsx
+++ b/app/classifier/drawing-tools/ellipse.cjsx
@@ -10,7 +10,7 @@ MINIMUM_RADIUS = 5
 GUIDE_WIDTH = 1
 GUIDE_DASH = [4, 4]
 DELETE_BUTTON_ANGLE = 45
-BUFFER = 40
+BUFFER = 44
 
 module.exports = React.createClass
   displayName: 'EllipseTool'

--- a/app/classifier/drawing-tools/ellipse.cjsx
+++ b/app/classifier/drawing-tools/ellipse.cjsx
@@ -10,7 +10,7 @@ MINIMUM_RADIUS = 5
 GUIDE_WIDTH = 1
 GUIDE_DASH = [4, 4]
 DELETE_BUTTON_ANGLE = 45
-BUFFER = 12
+BUFFER = 18
 
 module.exports = React.createClass
   displayName: 'EllipseTool'
@@ -51,16 +51,8 @@ module.exports = React.createClass
 
   getDeletePosition: ->
     theta = (DELETE_BUTTON_ANGLE - @props.mark.angle) * (Math.PI / 180)
-    x = @props.mark.rx * Math.cos theta
-    y = -1 * @props.mark.ry * Math.sin theta
-    yHandle = -1 * @props.mark.ry
-    x += BUFFER / @props.scale.horizontal if @calculateDistance(x, @props.mark.rx, y, 0) < BUFFER / @props.scale.horizontal
-    y += BUFFER / @props.scale.vertical if @calculateDistance(x, 0, y, yHandle) < BUFFER / @props.scale.vertical
-    x: x
-    y: y
-
-  calculateDistance: (x1, x2, y1, y2) ->
-    Math.sqrt(Math.pow(x1 - x2, 2) + Math.pow(y1 - y2, 2))
+    x: (@props.mark.rx + (BUFFER / @props.scale.horizontal)) * Math.cos theta
+    y: -1 * (@props.mark.ry + (BUFFER / @props.scale.vertical)) * Math.sin theta
 
   render: ->
     positionAndRotate = "

--- a/app/classifier/drawing-tools/ellipse.cjsx
+++ b/app/classifier/drawing-tools/ellipse.cjsx
@@ -10,7 +10,7 @@ MINIMUM_RADIUS = 5
 GUIDE_WIDTH = 1
 GUIDE_DASH = [4, 4]
 DELETE_BUTTON_ANGLE = 45
-BUFFER = 18
+BUFFER = 16
 
 module.exports = React.createClass
   displayName: 'EllipseTool'

--- a/app/classifier/drawing-tools/ellipse.cjsx
+++ b/app/classifier/drawing-tools/ellipse.cjsx
@@ -10,7 +10,7 @@ MINIMUM_RADIUS = 5
 GUIDE_WIDTH = 1
 GUIDE_DASH = [4, 4]
 DELETE_BUTTON_ANGLE = 45
-BUFFER = 44
+BUFFER = 12
 
 module.exports = React.createClass
   displayName: 'EllipseTool'
@@ -54,8 +54,8 @@ module.exports = React.createClass
     x = @props.mark.rx * Math.cos theta
     y = -1 * @props.mark.ry * Math.sin theta
     yHandle = -1 * @props.mark.ry
-    x += BUFFER if @calculateDistance(x, @props.mark.rx, y, 0) < BUFFER
-    y += BUFFER if @calculateDistance(x, 0, y, yHandle) < BUFFER
+    x += BUFFER / @props.scale.horizontal if @calculateDistance(x, @props.mark.rx, y, 0) < BUFFER / @props.scale.horizontal
+    y += BUFFER / @props.scale.vertical if @calculateDistance(x, 0, y, yHandle) < BUFFER / @props.scale.vertical
     x: x
     y: y
 

--- a/app/classifier/drawing-tools/line.cjsx
+++ b/app/classifier/drawing-tools/line.cjsx
@@ -7,6 +7,7 @@ DragHandle = require './drag-handle'
 
 MINIMUM_LENGTH = 5
 GRAB_STROKE_WIDTH = 6
+BUFFER = 40
 
 module.exports = React.createClass
   displayName: 'LineTool'
@@ -32,9 +33,30 @@ module.exports = React.createClass
       {x1, y1, x2, y2} = mark
       DrawingToolRoot.distance(x1, y1, x2, y2) > MINIMUM_LENGTH
 
+  getDeletePosition: (x1, y1, x2, y2) ->
+    x = (x1 + x2) / 2
+    y = (y1 + y2) / 2
+    if @calculateDistance(x, x1, y, y1) is 'x'
+      x += BUFFER
+    else if @calculateDistance(x, x1, y, y1) is 'y'
+      y += BUFFER
+    x: x
+    y: y
+
+  calculateDistance: (deleteBtnX, handleBtnX, deleteBtnY, handleBtnY) ->
+    xDistance = Math.abs(deleteBtnX - handleBtnX)
+    yDistance = Math.abs(deleteBtnY - handleBtnY)
+    if xDistance < BUFFER and yDistance < BUFFER
+      if yDistance > xDistance
+        'x'
+      else if xDistance > yDistance
+        'y'
+
   render: ->
     {x1, y1, x2, y2} = @props.mark
     points = {x1, y1, x2, y2}
+
+    deletePosition = @getDeletePosition(x1, y1, x2, y2)
 
     <DrawingToolRoot tool={this}>
       <line {...points} />
@@ -45,7 +67,7 @@ module.exports = React.createClass
 
       {if @props.selected
         <g>
-          <DeleteButton tool={this} x={(x1 + x2) / 2} y={(y1 + y2) / 2} />
+          <DeleteButton tool={this} x={deletePosition.x} y={deletePosition.y} />
           <DragHandle x={x1} y={y1} scale={@props.scale} onDrag={@handleHandleDrag.bind this, 1} />
           <DragHandle x={x2} y={y2} scale={@props.scale} onDrag={@handleHandleDrag.bind this, 2} />
         </g>}

--- a/app/classifier/drawing-tools/line.cjsx
+++ b/app/classifier/drawing-tools/line.cjsx
@@ -7,7 +7,7 @@ DragHandle = require './drag-handle'
 
 MINIMUM_LENGTH = 5
 GRAB_STROKE_WIDTH = 6
-BUFFER = 44
+BUFFER = 12
 
 module.exports = React.createClass
   displayName: 'LineTool'
@@ -37,16 +37,16 @@ module.exports = React.createClass
     x = (x1 + x2) / 2
     y = (y1 + y2) / 2
     if @calculateDistance(x, x1, y, y1) is 'x'
-      x += BUFFER
+      x += BUFFER / @props.scale.horizontal
     else if @calculateDistance(x, x1, y, y1) is 'y'
-      y += BUFFER
+      y += BUFFER / @props.scale.vertical
     x: x
     y: y
 
   calculateDistance: (deleteBtnX, handleBtnX, deleteBtnY, handleBtnY) ->
     xDistance = Math.abs(deleteBtnX - handleBtnX)
     yDistance = Math.abs(deleteBtnY - handleBtnY)
-    if xDistance < BUFFER and yDistance < BUFFER
+    if xDistance < BUFFER / @props.scale.horizontal and yDistance < BUFFER / @props.scale.vertical
       if yDistance >= xDistance
         'x'
       else if xDistance >= yDistance

--- a/app/classifier/drawing-tools/line.cjsx
+++ b/app/classifier/drawing-tools/line.cjsx
@@ -8,7 +8,7 @@ DragHandle = require './drag-handle'
 MINIMUM_LENGTH = 5
 GRAB_STROKE_WIDTH = 6
 BUFFER = 16
-DELETE_BUTTON_WEIGHT = 8
+DELETE_BUTTON_WIDTH = 8
 
 module.exports = React.createClass
   displayName: 'LineTool'
@@ -36,11 +36,11 @@ module.exports = React.createClass
 
   getDeletePosition: (x1, y1, x2, y2) ->
     scale = (@props.scale.horizontal + @props.scale.vertical) / 2
-    x = x1 + (BUFFER / @props.scale.horizontal)
-    if (@props.containerRect.width / @props.scale.horizontal) < x + (DELETE_BUTTON_WEIGHT / scale)
-      x = x - ((BUFFER / @props.scale.horizontal) * 2)
-    if @calculateDistance(x, x2, y1, y2) < DELETE_BUTTON_WEIGHT / scale
-      y1 = y1 - (BUFFER / @props.scale.horizontal)
+    x = x1 + (BUFFER / scale)
+    if (@props.containerRect.width / @props.scale.horizontal) < x + (DELETE_BUTTON_WIDTH / scale)
+      x = x - ((BUFFER / scale) * 2)
+    if @calculateDistance(x, x2, y1, y2) < DELETE_BUTTON_WIDTH / scale
+      y1 = y1 - (BUFFER / scale)
     x: x
     y: y1
 

--- a/app/classifier/drawing-tools/line.cjsx
+++ b/app/classifier/drawing-tools/line.cjsx
@@ -7,7 +7,8 @@ DragHandle = require './drag-handle'
 
 MINIMUM_LENGTH = 5
 GRAB_STROKE_WIDTH = 6
-BUFFER = 12
+BUFFER = 16
+DELETE_BUTTON_WEIGHT = 8
 
 module.exports = React.createClass
   displayName: 'LineTool'
@@ -34,23 +35,17 @@ module.exports = React.createClass
       DrawingToolRoot.distance(x1, y1, x2, y2) > MINIMUM_LENGTH
 
   getDeletePosition: (x1, y1, x2, y2) ->
-    x = (x1 + x2) / 2
-    y = (y1 + y2) / 2
-    if @calculateDistance(x, x1, y, y1) is 'x'
-      x += BUFFER / @props.scale.horizontal
-    else if @calculateDistance(x, x1, y, y1) is 'y'
-      y += BUFFER / @props.scale.vertical
+    scale = (@props.scale.horizontal + @props.scale.vertical) / 2
+    x = x1 + (BUFFER / @props.scale.horizontal)
+    if (@props.containerRect.width / @props.scale.horizontal) < x + (DELETE_BUTTON_WEIGHT / scale)
+      x = x - ((BUFFER / @props.scale.horizontal) * 2)
+    if @calculateDistance(x, x2, y1, y2) < DELETE_BUTTON_WEIGHT / scale
+      y1 = y1 - (BUFFER / @props.scale.horizontal)
     x: x
-    y: y
+    y: y1
 
   calculateDistance: (deleteBtnX, handleBtnX, deleteBtnY, handleBtnY) ->
-    xDistance = Math.abs(deleteBtnX - handleBtnX)
-    yDistance = Math.abs(deleteBtnY - handleBtnY)
-    if xDistance < BUFFER / @props.scale.horizontal and yDistance < BUFFER / @props.scale.vertical
-      if yDistance >= xDistance
-        'x'
-      else if xDistance >= yDistance
-        'y'
+    Math.sqrt(Math.pow(deleteBtnX - handleBtnX, 2) + Math.pow(deleteBtnY - handleBtnY, 2))
 
   render: ->
     {x1, y1, x2, y2} = @props.mark

--- a/app/classifier/drawing-tools/line.cjsx
+++ b/app/classifier/drawing-tools/line.cjsx
@@ -7,7 +7,7 @@ DragHandle = require './drag-handle'
 
 MINIMUM_LENGTH = 5
 GRAB_STROKE_WIDTH = 6
-BUFFER = 40
+BUFFER = 44
 
 module.exports = React.createClass
   displayName: 'LineTool'
@@ -47,9 +47,9 @@ module.exports = React.createClass
     xDistance = Math.abs(deleteBtnX - handleBtnX)
     yDistance = Math.abs(deleteBtnY - handleBtnY)
     if xDistance < BUFFER and yDistance < BUFFER
-      if yDistance > xDistance
+      if yDistance >= xDistance
         'x'
-      else if xDistance > yDistance
+      else if xDistance >= yDistance
         'y'
 
   render: ->

--- a/app/classifier/drawing-tools/line.cjsx
+++ b/app/classifier/drawing-tools/line.cjsx
@@ -36,16 +36,17 @@ module.exports = React.createClass
 
   getDeletePosition: (x1, y1, x2, y2) ->
     scale = (@props.scale.horizontal + @props.scale.vertical) / 2
-    x = x1 + (BUFFER / scale)
-    if (@props.containerRect.width / @props.scale.horizontal) < x + (DELETE_BUTTON_WIDTH / scale)
-      x = x - ((BUFFER / scale) * 2)
-    if @calculateDistance(x, x2, y1, y2) < DELETE_BUTTON_WIDTH / scale
-      y1 = y1 - (BUFFER / scale)
+    x = if x1 > x2 then x1 + (BUFFER / scale) else x1 - (BUFFER / scale)
+    if @outOfBounds(x, scale)
+      x = (x1 + x2) / 2
+      y1 = (y1 + y2) / 2
     x: x
     y: y1
 
-  calculateDistance: (deleteBtnX, handleBtnX, deleteBtnY, handleBtnY) ->
-    Math.sqrt(Math.pow(deleteBtnX - handleBtnX, 2) + Math.pow(deleteBtnY - handleBtnY, 2))
+  outOfBounds: (deleteBtnX, scale) ->
+    leftSide = deleteBtnX - (DELETE_BUTTON_WIDTH / scale) < 0
+    rightSide = (@props.containerRect.width / @props.scale.horizontal) < deleteBtnX + (DELETE_BUTTON_WIDTH / scale)
+    leftSide or rightSide
 
   render: ->
     {x1, y1, x2, y2} = @props.mark

--- a/app/classifier/drawing-tools/poly-curve.cjsx
+++ b/app/classifier/drawing-tools/poly-curve.cjsx
@@ -11,7 +11,7 @@ GUIDE_WIDTH = 1
 GUIDE_DASH = [4, 4]
 # fraction of line lenght along (x) and perpendicular (y) to the line to place control point
 DEFAULT_CURVE = {x: 0.5, y: 0}
-BUFFER = 12
+BUFFER = 10
 
 DELETE_BUTTON_WEIGHT = 0.75 # fraction of line lenght to place delete button
 
@@ -70,12 +70,10 @@ module.exports = React.createClass
     if control?
       x = (1 - t) * (1 - t) * start.x + 2 * (1 - t) * t * control.x + t * t * end.x
       y = (1 - t) * (1 - t) * start.y + 2 * (1 - t) * t * control.y + t * t * end.y
-      points = [start, end, control]
-      for i in points
-        if @calculateDistance(x, i.x, y, i.y) is 'x'
-          x += BUFFER / @props.scale.horizontal
-        else if @calculateDistance(x, i.x, y, i.y) is 'y'
-          y += BUFFER / @props.scale.vertical
+      for point in @props.mark.points
+        if @calculateDistance(x, point.x, y, point.y) < BUFFER / ((@props.scale.horizontal + @props.scale.vertical) / 2)
+          x = x - (BUFFER / @props.scale.horizontal)
+          y = y - (BUFFER / @props.scale.vertical)
       x: x
       y: y
     else
@@ -94,14 +92,8 @@ module.exports = React.createClass
   componentWillUnmount: ->
     document.removeEventListener 'mousemove', @handleMouseMove
 
-  calculateDistance: (x1, x2, y1, y2) ->
-    xDistance = Math.abs(x1 - x2)
-    yDistance = Math.abs(y1 - y2)
-    if xDistance < BUFFER / @props.scale.horizontal and yDistance < BUFFER / @props.scale.vertical
-      if yDistance >= xDistance
-        'x'
-      else if xDistance >= yDistance
-        'y'
+  calculateDistance: (deleteBtnX, handleBtnX, deleteBtnY, handleBtnY) ->
+    Math.sqrt(Math.pow(deleteBtnX - handleBtnX, 2) + Math.pow(deleteBtnY - handleBtnY, 2))
 
   render: ->
     {points} = @props.mark

--- a/app/classifier/drawing-tools/poly-curve.cjsx
+++ b/app/classifier/drawing-tools/poly-curve.cjsx
@@ -11,7 +11,7 @@ GUIDE_WIDTH = 1
 GUIDE_DASH = [4, 4]
 # fraction of line lenght along (x) and perpendicular (y) to the line to place control point
 DEFAULT_CURVE = {x: 0.5, y: 0}
-BUFFER = 10
+BUFFER = 16
 
 DELETE_BUTTON_WEIGHT = 0.75 # fraction of line lenght to place delete button
 
@@ -68,12 +68,11 @@ module.exports = React.createClass
     # t is in the range [0,1]
     # if control is undefined just return the point t along the line between start and end
     if control?
+      buffer = BUFFER / @props.scale.horizontal
       x = (1 - t) * (1 - t) * start.x + 2 * (1 - t) * t * control.x + t * t * end.x
       y = (1 - t) * (1 - t) * start.y + 2 * (1 - t) * t * control.y + t * t * end.y
       for point in @props.mark.points
-        if @calculateDistance(x, point.x, y, point.y) < BUFFER / ((@props.scale.horizontal + @props.scale.vertical) / 2)
-          x = x - (BUFFER / @props.scale.horizontal)
-          y = y - (BUFFER / @props.scale.vertical)
+        x = point.x - buffer if @calculateDistance(x, point.x, y, point.y) < buffer
       x: x
       y: y
     else

--- a/app/classifier/drawing-tools/poly-curve.cjsx
+++ b/app/classifier/drawing-tools/poly-curve.cjsx
@@ -11,7 +11,7 @@ GUIDE_WIDTH = 1
 GUIDE_DASH = [4, 4]
 # fraction of line lenght along (x) and perpendicular (y) to the line to place control point
 DEFAULT_CURVE = {x: 0.5, y: 0}
-BUFFER = 44
+BUFFER = 12
 
 DELETE_BUTTON_WEIGHT = 0.75 # fraction of line lenght to place delete button
 
@@ -73,9 +73,9 @@ module.exports = React.createClass
       points = [start, end, control]
       for i in points
         if @calculateDistance(x, i.x, y, i.y) is 'x'
-          x += BUFFER
+          x += BUFFER / @props.scale.horizontal
         else if @calculateDistance(x, i.x, y, i.y) is 'y'
-          y += BUFFER
+          y += BUFFER / @props.scale.vertical
       x: x
       y: y
     else
@@ -97,7 +97,7 @@ module.exports = React.createClass
   calculateDistance: (x1, x2, y1, y2) ->
     xDistance = Math.abs(x1 - x2)
     yDistance = Math.abs(y1 - y2)
-    if xDistance < BUFFER and yDistance < BUFFER
+    if xDistance < BUFFER / @props.scale.horizontal and yDistance < BUFFER / @props.scale.vertical
       if yDistance >= xDistance
         'x'
       else if xDistance >= yDistance

--- a/app/classifier/drawing-tools/poly-curve.cjsx
+++ b/app/classifier/drawing-tools/poly-curve.cjsx
@@ -11,7 +11,7 @@ GUIDE_WIDTH = 1
 GUIDE_DASH = [4, 4]
 # fraction of line lenght along (x) and perpendicular (y) to the line to place control point
 DEFAULT_CURVE = {x: 0.5, y: 0}
-BUFFER = 40
+BUFFER = 44
 
 DELETE_BUTTON_WEIGHT = 0.75 # fraction of line lenght to place delete button
 
@@ -95,15 +95,12 @@ module.exports = React.createClass
     document.removeEventListener 'mousemove', @handleMouseMove
 
   calculateDistance: (x1, x2, y1, y2) ->
-    Math.sqrt(Math.pow(x1 - x2, 2) + Math.pow(y1 - y2, 2))
-
-  calculateDistance: (x1, x2, y1, y2) ->
     xDistance = Math.abs(x1 - x2)
     yDistance = Math.abs(y1 - y2)
     if xDistance < BUFFER and yDistance < BUFFER
-      if yDistance > xDistance
+      if yDistance >= xDistance
         'x'
-      else if xDistance > yDistance
+      else if xDistance >= yDistance
         'y'
 
   render: ->

--- a/app/classifier/drawing-tools/poly-curve.cjsx
+++ b/app/classifier/drawing-tools/poly-curve.cjsx
@@ -11,6 +11,7 @@ GUIDE_WIDTH = 1
 GUIDE_DASH = [4, 4]
 # fraction of line lenght along (x) and perpendicular (y) to the line to place control point
 DEFAULT_CURVE = {x: 0.5, y: 0}
+BUFFER = 40
 
 DELETE_BUTTON_WEIGHT = 0.75 # fraction of line lenght to place delete button
 
@@ -62,16 +63,24 @@ module.exports = React.createClass
       x: (dx * control.x) - (dy * control.y) + start.x
       y: (dy * control.x) + (dx * control.y) + start.y
 
-    positionAlongCurve: (start, end, control, t) ->
-      # t is how far along the curve you want the pont
-      # t is in the range [0,1]
-      # if control is undefined just return the point t along the line between start and end
-      if control?
-        x: (1 - t) * (1 - t) * start.x + 2 * (1 - t) * t * control.x + t * t * end.x
-        y: (1 - t) * (1 - t) * start.y + 2 * (1 - t) * t * control.y + t * t * end.y
-      else
-        x: (1 - t) * start.x + t * end.x
-        y: (1 - t) * start.y + t * end.y
+  positionAlongCurve: (start, end, control, t) ->
+    # t is how far along the curve you want the pont
+    # t is in the range [0,1]
+    # if control is undefined just return the point t along the line between start and end
+    if control?
+      x = (1 - t) * (1 - t) * start.x + 2 * (1 - t) * t * control.x + t * t * end.x
+      y = (1 - t) * (1 - t) * start.y + 2 * (1 - t) * t * control.y + t * t * end.y
+      points = [start, end, control]
+      for i in points
+        if @calculateDistance(x, i.x, y, i.y) is 'x'
+          x += BUFFER
+        else if @calculateDistance(x, i.x, y, i.y) is 'y'
+          y += BUFFER
+      x: x
+      y: y
+    else
+      x: (1 - t) * start.x + t * end.x
+      y: (1 - t) * start.y + t * end.y
 
   componentWillMount: ->
     @setState
@@ -84,6 +93,18 @@ module.exports = React.createClass
 
   componentWillUnmount: ->
     document.removeEventListener 'mousemove', @handleMouseMove
+
+  calculateDistance: (x1, x2, y1, y2) ->
+    Math.sqrt(Math.pow(x1 - x2, 2) + Math.pow(y1 - y2, 2))
+
+  calculateDistance: (x1, x2, y1, y2) ->
+    xDistance = Math.abs(x1 - x2)
+    yDistance = Math.abs(y1 - y2)
+    if xDistance < BUFFER and yDistance < BUFFER
+      if yDistance > xDistance
+        'x'
+      else if xDistance > yDistance
+        'y'
 
   render: ->
     {points} = @props.mark
@@ -100,7 +121,7 @@ module.exports = React.createClass
     lastPoint = points[points.length - 1]
 
     deleteButtonPosition =
-      @constructor.positionAlongCurve(firstPoint, secondPoint, firstControlPoint , DELETE_BUTTON_WEIGHT)
+      @positionAlongCurve(firstPoint, secondPoint, firstControlPoint , DELETE_BUTTON_WEIGHT)
 
     svgPath = "M#{firstPoint.x} #{firstPoint.y} "
     svgPathHelpers = "M#{firstPoint.x} #{firstPoint.y} "

--- a/app/classifier/drawing-tools/polygon.cjsx
+++ b/app/classifier/drawing-tools/polygon.cjsx
@@ -7,7 +7,7 @@ DeleteButton = require './delete-button'
 
 FINISHER_RADIUS = 8
 GRAB_STROKE_WIDTH = 6
-BUFFER = 14
+BUFFER = 16
 
 DELETE_BUTTON_WEIGHT = 5 # Weight of the second point.
 
@@ -94,11 +94,11 @@ module.exports = React.createClass
     </DrawingToolRoot>
 
   getDeletePosition: (firstPoint, secondPoint) ->
+    buffer = BUFFER / @props.scale.horizontal
     x = (firstPoint.x + ((DELETE_BUTTON_WEIGHT - 1) * secondPoint.x)) / DELETE_BUTTON_WEIGHT
     y = (firstPoint.y + ((DELETE_BUTTON_WEIGHT - 1) * secondPoint.y)) / DELETE_BUTTON_WEIGHT
     for point in @props.mark.points
-      if @calculateDistance(x, point.x, y, point.y) < BUFFER / @props.scale.horizontal
-        x = x - (BUFFER / @props.scale.horizontal)
+      x = point.x - buffer if @calculateDistance(x, point.x, y, point.y) < buffer
     x: x
     y: y
 

--- a/app/classifier/drawing-tools/polygon.cjsx
+++ b/app/classifier/drawing-tools/polygon.cjsx
@@ -7,7 +7,7 @@ DeleteButton = require './delete-button'
 
 FINISHER_RADIUS = 8
 GRAB_STROKE_WIDTH = 6
-BUFFER = 50
+BUFFER = 14
 
 DELETE_BUTTON_WEIGHT = 5 # Weight of the second point.
 
@@ -100,16 +100,16 @@ module.exports = React.createClass
     points = [firstPoint, secondPoint]
     for i in points
       if @calculateDistance(x, i.x, y, i.y) is 'x' and multiplePoints
-        x += BUFFER
+        x += BUFFER / @props.scale.horizontal
       else if @calculateDistance(x, i.x, y, i.y) is 'y' and multiplePoints
-        y += BUFFER
+        y += BUFFER / @props.scale.vertical
     x: x
     y: y
 
   calculateDistance: (x1, x2, y1, y2) ->
     xDistance = Math.abs(x1 - x2)
     yDistance = Math.abs(y1 - y2)
-    if xDistance < BUFFER and yDistance < BUFFER
+    if xDistance < BUFFER / @props.scale.horizontal and yDistance < BUFFER / @props.scale.vertical
       if yDistance >= xDistance
         'x'
       else if xDistance >= yDistance

--- a/app/classifier/drawing-tools/polygon.cjsx
+++ b/app/classifier/drawing-tools/polygon.cjsx
@@ -7,6 +7,7 @@ DeleteButton = require './delete-button'
 
 FINISHER_RADIUS = 8
 GRAB_STROKE_WIDTH = 6
+BUFFER = 40
 
 DELETE_BUTTON_WEIGHT = 5 # Weight of the second point.
 
@@ -64,9 +65,7 @@ module.exports = React.createClass
       points.push [firstPoint.x, firstPoint.y].join ','
     points = points.join '\n'
 
-    deleteButtonPosition =
-      x: (firstPoint.x + ((DELETE_BUTTON_WEIGHT - 1) * secondPoint.x)) / DELETE_BUTTON_WEIGHT
-      y: (firstPoint.y + ((DELETE_BUTTON_WEIGHT - 1) * secondPoint.y)) / DELETE_BUTTON_WEIGHT
+    deleteButtonPosition = @getDeletePosition(firstPoint, secondPoint, lastPoint)
 
     <DrawingToolRoot tool={this}>
       <Draggable onDrag={@handleMainDrag} onEnd={deleteIfOutOfBounds.bind null, this} disabled={@props.disabled}>
@@ -93,6 +92,30 @@ module.exports = React.createClass
             </g>}
         </g>}
     </DrawingToolRoot>
+
+  getDeletePosition: (firstPoint, secondPoint, lastPoint) ->
+    multiplePoints = firstPoint != lastPoint
+    x = (firstPoint.x + ((DELETE_BUTTON_WEIGHT - 1) * secondPoint.x)) / DELETE_BUTTON_WEIGHT
+    y = (firstPoint.y + ((DELETE_BUTTON_WEIGHT - 1) * secondPoint.y)) / DELETE_BUTTON_WEIGHT
+    if @calculateDistance(x, firstPoint.x, y, firstPoint.y) is 'x'
+      x += BUFFER
+    else if @calculateDistance(x, firstPoint.x, y, firstPoint.y) is 'y'
+      y += BUFFER
+    if @calculateDistance(x, secondPoint.x, y, secondPoint.y) is 'x' and multiplePoints
+      x += BUFFER
+    else if @calculateDistance(x, secondPoint.x, y, secondPoint.y) is 'y' and multiplePoints
+      y += BUFFER
+    x: x
+    y: y
+
+  calculateDistance: (x1, x2, y1, y2) ->
+    xDistance = Math.abs(x1 - x2)
+    yDistance = Math.abs(y1 - y2)
+    if xDistance < BUFFER and yDistance < BUFFER
+      if yDistance > xDistance
+        'x'
+      else if xDistance > yDistance
+        'y'
 
   handleMouseMove: (e) ->
     xPos = e.pageX

--- a/app/classifier/drawing-tools/polygon.cjsx
+++ b/app/classifier/drawing-tools/polygon.cjsx
@@ -7,7 +7,7 @@ DeleteButton = require './delete-button'
 
 FINISHER_RADIUS = 8
 GRAB_STROKE_WIDTH = 6
-BUFFER = 40
+BUFFER = 50
 
 DELETE_BUTTON_WEIGHT = 5 # Weight of the second point.
 
@@ -97,14 +97,12 @@ module.exports = React.createClass
     multiplePoints = firstPoint != lastPoint
     x = (firstPoint.x + ((DELETE_BUTTON_WEIGHT - 1) * secondPoint.x)) / DELETE_BUTTON_WEIGHT
     y = (firstPoint.y + ((DELETE_BUTTON_WEIGHT - 1) * secondPoint.y)) / DELETE_BUTTON_WEIGHT
-    if @calculateDistance(x, firstPoint.x, y, firstPoint.y) is 'x'
-      x += BUFFER
-    else if @calculateDistance(x, firstPoint.x, y, firstPoint.y) is 'y'
-      y += BUFFER
-    if @calculateDistance(x, secondPoint.x, y, secondPoint.y) is 'x' and multiplePoints
-      x += BUFFER
-    else if @calculateDistance(x, secondPoint.x, y, secondPoint.y) is 'y' and multiplePoints
-      y += BUFFER
+    points = [firstPoint, secondPoint]
+    for i in points
+      if @calculateDistance(x, i.x, y, i.y) is 'x' and multiplePoints
+        x += BUFFER
+      else if @calculateDistance(x, i.x, y, i.y) is 'y' and multiplePoints
+        y += BUFFER
     x: x
     y: y
 
@@ -112,9 +110,9 @@ module.exports = React.createClass
     xDistance = Math.abs(x1 - x2)
     yDistance = Math.abs(y1 - y2)
     if xDistance < BUFFER and yDistance < BUFFER
-      if yDistance > xDistance
+      if yDistance >= xDistance
         'x'
-      else if xDistance > yDistance
+      else if xDistance >= yDistance
         'y'
 
   handleMouseMove: (e) ->

--- a/app/classifier/drawing-tools/polygon.cjsx
+++ b/app/classifier/drawing-tools/polygon.cjsx
@@ -65,7 +65,7 @@ module.exports = React.createClass
       points.push [firstPoint.x, firstPoint.y].join ','
     points = points.join '\n'
 
-    deleteButtonPosition = @getDeletePosition(firstPoint, secondPoint, lastPoint)
+    deleteButtonPosition = @getDeletePosition(firstPoint, secondPoint)
 
     <DrawingToolRoot tool={this}>
       <Draggable onDrag={@handleMainDrag} onEnd={deleteIfOutOfBounds.bind null, this} disabled={@props.disabled}>
@@ -93,27 +93,17 @@ module.exports = React.createClass
         </g>}
     </DrawingToolRoot>
 
-  getDeletePosition: (firstPoint, secondPoint, lastPoint) ->
-    multiplePoints = firstPoint != lastPoint
+  getDeletePosition: (firstPoint, secondPoint) ->
     x = (firstPoint.x + ((DELETE_BUTTON_WEIGHT - 1) * secondPoint.x)) / DELETE_BUTTON_WEIGHT
     y = (firstPoint.y + ((DELETE_BUTTON_WEIGHT - 1) * secondPoint.y)) / DELETE_BUTTON_WEIGHT
-    points = [firstPoint, secondPoint]
-    for i in points
-      if @calculateDistance(x, i.x, y, i.y) is 'x' and multiplePoints
-        x += BUFFER / @props.scale.horizontal
-      else if @calculateDistance(x, i.x, y, i.y) is 'y' and multiplePoints
-        y += BUFFER / @props.scale.vertical
+    for point in @props.mark.points
+      if @calculateDistance(x, point.x, y, point.y) < BUFFER / @props.scale.horizontal
+        x = x - (BUFFER / @props.scale.horizontal)
     x: x
     y: y
 
-  calculateDistance: (x1, x2, y1, y2) ->
-    xDistance = Math.abs(x1 - x2)
-    yDistance = Math.abs(y1 - y2)
-    if xDistance < BUFFER / @props.scale.horizontal and yDistance < BUFFER / @props.scale.vertical
-      if yDistance >= xDistance
-        'x'
-      else if xDistance >= yDistance
-        'y'
+  calculateDistance: (deleteBtnX, handleBtnX, deleteBtnY, handleBtnY) ->
+    Math.sqrt(Math.pow(deleteBtnX - handleBtnX, 2) + Math.pow(deleteBtnY - handleBtnY, 2))
 
   handleMouseMove: (e) ->
     xPos = e.pageX

--- a/app/classifier/drawing-tools/rectangle.cjsx
+++ b/app/classifier/drawing-tools/rectangle.cjsx
@@ -7,7 +7,7 @@ DeleteButton = require './delete-button'
 
 MINIMUM_SIZE = 5
 DELETE_BUTTON_DISTANCE = 9 / 10
-BUFFER = 44
+BUFFER = 12
 
 module.exports = React.createClass
   displayName: 'RectangleTool'
@@ -80,8 +80,8 @@ module.exports = React.createClass
     </DrawingToolRoot>
 
   getDeletePosition: (x, y, width, height) ->
-    y -= BUFFER if width < BUFFER * 2
-    x: Math.min(x + (width - 40), x + (width * DELETE_BUTTON_DISTANCE))
+    y -= BUFFER / @props.scale.vertical if width < (BUFFER / @props.scale.vertical) * 2
+    x: Math.min(x + (width - (BUFFER / @props.scale.horizontal)), x + (width * DELETE_BUTTON_DISTANCE))
     y: y
 
   handleMainDrag: (e, d) ->

--- a/app/classifier/drawing-tools/rectangle.cjsx
+++ b/app/classifier/drawing-tools/rectangle.cjsx
@@ -7,7 +7,7 @@ DeleteButton = require './delete-button'
 
 MINIMUM_SIZE = 5
 DELETE_BUTTON_DISTANCE = 9 / 10
-BUFFER = 12
+BUFFER = 16
 
 module.exports = React.createClass
   displayName: 'RectangleTool'
@@ -53,7 +53,7 @@ module.exports = React.createClass
   render: ->
     {x, y, width, height} = @props.mark
 
-    deletePosition = @getDeletePosition(x, y, width, height)
+    deletePosition = @getDeletePosition(x, width)
 
     points = [
       [x, y].join ','
@@ -70,7 +70,7 @@ module.exports = React.createClass
 
       {if @props.selected
         <g>
-          <DeleteButton tool={this} x={deletePosition.x} y={deletePosition.y} />
+          <DeleteButton tool={this} x={deletePosition.x} y={y} />
 
           <DragHandle x={x} y={y} scale={@props.scale} onDrag={@handleTopLeftDrag} onEnd={@normalizeMark} />
           <DragHandle x={x + width} y={y} scale={@props.scale} onDrag={@handleTopRightDrag} onEnd={@normalizeMark} />
@@ -79,10 +79,11 @@ module.exports = React.createClass
         </g>}
     </DrawingToolRoot>
 
-  getDeletePosition: (x, y, width, height) ->
-    y -= BUFFER / @props.scale.vertical if width < (BUFFER / @props.scale.vertical) * 2
-    x: Math.min(x + (width - (BUFFER / @props.scale.horizontal)), x + (width * DELETE_BUTTON_DISTANCE))
-    y: y
+  getDeletePosition: (x, width) ->
+    x = x + (width + (BUFFER / @props.scale.horizontal))
+    if (@props.containerRect.width / @props.scale.horizontal) < x + (8 / @props.scale.horizontal)
+      x = x - ((BUFFER / @props.scale.horizontal) * 2)
+    x: x
 
   handleMainDrag: (e, d) ->
     @props.mark.x += d.x / @props.scale.horizontal

--- a/app/classifier/drawing-tools/rectangle.cjsx
+++ b/app/classifier/drawing-tools/rectangle.cjsx
@@ -6,7 +6,7 @@ deleteIfOutOfBounds = require './delete-if-out-of-bounds'
 DeleteButton = require './delete-button'
 
 MINIMUM_SIZE = 5
-DELETE_BUTTON_DISTANCE = 9 / 10
+DELETE_BUTTON_WIDTH = 8
 BUFFER = 16
 
 module.exports = React.createClass
@@ -80,9 +80,10 @@ module.exports = React.createClass
     </DrawingToolRoot>
 
   getDeletePosition: (x, width) ->
-    x = x + (width + (BUFFER / @props.scale.horizontal))
-    if (@props.containerRect.width / @props.scale.horizontal) < x + (8 / @props.scale.horizontal)
-      x = x - ((BUFFER / @props.scale.horizontal) * 2)
+    scale = @props.scale.horizontal
+    x += width + (BUFFER / scale)
+    if (@props.containerRect.width / scale) < x + (DELETE_BUTTON_WIDTH / scale)
+      x -= (BUFFER / scale) * 2
     x: x
 
   handleMainDrag: (e, d) ->

--- a/app/classifier/drawing-tools/rectangle.cjsx
+++ b/app/classifier/drawing-tools/rectangle.cjsx
@@ -7,6 +7,7 @@ DeleteButton = require './delete-button'
 
 MINIMUM_SIZE = 5
 DELETE_BUTTON_DISTANCE = 9 / 10
+BUFFER = 40
 
 module.exports = React.createClass
   displayName: 'RectangleTool'
@@ -52,6 +53,8 @@ module.exports = React.createClass
   render: ->
     {x, y, width, height} = @props.mark
 
+    deletePosition = @getDeletePosition(x, y, width, height)
+
     points = [
       [x, y].join ','
       [x + width, y].join ','
@@ -67,7 +70,7 @@ module.exports = React.createClass
 
       {if @props.selected
         <g>
-          <DeleteButton tool={this} x={x + (width * DELETE_BUTTON_DISTANCE)} y={y} />
+          <DeleteButton tool={this} x={deletePosition.x} y={deletePosition.y} />
 
           <DragHandle x={x} y={y} scale={@props.scale} onDrag={@handleTopLeftDrag} onEnd={@normalizeMark} />
           <DragHandle x={x + width} y={y} scale={@props.scale} onDrag={@handleTopRightDrag} onEnd={@normalizeMark} />
@@ -75,6 +78,11 @@ module.exports = React.createClass
           <DragHandle x={x} y={y + height} scale={@props.scale} onDrag={@handleBottomLeftDrag} onEnd={@normalizeMark} />
         </g>}
     </DrawingToolRoot>
+
+  getDeletePosition: (x, y, width, height) ->
+    y -= BUFFER if x + width - x < BUFFER * 2
+    x: Math.min(x + (width - 40), x + (width * DELETE_BUTTON_DISTANCE))
+    y: y
 
   handleMainDrag: (e, d) ->
     @props.mark.x += d.x / @props.scale.horizontal

--- a/app/classifier/drawing-tools/rectangle.cjsx
+++ b/app/classifier/drawing-tools/rectangle.cjsx
@@ -7,7 +7,7 @@ DeleteButton = require './delete-button'
 
 MINIMUM_SIZE = 5
 DELETE_BUTTON_DISTANCE = 9 / 10
-BUFFER = 40
+BUFFER = 44
 
 module.exports = React.createClass
   displayName: 'RectangleTool'
@@ -80,7 +80,7 @@ module.exports = React.createClass
     </DrawingToolRoot>
 
   getDeletePosition: (x, y, width, height) ->
-    y -= BUFFER if x + width - x < BUFFER * 2
+    y -= BUFFER if width < BUFFER * 2
     x: Math.min(x + (width - 40), x + (width * DELETE_BUTTON_DISTANCE))
     y: y
 


### PR DESCRIPTION
Fixes #649 

This fix keeps delete buttons from being placed over drag handles for shapes. The buffer size (44 pixels) seemed appropriate and adhered to some guidelines for finger size. The buffer is a bit larger in the polygon because there is an additional outer circle along one handle.

Staged at: https://adjust-delete-button.pfe-preview.zooniverse.org/