### PR TITLE
increase page_size in workflows request to API

### DIFF
--- a/app/lib/get-workflows-in-order.coffee
+++ b/app/lib/get-workflows-in-order.coffee
@@ -1,5 +1,7 @@
-getWorkflowsInOrder = (project, query) ->
+getWorkflowsInOrder = (project, query = {}) ->
   order = project.configuration?.workflow_order ? []
+  unless query?.page_size?
+    query['page_size'] = 50
 
   project.get('workflows', query).then (workflows) ->
     workflowsByID = {}

--- a/app/pages/admin/project-status.cjsx
+++ b/app/pages/admin/project-status.cjsx
@@ -7,6 +7,7 @@ ChangeListener = require '../../components/change-listener'
 ProjectIcon = require '../../components/project-icon'
 AutoSave = require '../../components/auto-save'
 handleInputChange = require '../../lib/handle-input-change'
+getWorkflowsInOrder = require '../../lib/get-workflows-in-order'
 WorkflowToggle = require '../../components/workflow-toggle'
 
 EXPERIMENTAL_FEATURES = [
@@ -168,7 +169,7 @@ ProjectStatus = React.createClass
         <ProjectExperimentalFeatures project={@props.project} />
         <div className="project-status__section">
           <h4>Workflow Settings</h4>
-          <PromiseRenderer promise={@props.project.get('workflows')}>{(workflows) =>
+          <PromiseRenderer promise={getWorkflowsInOrder @props.project}>{(workflows) =>
             if workflows.length is 0
               <div className="workflow-status-list">No workflows found</div>
             else

--- a/app/pages/admin/project-status.cjsx
+++ b/app/pages/admin/project-status.cjsx
@@ -169,7 +169,7 @@ ProjectStatus = React.createClass
         <ProjectExperimentalFeatures project={@props.project} />
         <div className="project-status__section">
           <h4>Workflow Settings</h4>
-          <PromiseRenderer promise={getWorkflowsInOrder @props.project}>{(workflows) =>
+          <PromiseRenderer promise={getWorkflowsInOrder @props.project, fields: 'display_name,active'}>{(workflows) =>
             if workflows.length is 0
               <div className="workflow-status-list">No workflows found</div>
             else

--- a/app/pages/lab/project.cjsx
+++ b/app/pages/lab/project.cjsx
@@ -91,7 +91,7 @@ EditProjectPage = React.createClass
           <li>
             <br />
             <div className="nav-list-header">Workflows</div>
-            <PromiseRenderer promise={getWorkflowsInOrder @props.project}>{(workflows) =>
+            <PromiseRenderer promise={getWorkflowsInOrder @props.project, fields: 'display_name'}>{(workflows) =>
               renderWorkflowListItem = (workflow) =>
                 <Link to={@labPath "/workflow/#{workflow.id}"} className="nav-list-item" activeClassName="active">
                   {workflow.display_name}

--- a/app/pages/lab/visibility.cjsx
+++ b/app/pages/lab/visibility.cjsx
@@ -197,7 +197,7 @@ module.exports = React.createClass
       <hr/>
 
       <p className="form-label">Workflow Settings</p>
-      <PromiseRenderer promise={getWorkflowsInOrder @props.project}>{(workflows) =>
+      <PromiseRenderer promise={getWorkflowsInOrder @props.project, fields: 'display_name,active'}>{(workflows) =>
         if workflows.length is 0
           <div className="workflow-status-list">No workflows found</div>
         else

--- a/app/pages/lab/visibility.cjsx
+++ b/app/pages/lab/visibility.cjsx
@@ -3,6 +3,7 @@ WorkflowToggle = require '../../components/workflow-toggle'
 PromiseRenderer = require '../../components/promise-renderer'
 SetToggle = require '../../lib/set-toggle'
 Dialog = require 'modal-form/dialog'
+getWorkflowsInOrder = require '../../lib/get-workflows-in-order'
 
 module.exports = React.createClass
   displayName: 'EditProjectVisibility'
@@ -196,7 +197,7 @@ module.exports = React.createClass
       <hr/>
 
       <p className="form-label">Workflow Settings</p>
-      <PromiseRenderer promise={@props.project.get('workflows')}>{(workflows) =>
+      <PromiseRenderer promise={getWorkflowsInOrder @props.project}>{(workflows) =>
         if workflows.length is 0
           <div className="workflow-status-list">No workflows found</div>
         else

--- a/app/pages/lab/workflow.cjsx
+++ b/app/pages/lab/workflow.cjsx
@@ -620,7 +620,7 @@ module.exports = React.createClass
       workflowID: ''
 
   render: ->
-    <PromiseRenderer promise={apiClient.type('workflows').get @props.params.workflowID}>{(workflow) =>
+    <PromiseRenderer promise={apiClient.type('workflows').get @props.params.workflowID, {}}>{(workflow) =>
       <ChangeListener target={workflow}>{=>
         <EditWorkflowPage {...@props} workflow={workflow} />
       }</ChangeListener>

--- a/app/pages/project/classify.cjsx
+++ b/app/pages/project/classify.cjsx
@@ -11,6 +11,7 @@ FinishedBanner = require './finished-banner'
 Classifier = require '../../classifier'
 seenThisSession = require '../../lib/seen-this-session'
 MiniCourse = require '../../lib/mini-course'
+getWorkflowsInOrder = require '../../lib/get-workflows-in-order'
 
 FAILED_CLASSIFICATION_QUEUE_NAME = 'failed-classifications'
 
@@ -111,7 +112,7 @@ module.exports = React.createClass
       currentWorkflowForProject[props.project.id]
 
   getRandomWorkflow: (project) ->
-    project.get('workflows', active: true).then (workflows) =>
+    getWorkflowsInOrder(project, active: true).then (workflows) =>
       if workflows.length is 0
         throw new Error "No workflows for project #{project.id}"
         project.uncacheLink 'workflows'

--- a/app/pages/project/classify.cjsx
+++ b/app/pages/project/classify.cjsx
@@ -112,7 +112,7 @@ module.exports = React.createClass
       currentWorkflowForProject[props.project.id]
 
   getRandomWorkflow: (project) ->
-    getWorkflowsInOrder(project, active: true).then (workflows) =>
+    getWorkflowsInOrder(project, {active: true, fields: 'finished_at'}).then (workflows) =>
       if workflows.length is 0
         throw new Error "No workflows for project #{project.id}"
         project.uncacheLink 'workflows'
@@ -121,7 +121,7 @@ module.exports = React.createClass
         @setState {projectIsComplete}
         randomIndex = Math.floor Math.random() * workflows.length
         # console.log 'Chose random workflow', workflows[randomIndex].id
-        workflows[randomIndex]
+        @getWorkflow project, workflows[randomIndex].id
 
   createNewClassification: (project, workflow) ->
     @setState {workflow}

--- a/app/pages/project/finished-banner.cjsx
+++ b/app/pages/project/finished-banner.cjsx
@@ -34,9 +34,7 @@ module.exports = React.createClass
     if project.redirect
       Promise.resolve false
     else
-      getWorkflowsInOrder(project).then (allWorkflows) ->
-        activeWorkflows = allWorkflows.filter (workflow) ->
-          workflow.active
+      getWorkflowsInOrder(project, {active: true, fields: 'finished_at'}).then (activeWorkflows) ->
         if activeWorkflows.length is 0
           # No active workflows? This is probably a custom project.
           false

--- a/app/pages/project/finished-banner.cjsx
+++ b/app/pages/project/finished-banner.cjsx
@@ -1,5 +1,6 @@
 React = require 'react'
 {Link} = require 'react-router'
+getWorkflowsInOrder = require '../../lib/get-workflows-in-order'
 
 THREE_DAYS = 3 * 24 * 60 * 60 * 1000
 
@@ -33,7 +34,7 @@ module.exports = React.createClass
     if project.redirect
       Promise.resolve false
     else
-      project.get('workflows').then (allWorkflows) ->
+      getWorkflowsInOrder(project).then (allWorkflows) ->
         activeWorkflows = allWorkflows.filter (workflow) ->
           workflow.active
         if activeWorkflows.length is 0

--- a/app/pages/project/home.cjsx
+++ b/app/pages/project/home.cjsx
@@ -21,7 +21,7 @@ module.exports = React.createClass
       if project._workflows?
         @setState workflows: project._workflows
       else
-        workflows = getWorkflowsInOrder project, active: true
+        workflows = getWorkflowsInOrder project, {active: true, fields: 'display_name'}
 
         workflows.then (workflows) =>
           project._workflows = workflows

--- a/app/pages/project/stats/index.cjsx
+++ b/app/pages/project/stats/index.cjsx
@@ -12,7 +12,7 @@ ProjectStatsPageController = React.createClass
     workflowList: []
 
   componentDidMount: ->
-    getWorkflowsInOrder @props.project, active: true
+    getWorkflowsInOrder @props.project, active: true, fields: 'classifications_count,completeness,display_name,retired_set_member_subjects_count,retirement,subjects_count'
       .then (workflows) =>
         @setState workflowList: workflows
 

--- a/app/pages/project/stats/stats.cjsx
+++ b/app/pages/project/stats/stats.cjsx
@@ -41,8 +41,7 @@ GraphSelect = React.createClass
     if @props.workflows?
       options = [<option value={"project_id=#{@props.projectId}"} key={"workflowSelectAll"}>All</option>]
       for workflow, key in @props.workflows
-        if workflow?.active
-          options.push(<option value={"workflow_id=#{workflow.id}"} key={"workflowSelect#{key}"}>{workflow.display_name}</option>)
+        options.push(<option value={"workflow_id=#{workflow.id}"} key={"workflowSelect#{key}"}>{workflow.display_name}</option>)
       if options.length > 1
         value = if @props.workflowId then "workflow_id=#{@props.workflowId}" else "project_id=#{@props.projectId}"
         <span>


### PR DESCRIPTION
Temporary solution to issue #2819.

API workflow response limited to 20 items, NfN has over 20 active workflows, so new workflows not showing up in Project Builder.

Temporary solution is to increase page_size param from 20 (default) to 50.