### PR TITLE
Allow Grid Tool to Map Cells Before Classification Sent

### DIFF
--- a/app/classifier/drawing-tools/grid.cjsx
+++ b/app/classifier/drawing-tools/grid.cjsx
@@ -73,21 +73,16 @@ module.exports = React.createClass
 
     mapCells: (annotations) ->
       currentAnnotation = annotations[annotations.length - 1]
-      rowID = false
+      templateType = 'templateID'
       currentAnnotation.value.map (mark) ->
-        rowID = true if mark._rowID
-      if rowID is true
-        templateType = '_rowID'
-      else
-        templateType = 'templateID'
+        templateType = '_rowID' if mark._rowID
       currentAnnotation.value.sort (a,b) ->
         parseFloat(a.y) - parseFloat(b.y) || parseFloat(a.x) - parseFloat(b.x)
-      tempID = null
       column = 'a'
       row = 1
       for cell in currentAnnotation.value
         if cell[templateType]
-          tempID = cell[templateType] if tempID is null
+          tempID = cell[templateType] unless tempID
           if cell[templateType] == tempID
             cell.column = column
             cell.row = row

--- a/app/classifier/drawing-tools/grid.cjsx
+++ b/app/classifier/drawing-tools/grid.cjsx
@@ -71,6 +71,34 @@ module.exports = React.createClass
         cell.height = mark.height if type is 'row'
       templateCopy
 
+    mapCells: (annotations) ->
+      currentAnnotation = annotations[annotations.length - 1]
+      rowID = false
+      currentAnnotation.value.map (mark) ->
+        rowID = true if mark._rowID
+      if rowID is true
+        templateType = '_rowID'
+      else
+        templateType = 'templateID'
+      currentAnnotation.value.sort (a,b) ->
+        parseFloat(a.y) - parseFloat(b.y) || parseFloat(a.x) - parseFloat(b.x)
+      tempID = null
+      column = 'a'
+      row = 1
+      for cell in currentAnnotation.value
+        if cell[templateType]
+          tempID = cell[templateType] if tempID is null
+          if cell[templateType] == tempID
+            cell.column = column
+            cell.row = row
+            column = String.fromCharCode(column.charCodeAt(0)+1)
+          else
+            row = row + 1
+            tempID = cell[templateType]
+            cell.column = 'a'
+            cell.row = row
+            column = 'b'
+
   initCoords: null
 
   componentWillMount: ->

--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -17,6 +17,7 @@ workflowAllowsFlipbook = require '../lib/workflow-allows-flipbook'
 workflowAllowsSeparateFrames = require '../lib/workflow-allows-separate-frames'
 WorldWideTelescope = require './world_wide_telescope'
 MiniCourseButton = require './mini-course-button'
+GridTool = require './drawing-tools/grid'
 
 PULSAR_HUNTERS_SLUG = 'zooniverse/pulsar-hunters'
 
@@ -405,6 +406,11 @@ Classifier = React.createClass
     @props.classification.update 'annotations'
 
   completeClassification: ->
+    currentAnnotation = @props.classification.annotations[@props.classification.annotations.length - 1]
+    currentTask = @props.workflow.tasks[currentAnnotation?.task]
+    currentTask.tools.map (tool) =>
+      if tool.type is 'grid'
+        GridTool.mapCells @props.classification.annotations
     @props.classification.update
       completed: true
       'metadata.session': getSessionID()

--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -408,7 +408,7 @@ Classifier = React.createClass
   completeClassification: ->
     currentAnnotation = @props.classification.annotations[@props.classification.annotations.length - 1]
     currentTask = @props.workflow.tasks[currentAnnotation?.task]
-    currentTask.tools.map (tool) =>
+    currentTask?.tools?.map (tool) =>
       if tool.type is 'grid'
         GridTool.mapCells @props.classification.annotations
     @props.classification.update

--- a/app/classifier/tasks/drawing/grid-buttons.cjsx
+++ b/app/classifier/tasks/drawing/grid-buttons.cjsx
@@ -12,35 +12,6 @@ module.exports = React.createClass
       @clearRow()
       @activateTemplate 'grid'
 
-  componentWillUnmount: ->
-    rowID = false
-    @props.annotation.value.map (mark) ->
-      rowID = true if mark._rowID
-    if rowID is true
-      @rowMap '_rowID'
-    else
-      @rowMap 'templateID'
-
-  rowMap: (templateType) ->
-    @props.annotation.value.sort (a,b) ->
-      parseFloat(a.y) - parseFloat(b.y) || parseFloat(a.x) - parseFloat(b.x)
-    tempID = null
-    column = 'a'
-    row = 1
-    for cell in @props.annotation.value
-      if cell[templateType]
-        tempID = cell[templateType] if tempID is null
-        if cell[templateType] == tempID
-          cell.column = column
-          cell.row = row
-          column = String.fromCharCode(column.charCodeAt(0)+1)
-        else
-          row = row + 1
-          tempID = cell[templateType]
-          cell.column = 'a'
-          cell.row = row
-          column = 'b'
-
   activateTemplate: (type) ->
     @props.preferences.preferences.activeTemplate = type
     @props.preferences.update 'preferences'


### PR DESCRIPTION
Originally, cell rows and columns were mapped with component unmount, which was occurring after the classification was sent to the exporter. Cells are now mapped before a classification is sent. 