### PR TITLE
Prevent undefined ref from disrupting navigation.

### DIFF
--- a/app/talk/search-input.cjsx
+++ b/app/talk/search-input.cjsx
@@ -21,7 +21,7 @@ module.exports = React.createClass
   onSearchSubmit: (e) ->
     e.preventDefault()
     {owner, name} = @props.params
-    inputValue = @searchInput().value
+    inputValue = @refs.talkSearchInput?.value
     @logSearch inputValue
 
     if owner and name
@@ -32,14 +32,12 @@ module.exports = React.createClass
     else
       @history.pushState(null, "/talk/search", {query: inputValue})
 
-  searchInput: ->
-    @refs.talkSearchInput
-
   componentWillReceiveProps: (nextProps) ->
+    return unless @refs.talkSearchInput
     if nextProps.location.query?.query
-      @searchInput().value = nextProps.location.query.query
+      @refs.talkSearchInput.value = nextProps.location.query.query
     else
-      @searchInput().value = ''
+      @refs.talkSearchInput.value = ''
 
   render: ->
     <form className="talk-search-form" onSubmit={ @onSearchSubmit }>


### PR DESCRIPTION
Closes #2830

Oddly enough, it was an undefined component ref that was causing #2830. 

To reproduce the original issue

![double-icon](https://cloud.githubusercontent.com/assets/122990/17336347/6ba47db6-58a3-11e6-8cee-0403af3fdda5.gif)

And the fixed version:

![fixed-icon](https://cloud.githubusercontent.com/assets/122990/17336349/6fccdd98-58a3-11e6-82cd-22c87b0bfe96.gif)

