### PR TITLE
fixes navigation on empty stats page

### DIFF
--- a/app/pages/project/stats/stats.cjsx
+++ b/app/pages/project/stats/stats.cjsx
@@ -54,7 +54,7 @@ GraphSelect = React.createClass
 
   handleWorkflowSelect: (event) ->
     @props.handleWorkflowChange(@props.type, event)
-  
+
   getRange: ->
     if @props.range?
       range = []

--- a/app/pages/project/stats/stats.cjsx
+++ b/app/pages/project/stats/stats.cjsx
@@ -54,18 +54,22 @@ GraphSelect = React.createClass
 
   handleWorkflowSelect: (event) ->
     @props.handleWorkflowChange(@props.type, event)
+  
+  getRange: ->
+    if @props.range?
+      range = []
+      for r in @props.range.split(',')
+        if r
+          range.push(parseInt(r, 10))
+        else
+          range.push(undefined)
+    else
+      range = [undefined, undefined]
+    range
 
   render: ->
     if @state.statData?
-      if @props.range?
-        range = []
-        for r in @props.range.split(',')
-          if r
-            range.push(parseInt(r, 10))
-          else
-            range.push(undefined)
-      else
-        range = [undefined, undefined]
+      range = @getRange()
       workflowSelect = @workflowSelect()
       <div>
         {@props.type[0].toUpperCase() + @props.type.substring(1)}s per{' '}

--- a/app/pages/project/stats/stats.cjsx
+++ b/app/pages/project/stats/stats.cjsx
@@ -56,28 +56,33 @@ GraphSelect = React.createClass
     @props.handleWorkflowChange(@props.type, event)
 
   render: ->
-    if @props.range?
-      range = []
-      for r in @props.range.split(',')
-        if r
-          range.push(parseInt(r, 10))
-        else
-          range.push(undefined)
+    if @state.statData?
+      if @props.range?
+        range = []
+        for r in @props.range.split(',')
+          if r
+            range.push(parseInt(r, 10))
+          else
+            range.push(undefined)
+      else
+        range = [undefined, undefined]
+      workflowSelect = @workflowSelect()
+      <div>
+        {@props.type[0].toUpperCase() + @props.type.substring(1)}s per{' '}
+        <select value={@props.by} onChange={@handleGraphChange.bind this, @props.type}>
+          <option value="hour">hour</option>
+          <option value="day">day</option>
+          <option value="week">week</option>
+          <option value="month">month</option>
+        </select>
+        {workflowSelect}
+        <br />
+        {<Graph data={@state.statData} by={@props.by} range={range} num={24} handleRangeChange={@handleRangeChange} />}
+      </div>
     else
-      range = [undefined, undefined]
-    workflowSelect = @workflowSelect()
-    <div>
-      {@props.type[0].toUpperCase() + @props.type.substring(1)}s per{' '}
-      <select value={@props.by} onChange={@handleGraphChange.bind this, @props.type}>
-        <option value="hour">hour</option>
-        <option value="day">day</option>
-        <option value="week">week</option>
-        <option value="month">month</option>
-      </select>
-      {workflowSelect}
-      <br />
-      {<Graph data={@state.statData} by={@props.by} range={range} num={24} handleRangeChange={@handleRangeChange} /> if @state.statData?}
-    </div>
+      <div>
+        There is no stats data available at this time.
+      </div>
 
   handleGraphChange: (which, e) ->
     @props.handleGraphChange(which, e)


### PR DESCRIPTION
This fixes #2655 

The code will now render the text `There is not stats data available at this time.` instead of an empty graph when there is no data for a projects.