### PR TITLE
props.user is always undefined on first mount

### DIFF
--- a/app/pages/lab/project.cjsx
+++ b/app/pages/lab/project.cjsx
@@ -236,10 +236,6 @@ module.exports = React.createClass
   mixins: [TitleMixin, History]
   title: 'Edit'
 
-  componentDidMount: ->
-    unless @props.user
-      @history.pushState(null, "/lab")
-
   componentWillReceiveProps: (nextProps) ->
     unless nextProps.user
       @history.pushState(null, "/lab")


### PR DESCRIPTION
Remove the first user check since we should wait until the auth request has happened.
Fixes #2767