### PR TITLE
Add react-router-scroll and basic scroll to top functionality

### DIFF
--- a/app/main.cjsx
+++ b/app/main.cjsx
@@ -1,6 +1,7 @@
 React = require 'react'
 ReactDOM = require 'react-dom'
-{Router, browserHistory} = require 'react-router'
+{ applyRouterMiddleware, Router, browserHistory } = require 'react-router'
+useScroll = require 'react-router-scroll/lib/useScroll'
 routes = require './router'
 style = require '../css/main.styl'
 
@@ -11,7 +12,7 @@ if location?.hash.charAt(1) is '/'
 browserHistory.listen ->
   dispatchEvent new CustomEvent 'locationchange'
 
-ReactDOM.render <Router history={browserHistory}>{routes}</Router>,
+ReactDOM.render <Router history={browserHistory} render={applyRouterMiddleware(useScroll())}>{routes}</Router>,
   document.getElementById('panoptes-main-container')
 
 # Are we connected to the latest back end?

--- a/app/talk/lib/paginator.cjsx
+++ b/app/talk/lib/paginator.cjsx
@@ -10,7 +10,6 @@ module.exports = React.createClass
     page: React.PropTypes.number                  # page number
     onPageChange: React.PropTypes.func.isRequired # passed (page) on change
     firstAndLast: React.PropTypes.bool            # optional, add 'first' & 'last' buttons
-    scrollOnChange: React.PropTypes.bool          # optional, scroll to top of page on change
     pageSelector: React.PropTypes.bool            # show page selector?
     pageKey: React.PropTypes.string               # optional name for key param (defaults to 'page')
 
@@ -23,7 +22,6 @@ module.exports = React.createClass
       updateQueryParams @history, queryChange
     firstAndLast: true
     pageSelector: true
-    scrollOnChange: true
     previousLabel: <span><i className="fa fa-long-arrow-left" /> Previous</span>
     nextLabel: <span>Next <i className="fa fa-long-arrow-right" /></span>
 
@@ -40,7 +38,6 @@ module.exports = React.createClass
 
   setPage: (activePage) ->
     @props.onPageChange.call(this, activePage)
-    window.scrollTo(0,0) if @props.scrollOnChange
 
   onClickNext: ->
     @logClick 'next-page'

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "react-interpolate-component": "~0.8.0",
     "react-pullout": "~1.0.1",
     "react-router": "~2.4.1",
+    "react-router-scroll": "~0.3.0",
     "react-select": "~0.9.1",
     "react-swipe": "~3.0.0",
     "react-translate-component": "~0.10.0",


### PR DESCRIPTION
Closes #2762 and #2719 by adding react-router-scroll middleware.