### PR TITLE
Only display recent projects that have user classifications

### DIFF
--- a/app/pages/home-logged-in.cjsx
+++ b/app/pages/home-logged-in.cjsx
@@ -72,9 +72,10 @@ RecentProjects = React.createClass
   
   componentWillMount: ->
     @props.user
-      .get("project_preferences", page_size: 4, sort: '-updated_at')
+      .get("project_preferences", page_size: 10, sort: '-updated_at')
       .then (projectPreferences) =>
-        userProjects = projectPreferences.map (projectPreference) -> projectPreference.links.project
+        userProjects = projectPreferences.map (projectPreference) -> projectPreference.links.project if projectPreference.activity_count > 0
+        userProjects = userProjects.filter(Boolean).slice 0, 4
         activityCounts = {}
         if userProjects.length > 0
           activityCounts[projectPreference.links.project] = projectPreference.activity_count for projectPreference in projectPreferences

--- a/app/pages/home-logged-in.cjsx
+++ b/app/pages/home-logged-in.cjsx
@@ -60,6 +60,55 @@ FeaturedProjects = React.createClass
       <Link to="/projects" className="call-to-action standard-button x-large"><Translate content="home.featuredProjects.button" /></Link>
     </div>
 
+RecentProjects = React.createClass
+  displayName: 'RecentProjects'
+  
+  getInitialState: ->
+    projects: []
+    activityCounts: {}
+    title: ""
+    href: ''
+    action: ""
+  
+  componentWillMount: ->
+    @props.user
+      .get("project_preferences", page_size: 4, sort: '-updated_at')
+      .then (projectPreferences) =>
+        userProjects = projectPreferences.map (projectPreference) -> projectPreference.links.project
+        activityCounts = {}
+        if userProjects.length > 0
+          activityCounts[projectPreference.links.project] = projectPreference.activity_count for projectPreference in projectPreferences
+          @setState
+            activityCounts: activityCounts
+            title: "home.recentProjects.title"
+            href: "/users/#{@props.user.login}/stats"
+            action: "home.recentProjects.button"
+          projectsPromise = apiClient.type('projects').get(userProjects)
+        else
+          @setState
+            title: "home.recentProjects.altTitle"
+            href: '/projects'
+            action: "home.recentProjects.altButton"
+          projectsPromise = apiClient.type('projects').get(launch_approved: true, page_size: 4, cards: true)
+        projectsPromise
+      .then (projects) =>
+        @setState {projects}
+  
+  render: ->
+    <div className="recent-projects">
+      <Translate component="h5" content={@state.title} />
+      <div className="recent-projects-list">
+        {for project in @state.projects
+          badge = @state.activityCounts[project.id] ? 0
+          <div key={project.id}>
+            <ProjectIcon project={project} badge={badge} />
+            &ensp;
+          </div>}
+      </div>
+      <Link to={@state.href} className="call-to-action standard-button x-large"><Translate content={@state.action} /></Link>
+    </div>
+    
+
 module.exports = React.createClass
   displayName: 'HomePage'
 
@@ -81,39 +130,7 @@ module.exports = React.createClass
       <div className="flex-container">
         <section className="hero on-dark">
           <ZooniverseLogoType />
-          <PromiseRenderer promise={@lastFourProjects()}>{(projectPreferences) =>
-            if projectPreferences.length > 0
-              <div className="recent-projects">
-                <Translate component="h5" content="home.recentProjects.title" />
-                <div className="recent-projects-list">
-                  {projectPreferences.map (projectPreference) =>
-                    <PromiseRenderer key={projectPreference.id} promise={projectPreference.get 'project'} catch={null} then={(project) =>
-                      if project?
-                        <div>
-                          <ProjectIcon project={project} badge={projectPreference.activity_count} />
-                          &ensp;
-                        </div>
-                      else
-                        null
-                    } />}
-                </div>
-                <Link to="#{baseLink}users/#{@props.user.login}/stats" className="call-to-action standard-button x-large"><Translate content="home.recentProjects.button" /></Link>
-              </div>
-            else
-              <div className="recent-projects">
-                <Translate component="h5" content="home.recentProjects.altTitle" />
-                <PromiseRenderer promise={apiClient.type('projects').get(launch_approved: true, page_size: 4, cards: true)}>{(projects) =>
-                  <div className="recent-projects-list">
-                    {projects.map (project) ->
-                      <div>
-                        <ProjectIcon key={project.id} project={project} />
-                        &ensp;
-                      </div>}
-                  </div>
-                }</PromiseRenderer>
-                <Link to="/projects" className="call-to-action standard-button hero-button x-large"><Translate content="home.recentProjects.altButton" /></Link>
-              </div>
-          }</PromiseRenderer>
+          <RecentProjects user={@props.user} />
         </section>
       </div>
 


### PR DESCRIPTION
Filter a user's recent projects for those with activity count > 0.
Also removes a couple of PromiseRenderers from the logged-in home page.
Closes #2865 