### PR TITLE
Workflow levels

### DIFF
--- a/app/pages/admin/project-status.cjsx
+++ b/app/pages/admin/project-status.cjsx
@@ -25,7 +25,7 @@ EXPERIMENTAL_FEATURES = [
   'column'
   'grid'
   'invert'
-  'workflow level'
+  'workflow assignment'
 ]
 
 ProjectToggle = React.createClass
@@ -214,7 +214,7 @@ ProjectStatus = React.createClass
         <ProjectExperimentalFeatures project={@props.project} />
         <div className="project-status__section">
           <h4>Workflow Settings</h4>
-          <small>The workflow level dropdown is for the workflow level experimental feature.</small>
+          <small>The workflow level dropdown is for the workflow assignemnt experimental feature.</small>
           {if @state.error
             <div>{@state.error}</div>}
           {if @state.workflows.length is 0

--- a/app/pages/admin/project-status.cjsx
+++ b/app/pages/admin/project-status.cjsx
@@ -158,21 +158,25 @@ ProjectStatus = React.createClass
     project: null
 
   componentDidMount: ->
-    getWorkflowsInOrder @props.project, fields: 'display_name,active,configuration'
-      .then (workflows) =>
-        usedWorkflowLevels = @getUsedWorkflowLevels(workflows)
-        @setState usedWorkflowLevels: usedWorkflowLevels, workflows: workflows
+    @getWorkflows()
 
   onChangeWorkflowLevel: (workflow, event) ->
     selected = event.target.value
+    workflowToUpdate = workflow
+
+    # In Autosave component
     if selected is 'none'
-      workflow.update({ 'configuration.level': undefined })
+      workflowToUpdate.update({ 'configuration.level': undefined })
     else
-      workflow.update({ 'configuration.level': selected })
+      workflowToUpdate.update({ 'configuration.level': selected })
 
-    usedWorkflowLevels = @getUsedWorkflowLevels(@state.workflows);
+    @getWorkflows()
 
-    @setState usedWorkflowLevels: usedWorkflowLevels
+  getWorkflows: ->
+    getWorkflowsInOrder @props.project, fields: 'display_name,active,configuration'
+      .then (workflows) =>
+        usedWorkflowLevels = @getUsedWorkflowLevels(workflows)
+        @setState { usedWorkflowLevels, workflows }
 
   getUsedWorkflowLevels: (workflows) ->
     usedWorkflowLevels = []

--- a/app/pages/admin/project-status.cjsx
+++ b/app/pages/admin/project-status.cjsx
@@ -202,37 +202,36 @@ ProjectStatus = React.createClass
         <ProjectExperimentalFeatures project={@props.project} />
         <div className="project-status__section">
           <h4>Workflow Settings</h4>
+          <small>The workflow level dropdown is for the workflow level experimental feature.</small>
           {if @state.workflows.length is 0
-            <div className="workflow-status-list">No workflows found</div>
+            <div>No workflows found</div>
           else
-            <div className="workflow-status-list">
-              <h4>Workflow Settings</h4>
-              <div className="workflow-status-list">
-                <ul className="project-status__section-list">
-                  {@state.workflows.map (workflow) =>
-                    <li key={workflow.id}>
-                      <WorkflowToggle workflow={workflow} project={@props.project} field="active" />
-                      <AutoSave resource={workflow}>
-                        <select
-                          onChange={@onChangeWorkflowLevel.bind(null, workflow)}
-                          value={if workflow.configuration.level? then workflow.configuration.level}
-                        >
-                          <option value="none">none</option>
-                          {@state.workflows.map (workflow, i) =>
-                            value = String(i + 1)
-                            <option
-                              key={i + Math.random()}
-                              value={value}
-                              disabled={@state.usedWorkflowLevels.indexOf(value) > -1}
-                            >
-                              {value}
-                            </option>}
-                        </select>
-                      </AutoSave>
-                    </li>}
-                </ul>
-              </div>
-           </div>}
+            <ul className="project-status__section-list">
+              {@state.workflows.map (workflow) =>
+                <li key={workflow.id} className="section-list__item">
+                  <WorkflowToggle workflow={workflow} project={@props.project} field="active" />{' | '}
+                  <AutoSave resource={workflow}>
+                    <label>
+                      Level:{' '}
+                      <select
+                        onChange={@onChangeWorkflowLevel.bind(null, workflow)}
+                        value={if workflow.configuration.level? then workflow.configuration.level}
+                      >
+                        <option value="none">none</option>
+                        {@state.workflows.map (workflow, i) =>
+                          value = String(i + 1)
+                          <option
+                            key={i + Math.random()}
+                            value={value}
+                            disabled={@state.usedWorkflowLevels.indexOf(value) > -1}
+                          >
+                            {value}
+                          </option>}
+                      </select>
+                    </label>
+                  </AutoSave>
+                </li>}
+            </ul>}
         </div>
         <hr />
         <div className="project-status__section">


### PR DESCRIPTION
This adds a UI for admins to add an arbitrary workflow "level" to the workflow configuration that will be used in the experimental workflow promotion feature for gravity spy. This is so that I don't have to hard code specific workflow ids into the classifier. Closes #2643. Staged at https://workflow-levels.pfe-preview.zooniverse.org/