### PR TITLE
Edit lab side-bar subject sets list API call

### DIFF
--- a/app/pages/lab/project.cjsx
+++ b/app/pages/lab/project.cjsx
@@ -123,7 +123,7 @@ EditProjectPage = React.createClass
           <li>
             <br />
             <div className="nav-list-header">Subject sets</div>
-            <PromiseRenderer promise={@props.project.get 'subject_sets', page_size: 100}>{(subjectSets) =>
+            <PromiseRenderer promise={@props.project.get 'subject_sets', sort: 'display_name', page_size: 100}>{(subjectSets) =>
               <ul className="nav-list">
                 {renderSubjectSetListItem = (subjectSet) ->
                   subjectSetListLabel = subjectSet.display_name || <i>{'Untitled subject set'}</i>

--- a/app/pages/lab/project.cjsx
+++ b/app/pages/lab/project.cjsx
@@ -123,7 +123,7 @@ EditProjectPage = React.createClass
           <li>
             <br />
             <div className="nav-list-header">Subject sets</div>
-            <PromiseRenderer promise={@props.project.get 'subject_sets'}>{(subjectSets) =>
+            <PromiseRenderer promise={@props.project.get 'subject_sets', page_size: 100}>{(subjectSets) =>
               <ul className="nav-list">
                 {renderSubjectSetListItem = (subjectSet) ->
                   subjectSetListLabel = subjectSet.display_name || <i>{'Untitled subject set'}</i>


### PR DESCRIPTION
Temporary solution to #1136, #2752.

Better solution still Generalized Pagination #2852, which if I have time I'll try and start asap, but if not done before ZTM, something to keep in mind for then.

@camallen, @srallen - similar to recent workflow API call change I know this isn't ideal, but helps until pagination implemented. This change is for only within the Project Builder, subject sets left side bar list; smaller scope than workflow call change.