### PR TITLE
Show buttons for workflows on the home page based on level

### DIFF
--- a/app/pages/admin/project-status.cjsx
+++ b/app/pages/admin/project-status.cjsx
@@ -214,7 +214,7 @@ ProjectStatus = React.createClass
         <ProjectExperimentalFeatures project={@props.project} />
         <div className="project-status__section">
           <h4>Workflow Settings</h4>
-          <small>The workflow level dropdown is for the workflow assignemnt experimental feature.</small>
+          <small>The workflow level dropdown is for the workflow assignment experimental feature.</small>
           {if @state.error
             <div>{@state.error}</div>}
           {if @state.workflows.length is 0
@@ -232,7 +232,7 @@ ProjectStatus = React.createClass
                     >
                       <option value="none">none</option>
                       {@state.workflows.map (workflow, i) =>
-                        value = String(i + 1)
+                        value = i + 1
                         <option
                           key={i + Math.random()}
                           value={value}

--- a/app/pages/project/home.cjsx
+++ b/app/pages/project/home.cjsx
@@ -52,7 +52,7 @@ module.exports = React.createClass
             <small>at {@props.project.redirect}</small>
           </a>
         # For Gravity Spy
-        else if @props.project.experimental_tools.indexOf 'workflow assignment' isnt -1
+        else if @props.project.experimental_tools.indexOf('workflow assignment') isnt -1
           if @props.user?
             currentWorkflowAtLevel = @state.workflows?.filter (workflow) =>
               workflow if workflow.id is @props.preferences?.settings.workflow_id
@@ -67,6 +67,10 @@ module.exports = React.createClass
                   onClick={@handleWorkflowSelection.bind this, workflow}
                 >
                   {workflow.display_name}
+                </Link>
+              else # Show something if workflow config levels aren't set.
+                <Link to={"/projects/#{@props.project.slug}/classify"} className="call-to-action standard-button">
+                  Get started!
                 </Link>
           else
             <Link to={"/projects/#{@props.project.slug}/classify"} className="call-to-action standard-button">

--- a/app/pages/project/home.cjsx
+++ b/app/pages/project/home.cjsx
@@ -68,10 +68,6 @@ module.exports = React.createClass
                 >
                   {workflow.display_name}
                 </Link>
-              else # Show something if workflow config levels aren't set.
-                <Link to={"/projects/#{@props.project.slug}/classify"} className="call-to-action standard-button">
-                  Get started!
-                </Link>
           else
             <Link to={"/projects/#{@props.project.slug}/classify"} className="call-to-action standard-button">
               Get started!

--- a/app/pages/project/home.cjsx
+++ b/app/pages/project/home.cjsx
@@ -1,7 +1,5 @@
 React = require 'react'
 {Markdown} = (require 'markdownz').default
-HandlePropChanges = require '../../lib/handle-prop-changes'
-PromiseToSetState = require '../../lib/promise-to-set-state'
 FinishedBanner = require './finished-banner'
 ProjectMetadata = require './metadata'
 getWorkflowsInOrder = require '../../lib/get-workflows-in-order'
@@ -10,26 +8,30 @@ getWorkflowsInOrder = require '../../lib/get-workflows-in-order'
 module.exports = React.createClass
   displayName: 'ProjectHomePage'
 
-  mixins: [HandlePropChanges, PromiseToSetState]
-
   contextTypes:
     geordi: React.PropTypes.object
 
-  propChangeHandlers:
-    project: (project) ->
-      # TODO: Build this kind of caching into json-api-client.
-      if project._workflows?
-        @setState workflows: project._workflows
-      else
-        workflows = getWorkflowsInOrder project, {active: true, fields: 'display_name'}
-
-        workflows.then (workflows) =>
-          project._workflows = workflows
-
-        @promiseToSetState {workflows}
-
   getInitialState: ->
     workflows: []
+
+  componentDidMount: -> 
+    @getWorkflows(@props.project)
+
+  componentWillReceiveProps: (nextProps) ->
+    if nextProps.project isnt @props.project
+      @getWorkflows(nextProps.project)
+
+  getWorkflows: (project) ->
+    # TODO: Build this kind of caching into json-api-client
+    if project._workflows?
+      @setState workflows: project._workflows
+    else
+      workflows = getWorkflowsInOrder project, {active: true, fields: 'display_name,configuration'}
+
+      workflows.then (workflows) =>
+        project._workflows = workflows
+
+        @setState workflows: project._workflows
 
   handleWorkflowSelection: (workflow) ->
     @props.onChangePreferences 'preferences.selected_workflow', workflow?.id
@@ -49,6 +51,27 @@ module.exports = React.createClass
             <strong>Visit the project</strong><br />
             <small>at {@props.project.redirect}</small>
           </a>
+        # For Gravity Spy
+        else if @props.project.experimental_tools.indexOf 'workflow assignment' isnt -1
+          if @props.user?
+            currentWorkflowAtLevel = @state.workflows?.filter (workflow) =>
+              workflow if workflow.id is @props.preferences?.settings.workflow_id
+            currentLevel = if currentWorkflowAtLevel.length > 0 then currentWorkflowAtLevel[0].configuration.level else 1
+            @state.workflows?.map (workflow) =>
+              if workflow.configuration.level <= currentLevel and workflow.configuration.level?
+                <Link
+                  to={"/projects/#{@props.project.slug}/classify"}
+                  query={workflow: workflow.id}
+                  key={workflow.id + Math.random()}
+                  className="call-to-action standard-button"
+                  onClick={@handleWorkflowSelection.bind this, workflow}
+                >
+                  {workflow.display_name}
+                </Link>
+          else
+            <Link to={"/projects/#{@props.project.slug}/classify"} className="call-to-action standard-button">
+              Get started!
+            </Link>
         else if @props.project.configuration?.user_chooses_workflow
           @state.workflows.map (workflow) =>
             <Link


### PR DESCRIPTION
For Gravity Spy: This adds a feature that filters the workflow buttons on the project home page based on the user's level. If logged out, then the standard 'Get Started' button will show and the default workflow will load.

I also refactored the home page to not use `PromiseToSetState` or `HandlePropChanges`. These abstracted away the lifecycle of the component making it difficult to reason about what was happening and difficult to debug since errors were set in the state instead of logging to the console.

Staged at: https://workflow-level-buttons.pfe-preview.zooniverse.org/projects/srallen086/workflow-assignment-testing

When you're ready to test this out, let me know because I will need to modify your user account's project preference's settings via the python client so you can see what the new functionality does.