### PR TITLE
Workflow assignment dialog

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,6 +3,7 @@
   "plugins": ["react"],
   "rules": {
     "react/prefer-es6-class": 0,
-    "react/prefer-stateless-function": 0
+    "react/prefer-stateless-function": 0,
+    "react/no-multi-comp": 0
   }
 }

--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -278,6 +278,7 @@ Classifier = React.createClass
             annotations={@props.classification.annotations}
             subject={@props.subject}
             user_name={@props.user.display_name}
+            workflow={@props.workflow}
           />
         </strong>
         }

--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -46,13 +46,13 @@ Classifier = React.createClass
   componentDidMount: ->
     @loadSubject @props.subject
     @prepareToClassify @props.classification
-    {workflow, project, user} = @props
-    Tutorial.startIfNecessary {workflow, user}
+    {workflow, project, preferences, user} = @props
+    Tutorial.startIfNecessary {workflow, user, preferences}
 
   componentWillReceiveProps: (nextProps) ->
     if nextProps.project isnt @props.project or nextProps.user isnt @props.user
-      {workflow, project, user} = nextProps
-      Tutorial.startIfNecessary {workflow, user}
+      {workflow, project, user, preferences} = nextProps
+      Tutorial.startIfNecessary {workflow, user, preferences}
     if nextProps.subject isnt @props.subject
       @loadSubject subject
     if nextProps.classification isnt @props.classification
@@ -278,7 +278,6 @@ Classifier = React.createClass
             annotations={@props.classification.annotations}
             subject={@props.subject}
             user_name={@props.user.display_name}
-            workflow={@props.workflow}
           />
         </strong>
         }

--- a/app/components/workflow-assignment-dialog.jsx
+++ b/app/components/workflow-assignment-dialog.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Dialog from 'modal-form/dialog';
+import ReactDOM from 'react-dom';
 
 const WorkflowAssignmentDialog = React.createClass({
   statics: {
@@ -19,6 +20,14 @@ const WorkflowAssignmentDialog = React.createClass({
     },
   },
 
+  handlePromotionDecline() {
+    // Hacky way to get the dialog to close.
+    // Need to rework Modal Form to allow custom cancel events on child DOM elements
+    const closeButton =
+      ReactDOM.findDOMNode(this).parentNode.querySelector('.modal-dialog-close-button');
+    closeButton.click();
+  },
+
   render() {
     return (
       <div className="content-container">
@@ -26,10 +35,14 @@ const WorkflowAssignmentDialog = React.createClass({
           Congratulations! Because you're doing so well, you can level up and
           access more types of glitches, have more options for classifying them,
           and see glitches that our computer algorithms are even less confident in.
-          If you prefer to stay at this level, you can choose to stay. You can switch
-          back to a previous workflow from the project home page.
+          If you prefer to stay at this level, you can choose to stay.
         </p>
-        <button type="submit">Try the new workflow</button>
+        <div className="workflow-assignment-dialog__buttons">
+          <button className="standard-button" type="submit">Try the new workflow</button>
+          <button className="minor-button" onClick={this.handlePromotionDecline} type="button">
+            No, thanks
+          </button>
+        </div>
       </div>
     );
   },

--- a/app/components/workflow-assignment-dialog.jsx
+++ b/app/components/workflow-assignment-dialog.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import Dialog from 'modal-form/dialog';
+
+const WorkflowAssignmentDialog = React.createClass({
+  statics: {
+    start(history, location, preferences) {
+      return Dialog.alert(<WorkflowAssignmentDialog />, {
+        className: 'workflow-assignment-dialog',
+        closeButton: true,
+        onSubmit: this.handleNewWorkflowAssignment.bind(null, history, location, preferences),
+      });
+    },
+
+    handleNewWorkflowAssignment(history, location, preferences) {
+      history.push({
+        pathname: location.pathname,
+        query: { workflow: preferences.settings.workflow_id },
+      });
+    },
+  },
+
+  render() {
+    return (
+      <div className="content-container">
+        <p>
+          Congratulations! Because you're doing so well, you can level up and
+          access more types of glitches, have more options for classifying them,
+          and see glitches that our computer algorithms are even less confident in.
+          If you prefer to stay at this level, you can choose to stay. You can switch
+          back to a previous workflow from the project home page.
+        </p>
+        <button type="submit">Try the new workflow</button>
+      </div>
+    );
+  },
+});
+
+export default WorkflowAssignmentDialog;

--- a/app/lib/tutorial.cjsx
+++ b/app/lib/tutorial.cjsx
@@ -24,22 +24,17 @@ module.exports = React.createClass
       else
         Promise.resolve()
 
-    startIfNecessary: ({workflow, user}) ->
+    startIfNecessary: ({workflow, user, preferences}) ->
       @find({workflow}).then (tutorial) =>
         if tutorial?
-          @checkIfCompleted(tutorial, user).then (completed) =>
+          @checkIfCompleted(tutorial, user, preferences).then (completed) =>
             unless completed
               @start tutorial, user
 
-    checkIfCompleted: (tutorial, user) ->
+    checkIfCompleted: (tutorial, user, preferences) ->
       if user?
-        tutorial.get('project').then (project) =>
-          user.get 'project_preferences', project_id: project.id
-            .catch =>
-              []
-            .then ([projectPreferences]) =>
-              window.prefs = projectPreferences
-              projectPreferences?.preferences?.tutorials_completed_at?[tutorial.id]?
+        window.prefs = preferences
+        Promise.resolve preferences?.preferences?.tutorials_completed_at?[tutorial.id]?
       else
         Promise.resolve completedThisSession[tutorial.id]?
 

--- a/app/pages/project/classify.cjsx
+++ b/app/pages/project/classify.cjsx
@@ -100,7 +100,7 @@ module.exports = React.createClass
   shouldWorkflowAssignmentPrompt: (preferences) ->
     # Only for Gravity Spy which is assigning workflows to logged in users
     assignedWorkflowID = preferences?.settings?.workflow_id
-    if @props.project.experimental_tools.indexOf 'workflow assignment' > -1 and @props.user?
+    if @props.project.experimental_tools.indexOf('workflow assignment') > -1 and @props.user?
       if assignedWorkflowID? and assignedWorkflowID isnt @props.location.query.workflow
         @setState promptWorkflowAssignmentDialog: true if @state.promptWorkflowAssignmentDialog is false
 

--- a/app/pages/project/classify.cjsx
+++ b/app/pages/project/classify.cjsx
@@ -13,6 +13,7 @@ seenThisSession = require '../../lib/seen-this-session'
 MiniCourse = require '../../lib/mini-course'
 getWorkflowsInOrder = require '../../lib/get-workflows-in-order'
 `import CustomSignInPrompt from './custom-sign-in-prompt'`
+`import WorkflowAssignmentDialog from '../../components/workflow-assignment-dialog'`
 
 FAILED_CLASSIFICATION_QUEUE_NAME = 'failed-classifications'
 
@@ -77,6 +78,7 @@ module.exports = React.createClass
     classification: null
     projectIsComplete: false
     demoMode: sessionDemoMode
+    promptWorkflowAssignmentDialog: false
 
   propChangeHandlers:
     project: 'loadAppropriateClassification'
@@ -92,6 +94,16 @@ module.exports = React.createClass
   componentWillUnmount: () ->
     @context.geordi?.forget ['workflowID']
 
+  componentWillReceiveProps: (nextProps) ->
+    @shouldWorkflowAssignmentPrompt(nextProps.preferences)
+
+  shouldWorkflowAssignmentPrompt: (preferences) ->
+    # Only for Gravity Spy which is assigning workflows to logged in users
+    assignedWorkflowID = preferences?.settings?.workflow_id
+    if @props.project.experimental_tools.indexOf 'workflow assignment' > -1 and @props.user?
+      if assignedWorkflowID? and assignedWorkflowID isnt @props.location.query.workflow
+        @setState promptWorkflowAssignmentDialog: true if @state.promptWorkflowAssignmentDialog is false
+
   loadAppropriateClassification: (_, props = @props) ->
     # To load the right classification, we'll need to know which workflow the user expects.
     # console.log 'Loading appropriate classification'
@@ -103,7 +115,7 @@ module.exports = React.createClass
 
   getCurrentWorkflow: (props = @props) ->
     if props.location.query?.workflow?
-      # console.log 'Workflow specified as', props.query.workflow
+      # console.log 'Workflow specified as', props.location.query.workflow
       # Prefer the workflow specified in the query.
       @getWorkflow props.project, props.location.query.workflow
     else
@@ -181,6 +193,7 @@ module.exports = React.createClass
     # If there aren't any left (or there weren't any to begin with), refill the list.
     if upcomingSubjects.forWorkflow[workflow.id].length is 0
       # console.log 'Fetching subjects'
+      @maybePromptWorkflowAssignmentDialog()
       subjectQuery =
         workflow_id: workflow.id
         sort: 'queued' unless SKIP_CELLECT
@@ -331,6 +344,21 @@ module.exports = React.createClass
     if classificationsThisSession % PROMPT_MINI_COURSE_EVERY is 0
       MiniCourse.startIfNecessary {workflow: @state.workflow, preferences: @props.preferences, project: @props.project, user: @props.user}
 
+  maybePromptWorkflowAssignmentDialog: (nextWorkflow) ->
+    if @state.promptWorkflowAssignmentDialog
+      WorkflowAssignmentDialog.start(@props.history, @props.location, @props.preferences)
+        .then =>
+          @loadAnotherSubject()
+
+          if @props.location.query.workflow isnt @props.preferences.preferences.selected_workflow
+            @props.preferences.update({ 'preferences.selected_workflow': @props.preferences.settings.workflow_id });
+            @props.preferences.save()
+              .then =>
+                @setState promptWorkflowAssignmentDialog: false
+          else
+            @setState promptWorkflowAssignmentDialog: false
+
+               
 # For debugging:
 window.currentWorkflowForProject = currentWorkflowForProject
 window.currentClassifications = currentClassifications

--- a/app/pages/project/index.cjsx
+++ b/app/pages/project/index.cjsx
@@ -77,7 +77,7 @@ ProjectPage = React.createClass
       @updateSugarSubscription nextProps.project
       @context.geordi?.remember projectToken: nextProps.project?.slug
     else if nextProps.preferences?.preferences.selected_workflow isnt @state.selectedWorkflow?.id
-      @getSelectedWorkflow nextProps.project, nextProps.preferences
+      @getSelectedWorkflow(nextProps.project, nextProps.preferences)
 
   fetchInfo: (project) ->
     @setState
@@ -106,9 +106,16 @@ ProjectPage = React.createClass
   getSelectedWorkflow: (project, preferences) ->
     @setState selectedWorkflow: 'PENDING'
 
-    preferredWorkflowID = preferences?.preferences.selected_workflow ? project.configuration?.default_workflow
+    # preference user selected workflow, then project owner set workflow, then default workflow
+    if preferences?.preferences.selected_workflow 
+      preferredWorkflowID = preferences?.preferences.selected_workflow
+    else if preferences?.settings.workflow_id
+      preferredWorkflowID = preferences?.settings.workflow_id
+    else if project.configuration?.default_workflow 
+      preferredWorkflowID = project.configuration?.default_workflow
+
     if preferredWorkflowID?
-      apiClient.type('workflows').get preferredWorkflowID
+      apiClient.type('workflows').get preferredWorkflowID, {}
         .then (workflow) =>
           if workflow.active
             @setState selectedWorkflow: workflow
@@ -253,6 +260,12 @@ ProjectPageController = React.createClass
   componentDidMount: ->
     @_boundForceUpdate = @forceUpdate.bind this
     @fetchProjectData @props.params.owner, @props.params.name, @props.user
+      # .then =>
+      #   # For testing! Simulating a new assignment coming in after some time.
+      #   setTimeout ( => 
+      #     console.log('set selected workfow')
+      #     @state.preferences.update "preferences.selected_workflow": '2333'
+      #   ), 5000
 
   componentWillReceiveProps: (nextProps) ->
     {owner, name} = nextProps.params

--- a/app/pages/project/index.cjsx
+++ b/app/pages/project/index.cjsx
@@ -260,12 +260,6 @@ ProjectPageController = React.createClass
   componentDidMount: ->
     @_boundForceUpdate = @forceUpdate.bind this
     @fetchProjectData @props.params.owner, @props.params.name, @props.user
-      .then =>
-        # For testing! Simulating a new assignment coming in after some time.
-        setTimeout ( => 
-          console.log('set selected workfow')
-          @state.preferences.update "preferences.selected_workflow": '2333'
-        ), 5000
 
   componentWillReceiveProps: (nextProps) ->
     {owner, name} = nextProps.params

--- a/app/pages/project/index.cjsx
+++ b/app/pages/project/index.cjsx
@@ -260,12 +260,12 @@ ProjectPageController = React.createClass
   componentDidMount: ->
     @_boundForceUpdate = @forceUpdate.bind this
     @fetchProjectData @props.params.owner, @props.params.name, @props.user
-      # .then =>
-      #   # For testing! Simulating a new assignment coming in after some time.
-      #   setTimeout ( => 
-      #     console.log('set selected workfow')
-      #     @state.preferences.update "preferences.selected_workflow": '2333'
-      #   ), 5000
+      .then =>
+        # For testing! Simulating a new assignment coming in after some time.
+        setTimeout ( => 
+          console.log('set selected workfow')
+          @state.preferences.update "preferences.selected_workflow": '2333'
+        ), 5000
 
   componentWillReceiveProps: (nextProps) ->
     {owner, name} = nextProps.params

--- a/css/main.styl
+++ b/css/main.styl
@@ -37,6 +37,7 @@
 @require './field-guide'
 @require './tutorial'
 @require './mini-course-dialog'
+@require './workflow-assignment-dialog'
 @require './disciplines-slider'
 @require './survey-task'
 @require "./drawing-tool"

--- a/css/workflow-assignment-dialog.styl
+++ b/css/workflow-assignment-dialog.styl
@@ -1,0 +1,7 @@
+.modal-form-underlay.workflow-assignment-dialog
+  background-color: rgba(0,0,0,0.6)
+
+.modal-form.workflow-assignment-dialog
+  border-radius: 8px
+  max-width: 400px
+  padding: 0 0 1.5em

--- a/css/workflow-assignment-dialog.styl
+++ b/css/workflow-assignment-dialog.styl
@@ -5,3 +5,11 @@
   border-radius: 8px
   max-width: 400px
   padding: 0 0 1.5em
+  
+  .modal-dialog-close-button
+    background: MAIN_HIGHLIGHT
+    text-shadow: none
+  
+  .workflow-assignment-dialog__buttons
+    display: flex
+    justify-content: space-between


### PR DESCRIPTION
This adds the dialog UI for workflow assignment/promotion as well as a bug fix for the Tutorial and removed a redundant API call. Also, updated the eslint file and changed it to `.eslintrc` so it would work with Sublime.

Still need to:
- Finalize copy for the dialog
- Finalize any styling for the dialog
- Do some additional testing when I can successfully get Project Preferences of another user and promote them (via python client)

This leaves out the potential opt out feature. I think that's gonna take more thought and time if we do it at all. FYI @trouille 

Staged at: https://workflow-assignment-dialog.pfe-preview.zooniverse.org/projects/srallen086/workflow-assignment-testing