### PR TITLE
add gravity spy gold standard feedback

### DIFF
--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -383,21 +383,26 @@ Classifier = React.createClass
     for annotation in classification.annotations when @props.workflow.tasks[annotation.task].type is 'survey'
       for value in annotation.value
         choiceLabels.push @props.workflow.tasks[annotation.task].choices[value.choice].label
-    match = choiceLabels.some (label) => label is @props.subject.metadata['#Label']
+    match = choiceLabels.every (label) => label is @props.subject.metadata['#Label']
 
     <div>
     {if match
       <div>
         <p>Good work!</p>
         <p>When our experts classified this image,<br />they also thought it was a {@props.subject.metadata['#Label']}!</p>
+        {if choiceLabels.length > 1
+          <p>You should only assign 1 label.</p>}
       </div>
     else
       <div>
         <p>You responded {choiceLabels.join(', ')}.</p>
+        {if choiceLabels.length > 1
+          <p>You should only assign 1 label.</p>}
         <p>When our experts classified this image,<br />they labeled it as a {@props.subject.metadata['#Label']}.</p>
         <p>Some of the glitch classes can look quite similar,<br />so please keep trying your best.</p>
         <p>Check out the tutorial and the field guide for more guidance.</p>
       </div>}
+
 
       <hr />
 
@@ -478,10 +483,7 @@ Classifier = React.createClass
     <p className="back-button-warning" >Going back will clear your work for the current task.</p>
 
   subjectIsGravitySpyGoldStandard: ->
-    if @props.workflow.configuration?.gravity_spy_gold_standard and @props.subject.metadata?['#Type'] is 'Gold'
-      true
-    else
-      false
+    @props.workflow.configuration?.gravity_spy_gold_standard and @props.subject.metadata?['#Type'] is 'Gold'
 
 module.exports = React.createClass
   displayName: 'ClassifierWrapper'

--- a/app/pages/admin/project-status.cjsx
+++ b/app/pages/admin/project-status.cjsx
@@ -26,6 +26,7 @@ EXPERIMENTAL_FEATURES = [
   'grid'
   'invert'
   'workflow assignment'
+  'Gravity Spy Gold Standard'
 ]
 
 ProjectToggle = React.createClass

--- a/app/pages/lab/workflow.cjsx
+++ b/app/pages/lab/workflow.cjsx
@@ -286,6 +286,24 @@ EditWorkflowPage = React.createClass
               <hr />
             </div>}
 
+          {if 'Gravity Spy Gold Standard' in @props.project.experimental_tools
+            <div>
+              <div>
+                <AutoSave resource={@props.workflow}>
+                  <span className="form-label">Gravity Spy Gold Standard</span><br />
+                  <small className="form-help">Notify a user how they've classified a Gold Standard subject.</small>
+                  <br />
+                  <label htmlFor="gravity_spy_gold_standard">
+                    <input type="checkbox" onChange={@handleSetGravitySpyGoldStandard} checked={@props.workflow.configuration.gravity_spy_gold_standard}/>
+                    Gravity Spy Gold Standard
+                  </label>
+                </AutoSave>
+              </div>
+
+              <hr />
+
+            </div>}
+
           <AutoSave tag="div" resource={@props.workflow}>
             <span className="form-label">Multi-image options</span><br />
             <small className="form-help">Choose how to display multiple images</small>
@@ -509,6 +527,10 @@ EditWorkflowPage = React.createClass
   handleSetInvert: (e) ->
     @props.workflow.update
       'configuration.invert_subject': e.target.checked
+
+  handleSetGravitySpyGoldStandard: (e) ->
+    @props.workflow.update
+      'configuration.gravity_spy_gold_standard': e.target.checked
 
   handleSetWorldWideTelescope: (e) ->
     if !@props.workflow.configuration.custom_summary

--- a/app/pages/lab/workflow.cjsx
+++ b/app/pages/lab/workflow.cjsx
@@ -293,7 +293,7 @@ EditWorkflowPage = React.createClass
                   <span className="form-label">Gravity Spy Gold Standard</span><br />
                   <small className="form-help">Notify a user how they've classified a Gold Standard subject.</small>
                   <br />
-                  <label htmlFor="gravity_spy_gold_standard">
+                  <label>
                     <input type="checkbox" onChange={@handleSetGravitySpyGoldStandard} checked={@props.workflow.configuration.gravity_spy_gold_standard}/>
                     Gravity Spy Gold Standard
                   </label>

--- a/app/pages/project/classify.cjsx
+++ b/app/pages/project/classify.cjsx
@@ -231,7 +231,8 @@ module.exports = React.createClass
           onLoad={@scrollIntoView}
           demoMode={@state.demoMode}
           onChangeDemoMode={@handleDemoModeChange}
-          onComplete={if @state.workflow?.configuration?.hide_classification_summaries then @saveClassificationAndLoadAnotherSubject else @saveClassification}
+          onComplete={@saveClassification}
+          onCompleteAndLoadAnotherSubject={@saveClassificationAndLoadAnotherSubject}
           onClickNext={@loadAnotherSubject}
         />
       else if @state.rejected.classification?


### PR DESCRIPTION
[staged branch and testing project here](https://gs-gold-standard-notice.pfe-preview.zooniverse.org/projects/markb-panoptes/gravity-spy-gold-standard-notice-test-project).

let me know staging user and I'll add to test project. the test project has a test gold standard subject set and a test regular subject set.

even though there should only be one selection made, if user makes multiple selections, should `match` be strict (`.every`) or forgiving (`.some`, current setup)?

currently, `hide_classification_summaries` is needed to be checked to hide a regular subject's summary, but that's easily change-able if preferred.

possible ToDo - in wrong response, link references to Tutorial and Field Guide. Though there maybe an argument to leave as is so primary action is to click Next and continue classifying, where they can access those resources within the next subject.