### PR TITLE
Fix for classify button

### DIFF
--- a/app/pages/project/classify.cjsx
+++ b/app/pages/project/classify.cjsx
@@ -352,7 +352,7 @@ module.exports = React.createClass
           @loadAnotherSubject()
 
           if @props.location.query.workflow isnt @props.preferences.preferences.selected_workflow
-            @props.preferences.update({ 'preferences.selected_workflow': @props.preferences.settings.workflow_id });
+            @props.preferences.update({ 'preferences.selected_workflow': @props.preferences?.settings?.workflow_id });
             @props.preferences.save()
               .then =>
                 @setState promptWorkflowAssignmentDialog: false

--- a/app/pages/project/index.cjsx
+++ b/app/pages/project/index.cjsx
@@ -55,7 +55,6 @@ ProjectPage = React.createClass
     selectedWorkflow: null
 
   componentDidMount: ->
-    console.log "componentDidMount"
     @context.setAppHeaderVariant 'demoted'
     unless @props.user?
       @context.revealSiteHeader()
@@ -359,7 +358,7 @@ ProjectPageController = React.createClass
         if @state.error.message is 'NOT_FOUND'
           <div className="content-container">
             <p>Project <code>{slug}</code> not found.</p>
-            <p>{"If you're sure the URL is correct, you might not have permission to view this project."}</p>
+            <p>"If you're sure the URL is correct, you might not have permission to view this project."</p>
           </div>
         else
           <div className="content-container">

--- a/app/pages/project/index.cjsx
+++ b/app/pages/project/index.cjsx
@@ -55,6 +55,7 @@ ProjectPage = React.createClass
     selectedWorkflow: null
 
   componentDidMount: ->
+    console.log "componentDidMount"
     @context.setAppHeaderVariant 'demoted'
     unless @props.user?
       @context.revealSiteHeader()
@@ -105,11 +106,10 @@ ProjectPage = React.createClass
 
   getSelectedWorkflow: (project, preferences) ->
     @setState selectedWorkflow: 'PENDING'
-
     # preference user selected workflow, then project owner set workflow, then default workflow
-    if preferences?.preferences.selected_workflow 
+    if preferences?.preferences.selected_workflow?
       preferredWorkflowID = preferences?.preferences.selected_workflow
-    else if preferences?.settings.workflow_id
+    else if preferences?.settings?.workflow_id
       preferredWorkflowID = preferences?.settings.workflow_id
     else if project.configuration?.default_workflow 
       preferredWorkflowID = project.configuration?.default_workflow
@@ -359,7 +359,7 @@ ProjectPageController = React.createClass
         if @state.error.message is 'NOT_FOUND'
           <div className="content-container">
             <p>Project <code>{slug}</code> not found.</p>
-            <p>If you're sure the URL is correct, you might not have permission to view this project.</p>
+            <p>{"If you're sure the URL is correct, you might not have permission to view this project."}</p>
           </div>
         else
           <div className="content-container">


### PR DESCRIPTION
This PR fixes an issue with the Classify button not fully loading for non-signed in users in Chrome, and for Safari and Firefox, generally. 
<img width="610" alt="screen shot 2016-08-29 at 4 57 36 pm" src="https://cloud.githubusercontent.com/assets/7684729/18071207/7eb2137e-6e19-11e6-98da-dbb8206f3c51.png">

I added a few more checks for the existence of the preferences object, which seems to have fixed the button. 