### PR TITLE
Remove Username From Hash Compute

### DIFF
--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -276,7 +276,6 @@ Classifier = React.createClass
           <WorldWideTelescope
             annotations={@props.classification.annotations}
             subject={@props.subject}
-            user_name={@props.user.display_name}
             workflow={@props.workflow}
           />
         </strong>}

--- a/app/classifier/world_wide_telescope.cjsx
+++ b/app/classifier/world_wide_telescope.cjsx
@@ -118,7 +118,7 @@ class StarChart
     coords
 
 class Plate
-  constructor: (@starChart, @url, @user_name) ->
+  constructor: (@starChart, @url) ->
     @imageBounds = @starChart.bounds()
     [xRange, yRange] = [@starChart.xAxis.range, @starChart.yAxis.range]
 
@@ -183,8 +183,7 @@ class Plate
     else 90
 
   computeName: ->
-    hashTime = crypto.createHash('md5').update(new Date().toString()).digest('hex').slice(0, 10)
-    @user_name + hashTime
+    crypto.createHash('md5').update(new Date().toString()).digest('hex').slice(0, 10)
 
   getWwtUrl: ->
     base = "http://www.worldwidetelescope.org/wwtweb/ShowImage.aspx"
@@ -309,7 +308,7 @@ module.exports = React.createClass
 
       for chart in @charts
         if chart.valid
-          plates.push(new Plate(chart, subjImage, @props.user_name))
+          plates.push(new Plate(chart, subjImage))
 
     <div>
       {plates.map (plate, idx) ->


### PR DESCRIPTION
Fixes #2929 .

Describe your changes.
In order for WorldWide Telescope to work, it needed a unique name for each link. Originally, the username was included with this unique name, however, this isn't necessary and a hash will suffice. By removing the username, a non-logged-in user can complete classifications.

# Review Checklist

- [X] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [X] Does it work on mobile?
- [X] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [X] Did you deploy a staging branch?

https://fix-2929.pfe-preview.zooniverse.org/

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
