### PR TITLE
Use default workflows

### DIFF
--- a/app/pages/project/home.cjsx
+++ b/app/pages/project/home.cjsx
@@ -14,6 +14,12 @@ module.exports = React.createClass
   getInitialState: ->
     workflows: []
 
+  getDefaultProps: ->
+    owner: {}
+    project: {}
+    selectedWorkflow: null
+    user: null
+
   componentDidMount: -> 
     @getWorkflows(@props.project)
 
@@ -69,9 +75,18 @@ module.exports = React.createClass
                   {workflow.display_name}
                 </Link>
           else
-            <Link to={"/projects/#{@props.project.slug}/classify"} className="call-to-action standard-button">
-              Get started!
-            </Link>
+            if @props.selectedWorkflow?
+              <Link 
+                to={"/projects/#{@props.project.slug}/classify"}
+                query={workflow: @props.selectedWorkflow.id}
+                className="call-to-action standard-button"
+              >
+                Get started!
+              </Link>
+            else
+              <Link to={"/projects/#{@props.project.slug}/classify"} className="call-to-action standard-button">
+                Get started!
+              </Link>
         else if @props.project.configuration?.user_chooses_workflow
           @state.workflows.map (workflow) =>
             <Link
@@ -83,6 +98,14 @@ module.exports = React.createClass
             >
               {workflow.display_name}
             </Link>
+        else if @props.selectedWorkflow?
+          <Link 
+            to={"/projects/#{@props.project.slug}/classify"}
+            query={workflow: @props.selectedWorkflow.id}
+            className="call-to-action standard-button"
+          >
+            Get started!
+          </Link>
         else
           <Link to={"/projects/#{@props.project.slug}/classify"} className="call-to-action standard-button">
             Get started!

--- a/app/pages/project/index.cjsx
+++ b/app/pages/project/index.cjsx
@@ -224,7 +224,8 @@ ProjectPage = React.createClass
         project: @props.project
         owner: @props.owner
         preferences: @props.preferences
-        onChangePreferences: @props.onChangePreferences}
+        onChangePreferences: @props.onChangePreferences
+        selectedWorkflow: @state.selectedWorkflow}
 
       {unless @props.project.launch_approved or @props.project.beta_approved
         <Translate component="p" className="project-disclaimer" content="project.disclaimer" />}
@@ -358,7 +359,7 @@ ProjectPageController = React.createClass
         if @state.error.message is 'NOT_FOUND'
           <div className="content-container">
             <p>Project <code>{slug}</code> not found.</p>
-            <p>"If you're sure the URL is correct, you might not have permission to view this project."</p>
+            <p>If you're sure the URL is correct, you might not have permission to view this project.</p>
           </div>
         else
           <div className="content-container">


### PR DESCRIPTION
Fixes some issue discussed in the front end channel.

This fixes the following scenarios:
- A logged out user clicks 'Get Started' and the project has a default workflow set, the default workflow id is now passed as a param. Before a random workflow was selected.
- A user navigates directly to a project's classify page. If logged in and there is a selected workflow passed down as a prop, then load that workflow.
- Do not show the workflow assignment dialog if the workflow query is undefined

This does not fix when a user browses directly to the classify page and is not logged in, then random workflows are still being loaded. I'm working on another branch to do some refactoring since I'm starting to dislike some of the dependency on the workflow query in the URL and there are redundant API calls for the workflow. This is a good stop gap until I'm done with that.

Staged: https://use-default-workflows.pfe-preview.zooniverse.org/

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
