### PR TITLE
Fix link markdown in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ We're migrating from coffeescript to ES6. This can be done incrementally by writ
 
 An ESLint configuration file is setup in the root of the repository for you to use with your text editor to lint both ES6 and use Airbnb's React style guide.
 
-A (guide)[https://toddmotto.com/react-create-class-versus-component/] on writing native classes versus using `React.createClass()`
+A [guide](https://toddmotto.com/react-create-class-versus-component/) on writing native classes versus using `React.createClass()`
 
 ## Custom projects
 


### PR DESCRIPTION
Fixes # 2940.

Describe your changes.
[guide](https://toddmotto.com/react-create-class-versus-component/) replaces (guide)[https://toddmotto.com/react-create-class-versus-component/]
# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
