### PR TITLE
Remove the loading overlay from video

### DIFF
--- a/app/components/frame-viewer.cjsx
+++ b/app/components/frame-viewer.cjsx
@@ -44,10 +44,6 @@ module.exports = React.createClass
         </div>
       when 'video'
         <VideoPlayer src={src} type={type} format={format} frame={@props.frame} onLoad={@handleLoad}>
-        {if @state.loading
-          <div className="loading-cover" style={@constructor.overlayStyle}>
-            <LoadingIndicator />
-          </div>}
         </VideoPlayer>
 
     if FrameWrapper


### PR DESCRIPTION
Fixes the iOS half of #2937 .

Mobile Safari never fires the `canplay` event to indicate that a video subject is available to play, so I've deleted the loading animation for video subjects, in favour of letting the browser indicate video loading via the `<video>` element.

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
