### PR TITLE
Position dialogs over other content

### DIFF
--- a/css/dialog.styl
+++ b/css/dialog.styl
@@ -1,6 +1,6 @@
 .dialog-container
   position: relative
-  z-index: 1
+  z-index: 10
 
 .dialog-underlay
   align-items: center


### PR DESCRIPTION
Fixes #2965  .

Describe your changes.

Increases dialog z-index to display over all other content.

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?