### PR TITLE
Add workflow configuration for cloning markers on multi-image subjects.

### DIFF
--- a/app/classifier/tasks/drawing/markings-renderer.cjsx
+++ b/app/classifier/tasks/drawing/markings-renderer.cjsx
@@ -35,50 +35,89 @@ module.exports = React.createClass
 
   render: ->
     skippedMarks = 0
-
     <g>
       {for annotation in @props.classification?.annotations ? []
+        
         annotation._key ?= Math.random()
         isPriorAnnotation = annotation isnt @props.annotation
         taskDescription = @props.workflow.tasks[annotation.task]
         if taskDescription.type is 'drawing'
-          <g key={annotation._key} className="marks-for-annotation" data-disabled={isPriorAnnotation || null}>
-            {for mark, i in annotation.value when parseInt(mark.frame) is parseInt(@props.frame)
-              mark._key ?= Math.random()
+          if @props.workflow.configuration.multi_image_tool
+            <g key={annotation._key} className="marks-for-annotation" data-disabled={isPriorAnnotation || null}>
+                {for mark, i in annotation.value
+                  mark._key ?= Math.random()
 
-              if skippedMarks < @props.classification._hideMarksBefore and not @props.classification.completed
-                skippedMarks += 1
-                continue
+                  if skippedMarks < @props.classification._hideMarksBefore and not @props.classification.completed
+                    skippedMarks += 1
+                    continue
 
-              if mark._copy?
-                continue
+                  if mark._copy?
+                    continue
 
-              toolDescription = taskDescription.tools[mark.tool]
+                  toolDescription = taskDescription.tools[mark.tool]
 
-              toolEnv =
-                containerRect: @props.containerRect
-                scale: @props.scale
-                disabled: isPriorAnnotation
-                selected: mark is @state.selection and not isPriorAnnotation
-                getEventOffset: @props.getEventOffset
-                preferences: @props.preferences
+                  toolEnv =
+                    containerRect: @props.containerRect
+                    scale: @props.scale
+                    disabled: isPriorAnnotation
+                    selected: mark is @state.selection and not isPriorAnnotation
+                    getEventOffset: @props.getEventOffset
+                    preferences: @props.preferences
 
-              toolProps =
-                classification: @props.classification
-                mark: mark
-                details: toolDescription.details
-                color: toolDescription.color
-                size: toolDescription.size
+                  toolProps =
+                    classification: @props.classification
+                    mark: mark
+                    details: toolDescription.details
+                    color: toolDescription.color
+                    size: toolDescription.size
 
-              toolMethods =
-                onChange: @handleChange.bind this, i
-                onSelect: @handleSelect.bind this, annotation, mark
-                onDeselect: @handleDeselect
-                onDestroy: @handleDestroy.bind this, annotation, mark
+                  toolMethods =
+                    onChange: @handleChange.bind this, i
+                    onSelect: @handleSelect.bind this, annotation, mark
+                    onDeselect: @handleDeselect
+                    onDestroy: @handleDestroy.bind this, annotation, mark
 
-              ToolComponent = drawingTools[toolDescription.type]
-              <ToolComponent key={mark._key} {...toolProps} {...toolEnv} {...toolMethods} />}
-          </g>}
+                  ToolComponent = drawingTools[toolDescription.type]
+                  <ToolComponent key={mark._key} {...toolProps} {...toolEnv} {...toolMethods} />}
+            </g>
+          else   
+            <g key={annotation._key} className="marks-for-annotation" data-disabled={isPriorAnnotation || null}>
+                {for mark, i in annotation.value when parseInt(mark.frame) is parseInt(@props.frame)
+                  mark._key ?= Math.random()
+
+                  if skippedMarks < @props.classification._hideMarksBefore and not @props.classification.completed
+                    skippedMarks += 1
+                    continue
+
+                  if mark._copy?
+                    continue
+
+                  toolDescription = taskDescription.tools[mark.tool]
+
+                  toolEnv =
+                    containerRect: @props.containerRect
+                    scale: @props.scale
+                    disabled: isPriorAnnotation
+                    selected: mark is @state.selection and not isPriorAnnotation
+                    getEventOffset: @props.getEventOffset
+                    preferences: @props.preferences
+
+                  toolProps =
+                    classification: @props.classification
+                    mark: mark
+                    details: toolDescription.details
+                    color: toolDescription.color
+                    size: toolDescription.size
+
+                  toolMethods =
+                    onChange: @handleChange.bind this, i
+                    onSelect: @handleSelect.bind this, annotation, mark
+                    onDeselect: @handleDeselect
+                    onDestroy: @handleDestroy.bind this, annotation, mark
+
+                  ToolComponent = drawingTools[toolDescription.type]
+                  <ToolComponent key={mark._key} {...toolProps} {...toolEnv} {...toolMethods} />}
+            </g>}
     </g>
 
   handleChange: (markIndex, mark) ->

--- a/app/classifier/tasks/drawing/markings-renderer.cjsx
+++ b/app/classifier/tasks/drawing/markings-renderer.cjsx
@@ -36,88 +36,48 @@ module.exports = React.createClass
   render: ->
     skippedMarks = 0
     <g>
-      {for annotation in @props.classification?.annotations ? []
-        
+      {for annotation in @props.classification?.annotations ? []      
         annotation._key ?= Math.random()
         isPriorAnnotation = annotation isnt @props.annotation
         taskDescription = @props.workflow.tasks[annotation.task]
         if taskDescription.type is 'drawing'
-          if @props.workflow.configuration.multi_image_tool
-            <g key={annotation._key} className="marks-for-annotation" data-disabled={isPriorAnnotation || null}>
-                {for mark, i in annotation.value
-                  mark._key ?= Math.random()
+          <g key={annotation._key} className="marks-for-annotation" data-disabled={isPriorAnnotation || null}>
+            {for mark, i in annotation.value when @props.workflow.configuration.multi_image_clone_markers or parseInt(mark.frame) is parseInt(@props.frame)
+              mark._key ?= Math.random()
 
-                  if skippedMarks < @props.classification._hideMarksBefore and not @props.classification.completed
-                    skippedMarks += 1
-                    continue
+              if skippedMarks < @props.classification._hideMarksBefore and not @props.classification.completed
+                skippedMarks += 1
+                continue
 
-                  if mark._copy?
-                    continue
+              if mark._copy?
+                continue
 
-                  toolDescription = taskDescription.tools[mark.tool]
+              toolDescription = taskDescription.tools[mark.tool]
 
-                  toolEnv =
-                    containerRect: @props.containerRect
-                    scale: @props.scale
-                    disabled: isPriorAnnotation
-                    selected: mark is @state.selection and not isPriorAnnotation
-                    getEventOffset: @props.getEventOffset
-                    preferences: @props.preferences
+              toolEnv =
+                containerRect: @props.containerRect
+                scale: @props.scale
+                disabled: isPriorAnnotation
+                selected: mark is @state.selection and not isPriorAnnotation
+                getEventOffset: @props.getEventOffset
+                preferences: @props.preferences
 
-                  toolProps =
-                    classification: @props.classification
-                    mark: mark
-                    details: toolDescription.details
-                    color: toolDescription.color
-                    size: toolDescription.size
+              toolProps =
+                classification: @props.classification
+                mark: mark
+                details: toolDescription.details
+                color: toolDescription.color
+                size: toolDescription.size
 
-                  toolMethods =
-                    onChange: @handleChange.bind this, i
-                    onSelect: @handleSelect.bind this, annotation, mark
-                    onDeselect: @handleDeselect
-                    onDestroy: @handleDestroy.bind this, annotation, mark
+              toolMethods =
+                onChange: @handleChange.bind this, i
+                onSelect: @handleSelect.bind this, annotation, mark
+                onDeselect: @handleDeselect
+                onDestroy: @handleDestroy.bind this, annotation, mark
 
-                  ToolComponent = drawingTools[toolDescription.type]
-                  <ToolComponent key={mark._key} {...toolProps} {...toolEnv} {...toolMethods} />}
-            </g>
-          else   
-            <g key={annotation._key} className="marks-for-annotation" data-disabled={isPriorAnnotation || null}>
-                {for mark, i in annotation.value when parseInt(mark.frame) is parseInt(@props.frame)
-                  mark._key ?= Math.random()
-
-                  if skippedMarks < @props.classification._hideMarksBefore and not @props.classification.completed
-                    skippedMarks += 1
-                    continue
-
-                  if mark._copy?
-                    continue
-
-                  toolDescription = taskDescription.tools[mark.tool]
-
-                  toolEnv =
-                    containerRect: @props.containerRect
-                    scale: @props.scale
-                    disabled: isPriorAnnotation
-                    selected: mark is @state.selection and not isPriorAnnotation
-                    getEventOffset: @props.getEventOffset
-                    preferences: @props.preferences
-
-                  toolProps =
-                    classification: @props.classification
-                    mark: mark
-                    details: toolDescription.details
-                    color: toolDescription.color
-                    size: toolDescription.size
-
-                  toolMethods =
-                    onChange: @handleChange.bind this, i
-                    onSelect: @handleSelect.bind this, annotation, mark
-                    onDeselect: @handleDeselect
-                    onDestroy: @handleDestroy.bind this, annotation, mark
-
-                  ToolComponent = drawingTools[toolDescription.type]
-                  <ToolComponent key={mark._key} {...toolProps} {...toolEnv} {...toolMethods} />}
-            </g>}
+              ToolComponent = drawingTools[toolDescription.type]
+              <ToolComponent key={mark._key} {...toolProps} {...toolEnv} {...toolMethods} />}
+          </g>}
     </g>
 
   handleChange: (markIndex, mark) ->

--- a/app/classifier/tasks/drawing/markings-renderer.cjsx
+++ b/app/classifier/tasks/drawing/markings-renderer.cjsx
@@ -42,7 +42,7 @@ module.exports = React.createClass
         taskDescription = @props.workflow.tasks[annotation.task]
         if taskDescription.type is 'drawing'
           <g key={annotation._key} className="marks-for-annotation" data-disabled={isPriorAnnotation || null}>
-            {for mark, i in annotation.value when @props.workflow.configuration.multi_image_clone_markers or parseInt(mark.frame) is parseInt(@props.frame)
+            {for mark, i in annotation.value when @props.workflow?.configuration.multi_image_clone_markers or parseInt(mark.frame) is parseInt(@props.frame)
               mark._key ?= Math.random()
 
               if skippedMarks < @props.classification._hideMarksBefore and not @props.classification.completed

--- a/app/components/multi-image-subject-options-editor.cjsx
+++ b/app/components/multi-image-subject-options-editor.cjsx
@@ -48,9 +48,17 @@ module.exports = React.createClass
             <input type="radio" id="multi_image_grid3" name="multi_image_layout" value="grid3" onChange={@handleSelectLayout} />
             <label htmlFor="multi_image_grid3">Grid (3col)</label>
           </div>}
+        <div>
+          <input type="checkbox" id="multi_image_clone_markers" name="multi_image_tool" onChange={@handleSelectTool} />
+          <label htmlFor="multi_image_clone_markers">Clone markers in all frames</label>
+        </div>  
       </div>
     }</ChangeListener>
-
+    
+  handleSelectTool: (e) ->
+    @props.workflow.update
+      'configuration.multi_image_tool': e.target.checked
+    
   handleSelectMode: (e) ->
     mode = e.target.value
     @props.workflow.update

--- a/app/components/multi-image-subject-options-editor.cjsx
+++ b/app/components/multi-image-subject-options-editor.cjsx
@@ -49,15 +49,15 @@ module.exports = React.createClass
             <label htmlFor="multi_image_grid3">Grid (3col)</label>
           </div>}
         <div>
-          <input type="checkbox" id="multi_image_clone_markers" name="multi_image_tool" onChange={@handleSelectTool} />
+          <input type="checkbox" id="multi_image_clone_markers" name="multi_image_clone_markers" onChange={@toggleCloneMarks} />
           <label htmlFor="multi_image_clone_markers">Clone markers in all frames</label>
         </div>  
       </div>
     }</ChangeListener>
     
-  handleSelectTool: (e) ->
+  toggleCloneMarks: (e) ->
     @props.workflow.update
-      'configuration.multi_image_tool': e.target.checked
+      'configuration.multi_image_clone_markers': e.target.checked
     
   handleSelectMode: (e) ->
     mode = e.target.value


### PR DESCRIPTION
Fixes #2888 

Removes `when parseInt(mark.frame) is parseInt(@props.frame)`, if the clone markers option is selected.

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile? Tested on iOS
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://fix-2888.pfe-preview.zooniverse.org/

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
