### PR TITLE
Fix internal links for comments

### DIFF
--- a/app/pages/profile/comment-link.cjsx
+++ b/app/pages/profile/comment-link.cjsx
@@ -3,6 +3,7 @@ moment = require 'moment'
 apiClient = require 'panoptes-client/lib/api-client'
 talkClient = require 'panoptes-client/lib/talk-client'
 {Markdown} = (require 'markdownz').default
+{Link} = require 'react-router'
 
 module.exports = React.createClass
   displayName: 'CommentLink'
@@ -46,7 +47,7 @@ module.exports = React.createClass
           Promise.resolve "/talk/#{board.id}/#{discussion.id}?comment=#{comment.id}"
         href.then (href) =>
           @setState
-            href: window.location.origin + href
+            href: href
 
   render: ->
     <div className="profile-feed-comment-link">
@@ -57,7 +58,7 @@ module.exports = React.createClass
         {if @state.board?.id and @state.discussion?.id
           <span>
             {' '}in{' '}
-            <a href={@state.href}>
+            <Link to={@state.href}>
               {if @state.boardProject? and @state.owner? and !@props.project?
                 <span>
                   <strong className="comment-project" title="#{@state.owner.display_name}/#{@state.boardProject.display_name}">{@state.boardProject.display_name}</strong>
@@ -66,7 +67,7 @@ module.exports = React.createClass
               <strong className="comment-board">{@state.board?.title}</strong>
               <span>{' '}➞{' '}</span>
               <strong className="comment-discussion">{@state.discussion?.title}</strong>
-            </a>
+            </Link>
           </span>}
       </header>
 

--- a/app/pages/profile/comment-link.cjsx
+++ b/app/pages/profile/comment-link.cjsx
@@ -41,8 +41,7 @@ module.exports = React.createClass
                 boardProject: project
               project.get('owner').then (owner) =>
                 @setState({owner})
-                [owner, name] = project.slug.split('/')
-                "/projects/#{owner}/#{name}/talk/#{board.id}/#{discussion.id}?comment=#{comment.id}"
+                "/projects/#{project.slug}/talk/#{board.id}/#{discussion.id}?comment=#{comment.id}"
         else
           Promise.resolve "/talk/#{board.id}/#{discussion.id}?comment=#{comment.id}"
         href.then (href) =>

--- a/app/talk/comment-link.cjsx
+++ b/app/talk/comment-link.cjsx
@@ -1,5 +1,6 @@
 React = require 'react'
 talkConfig = require './config'
+{Link} = require 'react-router'
 
 PAGE_SIZE = talkConfig.discussionPageSize
 
@@ -18,22 +19,17 @@ module.exports = React.createClass
 
   projectCommentUrl: ->
     {comment} = @props
-    [ownerName, projectName] = comment.project_slug.split('/')
-    window.location.origin + "/projects/#{ownerName}/#{projectName}/talk/#{comment.board_id}/#{comment.discussion_id}?comment=#{comment.id}"
+    "/projects/#{comment.project_slug}/talk/#{comment.board_id}/#{comment.discussion_id}?comment=#{comment.id}"
 
   mainTalkCommentUrl: ->
     {comment} = @props
-    window.location.origin + "/talk/#{comment.board_id}/#{comment.discussion_id}?comment=#{comment.id}"
+    "/talk/#{comment.board_id}/#{comment.discussion_id}?comment=#{comment.id}"
 
   render: ->
-    <div className="talk-comment-link">
-      {if @projectComment()
-        <a href={@projectCommentUrl()}>
-          {@props.children ? @projectCommentUrl()}
-        </a>
+    href = if @projectComment() then @projectCommentUrl() else @mainTalkCommentUrl()
 
-      else
-        <a href={@mainTalkCommentUrl()}>
-          {@props.children ? @mainTalkCommentUrl()}
-        </a>}
+    <div className="talk-comment-link">
+      <Link to={href}>
+        {@props.children ? window.location.origin + href}
+      </Link>
     </div>


### PR DESCRIPTION
Fixes #2798 .

Describe your changes.
Replaces `<a>` with `<Link>` for internal links, so that the page doesn't reload when the link is followed.

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://fix-2798.pfe-preview.zooniverse.org/?env=production

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
