### PR TITLE
Remove scrollIntoView

### DIFF
--- a/app/pages/project/classify.cjsx
+++ b/app/pages/project/classify.cjsx
@@ -5,7 +5,6 @@ TitleMixin = require '../../lib/title-mixin'
 HandlePropChanges = require '../../lib/handle-prop-changes'
 PromiseToSetState = require '../../lib/promise-to-set-state'
 apiClient = require 'panoptes-client/lib/api-client'
-animatedScrollTo = require 'animated-scrollto'
 counterpart = require 'counterpart'
 FinishedBanner = require './finished-banner'
 Classifier = require '../../classifier'
@@ -246,7 +245,6 @@ module.exports = React.createClass
         <Classifier
           {...@props}
           classification={@state.classification}
-          onLoad={@scrollIntoView}
           demoMode={@state.demoMode}
           onChangeDemoMode={@handleDemoModeChange}
           onComplete={@saveClassification}
@@ -258,15 +256,6 @@ module.exports = React.createClass
       else
         <span>Loading classification</span>}
     </div>
-
-  scrollIntoView: (e) ->
-    # Auto-scroll to top of the classification interface on load.
-    # It's not perfect, but it should make the location of everything more obvious.
-    lineHeight = parseFloat getComputedStyle(document.body).lineHeight
-    node = ReactDOM.findDOMNode(@)
-    idealScrollY = node.offsetTop - lineHeight
-    if Math.abs(idealScrollY - scrollY) > lineHeight
-      animatedScrollTo document.body, node.offsetTop - lineHeight, 333
 
   handleDemoModeChange: (newDemoMode) ->
     sessionDemoMode = newDemoMode


### PR DESCRIPTION
This removes the animated scroll on load of the classify page. It doesn't entirely make sense anymore with the project navbar redesign and it's a bit annoying. Change 👍 by @jwbmartin 

Staged at: https://remove-animated-scroll.pfe-preview.zooniverse.org/

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
