### PR TITLE
Remove React.findDOMNode

### DIFF
--- a/app/components/cropped-image.cjsx
+++ b/app/components/cropped-image.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+ReactDOM = require 'react-dom'
 
 module.exports = React.createClass
   XLINK_NS: 'http://www.w3.org/1999/xlink'
@@ -44,7 +45,7 @@ module.exports = React.createClass
     </svg>
 
   componentDidUpdate: ->
-    image = React.findDOMNode @refs.image
+    image = ReactDOM.findDOMNode @refs.image
     image.setAttribute 'width', @state.naturalWidth
     image.setAttribute 'height', @state.naturalHeight
     image.setAttributeNS @XLINK_NS, 'href', @props.src

--- a/app/talk/add-zoo-team-form.cjsx
+++ b/app/talk/add-zoo-team-form.cjsx
@@ -1,4 +1,5 @@
-React = {findDOMNode} = require 'react'
+React = require 'react'
+ReactDOM = require 'react-dom'
 UserSearch = require '../components/user-search.cjsx'
 talkClient = require 'panoptes-client/lib/talk-client'
 Feedback = require './mixins/feedback'
@@ -14,7 +15,7 @@ module.exports = React.createClass
     return unless window.confirm('Are you sure that you want to add this user to the Zooniverse team?')
 
     e.preventDefault()
-    userSelect = findDOMNode(@).querySelector('[name="userids"]')
+    userSelect = ReactDOM.findDOMNode(@).querySelector('[name="userids"]')
     userId = userSelect.value
 
     talkClient.type('roles').create({

--- a/app/talk/comment.cjsx
+++ b/app/talk/comment.cjsx
@@ -74,7 +74,7 @@ module.exports = React.createClass
 
   onClickEdit: (e) ->
     @logItemClick 'edit-post'
-    React.findDOMNode(@).scrollIntoView()
+    ReactDOM.findDOMNode(@).scrollIntoView()
     @setState editing: true
     @removeFeedback()
 


### PR DESCRIPTION
`React.findDOMNode` was deprecated in React 14, and removed completely in 15.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?