### PR TITLE
Fix Survey size in IE11

### DIFF
--- a/css/survey-task.styl
+++ b/css/survey-task.styl
@@ -211,15 +211,13 @@ $survey-task-pill-button
   background:  #f7f7f7
   border-radius: 8px
   color: #6b6a6a
-  display: flex
-  flex-direction: column
+  display: block
   font-size: 14px
   justify-content: space-between
   height: 100%
   padding: 1em
 
 .survey-task-choice-content
-  flex-grow: 100 // arbitrarily large number
   position: relative
 
 .survey-task-choice-label


### PR DESCRIPTION
* Fixes the gargantuan size of the Survey task when viewed in IE11, by changing `survey-task-choice`'s `display: flex` to `display: block`

Issue: When viewing a Survey Task on IE11, it looks like...

![screen shot 2016-09-07 at 15 13 45](https://cloud.githubusercontent.com/assets/13952701/18318231/cd1fe120-7518-11e6-89bd-f10df82fcd2d.png)
![screen shot 2016-09-07 at 15 15 11](https://cloud.githubusercontent.com/assets/13952701/18318233/cfb55a14-7518-11e6-8273-21d0be381b2c.png)
_The "Nothing Here" choice goes on for 2 pages of nothing there._

Example: https://zooniverse.org/projects/zooniverse/wildcam-gorongosa/classify

Analysis:
* Examining the structure of the HTML component...
```
div.survey-task-choice  //display:flex
  div.survey-task-image-flipper
  div.survey-task-choice-content  //flex-grow: 100
  div
```
* ...we see a rather weird interaction. In IE11, the first and last divs assume `flex: 1` (because... IE) so it stretches to fit the parent container. And because IE11 is insane, it always has this weird issue where the parent container's size is dependent on the child elements' sizes but the children's size is dependent on the parent's size but the parent's size depends on the oh no I've gone crosseyed.
* Ergo, inappropriately gargantuan survey task component.

Solution:
* My **recommended** solution is to remove `display:flex` from div.survey-task-choice as I cannot discern why the survey-task-choice needs to be flexed.
  * That said, I'd like to get @srallen's opinion on this issue, as the flexes were added in #1909, and styles like `.survey-task-choice-content { flex-grow: 100 // arbitrarily large number }` were added for a specific reason.
  * I've only tested this PR using the wildcam-gorongosa project, so I may be missing other use cases (Wildlife Watch USA maybe?)

![screen shot 2016-09-07 at 16 06 17](https://cloud.githubusercontent.com/assets/13952701/18319136/6275a1c6-751c-11e6-82ca-d07b4c09c2e6.png)
_This is how we expect the survey to look like. Control sample taken from Chrome visiting zooniverse.org_

Notes:
* If `div.survey-task-choice` needs to remain `display: flex` for any reason, an **alternative** solution is to set...
```
.survey-task-image-flipper
  flex: 0 0 auto
```
* ...but I'll need to run tests before I can resubmit the alternative as a PR.

Tested on OSX+Chrome53/FF48/Safari9 and Win7+IE11. Ready for review!
EDIT: Also tested on Android6.0.1+Chrome52

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?  //Yes: https://fix-ie11-survey-size.pfe-preview.zooniverse.org/projects/zooniverse/wildcam-gorongosa/classify?env=production (Thanks, Jim!)
