### PR TITLE
Add top/bottom margins to the project card listing

### DIFF
--- a/css/owned-card.styl
+++ b/css/owned-card.styl
@@ -11,6 +11,7 @@
   overflow: hidden
   position: relative
   font-size: 14px
+  margin-top: 2.33em
 
 .collection-card,
 .project-card

--- a/css/owned-list-pages.styl
+++ b/css/owned-list-pages.styl
@@ -12,7 +12,7 @@
 
   .resources-container
     background: #ebebeb
-    padding: 0 3vw
+    padding: 0 3vw 2.33em
 
     .resource-results-counter
       color: rgba(100, 100, 100, 0.5)
@@ -35,7 +35,7 @@
         color: PROJECT_SUBMENU_BLUE
 
   .pagination
-    padding: 2.33em 0
+    padding: 2.33em 0 0
     text-align: center
 
     .pill-button

--- a/css/project-list-pages.styl
+++ b/css/project-list-pages.styl
@@ -6,7 +6,7 @@
 
 .resources-container
   background: #ebebeb
-  padding: 0 3vw
+  padding: 0 3vw 2.33em
   text-align: center
 
   .resource-results-counter


### PR DESCRIPTION
Fixes #2990 .

Describe your changes.
Removes pagination padding and replaces with margins on the project card listing.

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://fix-2990.pfe-preview.zooniverse.org/

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?