### PR TITLE
update css for survey-task-chooser-choice-button children

### DIFF
--- a/app/classifier/tasks/survey/chooser.cjsx
+++ b/app/classifier/tasks/survey/chooser.cjsx
@@ -103,12 +103,12 @@ module.exports = React.createClass
           for choiceID, i in sortedFilteredChoices
             choice = @props.task.choices[choiceID]
             <button key={choiceID + i} type="button" className="survey-task-chooser-choice-button" onClick={@props.onChoose.bind null, choiceID}>
-              <div className="survey-task-chooser-choice">
+              <span className="survey-task-chooser-choice">
                 {if choice.images?.length > 0
                   thumbnailSrc = @props.task.images[choice.images[0]]
                   <span className="survey-task-chooser-choice-thumbnail" role="presentation" style={backgroundImage: "url('#{thumbnailSrc}')"}></span>}
                 <span className="survey-task-chooser-choice-label">{choice.label}</span>
-              </div>
+              </span>
             </button>}
       </div>
       <div style={textAlign: 'center'}>

--- a/css/survey-task.styl
+++ b/css/survey-task.styl
@@ -141,7 +141,11 @@ $survey-task-pill-button
 
   > *
     margin: 0.3em 0.6em
-    display: inline-table;
+
+.survey-task-chooser-choice
+  display: flex
+  justify-content: flex-start
+  align-items: center
 
 .survey-task-chooser-choice-thumbnail
   background-size: cover

--- a/css/survey-task.styl
+++ b/css/survey-task.styl
@@ -141,6 +141,7 @@ $survey-task-pill-button
 
   > *
     margin: 0.3em 0.6em
+    display: inline-table;
 
 .survey-task-chooser-choice-thumbnail
   background-size: cover


### PR DESCRIPTION
Fixes #2996

This updates the css for `survey-task-chooser-choice-button>*` so survey task buttons look the same on firefox as other browsers.

Staged at: https://fix-2996.pfe-preview.zooniverse.org/

Note: I have not tested this on Edge.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
