### PR TITLE
Don't scroll for links to document fragments

### DIFF
--- a/app/main.cjsx
+++ b/app/main.cjsx
@@ -15,7 +15,9 @@ browserHistory.listen ->
 # make sure project stats page does not scroll back to the top when the URL changes
 shouldUpdateScroll = (prevRouterProps, routerProps) ->
   pathname = routerProps.location.pathname.split('/')
-  if ('stats' in pathname) and ('projects' in pathname)
+  isStats = ('stats' in pathname) and ('projects' in pathname)
+  hashChange = routerProps.location.hash.length
+  if isStats or hashChange
     false
   else
     true


### PR DESCRIPTION
Should fix markdown footnote links, discussed here on Talk: https://www.zooniverse.org/talk/18/87732?comment=164609&page=1
and tested here: https://www.zooniverse.org/talk/13/18624?comment=164558&page=2

Describe your changes.
Turns off scroll-to-top if the hash changed in the window location.

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://fragment-links.pfe-preview.zooniverse.org

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
