### PR TITLE
Refactor workflow selection

### DIFF
--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -24,6 +24,13 @@ Classifier = React.createClass
   contextTypes:
     geordi: React.PropTypes.object
 
+  propTypes:
+    user: React.PropTypes.object
+    workflow: React.PropTypes.object
+    subject: React.PropTypes.object
+    classification: React.PropTypes.object
+    onLoad: React.PropTypes.func
+
   getDefaultProps: ->
     user: null
     workflow: null
@@ -44,7 +51,7 @@ Classifier = React.createClass
   componentWillReceiveProps: (nextProps) ->
     if nextProps.project isnt @props.project or nextProps.user isnt @props.user
       {workflow, project, user, preferences} = nextProps
-      Tutorial.startIfNecessary {workflow, user, preferences}
+      Tutorial.startIfNecessary {workflow, user, preferences} if preferences?
     if nextProps.subject isnt @props.subject
       @loadSubject subject
     if nextProps.classification isnt @props.classification
@@ -395,16 +402,25 @@ Classifier = React.createClass
 module.exports = React.createClass
   displayName: 'ClassifierWrapper'
 
+  propTypes:
+    classification: React.PropTypes.object
+    onLoad: React.PropTypes.func
+    onComplete: React.PropTypes.func
+    onCompleteAndLoadAnotherSubject: React.PropTypes.func
+    onClickNext: React.PropTypes.func
+    workflow: React.PropTypes.object
+    user: React.PropTypes.object
+
   getDefaultProps: ->
-    user: null
     classification: {}
     onLoad: Function.prototype
     onComplete: Function.prototype
     onCompleteAndLoadAnotherSubject: Function.prototype
     onClickNext: Function.prototype
+    workflow: null
+    user: null
 
   getInitialState: ->
-    workflow: null
     subject: null
     expertClassifier: null
     userRoles: []
@@ -422,14 +438,9 @@ module.exports = React.createClass
       @loadClassification nextProps.classification
 
   loadClassification: (classification) ->
-    @setState
-      workflow: null
-      subject: null
+    @setState subject: null
 
     # TODO: These underscored references are temporary stopgaps.
-
-    Promise.resolve(classification._workflow ? classification.get 'workflow').then (workflow) =>
-      @setState {workflow}
 
     Promise.resolve(classification._subjects ? classification.get 'subjects').then ([subject]) =>
       # We'll only handle one subject per classification right now.
@@ -454,9 +465,9 @@ module.exports = React.createClass
         @setState {expertClassifier, userRoles}
 
   render: ->
-    if @state.workflow? and @state.subject?
+    if @props.workflow? and @state.subject?
       <Classifier {...@props}
-        workflow={@state.workflow}
+        workflow={@props.workflow}
         subject={@state.subject}
         expertClassifier={@state.expertClassifier}
         userRoles={@state.userRoles} />

--- a/app/components/subject-viewer.cjsx
+++ b/app/components/subject-viewer.cjsx
@@ -45,6 +45,7 @@ module.exports = React.createClass
     allowSeparateFrames: false
     metadataPrefixes: ['#', '!']
     metadataFilters: ['#', '!']
+    workflow: null
 
   getInitialState: ->
     loading: true

--- a/app/components/workflow-assignment-dialog.jsx
+++ b/app/components/workflow-assignment-dialog.jsx
@@ -13,9 +13,8 @@ const WorkflowAssignmentDialog = React.createClass({
     },
 
     handleNewWorkflowAssignment(history, location, preferences) {
-      history.push({
-        pathname: location.pathname,
-        query: { workflow: preferences.settings.workflow_id },
+      preferences.update({
+        'preferences.selected_workflow': preferences.settings.workflow_id,
       });
     },
   },

--- a/app/components/workflow-assignment-dialog.jsx
+++ b/app/components/workflow-assignment-dialog.jsx
@@ -4,17 +4,10 @@ import ReactDOM from 'react-dom';
 
 const WorkflowAssignmentDialog = React.createClass({
   statics: {
-    start(history, location, preferences) {
+    start() {
       return Dialog.alert(<WorkflowAssignmentDialog />, {
         className: 'workflow-assignment-dialog',
         closeButton: true,
-        onSubmit: this.handleNewWorkflowAssignment.bind(null, history, location, preferences),
-      });
-    },
-
-    handleNewWorkflowAssignment(history, location, preferences) {
-      preferences.update({
-        'preferences.selected_workflow': preferences.settings.workflow_id,
       });
     },
   },

--- a/app/pages/project/classify.cjsx
+++ b/app/pages/project/classify.cjsx
@@ -97,14 +97,12 @@ module.exports = React.createClass
         currentClassifications.forWorkflow[@props.selectedWorkflow?.id] = null
         @setState { classification: null }
         @loadAppropriateClassification(nextProps)
-    console.log('nextProps.loadingSelectedWorkflow', nextProps.loadingSelectedWorkflow)
     @shouldWorkflowAssignmentPrompt(nextProps.preferences) unless nextProps.loadingSelectedWorkflow
 
   shouldWorkflowAssignmentPrompt: (preferences) ->
     # Only for Gravity Spy which is assigning workflows to logged in users
     if @props.project.experimental_tools.indexOf('workflow assignment') > -1 and @props.user?
       assignedWorkflowID = preferences?.settings?.workflow_id
-      console.log('should?', assignedWorkflowID? and @props.selectedWorkflow? and assignedWorkflowID isnt @props.selectedWorkflow?.id)
       if assignedWorkflowID? and @props.selectedWorkflow? and assignedWorkflowID isnt @props.selectedWorkflow?.id
         @setState promptWorkflowAssignmentDialog: true if @state.promptWorkflowAssignmentDialog is false
 
@@ -317,7 +315,7 @@ module.exports = React.createClass
     if @state.promptWorkflowAssignmentDialog
       WorkflowAssignmentDialog.start()
         .then =>
-          @setState({ promptWorkflowAssignmentDialog: false }, console.log('setting state to false', @state.promptWorkflowAssignmentDialog))
+          @setState { promptWorkflowAssignmentDialog: false }
         .then =>
           if props.preferences.selected_workflow isnt props.preferences.settings.workflow_id
             props.preferences.update

--- a/app/pages/project/classify.cjsx
+++ b/app/pages/project/classify.cjsx
@@ -128,18 +128,6 @@ module.exports = React.createClass
       currentWorkflowForProject[props.project.id] ?= @getRandomWorkflow props.project
       currentWorkflowForProject[props.project.id]
 
-  getRandomWorkflow: (project) ->
-    getWorkflowsInOrder(project, {active: true, fields: 'finished_at'}).then (workflows) =>
-      if workflows.length is 0
-        throw new Error "No workflows for project #{project.id}"
-        project.uncacheLink 'workflows'
-      else
-        projectIsComplete = (true for workflow in workflows when not workflow.finished_at?).length is 0
-        @setState {projectIsComplete}
-        randomIndex = Math.floor Math.random() * workflows.length
-        # console.log 'Chose random workflow', workflows[randomIndex].id
-        @getWorkflow project, workflows[randomIndex].id
-
   createNewClassification: (project, workflow) ->
     @setState {workflow}
     # A subject set is only specified if the workflow is grouped.

--- a/app/pages/project/classify.cjsx
+++ b/app/pages/project/classify.cjsx
@@ -261,12 +261,10 @@ module.exports = React.createClass
           console?.log 'Demo mode: Did NOT save classification'
         else
           console?.log 'Saved classification', classification.id
-          Promise.all([
-            classification.get 'workflow'
-            classification.get 'subjects'
-          ]).then ([workflow, subjects]) ->
-            seenThisSession.add workflow, subjects
-            classification.destroy()
+          classification.get('subjects')
+            .then (subjects) =>
+              seenThisSession.add @props.workflow, subjects
+              classification.destroy()
         @saveAllQueuedClassifications()
       .catch (error) =>
         console?.warn 'Failed to save classification:', error

--- a/app/pages/project/home.cjsx
+++ b/app/pages/project/home.cjsx
@@ -11,33 +11,12 @@ module.exports = React.createClass
   contextTypes:
     geordi: React.PropTypes.object
 
-  getInitialState: ->
-    workflows: []
-
   getDefaultProps: ->
+    activeWorkflows: []
     owner: {}
     project: {}
     selectedWorkflow: null
     user: null
-
-  componentDidMount: -> 
-    @getWorkflows(@props.project)
-
-  componentWillReceiveProps: (nextProps) ->
-    if nextProps.project isnt @props.project
-      @getWorkflows(nextProps.project)
-
-  getWorkflows: (project) ->
-    # TODO: Build this kind of caching into json-api-client
-    if project._workflows?
-      @setState workflows: project._workflows
-    else
-      workflows = getWorkflowsInOrder project, {active: true, fields: 'display_name,configuration'}
-
-      workflows.then (workflows) =>
-        project._workflows = workflows
-
-        @setState workflows: project._workflows
 
   handleWorkflowSelection: (workflow) ->
     @props.onChangePreferences 'preferences.selected_workflow', workflow?.id
@@ -60,10 +39,10 @@ module.exports = React.createClass
         # For Gravity Spy
         else if @props.project.experimental_tools.indexOf('workflow assignment') isnt -1
           if @props.user?
-            currentWorkflowAtLevel = @state.workflows?.filter (workflow) =>
+            currentWorkflowAtLevel = @props.activeWorkflows?.filter (workflow) =>
               workflow if workflow.id is @props.preferences?.settings.workflow_id
             currentLevel = if currentWorkflowAtLevel.length > 0 then currentWorkflowAtLevel[0].configuration.level else 1
-            @state.workflows?.map (workflow) =>
+            @props.activeWorkflows?.map (workflow) =>
               if workflow.configuration.level <= currentLevel and workflow.configuration.level?
                 <Link
                   to={"/projects/#{@props.project.slug}/classify"}
@@ -78,7 +57,7 @@ module.exports = React.createClass
               Get started!
             </Link>
         else if @props.project.configuration?.user_chooses_workflow
-          @state.workflows.map (workflow) =>
+          @props.activeWorkflows.map (workflow) =>
             <Link
               to={"/projects/#{@props.project.slug}/classify"}
               key={workflow.id + Math.random()}

--- a/app/pages/project/home.cjsx
+++ b/app/pages/project/home.cjsx
@@ -15,7 +15,6 @@ module.exports = React.createClass
     activeWorkflows: []
     owner: {}
     project: {}
-    selectedWorkflow: null
     user: null
 
   handleWorkflowSelection: (workflow) ->

--- a/app/pages/project/home.cjsx
+++ b/app/pages/project/home.cjsx
@@ -67,7 +67,6 @@ module.exports = React.createClass
               if workflow.configuration.level <= currentLevel and workflow.configuration.level?
                 <Link
                   to={"/projects/#{@props.project.slug}/classify"}
-                  query={workflow: workflow.id}
                   key={workflow.id + Math.random()}
                   className="call-to-action standard-button"
                   onClick={@handleWorkflowSelection.bind this, workflow}
@@ -75,37 +74,19 @@ module.exports = React.createClass
                   {workflow.display_name}
                 </Link>
           else
-            if @props.selectedWorkflow?
-              <Link 
-                to={"/projects/#{@props.project.slug}/classify"}
-                query={workflow: @props.selectedWorkflow.id}
-                className="call-to-action standard-button"
-              >
-                Get started!
-              </Link>
-            else
-              <Link to={"/projects/#{@props.project.slug}/classify"} className="call-to-action standard-button">
-                Get started!
-              </Link>
+            <Link to={"/projects/#{@props.project.slug}/classify"} className="call-to-action standard-button">
+              Get started!
+            </Link>
         else if @props.project.configuration?.user_chooses_workflow
           @state.workflows.map (workflow) =>
             <Link
               to={"/projects/#{@props.project.slug}/classify"}
-              query={workflow: workflow.id}
               key={workflow.id + Math.random()}
               className="call-to-action standard-button"
               onClick={@handleWorkflowSelection.bind this, workflow}
             >
               {workflow.display_name}
             </Link>
-        else if @props.selectedWorkflow?
-          <Link 
-            to={"/projects/#{@props.project.slug}/classify"}
-            query={workflow: @props.selectedWorkflow.id}
-            className="call-to-action standard-button"
-          >
-            Get started!
-          </Link>
         else
           <Link to={"/projects/#{@props.project.slug}/classify"} className="call-to-action standard-button">
             Get started!

--- a/app/pages/project/index.cjsx
+++ b/app/pages/project/index.cjsx
@@ -82,14 +82,11 @@ ProjectPage = React.createClass
     # Only call to get workflow if we know if there is a user or not, have preferences, and the project is finished loading
     if nextContext.initialLoadComplete and not nextProps.loading and nextProps.preferences
       if @state.selectedWorkflow is null
-        console.log('selectedWorkflow is null')
         @getSelectedWorkflow(nextProps.project, nextProps.preferences)
       else if nextProps.preferences?.preferences.selected_workflow? and @state.selectedWorkflow? 
         if nextProps.preferences?.preferences.selected_workflow isnt @state.selectedWorkflow.id
-          console.log('selected workflow exists but doesnt match current state workflow', nextProps.preferences?.preferences.selected_workflow, @state.selectedWorkflow?.id)
           @getSelectedWorkflow(nextProps.project, nextProps.preferences)
       else if @props.user isnt nextProps.user
-        console.log('next user isnt user')
         @getSelectedWorkflow(nextProps.project, nextProps.preferences)
 
   fetchInfo: (project) ->
@@ -140,7 +137,6 @@ ProjectPage = React.createClass
       preferredWorkflowID = @selectRandomWorkflow(project)
 
     if preferredWorkflowID?
-      console.log('getting selected workflow', preferredWorkflowID)
       @getWorkflow(project, preferredWorkflowID)
     else
       @setState selectedWorkflow: null
@@ -148,7 +144,6 @@ ProjectPage = React.createClass
   checkIfProjectIsComplete: (project) ->
     projectIsComplete = (true for workflow in @state.activeWorkflows when not workflow.finished_at?).length is 0
     @setState { projectIsComplete }
-    console.log('checked if project is complete', @state.projectIsComplete)
 
   selectRandomWorkflow: (project) ->
     linkedWorkflows = project.links.workflows
@@ -158,7 +153,7 @@ ProjectPage = React.createClass
       project.uncacheLink 'workflows'
     else
       randomIndex = Math.floor Math.random() * @state.activeWorkflows.length
-      console.log 'Chose random workflow', linkedWorkflows[randomIndex]
+      # console.log 'Chose random workflow', linkedWorkflows[randomIndex]
       linkedWorkflows[randomIndex]
 
   getWorkflow: (project, workflowID) ->


### PR DESCRIPTION
This is a refactor on how the workflows are selected and fetched for projects. The goal is to reduce the number of API calls for workflows since now it is no longer fetched after every classification. This also moves the code into the index file of the project (`ProjectPageController` and `ProjectPage` components) which I think will get us one step closer to eventually refactoring to use a store or observables based framework (Redux, Rx.js, and/or MobX). In addition, this necessitated a refactor on some of the code I wrote for the workflow promotion for Gravity Spy.

The workflow selection will now be consistent whether a user is logged in or not, navigates directly to a project's `/classify` page, navigates from a project's talk, or uses the button(s) available on the project home page.

Projects to test with:

Gravity Spy's workflow promotion: 
https://refactor-workflow-selection.pfe-preview.zooniverse.org/projects/zooniverse/gravity-spy?env=production
Their promotion algorithm is now working, so you should get promoted using the beginner workflow relatively quickly. There is a known issue where the dialog pops up twice. This PR does not fix this and I'll submit a separate PR for it.

A project that is finished, since that is part of the code that got moved with the workflow selection:
https://refactor-workflow-selection.pfe-preview.zooniverse.org/projects/jukoch/pattern-perception?env=production

A project that allows users to choose which workflow to work on:
https://refactor-workflow-selection.pfe-preview.zooniverse.org/projects/mschwamb/comet-hunters?env=production

A project that uses random workflow selection:
https://refactor-workflow-selection.pfe-preview.zooniverse.org/projects/mschwamb/planet-four-terrains?env=production

Sometimes the workflow is fetched a couple of times when you first visit the project since I think some further refactoring could be done with the `componentWillReceiveProps` moment in the controller's component lifecycle, however, I added several conditionals to hopefully reduce this as much as possible, by checking if the project has finished loaded, if we know if there's a user or not, and if the preferences have finished loading. 

I'm hoping to get this merged sometime early next week for the Gravity Spy beta, but it's not essential. Since this touches an important part of the classifier, I'd like a couple of people to review if you have the time. Feel free to reassign if not.

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?