### PR TITLE
Move image flipper pips to relative positioning below image

### DIFF
--- a/app/classifier/tasks/survey/choice.cjsx
+++ b/app/classifier/tasks/survey/choice.cjsx
@@ -23,14 +23,14 @@ ImageFlipper = React.createClass
     <span className="survey-task-image-flipper">
       {@renderPreload()}
       <img src={@props.images[@state.frame]} className="survey-task-image-flipper-image" />
-      <span className="survey-task-image-flipper-pips">
+      <div className="survey-task-image-flipper-pips">
         {unless @props.images.length is 1
           for index in [0...@props.images.length]
             <span key={@props.images[index]}>
               <button type="button" className="survey-task-image-flipper-pip" disabled={index is @state.frame} onClick={@handleFrameChange.bind this, index}>{index + 1}</button>
               {' '}
             </span>}
-      </span>
+      </div>
     </span>
 
   renderPreload: ->

--- a/css/survey-task.styl
+++ b/css/survey-task.styl
@@ -191,11 +191,12 @@ $survey-task-pill-button
   width: 100%
 
 .survey-task-image-flipper-pips
-  bottom: 2px
+  bottom: -20px
   left: 50%
   line-height: 1
   position: absolute
   transform: translateX(-50%)
+  z-index: 1
 
 .survey-task-image-flipper-pip
   @extends $reset-button

--- a/css/survey-task.styl
+++ b/css/survey-task.styl
@@ -191,12 +191,9 @@ $survey-task-pill-button
   width: 100%
 
 .survey-task-image-flipper-pips
-  bottom: -20px
-  left: 50%
-  line-height: 1
-  position: absolute
-  transform: translateX(-50%)
-  z-index: 1
+  margin: 2px 0
+  position: relative
+  text-align: center
 
 .survey-task-image-flipper-pip
   @extends $reset-button


### PR DESCRIPTION
Fixes #2999.

Fixes the CSS for the image flipper pips since position on top of the image was hiding the x-axis info in the image for Gravity Spy.

https://fix-2999.pfe-preview.zooniverse.org/projects?env=production

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile? Yeah on mobile safari on iOS 9.
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
