### PR TITLE
Swap out History mixin in collections

### DIFF
--- a/app/collections/settings.cjsx
+++ b/app/collections/settings.cjsx
@@ -64,7 +64,7 @@ module.exports = React.createClass
     @props.collection.stopListening 'delete'
 
   redirect: ->
-    @context.router.push(null, "/collections")
+    @context.router.push '/collections'
 
   confirmDelete: ->
     alert (resolve) =>

--- a/app/collections/settings.cjsx
+++ b/app/collections/settings.cjsx
@@ -1,5 +1,4 @@
 React = require 'react'
-{History} = require 'react-router'
 DisplayNameSlugEditor = require '../partials/display-name-slug-editor'
 alert = require '../lib/alert'
 SetToggle = require '../lib/set-toggle'
@@ -44,8 +43,11 @@ CollectionDeleteDialog = React.createClass
 
 module.exports = React.createClass
   displayName: "CollectionSettings"
-  mixins: [History, SetToggle, CollectionRole]
+  mixins: [SetToggle, CollectionRole]
   setterProperty: 'collection'
+
+  contextTypes:
+    router: React.PropTypes.object.isRequired
 
   getDefaultProps: ->
     collection: null
@@ -62,7 +64,7 @@ module.exports = React.createClass
     @props.collection.stopListening 'delete'
 
   redirect: ->
-    @history.pushState(null, "/collections")
+    @context.router.push(null, "/collections")
 
   confirmDelete: ->
     alert (resolve) =>

--- a/app/collections/show-list.cjsx
+++ b/app/collections/show-list.cjsx
@@ -43,7 +43,7 @@ module.exports = React.createClass
     nextQuery = Object.assign {}, @props.location.query, { page }
     currentPath = @props.location.pathname
 
-    @context.router.push(null, @context.router.createHref(currentPath, nextQuery))
+    @context.router.push @context.router.createHref(currentPath, nextQuery)
 
   handleDeleteSubject: (subject) ->
     @props.collection.removeLink 'subjects', [subject.id.toString()]

--- a/app/collections/show-list.cjsx
+++ b/app/collections/show-list.cjsx
@@ -7,7 +7,7 @@ Paginator = require '../talk/lib/paginator'
 PromiseRenderer = require '../components/promise-renderer'
 SubjectViewer = require '../components/subject-viewer'
 Loading = require '../components/loading-indicator'
-{Link, History} = require 'react-router'
+{Link} = require 'react-router'
 
 VALID_COLLECTION_MEMBER_SUBJECTS_PARAMS = ['page', 'page_size']
 
@@ -18,10 +18,10 @@ counterpart.registerTranslations 'en',
 
 module.exports = React.createClass
   displayName: 'CollectionShowList'
-  mixins: [History]
 
   contextTypes:
-    geordi: React.PropTypes.object
+    geordi: React.PropTypes.object.isRequired
+    router: React.PropTypes.object.isRequired
 
   componentDidMount: ->
     @fetchCollectionSubjects pick @props.location.query, VALID_COLLECTION_MEMBER_SUBJECTS_PARAMS
@@ -43,7 +43,7 @@ module.exports = React.createClass
     nextQuery = Object.assign {}, @props.location.query, { page }
     currentPath = @props.location.pathname
 
-    @history.pushState(null, @history.createHref(currentPath, nextQuery))
+    @context.router.push(null, @context.router.createHref(currentPath, nextQuery))
 
   handleDeleteSubject: (subject) ->
     @props.collection.removeLink 'subjects', [subject.id.toString()]


### PR DESCRIPTION
As the History mixin is deprecated as of `react-router` 2, I'm replacing it with `context.router` throughout. To keep the PRs small and easily testable, I'm creating them by area of function; this is for collections.

Related: #2705