### PR TITLE
Swap out History mixin in Talk

### DIFF
--- a/app/talk/board.cjsx
+++ b/app/talk/board.cjsx
@@ -1,6 +1,6 @@
 React = require 'react'
 ReactDOM = require 'react-dom'
-{Link, History} = require 'react-router'
+{Link} = require 'react-router'
 DiscussionPreview = require './discussion-preview'
 talkClient = require 'panoptes-client/lib/talk-client'
 FollowBoard = require './follow-board'
@@ -25,10 +25,10 @@ PAGE_SIZE = talkConfig.boardPageSize
 
 module.exports = React.createClass
   displayName: 'TalkBoard'
-  mixins: [History]
 
   contextTypes:
     geordi: React.PropTypes.object
+    router: React.PropTypes.object.isRequired
 
   getInitialState: ->
     discussions: []
@@ -90,11 +90,11 @@ module.exports = React.createClass
       if @state.board.section is 'zooniverse'
         @boardRequest().delete()
           .then =>
-            @history.pushState(null, "/talk")
+            @context.router.push(null, "/talk")
       else
         @boardRequest().delete()
           .then =>
-            @history.pushState(null, "/projects/#{owner}/#{name}/talk")
+            @context.router.push(null, "/projects/#{owner}/#{name}/talk")
 
   onEditBoard: (e) ->
     e.preventDefault()

--- a/app/talk/board.cjsx
+++ b/app/talk/board.cjsx
@@ -90,11 +90,11 @@ module.exports = React.createClass
       if @state.board.section is 'zooniverse'
         @boardRequest().delete()
           .then =>
-            @context.router.push(null, "/talk")
+            @context.router.push '/talk'
       else
         @boardRequest().delete()
           .then =>
-            @context.router.push(null, "/projects/#{owner}/#{name}/talk")
+            @context.router.push "/projects/#{owner}/#{name}/talk"
 
   onEditBoard: (e) ->
     e.preventDefault()

--- a/app/talk/breadcrumbs.cjsx
+++ b/app/talk/breadcrumbs.cjsx
@@ -11,7 +11,7 @@ module.exports = React.createClass
 
   crumbCatch: (e) ->
     if e.message.indexOf('not allowed to show') isnt -1
-      @context.router.replace(null, "/talk/not-found")
+      @context.router.replace '/talk/not-found'
 
   boardLink: (board) ->
     <Link to="#{@rootTalkPath()}/#{board.id}">

--- a/app/talk/breadcrumbs.cjsx
+++ b/app/talk/breadcrumbs.cjsx
@@ -6,9 +6,12 @@ PromiseRenderer = require '../components/promise-renderer'
 module.exports = React.createClass
   displayName: 'TalkBreadcrumbs'
 
+  contextTypes:
+    router: React.PropTypes.object.isRequired
+
   crumbCatch: (e) ->
     if e.message.indexOf('not allowed to show') isnt -1
-      @history.replaceState(null, "/talk/not-found")
+      @context.router.replace(null, "/talk/not-found")
 
   boardLink: (board) ->
     <Link to="#{@rootTalkPath()}/#{board.id}">

--- a/app/talk/discussion.cjsx
+++ b/app/talk/discussion.cjsx
@@ -4,7 +4,6 @@ Comment = require './comment'
 CommentBox = require './comment-box'
 commentValidations = require './lib/comment-validations'
 {getErrors} = require './lib/validations'
-{History} = require 'react-router'
 talkClient = require 'panoptes-client/lib/talk-client'
 Paginator = require './lib/paginator'
 PromiseRenderer = require '../components/promise-renderer'
@@ -27,7 +26,9 @@ PAGE_SIZE = talkConfig.discussionPageSize
 
 module.exports = React.createClass
   displayName: 'TalkDiscussion'
-  mixins: [History]
+
+  contextTypes:
+    router: React.PropTypes.object.isRequired
 
   getInitialState: ->
     comments: []
@@ -64,7 +65,7 @@ module.exports = React.createClass
 
         if page isnt @props.location.query.page
           @props.location.query.page = page
-          @history.replaceState(null, @props.location.pathname, @props.location.query)
+          @context.router.replace(null, @props.location.pathname, @props.location.query)
 
       @setComments(@props.location.query.page ? 1)
 
@@ -84,9 +85,9 @@ module.exports = React.createClass
         else
           {board, owner, name} = @props.params
           if (owner and name)
-            @history.pushState(null, "/projects/#{owner}/#{name}/talk/#{board}")
+            @context.router.push(null, "/projects/#{owner}/#{name}/talk/#{board}")
           else
-            @history.pushState(null, "/talk/#{board}")
+            @context.router.push(null, "/talk/#{board}")
 
   setCommentsMeta: (page = @props.location.query?.page) ->
     @commentsRequest(page).then (comments) =>
@@ -186,9 +187,9 @@ module.exports = React.createClass
           @setComments(@props.location.query.page)
           {owner, name} = @props.params
           if (owner and name)
-            @history.pushState(null, "/projects/#{owner}/#{name}/talk")
+            @context.router.push(null, "/projects/#{owner}/#{name}/talk")
           else
-            @history.pushState(null, "/talk")
+            @context.router.push(null, "/talk")
 
   commentValidations: (commentBody) ->
     # TODO: return true if any additional validations fail
@@ -212,9 +213,9 @@ module.exports = React.createClass
           {owner, name} = @props.params
 
           if (owner and name)
-            @history.pushState(null, "/projects/#{owner}/#{name}/talk/#{board_id}/#{}", @props.location.query)
+            @context.router.push(null, "/projects/#{owner}/#{name}/talk/#{board_id}/#{}", @props.location.query)
           else
-            @history.pushState(null, "/talk/#{board_id}/", @props.location.query)
+            @context.router.push(null, "/talk/#{board_id}/", @props.location.query)
         else
           @setDiscussion()
 

--- a/app/talk/discussion.cjsx
+++ b/app/talk/discussion.cjsx
@@ -65,7 +65,9 @@ module.exports = React.createClass
 
         if page isnt @props.location.query.page
           @props.location.query.page = page
-          @context.router.replace(null, @props.location.pathname, @props.location.query)
+          @context.router.replace
+            pathname: @props.location.pathname
+            query: @props.location.query
 
       @setComments(@props.location.query.page ? 1)
 
@@ -85,9 +87,9 @@ module.exports = React.createClass
         else
           {board, owner, name} = @props.params
           if (owner and name)
-            @context.router.push(null, "/projects/#{owner}/#{name}/talk/#{board}")
+            @context.router.push "/projects/#{owner}/#{name}/talk/#{board}"
           else
-            @context.router.push(null, "/talk/#{board}")
+            @context.router.push "/talk/#{board}"
 
   setCommentsMeta: (page = @props.location.query?.page) ->
     @commentsRequest(page).then (comments) =>
@@ -187,9 +189,9 @@ module.exports = React.createClass
           @setComments(@props.location.query.page)
           {owner, name} = @props.params
           if (owner and name)
-            @context.router.push(null, "/projects/#{owner}/#{name}/talk")
+            @context.router.push "/projects/#{owner}/#{name}/talk"
           else
-            @context.router.push(null, "/talk")
+            @context.router.push "/talk"
 
   commentValidations: (commentBody) ->
     # TODO: return true if any additional validations fail
@@ -213,9 +215,13 @@ module.exports = React.createClass
           {owner, name} = @props.params
 
           if (owner and name)
-            @context.router.push(null, "/projects/#{owner}/#{name}/talk/#{board_id}/#{}", @props.location.query)
+            @context.router.push
+              pathname: "/projects/#{owner}/#{name}/talk/#{board_id}/#{}"
+              query: @props.location.query
           else
-            @context.router.push(null, "/talk/#{board_id}/", @props.location.query)
+            @context.router.push
+              pathname: "/talk/#{board_id}/"
+              query: @props.location.query
         else
           @setDiscussion()
 

--- a/app/talk/inbox-conversation.cjsx
+++ b/app/talk/inbox-conversation.cjsx
@@ -6,12 +6,15 @@ SingleSubmitButton = require '../components/single-submit-button'
 HandlePropChanges = require '../lib/handle-prop-changes'
 {Markdown} = (require 'markdownz').default
 CommentBox = require './comment-box'
-{Link, History} = require 'react-router'
+{Link} = require 'react-router'
 {timestamp} = require './lib/time'
 
 module.exports = React.createClass
   displayName: 'InboxConversation'
-  mixins: [HandlePropChanges, History]
+  mixins: [HandlePropChanges]
+
+  contextTypes:
+    router: React.PropTypes.object.isRequired
 
   getInitialState: ->
     messages: []
@@ -72,7 +75,7 @@ module.exports = React.createClass
     e.preventDefault()
     if confirm 'Are you sure you want to archive this conversation?'
       @state.conversation.delete().then =>
-        @history.pushState(null, '/inbox')
+        @context.router.push(null, '/inbox')
 
   render: ->
     if @props.user

--- a/app/talk/inbox-conversation.cjsx
+++ b/app/talk/inbox-conversation.cjsx
@@ -75,7 +75,7 @@ module.exports = React.createClass
     e.preventDefault()
     if confirm 'Are you sure you want to archive this conversation?'
       @state.conversation.delete().then =>
-        @context.router.push(null, '/inbox')
+        @context.router.push '/inbox'
 
   render: ->
     if @props.user

--- a/app/talk/inbox-form.cjsx
+++ b/app/talk/inbox-form.cjsx
@@ -49,7 +49,7 @@ module.exports = React.createClass
 
     talkClient.type('conversations').create(conversation).save()
       .then (conversation) =>
-        @context.router.push(null, "/inbox/#{conversation.id}")
+        @context.router.push "/inbox/#{conversation.id}"
 
   render: ->
     <div className="inbox-form talk-module">

--- a/app/talk/inbox-form.cjsx
+++ b/app/talk/inbox-form.cjsx
@@ -2,7 +2,6 @@ React = require 'react'
 ReactDOM = require 'react-dom'
 talkClient = require 'panoptes-client/lib/talk-client'
 UserSearch = require '../components/user-search'
-{History} = require 'react-router'
 {getErrors} = require './lib/validations'
 subjectValidations = require './lib/message-subject-validations'
 messageValidations = require './lib/message-validations'
@@ -10,13 +9,13 @@ CommentBox = require './comment-box'
 
 module.exports = React.createClass
   displayName: 'InboxForm'
-  mixins: [History]
 
   propTypes:
     user: React.PropTypes.object
 
   contextTypes:
     geordi: React.PropTypes.object
+    router: React.PropTypes.object.isRequired
 
   getInitialState: ->
     validationErrors: []
@@ -50,7 +49,7 @@ module.exports = React.createClass
 
     talkClient.type('conversations').create(conversation).save()
       .then (conversation) =>
-        @history.pushState(null, "/inbox/#{conversation.id}")
+        @context.router.push(null, "/inbox/#{conversation.id}")
 
   render: ->
     <div className="inbox-form talk-module">

--- a/app/talk/inbox.cjsx
+++ b/app/talk/inbox.cjsx
@@ -42,7 +42,7 @@ module.exports = React.createClass
     @goToPage(page)
 
   goToPage: (n) ->
-    @context.router.push(null, "/inbox?page=#{n}")
+    @context.router.push "/inbox?page=#{n}"
     @setConversations(n)
 
   message: (data, i) ->

--- a/app/talk/inbox.cjsx
+++ b/app/talk/inbox.cjsx
@@ -3,7 +3,7 @@ talkClient = require 'panoptes-client/lib/talk-client'
 apiClient = require 'panoptes-client/lib/api-client'
 PromiseRenderer = require '../components/promise-renderer'
 Paginator = require './lib/paginator'
-{Link, History} = require 'react-router'
+{Link} = require 'react-router'
 Loading = require '../components/loading-indicator'
 InboxForm = require './inbox-form'
 talkConfig = require './config'
@@ -17,7 +17,9 @@ promptToSignIn = -> alert (resolve) -> <SignInPrompt onChoose={resolve} />
 
 module.exports = React.createClass
   displayName: 'TalkInbox'
-  mixins: [History]
+
+  contextTypes:
+    router: React.PropTypes.object.isRequired
 
   getDefaultProps: ->
     location: query: page: 1
@@ -40,7 +42,7 @@ module.exports = React.createClass
     @goToPage(page)
 
   goToPage: (n) ->
-    @history.pushState(null, "/inbox?page=#{n}")
+    @context.router.push(null, "/inbox?page=#{n}")
     @setConversations(n)
 
   message: (data, i) ->

--- a/app/talk/latest-comment-link.cjsx
+++ b/app/talk/latest-comment-link.cjsx
@@ -21,6 +21,9 @@ module.exports = React.createClass
     discussion: React.PropTypes.object
     title: React.PropTypes.bool
     preview: React.PropTypes.bool
+
+  contextTypes:
+    geordi: React.PropTypes.object
     router: React.PropTypes.object.isRequired
 
   getDefaultProps: ->
@@ -31,9 +34,6 @@ module.exports = React.createClass
     commentUser: null
     latestCommentText: ''
     roles: []
-
-  contextTypes:
-    geordi: React.PropTypes.object
 
   logProfileClick: (profileItem) ->
     @context.geordi?.logEvent

--- a/app/talk/latest-comment-link.cjsx
+++ b/app/talk/latest-comment-link.cjsx
@@ -4,7 +4,7 @@ talkClient = require 'panoptes-client/lib/talk-client'
 {timeAgo} = require './lib/time'
 DisplayRoles = require './lib/display-roles'
 Avatar = require '../partials/avatar'
-{Link, History} = require 'react-router'
+{Link} = require 'react-router'
 {Markdown} = (require 'markdownz').default
 
 PAGE_SIZE = require('./config').discussionPageSize
@@ -15,13 +15,13 @@ truncate = (string = '', ending = '', length = 80) ->
 
 module.exports = React.createClass
   displayName: 'TalkLatestCommentComment'
-  mixins: [History]
 
   propTypes:
     project: React.PropTypes.object
     discussion: React.PropTypes.object
     title: React.PropTypes.bool
     preview: React.PropTypes.bool
+    router: React.PropTypes.object.isRequired
 
   getDefaultProps: ->
     title: false
@@ -51,7 +51,7 @@ module.exports = React.createClass
     @updateRoles comment
     apiClient.type('users').get(comment.user_id).then (commentUser) =>
       @setState {commentUser}
-  
+
   componentWillReceiveProps: (newProps) ->
     oldComment = @props.comment or @props.discussion?.latest_comment
     comment = newProps.comment or newProps.discussion?.latest_comment
@@ -69,11 +69,11 @@ module.exports = React.createClass
       logClick = @context.geordi?.makeHandler? 'discussion-time'
     if @props.params?.owner and @props.params?.name
       {owner, name} = @props.params
-      <Link className={className} onClick={logClick?.bind(this, childtext)} to={@history.createHref("/projects/#{owner}/#{name}/talk/#{@props.discussion.board_id}/#{@props.discussion.id}", query)}>
+      <Link className={className} onClick={logClick?.bind(this, childtext)} to={@context.router.createHref("/projects/#{owner}/#{name}/talk/#{@props.discussion.board_id}/#{@props.discussion.id}", query)}>
         {childtext}
       </Link>
     else
-      <Link className={className} onClick={logClick?.bind(this, childtext)} to={@history.createHref("/talk/#{@props.discussion.board_id}/#{@props.discussion.id}", query)}>
+      <Link className={className} onClick={logClick?.bind(this, childtext)} to={@context.router.createHref("/talk/#{@props.discussion.board_id}/#{@props.discussion.id}", query)}>
         {childtext}
       </Link>
 

--- a/app/talk/latest-comment-link.cjsx
+++ b/app/talk/latest-comment-link.cjsx
@@ -14,7 +14,7 @@ truncate = (string = '', ending = '', length = 80) ->
   string.trim().slice(0, (length - ending.length)) + ending
 
 module.exports = React.createClass
-  displayName: 'TalkLatestCommentComment'
+  displayName: 'TalkLatestCommentLink'
 
   propTypes:
     project: React.PropTypes.object

--- a/app/talk/lib/paginator.cjsx
+++ b/app/talk/lib/paginator.cjsx
@@ -1,5 +1,4 @@
 React = require 'react'
-{History} = require 'react-router'
 updateQueryParams = require './update-query-params'
 
 module.exports = React.createClass
@@ -13,23 +12,22 @@ module.exports = React.createClass
     pageSelector: React.PropTypes.bool            # show page selector?
     pageKey: React.PropTypes.string               # optional name for key param (defaults to 'page')
 
+  contextTypes:
+    geordi: React.PropTypes.object
+    router: React.PropTypes.object.isRequired
+
   getDefaultProps: ->
     page: 1
     pageKey: 'page'
     onPageChange: (page) ->
       queryChange = { }
       queryChange[@props.pageKey] = page
-      updateQueryParams @history, queryChange
+      updateQueryParams @context.router, queryChange
     firstAndLast: true
     pageSelector: true
     previousLabel: <span><i className="fa fa-long-arrow-left" /> Previous</span>
     nextLabel: <span>Next <i className="fa fa-long-arrow-right" /></span>
 
-  mixins: [History]
-
-  contextTypes:
-    geordi: React.PropTypes.object
-  
   componentDidMount: ->
     @logClick = @context.geordi?.makeHandler 'change-page'
 

--- a/app/talk/lib/update-query-params.coffee
+++ b/app/talk/lib/update-query-params.coffee
@@ -11,4 +11,4 @@ parseQuery = ->
 module.exports = (reactHistory, queryChange) ->
   nextQuery = Object.assign { }, parseQuery(), queryChange
   nextHref = reactHistory.createHref window.location.pathname, nextQuery
-  reactHistory.pushState null, nextHref
+  reactHistory.push null, nextHref

--- a/app/talk/lib/update-query-params.coffee
+++ b/app/talk/lib/update-query-params.coffee
@@ -11,4 +11,4 @@ parseQuery = ->
 module.exports = (reactHistory, queryChange) ->
   nextQuery = Object.assign { }, parseQuery(), queryChange
   nextHref = reactHistory.createHref window.location.pathname, nextQuery
-  reactHistory.push null, nextHref
+  reactHistory.push nextHref

--- a/app/talk/moderations.cjsx
+++ b/app/talk/moderations.cjsx
@@ -4,13 +4,14 @@ auth = require 'panoptes-client/lib/auth'
 Paginator = require './lib/paginator'
 Loading = require '../components/loading-indicator'
 page_size = require('./config').moderationsPageSize
-{History} = require 'react-router'
 updateQueryParams = require './lib/update-query-params'
 ModerationComment = require './moderation/comment'
 
 module.exports = React.createClass
   displayName: 'TalkModerations'
-  mixins: [History]
+
+  contextTypes:
+    router: React.PropTypes.object.isRequired
 
   getInitialState: ->
     moderations: []
@@ -53,7 +54,7 @@ module.exports = React.createClass
       @setModerations()
 
   filterByAction: (action) ->
-    updateQueryParams @history, state: action
+    updateQueryParams @context.router, state: action
 
   nameOf: (action) ->
     switch action

--- a/app/talk/private-message-form.cjsx
+++ b/app/talk/private-message-form.cjsx
@@ -32,7 +32,7 @@ module.exports = React.createClass
       .then (conversation) =>
         talkClient.type('conversations').create(conversation).save()
           .then (conversation) =>
-            @context.router.push(null, "/inbox/#{conversation.id}")
+            @context.router.push "/inbox/#{conversation.id}"
 
   render: ->
     <div className="talk talk-module">

--- a/app/talk/private-message-form.cjsx
+++ b/app/talk/private-message-form.cjsx
@@ -2,15 +2,14 @@ React = require 'react'
 ReactDOM = require 'react-dom'
 apiClient = require 'panoptes-client/lib/api-client'
 talkClient = require 'panoptes-client/lib/talk-client'
-{History} = require 'react-router'
 CommentBox = require './comment-box'
 
 module.exports = React.createClass
   displayName: 'PrivateMessageForm'
-  mixins: [History]
 
   contextTypes:
     geordi: React.PropTypes.object
+    router: React.PropTypes.object.isRequired
 
   logClick: ->
     @context?.geordi?.logEvent
@@ -33,7 +32,7 @@ module.exports = React.createClass
       .then (conversation) =>
         talkClient.type('conversations').create(conversation).save()
           .then (conversation) =>
-            @history.pushState(null, "/inbox/#{conversation.id}")
+            @context.router.push(null, "/inbox/#{conversation.id}")
 
   render: ->
     <div className="talk talk-module">

--- a/app/talk/quick-subject-comment-form.cjsx
+++ b/app/talk/quick-subject-comment-form.cjsx
@@ -3,7 +3,6 @@ CommentBox = require './comment-box'
 talkClient = require 'panoptes-client/lib/talk-client'
 apiClient = require 'panoptes-client/lib/api-client'
 projectSection = require './lib/project-section'
-{State, History} = require 'react-router'
 merge = require 'lodash.merge'
 {getErrors} = require './lib/validations'
 commentValidations = require './lib/comment-validations'
@@ -19,11 +18,13 @@ PAGE_SIZE = talkConfig.discussionPageSize
 
 module.exports = React.createClass
   displayName: 'TalkQuickSubjectCommentForm'
-  mixins: [State, History]
 
   propTypes:
     subject: React.PropTypes.object
     user: React.PropTypes.object
+
+  contextTypes:
+    router: React.PropTypes.object.isRequired
 
   getInitialState: ->
     commentValidationErrors: []
@@ -59,7 +60,7 @@ module.exports = React.createClass
 
                     talkClient.type('comments').create(comment).save()
                       .then (comment) =>
-                        @history.pushState(null, "/projects/#{owner}/#{name}/talk/#{discussion.board_id}/#{discussion.id}?comment=#{comment.id}")
+                        @context.router.push(null, "/projects/#{owner}/#{name}/talk/#{discussion.board_id}/#{discussion.id}?comment=#{comment.id}")
                   else
                     focus_id = +@props.subject?.id
                     focus_type = 'Subject' if !!focus_id
@@ -77,7 +78,7 @@ module.exports = React.createClass
                       }
                     talkClient.type('discussions').create(discussion).save()
                       .then (discussion) =>
-                        @history.pushState(null, "/projects/#{owner}/#{name}/talk/#{discussion.board_id}/#{discussion.id}")
+                        @context.router.push(null, "/projects/#{owner}/#{name}/talk/#{discussion.board_id}/#{discussion.id}")
 
             else
               throw new Error("A board for subject comments has not been setup for this project yet.")

--- a/app/talk/quick-subject-comment-form.cjsx
+++ b/app/talk/quick-subject-comment-form.cjsx
@@ -60,7 +60,7 @@ module.exports = React.createClass
 
                     talkClient.type('comments').create(comment).save()
                       .then (comment) =>
-                        @context.router.push(null, "/projects/#{owner}/#{name}/talk/#{discussion.board_id}/#{discussion.id}?comment=#{comment.id}")
+                        @context.router.push "/projects/#{owner}/#{name}/talk/#{discussion.board_id}/#{discussion.id}?comment=#{comment.id}"
                   else
                     focus_id = +@props.subject?.id
                     focus_type = 'Subject' if !!focus_id
@@ -78,7 +78,7 @@ module.exports = React.createClass
                       }
                     talkClient.type('discussions').create(discussion).save()
                       .then (discussion) =>
-                        @context.router.push(null, "/projects/#{owner}/#{name}/talk/#{discussion.board_id}/#{discussion.id}")
+                        @context.router.push "/projects/#{owner}/#{name}/talk/#{discussion.board_id}/#{discussion.id}"
 
             else
               throw new Error("A board for subject comments has not been setup for this project yet.")

--- a/app/talk/recents.cjsx
+++ b/app/talk/recents.cjsx
@@ -1,6 +1,6 @@
 React = require 'react'
 Comment = require './comment'
-{Link, History} = require 'react-router'
+{Link} = require 'react-router'
 talkClient = require 'panoptes-client/lib/talk-client'
 Paginator = require './lib/paginator'
 updateQueryParams = require './lib/update-query-params'
@@ -9,7 +9,9 @@ talkConfig = require './config'
 
 module.exports = React.createClass
   displayName: 'TalkRecents'
-  mixins: [History]
+
+  contextTypes:
+    router: React.PropTypes.object.isRequired
 
   getInitialState: ->
     comments: []
@@ -58,7 +60,7 @@ module.exports = React.createClass
 
   toggleNotes: ->
     # Always reset to first page when toggling
-    updateQueryParams @history, showNotes: @refs.showNotes.checked, page: 1
+    updateQueryParams @context.router, showNotes: @refs.showNotes.checked, page: 1
     @getComments()
 
   commentTitle: (comment) ->

--- a/app/talk/search-input.cjsx
+++ b/app/talk/search-input.cjsx
@@ -1,9 +1,7 @@
 React = require 'react'
-{History} = require 'react-router'
 
 module.exports = React.createClass
   displayName: 'TalkSearchInput'
-  mixins: [History]
 
   propTypes:
     params: React.PropTypes.object
@@ -12,6 +10,7 @@ module.exports = React.createClass
 
   contextTypes:
     geordi: React.PropTypes.object
+    router: React.PropTypes.object.isRequired
 
   logSearch: (value) ->
     @context?.geordi?.logEvent
@@ -26,11 +25,11 @@ module.exports = React.createClass
 
     if owner and name
       if inputValue.match(/\#[-\w\d]{3,40}/) # searches for #hashtags
-        @history.pushState(null, "/projects/#{owner}/#{name}/talk/tags/#{inputValue.slice(1, inputValue.length)}")
+        @context.router.push(null, "/projects/#{owner}/#{name}/talk/tags/#{inputValue.slice(1, inputValue.length)}")
       else
-        @history.pushState(null, "/projects/#{owner}/#{name}/talk/search", {query: inputValue})
+        @context.router.push(null, "/projects/#{owner}/#{name}/talk/search", {query: inputValue})
     else
-      @history.pushState(null, "/talk/search", {query: inputValue})
+      @context.router.push(null, "/talk/search", {query: inputValue})
 
   componentWillReceiveProps: (nextProps) ->
     return unless @refs.talkSearchInput

--- a/app/talk/search-input.cjsx
+++ b/app/talk/search-input.cjsx
@@ -25,11 +25,15 @@ module.exports = React.createClass
 
     if owner and name
       if inputValue.match(/\#[-\w\d]{3,40}/) # searches for #hashtags
-        @context.router.push(null, "/projects/#{owner}/#{name}/talk/tags/#{inputValue.slice(1, inputValue.length)}")
+        @context.router.push "/projects/#{owner}/#{name}/talk/tags/#{inputValue.slice(1, inputValue.length)}"
       else
-        @context.router.push(null, "/projects/#{owner}/#{name}/talk/search", {query: inputValue})
+        @context.router.push
+          pathname: "/projects/#{owner}/#{name}/talk/search"
+          query: {query: inputValue}
     else
-      @context.router.push(null, "/talk/search", {query: inputValue})
+      @context.router.push
+        pathname: "/talk/search"
+        query: {query: inputValue}
 
   componentWillReceiveProps: (nextProps) ->
     return unless @refs.talkSearchInput

--- a/app/talk/search.cjsx
+++ b/app/talk/search.cjsx
@@ -1,5 +1,4 @@
 React = require 'react'
-{History} = require 'react-router'
 talkClient = require 'panoptes-client/lib/talk-client'
 Paginator = require './lib/paginator'
 TalkSearchResult = require './search-result'
@@ -23,13 +22,13 @@ filterObjectKeys = (object, validKeys) ->
 
 module.exports = React.createClass
   displayName: 'TalkSearch'
-  mixins: [History]
 
   contextTypes:
     geordi: React.PropTypes.object
+    router: React.PropTypes.object.isRequired
 
   goBack: (linkName) ->
-    @history.goBack()
+    @context.router.goBack()
     @context.geordi?.logEvent
       type: linkName
 
@@ -75,7 +74,7 @@ module.exports = React.createClass
   goToPage: (n) ->
     nextQuery = Object.assign {}, @props.location.query, {page: n}
 
-    @history.pushState(null, location.pathname, nextQuery)
+    @context.router.push(null, location.pathname, nextQuery)
 
   render: ->
     numberOfResults = @state.results.length

--- a/app/talk/search.cjsx
+++ b/app/talk/search.cjsx
@@ -74,7 +74,9 @@ module.exports = React.createClass
   goToPage: (n) ->
     nextQuery = Object.assign {}, @props.location.query, {page: n}
 
-    @context.router.push(null, location.pathname, nextQuery)
+    @context.router.push
+      pathname: location.pathname
+      query: nextQuery
 
   render: ->
     numberOfResults = @state.results.length

--- a/app/talk/tags.cjsx
+++ b/app/talk/tags.cjsx
@@ -1,5 +1,5 @@
 React = require 'react'
-{Link, History} = require 'react-router'
+{Link} = require 'react-router'
 talkClient = require 'panoptes-client/lib/talk-client'
 apiClient = require 'panoptes-client/lib/api-client'
 Paginator = require './lib/paginator'
@@ -13,7 +13,9 @@ ProjectLinker = require './lib/project-linker'
 
 module.exports = React.createClass
   displayName: 'TalkTags'
-  mixins: [History]
+
+  contextTypes:
+    router: React.PropTypes.object.isRequired
 
   getInitialState: ->
     tags: null
@@ -49,7 +51,7 @@ module.exports = React.createClass
     <div className="talk-search">
       <h1>Subjects tagged with #{@props.params.tag}</h1>
 
-      <button className="link-style" type="button" onClick={@history.goBack}>
+      <button className="link-style" type="button" onClick={@context.router.goBack}>
         <i className="fa fa-backward" /> Back
       </button>
 


### PR DESCRIPTION
Swap out the History mixin for `context.router` in Talk.

Related to #3018 