### PR TITLE
Use History.push for internal links in Talk comments

### DIFF
--- a/app/components/wrapped-markdown.jsx
+++ b/app/components/wrapped-markdown.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import markdownz from 'markdownz';
+import { browserHistory } from 'react-router';
+const Markdown = markdownz.Markdown;
+
+const WrappedMarkdown = React.createClass({
+  propTypes: {
+    content: React.PropTypes.string,
+    project: React.PropTypes.object,
+    header: React.PropTypes.string,
+  },
+
+  onClick(e) {
+    if (e.target.origin === window.location.origin) {
+      const newURL = e.target.pathname + e.target.search + e.target.hash;
+      browserHistory.push(newURL);
+      e.preventDefault();
+    }
+  },
+
+  render() {
+    return (
+      <div onClick={this.onClick}>
+        <Markdown
+          content={this.props.content}
+          project={this.props.project}
+          header={this.props.header}
+        />
+      </div>
+    );
+  },
+});
+
+export default WrappedMarkdown;

--- a/app/talk/comment.cjsx
+++ b/app/talk/comment.cjsx
@@ -18,7 +18,7 @@ SubjectViewer = require '../components/subject-viewer'
 SingleSubmitButton = require '../components/single-submit-button'
 DisplayRoles = require './lib/display-roles'
 CommentContextIcon = require './lib/comment-context-icon'
-{Markdown} = (require 'markdownz').default
+`import WrappedMarkdown from '../components/wrapped-markdown';`
 DEFAULT_AVATAR = '/assets/simple-avatar.jpg'
 
 module.exports = React.createClass
@@ -142,7 +142,7 @@ module.exports = React.createClass
           </span>
           }
       </p>
-      <Markdown project={@props.project} content={comment.body} />
+      <WrappedMarkdown project={@props.project} content={comment.body} />
     </div>
 
   # Render the focus if the comment has a focus AND
@@ -231,7 +231,7 @@ module.exports = React.createClass
                 catch={null}
                 />}
 
-            <Markdown content={@props.data.body} project={@props.project} header={null}/>
+            <WrappedMarkdown content={@props.data.body} project={@props.project} header={null}/>
 
             {if @props.linked
               <div style={textAlign: "right"}>


### PR DESCRIPTION
Fixes #2798 (finally?) and should address angry comments  complaining that the site randomly zooms in and out when following links from Talk subjects.

Describe your changes.
Wraps Markdown in a listener that overrides default link behaviour for internal links.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://fix-talk-comment-links.pfe-preview.zooniverse.org/

## Optional

- [x] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?