### PR TITLE
Removed note about testAnnotationQuality

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,6 @@ Each component also needs a few static methods:
 
 - `isAnnotationComplete`: Given a task and an annotation, this determines whether or not the classifier will allow the user to move on to the next task.
 
-- `testAnnotationQuality`: Given the user's annotation and a known-good "gold standard" annotation for the same task, this returns a number between 0 (totally wrong) and 1 (totally correct) indicating how close the user's annotation is to the standard.
-
 #### Task editors
 
 Make sure you call `this.props.onChange` with the updated task when it changes.


### PR DESCRIPTION
I missed this in the PR for removing the gold standard classifications importer. The `testAnnotationQuality` function depended on gold standard classifications being loaded and as written won't work with that feature removed. At a later date, it may be of interest to look through the commit history and do a rewrite of these using gold standard subject metadata compared to a volunteer's classification instead. In the meantime, the readme shouldn't have a reference to it.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
