### PR TITLE
Fix for gs typo

### DIFF
--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -300,11 +300,19 @@ Classifier = React.createClass
         choiceLabels.push @props.workflow.tasks[annotation.task].choices[value.choice].label
     match = choiceLabels.every (label) => label is @props.subject.metadata['#Label']
 
+    # Temp fix for typos in subject metadata
+    label = @props.subject.metadata['#Label']
+    if @props.subject.links.subject_sets.indexOf('5984') > -1 # Issue in Subject Set 5984
+      if @props.subject.metadata['#Label'] is 'Low Frequency Lines'
+        label = 'Low Frequency Line'
+      else if @props.subject.metadata['#Label'] is 'Air Compressor'
+        label = 'Air Compressor (50 Hz)'
+
     <div>
     {if match
       <div>
         <p>Good work!</p>
-        <p>When our experts classified this image,<br />they also thought it was a {@props.subject.metadata['#Label']}!</p>
+        <p>When our experts classified this image,<br />they also thought it was a {label}!</p>
         {if choiceLabels.length > 1
           <p>You should only assign 1 label.</p>}
       </div>
@@ -313,7 +321,7 @@ Classifier = React.createClass
         <p>You responded {choiceLabels.join(', ')}.</p>
         {if choiceLabels.length > 1
           <p>You should only assign 1 label.</p>}
-        <p>When our experts classified this image,<br />they labeled it as a {@props.subject.metadata['#Label']}.</p>
+        <p>When our experts classified this image,<br />they labeled it as a {label}.</p>
         <p>Some of the glitch classes can look quite similar,<br />so please keep trying your best.</p>
         <p>Check out the tutorial and the field guide for more guidance.</p>
       </div>}

--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -293,26 +293,29 @@ Classifier = React.createClass
           </p>}
     </TriggeredModalForm>
 
+  # Temp fix for typos in subject metadata
+  checkGravitySpyGoldStandardLabel: (label) ->
+    if @props.subject.metadata['#Label'] is 'Low Frequency Lines'
+      'Low Frequency Line'
+    else if @props.subject.metadata['#Label'] is 'Air Compressor'
+      'Air Compressor (50 Hz)'
+    else
+      @props.subject.metadata['#Label']
+
   renderGravitySpyGoldStandard: (classification) ->
     choiceLabels = []
+    metadataLabel = @checkGravitySpyGoldStandardLabel(@props.subject.metadata['#Label'])
+
     for annotation in classification.annotations when @props.workflow.tasks[annotation.task].type is 'survey'
       for value in annotation.value
         choiceLabels.push @props.workflow.tasks[annotation.task].choices[value.choice].label
-    match = choiceLabels.every (label) => label is @props.subject.metadata['#Label']
-
-    # Temp fix for typos in subject metadata
-    label = @props.subject.metadata['#Label']
-    if @props.subject.links.subject_sets.indexOf('5984') > -1 # Issue in Subject Set 5984
-      if @props.subject.metadata['#Label'] is 'Low Frequency Lines'
-        label = 'Low Frequency Line'
-      else if @props.subject.metadata['#Label'] is 'Air Compressor'
-        label = 'Air Compressor (50 Hz)'
+    match = choiceLabels.every (label) => label is metadataLabel
 
     <div>
     {if match
       <div>
         <p>Good work!</p>
-        <p>When our experts classified this image,<br />they also thought it was a {label}!</p>
+        <p>When our experts classified this image,<br />they also thought it was a {metadataLabel}!</p>
         {if choiceLabels.length > 1
           <p>You should only assign 1 label.</p>}
       </div>
@@ -321,7 +324,7 @@ Classifier = React.createClass
         <p>You responded {choiceLabels.join(', ')}.</p>
         {if choiceLabels.length > 1
           <p>You should only assign 1 label.</p>}
-        <p>When our experts classified this image,<br />they labeled it as a {label}.</p>
+        <p>When our experts classified this image,<br />they labeled it as a {metadataLabel}.</p>
         <p>Some of the glitch classes can look quite similar,<br />so please keep trying your best.</p>
         <p>Check out the tutorial and the field guide for more guidance.</p>
       </div>}


### PR DESCRIPTION
Fixes typos in label metadata. This can be fixed in the back end, but in the meantime, this will check the label for known typos. With the incorrect labels, volunteers are being shown the 'incorrect' gold standard summary page in error. These labels apply to the level 4 workflow, fyi.

Staged at https://fix-for-gs-typo.pfe-preview.zooniverse.org/projects/zooniverse/gravity-spy/classify

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
