### PR TITLE
Remove History mixin from pages

### DIFF
--- a/app/pages/admin/project-status-list.cjsx
+++ b/app/pages/admin/project-status-list.cjsx
@@ -3,12 +3,10 @@ PromiseRenderer = require '../../components/promise-renderer'
 apiClient = require 'panoptes-client/lib/api-client'
 Paginator = require '../../talk/lib/paginator'
 ProjectIcon = require '../../components/project-icon'
-{History, Link} = require 'react-router'
+{Link} = require 'react-router'
 
 module.exports = React.createClass
   displayName: "ProjectStatusPage"
-
-  mixins: [History]
 
   getProjects: ->
     query =

--- a/app/pages/lab/project.cjsx
+++ b/app/pages/lab/project.cjsx
@@ -1,5 +1,5 @@
 React = require 'react'
-{History, Link, IndexLink} = require 'react-router'
+{Link, IndexLink} = require 'react-router'
 PromiseRenderer = require '../../components/promise-renderer'
 LoadingIndicator = require '../../components/loading-indicator'
 TitleMixin = require '../../lib/title-mixin'
@@ -18,7 +18,10 @@ DELETE_CONFIRMATION_PHRASE = 'I AM DELETING THIS PROJECT'
 EditProjectPage = React.createClass
   displayName: 'EditProjectPage'
 
-  mixins: [TitleMixin, History]
+  mixins: [TitleMixin]
+
+  contextTypes:
+    router: React.PropTypes.object.isRequired
 
   title: ->
     @props.project.display_name
@@ -186,7 +189,7 @@ EditProjectPage = React.createClass
   handleWorkflowCreation: (workflow) ->
     @hideCreateWorkflow()
     newLocation = Object.assign {}, @props.location, pathname: "/lab/#{@props.project.id}/workflow/#{workflow.id}"
-    @props.history.push newLocation
+    @context.router.push newLocation
     @props.project.uncacheLink 'workflows'
     @props.project.uncacheLink 'subject_sets' # An "expert" subject set is automatically created with each workflow.
 
@@ -202,7 +205,7 @@ EditProjectPage = React.createClass
 
     subjectSet.save()
       .then =>
-        @history.pushState(null, "/lab/#{@props.project.id}/subject-set/#{subjectSet.id}")
+        @context.router.push "/lab/#{@props.project.id}/subject-set/#{subjectSet.id}"
       .catch (error) =>
         @setState subjectSetCreationError: error
       .then =>
@@ -223,7 +226,7 @@ EditProjectPage = React.createClass
 
       this.props.project.delete()
         .then =>
-          @history.pushState(null, "/lab")
+          @context.router.push '/lab'
         .catch (error) =>
           @setState deletionError: error
         .then =>
@@ -232,12 +235,12 @@ EditProjectPage = React.createClass
 
 module.exports = React.createClass
   displayName: 'EditProjectPageWrapper'
-  mixins: [TitleMixin, History]
+  mixins: [TitleMixin]
   title: 'Edit'
 
   componentWillReceiveProps: (nextProps) ->
     unless nextProps.user
-      @history.pushState(null, "/lab")
+      @context.router.push '/lab'
 
   getDefaultProps: ->
     params:

--- a/app/pages/lab/project.cjsx
+++ b/app/pages/lab/project.cjsx
@@ -238,6 +238,9 @@ module.exports = React.createClass
   mixins: [TitleMixin]
   title: 'Edit'
 
+  contextTypes:
+    router: React.PropTypes.object.isRequired
+
   componentWillReceiveProps: (nextProps) ->
     unless nextProps.user
       @context.router.push '/lab'

--- a/app/pages/lab/subject-set.cjsx
+++ b/app/pages/lab/subject-set.cjsx
@@ -5,7 +5,6 @@ PromiseRenderer = require '../../components/promise-renderer'
 apiClient = require 'panoptes-client/lib/api-client'
 ChangeListener = require '../../components/change-listener'
 Papa = require 'papaparse'
-{History} = require 'react-router'
 alert = require '../../lib/alert'
 SubjectViewer = require '../../components/subject-viewer'
 SubjectUploader = require '../../partials/subject-uploader'
@@ -113,7 +112,8 @@ SubjectSetListing = React.createClass
 EditSubjectSetPage = React.createClass
   displayName: 'EditSubjectSetPage'
 
-  mixins: [History]
+  contextTypes:
+    router: React.PropTypes.object.isRequired
 
   getDefaultProps: ->
     subjectSet: null
@@ -164,7 +164,7 @@ EditSubjectSetPage = React.createClass
           <strong>Drag-and-drop or click to upload manifests and subject images here.</strong><br />
           Manifests must be <code>.csv</code> or <code>.tsv</code>. The first row should define metadata headers. All other rows should include at least one reference to an image filename in the same directory as the manifest.<br />
           Headers that begin with "#" or "//" denote private fields that will not be visible to classifiers in the main classification interface or in the Talk discussion tool.<br />
-          Headers that begin with "!" denote fields that <strong>will not</strong> be visible to classifiers in the main classification interface but <strong>will be </strong> visible after classification in the Talk discussion tool.<br /> 
+          Headers that begin with "!" denote fields that <strong>will not</strong> be visible to classifiers in the main classification interface but <strong>will be </strong> visible after classification in the Talk discussion tool.<br />
           Subject images can be up to {MAX_FILE_SIZE / 1024}KB and any of: {<span key={ext}><code>{ext}</code>{', ' if VALID_SUBJECT_EXTENSIONS[i + 1]?}</span> for ext, i in VALID_SUBJECT_EXTENSIONS}{' '}
           and may not contain {<span key={char}><kbd>{char}</kbd>{', ' if INVALID_FILENAME_CHARS[i + 1]?}</span> for char, i in INVALID_FILENAME_CHARS}<br />
         </UploadDropTarget>
@@ -318,7 +318,7 @@ EditSubjectSetPage = React.createClass
         .then =>
           announceSetChange()
           @props.project.uncacheLink 'subject_sets'
-          @history.pushState(null, "/lab/#{@props.project.id}")
+          @context.router.push "/lab/#{@props.project.id}"
         .catch (error) =>
           @setState deletionError: error
         .then =>

--- a/app/pages/lab/workflow-viewer/index.cjsx
+++ b/app/pages/lab/workflow-viewer/index.cjsx
@@ -3,12 +3,15 @@ apiClient = require 'panoptes-client/lib/api-client'
 PromiseRenderer = require '../../../components/promise-renderer'
 ChangeListener = require '../../../components/change-listener'
 WorkflowNodes = require './workflow'
-{History, Navigation} = require 'react-router'
+{Navigation} = require 'react-router'
 
 WorkflowVis = React.createClass
   displayName: 'WorkflowVis'
 
-  mixins: [History, Navigation]
+  mixins: [Navigation]
+
+  contextTypes:
+    router: React.PropTypes.object.isRequired
 
   getInitialState: ->
     # make a new jsPlumb instance each time component is mounted
@@ -20,7 +23,7 @@ WorkflowVis = React.createClass
   workflowLink: ->
     [owner, name] = @props.project.slug.split('/')
     viewQuery = workflow: @props.workflow.id, reload: 0
-    @history.createHref("/projects/#{owner}/#{name}/classify", viewQuery)
+    @context.router.createHref "/projects/#{owner}/#{name}/classify", viewQuery
 
   render: ->
     <div>

--- a/app/pages/lab/workflow.cjsx
+++ b/app/pages/lab/workflow.cjsx
@@ -6,7 +6,7 @@ ModalFormDialog = require 'modal-form/dialog'
 apiClient = require 'panoptes-client/lib/api-client'
 ChangeListener = require '../../components/change-listener'
 RetirementRulesEditor = require '../../components/retirement-rules-editor'
-{History, Link} = require 'react-router'
+{Link} = require 'react-router'
 MultiImageSubjectOptionsEditor = require '../../components/multi-image-subject-options-editor'
 tasks = require '../../classifier/tasks'
 AutoSave = require '../../components/auto-save'
@@ -22,7 +22,8 @@ else
 EditWorkflowPage = React.createClass
   displayName: 'EditWorkflowPage'
 
-  mixins: [History]
+  contextTypes:
+    router: React.PropTypes.object.isRequired
 
   getDefaultProps: ->
     workflow: null
@@ -38,7 +39,7 @@ EditWorkflowPage = React.createClass
   workflowLink: ->
     [owner, name] = @props.project.slug.split('/')
     viewQuery = workflow: @props.workflow.id, reload: @state.forceReloader
-    @history.createHref("/projects/#{owner}/#{name}/classify", viewQuery)
+    @context.router.createHref "/projects/#{owner}/#{name}/classify", viewQuery
 
   showCreateWorkflow: ->
     @setState workflowCreationInProgress: true
@@ -49,7 +50,7 @@ EditWorkflowPage = React.createClass
   handleWorkflowCreation: (workflow) ->
     @hideCreateWorkflow()
     newLocation = Object.assign {}, @props.location, pathname: "/lab/#{@props.project.id}/workflow/#{workflow.id}"
-    @props.history.push newLocation
+    @context.router.push newLocation
     @props.project.uncacheLink 'workflows'
     @props.project.uncacheLink 'subject_sets' # An "expert" subject set is automatically created with each workflow.
 
@@ -561,7 +562,7 @@ EditWorkflowPage = React.createClass
 
       @props.workflow.delete().then =>
         @props.project.uncacheLink 'workflows'
-        @history.pushState(null, "/lab/#{@props.project.id}")
+        @context.router "/lab/#{@props.project.id}"
       .catch (error) =>
         @setState deletionError: error
       .then =>

--- a/app/pages/project/stats/index.cjsx
+++ b/app/pages/project/stats/index.cjsx
@@ -1,12 +1,14 @@
 React = require 'react'
-{History} = require 'react-router'
 PromiseToSetState = require '../../../lib/promise-to-set-state'
 qs = require 'qs'
 ProjectStatsPage = require './stats'
 getWorkflowsInOrder = require '../../../lib/get-workflows-in-order'
 
 ProjectStatsPageController = React.createClass
-  mixins: [History, PromiseToSetState]
+  mixins: [PromiseToSetState]
+
+  contextTypes:
+    router: React.PropTypes.object.isRequired
 
   getInitialState: ->
     workflowList: []
@@ -21,7 +23,9 @@ ProjectStatsPageController = React.createClass
     query[which] = e.target.value
     query["#{which}Range"] = undefined
     {owner, name} = @props.params
-    @history.replaceState(null, "/projects/#{owner}/#{name}/stats/", query)
+    @context.router.replace
+      pathname: "/projects/#{owner}/#{name}/stats/"
+      query: query
 
   handleWorkflowChange: (which, e) ->
     query = qs.parse location.search.slice 1
@@ -32,13 +36,17 @@ ProjectStatsPageController = React.createClass
       query['workflow_id'] = undefined
     query["#{which}Range"] = undefined
     {owner, name} = @props.params
-    @history.replaceState(null, "/projects/#{owner}/#{name}/stats/", query)
+    @context.router.replace
+      pathname: "/projects/#{owner}/#{name}/stats/"
+      query: query
 
   handleRangeChange: (which, range) ->
     query = qs.parse location.search.slice 1
     query["#{which}Range"] = range
     {owner, name} = @props.params
-    @history.replaceState(null, "/projects/#{owner}/#{name}/stats/", query)
+    @context.router.replace
+      pathname: "/projects/#{owner}/#{name}/stats/"
+      query: query
 
   getQuery: (which) ->
     qs.parse(location.search.slice(1))[which]


### PR DESCRIPTION
Removes the History mixin from all page components and swaps in `context.router`

Related: #3018, #3020 