### PR TITLE
add allow workflow query admin option

### DIFF
--- a/app/pages/admin/project-status.cjsx
+++ b/app/pages/admin/project-status.cjsx
@@ -26,6 +26,7 @@ EXPERIMENTAL_FEATURES = [
   'invert'
   'workflow assignment'
   'Gravity Spy Gold Standard'
+  'allow workflow query'
 ]
 
 ProjectToggle = React.createClass

--- a/app/pages/project/index.cjsx
+++ b/app/pages/project/index.cjsx
@@ -132,7 +132,9 @@ ProjectPage = React.createClass
   getSelectedWorkflow: (project, preferences) ->
     # preference user selected workflow, then project owner set workflow, then default workflow
     # if none of those are set, select random workflow
-    if preferences?.preferences.selected_workflow?
+    if @props.location.query?.workflow? and 'allow workflow query' in @props.project.experimental_tools
+      preferredWorkflowID = @props.location.query.workflow
+    else if preferences?.preferences.selected_workflow?
       preferredWorkflowID = preferences?.preferences.selected_workflow
     else if preferences?.settings?.workflow_id?
       preferredWorkflowID = preferences?.settings.workflow_id

--- a/app/pages/project/index.cjsx
+++ b/app/pages/project/index.cjsx
@@ -134,6 +134,8 @@ ProjectPage = React.createClass
     # if none of those are set, select random workflow
     if @props.location.query?.workflow? and 'allow workflow query' in @props.project.experimental_tools
       preferredWorkflowID = @props.location.query.workflow
+      unless preferences?.preferences.selected_workflow is preferredWorkflowID
+        @props.onChangePreferences 'preferences.selected_workflow', preferredWorkflowID
     else if preferences?.preferences.selected_workflow?
       preferredWorkflowID = preferences?.preferences.selected_workflow
     else if preferences?.settings?.workflow_id?


### PR DESCRIPTION
- add "allow workflow query" option as experimental tool in project's admin page
- add conditional for setting workflow that if workflow query in url and experimental feature enabled, then set workflow to query

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? [Staged Branch](https://allow-workflow-query.pfe-preview.zooniverse.org/).

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
