### PR TITLE
increase z-index for metadata and subtask modal

### DIFF
--- a/css/modal-form.styl
+++ b/css/modal-form.styl
@@ -3,7 +3,7 @@
 
 .modal-form-underlay
   background: rgba(gray, 0.2)
-  z-index: 1
+  z-index: 10
 
 .modal-form-pointer
   background: white


### PR DESCRIPTION
Fixes #3006. The subject metadata modal and the subTask modal in the workflow editor were hidden behind other modals. 

Describe your changes.
I increased the z-index for the modals. 

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
