### PR TITLE
Fix min/max for drawing tools

### DIFF
--- a/app/classifier/tasks/drawing/min-max-editor.jsx
+++ b/app/classifier/tasks/drawing/min-max-editor.jsx
@@ -10,35 +10,49 @@ const MinMaxEditor = React.createClass({
 
   getInitialState() {
     return {
-      min: null,
-      max: null,
+      tool: null,
     };
   },
 
   componentWillMount() {
-    this.setState({ min: this.props.choice.min, max: this.props.choice.max });
+    this.setState({
+      tool: this.props.choice,
+    });
   },
 
   componentWillReceiveProps(newProps) {
-    this.setState({ min: newProps.choice.min, max: newProps.choice.max });
+    this.setState({
+      tool: newProps.choice,
+    });
   },
 
   onChangeMin(e) {
-    this.setState({ min: e.target.value });
-    this.updateWorkflow(e.target.name, e.target.value);
+    const tool = this.state.tool;
+    if (e.target.value) {
+      tool.min = e.target.value;
+    } else {
+      delete tool.min;
+    }
+    this.updateWorkflow(tool);
   },
 
   onChangeMax(e) {
-    const newMax = e.target.value && e.target.value < this.state.min ?
-      this.state.min :
+    const tool = this.state.tool;
+    const newMax = e.target.value && e.target.value < this.state.tool.min ?
+      this.state.tool.min :
       e.target.value;
-    this.setState({ max: newMax });
-    this.updateWorkflow(e.target.name, newMax);
+    if (newMax) {
+      tool.max = newMax;
+    } else {
+      delete tool.max;
+    }
+    this.updateWorkflow(tool);
   },
 
-  updateWorkflow(name, value) {
+  updateWorkflow(tool) {
     const changes = {};
-    changes[name] = value;
+    changes[this.props.name] = tool;
+    this.setState({ tool });
     this.props.workflow.update(changes);
   },
 
@@ -52,7 +66,7 @@ const MinMaxEditor = React.createClass({
             inputMode="numeric"
             name={`${this.props.name}.min`}
             min="0"
-            value={this.state.min}
+            value={this.state.tool.min}
             placeholder="0"
             size="5"
             style={{ width: '5ch' }}
@@ -65,8 +79,8 @@ const MinMaxEditor = React.createClass({
             type="number"
             inputMode="numeric"
             name={`${this.props.name}.max`}
-            min={this.state.min ? this.state.min : 0}
-            value={this.state.max}
+            min={this.state.tool.min ? this.state.tool.min : 0}
+            value={this.state.tool.max}
             placeholder="∞"
             size="5"
             style={{ width: '5ch' }}

--- a/app/classifier/tasks/drawing/min-max-editor.jsx
+++ b/app/classifier/tasks/drawing/min-max-editor.jsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import AutoSave from '../../../components/auto-save';
+
+const MinMaxEditor = React.createClass({
+  propTypes: {
+    name: React.PropTypes.string,
+    choice: React.PropTypes.object,
+    workflow: React.PropTypes.object,
+  },
+
+  getInitialState() {
+    return {
+      min: null,
+      max: null,
+    };
+  },
+
+  componentWillMount() {
+    this.setState({ min: this.props.choice.min, max: this.props.choice.max });
+  },
+
+  componentWillReceiveProps(newProps) {
+    this.setState({ min: newProps.choice.min, max: newProps.choice.max });
+  },
+
+  onChangeMin(e) {
+    this.setState({ min: e.target.value });
+    this.updateWorkflow(e.target.name, e.target.value);
+  },
+
+  onChangeMax(e) {
+    const newMax = e.target.value && e.target.value < this.state.min ?
+      this.state.min :
+      e.target.value;
+    this.setState({ max: newMax });
+    this.updateWorkflow(e.target.name, newMax);
+  },
+
+  updateWorkflow(name, value) {
+    const changes = {};
+    changes[name] = value;
+    this.props.workflow.update(changes);
+  },
+
+  render() {
+    return (
+      <div className="min-max-editor workflow-choice-setting">
+        <AutoSave resource={this.props.workflow}>
+          Min{' '}
+          <input
+            type="number"
+            inputMode="numeric"
+            name={`${this.props.name}.min`}
+            min="0"
+            value={this.state.min}
+            placeholder="0"
+            size="5"
+            style={{ width: '5ch' }}
+            onChange={this.onChangeMin}
+          />
+        </AutoSave>
+        <AutoSave resource={this.props.workflow}>
+          Max{' '}
+          <input
+            type="number"
+            inputMode="numeric"
+            name={`${this.props.name}.max`}
+            min={this.state.min ? this.state.min : 0}
+            value={this.state.max}
+            placeholder="∞"
+            size="5"
+            style={{ width: '5ch' }}
+            onChange={this.onChangeMax}
+          />
+        </AutoSave>
+      </div>
+    );
+  },
+});
+
+export default MinMaxEditor;

--- a/app/classifier/tasks/drawing/min-max-editor.jsx
+++ b/app/classifier/tasks/drawing/min-max-editor.jsx
@@ -33,6 +33,9 @@ const MinMaxEditor = React.createClass({
     } else {
       delete tool.min;
     }
+    if (tool.max && tool.max < tool.min) {
+      tool.max = tool.min;
+    }
     this.updateWorkflow(tool);
   },
 

--- a/app/classifier/tasks/generic-editor.cjsx
+++ b/app/classifier/tasks/generic-editor.cjsx
@@ -9,6 +9,8 @@ NextTaskSelector = require './next-task-selector'
 {MarkdownEditor} = (require 'markdownz').default
 MarkdownHelp = require '../../partials/markdown-help'
 
+`import MinMaxEditor from './drawing/min-max-editor';`
+
 module.exports = React.createClass
   displayName: 'GenericTaskEditor'
 
@@ -144,32 +146,13 @@ module.exports = React.createClass
                         </select>
                       </AutoSave>
                     </div>
-
-                    <div key="min-max" className="min-max-editor workflow-choice-setting">
-                      <AutoSave resource={@props.workflow}>
-                        Min{' '}
-                        <input type="number"
-                          name="#{@props.taskPrefix}.#{choicesKey}.#{index}.min"
-                          value={choice.min}
-                          placeholder="0"
-                          style={width: '3ch'}
-                          onBlur={handleChange}
-                          data-json-value={true}
-                         />
-                      </AutoSave>
-                      <AutoSave resource={@props.workflow}>
-                        Max{' '}
-                        <input
-                          type="number"
-                          name="#{@props.taskPrefix}.#{choicesKey}.#{index}.max"
-                          value={choice.max}
-                          placeholder="∞"
-                          style={width: '3ch'}
-                          onBlur={handleChange}
-                          data-json-value={true}
-                         />
-                      </AutoSave>
-                    </div>
+                    
+                    <MinMaxEditor
+                      key='min-max'
+                      workflow={@props.workflow}
+                      name="#{@props.taskPrefix}.#{choicesKey}.#{index}"
+                      choice={choice}
+                    />
                     
                     if 'size' in options
                       <div key="size" className="workflow-choice-setting">


### PR DESCRIPTION
Fixes #3014 .

Describe your changes.
Deletes max/min keys from a drawing tool when their value is an empty string.
Sets some sensible minimum values for min and max number of points.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://fix-min-max.pfe-preview.zooniverse.org/

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?