### PR TITLE
Adds a notification counter to application context

### DIFF
--- a/app/components/pass-context.cjsx
+++ b/app/components/pass-context.cjsx
@@ -7,12 +7,16 @@ module.exports = React.createClass
     router: routerShape
     user: React.PropTypes.object
     geordi: React.PropTypes.object
+    notificationsCounter: React.PropTypes.object
+    unreadNotificationsCount: React.PropTypes.number
 
   childContextTypes:
     initialLoadComplete: React.PropTypes.bool
     router: routerShape
     user: React.PropTypes.object
     geordi: React.PropTypes.object
+    notificationsCounter: React.PropTypes.object
+    unreadNotificationsCount: React.PropTypes.number
 
   getChildContext: ->
     @props.context

--- a/app/lib/notifications-counter.js
+++ b/app/lib/notifications-counter.js
@@ -28,7 +28,7 @@ class NotificationsCounter {
 
   setSection() {
     if(this.owner && this.name) {
-      let slug = `${this.owner}/${this.name}`;
+      const slug = `${this.owner}/${this.name}`;
 
       if(this.slug !== slug) {
         this.slug = slug;

--- a/app/lib/notifications-counter.js
+++ b/app/lib/notifications-counter.js
@@ -1,0 +1,83 @@
+import apiClient from 'panoptes-client/lib/api-client';
+import talkClient from 'panoptes-client/lib/talk-client';
+
+class NotificationsCounter {
+  constructor() {
+    this.callbacks = [];
+  }
+
+  update(user, owner, name) {
+    if(!user) {
+      return Promise.resolve(0);
+    }
+
+    if(this.loading) {
+      return;
+    }
+
+    this.loading = true;
+
+    this.owner = owner;
+    this.name = name;
+    this.setSection().then((section) => {
+      this.countUnread().then(() => {
+        this.loading = false;
+      });
+    });
+  }
+
+  setSection() {
+    if(this.owner && this.name) {
+      let slug = `${this.owner}/${this.name}`;
+
+      if(this.slug !== slug) {
+        this.slug = slug;
+        return this.getProject(slug).then((projects) => {
+          return this.section = `project-${projects[0].id}`;
+        });
+      } else {
+        return Promise.resolve(this.section);
+      }
+    } else {
+      this.owner = this.name = this.slug = this.section = null;
+      return Promise.resolve(null);
+    }
+  }
+
+  getProject(slug) {
+    return apiClient.type('projects').get({slug});
+  }
+
+  getNotifications() {
+    return talkClient.type('notifications').get({
+      delivered: false,
+      page_size: 1,
+      section: this.section
+    });
+  }
+
+  countUnread() {
+    return this.getNotifications().then((notifications) => {
+      try {
+        this.setUnread(notifications[0].getMeta().count);
+      } catch(e) {
+        this.setUnread(0);
+      }
+    });
+  }
+
+  setUnread(count) {
+    if(this.unreadCount !== count) {
+      this.unreadCount = count;
+      this.callbacks.map((callback) => {
+        callback(count);
+      });
+    }
+  }
+
+  listen(fn) {
+    this.callbacks.push(fn);
+  }
+}
+
+export default NotificationsCounter;

--- a/app/pages/notifications.cjsx
+++ b/app/pages/notifications.cjsx
@@ -8,6 +8,9 @@ Notification = require './notifications/notification'
 module.exports = React.createClass
   displayName: 'NotificationsPage'
 
+  contextTypes:
+    notificationsCounter: React.PropTypes.object
+
   propTypes:
     project: React.PropTypes.object
     user: React.PropTypes.object
@@ -83,6 +86,7 @@ module.exports = React.createClass
     for notification in @state.notifications
       notification.update delivered: true
     @setState unreadCount: 0
+    @context.notificationsCounter.setUnread 0
 
   title: ->
     if @props.project

--- a/app/partials/app.cjsx
+++ b/app/partials/app.cjsx
@@ -20,19 +20,21 @@ PanoptesApp = React.createClass
     initialLoadComplete: @state.initialLoadComplete
     user: @state.user
     geordi: @geordiLogger
-    notificationsCounter: @state.notificationsCounter
+    notificationsCounter: @props.notificationsCounter
     unreadNotificationsCount: @state.unreadNotificationsCount
 
   getInitialState: ->
     initialLoadComplete: false
     user: null
+
+  getDefaultProps: ->
     notificationsCounter: new NotificationsCounter()
 
   componentWillMount: ->
     @geordiLogger = new GeordiLogger
 
   componentDidMount: ->
-    @state.notificationsCounter.listen (unreadNotificationsCount) =>
+    @props.notificationsCounter.listen (unreadNotificationsCount) =>
       @setState {unreadNotificationsCount}
 
     auth.listen 'change', @handleAuthChange
@@ -58,7 +60,7 @@ PanoptesApp = React.createClass
     user or= @state.user
     params or= @props.params
     {owner, name} = params
-    @state.notificationsCounter.update(user, owner, name)
+    @props.notificationsCounter.update(user, owner, name)
 
   render: ->
     <div className="panoptes-main">

--- a/app/partials/app.cjsx
+++ b/app/partials/app.cjsx
@@ -4,6 +4,7 @@ IOStatus = require './io-status'
 AppLayout = require('../layout').default
 GeordiLogger = require '../lib/geordi-logger'
 {generateSessionID} = require '../lib/session'
+NotificationsCounter = require('../lib/notifications-counter').default
 
 PanoptesApp = React.createClass
   geordiLogger: null # Maintains project and subject context for the Geordi client
@@ -12,20 +13,28 @@ PanoptesApp = React.createClass
     initialLoadComplete: React.PropTypes.bool
     user: React.PropTypes.object
     geordi: React.PropTypes.object
+    notificationsCounter: React.PropTypes.object
+    unreadNotificationsCount: React.PropTypes.number
 
   getChildContext: ->
     initialLoadComplete: @state.initialLoadComplete
     user: @state.user
     geordi: @geordiLogger
+    notificationsCounter: @state.notificationsCounter
+    unreadNotificationsCount: @state.unreadNotificationsCount
 
   getInitialState: ->
     initialLoadComplete: false
     user: null
+    notificationsCounter: new NotificationsCounter()
 
   componentWillMount: ->
     @geordiLogger = new GeordiLogger
-  
+
   componentDidMount: ->
+    @state.notificationsCounter.listen (unreadNotificationsCount) =>
+      @setState {unreadNotificationsCount}
+
     auth.listen 'change', @handleAuthChange
     generateSessionID()
     @handleAuthChange()
@@ -33,13 +42,23 @@ PanoptesApp = React.createClass
   componentWillUnmount: ->
     auth.stopListening 'change', @handleAuthChange
 
+  componentWillReceiveProps: (nextProps) ->
+    @updateNotificationsCount params: nextProps.params
+
   handleAuthChange: ->
     @geordiLogger.forget ['userID']
     auth.checkCurrent().then (user) =>
       @setState
         initialLoadComplete: true
         user: user
+      @updateNotificationsCount {user}
       @geordiLogger.remember userID: user.id if user?
+
+  updateNotificationsCount: ({user, params}) ->
+    user or= @state.user
+    params or= @props.params
+    {owner, name} = params
+    @state.notificationsCounter.update(user, owner, name)
 
   render: ->
     <div className="panoptes-main">

--- a/app/talk/lib/notifications-link.cjsx
+++ b/app/talk/lib/notifications-link.cjsx
@@ -6,55 +6,25 @@ talkClient = require 'panoptes-client/lib/talk-client'
 module.exports = React.createClass
   displayName: 'NotificationsLink'
 
-  componentWillReceiveProps: (nextProps) ->
-    return unless nextProps.user
-    {owner, name} = nextProps.params
-    if owner isnt @state.owner and name isnt @state.name
-      @setSection(owner, name).then =>
-        @getUndeliveredCount()
-
-  getInitialState: ->
-    unreadCount: null
-    section: null
-    owner: null
-    name: null
-
-  setSection: (owner, name) ->
-    if owner and name
-      apiClient.type('projects').get(slug: "#{owner}/#{name}").then ([project]) =>
-        section = "project-#{project.id}"
-        @setState {owner, name, section}
-    else
-      Promise.resolve().then =>
-        section = null
-        @setState {owner, name, section}
-
-  getUndeliveredCount: ->
-    query =
-      delivered: false
-      page_size: 1
-
-    query.section = @state.section if @state.section
-    talkClient.type('notifications').get(query).then (notifications) =>
-      unreadCount = notifications[0]?.getMeta()?.count or 0
-      @setState {unreadCount}
+  contextTypes:
+    unreadNotificationsCount: React.PropTypes.number
 
   label: ->
-    if @state.unreadCount > 0
+    if @context.unreadNotificationsCount > 0
       <i className="fa fa-bell fa-fw" />
     else
       <i className="fa fa-bell-o fa-fw" />
 
   ariaLabel: ->
-    if @state.unreadCount > 0
-      "Notifications (#{ @state.unreadCount } unread)"
+    if @context.unreadNotificationsCount > 0
+      "Notifications (#{ @context.unreadNotificationsCount } unread)"
     else
       'Notifications'
 
   render: ->
-    return null unless @props.user and @state.unreadCount?
+    return null unless @props.user and @context.unreadNotificationsCount?
 
-    {section, owner, name} = @state
+    {owner, name} = @props.params
     linkProps = @props.linkProps
     linkProps['aria-label'] = @ariaLabel()
 


### PR DESCRIPTION
Fixes #2951.

This moves notification counting into a separate class and adds that to the app context.

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://add-notifications-context.pfe-preview.zooniverse.org

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
