### PR TITLE
Fix multiple, empty subject images bug in subject-viewer ("for X of Y" bug)

### DIFF
--- a/app/components/subject-viewer.cjsx
+++ b/app/components/subject-viewer.cjsx
@@ -80,7 +80,8 @@ module.exports = React.createClass
     if @state.inFlipbookMode
       mainDisplay = @renderFrame @state.frame
     else
-      mainDisplay = (@renderFrame frame, {key: "frame-#{frame}"} for frame of @props.subject.locations)
+      mainDisplay = @props.subject.locations.map (frame, index) =>
+        @renderFrame index, {key: "frame-#{index}"}
 
     tools = switch type
       when 'image'


### PR DESCRIPTION
Fixes #3034 

Issue: In IE11, images in Camera CATalogue appeared tiny. This turned out to be caused by the PFE rendering multiple _empty_ subject images... for certain projects on certain browsers.

Analysis: In `app/components/subject-viewer.cjsx`, the CoffeeScript line `for frame of @props.subject.locations` doesn't behave the expected way.
* Given that subjects.locations is an Array, we expect `for X of Y` to return the array indexes: 0, 1, 2, 3, etc.
* In IE11, for subjects from Camera CATalogue, this would instead return "0", "entries", "key", "values".
* In Chrome 53, this would return "0", "values. (Although Chrome's flex rules would hide the empty subject images)
* In Firefox 48, this would return "0", which is the only correct behaviour.

Solution:
* The `for X of Y` construct needded to be replaced.
* In this case, we'll use `Array.map` to replicate the intended behaviour of the `for` loop.
* We can't use `for X in Y` because we want the index numbers, not the actual array items.

Testing:
* Testing was done on multiple projects.
  * Camera CATalogue (debug subject): https://fix-3034.pfe-preview.zooniverse.org/projects/panthera-research/camera-catalogue/classify?env=production
  * WildCam Gorongosa (control subject): https://fix-3034.pfe-preview.zooniverse.org/projects/zooniverse/wildcam-gorongosa/classify?env=production
  * Snapshot Wisconsin (control subject, multi-frames): https://fix-3034.pfe-preview.zooniverse.org/projects/zooniverse/snapshot-wisconsin/classify?env=production
  * Arizona Batwatch (control subject, video): https://fix-3034.pfe-preview.zooniverse.org/projects/zooniverse/arizona-batwatch/classify?env=production
* Expected behaviour: subject images should appear as visibly "correct" size:
![screen shot 2016-09-16 at 13 17 31](https://cloud.githubusercontent.com/assets/13952701/18594018/ea30b48c-7c35-11e6-8277-6c7338d455c1.png)
_good_
![screen shot 2016-09-16 at 14 20 57](https://cloud.githubusercontent.com/assets/13952701/18594028/f4764010-7c35-11e6-9722-d6b0de5caa94.png)
_bad_

Test Results:
* Win7+IE11: OK for all projects
* OSX+Chrome53: OK for all projects
* OSX+Firefox48: OK for all projects
* OSX+Safari9: OK for all projects
* Android+Chrome: OK for Camera CATalogue and Wildcam Gorongosa

Status: This is ready for review.

## Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
