### PR TITLE
Moving help text for field guide

### DIFF
--- a/app/pages/lab/field-guide/index.cjsx
+++ b/app/pages/lab/field-guide/index.cjsx
@@ -99,6 +99,7 @@ FieldGuideEditor = React.createClass
     <div>
       <header>
         <strong>Field guide</strong>
+        <p>A field guide is a place to store general project-specific information that volunteers will need to understand in order to complete classifications and talk about what they're seeing. It's available anywhere in your project.</p>
       </header>
 
       {if @state.guide?
@@ -141,7 +142,6 @@ FieldGuideEditor = React.createClass
       </div>
 
       <div className="form-help">
-        <p>A field guide is a place to store general project-specific information that volunteers will need to understand in order to complete classifications and talk about what they're seeing. It's available anywhere in your project.</p>
         <p>Information can be grouped into different sections, and each section should have a title and an icon. Content for each section is rendered with Markdown, so you can include any media you've uploaded for your project there.</p>
       </div>
 


### PR DESCRIPTION
I took a stab at closing #2964

Describe your changes.

Moving the first paragraph of the help to the header, so it always appears no matter what step/stage of site guide building someone is in. Currently there's no description that appears when you click on the site guide tab of the project builder. 


# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
 I tried moving the paragraph with its <p> text <p> to the header. so it always appears no matter what step/stage of site guide building someone is in. 
