### PR TITLE
Fix conditional so column tool shows up in dropdown

### DIFF
--- a/app/classifier/tasks/generic-editor.cjsx
+++ b/app/classifier/tasks/generic-editor.cjsx
@@ -124,8 +124,8 @@ module.exports = React.createClass
                           {for toolKey of drawingTools
                             <option key={toolKey} value={toolKey}>{toolKey}</option> unless toolKey in ["column", "grid"]}
                           {if @canUse("column")
-                            <option key="column" value="column">column</option>
-                          if @canUse("grid")
+                            <option key="column" value="column">column</option>}
+                          {if @canUse("grid")
                             <option key="grid" value="grid">grid</option>}
                         </select>
                       </AutoSave>


### PR DESCRIPTION
Fixes a conditional in the workflow editor so that the column rectangle tool shows up correctly if enabled for a project.

https://fix-column-rectangle.pfe-preview.zooniverse.org/ 
I can add you to a testing project to see this fix.

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
