### PR TITLE
Slight transparency for project pages, except Talk

### DIFF
--- a/app/layout/index.styl
+++ b/app/layout/index.styl
@@ -57,7 +57,15 @@
     transition: opacity 250ms, transform 125ms
 
     &--set-aside
-      opacity: 0.9
+      
+      .project-page
+
+        > div
+        > nav
+          opacity: 0.9
+
+        > .talk
+          opacity: 1
 
   &__page-header,
   &__page-content


### PR DESCRIPTION
Fixes #3047  

Describe your changes.
Applies .9 opacity to children of the project page, except Talk pages.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://talk-opacity.pfe-preview.zooniverse.org/

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
