### PR TITLE
Fix indentation errors

### DIFF
--- a/app/partials/markdown-help.cjsx
+++ b/app/partials/markdown-help.cjsx
@@ -84,7 +84,7 @@ module.exports = React.createClass
             <td>**_bolditalics_**</td>
             <td><Markdown>**_bolditalics_**</Markdown></td>
           </tr>
-            <tr>
+          <tr>
             <td>Superscript</td>
             <td>
                ^superscript^
@@ -95,7 +95,7 @@ module.exports = React.createClass
               <Markdown>^super\ script^</Markdown>
             </td>
           </tr>
-           <tr>
+          <tr>
             <td>Subscript</td>
             <td>
                ~subscript~


### PR DESCRIPTION
#3060 accidentally broke the markdown help with a whitespace error. This should fix it.