### PR TITLE
adding in line break needed in markdown help

### DIFF
--- a/app/partials/markdown-help.cjsx
+++ b/app/partials/markdown-help.cjsx
@@ -87,7 +87,7 @@ module.exports = React.createClass
           <tr>
             <td>Superscript</td>
             <td>
-               ^superscript^
+               ^superscript^<br/>
                 ^super\ script^
             </td>
             <td>
@@ -98,7 +98,7 @@ module.exports = React.createClass
           <tr>
             <td>Subscript</td>
             <td>
-               ~subscript~
+               ~subscript~<br/>
                 ~sub\ script~
             </td>
             <td>


### PR DESCRIPTION
forgot to add the line break so the two examples show up on the same line for superscript and subscript. This PR fixes that.