### PR TITLE
Added markdown rendering to repeated question in classification summary.

### DIFF
--- a/app/classifier/tasks/drawing/summary.cjsx
+++ b/app/classifier/tasks/drawing/summary.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+{Markdown} = (require 'markdownz').default
 
 module.exports = React.createClass
   displayName: 'DrawingSummary'
@@ -20,7 +21,9 @@ module.exports = React.createClass
   render: ->
     <div>
       <div className="question">
-        {@props.task.instruction}
+        <Markdown>
+          {@props.task.instruction}
+        </Markdown>
         {if @state.expanded
           <button type="button" className="toggle-more" onClick={@setState.bind this, expanded: false, null}>Less</button>
         else

--- a/app/classifier/tasks/multiple.cjsx
+++ b/app/classifier/tasks/multiple.cjsx
@@ -19,7 +19,9 @@ Summary = React.createClass
   render: ->
     <div>
       <div className="question">
-        {@props.task.question}
+        <Markdown>
+          {@props.task.question}
+        </Markdown>
         {if @state.expanded
           <button type="button" className="toggle-more" onClick={@setState.bind this, expanded: false, null}>Less</button>
         else

--- a/app/classifier/tasks/single.cjsx
+++ b/app/classifier/tasks/single.cjsx
@@ -19,7 +19,9 @@ Summary = React.createClass
   render: ->
     <div>
       <div className="question">
-        {@props.task.question}
+        <Markdown>
+          {@props.task.question}
+        </Markdown>
         {if @state.expanded
           <button type="button" className="toggle-more" onClick={@setState.bind this, expanded: false, null}>Less</button>
         else


### PR DESCRIPTION
Currently question text containing markdown formatting is not correctly rendered when the question text is repeated as part of the classification summary.

This PR adds code that enables markdown rendering in this situation

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
