### PR TITLE
Remove 100% height for small screens

### DIFF
--- a/css/landing-page.styl
+++ b/css/landing-page.styl
@@ -5,12 +5,11 @@
   color: #f9f9f9
   display: flex
   flex-direction: column
-  height: 100vh
+  min-height: 100vh
   justify-content: center
   padding: 2.5em 3vw
 
   @media screen and (max-width: 400px)
-    height: 100% // So content isn't cut off on small mobile screens
 
     svg
       margin-top: 15vh


### PR DESCRIPTION
Fixes #3068 .

Describe your changes.
Removes the `height: 100%` that was applied to `.landing-page`, which breaks the page layout when the content is longer than the viewport height.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch? https://fix-3068.pfe-preview.zooniverse.org/

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?