### PR TITLE
Update user details for latest comment links

### DIFF
--- a/app/talk/latest-comment-link.cjsx
+++ b/app/talk/latest-comment-link.cjsx
@@ -47,7 +47,7 @@ module.exports = React.createClass
 
   componentWillMount: ->
     comment = @props.comment or @props.discussion?.latest_comment
-    return unless comment
+    return unless comment?
     @updateRoles comment
     apiClient.type('users').get(comment.user_id).then (commentUser) =>
       @setState {commentUser}
@@ -55,7 +55,7 @@ module.exports = React.createClass
   componentWillReceiveProps: (newProps) ->
     oldComment = @props.comment or @props.discussion?.latest_comment
     comment = newProps.comment or newProps.discussion?.latest_comment
-    return if comment is oldComment
+    return if comment is oldComment or not comment?
     @updateRoles comment
     apiClient.type('users').get(comment.user_id).then (commentUser) =>
       @setState {commentUser}

--- a/app/talk/latest-comment-link.cjsx
+++ b/app/talk/latest-comment-link.cjsx
@@ -50,6 +50,13 @@ module.exports = React.createClass
     return unless comment
     apiClient.type('users').get(comment.user_id).then (commentUser) =>
       @setState {commentUser}
+  
+  componentWillReceiveProps: (newProps) ->
+    oldComment = @props.comment or @props.discussion?.latest_comment
+    comment = newProps.comment or newProps.discussion?.latest_comment
+    return unless comment isnt oldComment
+    apiClient.type('users').get(comment.user_id).then (commentUser) =>
+      @setState {commentUser}
 
   componentDidMount: ->
     latestCommentText = @refs?.markdownText?.textContent


### PR DESCRIPTION
Fixes #3067 .

Describe your changes.
Updates the latest comment link state if the comment props change.
Also rips out a PromiseRenderer that was requesting user roles from the API on every re-render.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://fix-3067.pfe-preview.zooniverse.org/

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [x] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?