### PR TITLE
Only Display Workflows with Subject Sets

### DIFF
--- a/app/pages/project/home.cjsx
+++ b/app/pages/project/home.cjsx
@@ -57,14 +57,15 @@ module.exports = React.createClass
             </Link>
         else if @props.project.configuration?.user_chooses_workflow
           @props.activeWorkflows.map (workflow) =>
-            <Link
-              to={"/projects/#{@props.project.slug}/classify"}
-              key={workflow.id + Math.random()}
-              className="call-to-action standard-button"
-              onClick={@handleWorkflowSelection.bind this, workflow}
-            >
-              {workflow.display_name}
-            </Link>
+            if workflow.links.subject_sets
+              <Link
+                to={"/projects/#{@props.project.slug}/classify"}
+                key={workflow.id + Math.random()}
+                className="call-to-action standard-button"
+                onClick={@handleWorkflowSelection.bind this, workflow}
+              >
+                {workflow.display_name}
+              </Link>
         else
           <Link to={"/projects/#{@props.project.slug}/classify"} className="call-to-action standard-button">
             Get started!


### PR DESCRIPTION
Fixes #1933  .

Describe your changes.
From a project home page, users can only select a workflow if an associated subject set is available.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
