### PR TITLE
Remove PromiseRenderer from Talk components

### DIFF
--- a/app/pages/notifications/started-discussion.cjsx
+++ b/app/pages/notifications/started-discussion.cjsx
@@ -42,7 +42,8 @@ module.exports = React.createClass
             <Comment
               data={@state.comment}
               user={@props.user}
-              project={@props.project} />
+              project={@props.project}
+              params={@props.params} />
           }
         </div>
       </div>

--- a/app/subjects/mention-list.cjsx
+++ b/app/subjects/mention-list.cjsx
@@ -36,7 +36,12 @@ module.exports = React.createClass
         <h2>Mentions:</h2>
         <div>
           {for mention, i in @state.mentions
-            <Comment key={"mention-#{mention.comment.id}-#{i}"} data={mention.comment} locked={true} linked={true} />}
+            <Comment
+              key={"mention-#{mention.comment.id}-#{i}"}
+              data={mention.comment}
+              locked={true}
+              linked={true}
+              params={@props.params} />}
         </div>
       </div>
     else

--- a/app/talk/inbox.cjsx
+++ b/app/talk/inbox.cjsx
@@ -1,7 +1,6 @@
 React = require 'react'
 talkClient = require 'panoptes-client/lib/talk-client'
 apiClient = require 'panoptes-client/lib/api-client'
-PromiseRenderer = require '../components/promise-renderer'
 Paginator = require './lib/paginator'
 {Link} = require 'react-router'
 Loading = require '../components/loading-indicator'
@@ -15,6 +14,47 @@ PAGE_SIZE = talkConfig.inboxPageSize
 
 promptToSignIn = -> alert (resolve) -> <SignInPrompt onChoose={resolve} />
 
+ConversationLink = React.createClass
+  displayName: 'ConversationLink'
+  
+  propTypes:
+    user: React.PropTypes.object
+    conversation: React.PropTypes.object
+
+  getInitialState: ->
+    users: []
+    messages: []
+  
+  componentWillMount: ->
+    apiClient
+      .type 'users'
+      .get @props.conversation.links.users.filter (userId) => userId isnt @props.user.id
+      .then (users) =>
+        @setState {users}
+
+    @props.conversation
+      .get 'messages', {page_size: 1, sort: '-created_at'}
+      .then (messages) =>
+        @setState {messages}
+
+  render: ->
+    unread = @props.conversation.is_unread
+    <div className="conversation-link #{if unread then 'unread' else ''}">
+      <div>
+        {@state.users.map (user, i) =>
+          <div key={user.id}>
+            <strong><Link key={user.id} to="/users/#{user.login}">{user.display_name}</Link></strong>
+            <div>{timeAgo(@state.messages[0]?.updated_at)}{', ' if i isnt (@state.users.length-1)}</div>
+          </div>}
+      </div>
+
+      <Link to="/inbox/#{@props.conversation.id}">
+        {if unread
+          <i className="fa fa-comments-o"/>}
+        {@props.conversation.title}
+      </Link>
+    </div>
+
 module.exports = React.createClass
   displayName: 'TalkInbox'
 
@@ -24,76 +64,68 @@ module.exports = React.createClass
   getDefaultProps: ->
     location: query: page: 1
 
-  componentWillReceiveProps: (nextProps) ->
-    unless nextProps.location.query.page is @props.location.query.page
-      @setConversations(nextProps.location.query.page)
+  getInitialState: ->
+    conversations: []
+  
+  componentWillMount: ->
+    @setConversations @props.user
 
-  setConversations: (page) ->
+  componentWillReceiveProps: (nextProps) ->
+    unless nextProps.user is @props.user
+      @setConversations(nextProps.user)
+    unless nextProps.location.query.page is @props.location.query.page
+      @setConversations(nextProps.user, nextProps.location.query.page)
+
+  setConversations: (user, page) ->
+    return unless user?
     conversationsQuery =
-      user_id: @props.user.id
+      user_id: user.id
       page_size: PAGE_SIZE
       page: @props.location.query.page
       sort: '-updated_at'
       include: 'users'
 
-    talkClient.type('conversations').get conversationsQuery
+    talkClient
+      .type 'conversations'
+      .get conversationsQuery
+      .then (conversations) =>
+        @setState {conversations}
 
   onPageChange: (page) ->
     @goToPage(page)
 
   goToPage: (n) ->
     @context.router.push "/inbox?page=#{n}"
-    @setConversations(n)
+    @setConversations(@props.user, n)
 
   message: (data, i) ->
     <p key={data.id} class>{data.body}</p>
-
-  conversationLink: (conversation, i) ->
-    unread = conversation.is_unread
-    <div className="conversation-link #{if unread then 'unread' else ''}" key={conversation.id}>
-      <PromiseRenderer promise={apiClient.type('users').get(conversation.links.users.filter (userId) => userId isnt @props.user.id)}>{(users) =>
-        <div>
-          {users.map (user, i) =>
-            <div key={user.id}>
-              <strong><Link key={user.id} to="/users/#{user.login}">{user.display_name}</Link></strong>
-                <PromiseRenderer promise={conversation.get('messages', {page_size: 1, sort: '-created_at'})}>{(messages) =>
-                  <div>{timeAgo(messages[0].updated_at)}{', ' if i isnt (users.length-1)}</div>
-                }</PromiseRenderer>
-            </div>}
-        </div>
-      }</PromiseRenderer>
-
-      <Link to="/inbox/#{conversation.id}">
-        {if unread
-          <i className="fa fa-comments-o"/>}
-        {conversation.title}
-      </Link>
-    </div>
 
   render: ->
     <div className="talk inbox content-container">
       {unless @props.user?
         <p>Please <button className="link-style" type="button" onClick={promptToSignIn}>sign in</button> to view your inbox</p>
       else
-        <PromiseRenderer promise={@setConversations()} pending={-><Loading />}>{(conversations = []) =>
-          <div>
-            <h1>Inbox</h1>
+        <div>
+          <h1>Inbox</h1>
 
-            {if conversations.length is 0
-              <p>You have not started any private conversations yet. Send users private messages by visiting their profile page.</p>
-            else
-              conversationsMeta = conversations[0].getMeta()
-              <div>
-                <div>{conversations.map(@conversationLink)}</div>
-                <Paginator
-                  page={+conversationsMeta.page}
-                  pageCount={+conversationsMeta.page_count} />
-              </div>}
-
+          {if @state.conversations.length is 0
+            <p>You have not started any private conversations yet. Send users private messages by visiting their profile page.</p>
+          else
+            conversationsMeta = @state.conversations[0].getMeta()
             <div>
-              <h1>Send a message</h1>
-              <InboxForm user={@props.user} />
-            </div>
+              {@state.conversations.map (conversation) => 
+                <ConversationLink conversation={conversation} user={@props.user} key={conversation.id} />
+              }
+              <Paginator
+                page={+conversationsMeta.page}
+                pageCount={+conversationsMeta.page_count} />
+            </div>}
+
+          <div>
+            <h1>Send a message</h1>
+            <InboxForm user={@props.user} />
           </div>
-        }</PromiseRenderer>}
+        </div>
+        }
     </div>

--- a/app/talk/lib/create-subject-default-button.cjsx
+++ b/app/talk/lib/create-subject-default-button.cjsx
@@ -40,8 +40,9 @@ module.exports = React.createClass
       permissions: {read: 'all', write: 'all'}
       section: @props.section
 
-    talkClient.type('boards').create(board).save()
-      .then => @props.onCreateBoard?(board)
+    talkClient.type('boards').create(board).save().then (defaultBoard) =>
+      @props.onCreateBoard?(board)
+      @setState {defaultBoard}
 
   render: ->
     if @state.defaultBoard?

--- a/app/talk/lib/create-subject-default-button.cjsx
+++ b/app/talk/lib/create-subject-default-button.cjsx
@@ -1,6 +1,5 @@
 React = require 'react'
 talkClient = require 'panoptes-client/lib/talk-client'
-PromiseRenderer = require '../../components/promise-renderer'
 SingleSubmitButton = require '../../components/single-submit-button'
 
 DEFAULT_BOARD_TITLE = 'Notes'            # Name of board to put subject comments
@@ -14,11 +13,24 @@ module.exports = React.createClass
     section: React.PropTypes.string
     onCreateBoard: React.PropTypes.func # passed (board) on create
 
-  defaultBoardPromise: ->
+  getInitialState: ->
+    defaultBoard: null
+
+  componentWillMount: ->
+    @getDefaultBoard @props.section
+
+  componentWillReceiveProps: (newProps) ->
+    @getDefaultBoard newProps.section if newProps.section isnt @props.section
+
+  getDefaultBoard: (section) ->
     talkClient
-      .type('boards')
-      .get({section: @props.section, subject_default: true})
-      .index(0)
+      .type 'boards'
+      .get
+        section: section
+        subject_default: true
+      .index 0
+      .then (defaultBoard) =>
+        @setState {defaultBoard}
 
   createSubjectDefaultBoard: ->
     board =
@@ -32,13 +44,11 @@ module.exports = React.createClass
       .then => @props.onCreateBoard?(board)
 
   render: ->
-    <PromiseRenderer promise={@defaultBoardPromise()}>{(defaultBoard) =>
-      if defaultBoard?
-        <div>
-          <i className="fa fa-check" /> Subject Default Board Setup
-        </div>
-      else
-        <SingleSubmitButton type="button" onClick={@createSubjectDefaultBoard}>
-          <i className="fa fa-photo" /> Activate Talk Subject Comments Board
-        </SingleSubmitButton>
-    }</PromiseRenderer>
+    if @state.defaultBoard?
+      <div>
+        <i className="fa fa-check" /> Subject Default Board Setup
+      </div>
+    else
+      <SingleSubmitButton type="button" onClick={@createSubjectDefaultBoard}>
+        <i className="fa fa-photo" /> Activate Talk Subject Comments Board
+      </SingleSubmitButton>

--- a/app/talk/lib/zoo-team.cjsx
+++ b/app/talk/lib/zoo-team.cjsx
@@ -1,5 +1,4 @@
 React = require 'react'
-PromiseRenderer = require '../../components/promise-renderer'
 talkClient = require 'panoptes-client/lib/talk-client'
 userIsZooniverseAdmin = require './user-is-zooniverse-admin'
 
@@ -12,17 +11,30 @@ module.exports = React.createClass
 
   getInitialState: ->
     open: false
+    roles: []
+
+  componentDidMount: ->
+    @updateRoles @props.user
+
+  componentWillReceiveProps: (newProps) ->
+    @updateRoles newProps.user if newProps.user isnt @props.user
+
+  updateRoles: (user) ->
+    talkClient.type 'roles'
+      .get
+        user_id: user.id
+        section: ['zooniverse', @props.section]
+        page_size: 100
+      .then (roles) =>
+        @setState {roles}
 
   render: ->
     {section} = @props
 
     <div>
-      <PromiseRenderer pending={null} promise={talkClient.type('roles').get(user_id: @props.user.id, section: ['zooniverse', section], page_size: 100)}>{(roles) =>
-
-        if userIsZooniverseAdmin(roles)
-          @props.children
-        else
-          null
-
-      }</PromiseRenderer>
+      {if userIsZooniverseAdmin(@state.roles)
+        @props.children
+      else
+        null
+      }
     </div>

--- a/app/talk/popular-tags.cjsx
+++ b/app/talk/popular-tags.cjsx
@@ -2,6 +2,24 @@ React = require 'react'
 talkClient = require 'panoptes-client/lib/talk-client'
 {Link} = require 'react-router'
 
+ProjectTag = (props) ->
+  tag = props.tag.name
+  <div className="truncated">
+    <Link to="/projects/#{props.project.slug}/talk/tags/#{tag}" onClick={props.onClick} >
+      #{tag}
+    </Link>
+    {' '}
+  </div>
+
+TalkTag = (props) ->
+  tag = props.tag.name
+  <div className="truncated">
+    <Link to="/talk/search/?query=#{tag}" onClick={props.onClick} >
+      #{tag}
+    </Link>
+    {' '}
+  </div>
+  
 module.exports = React.createClass
   displayName: 'TalkPopularTags'
 
@@ -34,20 +52,20 @@ module.exports = React.createClass
       .then (tags) =>
         @setState {tags}
 
-  tag: (talkTag, i) ->
-    logClick = @context.geordi?.makeHandler? 'hashtag-sidebar'
-    tag = talkTag.name
-    if @props.project
-      <div key={"#{talkTag.id}-#{i}"} className="truncated"><Link to="/projects/#{@props.project.slug}/talk/tags/#{tag}" onClick={logClick?.bind(this, tag)}>#{tag}</Link>{' '}</div>
-    else
-      <div key={"#{talkTag.id}-#{i}"} className="truncated"><Link to="/talk/search/?query=#{tag}" onClick={logClick?.bind(this, tag)}>#{tag}</Link>{' '}</div>
-
   render: ->
     <div className="talk-popular-tags">
       {if @state.tags?.length
         <div>
           {@props.header ? null}
-          <section>{@state.tags.map(@tag)}</section>
+          <section>
+            {@state.tags.map (tag) =>
+              logClick = @context.geordi?.makeHandler? 'hashtag-sidebar'
+              if @props.project
+                <ProjectTag key={tag.id} project={@props.project} tag={tag} onClick={logClick?.bind(this, tag)} />
+              else
+                <TalkTag key={tag.id} tag={tag} onClick={logClick?.bind(this, tag)} />
+            }
+          </section>
         </div>
       }
     </div>

--- a/app/talk/popular-tags.cjsx
+++ b/app/talk/popular-tags.cjsx
@@ -1,6 +1,5 @@
 React = require 'react'
 talkClient = require 'panoptes-client/lib/talk-client'
-PromiseRenderer = require '../components/promise-renderer'
 {Link} = require 'react-router'
 
 module.exports = React.createClass
@@ -12,6 +11,12 @@ module.exports = React.createClass
 
   contextTypes:
     geordi: React.PropTypes.object
+  
+  getInitialState: ->
+    tags: []
+  
+  componentWillMount: ->
+    @tagsRequest()
 
   tagsRequest: ->
     query =
@@ -23,7 +28,11 @@ module.exports = React.createClass
       query.taggable_type = @props.type
       query.taggable_id = @props.id
 
-    talkClient.type('tags/popular').get query
+    talkClient
+      .type 'tags/popular'
+      .get query
+      .then (tags) =>
+        @setState {tags}
 
   tag: (talkTag, i) ->
     logClick = @context.geordi?.makeHandler? 'hashtag-sidebar'
@@ -35,11 +44,10 @@ module.exports = React.createClass
 
   render: ->
     <div className="talk-popular-tags">
-      <PromiseRenderer promise={@tagsRequest()}>{(tags) =>
-        if tags?.length
-          <div>
-            {@props.header ? null}
-            <section>{tags.map(@tag)}</section>
-          </div>
-      }</PromiseRenderer>
+      {if @state.tags?.length
+        <div>
+          {@props.header ? null}
+          <section>{@state.tags.map(@tag)}</section>
+        </div>
+      }
     </div>


### PR DESCRIPTION
Describe your changes.
This makes a start at removing the PromiseRenderer component from Talk.
# Review Checklist
- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://talk-promise-renderer.pfe-preview.zooniverse.org
## Optional
- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [x] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
