### PR TITLE
Fix dev classifier

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,3 +13,4 @@ Describe your changes.
 
 - [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
 - [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
+- [ ] If changes are made to the classifier, does the dev classifier still work?

--- a/app/pages/dev-classifier/index.cjsx
+++ b/app/pages/dev-classifier/index.cjsx
@@ -73,7 +73,7 @@ DevClassifierPage = React.createClass
 
   render: ->
     <div className="content-container">
-      <Classifier user={@props.user}  project={@props.project} preferences={@props.preferences} classification={@props.classification} onClickNext={@reload} />
+      <Classifier user={@props.user}  project={@props.project} workflow={@props.classification._workflow} preferences={@props.preferences} classification={@props.classification} onClickNext={@reload} />
       <hr />
       <ClassificationViewer classification={@props.classification} />
     </div>

--- a/app/pages/dev-classifier/mock-data.coffee
+++ b/app/pages/dev-classifier/mock-data.coffee
@@ -29,7 +29,7 @@ workflow = apiClient.type('workflows').create
 
   configuration:
     enable_subject_flags: true
-    multi_image_mode: 'flipbook_and_separate'
+    enable_switching_flipbook_and_separate: true
     multi_image_layout: 'grid3'
     invert_subject: true
 


### PR DESCRIPTION
Some recent changes to the classifier, including my own, have broken the dev classifier. This fixes the dev classifier as well as add a checkbox to the PR template to remind us to check that it is working.

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://fix-dev-classifier.pfe-preview.zooniverse.org/

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?