### PR TITLE
Fix unique key warning in classifier

### DIFF
--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -223,13 +223,15 @@ Classifier = React.createClass
             disableInterventionFunction={@disableIntervention}
           />}
         <div className="coverable-task-container">
-          {persistentHooksBeforeTask.map (HookComponent) =>
-            <HookComponent {...taskHookProps} />}
+          {persistentHooksBeforeTask.map (HookComponent, i) =>
+            key = i + Math.random()
+            <HookComponent key={key} {...taskHookProps} />}
 
           <TaskComponent autoFocus={true} taskTypes={tasks} workflow={@props.workflow} task={task} preferences={@props.preferences} annotation={annotation} onChange={@handleAnnotationChange.bind this, classification} />
 
-          {persistentHooksAfterTask.map (HookComponent) =>
-            <HookComponent {...taskHookProps} />}
+          {persistentHooksAfterTask.map (HookComponent, i) =>
+            key = i + Math.random()
+            <HookComponent key={key} {...taskHookProps} />}
 
           <hr />
 


### PR DESCRIPTION
This fixes the annoying unique key React warning that would show up with the Classifier. I've added a key prop to the `HookComponent` in the `coverable-task-container` div.

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work? Need to merge #3081 before this can be checked. Can rebase once merged.
