### PR TITLE
Fix create href

### DIFF
--- a/app/collections/show-list.cjsx
+++ b/app/collections/show-list.cjsx
@@ -41,9 +41,9 @@ module.exports = React.createClass
 
   onPageChange: (page) ->
     nextQuery = Object.assign {}, @props.location.query, { page }
-    currentPath = @props.location.pathname
-
-    @context.router.push @context.router.createHref(currentPath, nextQuery)
+    @context.router.push
+      pathname: @props.location.pathname
+      query: nextQuery
 
   handleDeleteSubject: (subject) ->
     @props.collection.removeLink 'subjects', [subject.id.toString()]

--- a/app/pages/lab/workflow-viewer/index.cjsx
+++ b/app/pages/lab/workflow-viewer/index.cjsx
@@ -23,7 +23,9 @@ WorkflowVis = React.createClass
   workflowLink: ->
     [owner, name] = @props.project.slug.split('/')
     viewQuery = workflow: @props.workflow.id, reload: 0
-    @context.router.createHref "/projects/#{owner}/#{name}/classify", viewQuery
+    @context.router.createHref
+      pathname: "/projects/#{owner}/#{name}/classify"
+      query: viewQuery
 
   render: ->
     <div>

--- a/app/pages/lab/workflow.cjsx
+++ b/app/pages/lab/workflow.cjsx
@@ -39,7 +39,9 @@ EditWorkflowPage = React.createClass
   workflowLink: ->
     [owner, name] = @props.project.slug.split('/')
     viewQuery = workflow: @props.workflow.id, reload: @state.forceReloader
-    @context.router.createHref "/projects/#{owner}/#{name}/classify", viewQuery
+    @context.router.createHref
+      pathname: "/projects/#{owner}/#{name}/classify"
+      query: viewQuery
 
   showCreateWorkflow: ->
     @setState workflowCreationInProgress: true

--- a/app/talk/latest-comment-link.cjsx
+++ b/app/talk/latest-comment-link.cjsx
@@ -67,15 +67,16 @@ module.exports = React.createClass
   discussionLink: (childtext = '', query = {}, className = '') ->
     if className is "latest-comment-time"
       logClick = @context.geordi?.makeHandler? 'discussion-time'
+    locationObject =
+      pathname: "/talk/#{@props.discussion.board_id}/#{@props.discussion.id}"
+      query: query
     if @props.params?.owner and @props.params?.name
       {owner, name} = @props.params
-      <Link className={className} onClick={logClick?.bind(this, childtext)} to={@context.router.createHref("/projects/#{owner}/#{name}/talk/#{@props.discussion.board_id}/#{@props.discussion.id}", query)}>
-        {childtext}
-      </Link>
-    else
-      <Link className={className} onClick={logClick?.bind(this, childtext)} to={@context.router.createHref("/talk/#{@props.discussion.board_id}/#{@props.discussion.id}", query)}>
-        {childtext}
-      </Link>
+      locationObject.pathname = "/projects/#{owner}/#{name}" + locationObject.pathname
+
+    <Link className={className} onClick={logClick?.bind(this, childtext)} to={@context.router.createHref(locationObject)}>
+      {childtext}
+    </Link>
 
   updateRoles: (comment) ->
     talkClient

--- a/app/talk/lib/update-query-params.coffee
+++ b/app/talk/lib/update-query-params.coffee
@@ -10,5 +10,6 @@ parseQuery = ->
 
 module.exports = (reactHistory, queryChange) ->
   nextQuery = Object.assign { }, parseQuery(), queryChange
-  nextHref = reactHistory.createHref window.location.pathname, nextQuery
-  reactHistory.push nextHref
+  reactHistory.push
+    pathname: window.location.pathname
+    query: nextQuery


### PR DESCRIPTION
Fixes uses of `createHref` where multiple arguments were passed in instead of a location object. Also just took out some instances where `createHref` was being used to create a string to pass into `push`, as `push` will just take a location object.

Needs #3020 merging first and rebasing.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?