### PR TITLE
Fix prefs workflow selection

### DIFF
--- a/app/pages/project/index.cjsx
+++ b/app/pages/project/index.cjsx
@@ -175,7 +175,7 @@ ProjectPage = React.createClass
       workflow.id is selectedWorkflowID
 
     if selectedWorkflowIndex is -1
-      throw new Error "No workflow #{selectedWorkflowID} for project #{project.id}"
+      console.error "No workflow #{selectedWorkflowID} for project #{project.id}"
       @clearInvalidWorkflow(selectedWorkflowID)
         .then(@getSelectedWorkflow(project, @props.preferences))
     else
@@ -188,9 +188,9 @@ ProjectPage = React.createClass
       if selectedWorkflowID is preferences.preferences.selected_workflow
         preferences.update 'preferences.selected_workflow': undefined
         preferences.save()
-      else if selectedWorkflowID is preferences.settings?.workflow_id
-        preferences.update 'preferences.settings.workflow_id': undefined
-        preferences.save()
+      # else if selectedWorkflowID is preferences.settings?.workflow_id
+      #   preferences.update 'preferences.settings.workflow_id': undefined
+      #   preferences.save()
     )
 
   _lastSugarSubscribedID: null

--- a/app/pages/project/index.cjsx
+++ b/app/pages/project/index.cjsx
@@ -137,19 +137,19 @@ ProjectPage = React.createClass
     # preference workflow query, then user selected workflow, then project owner set workflow, then default workflow
     # if none of those are set, select random workflow
     if @props.location.query?.workflow? and ('allow workflow query' in @props.project.experimental_tools or @checkUserRoles(project, @props.user))
-      preferredWorkflowID = @props.location.query.workflow
-      unless preferences?.preferences.selected_workflow is preferredWorkflowID
-        @props.onChangePreferences 'preferences.selected_workflow', preferredWorkflowID
+      selectedWorkflowID = @props.location.query.workflow
+      unless preferences?.preferences.selected_workflow is selectedWorkflowID
+        @props.onChangePreferences 'preferences.selected_workflow', selectedWorkflowID
     else if preferences?.preferences.selected_workflow?
-      preferredWorkflowID = preferences?.preferences.selected_workflow
+      selectedWorkflowID = preferences?.preferences.selected_workflow
     else if preferences?.settings?.workflow_id?
-      preferredWorkflowID = preferences?.settings.workflow_id
+      selectedWorkflowID = preferences?.settings.workflow_id
     else if project.configuration?.default_workflow?
-      preferredWorkflowID = project.configuration?.default_workflow
+      selectedWorkflowID = project.configuration?.default_workflow
     else
-      preferredWorkflowID = @selectRandomWorkflow(project)
+      selectedWorkflowID = @selectRandomWorkflow(project)
 
-    @getWorkflow(project, preferredWorkflowID)
+    @isWorkflowInvalid(project, selectedWorkflowID)
 
   checkIfProjectIsComplete: (project) ->
     projectIsComplete = (true for workflow in @state.activeWorkflows when not workflow.finished_at?).length is 0
@@ -164,18 +164,34 @@ ProjectPage = React.createClass
       # console.log 'Chose random workflow', @state.activeWorkflows[randomIndex].id
       @state.activeWorkflows[randomIndex].id
 
-  getWorkflow: (project, selectedWorkflowID) ->
+  getWorkflow: (selectedWorkflowIndex) ->
+    @setState {
+      selectedWorkflow: @state.activeWorkflows[selectedWorkflowIndex],
+      loadingSelectedWorkflow: false
+    }
+
+  isWorkflowInvalid: (project, selectedWorkflowID) ->
     selectedWorkflowIndex = @state.activeWorkflows.findIndex (workflow, index) ->
       workflow.id is selectedWorkflowID
 
     if selectedWorkflowIndex is -1
       throw new Error "No workflow #{selectedWorkflowID} for project #{project.id}"
-      @setState { selectedWorkflow: null, loadingSelectedWorkflow: false }
+      @clearInvalidWorkflow(selectedWorkflowID)
+        .then(@getSelectedWorkflow(project, @props.preferences))
     else
-      @setState {
-        selectedWorkflow: @state.activeWorkflows[selectedWorkflowIndex],
-        loadingSelectedWorkflow: false
-      }
+      @getWorkflow(selectedWorkflowIndex)
+
+  clearInvalidWorkflow: (selectedWorkflowID) ->
+    preferences = @props.preferences
+
+    Promise.resolve(
+      if selectedWorkflowID is preferences.preferences.selected_workflow
+        preferences.update 'preferences.selected_workflow': undefined
+        preferences.save()
+      else if selectedWorkflowID is preferences.settings?.workflow_id
+        preferences.update 'preferences.settings.workflow_id': undefined
+        preferences.save()
+    )
 
   _lastSugarSubscribedID: null
 

--- a/app/pages/project/index.cjsx
+++ b/app/pages/project/index.cjsx
@@ -149,7 +149,7 @@ ProjectPage = React.createClass
     else
       selectedWorkflowID = @selectRandomWorkflow(project)
 
-    @isWorkflowInvalid(project, selectedWorkflowID)
+    @isWorkflowInactive(project, selectedWorkflowID)
 
   checkIfProjectIsComplete: (project) ->
     projectIsComplete = (true for workflow in @state.activeWorkflows when not workflow.finished_at?).length is 0
@@ -170,27 +170,27 @@ ProjectPage = React.createClass
       loadingSelectedWorkflow: false
     }
 
-  isWorkflowInvalid: (project, selectedWorkflowID) ->
+  isWorkflowInactive: (project, selectedWorkflowID) ->
     selectedWorkflowIndex = @state.activeWorkflows.findIndex (workflow, index) ->
       workflow.id is selectedWorkflowID
 
     if selectedWorkflowIndex is -1
       console.error "No workflow #{selectedWorkflowID} for project #{project.id}"
-      @clearInvalidWorkflow(selectedWorkflowID)
+      @clearInactiveWorkflow(selectedWorkflowID)
         .then(@getSelectedWorkflow(project, @props.preferences))
     else
       @getWorkflow(selectedWorkflowIndex)
 
-  clearInvalidWorkflow: (selectedWorkflowID) ->
+  clearInactiveWorkflow: (selectedWorkflowID) ->
     preferences = @props.preferences
 
     Promise.resolve(
       if selectedWorkflowID is preferences.preferences.selected_workflow
         preferences.update 'preferences.selected_workflow': undefined
-        preferences.save()
-      # else if selectedWorkflowID is preferences.settings?.workflow_id
-      #   preferences.update 'preferences.settings.workflow_id': undefined
-      #   preferences.save()
+      else if selectedWorkflowID is preferences.settings?.workflow_id
+        preferences.update 'preferences.settings.workflow_id': undefined
+
+      preferences.save()
     )
 
   _lastSugarSubscribedID: null


### PR DESCRIPTION
Fixes #3076 where a volunteer has an inactive workflow id in their preferences.

I refactored the workflow selection to first check the workflow id then clear it out of the preferences and try again if the workflow id is not active. 

@eatyourgreens I think you mentioned you were having this issue in MWP? Could you check if this fixes it for you: https://fix-prefs-workflow-selection.pfe-preview.zooniverse.org/?env=production

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [x] If changes are made to the classifier, does the dev classifier still work?