### PR TITLE
Add basic flow config

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,0 +1,9 @@
+[ignore]
+.*/node_modules/.*
+
+[include]
+
+[libs]
+
+[options]
+log.file=./flow.log

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,5 +12,6 @@ Describe your changes.
 ## Optional
 
 - [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
+- [ ] Have you [added a Flow declaration](https://flowtype.org/docs/getting-started.html) if there isn't one already?
 - [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
 - [ ] If changes are made to the classifier, does the dev classifier still work?

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@
 /dist
 
 npm-debug.log
+flow.log*
 
 .DS_Store

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "express": "~4.13.3",
     "extract-text-webpack-plugin": "~1.0.1",
     "file-loader": "~0.8.5",
+    "flow-bin": "~0.33.0",
     "html-webpack-plugin": "~2.16.0",
     "json-loader": "~0.5.4",
     "mocha": "~3.1.0",
@@ -90,6 +91,7 @@
     "stage-with-docker": "./bin/run-through-docker.sh 'npm run stage'",
     "_deploy": "export PATH_ROOT=www.zooniverse.org; npm run _build && npm run _publish",
     "deploy": "export NODE_ENV=production; npm run _deploy",
-    "test": "export NODE_ENV=development; mocha test/test.js"
+    "test": "export NODE_ENV=development; mocha test/test.js",
+    "flow": "flow; exit 0"
   }
 }


### PR DESCRIPTION
Adds a basic [flow](https://flowtype.org) config! Requires you to run `npm run flow` currently; it'd be sweet to add it in to the webpack config, but I couldn't quite get it done in the afternoon sesh :)

@srallen @simensta 