### PR TITLE
Add babel-plugin-transform-object-assign to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "babel-cli": "~6.7.7",
     "babel-loader": "~6.2.4",
     "babel-plugin-react-transform": "~2.0.2",
+    "babel-plugin-transform-object-assign": "~6.8.0",
     "babel-plugin-transform-react-jsx": "~6.7.5",
     "babel-preset-es2015": "~6.6.0",
     "check-dependencies": "~0.12.0",


### PR DESCRIPTION
As a prerequisite to merging zooniverse/markdownz#45.