### PR TITLE
Removed invert from experimental tools

### DIFF
--- a/app/pages/admin/project-status.cjsx
+++ b/app/pages/admin/project-status.cjsx
@@ -23,7 +23,6 @@ EXPERIMENTAL_FEATURES = [
   'hide previous marks'
   'column'
   'grid'
-  'invert'
   'workflow assignment'
   'Gravity Spy Gold Standard'
   'allow workflow query'

--- a/app/pages/lab/workflow.cjsx
+++ b/app/pages/lab/workflow.cjsx
@@ -298,15 +298,14 @@ EditWorkflowPage = React.createClass
 
           <hr />
 
-          {if 'invert' in @props.project.experimental_tools
-            <div>
-              <AutoSave tag="label" resource={@props.workflow}>
-                <input type="checkbox" name="invert_subject" checked={@props.workflow.configuration.invert_subject} onChange={@handleSetInvert} />
-                Allow Users To Flip Image Color
-              </AutoSave>
+          <div>
+            <AutoSave tag="label" resource={@props.workflow}>
+              <input type="checkbox" name="invert_subject" checked={@props.workflow.configuration.invert_subject} onChange={@handleSetInvert} />
+              Allow Users To Flip Image Color
+            </AutoSave>
 
-              <hr />
-            </div>}
+            <hr />
+          </div>
 
           <p>
             <AutoSave resource={@props.workflow}>


### PR DESCRIPTION
Decided during ZTM: invert is now publicly available.

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [x] If changes are made to the classifier, does the dev classifier still work?
