### PR TITLE
Make column drawing tool public

### DIFF
--- a/app/classifier/tasks/generic-editor.cjsx
+++ b/app/classifier/tasks/generic-editor.cjsx
@@ -122,9 +122,7 @@ module.exports = React.createClass
                         Type{' '}
                         <select name="#{@props.taskPrefix}.#{choicesKey}.#{index}.type" value={choice.type} onChange={handleChange}>
                           {for toolKey of drawingTools
-                            <option key={toolKey} value={toolKey}>{toolKey}</option> unless toolKey in ["column", "grid"]}
-                          {if @canUse("column")
-                            <option key="column" value="column">column</option>}
+                            <option key={toolKey} value={toolKey}>{toolKey}</option> unless toolKey in ["grid"]}
                           {if @canUse("grid")
                             <option key="grid" value="grid">grid</option>}
                         </select>
@@ -203,8 +201,7 @@ module.exports = React.createClass
                 <small className="form-help">*rectangle:* a box of any size and length-width ratio; this tool *cannot* be rotated.</small><br />
                 <small className="form-help">*circle:* a point and a radius.</small><br />
                 <small className="form-help">*ellipse:* an oval of any size and axis ratio; this tool *can* be rotated.</small><br />
-                {if @canUse("column")
-                  <small className="form-help">*column rectangle:* a box with full height but variable width; this tool *cannot* be rotated.</small>}
+                <small className="form-help">*column rectangle:* a box with full height but variable width; this tool *cannot* be rotated.</small>
                 {if @canUse("grid")
                   <small className="form-help">*grid table:* cells which can be made into a table for consecutive annotations.</small>}
               </div>}

--- a/app/pages/admin/project-status.cjsx
+++ b/app/pages/admin/project-status.cjsx
@@ -21,7 +21,6 @@ EXPERIMENTAL_FEATURES = [
   'pan and zoom'
   'worldwide telescope'
   'hide previous marks'
-  'column'
   'grid'
   'invert'
   'workflow assignment'


### PR DESCRIPTION
Decided at ZTM: Make column drawing tool public.

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [x] If changes are made to the classifier, does the dev classifier still work?
