### PR TITLE
Pan and zoom as workflow config and make public

### DIFF
--- a/app/components/frame-viewer.cjsx
+++ b/app/components/frame-viewer.cjsx
@@ -31,7 +31,7 @@ module.exports = React.createClass
     frame = @props.frame
     {type, format, src} = getSubjectLocation @props.subject, @props.frame
     FrameWrapper = @props.frameWrapper
-    zoomEnabled = @props.project? && 'pan and zoom' in @props.project?.experimental_tools
+    zoomEnabled = @props.workflow?.configuration.pan_and_zoom
     frameDisplay = switch type
       when 'image'
         <div className="subject-image-frame" >

--- a/app/pages/admin/project-status.cjsx
+++ b/app/pages/admin/project-status.cjsx
@@ -16,7 +16,6 @@ EXPERIMENTAL_FEATURES = [
   'dropdown'
   'mini-course'
   'hide classification summaries'
-  'pan and zoom'
   'worldwide telescope'
   'hide previous marks'
   'grid'

--- a/app/pages/dev-classifier/mock-data.coffee
+++ b/app/pages/dev-classifier/mock-data.coffee
@@ -33,6 +33,7 @@ workflow = apiClient.type('workflows').create
     multi_image_layout: 'grid3'
     invert_subject: true
     persist_annotations: true
+    pan_and_zoom: true
 
   first_task: 'init'
 
@@ -522,7 +523,6 @@ subject = apiClient.type('subjects').create
 project = apiClient.type('projects').create
   id: 'MOCK_PROJECT_FOR_CLASSIFIER'
   title: "The Dev Classifier"
-  experimental_tools: ['pan and zoom']
 
 preferences = apiClient.type('project_preferences').create
   preferences: {}

--- a/app/pages/lab/workflow.cjsx
+++ b/app/pages/lab/workflow.cjsx
@@ -307,6 +307,22 @@ EditWorkflowPage = React.createClass
 
             </div>}
 
+          <div>
+            <div>
+              <AutoSave resource={@props.workflow}>
+                <span className="form-label">Pan and zoom</span><br />
+                <small className="form-help">Pan and zoom allows the user to zoom in and out and pan the subject in the subject viewer.</small>
+                <br />
+                <label>
+                  <input ref="panAndZoomToggle" type="checkbox" checked={@props.workflow.configuration.pan_and_zoom} onChange={@handleSetPanAndZoom} />
+                  Pan and Zoom
+                </label>
+              </AutoSave>
+            </div>
+
+            <hr />
+          </div>
+
           <AutoSave tag="div" resource={@props.workflow}>
             <span className="form-label">Multi-image options</span><br />
             <small className="form-help">Choose how to display multiple images</small>
@@ -552,6 +568,10 @@ EditWorkflowPage = React.createClass
 
     @props.workflow.update changes
     @setState selectedTaskKey: nextTaskID
+
+  handleSetPanAndZoom: (e) ->
+    @props.workflow.update
+      'configuration.pan_and_zoom': e.target.checked
 
   handleSetHideClassificationSummaries: (e) ->
     @props.workflow.update

--- a/app/pages/lab/workflow.cjsx
+++ b/app/pages/lab/workflow.cjsx
@@ -311,7 +311,7 @@ EditWorkflowPage = React.createClass
             <div>
               <AutoSave resource={@props.workflow}>
                 <span className="form-label">Pan and zoom</span><br />
-                <small className="form-help">Pan and zoom allows the user to zoom in and out and pan the subject in the subject viewer.</small>
+                <small className="form-help">Pan and zoom allows the user to zoom in and out and pan image subjects in the classification interface.</small>
                 <br />
                 <label>
                   <input ref="panAndZoomToggle" type="checkbox" checked={@props.workflow.configuration.pan_and_zoom} onChange={@handleSetPanAndZoom} />


### PR DESCRIPTION
Makes pan and zoom a workflow config and public. Should not be merged until zooniverse/Panoptes#1991 is resolved.
# Review Checklist
- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://make-pan-zoom-public.pfe-preview.zooniverse.org/
## Optional
- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [x] If changes are made to the classifier, does the dev classifier still work?
