### PR TITLE
Make text tasks public

### DIFF
--- a/app/pages/admin/project-status.cjsx
+++ b/app/pages/admin/project-status.cjsx
@@ -13,7 +13,6 @@ WorkflowToggle = require '../../components/workflow-toggle'
 EXPERIMENTAL_FEATURES = [
   'survey'
   'crop'
-  'text'
   'combo'
   'dropdown'
   'mini-course'

--- a/app/pages/lab/data-dumps.cjsx
+++ b/app/pages/lab/data-dumps.cjsx
@@ -60,7 +60,9 @@ module.exports = React.createClass
               buttonKey="projectDetails.aggregationExport"
               contentType="application/x-gzip"
               exportType="aggregations_export"
-              newFeature=true />
+              newFeature=true 
+            />
+            <small className="form-help">Text tasks cannot be aggregated at this time.</small>
           </div>
           <hr />
 

--- a/app/pages/lab/workflow.cjsx
+++ b/app/pages/lab/workflow.cjsx
@@ -153,14 +153,13 @@ EditWorkflowPage = React.createClass
                       <small><strong>Drawing</strong></small>
                     </button>
                   </AutoSave>{' '}
-                  {if @canUseTask(@props.project, "text")
-                    <AutoSave resource={@props.workflow}>
-                      <button type="submit" className="minor-button" onClick={@addNewTask.bind this, 'text'} title="Text tasks: the volunteer writes free-form text into a dialog box.">
-                        <i className="fa fa-file-text-o fa-2x"></i>
-                        <br />
-                        <small><strong>Text</strong></small>
-                      </button>
-                    </AutoSave>}{' '}
+                  <AutoSave resource={@props.workflow}>
+                    <button type="submit" className="minor-button" onClick={@addNewTask.bind this, 'text'} title="Text tasks: the volunteer writes free-form text into a dialog box.">
+                      <i className="fa fa-file-text-o fa-2x"></i>
+                      <br />
+                      <small><strong>Text</strong></small>
+                    </button>
+                  </AutoSave>{' '}
                   {if @canUseTask(@props.project, "survey")
                     <AutoSave resource={@props.workflow}>
                       <button type="submit" className="minor-button" onClick={@addNewTask.bind this, 'survey'} title="Survey tasks: the volunteer identifies objects (usually animals) in the image(s) by filtering by their visible charactaristics, then answers questions about them.">


### PR DESCRIPTION
Decided during ZTM. This makes the text task type public with an added note on the data exports page that it cannot be aggregated at this time.

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [x] If changes are made to the classifier, does the dev classifier still work?
