### PR TITLE
Survey task fix require

### DIFF
--- a/app/classifier/tasks/survey/choice.cjsx
+++ b/app/classifier/tasks/survey/choice.cjsx
@@ -55,28 +55,23 @@ module.exports = React.createClass
   getInitialState: ->
     answers: {}
 
-  allFilledIn: ->
+  checkFilledIn: ->
+    # if there are no questions, don't make them fill one in
+    return true unless Utility.getQuestionIDs(@props.task, @props.choiceID).length
+
+    # if there are questions, it's fine as long as they've filled required ones in
+    answerProvided = []
     for questionID in Utility.getQuestionIDs(@props.task, @props.choiceID)
       question = @props.task.questions[questionID]
       if question.required
         answer = @state.answers[questionID]
-        if (not answer?) or (question.multiple and answer.length is 0)
-          return false
-    true
-
-  anyFilledIn: ->
-    # if there are no questions, don't make them fill one in
-    return true unless Utility.getQuestionIDs(@props.task, @props.choiceID).length
-
-    # if there are questions, it's fine as long as they've filled ONE in
-    for questionID in Utility.getQuestionIDs(@props.task, @props.choiceID)
-      question = @props.task.questions[questionID]
-      answer = @state.answers[questionID]
-      if(answer?)
-        return true
-
-    # they must fill out at least one
-    false
+        if (answer?.length isnt 0) and answer?
+          answerProvided.push true
+        else
+          answerProvided.push false
+      else
+        answerProvided.push true
+    canIdentify = answerProvided.every (answer) -> answer is true
 
   render: ->
     choice = @props.task.choices[@props.choiceID]
@@ -143,7 +138,7 @@ module.exports = React.createClass
       <div style={textAlign: 'center'}>
         <button type="button" className="minor-button" onClick={@props.onCancel}>Cancel</button>
         {' '}
-        <button type="button" className="standard-button" disabled={not @allFilledIn() or not @anyFilledIn()} onClick={@handleIdentification}>
+        <button type="button" className="standard-button" disabled={not @checkFilledIn()} onClick={@handleIdentification}>
           <strong>Identify</strong>
         </button>
       </div>

--- a/app/classifier/tasks/survey/choice.cjsx
+++ b/app/classifier/tasks/survey/choice.cjsx
@@ -125,7 +125,7 @@ module.exports = React.createClass
                   answerID is @state.answers[questionID]
                 <span key={answerID}>
                   <label className="survey-task-choice-answer" data-checked={isChecked || null}>
-                    <input name={questionID} type={inputType} checked={isChecked} onChange={@handleAnswer.bind this, questionID, answerID} />
+                    <input ref={questionID} name={questionID} type={inputType} checked={isChecked} onChange={@handleAnswer.bind this, questionID, answerID} />
                     {answer.label}
                   </label>
                   {' '}
@@ -152,10 +152,13 @@ module.exports = React.createClass
       else
         @state.answers[questionID].splice @state.answers[questionID].indexOf(answerID), 1
     else
-      @state.answers[questionID] = if e.target.checked
-        answerID
+      console.log 'e.target', answerID
+      console.log 'old answer', @state.answers[questionID]
+      if answerID is @state.answers[questionID]
+        delete @state.answers[questionID]
+        @refs[questionID].checked = false
       else
-        null
+        @state.answers[questionID] = answerID
     @setState answers: @state.answers
 
   handleIdentification: ->

--- a/app/classifier/tasks/survey/choice.cjsx
+++ b/app/classifier/tasks/survey/choice.cjsx
@@ -152,8 +152,6 @@ module.exports = React.createClass
       else
         @state.answers[questionID].splice @state.answers[questionID].indexOf(answerID), 1
     else
-      console.log 'e.target', answerID
-      console.log 'old answer', @state.answers[questionID]
       if answerID is @state.answers[questionID]
         delete @state.answers[questionID]
         @refs[questionID].checked = false


### PR DESCRIPTION
Fixes #3046.

- Changed survey task Identify button disabled logic.
- Changed behavior when clicking already checked radio button (previously nothing happened, now will uncheck and clear from answer)

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? [https://survey-task-fix-require.pfe-preview.zooniverse.org/](https://survey-task-fix-require.pfe-preview.zooniverse.org/)

demonstration of issues here: [https://master.pfe-preview.zooniverse.org/projects/markb-panoptes/survey-task-test-project/classify?reload=0&workflow=2658](https://master.pfe-preview.zooniverse.org/projects/markb-panoptes/survey-task-test-project/classify?reload=0&workflow=2658)

- note once clicking Human, can't click Identify, even though Wow! is not required
- Wow! can not be un-clicked

same workflow, working as intended, on staged branch here: [https://survey-task-fix-require.pfe-preview.zooniverse.org/projects/markb-panoptes/survey-task-test-project/classify?reload=0&workflow=2658](https://survey-task-fix-require.pfe-preview.zooniverse.org/projects/markb-panoptes/survey-task-test-project/classify?reload=0&workflow=2658)

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [x] If changes are made to the classifier, does the dev classifier still work?