### PR TITLE
Update markdownz to support table-of-contents links

### DIFF
--- a/app/components/wrapped-markdown.jsx
+++ b/app/components/wrapped-markdown.jsx
@@ -11,7 +11,8 @@ const WrappedMarkdown = React.createClass({
   },
 
   onClick(e) {
-    if (e.target.origin === window.location.origin) {
+    if (e.target.origin === window.location.origin &&
+      e.target.pathname !== window.location.pathname) {
       const newURL = e.target.pathname + e.target.search + e.target.hash;
       browserHistory.push(newURL);
       e.preventDefault();

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lodash.merge": "~2.4.1",
     "lodash.pick": "~3.1.0",
     "lodash.uniq": "~3.2.2",
-    "markdownz": "~4.1.4",
+    "markdownz": "~4.2",
     "modal-form": "~2.4.2",
     "moment": "~2.9.0",
     "panoptes-client": "~2.5.0",
@@ -42,6 +42,7 @@
   "devDependencies": {
     "babel-cli": "~6.7.7",
     "babel-loader": "~6.2.4",
+    "babel-plugin-add-module-exports": "~0.2.1",
     "babel-plugin-react-transform": "~2.0.2",
     "babel-plugin-transform-object-assign": "~6.8.0",
     "babel-plugin-transform-react-jsx": "~6.7.5",


### PR DESCRIPTION
Describe your changes.
Updates markdownz to include anchors for H1 and H2, so that `[[toc]]` will generate working links.
Adds a babel plugin that markdown-it-anchor needs.
Doesn't override default link behaviour if we stay on the same page, so that the browser will scroll to the specified heading.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://markdown-anchors.pfe-preview.zooniverse.org/

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
