### PR TITLE
collected-item delete-button z-index fix.

### DIFF
--- a/css/collections.styl
+++ b/css/collections.styl
@@ -47,6 +47,7 @@
       right: -0.3em
       top: -0.3em
       width: 1.3em
+      z-index: 1
 
       &:hover
         color: red


### PR DESCRIPTION
Fixes #2400 .
Partially (mouse-click)blocked delete-button on collected items.

Describe your changes.
Simple direct z-index fix.

Although the "*collection-subject-viewer-delete-button*" class is used after/in the "*subject-container*" class.
The "*subject-link*" class is applied(*[html part](https://github.com/zooniverse/Panoptes-Front-End/blob/ea6131abc4e7c09f363c326562723fc7795da33a/app/collections/show-list.cjsx#L81)*) after the button, which is *probably* the reason for the partial blocking of the delete button.

(*note: Chrome only user + no code testing available on this side*)

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?