### PR TITLE
Persist annotations utility

### DIFF
--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -59,7 +59,6 @@ Classifier = React.createClass
     @setState renderIntervention: true
 
   componentDidMount: ->
-    console.log('cacheClassification', @props.cacheClassification)
     experimentsClient.startOrResumeExperiment interventionMonitor, @context.geordi
     @setState renderIntervention: interventionMonitor?.shouldShowIntervention()
     interventionMonitor.on 'interventionRequested', @enableIntervention

--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -437,7 +437,6 @@ Classifier = React.createClass
 
     if @props.workflow.configuration.persist_annotations
       cachedAnnotation = @props.cacheClassification.isAnnotationCached(taskKey)
-      console.log('cachedAnnotation', cachedAnnotation)
       if cachedAnnotation?
         annotation = cachedAnnotation
 
@@ -447,6 +446,7 @@ Classifier = React.createClass
   # Back up:
   destroyCurrentAnnotation: ->
     lastAnnotation = @props.classification.annotations[@props.classification.annotations.length - 1]
+
     @props.classification.annotations.pop()
     @props.classification.update 'annotations'
 
@@ -456,7 +456,8 @@ Classifier = React.createClass
   completeClassification: ->
     if @props.workflow.configuration.persist_annotations
       @props.cacheClassification.delete()
-
+    
+    currentAnnotation = @props.classification.annotations[@props.classification.annotations.length - 1]
     currentTask = @props.workflow.tasks[currentAnnotation?.task]
     currentTask?.tools?.map (tool) =>
       if tool.type is 'grid'

--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -22,6 +22,9 @@ experimentsClient = require '../lib/experiments-client'
 interventionMonitor = require '../lib/intervention-monitor'
 `import CacheClassification from '../components/cache-classification'`
 
+# For easy debugging
+window.cachedClassification = CacheClassification
+
 Classifier = React.createClass
   displayName: 'Classifier'
 

--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -41,7 +41,6 @@ Classifier = React.createClass
     subject: null
     classification: null
     onLoad: Function.prototype
-    # cacheClassification: new CacheClassification
 
   getInitialState: ->
     backButtonWarning: false

--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -41,7 +41,7 @@ Classifier = React.createClass
     subject: null
     classification: null
     onLoad: Function.prototype
-    cacheClassification: new CacheClassification
+    # cacheClassification: new CacheClassification
 
   getInitialState: ->
     backButtonWarning: false
@@ -435,7 +435,7 @@ Classifier = React.createClass
     annotation.task = taskKey
 
     if @props.workflow.configuration.persist_annotations
-      cachedAnnotation = @props.cacheClassification.isAnnotationCached(taskKey)
+      cachedAnnotation = CacheClassification.isAnnotationCached(taskKey)
       if cachedAnnotation?
         annotation = cachedAnnotation
 
@@ -450,11 +450,11 @@ Classifier = React.createClass
     @props.classification.update 'annotations'
 
     if @props.workflow.configuration.persist_annotations
-      @props.cacheClassification.update(lastAnnotation)
+      CacheClassification.update(lastAnnotation)
 
   completeClassification: ->
     if @props.workflow.configuration.persist_annotations
-      @props.cacheClassification.delete()
+      CacheClassification.delete()
     
     currentAnnotation = @props.classification.annotations[@props.classification.annotations.length - 1]
     currentTask = @props.workflow.tasks[currentAnnotation?.task]

--- a/app/components/cache-classification.js
+++ b/app/components/cache-classification.js
@@ -26,23 +26,19 @@ class CacheClassification {
     } else {
       cachedClassification = this.state.cachedClassification;
     }
-    console.log('update taskKey', taskKey);
     const cachedAnnotation = this.isAnnotationCached(taskKey);
 
     if (cachedAnnotation) {
-      console.log('annotation is cached', cachedAnnotation);
       const index = cachedClassification.annotations.findIndex(
         (annotation) => annotation.task === taskKey);
-      console.log('index', index);
+
       if (index > -1) {
-        const newAnnotations = cachedClassification.annotations.slice(index, 1);
-        cachedClassification.annotations = newAnnotations;
+        cachedClassification.annotations.splice(index, 1);
       }
     }
     cachedClassification.annotations.push(newAnnotation);
 
     cachedClassification.update('annotations');
-    console.log('cachedClassification', cachedClassification);
   }
 
   delete() {
@@ -54,16 +50,12 @@ class CacheClassification {
 
     if (this.state.cachedClassification !== null) {
       const annotations = this.state.cachedClassification.annotations;
-      console.log('annotations, taskKey', annotations, taskKey);
       annotations.forEach((annotation) => {
-        console.log('annotation.task', annotation.task, taskKey);
         if (annotation.task === taskKey) {
-          console.log('annotation task is taskkey', annotation);
           annotationToReturn = annotation;
         }
       });
     }
-    console.log('annotationToReturn', annotationToReturn);
 
     return annotationToReturn;
   }

--- a/app/components/cache-classification.js
+++ b/app/components/cache-classification.js
@@ -1,0 +1,57 @@
+import apiClient from 'panoptes-client/lib/api-client';
+
+class CacheClassification {
+  constructor() {
+    this.state = {
+      cachedClassification: null,
+    };
+  }
+
+  create() {
+    apiClient.type('classifications').create({
+      annotations: [],
+      id: 'CACHED_CLASSIFICATION_DO_NOT_SAVE',
+    }).then((classification) => {
+      this.state = { cachedClassification: classification };
+      return this.state.cachedClassification;
+    });
+  }
+
+  update(newAnnotation) {
+    let cachedClassification;
+
+    if (this.state.cachedClassification === null) {
+      console.log('this.state.cachedClassification is null', this.state.cachedClassification);
+      cachedClassification = this.create();
+    } else {
+      cachedClassification = this.state.cachedClassification;
+    }
+    console.log('cachedClassification', cachedClassification);
+
+    cachedClassification.annotations[cachedClassification.annotations.length - 1] = newAnnotation;
+    cachedClassification.update('annotations');
+  }
+
+  delete() {
+    this.state = { cachedClassification: null };
+  }
+
+  isAnnotationCached(taskKey) {
+    if (this.state.cachedClassification !== null) {
+      const annotations = this.state.cachedClassification.annotations;
+
+      annotations.forEach((annotation) => {
+        if (annotation.task === taskKey) {
+          return annotation;
+        }
+
+        return null;
+      });
+    }
+
+    return null;
+  }
+}
+
+
+export default CacheClassification;

--- a/app/components/cache-classification.js
+++ b/app/components/cache-classification.js
@@ -8,28 +8,41 @@ class CacheClassification {
   }
 
   create() {
-    apiClient.type('classifications').create({
+    const cachedClassification = apiClient.type('classifications').create({
       annotations: [],
       id: 'CACHED_CLASSIFICATION_DO_NOT_SAVE',
-    }).then((classification) => {
-      this.state = { cachedClassification: classification };
-      return this.state.cachedClassification;
     });
+
+    this.state = { cachedClassification };
+    return this.state.cachedClassification;
   }
 
   update(newAnnotation) {
     let cachedClassification;
+    const taskKey = newAnnotation.task;
 
     if (this.state.cachedClassification === null) {
-      console.log('this.state.cachedClassification is null', this.state.cachedClassification);
       cachedClassification = this.create();
     } else {
       cachedClassification = this.state.cachedClassification;
     }
-    console.log('cachedClassification', cachedClassification);
+    console.log('update taskKey', taskKey);
+    const cachedAnnotation = this.isAnnotationCached(taskKey);
 
-    cachedClassification.annotations[cachedClassification.annotations.length - 1] = newAnnotation;
+    if (cachedAnnotation) {
+      console.log('annotation is cached', cachedAnnotation);
+      const index = cachedClassification.annotations.findIndex(
+        (annotation) => annotation.task === taskKey);
+      console.log('index', index);
+      if (index > -1) {
+        const newAnnotations = cachedClassification.annotations.slice(index, 1);
+        cachedClassification.annotations = newAnnotations;
+      }
+    }
+    cachedClassification.annotations.push(newAnnotation);
+
     cachedClassification.update('annotations');
+    console.log('cachedClassification', cachedClassification);
   }
 
   delete() {
@@ -37,19 +50,22 @@ class CacheClassification {
   }
 
   isAnnotationCached(taskKey) {
+    let annotationToReturn = null;
+
     if (this.state.cachedClassification !== null) {
       const annotations = this.state.cachedClassification.annotations;
-
+      console.log('annotations, taskKey', annotations, taskKey);
       annotations.forEach((annotation) => {
+        console.log('annotation.task', annotation.task, taskKey);
         if (annotation.task === taskKey) {
-          return annotation;
+          console.log('annotation task is taskkey', annotation);
+          annotationToReturn = annotation;
         }
-
-        return null;
       });
     }
+    console.log('annotationToReturn', annotationToReturn);
 
-    return null;
+    return annotationToReturn;
   }
 }
 

--- a/app/components/cache-classification.js
+++ b/app/components/cache-classification.js
@@ -5,6 +5,8 @@ class CacheClassification {
     this.state = {
       cachedClassification: null,
     };
+
+    window.cachedClassification = this.state.cachedClassification;
   }
 
   create() {

--- a/app/components/cache-classification.js
+++ b/app/components/cache-classification.js
@@ -1,19 +1,12 @@
-import apiClient from 'panoptes-client/lib/api-client';
-
 class CacheClassification {
   constructor() {
     this.state = {
       cachedClassification: null,
     };
-
-    window.cachedClassification = this.state.cachedClassification;
   }
 
   create() {
-    const cachedClassification = apiClient.type('classifications').create({
-      annotations: [],
-      id: 'CACHED_CLASSIFICATION_DO_NOT_SAVE',
-    });
+    const cachedClassification = { annotations: [] };
 
     this.state = { cachedClassification };
     return this.state.cachedClassification;
@@ -39,8 +32,6 @@ class CacheClassification {
       }
     }
     cachedClassification.annotations.push(newAnnotation);
-
-    cachedClassification.update('annotations');
   }
 
   delete() {

--- a/app/components/cache-classification.js
+++ b/app/components/cache-classification.js
@@ -63,5 +63,5 @@ class CacheClassification {
   }
 }
 
-
-export default CacheClassification;
+const cachedClassification = new CacheClassification;
+export default cachedClassification;

--- a/app/pages/admin/project-status.cjsx
+++ b/app/pages/admin/project-status.cjsx
@@ -28,7 +28,7 @@ EXPERIMENTAL_FEATURES = [
   'Gravity Spy Gold Standard'
   'allow workflow query'
   'expert comparison summary'
-  'persist answers'
+  'persist annotations'
 ]
 
 ProjectToggle = React.createClass

--- a/app/pages/dev-classifier/mock-data.coffee
+++ b/app/pages/dev-classifier/mock-data.coffee
@@ -32,6 +32,7 @@ workflow = apiClient.type('workflows').create
     enable_switching_flipbook_and_separate: true
     multi_image_layout: 'grid3'
     invert_subject: true
+    persist_annotations: true
 
   first_task: 'init'
 

--- a/app/pages/lab/workflow.cjsx
+++ b/app/pages/lab/workflow.cjsx
@@ -229,7 +229,7 @@ EditWorkflowPage = React.createClass
 
           <hr />
 
-          {if 'persist answers' in @props.project.experimental_tools
+          {if 'persist annotations' in @props.project.experimental_tools
             <div>
               <AutoSave resource={@props.workflow}>
               <span className="form-label">Set annotation persistence</span><br />

--- a/app/pages/lab/workflow.cjsx
+++ b/app/pages/lab/workflow.cjsx
@@ -229,6 +229,20 @@ EditWorkflowPage = React.createClass
 
           <hr />
 
+          {if 'persist answers' in @props.project.experimental_tools
+            <div>
+              <AutoSave resource={@props.workflow}>
+              <span className="form-label">Set annotation persistence</span><br />
+              <small className="form-help">Save the annotation of the task you are on when the back button is clicked.</small>
+              <br />
+              <label>
+                <input ref="persistAnnotation" type="checkbox" checked={@props.workflow.configuration.persist_annotations} onChange={@handlePersistAnnotationsToggle} />
+                Persist annotations
+              </label>
+              </AutoSave>
+              <hr />
+            </div>}
+
           <div>
             <AutoSave resource={@props.project}>
               <span className="form-label">Set as default</span><br />
@@ -478,6 +492,10 @@ EditWorkflowPage = React.createClass
   handleSetHideClassificationSummaries: (e) ->
     @props.workflow.update
       'configuration.hide_classification_summaries': e.target.checked
+
+  handlePersistAnnotationsToggle: (e) ->
+    @props.workflow.update
+      'configuration.persist_annotations': e.target.checked
 
   handleSetInvert: (e) ->
     @props.workflow.update


### PR DESCRIPTION
Fixes #2956. This adds the annotation persistence if the back button is clicked by storing it in a temporary cached classification resource separate from the classification in the classifier and then checking for and loading a cached annotation when the next button is clicked if the workflow is configured to use annotation persistence and `persist annotations` is added to a project's experimental tool's array.

This should be the functionality needed for NfN but also keep it from breaking if branching logic is added later. Annotations in the classifier are popped off as expected when back is clicked, re-added if it exists in the cache. This can be seen with the branching logic of the dev classifier.

Should be tested with the NfN project. I've added `persist annotations` to its experimental tools array already. @mcbouslog you'll need to enable the option for the workflows that need this. I'm not sure which or if all will.

One of their workflows: https://persist-annotations-utility.pfe-preview.zooniverse.org/projects/zooniverse/notes-from-nature/classify?reload=1&workflow=2343&env=production

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?

## Optional

- [x] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [x] If changes are made to the classifier, does the dev classifier still work?