### PR TITLE
Add Zoo alumni to ignore list for PRs

### DIFF
--- a/.mention-bot
+++ b/.mention-bot
@@ -1,3 +1,10 @@
 {
-  "requiredOrgs": ["zooniverse"]
+  "requiredOrgs": ["zooniverse"],
+  "userBlacklist": [
+    "alexbfree",
+    "aweiksnar",
+    "brian-c",
+    "chrissnyder",
+    "edpaget"
+  ]
 }


### PR DESCRIPTION
Stops mention-bot from bugging Zoo alums when making a PR.