### PR TITLE
edit focus for text and dropdown tasks

### DIFF
--- a/app/classifier/tasks/dropdown/index.cjsx
+++ b/app/classifier/tasks/dropdown/index.cjsx
@@ -93,7 +93,14 @@ module.exports = React.createClass
       @props.annotation.value = @props.task.selects.map -> {value: null, option: false}
 
     if @props.autoFocus is true
-      @refs['select-0'].getInputNode().focus()
+      @handleFocus()
+
+  componentDidUpdate: (prevProps) ->
+    if prevProps.task isnt @props.task and @props.autoFocus is true
+      @handleFocus()
+
+  handleFocus: ->
+    @refs['select-0'].getInputNode().focus()
 
   handleOptionsKeys: (i, value) ->
     {id, condition} = @props.task.selects[i]

--- a/app/classifier/tasks/text/index.cjsx
+++ b/app/classifier/tasks/text/index.cjsx
@@ -65,6 +65,10 @@ module.exports = React.createClass
       @setState textareaHeight: @state.initOffsetHeight, =>
         @updateHeight()
 
+  componentDidUpdate: (prevProps) ->
+    if prevProps.task isnt @props.task and @props.autoFocus is true
+      @refs.textInput.focus()
+
   setTagSelection: (e) ->
     textTag = e.target.value
     startTag = '[' + textTag + ']'


### PR DESCRIPTION
Fixes #2945.

The `autoFocus` attribute only works on initial page load, so component updates don't trigger intended focus. Examples of focus not working as intended...

 - [back to back text task workflow](https://master.pfe-preview.zooniverse.org/projects/markb-panoptes/focus-testing-project/classify?reload=3&workflow=2428)
 - [back to back combo tasks](https://master.pfe-preview.zooniverse.org/projects/markb-panoptes/focus-testing-project/classify?reload=2&workflow=2426) (2nd and 3rd tasks, with dropdown tasks as first task within combo tasks)

Examples on staged branch, working as intended...
- [back to back text task workflow](https://edit-focus-text-dropdown.pfe-preview.zooniverse.org/projects/markb-panoptes/focus-testing-project/classify?reload=3&workflow=2428)
- [back to back combo tasks](https://edit-focus-text-dropdown.pfe-preview.zooniverse.org/projects/markb-panoptes/focus-testing-project/classify?reload=2&workflow=2426) (2nd and 3rd tasks, with dropdown tasks as first task within combo tasks)

# Review Checklist

- [x] Does it work in all major browsers: ~~Firefox~~, ~~Chrome~~, Edge (unsure), Safari (didn't, still doesn't)?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [x] If changes are made to the classifier, does the dev classifier still work?
