### PR TITLE
Speed up stats API call

### DIFF
--- a/app/components/classifications-ribbon.cjsx
+++ b/app/components/classifications-ribbon.cjsx
@@ -1,7 +1,7 @@
 React = require 'react'
 apiClient = require 'panoptes-client/lib/api-client'
-getColorFromString = require('../lib/get-color-from-string').default
-getUserClassificationCounts = require('../lib/get-user-classification-counts').default
+`import getColorFromString from '../lib/get-color-from-string';`
+`import getUserClassificationCounts from '../lib/get-user-classification-counts';`
 
 ClassificationsRibbon = React.createClass
   displayName: 'ClassificationsRibbon'

--- a/app/components/classifications-ribbon.cjsx
+++ b/app/components/classifications-ribbon.cjsx
@@ -79,21 +79,15 @@ module.exports = React.createClass
   getClassificationCounts: (user) ->
     @setState loading: true
 
-    getUserClassificationCounts(@props.user).then (classificationCounts) =>
-      console.log('Got counts', classificationCounts)
-      awaitProjects = Promise.all Object.keys(classificationCounts).map (projectID) =>
-        return apiClient.type('projects').get projectID
-
-      awaitProjects.then (projects) =>
-        console.log('Got projects', projects)
-        pairs = []
-        for i in [0...projects.length]
-          pairs.push
-            project: projects[i].display_name
-            classifications: classificationCounts[projects[i].id]
-        @setState
-          loading: false
-          projects: pairs
+    getUserClassificationCounts(@props.user).then (projects) =>
+      pairs = []
+      for i in [0...projects.length]
+        pairs.push
+          project: projects[i].display_name
+          classifications: projects[i].activity_count
+      @setState
+        loading: false
+        projects: pairs
 
   render: ->
     if @state.loading

--- a/app/components/classifications-ribbon.cjsx
+++ b/app/components/classifications-ribbon.cjsx
@@ -1,5 +1,7 @@
 React = require 'react'
 apiClient = require 'panoptes-client/lib/api-client'
+getColorFromString = require('../lib/get-color-from-string').default
+getUserClassificationCounts = require('../lib/get-user-classification-counts').default
 
 ClassificationsRibbon = React.createClass
   displayName: 'ClassificationsRibbon'
@@ -10,15 +12,6 @@ ClassificationsRibbon = React.createClass
     cutoff: 1 / 50
     width: '100%'
     height: '1em'
-
-  getProjectColor: (name) ->
-    characters = name.split ''
-    hue = [0, characters...].reduce (code, character) ->
-      # Square the number so that e.g. "a" and "b" aren't so close.
-      return code + Math.pow character.charCodeAt(0), 2
-    saturation = 50 + (hue % 50)
-    hue %= 360
-    "hsl(#{hue}, #{saturation}%, 50%)"
 
   render: ->
     if @props.projects.length is 0
@@ -45,7 +38,7 @@ ClassificationsRibbon = React.createClass
             others.push {project, classifications}
             continue
           else
-            band = <rect key={project} fill={@getProjectColor project} stroke="none" x={lastX} y="0" width={width} height="1">
+            band = <rect key={project} fill={getColorFromString project} stroke="none" x={lastX} y="0" width={width} height="1">
               <title>
                 {project}: {classifications ? '?'}
               </title>
@@ -81,33 +74,26 @@ module.exports = React.createClass
 
   componentWillReceiveProps: (nextProps) ->
     unless nextProps.user is @props.user
-      @getClassificationCounts @props.user
+      @getClassificationCounts nextProps.user
 
   getClassificationCounts: (user) ->
     @setState loading: true
-    @getAllProjectPreferences(user).then (preferences) =>
-      projects = for preference in preferences
-        apiClient.type('projects').get(preference.links.project).catch =>
-          null
-      Promise.all(projects).then (projects) =>
-        counts = for i in  [0...preferences.length] when projects[i]?
-          project: projects[i].display_name
-          classifications: preferences[i].activity_count
+
+    getUserClassificationCounts(@props.user).then (classificationCounts) =>
+      console.log('Got counts', classificationCounts)
+      awaitProjects = Promise.all Object.keys(classificationCounts).map (projectID) =>
+        return apiClient.type('projects').get projectID
+
+      awaitProjects.then (projects) =>
+        console.log('Got projects', projects)
+        pairs = []
+        for i in [0...projects.length]
+          pairs.push
+            project: projects[i].display_name
+            classifications: classificationCounts[projects[i].id]
         @setState
           loading: false
-          projects: counts
-
-  getAllProjectPreferences: (user, _page = 1, _collection = []) ->
-    user.get('project_preferences', page: _page, include: 'project').then (projectPreferences) =>
-      if projectPreferences.length is 0
-        projectPreferences
-      else
-        _collection.push projectPreferences...
-        meta = projectPreferences[0].getMeta()
-        if meta.page is meta.page_count
-          _collection
-        else
-          @getAllProjectPreferences user, meta.page + 1, _collection
+          projects: pairs
 
   render: ->
     if @state.loading

--- a/app/components/project-icon.cjsx
+++ b/app/components/project-icon.cjsx
@@ -25,18 +25,9 @@ module.exports = React.createClass
 
   getDetails: (project) ->
     if project.avatar_src
-      @setState avatar: "http://#{ project.avatar_src }"
+      @setState avatar: "//#{ project.avatar_src }"
     else
-      apiClient.type 'avatars'
-        .get project.links?.avatar?.id
-        .then (avatar) =>
-          @setState avatar: avatar.src
-        .catch =>
-          project.get 'avatar'
-            .catch =>
-              null
-            .then (avatar) =>
-              @setState avatar: avatar.src
+      @setState avatar: '/assets/simple-avatar.jpg'
 
   render: ->
     content = [

--- a/app/components/project-icon.cjsx
+++ b/app/components/project-icon.cjsx
@@ -28,7 +28,7 @@ module.exports = React.createClass
       @setState avatar: "http://#{ project.avatar_src }"
     else
       apiClient.type 'avatars'
-        .get project.links.avatar.id
+        .get project.links?.avatar?.id
         .then (avatar) =>
           @setState avatar: avatar.src
         .catch =>

--- a/app/components/project-icon.cjsx
+++ b/app/components/project-icon.cjsx
@@ -24,20 +24,23 @@ module.exports = React.createClass
       @getDetails nextProps.project
 
   getDetails: (project) ->
-    apiClient.type 'avatars'
-      .get project.links.avatar.id
-      .then (avatar) =>
-        @setState {avatar}
-      .catch =>
-        project.get 'avatar'
-          .catch =>
-            null
-          .then (avatar) =>
-            @setState {avatar}
+    if project.avatar_src
+      @setState avatar: "http://#{ project.avatar_src }"
+    else
+      apiClient.type 'avatars'
+        .get project.links.avatar.id
+        .then (avatar) =>
+          @setState avatar: avatar.src
+        .catch =>
+          project.get 'avatar'
+            .catch =>
+              null
+            .then (avatar) =>
+              @setState avatar: avatar.src
 
   render: ->
     content = [
-      <img key="image" alt="" src={@state.avatar?.src ? @props.defaultAvatarSrc} />
+      <img key="image" alt="" src={@state.avatar ? @props.defaultAvatarSrc} />
       <div key="label" className="label">
         <span className="owner">{@props.project.links.owner?.display_name}</span><br />
         <span className="display-name"><strong>{@props.project.display_name}</strong></span>

--- a/app/lib/get-all-project-preferences.js
+++ b/app/lib/get-all-project-preferences.js
@@ -1,7 +1,6 @@
 function getAllProjectPreferences(user, _page = 1, _accumulator = []) {
   return user.get('project_preferences', {
     page: _page,
-    include: 'project',
   })
   .then((projectPreferences) => {
     if (projectPreferences.length === 0) {

--- a/app/lib/get-all-project-preferences.js
+++ b/app/lib/get-all-project-preferences.js
@@ -1,0 +1,21 @@
+function getAllProjectPreferences(user, _page = 1, _accumulator = []) {
+  return user.get('project_preferences', {
+    page: _page,
+    include: 'project',
+  })
+  .then((projectPreferences) => {
+    if (projectPreferences.length === 0) {
+      return projectPreferences;
+    } else {
+      _accumulator.push(...projectPreferences);
+      const meta = projectPreferences[0].getMeta();
+      if (meta.page === meta.page_count) {
+        return _accumulator;
+      } else {
+        return getAllProjectPreferences(user, meta.page + 1, _accumulator);
+      }
+    }
+  });
+}
+
+export default getAllProjectPreferences;

--- a/app/lib/get-color-from-string.js
+++ b/app/lib/get-color-from-string.js
@@ -1,0 +1,12 @@
+function getColorFromString(string) {
+  const characters = string.split('');
+  let hue = characters.reduce((code, character) => {
+    // Square the number so that e.g. "a" and "b" aren't so close.
+    return code + Math.pow(character.charCodeAt(0), 2);
+  }, 0);
+  const saturation = 50 + (hue % 50);
+  hue %= 360;
+  return `hsl(${hue}, ${saturation}%, 50%)`;
+}
+
+export default getColorFromString;

--- a/app/lib/get-user-classification-counts.js
+++ b/app/lib/get-user-classification-counts.js
@@ -3,14 +3,18 @@ import apiClient from 'panoptes-client/lib/api-client';
 
 function getUserClassificationCounts(user) {
   return getAllProjectPreferences(user).then((projectPreferences) => {
-    const projectIDs = projectPreferences.map((projectPreference) => {
+    const activePreferences = projectPreferences.filter((preference) => {
+      if (preference.activity_count > 0)
+        return preference;
+    });
+    const projectIDs = activePreferences.map((projectPreference) => {
       return projectPreference.links.project;
     });
-    return apiClient.type('projects').get({ id: projectIDs, cards: true, page_size: projectPreferences.length }).catch(() => {
+    return apiClient.type('projects').get({ id: projectIDs, cards: true, page_size: activePreferences.length }).catch(() => {
       return null;
     })
     .then((projects) => {
-      const classifications = projectPreferences.reduce((counts, projectPreference) => {
+      const classifications = activePreferences.reduce((counts, projectPreference) => {
         counts[projectPreference.links.project] = projectPreference.activity_count;
         return counts;
       }, {});

--- a/app/lib/get-user-classification-counts.js
+++ b/app/lib/get-user-classification-counts.js
@@ -1,0 +1,21 @@
+import getAllProjectPreferences from './get-all-project-preferences';
+import apiClient from 'panoptes-client/lib/api-client';
+
+function getUserClassificationCounts(user) {
+  return getAllProjectPreferences(user).then((projectPreferences) => {
+    return Promise.all(projectPreferences.map((projectPreference) => {
+      return apiClient.type('projects').get(projectPreference.links.project).catch(() => {
+        return null;
+      });
+    })).then((projects) => {
+      return projectPreferences.reduce((counts, projectPreference, i) => {
+        if (!!projects[i]) {
+          counts[projects[i].id] = projectPreference.activity_count;
+        }
+        return counts;
+      }, {});
+    });
+  });
+}
+
+export default getUserClassificationCounts;

--- a/app/pages/home-logged-in.cjsx
+++ b/app/pages/home-logged-in.cjsx
@@ -62,14 +62,14 @@ FeaturedProjects = React.createClass
 
 RecentProjects = React.createClass
   displayName: 'RecentProjects'
-  
+
   getInitialState: ->
     projects: []
     activityCounts: {}
     title: ""
     href: ''
     action: ""
-  
+
   componentWillMount: ->
     @props.user
       .get("project_preferences", page_size: 10, sort: '-updated_at')
@@ -94,7 +94,7 @@ RecentProjects = React.createClass
         projectsPromise
       .then (projects) =>
         @setState {projects}
-  
+
   render: ->
     if @state.projects.length > 0
       <div className="recent-projects">
@@ -111,7 +111,7 @@ RecentProjects = React.createClass
       </div>
     else
       null
-    
+
 
 module.exports = React.createClass
   displayName: 'HomePage'

--- a/app/pages/home-logged-in.cjsx
+++ b/app/pages/home-logged-in.cjsx
@@ -84,7 +84,7 @@ RecentProjects = React.createClass
             title: "home.recentProjects.title"
             href: "/users/#{@props.user.login}/stats"
             action: "home.recentProjects.button"
-          projectsPromise = apiClient.type('projects').get(id: userProjects, cards: true, include: ['avatar', 'owners'])
+          projectsPromise = apiClient.type('projects').get(id: userProjects, cards: true)
         else
           @setState
             title: "home.recentProjects.altTitle"

--- a/app/pages/home-logged-in.cjsx
+++ b/app/pages/home-logged-in.cjsx
@@ -84,7 +84,7 @@ RecentProjects = React.createClass
             title: "home.recentProjects.title"
             href: "/users/#{@props.user.login}/stats"
             action: "home.recentProjects.button"
-          projectsPromise = apiClient.type('projects').get userProjects, include: ['avatar', 'owners']
+          projectsPromise = apiClient.type('projects').get(id: userProjects, cards: true, include: ['avatar', 'owners'])
         else
           @setState
             title: "home.recentProjects.altTitle"

--- a/app/pages/profile/stats.cjsx
+++ b/app/pages/profile/stats.cjsx
@@ -3,7 +3,7 @@ apiClient = require 'panoptes-client/lib/api-client'
 ClassificationsRibbon = require '../../components/classifications-ribbon'
 PromiseRenderer = require '../../components/promise-renderer'
 ProjectIcon = require '../../components/project-icon'
-getAllProjectPreferences = require('../../lib/get-all-project-preferences').default
+getUserClassificationCounts = require('../../lib/get-user-classification-counts').default
 
 module.exports = React.createClass
   getDefaultProps: ->
@@ -27,18 +27,14 @@ module.exports = React.createClass
       @getProjectStats newProps.profileUser
 
   getProjectStats: (user) ->
-    getAllProjectPreferences(user)
-      .then (projectPreferences) =>
-        projectPreferences.map (projectPreference) =>
-          apiClient.type 'projects'
-            .get projectPreference.links.project
-            .then (project) =>
-              if projectPreference.activity_count > 0
-                project.activity_count = projectPreference.activity_count
-                @setState (state, props) ->
-                  projects = state.projects
-                  projects[project.id] = project
-                  {projects}
+    getUserClassificationCounts(user)
+      .then (projects) =>
+        projects.map (project, i) =>
+          if project.activity_count > 0
+            @setState (state, props) ->
+              projects = state.projects
+              projects[project.id] = project
+              {projects}
 
   render: ->
     <div className="content-container">

--- a/app/pages/profile/stats.cjsx
+++ b/app/pages/profile/stats.cjsx
@@ -3,7 +3,7 @@ apiClient = require 'panoptes-client/lib/api-client'
 ClassificationsRibbon = require '../../components/classifications-ribbon'
 PromiseRenderer = require '../../components/promise-renderer'
 ProjectIcon = require '../../components/project-icon'
-getUserClassificationCounts = require('../../lib/get-user-classification-counts').default
+`import getUserClassificationCounts from '../../lib/get-user-classification-counts';`
 
 module.exports = React.createClass
   getDefaultProps: ->

--- a/app/pages/profile/stats.cjsx
+++ b/app/pages/profile/stats.cjsx
@@ -3,12 +3,13 @@ apiClient = require 'panoptes-client/lib/api-client'
 ClassificationsRibbon = require '../../components/classifications-ribbon'
 PromiseRenderer = require '../../components/promise-renderer'
 ProjectIcon = require '../../components/project-icon'
+getAllProjectPreferences = require('../../lib/get-all-project-preferences').default
 
 module.exports = React.createClass
   getDefaultProps: ->
     user: null
     profileUser: null
-  
+
   getInitialState: ->
     projects: {}
 
@@ -20,13 +21,13 @@ module.exports = React.createClass
   componentWillUnmount: ->
     if @props.project? or @props.params?.profile_name?
       document.documentElement.classList.remove 'on-secondary-page'
-  
+
   componentWillReceiveProps: (newProps) ->
     if @props.user isnt newProps.user
       @getProjectStats newProps.profileUser
-  
+
   getProjectStats: (user) ->
-    ClassificationsRibbon::getAllProjectPreferences user
+    getAllProjectPreferences(user)
       .then (projectPreferences) =>
         projectPreferences.map (projectPreference) =>
           apiClient.type 'projects'
@@ -34,7 +35,7 @@ module.exports = React.createClass
             .then (project) =>
               if projectPreference.activity_count > 0
                 project.activity_count = projectPreference.activity_count
-                @setState (state, props) -> 
+                @setState (state, props) ->
                   projects = state.projects
                   projects[project.id] = project
                   {projects}


### PR DESCRIPTION
Refers to #2998 

Describe your changes.
Changes made in this PR speed up the API call to fetch project classifications for the stats page. This also reflects changes that will be made with the new signed in home page. Some refactoring was also made to handle redundant code, and the `ProjectIcon` component was made to handle a project resource card.

# Review Checklist

- [X] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [X] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [X] Did you deploy a staging branch?

https://stats-avatars-move.pfe-preview.zooniverse.org/

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?