### PR TITLE
Clarification of How to Become Beta Tester

### DIFF
--- a/app/pages/settings/email.cjsx
+++ b/app/pages/settings/email.cjsx
@@ -92,7 +92,7 @@ module.exports = React.createClass
         <AutoSave resource={@props.user}>
           <label>
             <input type="checkbox" name="beta_email_communication" checked={@props.user.beta_email_communication} onChange={handleInputChange.bind @props.user} />{' '}
-            Get beta project email updates
+            Get beta project email updates and become a beta tester
           </label>
         </AutoSave>
       </p>


### PR DESCRIPTION
I added in a slight wording change to the beta project email tick box in the Settings, to try to make it clearer that that's how you can become a beta tester - or rather get the emails that enable you to do the beta testing and therefore become one.

The change is inspired by talking to my uncle who is a big Zooniverse fan and volunteer, and hadn't realised that that's what that tick box does. 
