### PR TITLE
Changing Credited Name to Real Name on the Settings Page

### DIFF
--- a/app/pages/settings/account.cjsx
+++ b/app/pages/settings/account.cjsx
@@ -105,7 +105,7 @@ module.exports = React.createClass
             <br />
 
             <AutoSave resource={@props.user}>
-              <span className="form-label">Credited name</span>
+              <span className="form-label">Real name</span>
               <br />
               <input type="text" className="standard-input full" name="credited_name" value={@props.user.credited_name} onChange={handleInputChange.bind @props.user} />
             </AutoSave>


### PR DESCRIPTION
At the moment, when you sign up, you're asked for your 'Real Name', but on the settings page this is referred to as 'Credited Name'. This suggested change would alter the reference on the Settings page to 'Real Name' so that they match up.

It doesn't change anything deeper than what is displayed in the web page though, and it looks like in the code in other places it might still be being referred to as credited name. At the moment, I've no idea how to change any of that.

This suggestion is a result of the glossary that Meg and I are writing - it was in defining the term in the glossary that we noticed that they're called different things in the two places.