### PR TITLE
Highlight already used choices in the survey task

### DIFF
--- a/app/classifier/tasks/survey/chooser.cjsx
+++ b/app/classifier/tasks/survey/chooser.cjsx
@@ -100,9 +100,12 @@ module.exports = React.createClass
             <em>No matches.</em>
           </div>
         else
+          selectedChoices = (item.choice for item in @props.annotation.value)
+
           for choiceID, i in sortedFilteredChoices
             choice = @props.task.choices[choiceID]
-            <button key={choiceID + i} type="button" className="survey-task-chooser-choice-button" onClick={@props.onChoose.bind null, choiceID}>
+            chosenAlready = choiceID in selectedChoices
+            <button key={choiceID + i} type="button" className="survey-task-chooser-choice-button #{'survey-task-chooser-choice-button-chosen' if chosenAlready}" onClick={@props.onChoose.bind null, choiceID}>
               <span className="survey-task-chooser-choice">
                 {if choice.images?.length > 0
                   thumbnailSrc = @props.task.images[choice.images[0]]

--- a/app/classifier/tasks/survey/index.cjsx
+++ b/app/classifier/tasks/survey/index.cjsx
@@ -45,7 +45,7 @@ module.exports = React.createClass
   render: ->
     <div className="survey-task">
       {if @state.selectedChoiceID is ''
-        <Chooser task={@props.task} filters={@state.filters} onFilter={@handleFilter} onChoose={@handleChoice} />
+        <Chooser task={@props.task} filters={@state.filters} onFilter={@handleFilter} onChoose={@handleChoice} annotation={@props.annotation} />
       else
         <Choice task={@props.task} choiceID={@state.selectedChoiceID} onSwitch={@handleChoice} onCancel={@clearSelection} onConfirm={@handleAnnotation} />}
     </div>

--- a/css/survey-task.styl
+++ b/css/survey-task.styl
@@ -142,6 +142,9 @@ $survey-task-pill-button
   > *
     margin: 0.3em 0.6em
 
+.survey-task-chooser-choice-button-chosen
+  background: goldenrod
+
 .survey-task-chooser-choice
   display: flex
   justify-content: flex-start


### PR DESCRIPTION
Fixes my confusion where I don't notice that my selection actually got remembered.

While classifying, highlight survey choices in yellow if they've already emitted one annotation value. I don't particularly like having to pass in the annotation to the `Chooser`, open to suggestions.

![image](https://cloud.githubusercontent.com/assets/277/19393808/398859fa-922e-11e6-93f1-5645f2861e7d.png)

Branch at: https://survey-highlight-chosen-options.pfe-preview.zooniverse.org/projects/aliburchard/wildcam-gorongosa/classify

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
