### PR TITLE
Make text task available to sub-task

### DIFF
--- a/app/classifier/tasks/drawing-task-details-editor.cjsx
+++ b/app/classifier/tasks/drawing-task-details-editor.cjsx
@@ -65,14 +65,12 @@ module.exports = React.createClass
                 <br />
                 <small><strong>Question</strong></small>
               </button>{' '}
-              {
-                if @canUseTask("text")
-                  <button type="submit" className="minor-button" onClick={@handleAddTask.bind this, 'text'} title="Text tasks: the volunteer writes free-form text into a dialog box.">
-                    <i className="fa fa-file-text-o fa-2x"></i>
-                    <br />
-                    <small><strong>Text</strong></small>
-                  </button>
-              }
+
+              <button type="submit" className="minor-button" onClick={@handleAddTask.bind this, 'text'} title="Text tasks: the volunteer writes free-form text into a dialog box.">
+                <i className="fa fa-file-text-o fa-2x"></i>
+                <br />
+                <small><strong>Text</strong></small>
+              </button>
           </TriggeredModalForm>
         </p>
       </div>


### PR DESCRIPTION
Missed a conditional that hid the text task for sub-tasks.

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
