### PR TITLE
An inactive workflow shouldn't be a project's default

### DIFF
--- a/app/pages/lab/visibility.cjsx
+++ b/app/pages/lab/visibility.cjsx
@@ -10,13 +10,15 @@ module.exports = React.createClass
   getDefaultProps: ->
     project: null
 
-  getInitialState: ->
-    error: null
-    setting:
-      private: false
-      beta_requested: false
-      launch_requested: false
-    workflows: null
+  getInitialState: -> {
+    error: null,
+    setting: {
+      private: false,
+      beta_requested: false,
+      launch_requested: false,
+    },
+    workflows: null 
+  }
 
   mixins: [SetToggle]
 
@@ -71,7 +73,7 @@ module.exports = React.createClass
       .catch((error) =>
         @setState {error}
       ).then((workflow) =>
-        if not workflow.active and workflow.id is @props.project.configuration.default_workflow
+        if not workflow.active and workflow.id is @props.project.configuration?.default_workflow
           @props.project.update({ 'configuration.default_workflow': null })
           @props.project.save()
       ).then(() => @forceUpdate()) # Dislike. Eventually we should refactor to not have to call this.forceUpdate()

--- a/app/pages/lab/visibility.cjsx
+++ b/app/pages/lab/visibility.cjsx
@@ -1,6 +1,5 @@
 React = require 'react'
 WorkflowToggle = require '../../components/workflow-toggle'
-PromiseRenderer = require '../../components/promise-renderer'
 SetToggle = require '../../lib/set-toggle'
 Dialog = require 'modal-form/dialog'
 getWorkflowsInOrder = require '../../lib/get-workflows-in-order'
@@ -17,10 +16,17 @@ module.exports = React.createClass
       private: false
       beta_requested: false
       launch_requested: false
+    workflows: null
 
   mixins: [SetToggle]
 
   setterProperty: 'project'
+
+  componentDidMount: ->
+    getWorkflowsInOrder(@props.project, fields: 'display_name,active')
+      .then((workflows) =>
+        @setState({ workflows })
+      )
 
   isReviewable: ->
     not @props.project.private and
@@ -57,6 +63,18 @@ module.exports = React.createClass
       </div>,
       closeButton: true
     )
+
+  handleWorkflowSettingChange: (workflow, e) ->
+    checked = e.target.checked
+
+    workflow.update({ 'active': checked }).save()
+      .catch((error) =>
+        @setState {error}
+      ).then((workflow) =>
+        if not workflow.active and workflow.id is @props.project.configuration.default_workflow
+          @props.project.update({ 'configuration.default_workflow': null })
+          @props.project.save()
+      ).then(() => @forceUpdate()) # Dislike. Eventually we should refactor to not have to call this.forceUpdate()
 
   render: ->
     looksDisabled =
@@ -197,19 +215,27 @@ module.exports = React.createClass
       <hr/>
 
       <p className="form-label">Workflow Settings</p>
-      <PromiseRenderer promise={getWorkflowsInOrder @props.project, fields: 'display_name,active'}>{(workflows) =>
-        if workflows.length is 0
-          <div className="workflow-status-list">No workflows found</div>
-        else
-          <div className="workflow-status-list">
-            <ul>
-            {workflows.map (workflow) =>
-              <li key={workflow.id}>
-                <WorkflowToggle workflow={workflow} project={@props.project} field="active" />
-              </li>}
-            </ul>
-          </div>
-      }</PromiseRenderer>
+      {if @state.workflows is null
+        <div className="workflow-status-list">Loading workflows...</div>
+      else if @state.workflows.length is 0
+        <div className="workflow-status-list">No workflows found</div>
+      else
+        <div className="workflow-status-list">
+          <ul>
+          {@state.workflows.map (workflow) =>
+            setting = workflow.active
+            <li key={workflow.id}>
+              <span>
+                {workflow.id} - {workflow.display_name}:
+                <label style={whiteSpace: 'nowrap'}>
+                  <input type="checkbox" name="active" value={setting} checked={setting} onChange={@handleWorkflowSettingChange.bind(this, workflow)} />
+                  Active
+                </label>
+              </span>
+            </li>}
+          </ul>
+        </div>}
       <p className="form-help">In a live project active workflows are available to volunteers and cannot be edited. Inactive workflows can be edited if a project is live or in development.</p>
+      <p className="form-help">If an active workflow is the default workflow for the project and is made inactive, then it will be removed as the default workflow.</p>
       <p className="form-help">On a live project, if you want to switch which subjects sets are associated with an active workflow: set the workflow to inactive, next change which subject sets are linked in the Workflow Section within the Project Builder, then return the workflow to active.</p>
     </div>


### PR DESCRIPTION
This fixes a bug encountered with the Understanding Animal Faces project described on slack. The default workflow was made inactive and new visitors to the project's classify page would try to load the default workflow which produced an error as well as a loop to try to assign a workflow it couldn't.

Instead of tasking the classifier with clearing out an inactive default workflow, I think it makes more sense to have this action happen when the workflow is made inactive in the project builder. I also added a note for project builders so they know that the default setting for the project will be removed if the default workflow is made inactive. 

One issue is that the asterisk indicating the default won't disappear until the page is refreshed or they navigate to cause a reload of the sidebar in the project builder. I'm not sure how to fix this without refactoring to remove the `ChangeHandler` and `PromiseRenderer` handling the workflow listing in the sidebar, but this is not within scope of fixing this bug.

Staged branch: https://fix-workflow-selection-for-defaults.pfe-preview.zooniverse.org/

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [x] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state? Removed `PromiseRenderer` on the visibility page.
- [ ] If changes are made to the classifier, does the dev classifier still work?
