### PR TITLE
Hide mark details unless frame numbers match

### DIFF
--- a/app/classifier/tasks/drawing/markings-renderer.cjsx
+++ b/app/classifier/tasks/drawing/markings-renderer.cjsx
@@ -53,6 +53,11 @@ module.exports = React.createClass
                 continue
 
               toolDescription = taskDescription.tools[mark.tool]
+              
+              if parseInt(mark.frame) is parseInt(@props.frame)
+                {details} = toolDescription
+              else
+                details = null
 
               toolEnv =
                 containerRect: @props.containerRect
@@ -65,7 +70,7 @@ module.exports = React.createClass
               toolProps =
                 classification: @props.classification
                 mark: mark
-                details: toolDescription.details
+                details: details
                 color: toolDescription.color
                 size: toolDescription.size
 


### PR DESCRIPTION
Fixes #3132 .

Describe your changes.
Only shows subtask popups on the original marker.

Note that this might make it difficult to go back and edit subtasks, as you have to remember to click on the original mark that you placed, not one of its copies.
# Review Checklist
- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch? https://fix-3132.pfe-preview.zooniverse.org/
## Optional
- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
