### PR TITLE
increase default workflows page_size

### DIFF
--- a/app/lib/get-workflows-in-order.coffee
+++ b/app/lib/get-workflows-in-order.coffee
@@ -1,7 +1,9 @@
 getWorkflowsInOrder = (project, query = {}) ->
   order = project.configuration?.workflow_order ? []
+
+  # TODO remove default page_size once pagination solution implemented
   unless query?.page_size?
-    query['page_size'] = 50
+    query['page_size'] = 100
 
   project.get('workflows', query).then (workflows) ->
     workflowsByID = {}


### PR DESCRIPTION
Notes from Nature, currently (October 20th-23rd) participating in a special event called WeDigBio, hit the workflow response `page_size` max (50).

[Please review previous related pull request here](https://github.com/zooniverse/Panoptes-Front-End/pull/2820). As part of the previous pull request the workflow calls were optimized utilizing the `fields` param, and NfN is I believe the only project this additional increase will actually apply to.

Again, this is not the ideal solution, my apologies for not properly fixing, but this will solve the problem for the event currently underway.

I'll discuss with the Chicago team Monday (October 24th) to re-prioritize a proper solution.

Increases default workflow `page_size` from 50 to 75.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [X] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [X] Did you deploy a staging branch? https://increase-default-workflow-page_size.pfe-preview.zooniverse.org/

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
