### PR TITLE
Fix 2307

### DIFF
--- a/app/pages/lab/external-links-editor.jsx
+++ b/app/pages/lab/external-links-editor.jsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import AutoSave from '../../components/auto-save.coffee';
+import handleInputChange from '../../lib/handle-input-change.coffee';
+
+class ExternalLinksEditorRow extends React.Component {
+  render() {
+    return (
+      <AutoSave tag="tr" resource={this.props.project}>
+        <td>
+          <input type="text" name={`urls.${this.props.idx}.label`} value={this.props.link.label} onChange={handleInputChange.bind(this.props.project)} />
+        </td>
+        <td>
+          <input type="text" name={`urls.${this.props.idx}.url`} value={this.props.link.url} onChange={handleInputChange.bind(this.props.project)} />
+        </td>
+        <td>
+          <button type="button" onClick={this.props.handleRemoveLink}>
+            <i className="fa fa-remove"></i>
+          </button>
+        </td>
+      </AutoSave>
+    );
+  }
+}
+
+ExternalLinksEditorRow.propTypes = {
+  project: React.PropTypes.object,
+  link: React.PropTypes.object,
+  idx: React.PropTypes.number,
+  handleRemoveLink: React.PropTypes.func,
+};
+
+
+export default class ExternalLinksEditor extends React.Component {
+  constructor(props) {
+    super(props);
+    this.handleAddLink = this.handleAddLink.bind(this);
+    this.handleRemoveLink = this.handleRemoveLink.bind(this);
+  }
+
+  handleAddLink() {
+    const changes = {
+      [`urls.${this.props.project.urls.length}`]: {
+        label: 'Example',
+        url: 'https://example.com/',
+      },
+    };
+    this.props.project.update(changes);
+  }
+
+  handleRemoveLink(linkToRemove) {
+    const urlList = this.props.project.urls.slice();
+    const indexToRemove = urlList.findIndex(i => (i._key === linkToRemove._key));
+    if (indexToRemove > -1) {
+      urlList.splice(indexToRemove, 1);
+      const changes = {
+        urls: urlList,
+      };
+      this.props.project.update(changes);
+    }
+  }
+
+  render() {
+    const body = [];
+    let idx = 0;
+    for (const link of this.props.project.urls) {
+      if (!link._key) {
+        link._key = Math.random();
+      }
+      body.push(<ExternalLinksEditorRow idx={idx} key={link._key} link={link} project={this.props.project} handleRemoveLink={this.handleRemoveLink.bind(this, link)} />);
+      idx += 1;
+    }
+    return (
+      <div>
+        <table>
+          <thead>
+            <tr>
+              <th>Label</th>
+              <th>URL</th>
+            </tr>
+          </thead>
+          <tbody>
+            {body}
+          </tbody>
+        </table>
+
+        <AutoSave resource={this.props.project}>
+          <button type="button" onClick={this.handleAddLink}>Add a link</button>
+        </AutoSave>
+      </div>
+    );
+  }
+}
+
+ExternalLinksEditor.DefaultProps = {
+  project: {},
+};
+
+ExternalLinksEditor.propTypes = {
+  project: React.PropTypes.object,
+};

--- a/app/pages/lab/external-links-editor.jsx
+++ b/app/pages/lab/external-links-editor.jsx
@@ -45,6 +45,14 @@ export default class ExternalLinksEditor extends React.Component {
     }
   }
 
+  handleDisableDrag(event) {
+    event.target.parentElement.parentElement.setAttribute('draggable', false);
+  }
+
+  handleEnableDrag(event) {
+    event.target.parentElement.parentElement.setAttribute('draggable', true);
+  }
+
   renderRow(link) {
     // Find the links current position in the list
     const idx = this.props.project.urls.findIndex(i => (i._key === link._key));
@@ -56,6 +64,8 @@ export default class ExternalLinksEditor extends React.Component {
             name={`urls.${idx}.label`}
             value={link.label}
             onChange={handleInputChange.bind(this.props.project)}
+            onMouseDown={this.handleDisableDrag}
+            onMouseUp={this.handleEnableDrag}
           />
         </AutoSave>
         <AutoSave tag="td" resource={this.props.project}>
@@ -64,6 +74,8 @@ export default class ExternalLinksEditor extends React.Component {
             name={`urls.${idx}.url`}
             value={link.url}
             onChange={handleInputChange.bind(this.props.project)}
+            onMouseDown={this.handleDisableDrag}
+            onMouseUp={this.handleEnableDrag}
           />
         </AutoSave>
         <td>

--- a/app/pages/lab/external-links-editor.jsx
+++ b/app/pages/lab/external-links-editor.jsx
@@ -118,10 +118,10 @@ export default class ExternalLinksEditor extends React.Component {
   }
 }
 
-ExternalLinksEditor.DefaultProps = {
+ExternalLinksEditor.defaultProps = {
   project: {},
 };
 
 ExternalLinksEditor.propTypes = {
-  project: React.PropTypes.object,
+  project: React.PropTypes.object.isRequired,
 };

--- a/app/pages/lab/external-links-editor.spec.js
+++ b/app/pages/lab/external-links-editor.spec.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import assert from 'assert';
+import ExternalLinksEditor from './external-links-editor';
+import { shallow, render } from 'enzyme';
+
+const testProject = {
+  urls: [
+    {
+      label: 'Example1',
+      url: 'https://example.com/1',
+    },
+    {
+      label: 'Example2',
+      url: 'https://example.com/2',
+    },
+    {
+      label: 'Example3',
+      url: 'https://example.com/3',
+    },
+  ],
+};
+
+describe('ExternalLinksEditor', () => {
+  it('should render without crashing', () => {
+    shallow(<ExternalLinksEditor project={testProject} />);
+  });
+
+  it('should contain 3 table rows', () => {
+    const wrapper = render(<ExternalLinksEditor project={testProject} />);
+    const rows = wrapper.find('tbody > tr');
+    // assert there are the right number of rows
+    assert(rows.length, 3);
+    // assert the rows have the correct values
+    for (const idx of [0, 1, 2]) {
+      const inputLabel = wrapper.find(`input[name="urls.${idx}.label"]`);
+      const inputUrl = wrapper.find(`input[name="urls.${idx}.url"]`);
+      assert(inputLabel.get(0).attribs.value, testProject.urls[idx].label);
+      assert(inputUrl.get(0).attribs.value, testProject.urls[idx].url);
+    }
+  });
+});

--- a/app/pages/lab/project-details.cjsx
+++ b/app/pages/lab/project-details.cjsx
@@ -13,10 +13,12 @@ alert = require('../../lib/alert')
 {DISCIPLINES} = require '../../components/disciplines'
 Select = require 'react-select'
 `import CharLimit from '../../components/char-limit'`
+`import ExternalLinksEditor from './external-links-editor'`
 
 MAX_AVATAR_SIZE = 64000
 MAX_BACKGROUND_SIZE = 256000
 
+###
 ExternalLinksEditor = React.createClass
   displayName: 'ExternalLinksEditor'
 
@@ -67,6 +69,7 @@ ExternalLinksEditor = React.createClass
     changes =
       urls: (link for link in @props.project.urls when link isnt linkToRemove)
     @props.project.update changes
+###
 
 module.exports = React.createClass
   displayName: 'EditProjectDetails'

--- a/app/pages/lab/project-details.cjsx
+++ b/app/pages/lab/project-details.cjsx
@@ -18,59 +18,6 @@ Select = require 'react-select'
 MAX_AVATAR_SIZE = 64000
 MAX_BACKGROUND_SIZE = 256000
 
-###
-ExternalLinksEditor = React.createClass
-  displayName: 'ExternalLinksEditor'
-
-  getDefaultProps: ->
-    project: {}
-
-  render: ->
-    <div>
-      <table>
-        <thead>
-          <tr>
-            <th>Label</th>
-            <th>URL</th>
-          </tr>
-        </thead>
-        <tbody>
-          {for link, i in @props.project.urls
-            link._key ?= Math.random()
-            <AutoSave key={link._key} tag="tr" resource={@props.project}>
-              <td>
-                <input type="text" name="urls.#{i}.label" value={@props.project.urls[i].label} onChange={handleInputChange.bind @props.project} />
-              </td>
-              <td>
-                <input type="text" name="urls.#{i}.url" value={@props.project.urls[i].url} onChange={handleInputChange.bind @props.project} />
-              </td>
-              <td>
-                <button type="button" onClick={@handleRemoveLink.bind this, link}>
-                  <i className="fa fa-remove"></i>
-                </button>
-              </td>
-            </AutoSave>}
-        </tbody>
-      </table>
-
-      <AutoSave resource={@props.project}>
-        <button type="button" onClick={@handleAddLink}>Add a link</button>
-      </AutoSave>
-    </div>
-
-  handleAddLink: ->
-    changes = {}
-    changes["urls.#{@props.project.urls.length}"] =
-      label: 'Example'
-      url: 'https://example.com/'
-    @props.project.update changes
-
-  handleRemoveLink: (linkToRemove) ->
-    changes =
-      urls: (link for link in @props.project.urls when link isnt linkToRemove)
-    @props.project.update changes
-###
-
 module.exports = React.createClass
   displayName: 'EditProjectDetails'
 

--- a/css/lab.styl
+++ b/css/lab.styl
@@ -76,3 +76,9 @@
     .error
       padding: 0 10px
       color: FAILURE
+
+.external-links-table
+  >.drag-reorderable
+    > [draggable]
+      >td:first-of-type
+        border-left: 1ch solid rgba(gray, 0.2)

--- a/package.json
+++ b/package.json
@@ -99,6 +99,6 @@
     "stage-with-docker": "./bin/run-through-docker.sh 'npm run stage'",
     "_deploy": "export PATH_ROOT=www.zooniverse.org; npm run _build && npm run _publish",
     "deploy": "export NODE_ENV=production; npm run _deploy",
-    "test": "export NODE_ENV=development; mocha test/setup.js 'app/**/*.spec.js' --reporter nyan --compilers js:babel-core/register"
+    "test": "export NODE_ENV=development; mocha test/setup.js $(find app -name *.spec.js) --reporter nyan --compilers js:babel-core/register,coffee:coffee-script/register"
   }
 }


### PR DESCRIPTION
Fixes #2307 

Adds the ability to drag and drop the items of the `external links` table.  I have also extracted the external links editor into its own file and converted it to es6.

![external-link-editor](https://cloud.githubusercontent.com/assets/6557526/19598040/660ad5fe-9790-11e6-8abb-79ef5faefb97.gif)

The only eslint errors are about the use of `.bind()` and `._key`.  Both of these are in keeping with the current style of the code base and I think can be ignored.

This branched is staged at: https://fix-2307.pfe-preview.zooniverse.org/

~~Currently works in Chrome, but in Firefox the mouse can't be used to select the cursor position in the text box (not sure why this is).~~

**Edit**:
This now works in all browsers.  The `drag-reorderable` code does not support touch events, but everything else works on mobile.

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?

## Optional

- [x] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?