### PR TITLE
Don't Allow Single Task to Skip to End

### DIFF
--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -457,7 +457,7 @@ Classifier = React.createClass
   completeClassification: ->
     if @props.workflow.configuration.persist_annotations
       CacheClassification.delete()
-    
+
     currentAnnotation = @props.classification.annotations[@props.classification.annotations.length - 1]
     currentTask = @props.workflow.tasks[currentAnnotation?.task]
     currentTask?.tools?.map (tool) =>

--- a/app/classifier/tasks/single.cjsx
+++ b/app/classifier/tasks/single.cjsx
@@ -68,7 +68,7 @@ module.exports = React.createClass
       value: null
 
     isAnnotationComplete: (task, annotation) ->
-      annotation.value? or not task.required
+      annotation.value?
 
   getDefaultProps: ->
     task: null


### PR DESCRIPTION
Fixes #3120  .

Describe your changes.
Changes made will disable the "next" button when an answer/value isn't recorded for the single  choice task. This, in turn, makes each single choice task "required". However, it seems there would not be an instance when a volunteer should skip a single choice question without an answer.
# Review Checklist
- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [X] Did you deploy a staging branch?
  https://fix-3120.pfe-preview.zooniverse.org/projects/wgranger-test/single-task-bug/classify
## Optional
- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
