### PR TITLE
Prevent classification-page subject-image from moving around.

### DIFF
--- a/app/classifier/frame-annotator.cjsx
+++ b/app/classifier/frame-annotator.cjsx
@@ -77,6 +77,8 @@ module.exports = React.createClass
       svgStyle.background = 'black'
 
     svgProps = {}
+    if type is 'image' and not @props.loading
+      svgProps.preserveAspectRatio = 'xMinYMin meet'
 
     if TaskComponent?
       {BeforeSubject, InsideSubject, AfterSubject} = TaskComponent


### PR DESCRIPTION
Fixes #3149.

Describe your changes.
Locks the image inside the SVG container to the top/left corner of the SVG area.
# Review Checklist
- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?
## Optional
- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
###### _Local stuff: Chrome(49), Desktop, Windows(xp), 1024x768._
