### PR TITLE
Reveal Subject Count Badge

### DIFF
--- a/app/pages/collections/list.cjsx
+++ b/app/pages/collections/list.cjsx
@@ -128,6 +128,7 @@ List = React.createClass
                    imagePromise={@imagePromise(collection)}
                    linkTo={@cardLink(collection)}
                    translationObjectName={@props.translationObjectName}
+                   subjectCount={collection.links.subjects?.length}
                    skipOwner={@props.params?.collection_owner?} />}
             </div>
             <nav>

--- a/app/partials/collection-card.cjsx
+++ b/app/partials/collection-card.cjsx
@@ -8,6 +8,7 @@ FlexibleLink = React.createClass
   displayName: 'FlexibleLink'
 
   propTypes:
+    subjectCount: React.PropTypes.number
     to: React.PropTypes.string.isRequired
     skipOwner: React.PropTypes.bool
 
@@ -67,6 +68,7 @@ module.exports = React.createClass
 
     <FlexibleLink {...linkProps}>
       <div className="collection-card" ref="collectionCard">
+        <div key="badge" className="badge">{@props.subjectCount}</div>
         <svg className="card-space-maker" viewBox="0 0 2 1" width="100%"></svg>
         <div className="details">
           <div className="name"><span>{@props.collection.display_name}</span></div>

--- a/css/owned-card.styl
+++ b/css/owned-card.styl
@@ -82,11 +82,11 @@
     background: rgba(black, 0.4)
     border-radius: 2em
     color: white
+    float: right
     font-weight: bold
     height: 1.5em
     margin: 0.2em 0.2em 0 0
     padding: 0 0.5em
-    float: right
 
 .project-card
   height: 270px

--- a/css/owned-card.styl
+++ b/css/owned-card.styl
@@ -78,6 +78,16 @@
   .owner-public
     height: 3.6em
 
+  .badge
+    background: rgba(black, 0.4)
+    border-radius: 2em
+    color: white
+    font-weight: bold
+    height: 1.5em
+    margin: 0.2em 0.2em 0 0
+    padding: 0 0.5em
+    float: right
+
 .project-card
   height: 270px
   position: relative


### PR DESCRIPTION
Fixes #2791  .

Describe your changes.
Places a subject count badge for collection cards so users can see how many subjects are contained without opening the collection. This is visually similar to how we display the number of classifications a user has done per project.
# Review Checklist
- [X] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [X] Does it work on mobile?
- [X] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [X] Did you deploy a staging branch?

https://fix-2791.pfe-preview.zooniverse.org/
## Optional
- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
