### PR TITLE
Disable pusher in production while we debug issues

### DIFF
--- a/app/lib/pusher-env.js
+++ b/app/lib/pusher-env.js
@@ -1,5 +1,5 @@
 const pusherID = {
-  production: '79e8e05ea522377ba6db',
+  // production: '79e8e05ea522377ba6db',
   staging: '95781402b5854a712a03',
   development: '95781402b5854a712a03',
 };

--- a/app/pages/project/metadata.jsx
+++ b/app/pages/project/metadata.jsx
@@ -28,16 +28,20 @@ class ProjectMetadata extends React.Component {
   }
 
   componentDidMount() {
-    const channel = this.context.pusher.subscribe('panoptes');
-    channel.bind('classification', (data) => {
-      if (data.project_id === this.props.project.id) {
-        this.setState({ classificationsCount: this.state.classificationsCount + 1 });
-      }
-    });
+    if (this.context.pusher) {
+      const channel = this.context.pusher.subscribe('panoptes');
+      channel.bind('classification', (data) => {
+        if (data.project_id === this.props.project.id) {
+          this.setState({ classificationsCount: this.state.classificationsCount + 1 });
+        }
+      });
+    }
   }
 
   componentWillUnmount() {
-    this.context.pusher.unsubscribe('panoptes');
+    if (this.context.pusher) {
+      this.context.pusher.unsubscribe('panoptes');
+    }
   }
 
   render() {
@@ -65,7 +69,7 @@ class ProjectMetadata extends React.Component {
 }
 
 ProjectMetadata.contextTypes = {
-  pusher: React.PropTypes.object.isRequired,
+  pusher: React.PropTypes.object,
 };
 
 ProjectMetadata.propTypes = {

--- a/app/partials/app.cjsx
+++ b/app/partials/app.cjsx
@@ -34,7 +34,7 @@ PanoptesApp = React.createClass
 
   getDefaultProps: ->
     notificationsCounter: new NotificationsCounter()
-    pusher: new Pusher(pusherEnv, {encrypted: true});
+    pusher: (pusherEnv && new Pusher(pusherEnv, {encrypted: true}))
 
   componentWillMount: ->
     @geordiLogger = new GeordiLogger


### PR DESCRIPTION
Since deploying this, we've been going over our daily message cap. We're also seeing a lot of connects/disconnects. I wonder if it's counting connects and disconnects as "messages". Disabling this on production will stop going over the cap (if it's PFE that is causing that), and restore functions for other parties like SOCIAM.


# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
