### PR TITLE
Alteration of Header Size

### DIFF
--- a/css/secondary-page.styl
+++ b/css/secondary-page.styl
@@ -25,10 +25,10 @@
     .hero
       background-size: cover
       box-sizing: border-box
-      min-height: 250px
+      min-height: 190px
       overflow: auto
       background-color: LIGHT_GREEN_HEADER
-      padding: 140px 3vw 5px 3vw
+      padding: 80px 3vw 5px 3vw
 
       .hero-container
         margin: 0 auto

--- a/css/secondary-page.styl
+++ b/css/secondary-page.styl
@@ -25,7 +25,7 @@
     .hero
       background-size: cover
       box-sizing: border-box
-      min-height: 190px
+      min-height: 200px
       overflow: auto
       background-color: LIGHT_GREEN_HEADER
       padding: 80px 3vw 5px 3vw


### PR DESCRIPTION
Fixes # .

I've altered the size of the header, because there was a lot of space in it - @mschwamb raised an issue about it  - [#3156](https://github.com/zooniverse/Panoptes-Front-End/issues/3156)

I wasn't too sure what the min-height bit did, but shrinking it stopped having a visual effect on the header at 190px so that's what I've set it as in this PR. 
# Review Checklist
- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://headerspace.pfe-preview.zooniverse.org/
## Optional
- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
