### PR TITLE
Fix Back Button Bug with New Shortcut

### DIFF
--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -173,6 +173,9 @@ Classifier = React.createClass
     }</ChangeListener>
 
   renderTask: (classification, annotation, task) ->
+    taskKeys = Object.keys(@props.workflow.tasks)
+    visibleTasks = taskKeys.filter (key) => key if @props.workflow.tasks[key].type isnt 'shortcut'
+
     TaskComponent = tasks[task.type]
 
     # Should we disable the "Back" button?
@@ -244,7 +247,7 @@ Classifier = React.createClass
             <Shortcut task={task} workflow={@props.workflow} annotation={annotation} classification={@props.classification} />}
 
           <nav className="task-nav">
-            {if Object.keys(@props.workflow.tasks).length > 1
+            {if visibleTasks.length > 1
               <button type="button" className="back minor-button" disabled={onFirstAnnotation} onClick={@destroyCurrentAnnotation} onMouseEnter={@warningToggleOn} onFocus={@warningToggleOn} onMouseLeave={@warningToggleOff} onBlur={@warningToggleOff}>Back</button>}
             {if not nextTaskKey and @props.workflow.configuration?.hide_classification_summaries and @props.owner? and @props.project?
               [ownerName, name] = @props.project.slug.split('/')

--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -173,8 +173,7 @@ Classifier = React.createClass
     }</ChangeListener>
 
   renderTask: (classification, annotation, task) ->
-    taskKeys = Object.keys(@props.workflow.tasks)
-    visibleTasks = taskKeys.filter (key) => key if @props.workflow.tasks[key].type isnt 'shortcut'
+    visibleTasks = Object.keys(@props.workflow.tasks).filter (key) => key if @props.workflow.tasks[key].type isnt 'shortcut'
 
     TaskComponent = tasks[task.type]
 

--- a/app/classifier/tasks/drawing/summary.cjsx
+++ b/app/classifier/tasks/drawing/summary.cjsx
@@ -19,16 +19,14 @@ module.exports = React.createClass
     expanded: @props.expanded
 
   render: ->
-    marks = (mark for mark in @props.annotation.value)
-
     <div>
       <div className="question">
         <Markdown>
           {@props.task.instruction}
         </Markdown>
-        {if @state.expanded and marks.length isnt 0
+        {if @state.expanded and @props.annotation.value.length isnt 0
           <button type="button" className="toggle-more" onClick={@setState.bind this, expanded: false, null}>Less</button>
-        else if marks.length isnt 0
+        else if @props.annotation.value.length isnt 0
           <button type="button" className="toggle-more" onClick={@setState.bind this, expanded: true, null}>More</button>}
         {if @props.onToggle?
           if @props.inactive

--- a/app/classifier/tasks/drawing/summary.cjsx
+++ b/app/classifier/tasks/drawing/summary.cjsx
@@ -19,14 +19,16 @@ module.exports = React.createClass
     expanded: @props.expanded
 
   render: ->
+    marks = (mark for mark in @props.annotation.value)
+
     <div>
       <div className="question">
         <Markdown>
           {@props.task.instruction}
         </Markdown>
-        {if @state.expanded
+        {if @state.expanded and marks.length isnt 0
           <button type="button" className="toggle-more" onClick={@setState.bind this, expanded: false, null}>Less</button>
-        else
+        else if marks.length isnt 0
           <button type="button" className="toggle-more" onClick={@setState.bind this, expanded: true, null}>More</button>}
         {if @props.onToggle?
           if @props.inactive
@@ -49,5 +51,9 @@ module.exports = React.createClass
                   {for key, value of mark when key not in ['tool', 'sources'] and key.charAt(0) isnt '_'
                     <code key={key}><strong>{key}</strong>: {JSON.stringify value}&emsp;</code>}
                 </div>}
+          </div>
+        else
+          <div key={tool._key} className="answer">
+            <strong>{@stripMarkdownFromLabel(tool.label)}</strong> ({[].concat toolMarks.length} {@getCorrectSingularOrPluralOfDrawingType(tool.type,toolMarks.length)} marked)
           </div>}
     </div>


### PR DESCRIPTION
Fixes #3171  .

Describe your changes.
Doesn't display the back button if there is only one task and the experimental shortcut. I also noticed when testing this change that the drawing task summary needed to handle when a value wasn't present in the annotation (if, for example, the shortcut or "Nothing Here," is used. (See screenshot, with "Test" being the example drawing tool)

![screen shot 2016-11-01 at 12 58 25 pm](https://cloud.githubusercontent.com/assets/14099077/19900980/74b8342e-a033-11e6-9dc2-2c2f834191a3.png)

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [X] Did you deploy a staging branch?

https://fix-3171.pfe-preview.zooniverse.org/

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?