### PR TITLE
Subject Count Badge (zero case)

### DIFF
--- a/app/pages/collections/list.cjsx
+++ b/app/pages/collections/list.cjsx
@@ -128,7 +128,7 @@ List = React.createClass
                    imagePromise={@imagePromise(collection)}
                    linkTo={@cardLink(collection)}
                    translationObjectName={@props.translationObjectName}
-                   subjectCount={collection.links.subjects?.length}
+                   subjectCount={collection.links.subjects?.length ? 0}
                    skipOwner={@props.params?.collection_owner?} />}
             </div>
             <nav>


### PR DESCRIPTION
Fixes #3176.

Describe your changes.
Force default zero(number) on "subjectCount" in case a `undefined` outcome.
Should fix empty badge case on empty collections.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?