### PR TITLE
Fix props defined on the wrong component

### DIFF
--- a/app/partials/collection-card.cjsx
+++ b/app/partials/collection-card.cjsx
@@ -8,9 +8,7 @@ FlexibleLink = React.createClass
   displayName: 'FlexibleLink'
 
   propTypes:
-    subjectCount: React.PropTypes.number
     to: React.PropTypes.string.isRequired
-    skipOwner: React.PropTypes.bool
 
   contextTypes:
     geordi: React.PropTypes.object
@@ -35,6 +33,12 @@ module.exports = React.createClass
     imagePromise: React.PropTypes.object.isRequired
     linkTo: React.PropTypes.string.isRequired
     translationObjectName: React.PropTypes.string.isRequired
+    subjectCount: React.PropTypes.number
+    skipOwner: React.PropTypes.bool
+  
+  getDefaultProps: ->
+    subjectCount: 0
+    skipOwner: false
 
   collectionOwner: ->
     apiClient.type(@props.collection.links.owner.type).get(@props.collection.links.owner.id)


### PR DESCRIPTION
Fixes #3176 .

Describe your changes.
Defines some propTypes that were set on `FlexibleLink` rather than `CollectionCard` and sets some default values for them.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://collection-card-props.pfe-preview.zooniverse.org/

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?