### PR TITLE
add option to change completeness calculation

### DIFF
--- a/app/pages/lab/workflow.cjsx
+++ b/app/pages/lab/workflow.cjsx
@@ -70,6 +70,8 @@ EditWorkflowPage = React.createClass
 
     noTasksDefined = Object.keys(@props.workflow.tasks).length is 0
 
+    stats_completeness_type = @props.workflow.configuration.stats_completeness_type ? 'retirement'
+
     disabledStyle =
       opacity: 0.4
       pointerEvents: 'none'
@@ -331,6 +333,57 @@ EditWorkflowPage = React.createClass
           </p>
 
           <hr />
+          
+          <div>
+            <span className="form-label">How should the project completeness be calculated?</span>
+            <br />
+            <p className="form-help">
+              <small>
+                Use this option to change how your project's completeness is caclucated on the public statistics page.
+              </small>
+            </p>
+            <p className="form-help">
+              <small>
+              When using "Classification Count" the completeness will increase after each classification. The
+              {' '}total number of classifications needed to complete the workflow is estimated assuming a constant retirement limit.
+              {' '}If the retirement limit is changed and/or subjects sets are unlinked from an <b>active</b> workflow this estimate will be inaccurate.
+              {' '}To avoid these issues completed subject sets should not be removed, instead completed workflows should be deactivated
+              {' '}and new ones created for new subject sets (note: workflows can be copied using the <i className="fa fa-copy"/> button at the top of the page).
+              </small>
+            </p>
+            <p className="form-help">
+              <small>
+              When using "Retirement Count" the completeness will increase after each imge retires.  Since the images are
+              {' '}shown to users in a random order, this completeness estimage will be slow to increase until the project is close to being finished.
+              {' '}If your project does not have a constant retirement limit (e.g. it uses a custom retiment rule) and/or subject sets 
+              {' '}have been unlinked from a live workflow, this estimate will be the most accurate.
+              </small>
+            </p>
+            <AutoSave tag="div" resource={@props.workflow}>
+              <label>
+                <input
+                  type="radio"
+                  name="stats_completeness_type"
+                  value="classification"
+                  checked={stats_completeness_type == 'classification'}
+                  onChange={@handleSetStatsCompletenessType}
+                />
+                Classification Count
+              </label>
+              <br />
+              <label>
+                <input
+                  type="radio"
+                  name="stats_completeness_type"
+                  value="retirement"
+                  checked={stats_completeness_type == 'retirement'}
+                  onChange={@handleSetStatsCompletenessType}
+                />
+                Retirement Count
+              </label>
+            </AutoSave>
+          </div>
+          <hr />
 
           {if 'worldwide telescope' in @props.project.experimental_tools
             <div>
@@ -515,6 +568,10 @@ EditWorkflowPage = React.createClass
   handleSetGravitySpyGoldStandard: (e) ->
     @props.workflow.update
       'configuration.gravity_spy_gold_standard': e.target.checked
+
+  handleSetStatsCompletenessType: (e) ->
+    @props.workflow.update
+      'configuration.stats_completeness_type': e.target.value
 
   handleSetWorldWideTelescope: (e) ->
     if !@props.workflow.configuration.custom_summary

--- a/app/pages/lab/workflow.cjsx
+++ b/app/pages/lab/workflow.cjsx
@@ -353,8 +353,8 @@ EditWorkflowPage = React.createClass
             </p>
             <p className="form-help">
               <small>
-              When using "Retirement Count" the completeness will increase after each imge retires.  Since the images are
-              {' '}shown to users in a random order, this completeness estimage will be slow to increase until the project is close to being finished.
+              When using "Retirement Count" the completeness will increase after each image retires.  Since the images are
+              {' '}shown to users in a random order, this completeness estimate will be slow to increase until the project is close to being finished.
               {' '}If your project does not have a constant retirement limit (e.g. it uses a custom retiment rule) and/or subject sets 
               {' '}have been unlinked from a live workflow, this estimate will be the most accurate.
               </small>

--- a/app/pages/lab/workflow.cjsx
+++ b/app/pages/lab/workflow.cjsx
@@ -339,7 +339,7 @@ EditWorkflowPage = React.createClass
             <br />
             <p className="form-help">
               <small>
-                Use this option to change how your project's completeness is caclucated on the public statistics page.
+                Use this option to change how your project's completeness is calculated on the public statistics page.
               </small>
             </p>
             <p className="form-help">
@@ -353,8 +353,8 @@ EditWorkflowPage = React.createClass
             </p>
             <p className="form-help">
               <small>
-              When using "Retirement Count" the completeness will increase after each image retires.  Since the images are
-              {' '}shown to users in a random order, this completeness estimate will be slow to increase until the project is close to being finished.
+              When using "Retirement Count" the completeness will increase after each image retires (note: this value is re-calculated once an hour).
+              {' '}Since the images are shown to users in a random order, this completeness estimate will be slow to increase until the project is close to being finished.
               {' '}If your project does not have a constant retirement limit (e.g. it uses a custom retiment rule) and/or subject sets 
               {' '}have been unlinked from a live workflow, this estimate will be the most accurate.
               </small>

--- a/app/pages/project/stats/stats.jsx
+++ b/app/pages/project/stats/stats.jsx
@@ -274,7 +274,6 @@ export class WorkflowProgress extends React.Component {
         );
       }
       classificationsString += ` / ${total.toLocaleString()}`;
-      // not entirely sure why this first check is needed, but the code crashes without it
       if (this.props.workflow.configuration) {
         if (this.props.workflow.configuration.stats_completeness_type === 'classification') {
           completeness = this.props.workflow.classifications_count / total;

--- a/app/pages/project/stats/stats.jsx
+++ b/app/pages/project/stats/stats.jsx
@@ -245,6 +245,7 @@ export class WorkflowProgress extends React.Component {
     let eta;
     let total;
     let retiredDiv;
+    let completeness = this.props.workflow.completeness;
     if (this.props.workflow.retirement.criteria !== 'never_retire') {
       retiredDiv = (
         <div>
@@ -273,6 +274,12 @@ export class WorkflowProgress extends React.Component {
         );
       }
       classificationsString += ` / ${total.toLocaleString()}`;
+      // not entirely sure why this first check is needed, but the code crashes without it
+      if (this.props.workflow.configuration) {
+        if (this.props.workflow.configuration.stats_completeness_type === 'classification') {
+          completeness = this.props.workflow.classifications_count / total;
+        }
+      }
     }
     return (
       <div className="progress-element">
@@ -287,7 +294,7 @@ export class WorkflowProgress extends React.Component {
             {classificationsString}
           </div>
           {eta}
-          <Progress progress={this.props.workflow.completeness} />
+          <Progress progress={completeness} />
         </div>
       </div>
     );


### PR DESCRIPTION
Address the concerns brought up in the talk thread: https://www.zooniverse.org/talk/14/118004

This allows project builders to select between "classification count" or "retirement count" for calculating the completeness for each workflow that is presented on the project stats page.  It defaults to "retirement count" since that is the method returned by the backend.  It also adds help text describing how each method is calculated:

![screen shot 2016-11-03 at 4 47 44 pm](https://cloud.githubusercontent.com/assets/6557526/19975813/493db07c-a1e5-11e6-8a73-d02949108734.png)
 
Note: after this change goes live I think we should notify the project builders for live projects to let them know this is an option available to them.

@camallen feel free to re-assign this if you don't have time to look at it.

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? 
https://completion-stats-toggle.pfe-preview.zooniverse.org/

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
