### PR TITLE
Updated node version and fixed peer deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "panoptes-front-end",
   "dependencies": {
     "animated-scrollto": "~1.1.0",
-    "babelify": "~6.4.0",
     "chartist": "~0.9.5",
     "classnames": "~2.2.3",
     "counterpart": "~0.17.0",
@@ -42,6 +41,7 @@
   },
   "devDependencies": {
     "babel-cli": "~6.7.7",
+    "babel-core": "~6.18.2",
     "babel-loader": "~6.2.4",
     "babel-plugin-add-module-exports": "~0.2.1",
     "babel-plugin-react-transform": "~2.0.2",
@@ -59,11 +59,13 @@
     "css-loader": "~0.23.1",
     "ejs": "~2.3.3",
     "enzyme": "~2.4.1",
-    "eslint": "~2.11.1",
-    "eslint-config-airbnb": "~9.0.1",
+    "eslint": "~3.9.1",
+    "eslint-config-airbnb": "~13.0.0",
     "eslint-config-standard": "~5.3.1",
+    "eslint-plugin-import": "~2.2.0",
+    "eslint-plugin-jsx-a11y": "~2.2.3",
     "eslint-plugin-promise": "~1.3.2",
-    "eslint-plugin-react": "~5.1.1",
+    "eslint-plugin-react": "~6.6.0",
     "eslint-plugin-standard": "~1.3.2",
     "express": "~4.13.3",
     "extract-text-webpack-plugin": "~1.0.1",
@@ -87,8 +89,8 @@
     "webpack-split-by-path": "0.0.8"
   },
   "engines": {
-    "node": "^4.4.7",
-    "npm": "^2.14.7"
+    "node": "^6.9.1",
+    "npm": "^3.10.8"
   },
   "license": "Apache-2.0",
   "repository": "zooniverse/Panoptes-Front-End",


### PR DESCRIPTION
Updates node to 6.9.1 and npm to 3.10.8. Resolved the peer dependency warnings. Works locally and on staging: https://update-node.pfe-preview.zooniverse.org/

Also removed babelify which probably got missed when we switched to webpack.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
