### PR TITLE
move stats completeness settings to visibility tab

### DIFF
--- a/app/pages/lab/visibility.cjsx
+++ b/app/pages/lab/visibility.cjsx
@@ -25,7 +25,7 @@ module.exports = React.createClass
   setterProperty: 'project'
 
   componentDidMount: ->
-    getWorkflowsInOrder(@props.project, fields: 'display_name,active')
+    getWorkflowsInOrder(@props.project, fields: 'display_name,active,configuration')
       .then((workflows) =>
         @setState({ workflows })
       )
@@ -77,6 +77,12 @@ module.exports = React.createClass
           @props.project.update({ 'configuration.default_workflow': null })
           @props.project.save()
       ).then(() => @forceUpdate()) # Dislike. Eventually we should refactor to not have to call this.forceUpdate()
+
+  handleSetStatsCompletenessType: (workflow, e) ->
+    workflow.update({ 'configuration.stats_completeness_type': e.target.value }).save()
+      .catch((error) => 
+        @setState {error}
+      ).then(() => @forceUpdate())  
 
   render: ->
     looksDisabled =
@@ -223,21 +229,87 @@ module.exports = React.createClass
         <div className="workflow-status-list">No workflows found</div>
       else
         <div className="workflow-status-list">
-          <ul>
-          {@state.workflows.map (workflow) =>
-            setting = workflow.active
-            <li key={workflow.id}>
-              <span>
-                {workflow.id} - {workflow.display_name}:
-                <label style={whiteSpace: 'nowrap'}>
-                  <input type="checkbox" name="active" value={setting} checked={setting} onChange={@handleWorkflowSettingChange.bind(this, workflow)} />
-                  Active
-                </label>
-              </span>
-            </li>}
-          </ul>
+          <table>
+            <thead>
+              <tr>
+                <th>
+                  ID
+                </th>
+                <th>
+                  Name
+                </th>
+                <th>
+                  Status
+                </th>
+                <th>
+                  Completeness statistic
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+            {@state.workflows.map (workflow) =>
+              setting = workflow.active
+              stats_completeness_type = workflow.configuration.stats_completeness_type ? 'retirement'
+              <tr key={workflow.id}>
+                <td>
+                  {workflow.id}
+                  &emsp;
+                </td>
+                <td>
+                  {workflow.display_name}
+                  &emsp;
+                </td>
+                <td>
+                  <label style={whiteSpace: 'nowrap'}>
+                    <input type="checkbox" name="active" value={setting} checked={setting} onChange={@handleWorkflowSettingChange.bind(this, workflow)} />
+                    Active
+                  </label>
+                  &emsp;
+                </td>
+                <td>
+                  <label>
+                    <input
+                      type="radio"
+                      name="stats_completeness_type.#{workflow.id}"
+                      value="classification"
+                      checked={stats_completeness_type == 'classification'}
+                      onChange={@handleSetStatsCompletenessType.bind(this, workflow)}
+                    />
+                    Classification Count
+                  </label>
+                  &emsp;
+                  <label>
+                    <input
+                      type="radio"
+                      name="stats_completeness_type.#{workflow.id}"
+                      value="retirement"
+                      checked={stats_completeness_type == 'retirement'}
+                      onChange={@handleSetStatsCompletenessType.bind(this, workflow)}
+                    />
+                    Retirement Count
+                  </label>
+                </td>
+              </tr>}
+            </tbody>
+          </table>
         </div>}
+      <p className="form-label">Status</p>
       <p className="form-help">In a live project active workflows are available to volunteers and cannot be edited. Inactive workflows can be edited if a project is live or in development.</p>
       <p className="form-help">If an active workflow is the default workflow for the project and is made inactive, then it will be removed as the default workflow.</p>
       <p className="form-help">On a live project, if you want to switch which subjects sets are associated with an active workflow: set the workflow to inactive, next change which subject sets are linked in the Workflow Section within the Project Builder, then return the workflow to active.</p>
+      <p className="form-label">Completeness statistic</p>
+      <p className="form-help">Use this option to change how each workflow's completeness is calculated on the public statistics page.</p>
+      <p className="form-help">
+        When using "Classification Count" the completeness will increase after each classification. The
+        {' '}total number of classifications needed to complete the workflow is estimated assuming a constant retirement limit.
+        {' '}If the retirement limit is changed and/or subjects sets are unlinked from a <b>live</b> workflow this estimate will be inaccurate.
+        {' '}To avoid these issues completed subject sets should not be removed, instead completed workflows should be deactivated
+        {' '}and new ones created for new subject sets (note: workflows can be copied using the <i className="fa fa-copy"/> button at the top of a workflow's edit page).
+      </p>
+      <p className="form-help">
+        When using "Retirement Count" the completeness will increase after each image retires (note: this value is re-calculated once an hour).
+        {' '}Since the images are shown to users in a random order, this completeness estimate will be slow to increase until the project is close to being finished.
+        {' '}If your project does not have a constant retirement limit (e.g. it uses a custom retiment rule) and/or subject sets 
+        {' '}have been unlinked from a live workflow, this estimate will be the most accurate.
+      </p>
     </div>

--- a/app/pages/lab/workflow.cjsx
+++ b/app/pages/lab/workflow.cjsx
@@ -333,57 +333,6 @@ EditWorkflowPage = React.createClass
           </p>
 
           <hr />
-          
-          <div>
-            <span className="form-label">How should the project completeness be calculated?</span>
-            <br />
-            <p className="form-help">
-              <small>
-                Use this option to change how your project's completeness is calculated on the public statistics page.
-              </small>
-            </p>
-            <p className="form-help">
-              <small>
-              When using "Classification Count" the completeness will increase after each classification. The
-              {' '}total number of classifications needed to complete the workflow is estimated assuming a constant retirement limit.
-              {' '}If the retirement limit is changed and/or subjects sets are unlinked from an <b>active</b> workflow this estimate will be inaccurate.
-              {' '}To avoid these issues completed subject sets should not be removed, instead completed workflows should be deactivated
-              {' '}and new ones created for new subject sets (note: workflows can be copied using the <i className="fa fa-copy"/> button at the top of the page).
-              </small>
-            </p>
-            <p className="form-help">
-              <small>
-              When using "Retirement Count" the completeness will increase after each image retires (note: this value is re-calculated once an hour).
-              {' '}Since the images are shown to users in a random order, this completeness estimate will be slow to increase until the project is close to being finished.
-              {' '}If your project does not have a constant retirement limit (e.g. it uses a custom retiment rule) and/or subject sets 
-              {' '}have been unlinked from a live workflow, this estimate will be the most accurate.
-              </small>
-            </p>
-            <AutoSave tag="div" resource={@props.workflow}>
-              <label>
-                <input
-                  type="radio"
-                  name="stats_completeness_type"
-                  value="classification"
-                  checked={stats_completeness_type == 'classification'}
-                  onChange={@handleSetStatsCompletenessType}
-                />
-                Classification Count
-              </label>
-              <br />
-              <label>
-                <input
-                  type="radio"
-                  name="stats_completeness_type"
-                  value="retirement"
-                  checked={stats_completeness_type == 'retirement'}
-                  onChange={@handleSetStatsCompletenessType}
-                />
-                Retirement Count
-              </label>
-            </AutoSave>
-          </div>
-          <hr />
 
           {if 'worldwide telescope' in @props.project.experimental_tools
             <div>
@@ -568,10 +517,6 @@ EditWorkflowPage = React.createClass
   handleSetGravitySpyGoldStandard: (e) ->
     @props.workflow.update
       'configuration.gravity_spy_gold_standard': e.target.checked
-
-  handleSetStatsCompletenessType: (e) ->
-    @props.workflow.update
-      'configuration.stats_completeness_type': e.target.value
 
   handleSetWorldWideTelescope: (e) ->
     if !@props.workflow.configuration.custom_summary


### PR DESCRIPTION
Fixes #3190 

This moves the "workflow completeness statistic" option to the lab's visibility page.  This also has the nice side effect that this option can now be changed while a workflow is active.

Staged at: https://move-stats-type.pfe-preview.zooniverse.org/

@camallen feel free to re-assign if you don't have time to look at this.

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
