### PR TITLE
Add missing .push method when deleting workflows

### DIFF
--- a/app/pages/lab/workflow.cjsx
+++ b/app/pages/lab/workflow.cjsx
@@ -650,7 +650,7 @@ EditWorkflowPage = React.createClass
 
       @props.workflow.delete().then =>
         @props.project.uncacheLink 'workflows'
-        @context.router "/lab/#{@props.project.id}"
+        @context.router.push "/lab/#{@props.project.id}"
       .catch (error) =>
         @setState deletionError: error
       .then =>


### PR DESCRIPTION
Adds missing `push` method when confirming a workflow delete. Previously, the delete was successful but threw a `_this.context is not a function` error without redirecting.

Ref #1156 