### PR TITLE
Hide external links table if there are no links in project builder

### DIFF
--- a/app/pages/lab/external-links-editor.jsx
+++ b/app/pages/lab/external-links-editor.jsx
@@ -10,6 +10,7 @@ export default class ExternalLinksEditor extends React.Component {
     this.handleLinkReorder = this.handleLinkReorder.bind(this);
     this.handleRemoveLink = this.handleRemoveLink.bind(this);
     this.renderRow = this.renderRow.bind(this);
+    this.renderTable = this.renderTable.bind(this);
   }
 
   handleAddLink() {
@@ -87,28 +88,38 @@ export default class ExternalLinksEditor extends React.Component {
     );
   }
 
-  render() {
-    for (const link of this.props.project.urls) {
+  renderTable(urls) {
+    const tableUrls = [].concat(urls);
+    for (const link of tableUrls) {
       if (!link._key) {
         link._key = Math.random();
       }
     }
+
+    return (
+      <table className="external-links-table">
+        <thead>
+          <tr>
+            <th>Label</th>
+            <th>URL</th>
+          </tr>
+        </thead>
+        <DragReorderable
+          tag="tbody"
+          items={tableUrls}
+          render={this.renderRow}
+          onChange={this.handleLinkReorder}
+        />
+      </table>      
+    );
+  }
+
+  render() {
     return (
       <div>
-        <table className="external-links-table">
-          <thead>
-            <tr>
-              <th>Label</th>
-              <th>URL</th>
-            </tr>
-          </thead>
-          <DragReorderable
-            tag="tbody"
-            items={this.props.project.urls}
-            render={this.renderRow}
-            onChange={this.handleLinkReorder}
-          />
-        </table>
+        {(this.props.project.urls.length > 0)
+          ? this.renderTable(this.props.project.urls)
+          : null}
 
         <AutoSave resource={this.props.project}>
           <button type="button" onClick={this.handleAddLink}>Add a link</button>

--- a/app/pages/lab/external-links-editor.spec.js
+++ b/app/pages/lab/external-links-editor.spec.js
@@ -28,14 +28,20 @@ describe('ExternalLinksEditor', () => {
   it('should contain 3 table rows', () => {
     const wrapper = render(<ExternalLinksEditor project={testProject} />);
     const rows = wrapper.find('tbody > tr');
-    // assert there are the right number of rows
-    assert(rows.length, 3);
-    // assert the rows have the correct values
+
+    assert.strictEqual(rows.length, 3, 'the number of rows should equal the number of links');
+
     for (const idx of [0, 1, 2]) {
-      const inputLabel = wrapper.find(`input[name="urls.${idx}.label"]`);
-      const inputUrl = wrapper.find(`input[name="urls.${idx}.url"]`);
-      assert(inputLabel.get(0).attribs.value, testProject.urls[idx].label);
-      assert(inputUrl.get(0).attribs.value, testProject.urls[idx].url);
+      const inputLabel = wrapper.find(`input[name="urls.${idx}.label"]`).get(0).attribs.value;
+      const inputUrl = wrapper.find(`input[name="urls.${idx}.url"]`).get(0).attribs.value;
+      const testUrl = testProject.urls[idx];
+      assert.strictEqual(inputLabel, testUrl.label, 'the label should match the one passed in');
+      assert.strictEqual(inputUrl, testUrl.url, 'the url should match the one passed in');
     }
+  });
+
+  it('should not render a table if there are no URLs', () => {
+    const wrapper = shallow(<ExternalLinksEditor project={{ urls: [] }} />);
+    assert.equal(wrapper.contains('table'), false, `there shouldn't be a table if there are no links`);
   });
 });


### PR DESCRIPTION
Fixes #1730.

Only shows the external links table if there are links, stops props from being modified, update tests.
