### PR TITLE
handle video thumbnails

### DIFF
--- a/app/components/thumbnail.cjsx
+++ b/app/components/thumbnail.cjsx
@@ -10,6 +10,7 @@ module.exports = React.createClass
     width: MAX_THUMBNAIL_DIMENSION
     height: MAX_THUMBNAIL_DIMENSION
     origin: 'https://thumbnails.zooniverse.org'
+    format: 'image'
 
   getInitialState: ->
     failed: false
@@ -32,7 +33,14 @@ module.exports = React.createClass
       maxWidth: @props.width
       maxHeight: @props.height
 
-    <img {...@props} src={src} {...dimensions} style={style} onError={@handleError} />
+    if (@props.format == 'mp4')
+      <div>
+        <video width="300" controls>
+          <source src={@props.src} type="video/mp4" />
+         </video>
+      </div>
+    else
+      <img {...@props} src={src} {...dimensions} style={style} onError={@handleError} />
 
   handleError: ->
     unless @state.failed

--- a/app/talk/tags.cjsx
+++ b/app/talk/tags.cjsx
@@ -71,7 +71,7 @@ module.exports = React.createClass
                         Subject {tag.subject.id}
                       </Link>
                     </p>
-                    <Thumbnail src={getSubjectLocation(tag.subject).src} width={100} />
+                    <Thumbnail src={getSubjectLocation(tag.subject).src} width={100} format={getSubjectLocation(tag.subject).format} />
                     <ul className="tag-list">
                       {for subjectTag in tag.subjectTags
                         <li key={"tag-#{ tag.id }-#{ subjectTag.id }"}>


### PR DESCRIPTION
Fixes #3211 - uses a scaled video element for thumbs and thumbnail service for image media. 

Not sure about preloading on this and bandwidth use, etc. Staged here, https://video_thumbs.pfe-preview.zooniverse.org

These are useful links to test:
https://video_thumbs.pfe-preview.zooniverse.org/projects/zooniverse/arizona-batwatch/talk/tags/insect?env=production
https://video_thumbs.pfe-preview.zooniverse.org/projects/mschwamb/planet-four-terrains/talk/tags/spiders?env=production

Describe your changes.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
