### PR TITLE
Don't swallow all keypresses in the StepThrough component

### DIFF
--- a/app/components/step-through.jsx
+++ b/app/components/step-through.jsx
@@ -49,14 +49,15 @@ class StepThrough extends Component {
   }
 
   handleKeyDown(e) {
-    e.preventDefault();
     switch (e.which) {
       // left
       case 37:
+        e.preventDefault();
         this.goPrevious();
         break;
       // right
       case 39:
+        e.preventDefault();
         this.goNext();
         break;
     }


### PR DESCRIPTION
Fixes #3213 .

Describe your changes.
Stops the `StepThrough` component from running `preventDefault` on all keypresses, rather than just the left and right keys.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://fix-tutorial-scroll.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?