### PR TITLE
Removing 'dot' part from register-name warning-text.

### DIFF
--- a/app/partials/register-form.cjsx
+++ b/app/partials/register-form.cjsx
@@ -184,7 +184,7 @@ module.exports = React.createClass
     name = @refs.name.value
 
     exists = name.length isnt 0
-    badChars = (char for char in name.split('') when char.match(/[\w\-\']/) is null)
+    badChars = (char for char in name.split('') when char.match(/[\w\-\'\.]/) is null)
 
     @setState
       badNameChars: badChars

--- a/app/partials/register-form.cjsx
+++ b/app/partials/register-form.cjsx
@@ -14,7 +14,7 @@ counterpart.registerTranslations 'en',
     required: 'Required'
     looksGood: 'Looks good'
     userName: 'User name'
-    badChars: "Only letters, numbers, '.', '_', and '-'."
+    badChars: "Only letters, numbers, '_', and '-'."
     nameConflict: 'That username is taken'
     forgotPassword: 'Forget your password?'
     password: 'Password'


### PR DESCRIPTION
Fixes #3221.
>When Registering a Zooniverse account. The base-name field shows a 'invalid character in text' warning. Which conflicts on dot usage.

Describe your changes.
Removing the dot part from the warning text.
Note: Presuming here that dot's are not allowed in the users base-name, and the warning is wrong. (which could be a wrong assumption of mine!)

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
