### PR TITLE
fix dropdown task tab sequence

### DIFF
--- a/app/classifier/tasks/dropdown/index.cjsx
+++ b/app/classifier/tasks/dropdown/index.cjsx
@@ -149,7 +149,7 @@ module.exports = React.createClass
         {selectKeys.map (i) =>
           options = @getOptions(i)
           disabled = @getDisabledAttribute(i)
-          <div key={Math.random()}>
+          <div key={selects[i].id}>
             {if selects[i].title isnt @props.task.instruction
               <div>{selects[i].title}</div>}
             <Select


### PR DESCRIPTION
Fixes #2952.

Mistake on my part when originally building the dropdown task - `key` defined as `Math.random()`. When a select's input was updated it triggered `onChange` which updated state and re-rendered the entire component, throwing focus back to the first select (when multiple selects present), regardless of which select tabbing out of.

Setting `key` to the select's index fixes.

Here are a few workflows to test on:
- [simple](https://dropdown-tab-fix.pfe-preview.zooniverse.org/projects/markb-panoptes/focus-testing-project/classify?reload=0&workflow=2306)
- [combo](https://dropdown-tab-fix.pfe-preview.zooniverse.org/projects/markb-panoptes/focus-testing-project/classify?reload=0&workflow=2732)

# Review Checklist

- [X] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [X] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [X] Did you deploy a staging branch? - https://dropdown-tab-fix.pfe-preview.zooniverse.org
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [X] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
