### PR TITLE
Fix project search external links

### DIFF
--- a/app/pages/projects/project-filtering-interface.jsx
+++ b/app/pages/projects/project-filtering-interface.jsx
@@ -62,12 +62,13 @@ class ProjectFilteringInterface extends Component {
     apiClient.type('projects').get(query)
       .then(projects => {
         if (projects.length > 0) {
-          const pages = (projects[0] !== null && projects[0].getMeta() !== null)
-            ? projects[0].getMeta().page_count
-            : 0;
-          const projectCount = (projects[0] !== null && projects[0].getMeta() !== null)
-            ? projects[0].getMeta().count
-            : 0;
+          const hasMeta = (projects[0] !== null && projects[0].getMeta() !== null);
+          let pages = 0, projectCount = 0;
+          if (hasMeta) {
+            const meta = projects[0].getMeta();
+            pages = meta.page_count;
+            projectCount = meta.count;
+          }
           this.setState({ projects, pages, projectCount });
         } else {
           this.setState({ projects: [], pages: 0, projectCount: 0 });

--- a/app/pages/projects/projects-search-selector.jsx
+++ b/app/pages/projects/projects-search-selector.jsx
@@ -11,14 +11,12 @@ class SearchSelector extends Component {
     this.searchByName = this.searchByName.bind(this);
   }
 
-  navigateToProject(projectId) {
-    apiClient.type('projects').get(projectId)
-      .then(project => {
-        if (project.redirect != null && project.redirect.length !== 0) {
-          return browserHistory.push(project.redirect);
-        }
-        return browserHistory.push(['/projects', project.slug].join('/'));
-      });
+  navigateToProject(projectUrl) {
+    if (projectUrl.match(/^http.*/)) {
+      window.location.assign(projectUrl);
+    } else {
+      browserHistory.push(['/projects', projectUrl].join('/'));
+    }
   }
 
   searchByName(value, callback) {
@@ -32,9 +30,8 @@ class SearchSelector extends Component {
         page_size: 10,
       }).then(projects => {
         const opts = projects.map(project => ({
-          value: project.id,
-          label: project.display_name,
-          project,
+          value: project.redirect || project.slug,
+          label: project.display_name
         }));
         return callback(null, {
           options: opts || [],


### PR DESCRIPTION
Fixes #3228 - Allow external links to navigate correctly and avoid double lookups via the api.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [X] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [X] Did you deploy a staging branch? https://project_search_external_links.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?