### PR TITLE
Fix the settings and collaborators links for Favourites

### DIFF
--- a/app/collections/show.jsx
+++ b/app/collections/show.jsx
@@ -23,16 +23,16 @@ counterpart.registerTranslations('en', {
 
 const CollectionPage = React.createClass({
 
-  contextTypes: {
-    geordi: React.PropTypes.object,
-  },
-
   propTypes: {
     user: React.PropTypes.object,
     collection: React.PropTypes.object.isRequired,
     project: React.PropTypes.object,
     children: React.PropTypes.node,
     roles: React.PropTypes.array,
+  },
+
+  contextTypes: {
+    geordi: React.PropTypes.object,
   },
 
   getDefaultProps() {
@@ -79,7 +79,7 @@ const CollectionPage = React.createClass({
     if (!!this.props.project) {
       baseLink = `/projects/${this.props.project.slug}`;
     }
-    const baseCollectionLink = `${baseLink}/${baseType}/${this.props.collection.slug}`;
+    const baseCollectionLink = `${baseLink}/collections/${this.props.collection.slug}`;
     const baseCollectionsLink = `${baseLink}/${baseType}/${this.state.owner.login}`;
     const isOwner = !!this.props.user && this.props.user.id === this.state.owner.id;
     const profileLink = `${baseLink}/users/${this.state.owner.login}`;


### PR DESCRIPTION
Fixes #3227 
Fixes #2906 

Describe your changes.
Fixes the base URLs for favourites collections so that the index, settings and collaborators links work again.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://fix-favourites-collections.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
