### PR TITLE
Fix broken dev classifier

### DIFF
--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -99,7 +99,7 @@ Classifier = React.createClass
       showingExpertClassification: false
       subjectLoading: true
 
-    if @props.project.experimental_tools.indexOf('expert comparison summary') > -1
+    if @props.project.experimental_tools?.indexOf('expert comparison summary') > -1
       @getExpertClassification @props.workflow, @props.subject
 
     preloadSubject subject
@@ -317,7 +317,7 @@ Classifier = React.createClass
     <div>
       Thanks!
 
-      {if 'metadata based feedback' in @props.project.experimental_tools
+      {if @props.project.experimental_tools?.indexOf('metadata-based-feedback') > -1
         <MetadataBasedFeedback
           subject={@props.subject}
           classification={@props.classification}

--- a/app/pages/dev-classifier/mock-data.coffee
+++ b/app/pages/dev-classifier/mock-data.coffee
@@ -523,6 +523,7 @@ subject = apiClient.type('subjects').create
 project = apiClient.type('projects').create
   id: 'MOCK_PROJECT_FOR_CLASSIFIER'
   title: "The Dev Classifier"
+  experimental_tools: []
 
 preferences = apiClient.type('project_preferences').create
   preferences: {}


### PR DESCRIPTION
Fixes the broken dev classifier by adding existential operators to the instances of conditionals that check for `experimental_tools` on projects and adds an empty `experimental_tools` array to the mock project.

https://fix-broken-dev-classifier.pfe-preview.zooniverse.org/dev/classifier 

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [x] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?