### PR TITLE
Batch avatars call in my-builds

### DIFF
--- a/app/pages/home-for-user/my-builds.jsx
+++ b/app/pages/home-for-user/my-builds.jsx
@@ -54,21 +54,21 @@ const MyBuildsSection = React.createClass({
       this.setState({
         projects,
       });
-      projects.map((project) => {
-        if (project.links.avatar.id) {
-          apiClient.type('avatars').get(project.links.avatar.id)
-          .catch(() => {
-            return null;
-          })
-          .then((avatar) => {
+      return projects.map(project => project.links.avatar.id || null)
+        .filter(value => value !== null);
+    })
+    .then((projectAvatarIds) => {
+      if (projectAvatarIds.length > 0) {
+        apiClient.type('avatars').get(projectAvatarIds)
+          .then((avatars) => {
             const newState = Object.assign({}, this.state.avatars);
-            newState[project.id] = avatar;
+            avatars.map((avatar) => newState[avatar.links.linked.id] = avatar);
             this.setState({
-              avatars: newState
+              avatars: newState,
             });
-          });
-        }
-      });
+          })
+          .catch(error => console.error('Error getting project avatars', avatars));
+      }
     })
     .catch((error) => {
       this.setState({


### PR DESCRIPTION
Similar to #3244, I found a place in the new home page to batch some requests. Previously, requests were made individually through a `.map()` to get project avatars, this gets them all in one go.

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://refactor-my-builds.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
