### PR TITLE
[WIP] Gravity Spy split setup

### DIFF
--- a/app/pages/project/classify.cjsx
+++ b/app/pages/project/classify.cjsx
@@ -14,6 +14,7 @@ experimentsClient = require '../../lib/experiments-client'
 {Split} = require('seven-ten')
 {VisibilitySplit} = require('seven-ten')
 
+
 FAILED_CLASSIFICATION_QUEUE_NAME = 'failed-classifications'
 
 PROMPT_MINI_COURSE_EVERY = 5

--- a/app/pages/project/home-workflow-buttons.jsx
+++ b/app/pages/project/home-workflow-buttons.jsx
@@ -7,6 +7,7 @@ export default class ProjectHomeWorkflowButtons extends React.Component {
   constructor(props) {
     super(props);
 
+    this.handleSplitWorkflowAssignment = this.handleSplitWorkflowAssignment.bind(this);
     this.shouldWorkflowBeDisabled = this.shouldWorkflowBeDisabled.bind(this);
     this.renderRedirectLink = this.renderRedirectLink.bind(this);
     this.renderWorkflowButtons = this.renderWorkflowButtons.bind(this);
@@ -53,13 +54,41 @@ export default class ProjectHomeWorkflowButtons extends React.Component {
     return (<span>Loading...</span>);
   }
 
+  handleSplitWorkflowAssignment() {
+    console.log('lol')
+    let workflowAssignmentID = '2334';
+
+    if (process.env.NODE_ENV === 'production' || locationMatch(/\W?env=(production)/)) {
+      workflowAssignmentID = '2360';
+    }
+
+    if (this.props.split['home-buttons.visible']) {
+      this.props.onChangePreferences('preferences.selected_workflow', workflowAssignmentID);
+    }
+  }
+
   render() {
     if (this.props.project.redirect) {
       return this.renderRedirectLink();
     }
 
     if (this.props.showWorkflowButtons) {
-      return this.renderWorkflowButtons();
+      if (this.props.workflowAssignment && this.props.preferences === null) {
+        console.log('hey')
+        return (
+          <VisibilitySplit splits={this.props.splits} splitKey={'home-buttons.visible'} elementKey={'div'}>
+            <Link
+              to={`/projects/${this.props.project.slug}/classify`}
+              className="call-to-action standard-button"
+              onClick={this.handleSplitWorkflowAssignment}
+            >
+              Get started!
+            </Link>
+          </VisibilitySplit>
+        );
+      } else {
+        return this.renderWorkflowButtons();
+      }
     }
 
     return (

--- a/app/pages/project/home-workflow-buttons.jsx
+++ b/app/pages/project/home-workflow-buttons.jsx
@@ -26,6 +26,18 @@ export default class ProjectHomeWorkflowButtons extends React.Component {
     return false;
   }
 
+  handleSplitWorkflowAssignment() {
+    let workflowAssignmentID = '2334';
+
+    if (process.env.NODE_ENV === 'production' || locationMatch(/\W?env=(production)/)) {
+      workflowAssignmentID = '2360';
+    }
+
+    if (this.props.splits['workflow.assignment']) {
+      this.props.onChangePreferences('preferences.selected_workflow', workflowAssignmentID);
+    }
+  }
+
   renderRedirectLink() {
     return (<a href={this.props.project.redirect} className="call-to-action standard-button">
       <strong>Visit the project</strong><br />
@@ -54,29 +66,18 @@ export default class ProjectHomeWorkflowButtons extends React.Component {
     return (<span>Loading...</span>);
   }
 
-  handleSplitWorkflowAssignment() {
-    console.log('lol')
-    let workflowAssignmentID = '2334';
-
-    if (process.env.NODE_ENV === 'production' || locationMatch(/\W?env=(production)/)) {
-      workflowAssignmentID = '2360';
-    }
-
-    if (this.props.split['home-buttons.visible']) {
-      this.props.onChangePreferences('preferences.selected_workflow', workflowAssignmentID);
-    }
-  }
-
   render() {
     if (this.props.project.redirect) {
       return this.renderRedirectLink();
     }
 
     if (this.props.showWorkflowButtons) {
-      if (this.props.workflowAssignment && this.props.preferences === null) {
-        console.log('hey')
-        return (
-          <VisibilitySplit splits={this.props.splits} splitKey={'home-buttons.visible'} elementKey={'div'}>
+      if (this.props.splits && this.props.preferences && this.props.workflowAssignment) {
+        const gravitySpySplit = (this.props.splits['workflow.assignment']) ? this.props.splits['workflow.assignment'].variant.value.description === 'Apprentice workflow assignment' : false;
+        const newToProject = Object.keys(this.props.preferences.preferences).length === 0;
+
+        if (newToProject && gravitySpySplit) {
+          return (
             <Link
               to={`/projects/${this.props.project.slug}/classify`}
               className="call-to-action standard-button"
@@ -84,11 +85,11 @@ export default class ProjectHomeWorkflowButtons extends React.Component {
             >
               Get started!
             </Link>
-          </VisibilitySplit>
-        );
-      } else {
-        return this.renderWorkflowButtons();
+          );
+        }
       }
+
+      return this.renderWorkflowButtons();
     }
 
     return (
@@ -110,6 +111,7 @@ ProjectHomeWorkflowButtons.defaultProps = {
   preferences: {},
   project: {},
   showWorkflowButtons: false,
+  splits: {},
   workflowAssignment: false,
 };
 
@@ -117,6 +119,7 @@ ProjectHomeWorkflowButtons.propTypes = {
   activeWorkflows: React.PropTypes.arrayOf(React.PropTypes.object).isRequired,
   onChangePreferences: React.PropTypes.func.isRequired,
   preferences: React.PropTypes.shape({
+    preferences: React.PropTypes.object,
     settings: React.PropTypes.objectOf(React.PropTypes.string),
   }),
   project: React.PropTypes.shape({
@@ -124,5 +127,6 @@ ProjectHomeWorkflowButtons.propTypes = {
     slug: React.PropTypes.string,
   }).isRequired,
   showWorkflowButtons: React.PropTypes.bool.isRequired,
+  splits: React.PropTypes.object,
   workflowAssignment: React.PropTypes.bool,
 };

--- a/app/pages/project/home-workflow-buttons.jsx
+++ b/app/pages/project/home-workflow-buttons.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router';
 import ProjectHomeWorkflowButton from './home-workflow-button';
+import locationMatch from '../../lib/location-match';
 
 
 export default class ProjectHomeWorkflowButtons extends React.Component {

--- a/app/pages/project/home-workflow-buttons.spec.js
+++ b/app/pages/project/home-workflow-buttons.spec.js
@@ -33,7 +33,7 @@ describe('ProjectHomeWorkflowButtons', function() {
   describe('if workflow assignment is true', function() {
     beforeEach(function () {
       wrapper = mount(
-        <ProjectHomeWorkflowButtons activeWorkflows={testWorkflows} preferences={testUserPreferences} showWorkflowButtons={true} workflowAssignment={true} />,
+        <ProjectHomeWorkflowButtons activeWorkflows={testWorkflows} preferences={testUserPreferences} showWorkflowButtons={true} workflowAssignment={true} splits={null} />,
         { context: { user: { id: 1 } } }
       );
     });

--- a/app/pages/project/home.jsx
+++ b/app/pages/project/home.jsx
@@ -63,6 +63,7 @@ export default class ProjectHomePage extends React.Component {
             project={this.props.project}
             showWorkflowButtons={this.state.showWorkflowButtons}
             workflowAssignment={this.props.project.experimental_tools.includes('workflow assignment')}
+            splits={this.props.splits}
           />
         </div>
 
@@ -89,6 +90,7 @@ ProjectHomePage.defaultProps = {
   onChangePreferences: () => {},
   preferences: {},
   project: {},
+  splits: {},
 };
 
 ProjectHomePage.propTypes = {
@@ -103,5 +105,6 @@ ProjectHomePage.propTypes = {
     introduction: React.PropTypes.string,
     workflow_description: React.PropTypes.string,
   }).isRequired,
+  splits: React.PropTypes.object,
 };
 

--- a/css/project-page.styl
+++ b/css/project-page.styl
@@ -143,7 +143,7 @@
     &__buttons
       display: flex
       flex-direction: column
-      
+
       .call-to-action-button--disabled
         cursor: not-allowed
         opacity: 0.5


### PR DESCRIPTION
This adds the UI piece for the first a/b split test for Gravity Spy. The experiment is a 50/50 split between _new_ users to the project. One half will see the standard buttons and will start with the beginner workflow. One half will see the 'Get Started!' button and on click will have their project preferences updated to load the level 4 workflow aka apprentice workflow.

This PR depends on #3242, the experiment setup in Seven-Ten production, and Geordi integration, so it's labeled WIP. Once #3242 is merged, I'll rebase and clean up the commit history. 

https://gs-split-setup.pfe-preview.zooniverse.org/

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?