### PR TITLE
Bump markdownz to v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lodash.merge": "~2.4.1",
     "lodash.pick": "~3.1.0",
     "lodash.uniq": "~3.2.2",
-    "markdownz": "zooniverse/markdownz#react-15",
+    "markdownz": "zooniverse/markdownz#v5.0.0",
     "modal-form": "~2.4.2",
     "moment": "~2.9.0",
     "panoptes-client": "~2.5.0",


### PR DESCRIPTION
@eatyourgreens I've bumped markdownz to v5.0.0 after merging your react 15 PR there, and this will bump the markdownz version here