### PR TITLE
cap project stats page progress chart at 100%

### DIFF
--- a/app/pages/project/stats/charts.jsx
+++ b/app/pages/project/stats/charts.jsx
@@ -4,9 +4,13 @@ import moment from 'moment';
 import Rcslider from 'rc-slider';
 
 export const Progress = (props) => {
-  const percent = props.progress * 100;
+  let progress = props.progress;
+  if (props.progress > 1) {
+    progress = 1;
+  }
+  const percent = progress * 100;
   const data = {
-    series: [props.progress, 1 - props.progress],
+    series: [progress, 1 - progress],
   };
   return (
     <div className="svg-container progress-container">


### PR DESCRIPTION
Fixes the progress chart on the stats page to cap at 100%.

Example page it fixes: https://fix-over-100-percent-stats.pfe-preview.zooniverse.org/projects/vrooje/project-gaia/stats/?env=production

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
