### PR TITLE
Update polyfill to add Array.includes()

### DIFF
--- a/views/index.ejs
+++ b/views/index.ejs
@@ -69,7 +69,7 @@
 
     <div id="panoptes-main-container"></div>
 
-    <script src="https://cdn.polyfill.io/v1/polyfill.min.js?features=default,es6,Promise,fetch&amp;flags=gated"></script>
+    <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=default,es6,Promise,fetch,Array.prototype.includes&amp;flags=gated"></script>
     <script>('assign' in Object) || document.write('<script src="/fallback-polyfills.js"></'+'script>');</script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jsPlumb/2.0.7/jsPlumb.min.js"></script>
   </body>


### PR DESCRIPTION
Fixes #3275 .

Describe your changes.
Adds Array.prototype.includes to the polyfills.
Updates the polyfill.io URL from v1 to v2.

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
