### PR TITLE
Fetch collections again on user change.

### DIFF
--- a/app/collections/show.jsx
+++ b/app/collections/show.jsx
@@ -154,6 +154,12 @@ const CollectionPageWrapper = React.createClass({
     this.fetchCollection();
   },
 
+  componentWillReceiveProps(newProps) {
+    if (this.props.user !== newProps.user) {
+      this.fetchCollection();
+    }
+  },
+
   title() {
     return this.state.collection ? this.state.collection.display_name : '(Loading)';
   },


### PR DESCRIPTION
Fixes #3277 .

Describe your changes.
Fetches collections from the API when the user prop changes for collection pages.
Should fix the case of private collections incorrectly showing/not showing.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://fix-3277.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
