### PR TITLE
Return a discussion from TalkDiscussion.setDiscussion

### DIFF
--- a/app/talk/discussion.cjsx
+++ b/app/talk/discussion.cjsx
@@ -56,10 +56,10 @@ module.exports = React.createClass
     @shouldScrollToBottom = true if @props.location.query?.scrollToLastComment
 
   componentWillMount: ->
-    @setDiscussion().then =>
+    @setDiscussion().then (discussion) =>
       if @props.location.query?.comment
         commentId = @props.location.query.comment
-        comments = @state.discussion.links.comments
+        comments = discussion.links.comments
         commentNumber = comments.indexOf(commentId) + 1
         page = Math.ceil commentNumber / PAGE_SIZE
 
@@ -125,6 +125,8 @@ module.exports = React.createClass
             page_size: 100
           .then (boards) =>
             @setState {boards}
+
+        discussion[0]
 
   onUpdateComment: (textContent, subject, commentId) ->
     {discussion} = @props.params


### PR DESCRIPTION
Fixes #3279 .

Describe your changes.
Returns a discussion from `setDiscussion`, avoiding a case where `componentWillMount` runs before `this.state.discussion` has been set.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://fix-3279.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
Fixes #3279