### PR TITLE
final version--tell geordi to remember the first active experiment

### DIFF
--- a/app/pages/project/index.cjsx
+++ b/app/pages/project/index.cjsx
@@ -318,6 +318,9 @@ ProjectPageController = React.createClass
 
   mixins: [TitleMixin]
 
+  contextTypes:
+    geordi: React.PropTypes.object
+
   propTypes:
     params: React.PropTypes.object
     user: React.PropTypes.object
@@ -365,8 +368,15 @@ ProjectPageController = React.createClass
     if user
       Split.load("#{owner}/#{name}").then (splits) =>
         @setState {splits}
+        return unless splits
+        for split of splits
+          continue unless splits[split].state == 'active'
+          @context.geordi?.remember experiment: splits[split].name
+          @context.geordi?.remember cohort: splits[split].variant?.name
+          break
     else
       Split.clear()
+      @context.geordi?.forget ['experiment','cohort']
 
   fetchProjectData: (ownerName, projectName, user) ->
     @listenToPreferences null


### PR DESCRIPTION
Makes the Geordi logger semi-aware of experimental splits set up by seven-ten.

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [x] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
