### PR TITLE
Don't override Talk links for middle and right mouse buttons

### DIFF
--- a/app/components/wrapped-markdown.jsx
+++ b/app/components/wrapped-markdown.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import markdownz from 'markdownz';
 import { browserHistory } from 'react-router';
+
 const Markdown = markdownz.Markdown;
 
 const WrappedMarkdown = React.createClass({
@@ -11,8 +12,10 @@ const WrappedMarkdown = React.createClass({
   },
 
   onClick(e) {
+    const rightButtonPressed = (!!e.button && e.button > 0);
     if (e.target.origin === window.location.origin &&
-      e.target.pathname !== window.location.pathname) {
+      e.target.pathname !== window.location.pathname &&
+      !rightButtonPressed) {
       const newURL = e.target.pathname + e.target.search + e.target.hash;
       browserHistory.push(newURL);
       e.preventDefault();

--- a/app/components/wrapped-markdown.jsx
+++ b/app/components/wrapped-markdown.jsx
@@ -13,9 +13,11 @@ const WrappedMarkdown = React.createClass({
 
   onClick(e) {
     const rightButtonPressed = (!!e.button && e.button > 0);
+    const modifierKey = (e.ctrlKey || e.metaKey);
     if (e.target.origin === window.location.origin &&
       e.target.pathname !== window.location.pathname &&
-      !rightButtonPressed) {
+      !rightButtonPressed &&
+      !modifierKey) {
       const newURL = e.target.pathname + e.target.search + e.target.hash;
       browserHistory.push(newURL);
       e.preventDefault();


### PR DESCRIPTION
Fixes #3048 .

Describe your changes.
Checks for `e.button` and doesn't override links if it exists and is greater than 0, or if `e.ctrlKey` or `e.metaKey` are set.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://talk-links.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?