### PR TITLE
Gravity Spy workflow assignment split updates

### DIFF
--- a/app/pages/project/home-workflow-button.jsx
+++ b/app/pages/project/home-workflow-button.jsx
@@ -35,6 +35,12 @@ export default class ProjectHomeWorkflowButton extends React.Component {
       );
     }
 
+    if (this.props.workflowAssignment &&
+        this.props.workflow.configuration &&
+        !this.props.workflow.configuration.level) {
+      return (null);
+    }
+
     return (
       <Link
         to={`/projects/${this.props.project.slug}/classify`}
@@ -62,6 +68,9 @@ ProjectHomeWorkflowButton.propTypes = {
     slug: React.PropTypes.string,
   }).isRequired,
   workflow: React.PropTypes.shape({
+    configuration: React.PropTypes.shape({
+      level: React.PropTypes.string,
+    }),
     display_name: React.PropTypes.string,
     id: React.PropTypes.string,
   }).isRequired,

--- a/app/pages/project/home-workflow-buttons.jsx
+++ b/app/pages/project/home-workflow-buttons.jsx
@@ -28,10 +28,10 @@ export default class ProjectHomeWorkflowButtons extends React.Component {
   }
 
   handleSplitWorkflowAssignment() {
-    let workflowAssignmentID = '2334';
+    let workflowAssignmentID = '2758';
 
     if (process.env.NODE_ENV === 'production' || locationMatch(/\W?env=(production)/)) {
-      workflowAssignmentID = '2360';
+      workflowAssignmentID = '3063';
     }
 
     if (this.props.splits['workflow.assignment']) {
@@ -47,7 +47,7 @@ export default class ProjectHomeWorkflowButtons extends React.Component {
   }
 
   renderWorkflowButtons() {
-    if (this.props.activeWorkflows.length > 0) {
+    if (this.props.activeWorkflows.length > 0 && this.props.preferences) {
       return (
         <div className="call-to-action-container__buttons">
           {this.props.activeWorkflows.map((workflow) => {

--- a/app/pages/project/home-workflow-buttons.spec.js
+++ b/app/pages/project/home-workflow-buttons.spec.js
@@ -17,6 +17,10 @@ const testWorkflows = [
     configuration: { level: 3 },
     display_name: 'Advanced Workflow',
   },
+  { id: '6757',
+    configuration: { },
+    display_name: 'Active, no level workflow',
+  },
 ];
 
 const testUserPreferences = {
@@ -38,7 +42,7 @@ describe('ProjectHomeWorkflowButtons', function() {
       );
     });
 
-    it('should render workflow button options', function() {
+    it('should render active workflow button options that have a level', function() {
       assert.equal(wrapper.find('.standard-button').length, 3);
     });
 
@@ -57,7 +61,7 @@ describe('ProjectHomeWorkflowButtons', function() {
     });
 
     it('should render workflow button options', function() {
-      assert.equal(wrapper.find('.standard-button').length, 3);
+      assert.equal(wrapper.find('.standard-button').length, 4);
     });
   });
 


### PR DESCRIPTION
This updates which workflows are being used, hides active workflows that do not have an assigned level, updates tests, and fixes a minor bug where the buttons would flash while the preferences for a user were still loading and then would switch to the 'Get started!' if the user was a part of that split group.

https://gs-split-workflow-setup.pfe-preview.zooniverse.org/projects/srallen086/workflow-assignment-testing

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
