### PR TITLE
Fix Message Overflow for Small Screens

### DIFF
--- a/app/pages/home-for-user/recent-messages.jsx
+++ b/app/pages/home-for-user/recent-messages.jsx
@@ -174,19 +174,17 @@ const RecentCollectionsSection = React.createClass({
         </span>
         <img role="presentation" src={avatarSrc} className="recent-conversation-link__partner-avatar" />
         <span className="recent-conversation-link__partner">
-          {!!partner ? partner.display_name : LOADER_BULLETS}
+          {partner ? partner.display_name : LOADER_BULLETS}
         </span>
 
-        {screen.width > 400 && (
-          <div className="recent-conversation-link__preview">
-            <div className="recent-conversation-link__title">
-              {conversation.title}
-            </div>
-            <div className="recent-conversation-link__body-preview">
-              {!!message ? <StringTruncator>{message.body}</StringTruncator> : LOADER_BULLETS}
-            </div>
+        <div className="recent-conversation-link__preview">
+          <div className="recent-conversation-link__title">
+            {conversation.title}
           </div>
-        )}
+          <div className="recent-conversation-link__body-preview">
+            {message ? <StringTruncator>{message.body}</StringTruncator> : LOADER_BULLETS}
+          </div>
+        </div>
       </Link>
     );
   },

--- a/app/pages/home-for-user/recent-messages.jsx
+++ b/app/pages/home-for-user/recent-messages.jsx
@@ -177,7 +177,7 @@ const RecentCollectionsSection = React.createClass({
           {!!partner ? partner.display_name : LOADER_BULLETS}
         </span>
 
-        {screen.width > 350 && (
+        {screen.width > 400 && (
           <div className="recent-conversation-link__preview">
             <div className="recent-conversation-link__title">
               {conversation.title}

--- a/css/recent-messages.styl
+++ b/css/recent-messages.styl
@@ -45,7 +45,9 @@
     width: 2em
 
   &__preview
-    margin: 0 0.5ch;
+    margin: 0 0.5ch
+    overflow: hidden
+    white-space: nowrap
 
   &__title
     font-size: 1.2em

--- a/css/recent-messages.styl
+++ b/css/recent-messages.styl
@@ -14,6 +14,9 @@
   padding: 1ch 1em
   text-decoration: none
 
+  @media (max-width: 600px)
+    display: block
+
   &:hover
     box-shadow: 0 0 0 1px #eef2f5 inset
 
@@ -48,6 +51,11 @@
     margin: 0 0.5ch
     overflow: hidden
     white-space: nowrap
+
+    div
+      overflow: hidden
+      white-space: nowrap
+      text-overflow: ellipsis
 
   &__title
     font-size: 1.2em


### PR DESCRIPTION
**Describe your changes.**
On the landing page, longer messages are overflowing out of their parent DIV for smaller screens. This was first noticed on a Android with a larger screen (hence the branch name). CSS and screen size cutoff was changed.

https://android-view.pfe-preview.zooniverse.org/

<img width="296" alt="screen shot 2016-11-30 at 3 30 16 pm" src="https://cloud.githubusercontent.com/assets/14099077/20772193/34ef28f2-b712-11e6-8580-3ff7d7b257b3.png">

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
