### PR TITLE
Fix react-swipe-options

### DIFF
--- a/app/components/step-through.jsx
+++ b/app/components/step-through.jsx
@@ -1,4 +1,4 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
 import ReactSwipe from 'react-swipe';
 import animatedScrollTo from 'animated-scrollto';
@@ -119,14 +119,17 @@ class StepThrough extends Component {
 
   render() {
     const childrenCount = React.Children.count(this.props.children);
+    const swipeOptions = {
+      startSlide: this.state.step,
+      continuous: false,
+      callback: this.handleStep.bind(this, childrenCount),
+    };
     return (
       <div className="step-through" className={this.props.className} style={this.props.style}>
         <ReactSwipe 
           ref="swiper" 
-          className="step-through-content" 
-          startSlide={this.state.step} 
-          continuous={false} 
-          callback={this.handleStep.bind(this, childrenCount)}
+          className="step-through-content"
+          swipeOptions={swipeOptions}
         >
           {this.props.children}
         </ReactSwipe>

--- a/app/lib/tutorial.cjsx
+++ b/app/lib/tutorial.cjsx
@@ -4,7 +4,7 @@ MediaCard = require '../components/media-card'
 {Markdown} = (require 'markdownz').default
 apiClient = require 'panoptes-client/lib/api-client'
 
-`import StepThrough from '../components/step-through'`
+`import StepThrough from '../components/step-through';`
 
 completedThisSession = {}
 window?.tutorialsCompletedThisSession = completedThisSession


### PR DESCRIPTION
v5.0 changed how options are passed to react-swipe.
Fixes #3291

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch? https://react-swipe-options.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
