### PR TITLE
Add workflow stats visibility setting

### DIFF
--- a/app/pages/lab/visibility.cjsx
+++ b/app/pages/lab/visibility.cjsx
@@ -82,7 +82,15 @@ module.exports = React.createClass
     workflow.update({ 'configuration.stats_completeness_type': e.target.value }).save()
       .catch((error) => 
         @setState {error}
-      ).then(() => @forceUpdate())  
+      ).then(() => @forceUpdate())
+
+  handleWorkflowStatsVisibility: (workflow, e) ->
+    checked = e.target.checked
+
+    workflow.update({ 'configuration.stats_hidden': checked }).save()
+      .catch((error) =>
+        @setState { error }
+      ).then(() => @forceUpdate())
 
   render: ->
     looksDisabled =
@@ -244,6 +252,9 @@ module.exports = React.createClass
                 <th>
                   Completeness statistic
                 </th>
+                <th>
+                  Statistic visibility
+                </th>
               </tr>
             </thead>
             <tbody>
@@ -267,7 +278,7 @@ module.exports = React.createClass
                   &emsp;
                 </td>
                 <td>
-                  <label>
+                  <label style={whiteSpace: 'nowrap'}>
                     <input
                       type="radio"
                       name="stats_completeness_type.#{workflow.id}"
@@ -278,7 +289,7 @@ module.exports = React.createClass
                     Classification Count
                   </label>
                   &emsp;
-                  <label>
+                  <label style={whiteSpace: 'nowrap'}>
                     <input
                       type="radio"
                       name="stats_completeness_type.#{workflow.id}"
@@ -288,6 +299,20 @@ module.exports = React.createClass
                     />
                     Retirement Count
                   </label>
+                  &emsp;
+                </td>
+                <td>
+                  <label style={whiteSpace: 'nowrap'}>
+                    <input
+                      type="checkbox"
+                      name="stats_hidden.#{workflow.id}"
+                      value={workflow.configuration.stats_hidden}
+                      checked={workflow.configuration.stats_hidden}
+                      onChange={@handleWorkflowStatsVisibility.bind(this, workflow)}
+                    />
+                    Hide on Stats Page
+                  </label>
+                  &emsp;
                 </td>
               </tr>}
             </tbody>
@@ -311,5 +336,9 @@ module.exports = React.createClass
         {' '}Since the images are shown to users in a random order, this completeness estimate will be slow to increase until the project is close to being finished.
         {' '}If your project does not have a constant retirement limit (e.g. it uses a custom retiment rule) and/or subject sets 
         {' '}have been unlinked from a live workflow, this estimate will be the most accurate.
+      </p>
+      <p className="form-label">Statistics Visbiility</p>
+      <p className="form-help">
+        Active workflows are visible on the project's statistics page by default. If there is a reason to hide an active workflow from the statistics page, such as a workflow being used in an a/b split experiment, then toggle the "Hide on Stats Page" checkbox.
       </p>
     </div>

--- a/app/pages/project/stats/index.jsx
+++ b/app/pages/project/stats/index.jsx
@@ -20,6 +20,7 @@ class ProjectStatsPageController extends React.Component {
     const fields = [
       'classifications_count',
       'completeness',
+      'configuration',
       'display_name',
       'retired_set_member_subjects_count',
       'retirement,subjects_count',
@@ -30,7 +31,11 @@ class ProjectStatsPageController extends React.Component {
     };
     getWorkflowsInOrder(this.props.project, query)
       .then((workflows) => {
-        this.setState({ workflowList: workflows });
+        const workflowsSetToBeVisible =
+          workflows.filter((workflow) => { 
+            return (!workflow.configuration.stats_hidden ? workflow : null);
+        })
+        this.setState({ workflowList: workflowsSetToBeVisible });
       });
   }
 


### PR DESCRIPTION
This adds a workflow configuration setting to hide a workflow from the project's statistics page. Use case is if a project is using an active workflow for a specific a/b split and it doesn't make sense to make the stats for that workflow visible to volunteers. Gravity Spy currently has a split going on using an active workflow that will be made inactive once the experiment is done. Conceivably there may be other use cases for project builders to hide an active workflow from the stats page.

workflow id `3063` should not now be visible on Gravity Spy's stats page with this update:
https://hide-stats.pfe-preview.zooniverse.org/projects/zooniverse/gravity-spy/stats?env=production

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
