### PR TITLE
Add support for text files as subjects

### DIFF
--- a/app/components/frame-viewer.cjsx
+++ b/app/components/frame-viewer.cjsx
@@ -1,8 +1,9 @@
 React = require 'react'
 LoadingIndicator = require '../components/loading-indicator'
 getSubjectLocation = require '../lib/get-subject-location'
-`import VideoPlayer from './video-player'`
-`import PanZoom from './pan-zoom'`
+`import VideoPlayer from './video-player';`
+`import PanZoom from './pan-zoom';`
+`import TextViewer from './text-viewer';`
 
 SUBJECT_STYLE = display: 'block'
 NOOP = Function.prototype
@@ -45,6 +46,8 @@ module.exports = React.createClass
       when 'video'
         <VideoPlayer src={src} type={type} format={format} frame={@props.frame} onLoad={@handleLoad}>
         </VideoPlayer>
+      when 'text'
+        <TextViewer  src={src} type={type} format={format} frame={@props.frame} onLoad={@handleLoad} /> 
 
     if FrameWrapper
       <PanZoom ref="panZoom" enabled={zoomEnabled} frameDimensions={@state.frameDimensions}>

--- a/app/components/text-viewer.jsx
+++ b/app/components/text-viewer.jsx
@@ -1,4 +1,8 @@
 import React, { Component } from 'react';
+import ReactDOM from 'react-dom';
+
+const SUPPORTED_TYPES = ['text'];
+const SUPPORTED_FORMATS = ['plain'];
 
 class TextViewer extends Component {
   constructor(props) {
@@ -15,6 +19,9 @@ class TextViewer extends Component {
     })
     .then((content) => {
       this.setState({ content });
+      const e = new Event('load');
+      e.target = ReactDOM.findDOMNode(this);
+      this.props.onLoad(e);
     })
     .catch((e) => {
       const content = e.message;
@@ -23,9 +30,16 @@ class TextViewer extends Component {
   }
 
   render() {
+    let { content } = this.state;
+    if (SUPPORTED_TYPES.indexOf(this.props.type) === -1) {
+      content = `Unsupported type: ${this.props.type}`;
+    }
+    if (SUPPORTED_FORMATS.indexOf(this.props.format) === -1) {
+      content = `Unsupported format: ${this.props.format}`;
+    }
     return (
       <div>
-        {this.state.content}
+        { content }
       </div>
     );
   }
@@ -33,9 +47,15 @@ class TextViewer extends Component {
 
 TextViewer.propTypes = {
   src: React.PropTypes.string.isRequired,
-  type: React.PropTypes.string.isRequired,
-  format: React.PropTypes.string.isRequired,
-  onLoad: React.PropTypes.func.isRequired,
+  type: React.PropTypes.string,
+  format: React.PropTypes.string,
+  onLoad: React.PropTypes.func,
+};
+
+TextViewer.defaultProps = {
+  type: 'text',
+  format: 'plain',
+  onLoad: () => { return new Event('load'); },
 };
 
 export default TextViewer;

--- a/app/components/text-viewer.jsx
+++ b/app/components/text-viewer.jsx
@@ -19,14 +19,20 @@ class TextViewer extends Component {
     })
     .then((content) => {
       this.setState({ content });
-      const e = new Event('load');
-      e.target = ReactDOM.findDOMNode(this);
-      this.props.onLoad(e);
+      ReactDOM.findDOMNode(this).dispatchEvent(new Event('load'));
     })
     .catch((e) => {
       const content = e.message;
       this.setState({ content });
     });
+  }
+
+  componentDidMount() {
+    ReactDOM.findDOMNode(this).addEventListener('load', this.props.onLoad);
+  }
+
+  componentWillUnmount() {
+    ReactDOM.findDOMNode(this).removeEventListener('load', this.props.onLoad);
   }
 
   render() {
@@ -55,7 +61,7 @@ TextViewer.propTypes = {
 TextViewer.defaultProps = {
   type: 'text',
   format: 'plain',
-  onLoad: () => { return new Event('load'); },
+  onLoad: (e) => { console.log('text loaded', e); },
 };
 
 export default TextViewer;

--- a/app/components/text-viewer.jsx
+++ b/app/components/text-viewer.jsx
@@ -1,0 +1,41 @@
+import React, { Component } from 'react';
+
+class TextViewer extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      content: '',
+    };
+  }
+
+  componentWillMount() {
+    fetch(this.props.src)
+    .then((response) => {
+      return response.text();
+    })
+    .then((content) => {
+      this.setState({ content });
+    })
+    .catch((e) => {
+      const content = e.message;
+      this.setState({ content });
+    });
+  }
+
+  render() {
+    return (
+      <div>
+        {this.state.content}
+      </div>
+    );
+  }
+}
+
+TextViewer.propTypes = {
+  src: React.PropTypes.string.isRequired,
+  type: React.PropTypes.string.isRequired,
+  format: React.PropTypes.string.isRequired,
+  onLoad: React.PropTypes.func.isRequired,
+};
+
+export default TextViewer;


### PR DESCRIPTION
Describe your changes.
Adds a really simple viewer to load in a text file and render the contents.
To test, there's a file with text content as the second frame for this Diagnosis London subject.
https://text-subjects.pfe-preview.zooniverse.org/projects/eatyourgreens/diagnosis-london/talk/100/47640?env=production

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
A really simple viewer to load and render the contents of a text file.