### PR TITLE
Update to use transpiled markdownz

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lodash.merge": "~2.4.1",
     "lodash.pick": "~3.1.0",
     "lodash.uniq": "~3.2.2",
-    "markdownz": "~6.0",
+    "markdownz": "~7.0",
     "modal-form": "~2.4.2",
     "moment": "~2.9.0",
     "panoptes-client": "~2.5.0",

--- a/webpack.build.js
+++ b/webpack.build.js
@@ -58,11 +58,6 @@ module.exports = {
       exclude: /node_modules/,
       loader: 'babel',
     }, {
-      // explicitly include markdownz (and dependencies) to be transformed because it's es6
-      test: /\.jsx?$/,
-      include: /markdown/,
-      loader: 'babel',
-    }, {
       test: /\.cjsx$/,
       exclude: /node_modules/,
       loaders: ['babel', 'coffee', 'cjsx'],

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -40,11 +40,6 @@ var config = {
       exclude: /node_modules/,
       loader: 'babel'
     }, {
-      // explicitly include markdownz (and dependencies) to be transformed because it's es6
-      test: /\.jsx?$/,
-      include: /markdown/,
-      loader: 'babel?cacheDirectory'
-    }, {
       test: /\.cjsx$/,
       exclude: /node_modules/,
       loaders: ['babel?cacheDirectory', 'coffee', 'cjsx']


### PR DESCRIPTION
Use the new transpiled version of markdownz.

https://update-markdownz.pfe-preview.zooniverse.org/

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [x] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)
