### PR TITLE
Update seven-ten

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "react-select": "~1.0.0-rc",
     "react-swipe": "~5.0.3",
     "react-translate-component": "~0.13.0",
-    "seven-ten": "~2.0.1",
+    "seven-ten": "~3.0.0",
     "sort-into-columns": "~1.0.0",
     "sugar-client": "~1.0.1",
     "swipe-js-iso": "~2.0.1",


### PR DESCRIPTION
Towards #3288

Seven ten now specifies a `^6` node version.

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?
- [x] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
