### PR TITLE
Add default pages back to about project

### DIFF
--- a/app/pages/project/about/about-nav.jsx
+++ b/app/pages/project/about/about-nav.jsx
@@ -15,7 +15,7 @@ counterpart.registerTranslations('en', {
 
 const AboutNav = ({ pages, projectPath }) => (
   <span>
-    {pages.map((page) => 
+    {pages.map(page => 
       <Link key={page.slug}
         to={`${projectPath}/about/${page.slug}`} 
         activeClassName="active"

--- a/app/pages/project/about/index.jsx
+++ b/app/pages/project/about/index.jsx
@@ -31,6 +31,7 @@ class AboutProject extends Component {
 
   constructPagesData(apiResponse) {
     const availablePages = [];
+
     for (const url_key in SLUG_MAP) {
       const matchingPage = apiResponse.find(page => page.url_key === url_key);
       if (matchingPage && matchingPage.content && matchingPage.content !== '') {
@@ -39,27 +40,23 @@ class AboutProject extends Component {
           title: matchingPage.title,
           content: matchingPage.content,
         });
+      } else if (['science_case', 'team'].includes(url_key)) {
+        availablePages.push({ slug: SLUG_MAP[url_key] });
       }
     }
+
     return availablePages;
   }
 
   getPages() {
+    this.getTeam();
     return this.props.project.get('pages')
       .then(this.constructPagesData)
-      .then((availablePages) => {
-        this.setState({ 
-          pages: availablePages, 
-          loaded: true,
-        });
-        return availablePages;
-      })
-      .then((availablePages) => {
-        if (availablePages.find(page => page.slug === 'team')) {
-          this.getTeam();
-        }
-      })
-      .catch((error) => console.error('Error retrieving project pages', error));
+      .then(availablePages => this.setState({ 
+        pages: availablePages, 
+        loaded: true,
+      }))
+      .catch(error => console.error('Error retrieving project pages', error));
   }
 
   getTeam() {
@@ -71,16 +68,14 @@ class AboutProject extends Component {
           .catch((error) => console.error('Error retrieving project team users', error));
       })
       .then(team => this.setState({ team }))
-      .catch((error) => console.error('Error retrieving project team data', error));
+      .catch(error => console.error('Error retrieving project team data', error));
   }
 
   constructTeamData(roles, users) {
-    return users.map(user => {
-      return {
-        userResource: user,
-        roles: roles.find(role => user.id === role.links.owner.id).roles,
-      };
-    });
+    return users.map(user => ({
+      userResource: user,
+      roles: roles.find(role => user.id === role.links.owner.id).roles,
+    }));
   }
 
   render() {

--- a/app/pages/project/about/team.jsx
+++ b/app/pages/project/about/team.jsx
@@ -6,15 +6,20 @@ import counterpart from 'counterpart';
 import Avatar from '../../../partials/avatar';
 
 counterpart.registerTranslations('en', {
+  aboutPages: {
+    missingContent: {
+      team: 'This project has no team information.',
+    }
+  },
   projectRoles: {
-      title: 'The Team',
-      owner: 'Owner',
-      collaborator: 'Collaborator',
-      translator: 'Translator',
-      scientist: 'Researcher',
-      moderator: 'Moderator',
-      tester: 'Tester',
-      expert: 'Expert',
+    title: 'The Team',
+    owner: 'Owner',
+    collaborator: 'Collaborator',
+    translator: 'Translator',
+    scientist: 'Researcher',
+    moderator: 'Moderator',
+    tester: 'Tester',
+    expert: 'Expert',
   }
 });
 
@@ -48,7 +53,7 @@ const AboutProjectTeam = ({ pages, project, team }) => {
   const teamPage = pages.find(page => page.slug === 'team');
   const mainContent = (teamPage && teamPage.content && teamPage.content !== '') 
       ? teamPage.content 
-      : 'This project has no team information.';
+      : counterpart('aboutPages.missingContent.team');
   const aside = createTeamList(team);
 
   return <AboutPageLayout


### PR DESCRIPTION
Adds Research and Team as default about pages after a request on Talk - Research is the default page, and Team should be visible for the collaborators list even without content

cc @eatyourgreens 

Describe your changes.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
