### PR TITLE
Breakout version list, remove PromiseRenderer

### DIFF
--- a/app/pages/admin/project-status.cjsx
+++ b/app/pages/admin/project-status.cjsx
@@ -10,6 +10,8 @@ handleInputChange = require '../../lib/handle-input-change'
 getWorkflowsInOrder = require '../../lib/get-workflows-in-order'
 WorkflowToggle = require '../../components/workflow-toggle'
 
+`import VersionList from './project-status/version-list';`
+
 EXPERIMENTAL_FEATURES = [
   'crop'
   'combo'
@@ -122,27 +124,6 @@ ProjectRedirectToggle = React.createClass
         <span>{ @validUrlMessage() }</span>
       </AutoSave>
     </div>
-
-VersionList = React.createClass
-  displayName: "VersionList"
-
-  getDefaultProps: ->
-    project: null
-
-  render: ->
-    <PromiseRenderer promise={@props.project.get 'versions'}>{ (versions) =>
-      vs = versions.sort()
-      <h4>Recent Status Changes</h4>
-      <ul className="project-status__section-list">
-        {vs.map (version) =>
-          key = Object.keys(version.changeset)[0]
-          changes = 'from ' + version.changeset[key].join ' to '
-          m = moment(version.created_at)
-          <PromiseRenderer key={version.id} promise={apiClient.type('users').get(version.whodunnit)} >{ (user) =>
-            <li>{user.display_name} changed {key} {changes}  {m.fromNow()}</li>
-          }</PromiseRenderer>}
-      </ul>
-    }</PromiseRenderer>
 
 ProjectStatus = React.createClass
   displayName: "ProjectStatus"

--- a/app/pages/admin/project-status/version-list.jsx
+++ b/app/pages/admin/project-status/version-list.jsx
@@ -59,9 +59,9 @@ class VersionList extends Component {
         const userIds = uniq(versions.map(version => version.whodunnit));
         return apiClient.type('users').get(userIds)
           .then(users => ({ versions, users }))
-          .catch(error => console.error('Error retrieving version author data', error));    
+          .catch(error => console.error('Error retrieving version author data', error));
       })
-      .then(({versions, users}) => {
+      .then(({ versions, users }) => {
         this.setState({
           loading: false,
           versions: versions.sort((a, b) => new Date(b.created_at) - new Date(a.created_at)),
@@ -76,7 +76,7 @@ class VersionList extends Component {
       <div>
         <h4>Recent Status Changes</h4>
         <ul className="project-status__section-list">
-          {this.state.versions.map(version => 
+          {this.state.versions.map(version =>
             <li key={version.id}>{this.createVersionString(version)}</li>
           )}
         </ul>

--- a/app/pages/admin/project-status/version-list.jsx
+++ b/app/pages/admin/project-status/version-list.jsx
@@ -1,0 +1,88 @@
+import React, { Component } from 'react';
+import { Link } from 'react-router';
+import apiClient from 'panoptes-client/lib/api-client';
+import uniq from 'lodash.uniq';
+import moment from 'moment';
+import LoadingIndicator from '../../../components/loading-indicator';
+
+class VersionList extends Component {
+  constructor(props) {
+    super(props);
+    this.getVersions = this.getVersions.bind(this);
+    this.renderVersions = this.renderVersions.bind(this);
+    this.createVersionString = this.createVersionString.bind(this);
+    this.state = {
+      loading: false,
+      users: null,
+      versions: null,
+    };
+  }
+
+  componentDidMount() {
+    this.getVersions();
+  }
+
+  componentDidUpdate(prevProps) {
+    if (this.props.project !== prevProps.project) {
+      this.getVersions();
+    }
+  }
+
+  render() {
+    const { loading, versions, users } = this.state;
+    return (this.props.project && !loading && versions && users) ? this.renderVersions() : <LoadingIndicator />;
+  }
+
+  createVersionString(version) {
+    const versionAuthor = this.state.users.find(user => user.id === version.whodunnit);
+    const property = Object.keys(version.changeset)[0];
+    const oldValue = version.changeset[property][0];
+    const newValue = version.changeset[property][1];
+    const time = moment(version.created_at).fromNow();
+
+    const versionEntry = [versionAuthor.display_name, 'changed', property];
+    if (oldValue !== null && oldValue !== undefined) {
+      versionEntry.push('from', oldValue);
+    }
+    versionEntry.push('to', newValue, time);
+    return versionEntry.join(' ');
+  }
+
+  getVersions() {
+    if (!this.props.project) {
+      return false;
+    }
+
+    this.setState({ loading: true });
+    return this.props.project.get('versions')
+      .then(versions => {
+        const userIds = uniq(versions.map(version => version.whodunnit));
+        return apiClient.type('users').get(userIds)
+          .then(users => ({ versions, users }))
+          .catch(error => console.error('Error retrieving version author data', error));    
+      })
+      .then(({versions, users}) => {
+        this.setState({
+          loading: false,
+          versions: versions.sort((a, b) => new Date(b.created_at) - new Date(a.created_at)),
+          users,
+        });
+      })
+      .catch(error => console.error('Error retrieving version data', error));
+  }
+
+  renderVersions() {
+    return (
+      <div>
+        <h4>Recent Status Changes</h4>
+        <ul className="project-status__section-list">
+          {this.state.versions.map(version => 
+            <li key={version.id}>{this.createVersionString(version)}</li>
+          )}
+        </ul>
+      </div>
+    );
+  }
+}
+
+export default VersionList;


### PR DESCRIPTION
This starts on the refactor of the project status admin page. It breaks out the version list to a new ES6 component and removes the PromiseRenderers. I wanted to keep PRs small, and it's a bit of a beast of a component, so I'll do a section at a time.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://project-status-versions.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [x] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [x] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
