### PR TITLE
Pass a project to collection subject viewer

### DIFF
--- a/app/collections/show-list.cjsx
+++ b/app/collections/show-list.cjsx
@@ -48,7 +48,7 @@ SubjectNode = React.createClass
   render: ->
     logClick = @context.geordi?.makeHandler? 'about-menu'
     <div className="collection-subject-viewer">
-      <SubjectViewer defaultStyle={false} subject={@props.subject} user={@props.user}>
+      <SubjectViewer defaultStyle={false} subject={@props.subject} user={@props.user} project={@state.project}>
         {if @isOwnerOrCollaborator()
           <button type="button" className="collection-subject-viewer-delete-button" onClick={@props.onDelete}>
             <i className="fa fa-close" />


### PR DESCRIPTION
Fixes #1652 .

Describe your changes.
Passes a project prop to the subject viewer, which should enable the project and collections buttons.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch? https://collection-favourites.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?