### PR TITLE
Slight Reordering and rewording on Zooniverse News Section

### DIFF
--- a/app/pages/home-for-user/news-pullout.jsx
+++ b/app/pages/home-for-user/news-pullout.jsx
@@ -113,21 +113,21 @@ const NewsSection = React.createClass({
           <h2> Zooniverse News </h2>
 
           <div className="home-page-news-pullout news-section">
-            <h4> Recent Publications </h4>
-            {this.state.publications.map((article) => {
-              return this.renderPublication(article);
-            })}
-          </div>
-
-          <div className="home-page-news-pullout news-section">
             <h4> Newest Project </h4>
             <ProjectCard href={projLink} key={this.state.newestProject.id} project={this.state.newestProject} imageSrc={avatarSrc} />
           </div>
 
           <div className="home-page-news-pullout news-section">
-            <h4> Updated Projects </h4>
+            <h4> Participated Project Updates </h4>
             {this.props.updatedProjects.map((project) => {
               return this.renderUpdatedProjects(project);
+            })}
+          </div>
+          
+          <div className="home-page-news-pullout news-section">
+            <h4> Recent Publications </h4>
+            {this.state.publications.map((article) => {
+              return this.renderPublication(article);
             })}
           </div>
         </div>


### PR DESCRIPTION
Minor tweaks to the Zooniverse News Section on the logged-in user Zooniverse hompage - Addresses #3193 by shifting the Publications to the bottom of the list and changed  'Updated projects' --> 'Participated Project Updates'  which address most of #3191