### PR TITLE
Rotate and Draw

### DIFF
--- a/app/classifier/drawing-tools/circle.cjsx
+++ b/app/classifier/drawing-tools/circle.cjsx
@@ -75,8 +75,9 @@ module.exports = React.createClass
     </DrawingToolRoot>
 
   handleMainDrag: (e, d) ->
-    @props.mark.x += d.x / @props.scale.horizontal
-    @props.mark.y += d.y / @props.scale.vertical
+    difference = @props.normalizeDifference(e, d)
+    @props.mark.x += difference.x
+    @props.mark.y += difference.y
     @props.onChange @props.mark
 
   handleRadiusHandleDrag: (e, d) ->

--- a/app/classifier/drawing-tools/circle.cjsx
+++ b/app/classifier/drawing-tools/circle.cjsx
@@ -69,8 +69,8 @@ module.exports = React.createClass
 
       {if @props.selected
         <g>
-          <DeleteButton tool={this} x={deletePosition.x} y={deletePosition.y} rotate={@props.mark.angle} />
-          <DragHandle onDrag={@handleRadiusHandleDrag} x={@props.mark.r} y={0} scale={@props.scale} />
+          <DeleteButton tool={this} x={deletePosition.x} y={deletePosition.y} rotate={@props.mark.angle} getScreenCurrentTransformationMatrix={@props.getScreenCurrentTransformationMatrix} />
+          <DragHandle onDrag={@handleRadiusHandleDrag} x={@props.mark.r} y={0} scale={@props.scale} getScreenCurrentTransformationMatrix={@props.getScreenCurrentTransformationMatrix} />
         </g>}
     </DrawingToolRoot>
 

--- a/app/classifier/drawing-tools/column-rectangle.cjsx
+++ b/app/classifier/drawing-tools/column-rectangle.cjsx
@@ -50,10 +50,10 @@ module.exports = React.createClass
 
       {if @props.selected
         <g>
-          <DeleteButton tool={this} x={x + width + 20} y={15} />
+          <DeleteButton tool={this} x={x + width + 20} y={15} getScreenCurrentTransformationMatrix={@props.getScreenCurrentTransformationMatrix} />
 
-          <DragHandle x={x} y={(@props.containerRect.height / @props.scale.vertical) / 2} scale={@props.scale} onDrag={@handleLeftDrag} />
-          <DragHandle x={x + width} y={(@props.containerRect.height / @props.scale.vertical) / 2} scale={@props.scale} onDrag={@handleRightDrag} />
+          <DragHandle x={x} y={(@props.containerRect.height / @props.scale.vertical) / 2} scale={@props.scale} onDrag={@handleLeftDrag} getScreenCurrentTransformationMatrix={@props.getScreenCurrentTransformationMatrix} />
+          <DragHandle x={x + width} y={(@props.containerRect.height / @props.scale.vertical) / 2} scale={@props.scale} onDrag={@handleRightDrag} getScreenCurrentTransformationMatrix={@props.getScreenCurrentTransformationMatrix} />
         </g>}
     </DrawingToolRoot>
 

--- a/app/classifier/drawing-tools/column-rectangle.cjsx
+++ b/app/classifier/drawing-tools/column-rectangle.cjsx
@@ -58,16 +58,19 @@ module.exports = React.createClass
     </DrawingToolRoot>
 
   handleMainDrag: (e, d) ->
-    @props.mark.x += d.x / @props.scale.horizontal
+    difference = @props.normalizeDifference(e, d)
+    @props.mark.x += difference.x
     @props.onChange @props.mark
 
   handleLeftDrag: (e, d) ->
-    if @props.mark.width - d.x / @props.scale.horizontal >= MINIMUM_WIDTH
-      @props.mark.x += d.x / @props.scale.horizontal
-      @props.mark.width -= d.x / @props.scale.horizontal
+    difference = @props.normalizeDifference(e, d)
+    if @props.mark.width - difference.x >= MINIMUM_WIDTH
+      @props.mark.x += difference.x
+      @props.mark.width -= difference.x 
       @props.onChange @props.mark
 
   handleRightDrag: (e, d) ->
-    if @props.mark.width + d.x / @props.scale.horizontal >= MINIMUM_WIDTH
-      @props.mark.width += d.x / @props.scale.horizontal
+    difference = @props.normalizeDifference(e, d)
+    if @props.mark.width + difference.x >= MINIMUM_WIDTH
+      @props.mark.width += difference.x
       @props.onChange @props.mark

--- a/app/classifier/drawing-tools/delete-button.cjsx
+++ b/app/classifier/drawing-tools/delete-button.cjsx
@@ -22,10 +22,11 @@ module.exports = React.createClass
     destroyTransitionDuration: 300
 
   render: ->
+    matrix = @props.getScreenCurrentTransformationMatrix()
     transform = "
       translate(#{@props.x}, #{@props.y})
       rotate(#{@props.rotate})
-      scale(#{1 / @props.tool.props.scale.horizontal}, #{1 / @props.tool.props.scale.vertical})
+      matrix( #{1/matrix.a} 0 0 #{1/matrix.d} 0 0)
     "
 
     <g className="clickable drawing-tool-delete-button" transform={transform} stroke={STROKE_COLOR} strokeWidth={STROKE_WIDTH} onClick={@destroyTool}>

--- a/app/classifier/drawing-tools/drag-handle.cjsx
+++ b/app/classifier/drawing-tools/drag-handle.cjsx
@@ -8,6 +8,7 @@ module.exports = React.createClass
   displayName: 'DragHandle'
 
   render: ->
+    matrix = @props.getScreenCurrentTransformationMatrix()
     className = "drag-handle"
     if @props.className?
       className += " #{@props.className}"
@@ -17,8 +18,8 @@ module.exports = React.createClass
       strokeWidth: OVERSHOOT
       transform: """
         translate(#{@props.x}, #{@props.y})
-        scale(#{1 / @props.scale.horizontal}, #{1 / @props.scale.vertical})
+        matrix( #{1/matrix.a} 0 0 #{1/matrix.d} 0 0)
       """
-    <Draggable onStart={@props.onStart} onDrag={@props.onDrag} onEnd={@props.onEnd}>
+    <Draggable onStart={@props.onStart} onDrag={@props.onDrag} onEnd={@props.onEnd} >
       <circle className={className} r={RADIUS} {...styleProps} style={@props.style} />
     </Draggable>

--- a/app/classifier/drawing-tools/drag-handle.cjsx
+++ b/app/classifier/drawing-tools/drag-handle.cjsx
@@ -19,7 +19,6 @@ module.exports = React.createClass
         translate(#{@props.x}, #{@props.y})
         scale(#{1 / @props.scale.horizontal}, #{1 / @props.scale.vertical})
       """
-
     <Draggable onStart={@props.onStart} onDrag={@props.onDrag} onEnd={@props.onEnd}>
       <circle className={className} r={RADIUS} {...styleProps} style={@props.style} />
     </Draggable>

--- a/app/classifier/drawing-tools/ellipse.cjsx
+++ b/app/classifier/drawing-tools/ellipse.cjsx
@@ -76,9 +76,9 @@ module.exports = React.createClass
 
       {if @props.selected
         <g>
-          <DeleteButton tool={this} x={deletePosition.x} y={deletePosition.y} rotate={@props.mark.angle} />
-          <DragHandle onDrag={@handleRadiusHandleDrag.bind this, 'x'} x={@props.mark.rx} y={0} scale={@props.scale} />
-          <DragHandle onDrag={@handleRadiusHandleDrag.bind this, 'y'} x={0} y={-1 * @props.mark.ry} scale={@props.scale} />
+          <DeleteButton tool={this} x={deletePosition.x} y={deletePosition.y} rotate={@props.mark.angle} getScreenCurrentTransformationMatrix={@props.getScreenCurrentTransformationMatrix} />
+          <DragHandle onDrag={@handleRadiusHandleDrag.bind this, 'x'} x={@props.mark.rx} y={0} scale={@props.scale} getScreenCurrentTransformationMatrix={@props.getScreenCurrentTransformationMatrix} />
+          <DragHandle onDrag={@handleRadiusHandleDrag.bind this, 'y'} x={0} y={-1 * @props.mark.ry} scale={@props.scale} getScreenCurrentTransformationMatrix={@props.getScreenCurrentTransformationMatrix} />
         </g>}
     </DrawingToolRoot>
 

--- a/app/classifier/drawing-tools/ellipse.cjsx
+++ b/app/classifier/drawing-tools/ellipse.cjsx
@@ -83,8 +83,9 @@ module.exports = React.createClass
     </DrawingToolRoot>
 
   handleMainDrag: (e, d) ->
-    @props.mark.x += d.x / @props.scale.horizontal
-    @props.mark.y += d.y / @props.scale.vertical
+    difference = @props.normalizeDifference(e, d)
+    @props.mark.x += difference.x
+    @props.mark.y += difference.y
     @props.onChange @props.mark
 
   handleRadiusHandleDrag: (coord, e, d) ->

--- a/app/classifier/drawing-tools/grid.cjsx
+++ b/app/classifier/drawing-tools/grid.cjsx
@@ -120,7 +120,7 @@ module.exports = React.createClass
         </Draggable>}
         {if @props.selected
           <g>
-            <DeleteButton tool={this} x={@props.mark.x} y={@props.mark.y} />
+            <DeleteButton tool={this} x={@props.mark.x} y={@props.mark.y} getScreenCurrentTransformationMatrix={@props.getScreenCurrentTransformationMatrix} />
           </g>}
     </DrawingToolRoot>
 

--- a/app/classifier/drawing-tools/grid.cjsx
+++ b/app/classifier/drawing-tools/grid.cjsx
@@ -133,15 +133,17 @@ module.exports = React.createClass
       </Draggable>
 
   handleTemplateDrag: (e, d) ->
+    difference = @props.normalizeDifference(e, d)
     mobileTemplate = (i for i in @props.classification.annotations[@props.classification.annotations.length - 1].value when i.templateID is @props.mark.templateID)
     for cell in mobileTemplate
-      cell.x += d.x / @props.scale.horizontal
-      cell.y += d.y / @props.scale.vertical
+      cell.x += difference.x
+      cell.y += difference.y
     @setState template: mobileTemplate
 
   handleMainDrag: (e, d) ->
-    @props.mark.x += d.x / @props.scale.horizontal
-    @props.mark.y += d.y / @props.scale.vertical
+    difference = @props.normalizeDifference(e, d)
+    @props.mark.x += difference.x
+    @props.mark.y += difference.y
     @props.onChange @props.mark
 
   cellPoints: (mark) ->

--- a/app/classifier/drawing-tools/line.cjsx
+++ b/app/classifier/drawing-tools/line.cjsx
@@ -63,9 +63,9 @@ module.exports = React.createClass
 
       {if @props.selected
         <g>
-          <DeleteButton tool={this} x={deletePosition.x} y={deletePosition.y} />
-          <DragHandle x={x1} y={y1} scale={@props.scale} onDrag={@handleHandleDrag.bind this, 1} />
-          <DragHandle x={x2} y={y2} scale={@props.scale} onDrag={@handleHandleDrag.bind this, 2} />
+          <DeleteButton tool={this} x={deletePosition.x} y={deletePosition.y} getScreenCurrentTransformationMatrix={@props.getScreenCurrentTransformationMatrix} />
+          <DragHandle x={x1} y={y1} scale={@props.scale} onDrag={@handleHandleDrag.bind this, 1} getScreenCurrentTransformationMatrix={@props.getScreenCurrentTransformationMatrix} />
+          <DragHandle x={x2} y={y2} scale={@props.scale} onDrag={@handleHandleDrag.bind this, 2} getScreenCurrentTransformationMatrix={@props.getScreenCurrentTransformationMatrix} />
         </g>}
     </DrawingToolRoot>
 

--- a/app/classifier/drawing-tools/line.cjsx
+++ b/app/classifier/drawing-tools/line.cjsx
@@ -70,12 +70,14 @@ module.exports = React.createClass
     </DrawingToolRoot>
 
   handleStrokeDrag: (e, d) ->
-    for n in [1..2]
-      @props.mark["x#{n}"] += d.x / @props.scale.horizontal
-      @props.mark["y#{n}"] += d.y / @props.scale.vertical
+    for n in [1..2]      
+      difference = @props.normalizeDifference(e, d)
+      @props.mark["x#{n}"] += difference.x
+      @props.mark["y#{n}"] += difference.y
     @props.onChange @props.mark
 
   handleHandleDrag: (n, e, d) ->
-    @props.mark["x#{n}"] += d.x / @props.scale.horizontal
-    @props.mark["y#{n}"] += d.y / @props.scale.vertical
+    difference = @props.normalizeDifference(e,d)
+    @props.mark["x#{n}"] += difference.x
+    @props.mark["y#{n}"] += difference.y
     @props.onChange @props.mark

--- a/app/classifier/drawing-tools/point.cjsx
+++ b/app/classifier/drawing-tools/point.cjsx
@@ -77,6 +77,8 @@ module.exports = React.createClass
     </DrawingToolRoot>
 
   handleDrag: (e, d) ->
-    @props.mark.x += d.x / @props.scale.horizontal
-    @props.mark.y += d.y / @props.scale.vertical
+    difference = @props.normalizeDifference(e,d)
+    @props.mark.x += difference.x
+    @props.mark.y += difference.y 
     @props.onChange @props.mark
+    

--- a/app/classifier/drawing-tools/point.cjsx
+++ b/app/classifier/drawing-tools/point.cjsx
@@ -73,7 +73,7 @@ module.exports = React.createClass
       </Draggable>
 
       {if @props.selected
-        <DeleteButton tool={this} {...@getDeleteButtonPosition()} />}
+        <DeleteButton tool={this} {...@getDeleteButtonPosition()}  getScreenCurrentTransformationMatrix={@props.getScreenCurrentTransformationMatrix} />}
     </DrawingToolRoot>
 
   handleDrag: (e, d) ->

--- a/app/classifier/drawing-tools/point.cjsx
+++ b/app/classifier/drawing-tools/point.cjsx
@@ -28,13 +28,10 @@ module.exports = React.createClass
     initMove: ({x, y}) ->
       {x, y}
 
-    initValid: (mark, {containerRect, scale}) ->
-      markRect =
-        left: containerRect.left + (mark.x * scale.vertical)
-        top: containerRect.top + (mark.y * scale.horizontal)
-        width: 1
-        height: 1
-      isInBounds markRect, containerRect
+    initValid: (mark, {naturalHeight, naturalWidth}) ->
+      notBeyondWidth = mark.x < naturalWidth
+      notBeyondHeight = mark.y < naturalHeight
+      notBeyondWidth and notBeyondHeight
 
     initRelease: ->
       _inProgress: false

--- a/app/classifier/drawing-tools/poly-curve.cjsx
+++ b/app/classifier/drawing-tools/poly-curve.cjsx
@@ -159,19 +159,18 @@ module.exports = React.createClass
     </DrawingToolRoot>
 
   handleMouseMove: (e) ->
-    xPos = e.pageX
-    yPos = e.pageY
+    newCoord = @props.getEventOffset(e)
 
-    mouseWithinViewer = if xPos < @props.containerRect.left || xPos > @props.containerRect.right
+    mouseWithinViewer = if e.pageX < @props.containerRect.left || e.pageX > @props.containerRect.right
       false
-    else if yPos < @props.containerRect.top || yPos > @props.containerRect.bottom
+    else if e.pageY < @props.containerRect.top || e.pageY > @props.containerRect.bottom
       false
     else
       true
 
     @setState
-      mouseX: (xPos - @props.containerRect.left) / @props.scale.horizontal
-      mouseY: (yPos - @props.containerRect.top) / @props.scale.vertical
+      mouseX: newCoord.x
+      mouseY: newCoord.y
       mouseWithinViewer: mouseWithinViewer
 
   handleFinishClick: ->
@@ -186,12 +185,14 @@ module.exports = React.createClass
     @props.onChange @props.mark
 
   handleMainDrag: (e, d) ->
+    difference = @props.normalizeDifference(e, d)
     for point in @props.mark.points
-      point.x += d.x / @props.scale.horizontal
-      point.y += d.y / @props.scale.vertical
+      point.x += difference.x
+      point.y += difference.y
     @props.onChange @props.mark
 
   handleHandleDrag: (index, e, d) ->
-    @props.mark.points[index].x += d.x / @props.scale.horizontal
-    @props.mark.points[index].y += d.y / @props.scale.vertical
+    difference = @props.normalizeDifference(e, d)
+    @props.mark.points[index].x += difference.x
+    @props.mark.points[index].y += difference.y
     @props.onChange @props.mark

--- a/app/classifier/drawing-tools/poly-curve.cjsx
+++ b/app/classifier/drawing-tools/poly-curve.cjsx
@@ -135,7 +135,7 @@ module.exports = React.createClass
 
       {if @props.selected
         <g>
-          <DeleteButton tool={this} x={deleteButtonPosition.x} y={deleteButtonPosition.y} />
+          <DeleteButton tool={this} x={deleteButtonPosition.x} y={deleteButtonPosition.y} getScreenCurrentTransformationMatrix={@props.getScreenCurrentTransformationMatrix} />
           <path d={svgPathHelpers} strokeWidth={guideWidth} strokeDasharray={GUIDE_DASH} fill={'none'} />
 
           {if not @props.mark.closed and points.length and @state.mouseWithinViewer
@@ -149,7 +149,7 @@ module.exports = React.createClass
               className = "open-drag-handle"
             else
               className = undefined
-            <DragHandle className={className} key={i} x={point.x} y={point.y} scale={@props.scale} onDrag={@handleHandleDrag.bind this, i} />}
+            <DragHandle className={className} key={i} x={point.x} y={point.y} scale={@props.scale} onDrag={@handleHandleDrag.bind this, i} getScreenCurrentTransformationMatrix={@props.getScreenCurrentTransformationMatrix} />}
 
           {unless @props.mark.closed
             <g>

--- a/app/classifier/drawing-tools/polygon.cjsx
+++ b/app/classifier/drawing-tools/polygon.cjsx
@@ -106,19 +106,18 @@ module.exports = React.createClass
     Math.sqrt(Math.pow(deleteBtnX - handleBtnX, 2) + Math.pow(deleteBtnY - handleBtnY, 2))
 
   handleMouseMove: (e) ->
-    xPos = e.pageX
-    yPos = e.pageY
+    newCoord = @props.getEventOffset(e)
 
-    mouseWithinViewer = if xPos < @props.containerRect.left || xPos > @props.containerRect.right
+    mouseWithinViewer = if e.pageX < @props.containerRect.left || e.pageX > @props.containerRect.right
       false
-    else if yPos < @props.containerRect.top || yPos > @props.containerRect.bottom
+    else if e.pageY < @props.containerRect.top || e.pageY > @props.containerRect.bottom
       false
     else
       true
 
     @setState
-      mouseX: (xPos - @props.containerRect.left) / @props.scale.horizontal
-      mouseY: (yPos - @props.containerRect.top) / @props.scale.vertical
+      mouseX: newCoord.x 
+      mouseY: newCoord.y
       mouseWithinViewer: mouseWithinViewer
 
   handleFinishClick: ->
@@ -130,11 +129,13 @@ module.exports = React.createClass
 
   handleMainDrag: (e, d) ->
     for point in @props.mark.points
-      point.x += d.x / @props.scale.horizontal
-      point.y += d.y / @props.scale.vertical
+      difference = @props.normalizeDifference(e, d)
+      point.x += difference.x
+      point.y += difference.y
     @props.onChange @props.mark
 
   handleHandleDrag: (index, e, d) ->
-    @props.mark.points[index].x += d.x / @props.scale.horizontal
-    @props.mark.points[index].y += d.y / @props.scale.vertical
+    difference = @props.normalizeDifference(e, d)
+    @props.mark.points[index].x += difference.x
+    @props.mark.points[index].y += difference.y
     @props.onChange @props.mark

--- a/app/classifier/drawing-tools/polygon.cjsx
+++ b/app/classifier/drawing-tools/polygon.cjsx
@@ -74,7 +74,7 @@ module.exports = React.createClass
 
       {if @props.selected
         <g>
-          <DeleteButton tool={this} x={deleteButtonPosition.x} y={deleteButtonPosition.y} />
+          <DeleteButton tool={this} x={deleteButtonPosition.x} y={deleteButtonPosition.y} getScreenCurrentTransformationMatrix={@props.getScreenCurrentTransformationMatrix} />
 
           {if not @props.mark.closed and @props.mark.points.length and @state.mouseWithinViewer
             <line className="guideline" x1={lastPoint.x} y1={lastPoint.y} x2={@state.mouseX} y2={@state.mouseY} />}
@@ -83,7 +83,7 @@ module.exports = React.createClass
             <line className="guideline" x1={lastPoint.x} y1={lastPoint.y} x2={firstPoint.x} y2={firstPoint.y} />}
 
           {for point, i in @props.mark.points
-            <DragHandle key={i} x={point.x} y={point.y} scale={@props.scale} onDrag={@handleHandleDrag.bind this, i} />}
+            <DragHandle key={i} x={point.x} y={point.y} scale={@props.scale} onDrag={@handleHandleDrag.bind this, i} getScreenCurrentTransformationMatrix={@props.getScreenCurrentTransformationMatrix} />}
 
           {unless @props.mark.closed
             <g>

--- a/app/classifier/drawing-tools/rectangle.cjsx
+++ b/app/classifier/drawing-tools/rectangle.cjsx
@@ -87,32 +87,37 @@ module.exports = React.createClass
     x: x
 
   handleMainDrag: (e, d) ->
-    @props.mark.x += d.x / @props.scale.horizontal
-    @props.mark.y += d.y / @props.scale.vertical
+    difference = @props.normalizeDifference(e, d)
+    @props.mark.x += difference.x
+    @props.mark.y += difference.y
     @props.onChange @props.mark
 
   handleTopLeftDrag: (e, d) ->
-    @props.mark.x += d.x / @props.scale.horizontal
-    @props.mark.y += d.y / @props.scale.vertical
-    @props.mark.width -= d.x / @props.scale.horizontal
-    @props.mark.height -= d.y / @props.scale.vertical
+    difference = @props.normalizeDifference(e, d)
+    @props.mark.x += difference.x
+    @props.mark.y += difference.y
+    @props.mark.width -= difference.x
+    @props.mark.height -= difference.y
     @props.onChange @props.mark
 
   handleTopRightDrag: (e, d) ->
-    @props.mark.y += d.y / @props.scale.vertical
-    @props.mark.width += d.x / @props.scale.horizontal
-    @props.mark.height -= d.y / @props.scale.vertical
+    difference = @props.normalizeDifference(e, d)
+    @props.mark.y += difference.y
+    @props.mark.width += difference.x
+    @props.mark.height -= difference.y
     @props.onChange @props.mark
 
   handleBottomRightDrag: (e, d) ->
-    @props.mark.width += d.x / @props.scale.horizontal
-    @props.mark.height += d.y / @props.scale.vertical
+    difference = @props.normalizeDifference(e, d)
+    @props.mark.width += difference.x
+    @props.mark.height += difference.y
     @props.onChange @props.mark
 
   handleBottomLeftDrag: (e, d) ->
-    @props.mark.x += d.x / @props.scale.horizontal
-    @props.mark.width -= d.x / @props.scale.horizontal
-    @props.mark.height += d.y / @props.scale.vertical
+    difference = @props.normalizeDifference(e, d)
+    @props.mark.x += difference.x 
+    @props.mark.width -= difference.x
+    @props.mark.height += difference.y
     @props.onChange @props.mark
 
   normalizeMark: ->

--- a/app/classifier/drawing-tools/rectangle.cjsx
+++ b/app/classifier/drawing-tools/rectangle.cjsx
@@ -70,12 +70,12 @@ module.exports = React.createClass
 
       {if @props.selected
         <g>
-          <DeleteButton tool={this} x={deletePosition.x} y={y} />
+          <DeleteButton tool={this} x={deletePosition.x} y={y} getScreenCurrentTransformationMatrix={@props.getScreenCurrentTransformationMatrix} />
 
-          <DragHandle x={x} y={y} scale={@props.scale} onDrag={@handleTopLeftDrag} onEnd={@normalizeMark} />
-          <DragHandle x={x + width} y={y} scale={@props.scale} onDrag={@handleTopRightDrag} onEnd={@normalizeMark} />
-          <DragHandle x={x +  width} y={y + height} scale={@props.scale} onDrag={@handleBottomRightDrag} onEnd={@normalizeMark} />
-          <DragHandle x={x} y={y + height} scale={@props.scale} onDrag={@handleBottomLeftDrag} onEnd={@normalizeMark} />
+          <DragHandle x={x} y={y} scale={@props.scale} onDrag={@handleTopLeftDrag} onEnd={@normalizeMark} getScreenCurrentTransformationMatrix={@props.getScreenCurrentTransformationMatrix} />
+          <DragHandle x={x + width} y={y} scale={@props.scale} onDrag={@handleTopRightDrag} onEnd={@normalizeMark} getScreenCurrentTransformationMatrix={@props.getScreenCurrentTransformationMatrix} />
+          <DragHandle x={x +  width} y={y + height} scale={@props.scale} onDrag={@handleBottomRightDrag} onEnd={@normalizeMark} getScreenCurrentTransformationMatrix={@props.getScreenCurrentTransformationMatrix} />
+          <DragHandle x={x} y={y + height} scale={@props.scale} onDrag={@handleBottomLeftDrag} onEnd={@normalizeMark} getScreenCurrentTransformationMatrix={@props.getScreenCurrentTransformationMatrix} />
         </g>}
     </DrawingToolRoot>
 

--- a/app/classifier/drawing-tools/triangle.cjsx
+++ b/app/classifier/drawing-tools/triangle.cjsx
@@ -87,8 +87,9 @@ module.exports = React.createClass
     </DrawingToolRoot>
 
   handleMainDrag: (e, d) ->
-    @props.mark.x += d.x / @props.scale.horizontal
-    @props.mark.y += d.y / @props.scale.vertical
+    difference = @props.normalizeDifference(e, d)
+    @props.mark.x += difference.x
+    @props.mark.y += difference.y
     @props.onChange @props.mark
 
   handleRadiusHandleDrag: (e, d) ->

--- a/app/classifier/drawing-tools/triangle.cjsx
+++ b/app/classifier/drawing-tools/triangle.cjsx
@@ -81,8 +81,8 @@ module.exports = React.createClass
 
       {if @props.selected
         <g>
-          <DeleteButton tool={this} x={deletePosition.x} y={deletePosition.y} rotate={@props.mark.angle} />
-          <DragHandle onDrag={@handleRadiusHandleDrag} y={0-@props.mark.r} x={0} scale={@props.scale} />
+          <DeleteButton tool={this} x={deletePosition.x} y={deletePosition.y} rotate={@props.mark.angle} getScreenCurrentTransformationMatrix={@props.getScreenCurrentTransformationMatrix} />
+          <DragHandle onDrag={@handleRadiusHandleDrag} y={0-@props.mark.r} x={0} scale={@props.scale} getScreenCurrentTransformationMatrix={@props.getScreenCurrentTransformationMatrix} />
         </g>}
     </DrawingToolRoot>
 

--- a/app/classifier/frame-annotator.cjsx
+++ b/app/classifier/frame-annotator.cjsx
@@ -65,7 +65,7 @@ module.exports = React.createClass
     pointForSVGSystem = newPoint.matrixTransform(matrixForWindowCoordsToSVGUserSpaceCoords)
     pointForSVGSystem
 
-  # find the original matrix for the SVG coordinate space
+  # find the original matrix for the SVG coordinate system
   getMatrixForWindowCoordsToSVGUserSpaceCoords: ->
     transformationContainer = @refs.transformationContainer
     transformationContainer.getScreenCTM().inverse()
@@ -83,8 +83,6 @@ module.exports = React.createClass
   # get the offset of event coordiantes in terms of the SVG coordinate system
   getEventOffset: (e) ->
     eventOffset = @eventCoordsToSVGCoords(e.clientX, e.clientY)
-    console.log "eventOffset", eventOffset
-    eventOffset
 
   render: ->
     taskDescription = @props.workflow.tasks[@props.annotation?.task]
@@ -125,6 +123,8 @@ module.exports = React.createClass
       getEventOffset: this.getEventOffset
       onChange: @props.onChange
       preferences: @props.preferences
+      eventCoordsToSVGCoords: @eventCoordsToSVGCoords
+      normalizeDifference: @normalizeDifference
 
     for task, Component of tasks when Component.getSVGProps?
       for key, value of Component.getSVGProps hookProps

--- a/app/classifier/frame-annotator.cjsx
+++ b/app/classifier/frame-annotator.cjsx
@@ -54,6 +54,11 @@ module.exports = React.createClass
     vertical = sizeRect?.height / @props.naturalHeight || 0
     {horizontal, vertical}
 
+  # get current transformation matrix
+  getScreenCurrentTransformationMatrix: ()->
+    svg = @refs.svgSubjectArea
+    matrix = svg.getScreenCTM()
+
   # transforms the event coordinates 
   # to points in the SVG coordinate system
   eventCoordsToSVGCoords: (x, y) ->
@@ -123,8 +128,8 @@ module.exports = React.createClass
       getEventOffset: this.getEventOffset
       onChange: @props.onChange
       preferences: @props.preferences
-      eventCoordsToSVGCoords: @eventCoordsToSVGCoords
       normalizeDifference: @normalizeDifference
+      getScreenCurrentTransformationMatrix: @getScreenCurrentTransformationMatrix
 
     for task, Component of tasks when Component.getSVGProps?
       for key, value of Component.getSVGProps hookProps

--- a/app/classifier/frame-annotator.cjsx
+++ b/app/classifier/frame-annotator.cjsx
@@ -135,7 +135,7 @@ module.exports = React.createClass
         {if BeforeSubject?
           <BeforeSubject {...hookProps} />}
         <svg ref="svgSubjectArea" className="subject" style=svgStyle viewBox={createdViewBox} {...svgProps}>
-          <g ref="transformationContainer" >
+          <g ref="transformationContainer" transform={@props.transform} >
             <rect ref="sizeRect" width={@props.naturalWidth} height={@props.naturalHeight} fill="rgba(0, 0, 0, 0.01)" fillOpacity="0.01" stroke="none" />
             {if type is 'image'
               <Draggable onDrag={@props.panByDrag} disabled={@props.disabled}>

--- a/app/classifier/tasks/drawing/markings-renderer.cjsx
+++ b/app/classifier/tasks/drawing/markings-renderer.cjsx
@@ -74,6 +74,7 @@ module.exports = React.createClass
                 onSelect: @handleSelect.bind this, annotation, mark
                 onDeselect: @handleDeselect
                 onDestroy: @handleDestroy.bind this, annotation, mark
+                normalizeDifference: @props.normalizeDifference
 
               ToolComponent = drawingTools[toolDescription.type]
               <ToolComponent key={mark._key} {...toolProps} {...toolEnv} {...toolMethods} />}

--- a/app/classifier/tasks/drawing/markings-renderer.cjsx
+++ b/app/classifier/tasks/drawing/markings-renderer.cjsx
@@ -75,6 +75,7 @@ module.exports = React.createClass
                 onDeselect: @handleDeselect
                 onDestroy: @handleDestroy.bind this, annotation, mark
                 normalizeDifference: @props.normalizeDifference
+                getScreenCurrentTransformationMatrix: @props.getScreenCurrentTransformationMatrix
 
               ToolComponent = drawingTools[toolDescription.type]
               <ToolComponent key={mark._key} {...toolProps} {...toolEnv} {...toolMethods} />}

--- a/app/components/pan-zoom.jsx
+++ b/app/components/pan-zoom.jsx
@@ -319,7 +319,6 @@ const PanZoom = React.createClass({
 
   rotateClockwise() {
     let newRotation = this.state.rotation + 90
-    console.log("newRotation", newRotation)
     this.setState({
       rotation: newRotation,
       transform: `rotate(${newRotation} ${this.props.frameDimensions.width/2} ${this.props.frameDimensions.height/2})`

--- a/app/components/pan-zoom.jsx
+++ b/app/components/pan-zoom.jsx
@@ -116,10 +116,10 @@ const PanZoom = React.createClass({
               />
             </div>
             <div>
-              <button title="rotate" className={'fa fa-repeat'} onClick={this.rotateClockwise} />
+              <button title="rotate" className={'rotate fa fa-repeat'} onClick={this.rotateClockwise} />
             </div>
             <div>
-              <button title="reset zoom levels" className={'reset fa fa-refresh' + (this.cannotZoomOut() ? ' disabled' : '')} onClick={this.zoomReset} />
+              <button title="reset zoom levels" className={'reset fa fa-refresh' + (this.cannotResetZoomRotate() ? ' disabled' : '')} onClick={this.zoomReset} />
             </div>
           </div>
           : ''
@@ -135,6 +135,10 @@ const PanZoom = React.createClass({
 
   cannotZoomOut() {
     return this.props.frameDimensions.width === this.state.viewBoxDimensions.width && this.props.frameDimensions.height === this.state.viewBoxDimensions.height;
+  },
+
+  cannotResetZoomRotate() {
+    return this.cannotZoomOut() && this.state.rotation === 0
   },
 
   continuousZoom(change) {

--- a/app/components/pan-zoom.jsx
+++ b/app/components/pan-zoom.jsx
@@ -115,10 +115,10 @@ const PanZoom = React.createClass({
               />
             </div>
             <div>
-              <button title="reset zoom levels" className={"reset fa fa-refresh" + (this.cannotZoomOut() ? " disabled" : "")} onClick={ this.zoomReset } ></button>
+              <button title="rotate" className={"fa fa-repeat"} onClick={ this.rotateClockwise } />
             </div>
             <div>
-              <button title="rotate" className={"fa fa-repeat"} onClick={ this.rotateClockwise } />
+              <button title="reset zoom levels" className={"reset fa fa-refresh" + (this.cannotZoomOut() ? " disabled" : "")} onClick={ this.zoomReset } ></button>
             </div>
           </div>
           : ""

--- a/app/components/pan-zoom.jsx
+++ b/app/components/pan-zoom.jsx
@@ -16,7 +16,7 @@ const PanZoom = React.createClass({
       enabled: false,
       frameDimensions: {
         height: 0,
-        width: 0
+        width: 0,
       }
     };
   },
@@ -31,7 +31,9 @@ const PanZoom = React.createClass({
         height: 0
       },
       zooming: false,
-      zoomingTimeoutId: null
+      zoomingTimeoutId: null,
+      rotation: 0,
+      transform: ''
     };
   },
 
@@ -66,7 +68,9 @@ const PanZoom = React.createClass({
       return React.cloneElement(child, {
         viewBoxDimensions: this.state.viewBoxDimensions,
         panByDrag: this.panByDrag,
-        panEnabled: this.state.panEnabled
+        panEnabled: this.state.panEnabled,
+        transform: this.state.transform,
+        rotation: this.state.rotation
       });
     });
     return (
@@ -112,6 +116,9 @@ const PanZoom = React.createClass({
             </div>
             <div>
               <button title="reset zoom levels" className={"reset fa fa-refresh" + (this.cannotZoomOut() ? " disabled" : "")} onClick={ this.zoomReset } ></button>
+            </div>
+            <div>
+              <button title="rotate" className={"fa fa-repeat"} onClick={ this.rotateClockwise } />
             </div>
           </div>
           : ""
@@ -306,8 +313,16 @@ const PanZoom = React.createClass({
         height: this.state.viewBoxDimensions.height
       }
     });
-  }
+  },
 
+  rotateClockwise() {
+    let newRotation = this.state.rotation + 90
+    console.log("newRotation", newRotation)
+    this.setState({
+      rotation: newRotation,
+      transform: `rotate(${newRotation} ${this.props.frameDimensions.width/2} ${this.props.frameDimensions.height/2})`
+    });
+  }
 });
 
 export default PanZoom;

--- a/app/components/pan-zoom.jsx
+++ b/app/components/pan-zoom.jsx
@@ -1,3 +1,4 @@
+/* eslint no-unused-expressions: ["error", { "allowTernary": true }] */
 import React from 'react';
 
 const PanZoom = React.createClass({
@@ -16,7 +17,7 @@ const PanZoom = React.createClass({
       enabled: false,
       frameDimensions: {
         height: 0,
-        width: 0,
+        width: 0
       }
     };
   },
@@ -43,7 +44,7 @@ const PanZoom = React.createClass({
     if (this.props.enabled) {
       addEventListener('keydown', this.frameKeyPan);
       addEventListener('wheel', this.frameKeyPan);
-    };
+    }
   },
 
   componentWillUpdate(newProps) {
@@ -91,9 +92,9 @@ const PanZoom = React.createClass({
                 title="zoom out"
                 ref="zoomOut"
                 className={`zoom-out fa fa-minus ${this.cannotZoomOut() ? 'disabled' : ''}`}
-                onMouseDown={ this.continuousZoom.bind(this, 1.1 ) }
+                onMouseDown={this.continuousZoom.bind(this, 1.1)}
                 onMouseUp={this.stopZoom}
-                onKeyDown={this.keyDownZoomButton.bind(this,1.1)}
+                onKeyDown={this.keyDownZoomButton.bind(this, 1.1)}
                 onKeyUp={this.stopZoom}
                 onFocus={this.togglePanOn}
                 onBlur={this.togglePanOff}
@@ -105,23 +106,23 @@ const PanZoom = React.createClass({
                 title="zoom in"
                 ref="zoomIn"
                 className="zoom-in fa fa-plus"
-                onMouseDown={this.continuousZoom.bind(this, .9)}
+                onMouseDown={this.continuousZoom.bind(this, 0.9)}
                 onMouseUp={this.stopZoom}
-                onKeyDown={this.keyDownZoomButton.bind(this,.9)}
+                onKeyDown={this.keyDownZoomButton.bind(this, 0.9)}
                 onKeyUp={this.stopZoom}
                 onFocus={this.togglePanOn}
                 onBlur={this.togglePanOff}
-                onClick={this.handleFocus.bind(this, "zoomIn")}
+                onClick={this.handleFocus.bind(this, 'zoomIn')}
               />
             </div>
             <div>
-              <button title="rotate" className={"fa fa-repeat"} onClick={ this.rotateClockwise } />
+              <button title="rotate" className={'fa fa-repeat'} onClick={this.rotateClockwise} />
             </div>
             <div>
-              <button title="reset zoom levels" className={"reset fa fa-refresh" + (this.cannotZoomOut() ? " disabled" : "")} onClick={ this.zoomReset } ></button>
+              <button title="reset zoom levels" className={'reset fa fa-refresh' + (this.cannotZoomOut() ? ' disabled' : '')} onClick={this.zoomReset} />
             </div>
           </div>
-          : ""
+          : ''
         }
       </div>
     );
@@ -139,14 +140,14 @@ const PanZoom = React.createClass({
   continuousZoom(change) {
     this.clearZoomingTimeout();
     if (change === 0) return;
-    this.setState( {zooming: true}, () => {
+    this.setState({ zooming: true }, () => {
       let zoomNow = () => {
         // if !this.state.zooming, we don't want to continuously call setTimeout.
         // !this.state.zooming will be the case after a user creates a mouseup event.
         if (!this.state.zooming) return;
         this.zoom(change);
         this.clearZoomingTimeout();
-        this.setState( {zoomingTimeoutId: setTimeout(zoomNow, 200)} );
+        this.setState({ zoomingTimeoutId: setTimeout(zoomNow, 200) });
       };
       zoomNow();
     });
@@ -161,11 +162,11 @@ const PanZoom = React.createClass({
   zoom(change) {
     this.clearZoomingTimeout();
     if (!this.state.zooming) return;
-    let newNaturalWidth = this.state.viewBoxDimensions.width * change;
-    let newNaturalHeight = this.state.viewBoxDimensions.height * change;
+    const newNaturalWidth = this.state.viewBoxDimensions.width * change;
+    const newNaturalHeight = this.state.viewBoxDimensions.height * change;
 
-    let newNaturalX = this.state.viewBoxDimensions.x - (newNaturalWidth - this.state.viewBoxDimensions.width) / 2;
-    let newNaturalY = this.state.viewBoxDimensions.y - (newNaturalHeight - this.state.viewBoxDimensions.height) / 2;
+    const newNaturalX = this.state.viewBoxDimensions.x - ((newNaturalWidth - this.state.viewBoxDimensions.width) / 2);
+    const newNaturalY = this.state.viewBoxDimensions.y - ((newNaturalHeight - this.state.viewBoxDimensions.height) / 2);
 
     if ((newNaturalWidth > this.props.frameDimensions.width) || (newNaturalHeight * change > this.props.frameDimensions.height)) {
       this.zoomReset();
@@ -184,7 +185,7 @@ const PanZoom = React.createClass({
   keyDownZoomButton(change, e) {
     // only zoom if a user presses enter on the zoom button.
     if (e.which === 13) {
-      this.setState({zooming: true}, () => {
+      this.setState({ zooming: true }, () => {
         this.zoom(change);
       });
     }
@@ -192,7 +193,7 @@ const PanZoom = React.createClass({
 
   stopZoom(e) {
     e.stopPropagation();
-    this.setState({zooming: false});
+    this.setState({ zooming: false });
     this.continuousZoom(0);
   },
 
@@ -205,32 +206,32 @@ const PanZoom = React.createClass({
         y: 0
       },
       rotation: 0,
-      transform: `rotate(${0} ${this.props.frameDimensions.width/2} ${this.props.frameDimensions.height/2})`
+      transform: `rotate(${0} ${this.props.frameDimensions.width / 2} ${this.props.frameDimensions.height / 2})`
     });
   },
 
   togglePanOn() {
-    if (!this.state.panEnabled) this.setState({panEnabled: true});
+    if (!this.state.panEnabled) this.setState({ panEnabled: true });
   },
 
   togglePanOff() {
-    this.setState({panEnabled: false});
+    this.setState({ panEnabled: false });
   },
 
   toggleKeyPanZoom() {
-    this.setState({keyPanZoomEnabled: !this.state.keyPanZoomEnabled});
+    this.setState({ keyPanZoomEnabled: !this.state.keyPanZoomEnabled });
   },
 
   panByDrag(e, d) {
     if (!this.state.panEnabled) return;
 
-    let maximumX = (this.props.frameDimensions.width - this.state.viewBoxDimensions.width) + (this.props.frameDimensions.width * 0.6);
-    let minumumX = -(this.props.frameDimensions.width * 0.6);
-    let changedX = this.state.viewBoxDimensions.x -= d.x;
+    const maximumX = (this.props.frameDimensions.width - this.state.viewBoxDimensions.width) + (this.props.frameDimensions.width * 0.6);
+    const minumumX = -(this.props.frameDimensions.width * 0.6);
+    const changedX = this.state.viewBoxDimensions.x -= d.x;
 
-    let maximumY = (this.props.frameDimensions.height - this.state.viewBoxDimensions.height) + (this.props.frameDimensions.height * 0.6);
-    let minimumY = -(this.props.frameDimensions.height * 0.6);
-    let changedY = this.state.viewBoxDimensions.y -= d.y;
+    const maximumY = (this.props.frameDimensions.height - this.state.viewBoxDimensions.height) + (this.props.frameDimensions.height * 0.6);
+    const minimumY = -(this.props.frameDimensions.height * 0.6);
+    const changedY = this.state.viewBoxDimensions.y -= d.y;
 
     this.setState({
       viewBoxDimensions: {
@@ -244,7 +245,7 @@ const PanZoom = React.createClass({
 
   frameKeyPan(e) {
     if (!this.state.panEnabled) return;
-    let keypress = e.which;
+    const keypress = e.which;
     switch (keypress) {
       // left
       case 37:
@@ -270,29 +271,30 @@ const PanZoom = React.createClass({
       case 187:
       case 61:
         e.preventDefault();
-        this.setState({zooming: true});
-        this.zoom(.9);
+        this.setState({ zooming: true });
+        this.zoom(0.9);
         break;
       // zoom in - Chrome(189), Firefox(173)
       case 189:
       case 173:
         e.preventDefault();
-        this.setState({zooming: true});
+        this.setState({ zooming: true });
         this.zoom(1.1);
         break;
       // zooming by wheel
       case 1:
         e.preventDefault();
-        this.setState({zooming: true});
+        this.setState({ zooming: true });
         (e.deltaY > 0) ? this.zoom(1.1) : this.zoom(0.9);
         break;
+      // no default
     }
   },
 
   panHorizontal(direction) {
-    let maximumX = (this.props.frameDimensions.width - this.state.viewBoxDimensions.width) + (this.props.frameDimensions.width * 0.6);
-    let minumumX = -(this.props.frameDimensions.width * 0.6);
-    let changedX = this.state.viewBoxDimensions.x + direction;
+    const maximumX = (this.props.frameDimensions.width - this.state.viewBoxDimensions.width) + (this.props.frameDimensions.width * 0.6);
+    const minumumX = -(this.props.frameDimensions.width * 0.6);
+    const changedX = this.state.viewBoxDimensions.x + direction;
     this.setState({
       viewBoxDimensions: {
         x: Math.max(minumumX, Math.min(changedX, maximumX)),
@@ -304,9 +306,9 @@ const PanZoom = React.createClass({
   },
 
   panVertical(direction) {
-    let maximumY = (this.props.frameDimensions.height - this.state.viewBoxDimensions.height) + (this.props.frameDimensions.height * 0.6);
-    let minimumY = -(this.props.frameDimensions.height * 0.6);
-    let changedY = this.state.viewBoxDimensions.y + direction;
+    const maximumY = (this.props.frameDimensions.height - this.state.viewBoxDimensions.height) + (this.props.frameDimensions.height * 0.6);
+    const minimumY = -(this.props.frameDimensions.height * 0.6);
+    const changedY = this.state.viewBoxDimensions.y + direction;
     this.setState({
       viewBoxDimensions: {
         x: this.state.viewBoxDimensions.x,
@@ -318,10 +320,10 @@ const PanZoom = React.createClass({
   },
 
   rotateClockwise() {
-    let newRotation = this.state.rotation + 90
+    const newRotation = this.state.rotation + 90;
     this.setState({
       rotation: newRotation,
-      transform: `rotate(${newRotation} ${this.props.frameDimensions.width/2} ${this.props.frameDimensions.height/2})`
+      transform: `rotate(${newRotation} ${this.props.frameDimensions.width / 2} ${this.props.frameDimensions.height / 2})`
     });
   }
 });

--- a/app/components/pan-zoom.jsx
+++ b/app/components/pan-zoom.jsx
@@ -203,7 +203,9 @@ const PanZoom = React.createClass({
         height: this.props.frameDimensions.height,
         x: 0,
         y: 0
-      }
+      },
+      rotation: 0,
+      transform: `rotate(${0} ${this.props.frameDimensions.width/2} ${this.props.frameDimensions.height/2})`
     });
   },
 

--- a/app/components/pan-zoom.spec.js
+++ b/app/components/pan-zoom.spec.js
@@ -16,9 +16,10 @@ describe('PanZoom', function () {
       wrapper = shallow(<PanZoom enabled={true} />);
     });
 
-    it('should render a zoom-in, a zoom-out, and reset button', function () {
+    it('should render a zoom-in, a zoom-out, rotate, and reset button', function () {
       assert.equal(wrapper.find('button.zoom-out').length, 1);
       assert.equal(wrapper.find('button.zoom-in').length, 1);
+      assert.equal(wrapper.find('button.rotate').length, 1);
       assert.equal(wrapper.find('button.reset').length, 1);
     });
 
@@ -71,6 +72,33 @@ describe('PanZoom', function () {
         wrapper.setState({ viewBoxDimensions: { width: 100, height: 100, x: 0, y: 0 } });
 
         assert.equal(wrapper.instance().cannotZoomOut(), true);
+      });
+    });
+
+    describe('#cannotResetZoomRotate', function() {
+      let wrapper;
+      const originalFrameDimensions = { width: 100, height: 100, x: 0, y: 0 };
+
+      beforeEach(function () {
+        wrapper = mount(<PanZoom enabled={true} frameDimensions={originalFrameDimensions} />);
+      });
+
+      it('returns false if state.rotation is not 0', function () {
+        wrapper.setState({ viewBoxDimensions: { width: 100, height: 100, x: 0, y: 0 }, rotation: 90 });
+
+        assert.equal(wrapper.instance().cannotResetZoomRotate(), false);
+      });
+
+      it('returns false if there frameDimensions are not identical to viewBoxDimensions', function () {
+        wrapper.setState({ viewBoxDimensions: { width: 50, height: 50, x: 0, y: 0 }, rotation: 0 });
+
+        assert.equal(wrapper.instance().cannotResetZoomRotate(), false);
+      });
+
+      it('returns true if there is not room to zoom out and degrees rotated is 0', function () {
+        wrapper.setState({ viewBoxDimensions: { width: 100, height: 100, x: 0, y: 0 }, rotation: 0 });
+        
+        assert.equal(wrapper.instance().cannotResetZoomRotate(), true);
       });
     });
 
@@ -383,6 +411,29 @@ describe('PanZoom', function () {
         wrapper.instance().panVertical(200);
 
         assert.equal(wrapper.state('viewBoxDimensions').y, ceiling);
+      });
+    });
+
+    describe('#rotateClockwise()', function () {
+      let originalFrameDimensions;
+      let wrapper;
+
+      beforeEach(function () {
+        originalFrameDimensions = { width: 100, height: 100, x: 0, y: 0 };
+        wrapper = mount(<PanZoom enabled={true} frameDimensions={originalFrameDimensions} />);
+      });
+
+      it('should add 90 to this.state.rotation', function () {
+        wrapper.instance().rotateClockwise();
+
+        assert.equal(wrapper.state('rotation'), 90);
+      });
+
+      it('should create a new transformation statement with the updated rotation', function () {
+        wrapper.instance().rotateClockwise();
+        let updatedTransformation = `rotate(90 ${wrapper.props().frameDimensions.width / 2} ${wrapper.props().frameDimensions.height / 2})`
+
+        assert.equal(wrapper.state('transform'), updatedTransformation);
       });
     });
   });


### PR DESCRIPTION
Addresses #2867 by adding a rotate feature to PanZoom and scaling drawn marks, handles, and delete buttons using a SVG transformation matrix. Staged [here](https://rotate-and-draw.pfe-preview.zooniverse.org/dev/classifier).

Describe your changes.
**frame-annotator.cjsx**: added methods for scaling marks using an SVG transformation matrix.

**[drawing_tool_name].cjsx**: uses a new method from frame-annotator, #normalizeDifference(), to scale the difference when the component is dragged. 

**pan-zoom.cjsx**: added a rotate feature. The reset button should also reset the rotation.

**delete-button.cjsx, drag-handle.cjsx**: scales SVG elements using a transformation matrix.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?