### PR TITLE
Adding in markdown toolbar to Announcements textbox

### DIFF
--- a/app/pages/lab/project-details.cjsx
+++ b/app/pages/lab/project-details.cjsx
@@ -123,14 +123,14 @@ module.exports = React.createClass
             <small className="form-help">Add text here when you have multiple workflows and want to help your volunteers decide which one they should do. <CharLimit limit={500} string={@props.project.workflow_description ? ''} /></small>
           </p>
 
-          <p>
+          <div>
             <AutoSave resource={@props.project}>
               <span className="form-label">Announcement Banner</span>
               <br />
               <MarkdownEditor className="full" name="configuration.announcement" rows="2" value={@props.project.configuration?.announcement} project={@props.project} onChange={handleInputChange.bind @props.project} onHelp={-> alert <MarkdownHelp/>}/>
             </AutoSave>
             <small className="form-help">This text will appear as a banner at the top of all your project's pages. Only use this when you've got a big important announcement to make!</small>
-          </p>
+          </div>
 
           <div>
             <AutoSave resource={@props.project}>

--- a/app/pages/lab/project-details.cjsx
+++ b/app/pages/lab/project-details.cjsx
@@ -127,7 +127,7 @@ module.exports = React.createClass
             <AutoSave resource={@props.project}>
               <span className="form-label">Announcement Banner</span>
               <br />
-              <textarea className="standard-input full" name="configuration.announcement" value={@props.project.configuration?.announcement} onChange={handleInputChange.bind @props.project} />
+              <MarkdownEditor className="full" name="configuration.announcement" rows="2" value={@props.project.configuration?.announcement} project={@props.project} onChange={handleInputChange.bind @props.project} onHelp={-> alert <MarkdownHelp/>}/>
             </AutoSave>
             <small className="form-help">This text will appear as a banner at the top of all your project's pages. Only use this when you've got a big important announcement to make!</small>
           </p>


### PR DESCRIPTION
fixes #2318
took a stab at adding the markdown editing toolbar to the Announcements textbox