### PR TITLE
Remove History mixin

### DIFF
--- a/app/subjects/comment-form.cjsx
+++ b/app/subjects/comment-form.cjsx
@@ -1,5 +1,5 @@
 React = require 'react'
-{History, Link} = require 'react-router'
+{Link} = require 'react-router'
 talkClient = require 'panoptes-client/lib/talk-client'
 NewDiscussionForm = require '../talk/discussion-new-form'
 QuickSubjectCommentForm= require '../talk/quick-subject-comment-form'
@@ -9,7 +9,9 @@ alert = require '../lib/alert'
 
 module.exports = React.createClass
   displayName: 'SubjectCommentForm'
-  mixins: [History]
+
+  contextTypes:
+    router: React.PropTypes.object.isRequired
 
   componentWillMount: ->
     Promise.all([@getBoards(), @getSubjectDefaultBoard()]).then =>
@@ -31,7 +33,7 @@ module.exports = React.createClass
     {owner, name} = @props.params
     board = createdDiscussion.board_id
     discussion = createdDiscussion.id
-    @history.pushState(null, "/projects/#{owner}/#{name}/talk/#{board}/#{discussion}")
+    @context.router.push null, "/projects/#{owner}/#{name}/talk/#{board}/#{discussion}"
 
   linkToClassifier: (text) ->
     [owner, name] = @props.project.slug.split('/')


### PR DESCRIPTION
Removes the only instance of the History mixin left, ref #3218

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://remove-history-mixin.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
