### PR TITLE
Remove promise renderer from project-details.cjsx

### DIFF
--- a/app/pages/lab/project-details.cjsx
+++ b/app/pages/lab/project-details.cjsx
@@ -42,13 +42,23 @@ module.exports = React.createClass
         @setState({ researchers })
 
     avatar = @getAvatar()
-      .then ([avatar]) =>
+      .then (avatar) =>
+        # FireFox returns an object, other browsers return an array
+        if avatar.src?
+          avatar
+        else 
+          avatar = avatar[0]
         @setState {avatar}
       .catch (error) =>
         console.log error
 
     backround = @getBackground()
-      .then ([background]) =>
+      .then (background) =>
+        # FireFox returns an object, other browsers return an array
+        if background.src?
+          background
+        else 
+          background = background[0]
         @setState {background}
       .catch (error) =>
         console.log error
@@ -73,20 +83,29 @@ module.exports = React.createClass
   getAvatar: ->
     avatar = @props.project.get('avatar')
       .then (avatar) => if avatar? then avatar else null
-      .catch ->
+      .catch =>
         console.log error
 
   getBackground: ->
     background = @props.project.get('background')
       .then (background) => if background? then background else null
-      .catch (error) ->
+      .catch (error) =>
         console.log error
+
+  splitTags: (kind) ->
+    disciplineTagList = []
+    otherTagList = []
+    for t in @props.project.tags
+      if DISCIPLINES.some((el) -> el.value == t)
+        disciplineTagList.push(t)
+      else
+        otherTagList.push(t)
+    {disciplineTagList, otherTagList}
 
   render: ->
     # Failures on media GETs are acceptable here,
     # but the JSON-API lib doesn't cache failed requests,
     # so do it manually:
-
     avatarPlaceholder = <div className="form-help content-container">Drop an avatar image here</div>
     backgroundPlaceholder = <div className="form-help content-container">Drop a background image here</div>
 

--- a/app/pages/lab/project-details.cjsx
+++ b/app/pages/lab/project-details.cjsx
@@ -41,9 +41,17 @@ module.exports = React.createClass
       apiClient.type('users').get(scientists).then (researchers) =>
         @setState({ researchers })
 
-    @getAvatar()
+    avatar = @getAvatar()
       .then ([avatar]) =>
         @setState {avatar}
+      .catch (error) =>
+        console.log error
+
+    backround = @getBackground()
+      .then ([background]) =>
+        @setState {background}
+      .catch (error) =>
+        console.log error
 
   splitTags: (kind) ->
     disciplineTagList = []
@@ -65,29 +73,29 @@ module.exports = React.createClass
   getAvatar: ->
     avatar = @props.project.get('avatar')
       .then (avatar) => if avatar? then avatar else null
+      .catch ->
+        console.log error
+
+  getBackground: ->
+    background = @props.project.get('background')
+      .then (background) => if background? then background else null
+      .catch (error) ->
+        console.log error
 
   render: ->
-    console.log "render @state.avatar", @state.avatar
     # Failures on media GETs are acceptable here,
     # but the JSON-API lib doesn't cache failed requests,
     # so do it manually:
 
-    @avatarGet ?= @props.project.get 'avatar'
-      .catch ->
-        null
-
-    @backgroundGet ?= @props.project.get 'background'
-      .catch ->
-        null
-
-    placeholder = <div className="form-help content-container">Drop an avatar image here</div>
+    avatarPlaceholder = <div className="form-help content-container">Drop an avatar image here</div>
+    backgroundPlaceholder = <div className="form-help content-container">Drop a background image here</div>
 
     <div>
       <p className="form-help">Input the basic information about your project, and set up its home page.</p>
       <div className="columns-container">
         <div>
           Avatar<br />
-          <ImageSelector maxSize={MAX_AVATAR_SIZE} ratio={1} src={@state.avatar?.src} placeholder={placeholder} onChange={@handleMediaChange.bind this, 'avatar'} />
+          <ImageSelector maxSize={MAX_AVATAR_SIZE} ratio={1} src={@state.avatar?.src} placeholder={avatarPlaceholder} onChange={@handleMediaChange.bind this, 'avatar'} />
           {if @state.avatarError
             <div className="form-help error">{@state.avatarError.toString()}</div>}
 
@@ -96,10 +104,7 @@ module.exports = React.createClass
           <hr />
 
           Background image<br />
-          <PromiseRenderer promise={@backgroundGet} then={(background) =>
-            placeholder = <div className="form-help content-container">Drop a background image here</div>
-            <ImageSelector maxSize={MAX_BACKGROUND_SIZE} src={background?.src} placeholder={placeholder} onChange={@handleMediaChange.bind this, 'background'} />
-          } />
+          <ImageSelector maxSize={MAX_BACKGROUND_SIZE} src={@state.background?.src} placeholder={backgroundPlaceholder} onChange={@handleMediaChange.bind this, 'background'} />
           {if @state.backgroundError
             <div className="form-help error">{@state.backgroundError.toString()}</div>}
 

--- a/app/pages/lab/project-details.cjsx
+++ b/app/pages/lab/project-details.cjsx
@@ -41,6 +41,10 @@ module.exports = React.createClass
       apiClient.type('users').get(scientists).then (researchers) =>
         @setState({ researchers })
 
+    @getAvatar()
+      .then ([avatar]) =>
+        @setState {avatar}
+
   splitTags: (kind) ->
     disciplineTagList = []
     otherTagList = []
@@ -58,7 +62,12 @@ module.exports = React.createClass
       options.push Object.assign value: researcher.id, label: researcher.display_name
     options
 
+  getAvatar: ->
+    avatar = @props.project.get('avatar')
+      .then (avatar) => if avatar? then avatar else null
+
   render: ->
+    console.log "render @state.avatar", @state.avatar
     # Failures on media GETs are acceptable here,
     # but the JSON-API lib doesn't cache failed requests,
     # so do it manually:
@@ -71,15 +80,14 @@ module.exports = React.createClass
       .catch ->
         null
 
+    placeholder = <div className="form-help content-container">Drop an avatar image here</div>
+
     <div>
       <p className="form-help">Input the basic information about your project, and set up its home page.</p>
       <div className="columns-container">
         <div>
           Avatar<br />
-          <PromiseRenderer promise={@avatarGet} then={(avatar) =>
-            placeholder = <div className="form-help content-container">Drop an avatar image here</div>
-            <ImageSelector maxSize={MAX_AVATAR_SIZE} ratio={1} src={avatar?.src} placeholder={placeholder} onChange={@handleMediaChange.bind this, 'avatar'} />
-          } />
+          <ImageSelector maxSize={MAX_AVATAR_SIZE} ratio={1} src={@state.avatar?.src} placeholder={placeholder} onChange={@handleMediaChange.bind this, 'avatar'} />
           {if @state.avatarError
             <div className="form-help error">{@state.avatarError.toString()}</div>}
 

--- a/app/pages/lab/project-details.cjsx
+++ b/app/pages/lab/project-details.cjsx
@@ -1,7 +1,6 @@
 React = require 'react'
 AutoSave = require '../../components/auto-save'
 handleInputChange = require '../../lib/handle-input-change'
-PromiseRenderer = require '../../components/promise-renderer'
 ImageSelector = require '../../components/image-selector'
 apiClient = require 'panoptes-client/lib/api-client'
 putFile = require '../../lib/put-file'
@@ -28,8 +27,6 @@ module.exports = React.createClass
 
   getInitialState: ->
     {disciplineTagList, otherTagList} = @splitTags()
-    avatarError: null
-    backgroundError: null
     disciplineTagList: disciplineTagList
     otherTagList: otherTagList
     researchers: []
@@ -46,14 +43,8 @@ module.exports = React.createClass
 
     avatar = @props.project.get('avatar')
     background = @props.project.get('background')
-
     Promise.all([avatar, background])
       .then ([avatar, background]) => 
-        if avatar.src?
-            avatar
-        else 
-          avatar = avatar[0]
-          background = background[0]
         @setState {avatar, background}
       .catch (error) =>
         @setState {error}
@@ -89,8 +80,8 @@ module.exports = React.createClass
         <div>
           Avatar<br />
           <ImageSelector maxSize={MAX_AVATAR_SIZE} ratio={1} src={@state.avatar?.src} placeholder={avatarPlaceholder} onChange={@handleMediaChange.bind this, 'avatar'} />
-          {if @state.avatarError
-            <div className="form-help error">{@state.avatarError.toString()}</div>}
+          {if @state.error
+            <div className="form-help error">{@state.error.toString()}</div>}
 
           <p><small className="form-help">Pick a logo to represent your project. To add an image, either drag and drop or click to open your file viewer. For best results, use a square image of not more than 50 KB.</small></p>
 
@@ -98,8 +89,8 @@ module.exports = React.createClass
 
           Background image<br />
           <ImageSelector maxSize={MAX_BACKGROUND_SIZE} src={@state.background?.src} placeholder={backgroundPlaceholder} onChange={@handleMediaChange.bind this, 'background'} />
-          {if @state.backgroundError
-            <div className="form-help error">{@state.backgroundError.toString()}</div>}
+          {if @state.error
+            <div className="form-help error">{@state.error.toString()}</div>}
 
           <p><small className="form-help">This image will be the background for all of your project pages, including your project’s front page. To add an image, either drag and drop or left click to open your file viewer. For best results, use good quality images no more than 256 KB.</small></p>
 

--- a/app/pages/lab/project-details.cjsx
+++ b/app/pages/lab/project-details.cjsx
@@ -33,6 +33,9 @@ module.exports = React.createClass
     disciplineTagList: disciplineTagList
     otherTagList: otherTagList
     researchers: []
+    avatar: null
+    background: null
+    error: null
 
   componentWillMount: ->
     @props.project.get('project_roles', page_size: 100).then (roles) =>
@@ -41,26 +44,19 @@ module.exports = React.createClass
       apiClient.type('users').get(scientists).then (researchers) =>
         @setState({ researchers })
 
-    avatar = @getAvatar()
-      .then (avatar) =>
-        # FireFox returns an object, other browsers return an array
+    avatar = @props.project.get('avatar')
+    background = @props.project.get('background')
+
+    Promise.all([avatar, background])
+      .then ([avatar, background]) => 
         if avatar.src?
-          avatar
+            avatar
         else 
           avatar = avatar[0]
-        @setState {avatar}
-      .catch (error) =>
-        console.log error
-
-    backround = @getBackground()
-      .then (background) =>
-        # FireFox returns an object, other browsers return an array
-        if background.src?
-          background
-        else 
           background = background[0]
-        @setState {background}
+        @setState {avatar, background}
       .catch (error) =>
+        @setState {error}
         console.log error
 
   splitTags: (kind) ->
@@ -79,28 +75,6 @@ module.exports = React.createClass
     for researcher in @state.researchers
       options.push Object.assign value: researcher.id, label: researcher.display_name
     options
-
-  getAvatar: ->
-    avatar = @props.project.get('avatar')
-      .then (avatar) => if avatar? then avatar else null
-      .catch =>
-        console.log error
-
-  getBackground: ->
-    background = @props.project.get('background')
-      .then (background) => if background? then background else null
-      .catch (error) =>
-        console.log error
-
-  splitTags: (kind) ->
-    disciplineTagList = []
-    otherTagList = []
-    for t in @props.project.tags
-      if DISCIPLINES.some((el) -> el.value == t)
-        disciplineTagList.push(t)
-      else
-        otherTagList.push(t)
-    {disciplineTagList, otherTagList}
 
   render: ->
     # Failures on media GETs are acceptable here,


### PR DESCRIPTION
**Describe your changes.**
Removes the promise-renderer component from project-details.cjsx and, instead, stores the avatar and background in state. 

**Questions:**
1. What's the best way to handle the promise errors? [Currently, the errors are logged.](https://github.com/zooniverse/Panoptes-Front-End/blob/remove-promise-renderer-project-details/app/pages/lab/project-details.cjsx#L44) 

2. Firefox returns the avatar and background resource as an object, but Chrome and Safari return the resource in an array. [Is there a better way to handle this issue?](https://github.com/zooniverse/Panoptes-Front-End/blob/remove-promise-renderer-project-details/app/pages/lab/project-details.cjsx#L38)

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?