### PR TITLE
edit survey task keys to include vowels

### DIFF
--- a/app/classifier/tasks/survey/editor.cjsx
+++ b/app/classifier/tasks/survey/editor.cjsx
@@ -367,7 +367,7 @@ module.exports = React.createClass
     value?.charAt(0).toUpperCase() in ['T', 'X', 'Y', '1']
 
   makeID: (string) ->
-    string.replace(/[aeiouy\W]/gi, '').toUpperCase()
+    string.replace(/\W/g, '').toUpperCase()
 
   createChoice: (name) ->
     choiceID = @makeID name


### PR DESCRIPTION
Fixes #3290 (front-end issue, back-end issue [2066](https://github.com/zooniverse/Panoptes/issues/2066) pending).

Only applies to subsequent survey tasks, or subsequently re-imported survey tasks.

Historically with the survey task editor, to create the object keys for choices, characteristics and questions - vowels and whitespace were removed from the related human-readable label/string, and the string was capitalized.

This PR edits the regex to keep the vowels from the human-readable label/string, and leaves the removal of whitespace and capitalization as is.

This makes the keys more human-readable (as requested per #3290), and also makes the keys more unique (i.e. previously "Bear" and "Boar"'s keys would both be `br`, which would cause Boar's values to replace Bear's).

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [X] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [X] Did you deploy a [staging branch](https://edit-survey-task-key.pfe-preview.zooniverse.org/)?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
