### PR TITLE
Remove Field Guide from Project Homepage

### DIFF
--- a/app/pages/project/index.cjsx
+++ b/app/pages/project/index.cjsx
@@ -218,6 +218,7 @@ ProjectPage = React.createClass
 
   render: ->
     projectPath = "/projects/#{@props.project.slug}"
+    onHomePage = projectPath is @props.location.pathname
 
     pages = [{}, @state.pages...].reduce (map, page) =>
       map[page.url_key] = page
@@ -311,7 +312,7 @@ ProjectPage = React.createClass
       {unless @props.project.launch_approved or @props.project.beta_approved
         <Translate component="p" className="project-disclaimer" content="project.disclaimer" />}
 
-      <PotentialFieldGuide project={@props.project} />
+      <PotentialFieldGuide project={@props.project} onHomePage={onHomePage} />
     </div>
 
 

--- a/app/pages/project/index.cjsx
+++ b/app/pages/project/index.cjsx
@@ -218,7 +218,6 @@ ProjectPage = React.createClass
 
   render: ->
     projectPath = "/projects/#{@props.project.slug}"
-    onHomePage = projectPath is @props.location.pathname
 
     pages = [{}, @state.pages...].reduce (map, page) =>
       map[page.url_key] = page
@@ -312,7 +311,8 @@ ProjectPage = React.createClass
       {unless @props.project.launch_approved or @props.project.beta_approved
         <Translate component="p" className="project-disclaimer" content="project.disclaimer" />}
 
-      <PotentialFieldGuide project={@props.project} onHomePage={onHomePage} />
+      {unless @props.location.pathname is projectPath
+        <PotentialFieldGuide project={@props.project} />}
     </div>
 
 

--- a/app/pages/project/potential-field-guide.cjsx
+++ b/app/pages/project/potential-field-guide.cjsx
@@ -5,7 +5,6 @@ FieldGuide = require '../../components/field-guide'
 
 module.exports = React.createClass
   getDefaultProps: ->
-    onHomePage: false
     project: null
 
   getInitialState: ->
@@ -50,9 +49,7 @@ module.exports = React.createClass
     @setState revealed: not @state.revealed
 
   render: ->
-    activeFieldGuide = @state.guide? and @state.guide.items.length isnt 0
-
-    if activeFieldGuide and !@props.onHomePage
+    if @state.guide? and @state.guide.items.length isnt 0
       <Pullout className="field-guide-pullout" side="right" open={@state.revealed}>
         <button type="button" className="field-guide-pullout-toggle" onClick={@toggleFieldGuide}>
           <strong>Field guide</strong>

--- a/app/pages/project/potential-field-guide.cjsx
+++ b/app/pages/project/potential-field-guide.cjsx
@@ -5,6 +5,7 @@ FieldGuide = require '../../components/field-guide'
 
 module.exports = React.createClass
   getDefaultProps: ->
+    onHomePage: false
     project: null
 
   getInitialState: ->
@@ -49,7 +50,9 @@ module.exports = React.createClass
     @setState revealed: not @state.revealed
 
   render: ->
-    if @state.guide? and @state.guide.items.length isnt 0
+    activeFieldGuide = @state.guide? and @state.guide.items.length isnt 0
+
+    if activeFieldGuide and !@props.onHomePage
       <Pullout className="field-guide-pullout" side="right" open={@state.revealed}>
         <button type="button" className="field-guide-pullout-toggle" onClick={@toggleFieldGuide}>
           <strong>Field guide</strong>


### PR DESCRIPTION
Fixes #[2397](https://github.com/zooniverse/Panoptes-Front-End/issues/2397)

Describe your changes.
This removes the Field Guide tab from the right side of the project landing page. The tab will still be available on other project sections: Talk, About, Classify, Collect.

# Review Checklist

- [X] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [X] Does it work on mobile?
- [X] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [X] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)

https://field-guide-landing.pfe-preview.zooniverse.org/

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
