### PR TITLE
add UI to add-edit tutorial and mini-course title

### DIFF
--- a/app/pages/lab/workflow.cjsx
+++ b/app/pages/lab/workflow.cjsx
@@ -472,7 +472,7 @@ EditWorkflowPage = React.createClass
             toggleTutorial = @handleTutorialToggle.bind this, tutorial, workflowTutorials
             <label key={tutorial.id}>
               <input type={if tutorials.length is 1 then "checkbox" else "radio"} checked={assignedTutorial} onChange={toggleTutorial} />
-              Tutorial #{tutorial.id + ' ' + tutorial.display_name}
+              Tutorial #{tutorial.id} {" - #{tutorial.display_name}" if tutorial.display_name}
             </label>}
         </form>
       else
@@ -493,7 +493,7 @@ EditWorkflowPage = React.createClass
             toggleTutorial = @handleTutorialToggle.bind this, tutorial, workflowTutorials
             <label key={tutorial.id}>
               <input type={if projectTutorials.length is 1 then "checkbox" else "radio"} checked={assignedTutorial} onChange={toggleTutorial} />
-              Mini-Course #{tutorial.id + ' ' + tutorial.display_name}
+              Mini-Course #{tutorial.id} {" - #{tutorial.display_name}" if tutorial.display_name}
             </label>}
         </form>
       else

--- a/app/pages/lab/workflow.cjsx
+++ b/app/pages/lab/workflow.cjsx
@@ -472,7 +472,7 @@ EditWorkflowPage = React.createClass
             toggleTutorial = @handleTutorialToggle.bind this, tutorial, workflowTutorials
             <label key={tutorial.id}>
               <input type={if tutorials.length is 1 then "checkbox" else "radio"} checked={assignedTutorial} onChange={toggleTutorial} />
-              Tutorial #{tutorial.id}
+              Tutorial #{tutorial.id} {' - '} {tutorial.display_name}
             </label>}
         </form>
       else
@@ -493,7 +493,7 @@ EditWorkflowPage = React.createClass
             toggleTutorial = @handleTutorialToggle.bind this, tutorial, workflowTutorials
             <label key={tutorial.id}>
               <input type={if projectTutorials.length is 1 then "checkbox" else "radio"} checked={assignedTutorial} onChange={toggleTutorial} />
-              Mini-Course #{tutorial.id}
+              Mini-Course #{tutorial.id} {' - '} {tutorial.display_name}
             </label>}
         </form>
       else

--- a/app/pages/lab/workflow.cjsx
+++ b/app/pages/lab/workflow.cjsx
@@ -472,7 +472,7 @@ EditWorkflowPage = React.createClass
             toggleTutorial = @handleTutorialToggle.bind this, tutorial, workflowTutorials
             <label key={tutorial.id}>
               <input type={if tutorials.length is 1 then "checkbox" else "radio"} checked={assignedTutorial} onChange={toggleTutorial} />
-              Tutorial #{tutorial.id} {' - '} {tutorial.display_name}
+              Tutorial #{tutorial.id + ' ' + tutorial.display_name}
             </label>}
         </form>
       else
@@ -493,7 +493,7 @@ EditWorkflowPage = React.createClass
             toggleTutorial = @handleTutorialToggle.bind this, tutorial, workflowTutorials
             <label key={tutorial.id}>
               <input type={if projectTutorials.length is 1 then "checkbox" else "radio"} checked={assignedTutorial} onChange={toggleTutorial} />
-              Mini-Course #{tutorial.id} {' - '} {tutorial.display_name}
+              Mini-Course #{tutorial.id + ' ' + tutorial.display_name}
             </label>}
         </form>
       else

--- a/app/partials/project-modal-editor.cjsx
+++ b/app/partials/project-modal-editor.cjsx
@@ -6,6 +6,8 @@ FileButton = require '../components/file-button'
 debounce = require 'debounce'
 DragReorderable = require 'drag-reorderable'
 classnames = require 'classnames'
+AutoSave = require '../components/auto-save'
+handleInputChange = require '../lib/handle-input-change'
 
 ProjectModalStepEditor = React.createClass
   getDefaultProps: ->
@@ -82,7 +84,7 @@ ProjectModalEditor = React.createClass
 
     for step, index in stepsInNewOrder
       stepReorderedIndex = index if @props.projectModal.steps[@state.stepToEdit].content is step.content
-      
+
     @props.onStepOrderChange stepsInNewOrder
     @setState stepToEdit: stepReorderedIndex
 
@@ -92,7 +94,7 @@ ProjectModalEditor = React.createClass
 
   renderStepList: (step, i) ->
     step._key ?= Math.random()
-    buttonClasses = classnames 
+    buttonClasses = classnames
       "selected": @state.stepToEdit is i
       "project-modal-step-list-item-button": true
 
@@ -108,7 +110,11 @@ ProjectModalEditor = React.createClass
   render: ->
     <div className="project-modal-editor">
       <div className="project-modal-header">
-        <p className="form-label">{@props.kind} #{@props.projectModal.id}</p>
+        <AutoSave tag="label" resource={@props.projectModal}>
+          <span className="form-label">{@props.kind} #{@props.projectModal.id}</span>
+          <br />
+          <input type="text" name="display_name" value={@props.projectModal.display_name} className="standard-input full" onChange={handleInputChange.bind @props.projectModal} />
+        </AutoSave>
         <p><button className="pill-button" onClick={@props.onProjectModalDelete}>Delete {@props.kind}</button></p>
       </div>
       {if @props.projectModal.steps.length is 0
@@ -289,7 +295,8 @@ ProjectModalCreator = React.createClass
       kind: @props.kind
       links:
         project: @props.project.id
-        
+      display_name: "new #{@props.kind} title"
+
     @setState error: null
     apiClient.type('tutorials').create(projectModalData).save()
       .then (createdProjectModal) =>
@@ -329,7 +336,7 @@ ProjectModalEditorFetcher = React.createClass
       projectModals: null
     apiClient.type('tutorials').get project_id: project.id
       .then (projectModals) =>
-        filteredProjectModals = 
+        filteredProjectModals =
           if @props.kind is "tutorial"
             projectModal for projectModal in projectModals when projectModal.kind is @props.kind or projectModal.kind is null
           else if @props.kind is "mini-course"


### PR DESCRIPTION
Fixes #2959.

Adds text input to add or edit title for tutorials and mini-courses (both are a tutorial resource).
In workflow editor, tutorial/mini-course sections, displays tutorial/mini-course titles in list of options.

# Review Checklist

- [X] Does it work in all major browsers: ~~Firefox~~, ~~Chrome~~, ~~Edge~~, ~~Safari~~?
- [ ] Does it work on mobile?
- [X] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [X] Did you deploy a [staging branch]( https://tutorial-names.pfe-preview.zooniverse.org/)?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
