### PR TITLE
Play video on click

### DIFF
--- a/app/components/thumbnail.jsx
+++ b/app/components/thumbnail.jsx
@@ -7,9 +7,10 @@ export default class Thumbnail extends React.Component {
     super(props);
 
     this.state = {
-      failed: false,
+      failed: false
     };
 
+    this.playVideo = this.playVideo.bind(this);
     this.handleError = this.handleError.bind(this);
   }
 
@@ -24,23 +25,31 @@ export default class Thumbnail extends React.Component {
     }
   }
 
+  playVideo(e) {
+    if (e.target.paused) {
+      e.target.play();
+    } else {
+      e.target.pause();
+    }
+  }
+
   render() {
     const src = this.state.failed ? this.props.src : this.getThumbnailSrc(this.props);
 
     const dimensions = {
       width: null,
-      height: null,
+      height: null
     };
 
     const style = {
       maxWidth: this.props.width,
-      maxHeight: this.props.height,
+      maxHeight: this.props.height
     };
 
     if (this.props.format === 'mp4') {
       return (
         <div>
-          <video width="300" controls>
+          <video width="300" controls onClick={this.playVideo}>
             <source src={this.props.src} type="video/mp4" />
           </video>
         </div>

--- a/app/components/video-player.jsx
+++ b/app/components/video-player.jsx
@@ -11,19 +11,19 @@ const VideoPlayer = React.createClass({
     onLoad: React.PropTypes.func,
     showControls: React.PropTypes.bool,
     src: React.PropTypes.string,
-    type: React.PropTypes.string,
+    type: React.PropTypes.string
   },
 
   getDefaultProps() {
     return {
-      showControls: true,
+      showControls: true
     };
   },
 
   getInitialState() {
     return {
       playing: false,
-      playbackRate: 1,
+      playbackRate: 1
     };
   },
 
@@ -99,11 +99,6 @@ const VideoPlayer = React.createClass({
     const rates = [0.25, 0.5, 1];
     return (
       <div className="subject-video-frame">
-        <button
-          className="subject-video-frame__hidden-button"
-          onClick={this.playVideo.bind(this, !this.state.playing)}
-        />
-
         <video
           className="subject"
           ref="videoPlayer"
@@ -111,6 +106,7 @@ const VideoPlayer = React.createClass({
           type={`${this.props.type}/${this.props.format}`}
           preload="auto"
           onCanPlay={this.props.onLoad}
+          onClick={this.playVideo.bind(this, !this.state.playing)}
           onEnded={this.endVideo}
           onTimeUpdate={this.updateScrubber}
         >
@@ -155,7 +151,7 @@ const VideoPlayer = React.createClass({
         {this.props.children}
       </div>
     );
-  },
+  }
 
 });
 

--- a/app/components/video-player.jsx
+++ b/app/components/video-player.jsx
@@ -99,6 +99,11 @@ const VideoPlayer = React.createClass({
     const rates = [0.25, 0.5, 1];
     return (
       <div className="subject-video-frame">
+        <button
+          className="subject-video-frame__hidden-button"
+          onClick={this.playVideo.bind(this, !this.state.playing)}
+        />
+
         <video
           className="subject"
           ref="videoPlayer"
@@ -106,7 +111,6 @@ const VideoPlayer = React.createClass({
           type={`${this.props.type}/${this.props.format}`}
           preload="auto"
           onCanPlay={this.props.onLoad}
-          onClick={this.playVideo.bind(this, !this.state.playing)}
           onEnded={this.endVideo}
           onTimeUpdate={this.updateScrubber}
         >

--- a/app/components/video-player.jsx
+++ b/app/components/video-player.jsx
@@ -5,12 +5,19 @@ const IS_IE = 'ActiveXObject' in window;
 const VideoPlayer = React.createClass({
 
   propTypes: {
+    children: React.PropTypes.node,
+    format: React.PropTypes.string,
     frame: React.PropTypes.number,
+    onLoad: React.PropTypes.func,
+    showControls: React.PropTypes.bool,
     src: React.PropTypes.string,
     type: React.PropTypes.string,
-    format: React.PropTypes.string,
-    onLoad: React.PropTypes.func,
-    children: React.PropTypes.node,
+  },
+
+  getDefaultProps() {
+    return {
+      showControls: true,
+    };
   },
 
   getInitialState() {
@@ -21,18 +28,18 @@ const VideoPlayer = React.createClass({
   },
 
   componentDidMount() {
-    if (!!this.refs.videoScrubber) {
+    if (this.refs.videoScrubber) {
       this.refs.videoScrubber.value = 0;
       if (IS_IE) this.refs.videoScrubber.addEventListener('change', this.seekVideo);
     }
   },
 
   componentDidUpdate() {
-    if (!!this.refs.videoPlayer) this.refs.videoPlayer.playbackRate = this.state.playbackRate;
+    if (this.refs.videoPlayer) this.refs.videoPlayer.playbackRate = this.state.playbackRate;
   },
 
   componentWillUnmount() {
-    if (!!this.refs.videoScrubber && IS_IE) {
+    if (this.refs.videoScrubber && IS_IE) {
       this.refs.videoScrubber.removeEventListener('change', this.seekVideo);
     }
   },
@@ -84,7 +91,7 @@ const VideoPlayer = React.createClass({
         <span>
           {rate}&times;
         </span>
-      </label>)
+      </label>),
     );
   },
 
@@ -99,44 +106,48 @@ const VideoPlayer = React.createClass({
           type={`${this.props.type}/${this.props.format}`}
           preload="auto"
           onCanPlay={this.props.onLoad}
+          onClick={this.playVideo.bind(this, !this.state.playing)}
           onEnded={this.endVideo}
           onTimeUpdate={this.updateScrubber}
         >
           Your browser does not support the video format. Please upgrade your browser.
         </video>
-        <span className="subject-video-controls">
-          <span className="subject-frame-play-controls">
-          {(this.state.playing) ?
-            <button
-              type="button"
-              className="secret-button"
-              aria-label="Pause"
-              onClick={this.playVideo.bind(this, false)}
-            >
-              <i className="fa fa-pause fa-fw"></i>
-            </button> :
-            <button
-              type="button"
-              className="secret-button"
-              aria-label="Play"
-              onClick={this.playVideo.bind(this, true)}
-            >
-              <i className="fa fa-play fa-fw"></i>
-            </button>
-            }
+
+        {this.props.showControls && (
+          <span className="subject-video-controls">
+            <span className="subject-frame-play-controls">
+              {(this.state.playing) ?
+                <button
+                  type="button"
+                  className="secret-button"
+                  aria-label="Pause"
+                  onClick={this.playVideo.bind(this, false)}
+                >
+                  <i className="fa fa-pause fa-fw" />
+                </button> :
+                <button
+                  type="button"
+                  className="secret-button"
+                  aria-label="Play"
+                  onClick={this.playVideo.bind(this, true)}
+                >
+                  <i className="fa fa-play fa-fw" />
+                </button>
+                }
+            </span>
+            <input
+              type="range"
+              className="video-scrubber"
+              ref="videoScrubber"
+              min="0"
+              step="any"
+              onChange={this.seekVideo}
+            />
+            <span className="video-speed">
+            Speed: {this.renderSpeedControls(rates)}
+            </span>
           </span>
-          <input
-            type="range"
-            className="video-scrubber"
-            ref="videoScrubber"
-            min="0"
-            step="any"
-            onChange={this.seekVideo}
-          />
-          <span className="video-speed">
-          Speed: {this.renderSpeedControls(rates)}
-          </span>
-        </span>
+        )}
         {this.props.children}
       </div>
     );

--- a/css/subject-viewer.styl
+++ b/css/subject-viewer.styl
@@ -1,3 +1,11 @@
+.subject-video-frame
+  &__hidden-button
+    height: 100%
+    opacity: 0
+    position: absolute
+    width: 100%
+    z-index: 1
+
 .subject-viewer
   min-width: 0
   max-width: 100%
@@ -16,7 +24,8 @@
   .subject-video-controls
     display: inline-block
     position: relative
-    width: 30vw
+    width: 100%
+    z-index: 1
 
   .video-scrubber
     width: 80%

--- a/css/subject-viewer.styl
+++ b/css/subject-viewer.styl
@@ -1,11 +1,3 @@
-.subject-video-frame
-  &__hidden-button
-    height: 100%
-    opacity: 0
-    position: absolute
-    width: 100%
-    z-index: 1
-
 .subject-viewer
   min-width: 0
   max-width: 100%
@@ -24,8 +16,7 @@
   .subject-video-controls
     display: inline-block
     position: relative
-    width: 100%
-    z-index: 1
+    width: 30vw
 
   .video-scrubber
     width: 80%


### PR DESCRIPTION
Describe your changes.
This allows the ability for a video to play when clicking on the still image. A boolean prop is also added to give the component the ability to hide controls, if needed. Bat detective has video subjects to test functionality.

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)

https://video-click-play.pfe-preview.zooniverse.org/

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?