### PR TITLE
Fix import of the Thumbnail component

### DIFF
--- a/app/collections/preview.cjsx
+++ b/app/collections/preview.cjsx
@@ -2,9 +2,10 @@ React = require 'react'
 {Link} = require 'react-router'
 apiClient = require 'panoptes-client/lib/api-client'
 Loading = require '../components/loading-indicator'
-Thumbnail = require '../components/thumbnail'
 Avatar = require '../partials/avatar'
 getSubjectLocation = require '../lib/get-subject-location'
+
+`import Thumbnail from '../components/thumbnail';`
 
 module.exports = React.createClass
   displayName: 'CollectionPreview'

--- a/app/talk/discussion-preview.cjsx
+++ b/app/talk/discussion-preview.cjsx
@@ -2,9 +2,10 @@ React = require 'react'
 {Link} = require 'react-router'
 resourceCount = require './lib/resource-count'
 LatestCommentLink = require './latest-comment-link'
-Thumbnail = require '../components/thumbnail'
 apiClient = require 'panoptes-client/lib/api-client'
 getSubjectLocation = require '../lib/get-subject-location'
+
+`import Thumbnail from '../components/thumbnail';`
 
 module.exports = React.createClass
   displayName: 'TalkDiscussionPreview'

--- a/app/talk/tags.cjsx
+++ b/app/talk/tags.cjsx
@@ -4,12 +4,13 @@ talkClient = require 'panoptes-client/lib/talk-client'
 apiClient = require 'panoptes-client/lib/api-client'
 Paginator = require './lib/paginator'
 getSubjectLocation = require '../lib/get-subject-location'
-Thumbnail = require '../components/thumbnail'
 resourceCount = require './lib/resource-count'
 Loading = require '../components/loading-indicator'
 PopularTags = require './popular-tags'
 ActiveUsers = require './active-users'
 ProjectLinker = require './lib/project-linker'
+
+`import Thumbnail from '../components/thumbnail';`
 
 module.exports = React.createClass
   displayName: 'TalkTags'


### PR DESCRIPTION
Needs a backticked ES6 import to use in Coffeescript components

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?