### PR TITLE
Remove code for Gravity Spy split

### DIFF
--- a/app/pages/project/home-workflow-buttons.jsx
+++ b/app/pages/project/home-workflow-buttons.jsx
@@ -1,14 +1,11 @@
 import React from 'react';
 import { Link } from 'react-router';
 import ProjectHomeWorkflowButton from './home-workflow-button';
-import locationMatch from '../../lib/location-match';
-
 
 export default class ProjectHomeWorkflowButtons extends React.Component {
   constructor(props) {
     super(props);
 
-    this.handleSplitWorkflowAssignment = this.handleSplitWorkflowAssignment.bind(this);
     this.shouldWorkflowBeDisabled = this.shouldWorkflowBeDisabled.bind(this);
     this.renderRedirectLink = this.renderRedirectLink.bind(this);
     this.renderWorkflowButtons = this.renderWorkflowButtons.bind(this);
@@ -25,18 +22,6 @@ export default class ProjectHomeWorkflowButtons extends React.Component {
     }
 
     return false;
-  }
-
-  handleSplitWorkflowAssignment() {
-    let workflowAssignmentID = '2758';
-
-    if (process.env.NODE_ENV === 'production' || locationMatch(/\W?env=(production)/)) {
-      workflowAssignmentID = '3063';
-    }
-
-    if (this.props.splits['workflow.assignment']) {
-      this.props.onChangePreferences('preferences.selected_workflow', workflowAssignmentID);
-    }
   }
 
   renderRedirectLink() {
@@ -73,23 +58,6 @@ export default class ProjectHomeWorkflowButtons extends React.Component {
     }
 
     if (this.props.showWorkflowButtons) {
-      if (this.props.splits && this.props.preferences && this.props.workflowAssignment) {
-        const gravitySpySplit = (this.props.splits['workflow.assignment']) ? this.props.splits['workflow.assignment'].variant.value.description === 'Apprentice workflow assignment' : false;
-        const newToProject = Object.keys(this.props.preferences.preferences).length === 0;
-
-        if (newToProject && gravitySpySplit) {
-          return (
-            <Link
-              to={`/projects/${this.props.project.slug}/classify`}
-              className="call-to-action standard-button"
-              onClick={this.handleSplitWorkflowAssignment}
-            >
-              Get started!
-            </Link>
-          );
-        }
-      }
-
       return this.renderWorkflowButtons();
     }
 
@@ -103,7 +71,7 @@ export default class ProjectHomeWorkflowButtons extends React.Component {
 
 ProjectHomeWorkflowButtons.contextTypes = {
   geordi: React.PropTypes.object,
-  user: React.PropTypes.object,
+  user: React.PropTypes.object
 };
 
 ProjectHomeWorkflowButtons.defaultProps = {
@@ -113,7 +81,7 @@ ProjectHomeWorkflowButtons.defaultProps = {
   project: {},
   showWorkflowButtons: false,
   splits: {},
-  workflowAssignment: false,
+  workflowAssignment: false
 };
 
 ProjectHomeWorkflowButtons.propTypes = {
@@ -121,13 +89,13 @@ ProjectHomeWorkflowButtons.propTypes = {
   onChangePreferences: React.PropTypes.func.isRequired,
   preferences: React.PropTypes.shape({
     preferences: React.PropTypes.object,
-    settings: React.PropTypes.objectOf(React.PropTypes.string),
+    settings: React.PropTypes.objectOf(React.PropTypes.string)
   }),
   project: React.PropTypes.shape({
     redirect: React.PropTypes.string,
-    slug: React.PropTypes.string,
+    slug: React.PropTypes.string
   }).isRequired,
   showWorkflowButtons: React.PropTypes.bool.isRequired,
   splits: React.PropTypes.object,
-  workflowAssignment: React.PropTypes.bool,
+  workflowAssignment: React.PropTypes.bool
 };

--- a/app/pages/project/home-workflow-buttons.spec.js
+++ b/app/pages/project/home-workflow-buttons.spec.js
@@ -6,29 +6,29 @@ import { render, mount } from 'enzyme';
 
 const testWorkflows = [
   { id: '2342',
-    configuration: { level: 1 },
-    display_name: 'Beginner Workflow',
+    configuration: { level: '1' },
+    display_name: 'Beginner Workflow'
   },
   { id: '1234',
-    configuration: { level: 2 },
-    display_name: 'Intermediate Workflow',
+    configuration: { level: '2' },
+    display_name: 'Intermediate Workflow'
   },
   { id: '4321',
-    configuration: { level: 3 },
-    display_name: 'Advanced Workflow',
+    configuration: { level: '3' },
+    display_name: 'Advanced Workflow'
   },
   { id: '6757',
     configuration: { },
-    display_name: 'Active, no level workflow',
-  },
+    display_name: 'Active, no level workflow'
+  }
 ];
 
 const testUserPreferences = {
-  settings: { workflow_id: '1234' },
+  settings: { workflow_id: '1234' }
 };
 
 const testProject = {
-  redirect: 'www.testproject.com',
+  redirect: 'www.testproject.com'
 };
 
 describe('ProjectHomeWorkflowButtons', function() {


### PR DESCRIPTION
This removes the code specific to the a/b split that just ended for Gravity Spy.

https://gs-split-remove.pfe-preview.zooniverse.org/projects/zooniverse/gravity-spy?env=production

All logged in users should see all five workflow buttons, with some disabled if they haven't reach that level yet. Logged out should see 'Get Started!' button.

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [x] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?