### PR TITLE
Add browser env to eslint config

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,9 @@
 {
   "extends": "airbnb",
   "plugins": ["react"],
+  "env": {
+    "browser": true,
+  },
   "rules": {
     "react/jsx-boolean-value": ["error","always"],
     "react/prefer-es6-class": 0,


### PR DESCRIPTION
Missed in the eslint rule update. This adds the browser env to the config so that global variables like `window` or `location` aren't flagged as undefined.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?