### PR TITLE
Mark all read

### DIFF
--- a/app/pages/notifications/comment.cjsx
+++ b/app/pages/notifications/comment.cjsx
@@ -30,7 +30,7 @@ module.exports = React.createClass
         {if notification.delivered is false and !@props.startedDiscussion
           <i title="Unread" className="fa fa-star fa-lg" />}
 
-        <Link to={notification.url} {...@props} className="message-link">
+        <Link to={notification.url} className="message-link">
           {comment.discussion_title}
         </Link>
 
@@ -40,7 +40,7 @@ module.exports = React.createClass
           <Link className="user-profile-link" to="/users/#{commentUser.login}">
             <Avatar user={commentUser} />{' '}{commentUser.display_name}
           </Link>{' '}
-          <Link to={notification.url} {...@props} className="time-ago">
+          <Link to={notification.url} className="time-ago">
             {moment(comment.created_at).fromNow()}
           </Link>
         </div>

--- a/app/pages/notifications/message.cjsx
+++ b/app/pages/notifications/message.cjsx
@@ -22,7 +22,7 @@ module.exports = React.createClass
       <div className="conversation-message talk-module">
         {if notification.delivered is false
           <i title="Unread" className="fa fa-star fa-lg" />}
-        <Link to="/inbox/#{notification.source.conversation_id}" {...@props} className="message-link">
+        <Link to="/inbox/#{notification.source.conversation_id}" className="message-link">
           {notification.message}{' '}
           in {@props.data.conversation.title}
         </Link>
@@ -33,7 +33,7 @@ module.exports = React.createClass
           <Link className="user-profile-link" to="#{baseLink}users/#{@props.data.messageUser.login}">
             <Avatar user={@props.data.messageUser} />{' '}{@props.data.messageUser.display_name}
           </Link>{' '}
-          <Link to={"/inbox/#{notification.source.conversation_id}"} {...@props} className="time-ago">
+          <Link to={"/inbox/#{notification.source.conversation_id}"} className="time-ago">
             {moment(@props.data.message.created_at).fromNow()}
           </Link>
         </div>

--- a/app/pages/notifications/moderation.cjsx
+++ b/app/pages/notifications/moderation.cjsx
@@ -26,7 +26,7 @@ module.exports = React.createClass
         {if notification.delivered is false
           <i title="Unread" className="fa fa-star fa-lg" />}
         <div className="title">
-          <Link to={path} {...@props}>{notification.message}</Link>
+          <Link to={path}>{notification.message}</Link>
         </div>
 
         <Markdown>{@props.data.comment.body}</Markdown>
@@ -53,7 +53,7 @@ module.exports = React.createClass
 
           {' '}
 
-          <Link to={path} {...@props}>
+          <Link to={path}>
             {notification.message}{' '}
             {moment(notification.created_at).fromNow()}
           </Link>

--- a/app/pages/notifications/notification-section.jsx
+++ b/app/pages/notifications/notification-section.jsx
@@ -200,7 +200,7 @@ export default class NotificationSection extends Component {
           </div>
 
           <div className="notification-section__item">
-            <button className="notification-section__expand" title="Toggle Section">
+            <button title="Toggle Section">
               <i className={buttonType} />
             </button>
           </div>

--- a/app/pages/notifications/notification-section.jsx
+++ b/app/pages/notifications/notification-section.jsx
@@ -119,15 +119,15 @@ export default class NotificationSection extends Component {
   }
 
   markAllRead() {
-    talkClient.put('/notifications/read', { section: this.props.section });
     this.state.notificationData.forEach((data) => {
       data.notification.update({ delivered: true });
     });
     this.setState({ unread: 0 });
-    return talkClient.type('notifications').get({ page_size: 1, delivered: false })
-    .then(([notification]) => {
-      const count = notification.getMeta().count;
-      if (count === 0) this.context.notificationsCounter.setUnread(0);
+    return talkClient.put('/notifications/read', { section: this.props.section }).then(() => {
+      return talkClient.type('notifications').get({ page_size: 1, delivered: false }).then(([notification]) => {
+        const count = notification ? notification.getMeta().count : 0;
+        if (count === 0) this.context.notificationsCounter.setUnread(0);
+      });
     });
   }
 
@@ -223,6 +223,8 @@ export default class NotificationSection extends Component {
 
   render() {
     const l = this.state.currentMeta;
+    const firstNotification = (l.page * l.page_size) - (l.page_size - 1) || 0;
+    const lastNotification = Math.min(l.page_size * l.page, l.count) || 0;
 
     return (
       <div className="notification-section">
@@ -274,7 +276,7 @@ export default class NotificationSection extends Component {
               pageCount={this.state.lastMeta.page_count}
               pageSelector={false}
               previousLabel={<span><i className="fa fa-chevron-left" /> previous</span>}
-              totalItems={<span className="notification-section__item-count">{(l.page * l.page_size) - (l.page_size - 1)} - {Math.min(l.page_size * l.page, l.count)} of {l.count}</span>}
+              totalItems={<span className="notification-section__item-count">{firstNotification} - {lastNotification} of {l.count}</span>}
             />
           </div>
         )}

--- a/app/pages/notifications/notification-section.jsx
+++ b/app/pages/notifications/notification-section.jsx
@@ -121,10 +121,14 @@ export default class NotificationSection extends Component {
   markAllRead() {
     talkClient.put('/notifications/read', { section: this.props.section });
     this.state.notificationData.forEach((data) => {
-      data.notification.update({ delivered: true }).save();
+      data.notification.update({ delivered: true });
     });
     this.setState({ unread: 0 });
-    this.context.notificationsCounter.setUnread(0);
+    return talkClient.type('notifications').get({ page_size: 1, delivered: false })
+    .then(([notification]) => {
+      const count = notification.getMeta().count;
+      if (count === 0) this.context.notificationsCounter.setUnread(0);
+    });
   }
 
   markAsRead(position) {
@@ -200,7 +204,7 @@ export default class NotificationSection extends Component {
           </div>
 
           <div className="notification-section__item">
-            <button title="Toggle Section">
+            <button className="notification-section__expand" title="Toggle Section">
               <i className={buttonType} />
             </button>
           </div>
@@ -238,10 +242,9 @@ export default class NotificationSection extends Component {
         )}
 
         {(this.props.expanded && this.state.unread > 0) && (
-          <label htmlFor="markRead">
-            <input type="checkbox" onChange={this.markAllRead} />
+          <button onClick={this.markAllRead}>
             Mark All Read
-          </label>
+          </button>
         )}
 
         {(this.props.expanded && !this.state.loading) && (

--- a/app/pages/notifications/notification-section.jsx
+++ b/app/pages/notifications/notification-section.jsx
@@ -166,14 +166,21 @@ export default class NotificationSection extends Component {
   }
 
   unreadCircle() {
-    const centerNum = this.state.unread > 9 ? '30%' : '40%';
+    let centerNum = '40%';
+
+    if (this.state.unread > 99) {
+      centerNum = '20%';
+    } else if (this.state.unread > 9) {
+      centerNum = '30%';
+    }
+    const unreadNotifications = this.state.unread > 99 ? '99+' : this.state.unread;
 
     return (
       <svg className="notification-section__img">
         <circle cx="0" cy="0" r="100" fill="#E45950">
           <title> {`${this.state.unread} Unread Notification(s)`} </title>
         </circle>
-        <text x={centerNum} y="50%" stroke="white" strokeWidth="2px" dy=".3em">{this.state.unread}</text>
+        <text x={centerNum} y="50%" stroke="white" strokeWidth="2px" dy=".3em">{unreadNotifications}</text>
       </svg>
     );
   }
@@ -231,9 +238,10 @@ export default class NotificationSection extends Component {
         )}
 
         {(this.props.expanded && this.state.unread > 0) && (
-          <button onClickCapture={this.markAllRead}>
+          <label htmlFor="markRead">
+            <input type="checkbox" onChange={this.markAllRead} />
             Mark All Read
-          </button>
+          </label>
         )}
 
         {(this.props.expanded && !this.state.loading) && (

--- a/app/pages/notifications/notification-section.jsx
+++ b/app/pages/notifications/notification-section.jsx
@@ -118,24 +118,13 @@ export default class NotificationSection extends Component {
     });
   }
 
-  markAllRead(e, query = { page: 1, total: 0 }) {
-    return talkClient.type('notifications').get({ page: query.page, page_size: 50, delivered: false, section: this.props.section })
-    .catch((error) => {
-      this.setState({ error });
-    })
-    .then((notifications) => {
-      const count = notifications[0].getMeta().count;
-      query.total += notifications.length;
-      notifications.map((notification) => {
-        notification.update({ delivered: true }).save();
-      });
-      if (query.total < count) {
-        query.page += 1;
-        this.markAllRead(null, query);
-      } else {
-        this.setState({ unread: 0 });
-      }
+  markAllRead() {
+    talkClient.put('/notifications/read', { section: this.props.section });
+    this.state.notificationData.forEach((data) => {
+      data.notification.update({ delivered: true }).save();
     });
+    this.setState({ unread: 0 });
+    this.context.notificationsCounter.setUnread(0);
   }
 
   markAsRead(position) {
@@ -294,6 +283,10 @@ NotificationSection.propTypes = {
     display_name: React.PropTypes.string,
     login: React.PropTypes.string
   })
+};
+
+NotificationSection.contextTypes = {
+  notificationsCounter: React.PropTypes.object
 };
 
 NotificationSection.defaultProps = {

--- a/app/pages/notifications/started-discussion.cjsx
+++ b/app/pages/notifications/started-discussion.cjsx
@@ -4,7 +4,7 @@ Loading = require '../../components/loading-indicator'
 Comment = require './comment'
 
 module.exports = React.createClass
-  displayName: 'CommentNotification'
+  displayName: 'StartedDiscussionNotification'
 
   propTypes:
     data: React.PropTypes.object.isRequired
@@ -26,7 +26,7 @@ module.exports = React.createClass
             <i title="Unread" className="fa fa-star fa-lg" />}
 
           <div className="title">
-            <Link to={"#{slug}/talk/#{@props.data.discussion.board_id}/#{@props.data.discussion.id}"} {...@props}>
+            <Link to={"#{slug}/talk/#{@props.data.discussion.board_id}/#{@props.data.discussion.id}"}>
               {@props.notification.message}
             </Link>
           </div>

--- a/css/notification-section.styl
+++ b/css/notification-section.styl
@@ -37,12 +37,10 @@
     font-size: 0.8em
     padding: 0em 2em
 
-  &__expand
-    float: right
-
   button
     background: none !important
     border: none !important
+    float: right
     outline: none
     position: absolute
 

--- a/css/notification-section.styl
+++ b/css/notification-section.styl
@@ -37,12 +37,17 @@
     font-size: 0.8em
     padding: 0em 2em
 
+  &__expand
+    float: right
+
   button
     background: none !important
     border: none !important
-    float: right
     outline: none
     position: absolute
+
+    &:hover
+      color: inherit !important
 
   .fa-star
     color: #F0B200

--- a/css/notification-section.styl
+++ b/css/notification-section.styl
@@ -37,10 +37,12 @@
     font-size: 0.8em
     padding: 0em 2em
 
+  &__expand
+    float: right
+
   button
     background: none !important
     border: none !important
-    float: right
     outline: none
     position: absolute
 


### PR DESCRIPTION
Describe your changes.
This adds a "Mark All as Read" button to the notifications page. This was a suggestion brought up by a volunteer on general talk. This PR also adjusts how the unread count appears, as numbers over 99 were appearing off center.

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [X] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)

https://mark-all-read.pfe-preview.zooniverse.org/

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?