### PR TITLE
Sort collections and email preferences by display_name

### DIFF
--- a/app/pages/collections/list.cjsx
+++ b/app/pages/collections/list.cjsx
@@ -56,6 +56,7 @@ List = React.createClass
     if props.project?
       query.project_ids = props.project.id
     query.favorite = props.favorite
+    query.sort = 'display_name'
     Object.assign query, props.location.query
 
     apiClient

--- a/app/pages/settings/email.cjsx
+++ b/app/pages/settings/email.cjsx
@@ -25,7 +25,7 @@ module.exports = React.createClass
       @getProjectPreferences()
 
   getProjectPreferences: ->
-    @props.user.get('project_preferences', page: @state.page)
+    @props.user.get('project_preferences', page: @state.page, sort: 'display_name')
       .then (projectPreferences) =>
         if projectPreferences
           projects = for preference in projectPreferences


### PR DESCRIPTION
Fixes #1489 
Fixes #2455 

Describe your changes.
Adds `sort: 'display_name'` to the API calls for email project preferences and collections.

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://fix-1489-2455.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?