### PR TITLE
Add Researcher Quote to Project Lab

### DIFF
--- a/app/pages/lab/project-details.cjsx
+++ b/app/pages/lab/project-details.cjsx
@@ -35,8 +35,8 @@ module.exports = React.createClass
   componentWillMount: ->
     @props.project.get('project_roles', page_size: 100).then (roles) =>
       scientists = for role in roles when 'scientist' in role.roles
-        role.get 'owner'
-      Promise.all(scientists).then (researchers) =>
+        role.links.owner.id
+      apiClient.type('users').get(scientists).then (researchers) =>
         @setState({ researchers })
 
   splitTags: (kind) ->

--- a/app/pages/lab/project-details.cjsx
+++ b/app/pages/lab/project-details.cjsx
@@ -137,7 +137,7 @@ module.exports = React.createClass
             <small className="form-help">Add text here when you have multiple workflows and want to help your volunteers decide which one they should do. <CharLimit limit={500} string={@props.project.workflow_description ? ''} /></small>
           </p>
 
-          <p>
+          <div>
             <AutoSave resource={@props.project}>
               <span className="form-label">Researcher Quote</span>
               <br />
@@ -149,7 +149,7 @@ module.exports = React.createClass
               <textarea className="standard-input full" name="researcher_quote" value={@props.project.researcher_quote} onChange={handleInputChange.bind @props.project} />
             </AutoSave>
             <small className="form-help">This text will appear on a project landing page alongside an avatar of the selected researcher. <CharLimit limit={255} string={@props.project.researcher_quote ? ''} /></small>
-          </p>
+          </div>
 
           <div>
             <AutoSave resource={@props.project}>

--- a/app/pages/lab/project-details.cjsx
+++ b/app/pages/lab/project-details.cjsx
@@ -145,7 +145,7 @@ module.exports = React.createClass
                 placeholder="Choose a Researcher"
                 onChange={@handleResearcherChange}
                 options={@researcherOptions()}
-                value={@props.project.configuration.researcherID} />
+                value={@props.project?.configuration?.researcherID} />
               <textarea className="standard-input full" name="researcher_quote" value={@props.project.researcher_quote} onChange={handleInputChange.bind @props.project} />
             </AutoSave>
             <small className="form-help">This text will appear on a project landing page alongside an avatar of the selected researcher. <CharLimit limit={255} string={@props.project.researcher_quote ? ''} /></small>

--- a/app/pages/lab/project-details.cjsx
+++ b/app/pages/lab/project-details.cjsx
@@ -123,6 +123,15 @@ module.exports = React.createClass
             <small className="form-help">Add text here when you have multiple workflows and want to help your volunteers decide which one they should do. <CharLimit limit={500} string={@props.project.workflow_description ? ''} /></small>
           </p>
 
+          <p>
+            <AutoSave resource={@props.project}>
+              <span className="form-label">Researcher Quote</span>
+              <br />
+              <textarea className="standard-input full" name="researcher_quote" value={@props.project.researcher_quote} onChange={handleInputChange.bind @props.project} />
+            </AutoSave>
+            <small className="form-help">This text will appear on a project landing page alongside an avatar of the selected researcher. <CharLimit limit={255} string={@props.project.researcher_quote ? ''} /></small>
+          </p>
+
           <div>
             <AutoSave resource={@props.project}>
               <span className="form-label">Announcement Banner</span>


### PR DESCRIPTION
Describe your changes.
This adds the Researcher Quote field to the project lab page. It also allows for a primary researcher to be selected, whose avatar will appear on the project landing page. This should probably be merged concurrently with #3368.

https://researcher-quote.pfe-preview.zooniverse.org/

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [X] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?