### PR TITLE
Allow Video Subjects to Show with Discussion Preview

### DIFF
--- a/app/components/thumbnail.jsx
+++ b/app/components/thumbnail.jsx
@@ -47,9 +47,10 @@ export default class Thumbnail extends React.Component {
     };
 
     if (this.props.format === 'mp4') {
+      const width = this.props.width < 999 ? this.props.width : '300';
       return (
         <div>
-          <video width="300" controls onClick={this.playVideo}>
+          <video width={width} controls={this.props.controls} onClick={this.playVideo}>
             <source src={this.props.src} type="video/mp4" />
           </video>
         </div>
@@ -63,17 +64,19 @@ export default class Thumbnail extends React.Component {
 }
 
 Thumbnail.defaultProps = {
+  controls: true,
   format: 'image',
   height: MAX_THUMBNAIL_DIMENSION,
   origin: 'https://thumbnails.zooniverse.org',
   src: '',
-  width: MAX_THUMBNAIL_DIMENSION,
+  width: MAX_THUMBNAIL_DIMENSION
 };
 
 Thumbnail.propTypes = {
+  controls: React.PropTypes.bool,
   format: React.PropTypes.string,
   height: React.PropTypes.number,
   origin: React.PropTypes.string,
   src: React.PropTypes.string,
-  width: React.PropTypes.number,
+  width: React.PropTypes.number
 };

--- a/app/components/thumbnail.jsx
+++ b/app/components/thumbnail.jsx
@@ -47,10 +47,9 @@ export default class Thumbnail extends React.Component {
     };
 
     if (this.props.format === 'mp4') {
-      const width = this.props.width < 999 ? this.props.width : '300';
       return (
         <div>
-          <video width={width} controls={this.props.controls} onClick={this.playVideo}>
+          <video style={style} controls={this.props.controls} onClick={this.playVideo}>
             <source src={this.props.src} type="video/mp4" />
           </video>
         </div>

--- a/app/talk/discussion-preview.cjsx
+++ b/app/talk/discussion-preview.cjsx
@@ -64,7 +64,7 @@ module.exports = React.createClass
         {if @state.subject?
           subject = getSubjectLocation(@state.subject)
           <div className="subject-preview">
-            <Thumbnail src={subject.src} format={subject.format} width={100} controls={false} />
+            <Thumbnail src={subject.src} format={subject.format} width={100} height={150} controls={false} />
           </div>
         }
 

--- a/app/talk/discussion-preview.cjsx
+++ b/app/talk/discussion-preview.cjsx
@@ -62,8 +62,9 @@ module.exports = React.createClass
       <div className="preview-content">
 
         {if @state.subject?
+          subject = getSubjectLocation(@state.subject)
           <div className="subject-preview">
-            <Thumbnail src={getSubjectLocation(@state.subject).src} width={100} />
+            <Thumbnail src={subject.src} format={subject.format} width={100} controls={false} />
           </div>
         }
 

--- a/app/talk/discussion-preview.cjsx
+++ b/app/talk/discussion-preview.cjsx
@@ -41,18 +41,14 @@ module.exports = React.createClass
 
     if (@props.params?.owner and @props.params?.name) # get from url if possible
       {owner, name} = @props.params
-      projectTalk = "/projects/#{owner}/#{name}/talk/#{discussion.board_id}/#{discussion.id}"
-      <Link to={projectTalk} onClick={@logDiscussionClick.bind null, this}>{discussion.title}</Link>
+      "/projects/#{owner}/#{name}/talk/#{discussion.board_id}/#{discussion.id}"
 
     else if @props.project # otherwise fetch from project
       [owner, name] = @props.project.slug.split('/')
-      projectTalk = "/projects/#{owner}/#{name}/talk/#{discussion.board_id}/#{discussion.id}"
-      <Link to={projectTalk} onClick={@logDiscussionClick.bind null, this}>{discussion.title}</Link>
+      "/projects/#{owner}/#{name}/talk/#{discussion.board_id}/#{discussion.id}"
 
     else # link to zooniverse main talk
-      <Link to="/talk/#{discussion.board_id}/#{discussion.id}" onClick={@logDiscussionClick.bind null, this}>
-        {discussion.title}
-      </Link>
+      "/talk/#{discussion.board_id}/#{discussion.id}"
 
   render: ->
     {params, discussion} = @props
@@ -64,13 +60,17 @@ module.exports = React.createClass
         {if @state.subject?
           subject = getSubjectLocation(@state.subject)
           <div className="subject-preview">
-            <Thumbnail src={subject.src} format={subject.format} width={100} height={150} controls={false} />
+            <Link to={@discussionLink()} onClick={@logDiscussionClick.bind null, this}>
+              <Thumbnail src={subject.src} format={subject.format} width={100} height={150} controls={false} />
+            </Link>
           </div>
         }
 
         <h1>
           {<i className="fa fa-thumb-tack talk-sticky-pin"></i> if discussion.sticky}
-          {@discussionLink()}
+          <Link to={@discussionLink()} onClick={@logDiscussionClick.bind null, this}>
+            {discussion.title}
+          </Link>
         </h1>
 
         <LatestCommentLink {...@props} project={@props.project} discussion={discussion} comment={@props.comment} preview={true} />


### PR DESCRIPTION
Fixes #3352 .

Describe your changes.
Video subjects were not showing on the talk discussion preview. This is apparent when looking at Bat Detective, for example.

# Review Checklist

- [X] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [X] Does it work on mobile?
- [X] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [X] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)

https://fix-3352.pfe-preview.zooniverse.org/

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?