### PR TITLE
Fix broken project tags in project builder

### DIFF
--- a/app/pages/lab/project-details.cjsx
+++ b/app/pages/lab/project-details.cjsx
@@ -18,6 +18,8 @@ Select = require 'react-select'
 MAX_AVATAR_SIZE = 64000
 MAX_BACKGROUND_SIZE = 256000
 
+DISCIPLINE_NAMES = (discipline.value for discipline in DISCIPLINES)
+
 module.exports = React.createClass
   displayName: 'EditProjectDetails'
 
@@ -35,10 +37,11 @@ module.exports = React.createClass
     disciplineTagList = []
     otherTagList = []
     for t in @props.project.tags
-      if DISCIPLINES.some((el) -> el.value == t)
-        disciplineTagList.push(t)
+      name = t[1]
+      if name in DISCIPLINE_NAMES
+        disciplineTagList.push name
       else
-        otherTagList.push(t)
+        otherTagList.push name
     {disciplineTagList, otherTagList}
 
   render: ->


### PR DESCRIPTION
This is basically a quick fix for #3356.

I spent a bit of time playing with a single input for discipline/other tags, but I never got anything to feel less confusing.  In the meantime, this at least fixes the bug.

https://fix-project-tags.pfe-preview.zooniverse.org

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [x] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?