### PR TITLE
Team page aside restyle

### DIFF
--- a/app/pages/project/about/team.jsx
+++ b/app/pages/project/about/team.jsx
@@ -35,11 +35,13 @@ const createTeamList = (team) => (
             {teamMember.userResource.display_name}
             {' '}
           </span>
+          <br />
+          <span className="team-list-item__login">@{teamMember.userResource.login}</span>
           <span className="team-list-item__project-roles">
           {teamMember.roles.map(role => (
-            <Translate key={role} 
-              content={`projectRoles.${role}`} 
-              className={`project-role ${role}`} 
+            <Translate key={role}
+              content={`projectRoles.${role}`}
+              className={`project-role ${role}`}
             />
           ))}
           </span>
@@ -51,8 +53,8 @@ const createTeamList = (team) => (
 
 const AboutProjectTeam = ({ pages, project, team }) => {
   const teamPage = pages.find(page => page.slug === 'team');
-  const mainContent = (teamPage && teamPage.content && teamPage.content !== '') 
-      ? teamPage.content 
+  const mainContent = (teamPage && teamPage.content && teamPage.content !== '')
+      ? teamPage.content
       : counterpart('aboutPages.missingContent.team');
   const aside = createTeamList(team);
 
@@ -72,9 +74,10 @@ AboutProjectTeam.propTypes = {
   team: PropTypes.arrayOf(PropTypes.shape({
     userResource: PropTypes.shape({
       display_name: PropTypes.string.isRequired,
+      login: PropTypes.string.isRequired,
     }),
     roles: PropTypes.arrayOf(PropTypes.string).isRequired,
-  })), 
+  })),
 };
 
 export default AboutProjectTeam;

--- a/app/pages/project/about/team.jsx
+++ b/app/pages/project/about/team.jsx
@@ -1,8 +1,8 @@
 import React, { PropTypes } from 'react';
-import { Markdown } from 'markdownz';
-import AboutPageLayout from './about-page-layout';
+import { Link } from 'react-router';
 import Translate from 'react-translate-component';
 import counterpart from 'counterpart';
+import AboutPageLayout from './about-page-layout';
 import Avatar from '../../../partials/avatar';
 
 counterpart.registerTranslations('en', {
@@ -23,7 +23,7 @@ counterpart.registerTranslations('en', {
   }
 });
 
-const createTeamList = (team) => (
+const createTeamList = (team, projectSlug) => (
   <div>
     <Translate content="projectRoles.title" />
     <ul className="team-list">
@@ -32,17 +32,18 @@ const createTeamList = (team) => (
           <span className="team-list-item__display-name">
             <Avatar user={teamMember.userResource} className="avatar" />
             {' '}
-            {teamMember.userResource.display_name}
+            <Link to={`/projects/${projectSlug}/users/${teamMember.userResource.login}`}>{teamMember.userResource.display_name}</Link>
             {' '}
           </span>
           <br />
           <span className="team-list-item__login">@{teamMember.userResource.login}</span>
           <span className="team-list-item__project-roles">
-          {teamMember.roles.map(role => (
-            <Translate key={role}
-              content={`projectRoles.${role}`}
-              className={`project-role ${role}`}
-            />
+            {teamMember.roles.map(role => (
+              <Translate
+                key={role}
+                content={`projectRoles.${role}`}
+                className={`project-role ${role}`}
+              />
           ))}
           </span>
         </li>
@@ -56,14 +57,15 @@ const AboutProjectTeam = ({ pages, project, team }) => {
   const mainContent = (teamPage && teamPage.content && teamPage.content !== '')
       ? teamPage.content
       : counterpart('aboutPages.missingContent.team');
-  const aside = createTeamList(team);
+  const aside = createTeamList(team, project.slug);
 
-  return <AboutPageLayout
-    project={project}
-    mainContent={mainContent}
-    aside={aside}
-  />;
-}
+  return (
+    <AboutPageLayout
+      project={project}
+      mainContent={mainContent}
+      aside={aside}
+    />);
+};
 
 AboutProjectTeam.propTypes = {
   pages: PropTypes.arrayOf(PropTypes.shape({

--- a/css/project-page.styl
+++ b/css/project-page.styl
@@ -31,6 +31,11 @@
     &__display-name
       whitespace: nowrap
 
+    &__login
+      whitespace: nowrap
+      color: #afaeae
+      font-size: 0.8em
+
     &__project-roles
       display: flex
       flex-wrap: wrap
@@ -139,7 +144,7 @@
     flex: 1 0 auto
     flex-direction: column
     justify-content: center
-    
+
     &__buttons
       display: flex
       flex-direction: column

--- a/css/project-page.styl
+++ b/css/project-page.styl
@@ -30,6 +30,8 @@
 
     &__display-name
       whitespace: nowrap
+      a
+        color: #00979d
 
     &__login
       whitespace: nowrap

--- a/css/team-page.styl
+++ b/css/team-page.styl
@@ -5,7 +5,7 @@
   .secondary-page-side-bar
     flex-basis: 180px
     padding 0px 10px 0px 0px
-  
+
 
     nav
      .side-bar-button


### PR DESCRIPTION
Fixes #2218.

Changes aside of team members (users associated with project through Panoptes) to look and behave like Talk comment user avatar and names. Shows team member login for easy referencing in Talk, and links to team member's project comments.

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a [staging branch](https://team-page-restyle.pfe-preview.zooniverse.org/)? Or, more specifically [this project](https://team-page-restyle.pfe-preview.zooniverse.org/projects/markb-panoptes/focus-testing-project/about/team) has a few team members, and I have a project comment
- [x] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?