### PR TITLE
Fix version data not showing when there's no whodunnit

### DIFF
--- a/app/pages/admin/project-status/version-list.jsx
+++ b/app/pages/admin/project-status/version-list.jsx
@@ -35,12 +35,14 @@ class VersionList extends Component {
 
   createVersionString(version) {
     const versionAuthor = this.state.users.find(user => user.id === version.whodunnit);
-    const property = Object.keys(version.changeset)[0];
-    const oldValue = version.changeset[property][0];
-    const newValue = version.changeset[property][1];
+    const [property] = Object.keys(version.changeset);
+    const [oldValue, newValue] = version.changeset[property];    
     const time = moment(version.created_at).fromNow();
 
-    const versionEntry = [versionAuthor.display_name, 'changed', property];
+    // There are some versions that have no `whodunnit` property, so set a fallback. 
+    // It was probably a ghost.
+    const versionAuthorName = (versionAuthor) ? versionAuthor.display_name : '👻 SOMEONE 👻';
+    const versionEntry = [versionAuthorName, 'changed', property];
     if (oldValue !== null && oldValue !== undefined) {
       versionEntry.push('from', oldValue);
     }


### PR DESCRIPTION
On the project status page, if there's a whodunnit missing for a version, the version changes fail to load (first noted on Snapshot Wisconsin). This adds in a fallback to stop that from happening.

https://fix-project-log.pfe-preview.zooniverse.org/admin/project_status/zooniverse/snapshot-wisconsin?env=production

cc @trouille 

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://fix-project-log.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?