### PR TITLE
Make sure freehand tools only appear if enabled

### DIFF
--- a/app/classifier/tasks/generic-editor.cjsx
+++ b/app/classifier/tasks/generic-editor.cjsx
@@ -122,9 +122,13 @@ module.exports = React.createClass
                         Type{' '}
                         <select name="#{@props.taskPrefix}.#{choicesKey}.#{index}.type" value={choice.type} onChange={handleChange}>
                           {for toolKey of drawingTools
-                            <option key={toolKey} value={toolKey}>{toolKey}</option> unless toolKey in ["grid"]}
+                            <option key={toolKey} value={toolKey}>{toolKey}</option> unless toolKey in ["grid", "freehandLine", "freehandShape"]}
                           {if @canUse("grid")
                             <option key="grid" value="grid">grid</option>}
+                          {if @canUse("freehandLine")
+                            <option key="freehandLine" value="freehandLine">freehand line</option>}
+                          {if @canUse("freehandShape")
+                            <option key="freehandShape" value="freehandShape">freehand shape</option>}
                         </select>
                       </AutoSave>
                     </div>


### PR DESCRIPTION
Ugh, my bad - thanks for catching that @wgranger 

Freehand tools should now only appear when enabled.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://fix-freehand-tools.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?