### PR TITLE
Catch errors individually for project avatar and background requests

### DIFF
--- a/app/pages/lab/project-details.cjsx
+++ b/app/pages/lab/project-details.cjsx
@@ -42,13 +42,14 @@ module.exports = React.createClass
         @setState({ researchers })
 
     avatar = @props.project.get('avatar')
+      .catch (error) =>
+        console.log error
     background = @props.project.get('background')
+      .catch (error) =>
+        console.log error
     Promise.all([avatar, background])
       .then ([avatar, background]) =>
         @setState {avatar, background}
-      .catch (error) =>
-        @setState {error}
-        console.log error
 
   splitTags: (kind) ->
     disciplineTagList = []


### PR DESCRIPTION
Fixes #3390  .

Describe your changes.
Removes the catch() from the Promise for the project avatar and background images, which prevented both from being set if either one was missing.

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://project-background.pfe-preview.zooniverse.org
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?