### PR TITLE
Add Z-index to Dropdown

### DIFF
--- a/app/pages/lab/project-details.cjsx
+++ b/app/pages/lab/project-details.cjsx
@@ -144,6 +144,7 @@ module.exports = React.createClass
               <span className="form-label">Researcher Quote</span>
               <br />
               <Select
+                className="researcher-quote"
                 placeholder="Choose a Researcher"
                 onChange={@handleResearcherChange}
                 options={@researcherOptions()}

--- a/css/lab.styl
+++ b/css/lab.styl
@@ -1,3 +1,6 @@
+.researcher-quote
+  z-index: 2
+
 .data-exports
   .row
     margin: 0.8em 0


### PR DESCRIPTION
Describe your changes.
There was an issue with this dropdown. The input box below it (announcement banner) had a z-index applied to it, so the dropdown above was displaying behind that box. This was only apparent if there were enough researchers to cause the height of the dropdown to cascade under the announcement banner input.

https://researcher-css.pfe-preview.zooniverse.org/

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?