### PR TITLE
Restore user profile stats

### DIFF
--- a/app/pages/home-for-user/recent-projects.jsx
+++ b/app/pages/home-for-user/recent-projects.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
 import HomePageSection from './generic-section';
 import ProjectIcon from '../../components/project-icon';
 
@@ -10,10 +9,6 @@ class RecentProjectsSection extends React.Component {
     this.state = {
       allProjects: false
     };
-  }
-
-  componentDidUpdate() {
-    !this.state.allProjects && ReactDOM.findDOMNode(this).scrollIntoView();
   }
 
   toggleAllProjects() {
@@ -37,7 +32,7 @@ class RecentProjectsSection extends React.Component {
             <p> You have no recent projects. </p>
           </div>
         : [<div key="project-header" className="home-page-section__sub-header">
-            <a href="/#focus=projects" className="outlined-button" onClick={this.toggleAllProjects}>
+            <a href="/#projects" className="outlined-button" onClick={this.toggleAllProjects}>
               <span className="home-page-section__header-label">
                 See all
               </span>

--- a/app/pages/profile/user.jsx
+++ b/app/pages/profile/user.jsx
@@ -13,7 +13,8 @@ counterpart.registerTranslations('en', {
       favorites: 'Favorites',
       message: 'Message',
       moderation: 'Moderation',
-      settings: 'Settings'
+      settings: 'Settings',
+      stats: 'Your stats'
     }
   }
 });
@@ -74,11 +75,19 @@ class ProfileUser extends Component {
   renderUserLink() {
     const baseLink = this.props.project ? `/projects/${this.props.project.slug}/` : '/';
     const classes = classNames({ 'about-tabs': !!this.props.project });
-    return (
-      <Link to={`${baseLink}users/${this.props.profileUser.login}/message`} className={classes} activeClassName="active" onClick={this.logMessageClick}>
-        <Translate content="profile.nav.message" />
-      </Link>
-    );
+    if (this.props.user !== this.props.profileUser) {
+      return (
+        <Link to={`${baseLink}users/${this.props.profileUser.login}/message`} className={classes} activeClassName="active" onClick={this.logMessageClick}>
+          <Translate content="profile.nav.message" />
+        </Link>
+      );
+    } else {
+      return (
+        <Link to="/#projects" className={classes} onClick={this.logClick.bind(this, 'stats')}>
+          <Translate content="profile.nav.stats" />
+        </Link>
+      );
+    }
   }
 
   renderNavLinks() {
@@ -156,6 +165,7 @@ class ProfileUser extends Component {
 }
 
 ProfileUser.propTypes = {
+  children: PropTypes.node,
   user: PropTypes.object,
   project: PropTypes.object,
   profileUser: PropTypes.object.isRequired


### PR DESCRIPTION
Fixes #3392  .

Describe your changes.
Adds a stats link back to the user profile.
Adds some scrolling behaviour to the user home page when the location hash changes.
Removes a forceUpdate() in favour of setting component state.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://profile-stats.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?