### PR TITLE
Fix project icon links

### DIFF
--- a/app/components/project-icon.jsx
+++ b/app/components/project-icon.jsx
@@ -4,7 +4,7 @@ import ProjectCard from '../partials/project-card';
 const ProjectIcon = (props) => {
   return (
     <span className="stats-project-icon">
-      <ProjectCard project={props.project} />
+      <ProjectCard project={props.project} href={props.linkTo} />
       {!!props.badge && <div className="badge">{props.badge}</div>}
     </span>
   );
@@ -12,7 +12,8 @@ const ProjectIcon = (props) => {
 
 ProjectIcon.propTypes = {
   project: React.PropTypes.object,
-  badge: React.PropTypes.number
+  badge: React.PropTypes.number,
+  linkTo: React.PropTypes.string
 };
 
 export default ProjectIcon;

--- a/app/pages/admin/project-status-list.jsx
+++ b/app/pages/admin/project-status-list.jsx
@@ -69,9 +69,7 @@ class ProjectStatusList extends Component {
     const [owner, name] = project.slug.split('/');
     return (
       <div key={project.id}>
-        <Link to={`/admin/project_status/${owner}/${name}`}>
-          <ProjectIcon linkTo={false} project={project} />
-        </Link>
+        <ProjectIcon linkTo={`/admin/project_status/${owner}/${name}`} project={project} />
       </div>
     );
   }


### PR DESCRIPTION
Allow project icons to link to URLs other than the default project URL.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch? https://project-links.pfe-preview.zooniverse.org/?env=production
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?