### PR TITLE
Move select files button for media area

### DIFF
--- a/app/pages/lab/media-area/media-area-view.jsx
+++ b/app/pages/lab/media-area/media-area-view.jsx
@@ -66,14 +66,12 @@ export default class MediaAreaView extends React.Component {
         {(this.props.media && this.props.media.length === 0) ? <small><em>No media</em></small> : null}
 
         <ul className="media-area-list">
-          {this.props.media && this.renderMediaList()}
-
           <li className="media-area-item" style={{ alignSelf: 'stretch' }}>
             <div className="media-icon">
               <FileButton
                 className="media-area-add-button"
                 accept="image/*"
-                multiple
+                multiple={true}
                 style={addButtonStyle}
                 onSelect={this.props.onSelect}
               >
@@ -82,6 +80,8 @@ export default class MediaAreaView extends React.Component {
               <div className="media-icon-label">Select files</div>
             </div>
           </li>
+
+          {this.props.media && this.renderMediaList()}
         </ul>
 
         {this.props.children && <hr />}


### PR DESCRIPTION
Fixes #1092 by moving the select file button to the top of the unordered list the media area.

https://fix-1092.pfe-preview.zooniverse.org?env=production

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?