### PR TITLE
Remove Researcher Quote Section When Empty

### DIFF
--- a/app/pages/project/home.jsx
+++ b/app/pages/project/home.jsx
@@ -2,18 +2,10 @@ import React from 'react';
 import { Markdown } from 'markdownz';
 import apiClient from 'panoptes-client/lib/api-client';
 import talkClient from 'panoptes-client/lib/talk-client';
-import Translate from 'react-translate-component';
-import counterpart from 'counterpart';
 import FinishedBanner from './finished-banner';
 import TalkImages from './talk-images';
 import ProjectMetadata from './metadata';
 import ProjectHomeWorkflowButtons from './home-workflow-buttons';
-
-counterpart.registerTranslations('en', {
-  researchQuote: {
-    default: 'Your contribution helps further scientific discoveries.'
-  }
-});
 
 export default class ProjectHomePage extends React.Component {
   constructor(props) {
@@ -84,13 +76,6 @@ export default class ProjectHomePage extends React.Component {
 
   renderResearcherWords() {
     const avatarSrc = this.state.researcherAvatar || '/assets/simple-avatar.png';
-    let quote;
-
-    if (this.props.project.researcher_quote) {
-      quote = <span>&quot;{this.props.project.researcher_quote}&quot;</span>;
-    } else {
-      quote = <Translate component="span" content="researchQuote.default" />;
-    }
 
     return (
       <div className="project-home-page__researcher-words">
@@ -98,7 +83,7 @@ export default class ProjectHomePage extends React.Component {
 
         <div>
           <img role="presentation" src={avatarSrc} />
-          {quote}
+          <span>&quot;{this.props.project.researcher_quote}&quot;</span>
         </div>
       </div>
     );
@@ -133,7 +118,8 @@ export default class ProjectHomePage extends React.Component {
 
         <div className="project-home-page__container">
 
-          {this.renderResearcherWords()}
+          {this.props.project.researcher_quote && (
+            this.renderResearcherWords())}
 
           <div className="project-home-page__about-text">
             <h4>About {this.props.project.display_name}</h4>


### PR DESCRIPTION
**Describe your changes.**
Now that the new project landing page has been displayed for several days, and project owners are familiar with the Words from the Researcher section, the section can now be hidden if the field is blank. This removes the default text that existed before.

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)

https://remove-quote.pfe-preview.zooniverse.org/

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?