### PR TITLE
Add Subject Flags as Experimental Feature

### DIFF
--- a/app/pages/admin/project-status/experimental-features.jsx
+++ b/app/pages/admin/project-status/experimental-features.jsx
@@ -20,6 +20,7 @@ const experimentalFeatures = [
   'export classifications by workflow',
   'freehandLine',
   'freehandShape',
+  'enable subject flags'
 ];
 
 class ExperimentalFeatures extends Component {

--- a/app/pages/lab/workflow.cjsx
+++ b/app/pages/lab/workflow.cjsx
@@ -331,6 +331,24 @@ EditWorkflowPage = React.createClass
 
           <hr />
 
+          {if 'enable subject flags' in @props.project.experimental_tools
+            <div>
+              <div>
+                <AutoSave resource={@props.workflow}>
+                  <span className="form-label">Subject Flags</span><br />
+                  <small className="form-help">Flags allow volunteers to mark subjects as inappropriate.</small>
+                  <br />
+                  <label>
+                    <input type="checkbox" onChange={@enableSubjectFlags} checked={@props.workflow.configuration.enable_subject_flags}/>
+                    Enable Subject Flags
+                  </label>
+                </AutoSave>
+              </div>
+
+              <hr />
+
+            </div>}
+
           <div>
             <AutoSave tag="label" resource={@props.workflow}>
               <input type="checkbox" name="invert_subject" checked={@props.workflow.configuration.invert_subject} onChange={@handleSetInvert} />
@@ -537,6 +555,10 @@ EditWorkflowPage = React.createClass
   handleSetGravitySpyGoldStandard: (e) ->
     @props.workflow.update
       'configuration.gravity_spy_gold_standard': e.target.checked
+
+  enableSubjectFlags: (e) ->
+    @props.workflow.update
+      'configuration.enable_subject_flags': e.target.checked
 
   handleSetWorldWideTelescope: (e) ->
     if !@props.workflow.configuration.custom_summary


### PR DESCRIPTION
Fixes #3396 .

Describe your changes.
"Enable Subject Flags" is now available as an experimental feature. It will also need to be toggled in the project builder.

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)

https://fix-3396.pfe-preview.zooniverse.org/

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?