### PR TITLE
Remove DOM queries from user search

### DIFF
--- a/app/collections/collaborators.cjsx
+++ b/app/collections/collaborators.cjsx
@@ -51,7 +51,7 @@ RoleCreator = React.createClass
         <p className="form-help error">{errorMessage}</p>}
       <form style={style}>
         <div>
-          <UserSearch />
+          <UserSearch ref={(component) => @userSearch = component} />
         </div>
 
         <table className="standard-table">
@@ -76,8 +76,7 @@ RoleCreator = React.createClass
     node = ReactDOM.findDOMNode(@)
 
     checkboxes = node.querySelectorAll '[name="role"]'
-    userids = node.querySelector('[name="userids"]')
-    users = userids.value.split(',').map (id) -> parseInt(id)
+    users = @userSearch.value().map (option) -> parseInt option.value
     roles = for checkbox in checkboxes when checkbox.checked
       checkbox.value
 
@@ -94,7 +93,7 @@ RoleCreator = React.createClass
 
     Promise.all(roleSet.save() for roleSet in roleSets)
       .then =>
-        userids.value = ''
+        @userSearch.clear()
         for checkbox in checkboxes
           checkbox.checked = false
         @props.onAdd? arguments...

--- a/app/components/user-search.cjsx
+++ b/app/components/user-search.cjsx
@@ -24,6 +24,12 @@ module.exports = React.createClass
   onChange: (users) ->
     @setState {users}
 
+  clear: ->
+    @setState users: []
+
+  value: ->
+    @state.users
+
   searchUsers: (value) ->
     clearTimeout @queryTimeout
     onSearch = @props.onSearch

--- a/app/pages/admin/user-settings-list.jsx
+++ b/app/pages/admin/user-settings-list.jsx
@@ -24,8 +24,7 @@ class UserSettingsList extends Component {
 
   listUsers(e) {
     e.preventDefault();
-    const userSelect = this.list.querySelector('[name="userids"]');
-    const userId = userSelect.value;
+    const userId = this.userSearch.value().value;
 
     if (userId) {
       this.getEditUser(userId);
@@ -59,7 +58,7 @@ class UserSettingsList extends Component {
       <div ref={list => this.list = list}>
         <div className="columns-container">
           <div className="column">
-            <UserSearch multi={false} />
+            <UserSearch ref={(component) => { this.userSearch = component; }} multi={false} />
           </div>
           <button type="button" onClick={this.listUsers}>
             Find user

--- a/app/pages/lab/collaborators.cjsx
+++ b/app/pages/lab/collaborators.cjsx
@@ -56,7 +56,7 @@ CollaboratorCreator = React.createClass
         <p className="form-help error">{@state.error.toString()}</p>}
       <form style={style}>
         <div>
-          <UserSearch />
+          <UserSearch ref={(component) => @userSearch = component} />
         </div>
 
         <table className="standard-table">
@@ -80,8 +80,7 @@ CollaboratorCreator = React.createClass
     e.preventDefault()
     node = ReactDOM.findDOMNode(@)
     checkboxes = node.querySelectorAll '[name="role"]'
-    userids = node.querySelector('[name="userids"]')
-    users = userids.value.split(',').map (id) -> parseInt(id)
+    users = @userSearch.value().map (option) -> parseInt option.value
     roles = for checkbox in checkboxes when checkbox.checked
       checkbox.value
 
@@ -115,7 +114,7 @@ CollaboratorCreator = React.createClass
 
     Promise.all(roleSet.save() for roleSet in newRoles)
       .then =>
-        userids.value = ''
+        @userSearch.clear()
         for checkbox in checkboxes
           checkbox.checked = false
         @props.onAdd? arguments...

--- a/app/talk/add-zoo-team-form.cjsx
+++ b/app/talk/add-zoo-team-form.cjsx
@@ -15,8 +15,7 @@ module.exports = React.createClass
     return unless window.confirm('Are you sure that you want to add this user to the Zooniverse team?')
 
     e.preventDefault()
-    userSelect = ReactDOM.findDOMNode(@).querySelector('[name="userids"]')
-    userId = userSelect.value
+    userId = @userSearch.value().value
 
     talkClient.type('roles').create({
       name: 'admin'
@@ -37,7 +36,7 @@ module.exports = React.createClass
 
       <p style={color: 'red'}><strong>Careful:</strong> You are about to add someone to the Zooniverse team on Talk, this will grant them magical powers in the Zooniverse wide talk, and label them as 'Zooniverse Team'</p>
 
-      <UserSearch multi={false} />
+      <UserSearch ref={(component) => @userSearch = component} multi={false} />
 
       <button type="button" onClick={@onClickAddZooniverseTeamMember}>
         Add Member to The Zooniverse Team

--- a/app/talk/inbox-form.cjsx
+++ b/app/talk/inbox-form.cjsx
@@ -35,9 +35,7 @@ module.exports = React.createClass
 
   onSubmitMessage: (_, body) ->
     @logEvent 'send-message'
-    recipient_ids = ReactDOM.findDOMNode(@).querySelector('[name="userids"]').value
-      .split(',').map (id) -> parseInt(id)
-      .filter(Number)
+    recipient_ids = [parseInt @userSearch.value().value]
 
     title = @refs.subject.value
     user_id = @props.user.id
@@ -55,7 +53,7 @@ module.exports = React.createClass
     <div className="inbox-form talk-module">
       <div className="talk-form talk-moderation-children">
         <h2>To:</h2>
-        <UserSearch multi={false} onSearch={@logEvent.bind(this, 'username-search')} />
+        <UserSearch ref={(component) => @userSearch = component} multi={false} onSearch={@logEvent.bind(this, 'username-search')} />
 
         <h2>Message:</h2>
         <input placeholder="Subject" type="text" ref="subject"/>


### PR DESCRIPTION
Adds methods to get the selected user(s) from `UserSearch` and clear the select control.

Removes the DOM queries that got the values directly from hidden form inputs generated by `react-select`.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://user-search.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?