### PR TITLE
Fix new discussion routing

### DIFF
--- a/app/subjects/comment-form.cjsx
+++ b/app/subjects/comment-form.cjsx
@@ -33,7 +33,7 @@ module.exports = React.createClass
     {owner, name} = @props.params
     board = createdDiscussion.board_id
     discussion = createdDiscussion.id
-    @context.router.push null, "/projects/#{owner}/#{name}/talk/#{board}/#{discussion}"
+    @context.router.push "/projects/#{owner}/#{name}/talk/#{board}/#{discussion}"
 
   linkToClassifier: (text) ->
     [owner, name] = @props.project.slug.split('/')

--- a/app/talk/discussion-new-form.cjsx
+++ b/app/talk/discussion-new-form.cjsx
@@ -78,7 +78,7 @@ module.exports = React.createClass
       <input
         type="radio"
         name="board"
-        defaultChecked={i is 0} # pre-check the first
+        defaultChecked={i is 0}
         value={board.id} />
       {board.title}
     </label>


### PR DESCRIPTION
Fixes #3410 

~~I kind of think this has probably been broken since the React 15 upgrade.~~  Introduced [here](https://github.com/zooniverse/Panoptes-Front-End/commit/b91ed4c985929b09553b409750938c9a848ac0a4#diff-1c41117089744eb55872cae99e45d23dL34) when upgrading from `history.pushState` to `router.push`

Staged at https://fix-discussion-create.pfe-preview.zooniverse.org

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?