### PR TITLE
Fix Image Appearance on Tutorials

### DIFF
--- a/css/mini-course-dialog.styl
+++ b/css/mini-course-dialog.styl
@@ -3,7 +3,7 @@
 
 .mini-course-dialog
   padding: 0
-  
+
   &:not(.modal-form-underlay)
     border: solid 0.5em MINI_COURSE_BLUE
     border-radius: 8px
@@ -11,60 +11,60 @@
   @media screen and (max-width: 400px)
     margin-left: 0em
     margin-top: 1.75em
-        
+
   &__steps
     display: flex
     flex-direction: column
     max-height: 75vh
     width: 75vw
-      
+
     .steps__step
       overflow-y: auto
-      
+
       &-actions
         align-items: center
         display: flex
         justify-content: space-between
-        
+
         .action__opt-out
           color: #a1a1a1
           font-style: italic
           font-size: 0.75em
           margin: 0 0.25em
-          
+
         .action__buton
           background-color: MINI_COURSE_BLUE
-          
+
   .media-card.steps__step
     > .media-card-content
       margin: 1em 3vw
-      
+
       .markdown
         h1, h2, h3, h4, h5
           color: MINI_COURSE_BLUE
           font-size: 1.17em
-          
-        // Being co-opted for the image credit. TODO: Support figcaption for the media in tutorials and mini-courses  
+
+        // Being co-opted for the image credit. TODO: Support figcaption for the media in tutorials and mini-courses
         h6
           color: #a1a1a1
           font-style: italic
           margin: 0 0 0.5em
           text-align: right
           width: 100%
-          
+
           @media screen and (max-width: 400px)
             text-align: center
-          
+
         p
           color: #2b2b2b
           font-size: 0.9em
 
         a
           color: MINI_COURSE_BLUE
-        
+
   .media-card-header
     background-color: #111111
-    
+
   .media-card-media
     display: block
     margin: 0 auto

--- a/css/tutorial.styl
+++ b/css/tutorial.styl
@@ -29,6 +29,7 @@
     border-top-left-radius: 8px
     border-top-right-radius: 8px
     display: block
+    margin: auto
     max-width: 100%
 
 .step-through-direction

--- a/css/tutorial.styl
+++ b/css/tutorial.styl
@@ -25,8 +25,8 @@
     > .media-card-content
       @extends .content-container
 
-    img
-      max-width: 100%
+      img
+        max-width: 100%
 
   .media-card-media
     border-top-left-radius: 8px

--- a/css/tutorial.styl
+++ b/css/tutorial.styl
@@ -25,6 +25,9 @@
     > .media-card-content
       @extends .content-container
 
+    img
+      max-width: 100%
+
   .media-card-media
     border-top-left-radius: 8px
     border-top-right-radius: 8px


### PR DESCRIPTION
Fixes #3419.

Describe your changes.
Two Issues here: Smaller images were not being centered on tutorials. Also, larger images were showing outside of their container Div, hence the `max-width` change.

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)

https://fix-3419.pfe-preview.zooniverse.org/

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?