### PR TITLE
Move discussion reply box (and convert to ES6)

### DIFF
--- a/app/talk/discussion-comment.jsx
+++ b/app/talk/discussion-comment.jsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { Link } from 'react-router';
+import talkClient from 'panoptes-client/lib/talk-client';
+import Avatar from '../partials/avatar';
+import DisplayRoles from './lib/display-roles';
+import CommentBox from './comment-box';
+import SignInPrompt from '../partials/sign-in-prompt';
+import commentValidations from './lib/comment-validations';
+import alert from '../lib/alert';
+import { getErrors } from './lib/validations';
+
+class DiscussionComment extends React.Component {
+  constructor(props) {
+    super(props);
+    this.onSubmitComment = this.onSubmitComment.bind(this);
+    this.commentValidations = this.commentValidations.bind(this);
+    this.state = {
+      commentValidationErrors: []
+    };
+  }
+
+  onSubmitComment(e, textContent, subject, reply) {
+    let comment = {
+      user_id: this.props.user.id,
+      discussion_id: +this.props.params.discussion,
+      body: textContent
+    };
+    if (!!subject && subject.id) {
+      comment = Object.assign(comment, {
+        focus_id: +subject.id,
+        focus_type: 'Subject'
+      });
+    }
+    if (reply) {
+      comment = Object.assign(comment, {
+        reply_id: reply.comment.id
+      });
+    }
+
+    return talkClient.type('comments')
+    .create(comment)
+    .save()
+    .then(this.props.onSubmitComment);
+  }
+
+  commentValidations(commentBody) {
+    // TODO: return true if any additional validations fail
+    const commentValidationErrors = getErrors(commentBody, commentValidations);
+    this.setState({ commentValidationErrors });
+    return !!commentValidationErrors.length;
+  }
+
+  promptToSignIn() {
+    alert(resolve => <SignInPrompt onChoose={resolve} />);
+  }
+
+  render() {
+    if (this.props.user) {
+      const baseLink = this.props.project ? `projects/${this.props.project.slug}` : '/';
+      return (
+        <div>
+          <div className="talk-comment-author">
+            <Avatar user={this.props.user} />
+            <p>
+              <Link to={`${baseLink}users/${this.props.user.login}`}>{this.props.user.display_name}</Link>
+            </p>
+            <div className="user-mention-name">@{this.props.user.login}</div>
+            <DisplayRoles roles={this.props.roles} section={this.props.discussion.section} />
+          </div>
+
+          <CommentBox
+            user={this.props.user}
+            project={this.props.project}
+            validationCheck={this.commentValidations}
+            validationErrors={this.state.commentValidationErrors}
+            onSubmitComment={this.onSubmitComment}
+            reply={this.props.reply}
+            logSubmit={true}
+            onClickClearReply={this.props.onClearReply}
+            header={null}
+          />
+        </div>
+      );
+    } else {
+      return (
+        <p>Please <button className="link-style" type="button" onClick={this.promptToSignIn}>sign in</button> to contribute to the discussion</p>
+      );
+    }
+  }
+}
+
+DiscussionComment.propTypes = {
+  params: React.PropTypes.object,
+  project: React.PropTypes.object,
+  user: React.PropTypes.object,
+  roles: React.PropTypes.array,
+  discussion: React.PropTypes.object,
+  reply: React.PropTypes.object,
+  onSubmitComment: React.PropTypes.func,
+  onClearReply: React.PropTypes.func
+};
+
+export default DiscussionComment;

--- a/app/talk/discussion-comment.spec.js
+++ b/app/talk/discussion-comment.spec.js
@@ -43,4 +43,16 @@ describe('DiscussionComment', function() {
       assert.equal(wrapper.find(CommentBox).props().user, user);
     })
   });
+  
+  describe('comment validation', function(){
+    it('will not allow empty comments', function(){
+      // weirdly, comment validations returns true if validation fails.
+      assert.equal(wrapper.instance().commentValidations(''), true);
+      assert.equal(wrapper.state().commentValidationErrors[0], 'Comments cannot be empty');
+    });
+    it('will allow reasonable comments', function(){
+      assert.equal(wrapper.instance().commentValidations('Hello world, I\'m a valid comment.'), false);
+      assert.equal(wrapper.state().commentValidationErrors.length, 0);
+    });
+  });
 });

--- a/app/talk/discussion-comment.spec.js
+++ b/app/talk/discussion-comment.spec.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import assert from 'assert';
+import DiscussionComment from './discussion-comment';
+import CommentBox from './comment-box';
+import { shallow } from 'enzyme';
+
+const discussion = {
+  section: 1
+};
+
+const user = {
+  id: 1,
+  display_name: 'Test User'
+};
+
+describe('DiscussionComment', function() {
+  let wrapper;
+
+  describe('not logged in', function() {
+    it('will ask user to sign in', function() {
+      wrapper = shallow(<DiscussionComment discussion={discussion} user={null} />);
+      assert.equal(wrapper.find('.talk-comment-author').length, 0);
+      assert.equal(wrapper.contains(
+        <button
+          className="link-style"
+          type="button"
+          onClick={wrapper.instance().promptToSignIn} >
+            sign in
+        </button>),
+        true);
+    });
+  });
+
+  describe('logged in', function() {
+    beforeEach(function(){
+      wrapper = shallow(<DiscussionComment discussion={discussion} user={user} />);
+    });
+
+    it('will show a user avatar', function() {
+      assert.equal(wrapper.find('.talk-comment-author').length, 1);
+    });
+    it('will show a comment box', function(){
+      assert.equal(wrapper.find(CommentBox).props().user, user);
+    })
+  });
+});


### PR DESCRIPTION
Fixes #2973 .

Describe your changes.
Rewrites the discussion thread comment box in ES6 and moves it from the very bottom of the page to the bottom of the list of comments.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://fix-2973.pfe-preview.zooniverse.org/?env=production
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?