### PR TITLE
Fix broken notification tests

### DIFF
--- a/app/pages/notifications.spec.js
+++ b/app/pages/notifications.spec.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import assert from 'assert';
-// import Notifications from './notifications';
+import Notifications from './notifications';
 import { mount, shallow } from 'enzyme';
 
 const testNotifications = [
@@ -15,10 +15,13 @@ const testNotifications = [
   { id: '125',
     section: 'zooniverse',
   },
+  { id: '126',
+    section: 'project-4321',
+  }
 ];
 
-describe.skip('Notifications', function() {
-  let wrapper;
+describe('Notifications', function() {
+  let wrapper, notifications;
 
   describe('it will display according to user', function() {
     it('will ask user to sign in', function() {
@@ -37,16 +40,16 @@ describe.skip('Notifications', function() {
       wrapper = shallow(
         <Notifications user={{ id: 1 }} />,
       );
-      const arrangedNotifications = wrapper.instance().groupNotifications(testNotifications);
-      wrapper.setState({ projNotifications: arrangedNotifications });
+      wrapper.instance().groupNotifications(testNotifications);
+      notifications = shallow(wrapper.instance().renderNotifications())
     });
 
     it('will place zooniverse section first', function() {
-      assert.equal(wrapper.find('.list').childAt(0).prop('section'), 'zooniverse');
+      assert.equal(notifications.find('.list').childAt(0).prop('section'), 'zooniverse');
     });
 
     it('will display correct number of sections', function() {
-      assert.equal(wrapper.find('.list').children().length, 3);
+      assert.equal(notifications.find('.list').children().length, 3);
     });
   });
 });

--- a/app/pages/notifications/notification-section.spec.js
+++ b/app/pages/notifications/notification-section.spec.js
@@ -1,9 +1,7 @@
-// These tests are skipped until a solution can be found for cjsx imports with the coffee-script test compiler
-
 import React from 'react';
 import assert from 'assert';
 import { shallow } from 'enzyme';
-// import NotificationSection from './notification-section';
+import NotificationSection from './notification-section';
 
 const notifications = [
   { notification: {
@@ -26,7 +24,7 @@ const notifications = [
   },
 ];
 
-describe.skip('Notification Section', function() {
+describe('Notification Section', function() {
   let wrapper;
 
   describe('it can display a Zooniverse section', function () {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "check-engines": "~1.2.0",
     "cjsx-loader": "~3.0.0",
     "coffee-loader": "~0.7.2",
+    "coffee-react": "~5.0.1",
     "coffee-script": "~1.10.0",
     "copy-webpack-plugin": "~2.1.3",
     "css-loader": "~0.23.1",
@@ -110,6 +111,6 @@
     "stage-with-docker": "./bin/run-through-docker.sh 'npm run stage'",
     "_deploy": "export PATH_ROOT=www.zooniverse.org; npm run _build && npm run _publish",
     "deploy": "export NODE_ENV=production; npm run _deploy",
-    "test": "export NODE_ENV=development; mocha test/setup.js $(find app -name *.spec.js) --reporter nyan --compilers js:babel-core/register,coffee:coffee-script/register"
+    "test": "export NODE_ENV=development; mocha test/setup.js $(find app -name *.spec.js) --reporter nyan --compilers js:babel-core/register,coffee:coffee-script/register,cjsx:coffee-react/register"
   }
 }


### PR DESCRIPTION
Fixes the notification tests.
Uses `coffee-react` to parse cjsx components.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?