### PR TITLE
Add Back Project Specific Notifications Page

### DIFF
--- a/app/pages/notifications.jsx
+++ b/app/pages/notifications.jsx
@@ -100,7 +100,7 @@ export default class NotificationsPage extends React.Component {
       );
     } else if (this.state.projNotifications.length === 0) {
       notificationView = (
-        <div className="centering talk-module">
+        <div className="centering talk-module notifications-title">
           <Translate content="notifications.noNotifications" />
           <Translate content="notifications.participation" />
         </div>

--- a/app/pages/notifications.jsx
+++ b/app/pages/notifications.jsx
@@ -26,7 +26,7 @@ export default class NotificationsPage extends React.Component {
   }
 
   componentWillMount() { // eslint-disable-line
-    if (this.props.user) return this.getProjectNotifications();
+    if (this.props.user) this.getProjectNotifications();
   }
 
   componentWillReceiveProps(nextProps) { // eslint-disable-line
@@ -41,6 +41,9 @@ export default class NotificationsPage extends React.Component {
     talkClient.type('notifications').get({ page: 1, page_size: 50 })
     .then((projNotifications) => {
       this.groupNotifications(projNotifications);
+    })
+    .then(() => {
+      if (this.props.project) this.setState({ expanded: `project-${this.props.project.id}` });
     });
   }
 
@@ -58,6 +61,16 @@ export default class NotificationsPage extends React.Component {
         }
       }
     });
+    if (this.props.project && projectSections.indexOf(`project-${this.props.project.id}`) < 0) {
+      talkClient.type('notifications').get({ page: 1, page_size: 1, section: `project-${this.props.project.id}` })
+      .then(([notification]) => {
+        if (notification) {
+          projectNotifications.push(notification);
+          this.setState({ projNotifications: projectNotifications });
+          this.setState({ expanded: `project-${this.props.project.id}` });
+        }
+      });
+    }
     this.setState({ projNotifications: projectNotifications });
   }
 
@@ -69,8 +82,9 @@ export default class NotificationsPage extends React.Component {
         <div>
           <div className="list">
             {this.state.projNotifications.map((notification, i) => {
+              const opened = notification.section === this.state.expanded || this.state.projNotifications.length === 1;
               return (
-                <CollapsableSection key={i} callbackParent={this.onChildChanged} expanded={notification.section === this.state.expanded} section={notification.section}>
+                <CollapsableSection key={i} callbackParent={this.onChildChanged} expanded={opened} section={notification.section}>
                   <NotificationSection
                     key={notification.id}
                     location={this.props.location}
@@ -100,6 +114,7 @@ export default class NotificationsPage extends React.Component {
 
   render() {
     let signedIn;
+    const headerStyle = this.props.project ? 'notifications-title talk-module' : 'notifications-title';
 
     if (this.props.user) {
       signedIn = this.renderNotifications();
@@ -114,7 +129,7 @@ export default class NotificationsPage extends React.Component {
     return (
       <div className="talk notifications">
         <div className="content-container">
-          <h3 className="centering title notifications-title">
+          <h3 className={headerStyle}>
             <Translate content="notifications.title" />
           </h3>
 
@@ -128,6 +143,9 @@ export default class NotificationsPage extends React.Component {
 NotificationsPage.propTypes = {
   location: React.PropTypes.shape({
     query: React.PropTypes.object
+  }),
+  project: React.PropTypes.shape({
+    id: React.PropTypes.string
   }),
   user: React.PropTypes.shape({
     display_name: React.PropTypes.string,

--- a/app/pages/notifications.spec.js
+++ b/app/pages/notifications.spec.js
@@ -7,18 +7,22 @@ import { mount, shallow } from 'enzyme';
 
 const testNotifications = [
   { id: '123',
-    section: 'project-4321',
+    section: 'project-4321'
   },
   { id: '124',
-    section: 'project-1234',
+    section: 'project-1234'
   },
   { id: '125',
-    section: 'zooniverse',
+    section: 'zooniverse'
   },
   { id: '126',
-    section: 'project-4321',
+    section: 'project-4321'
   }
 ];
+
+const testProject = {
+  id: '1234'
+};
 
 describe('Notifications', function() {
   let wrapper, notifications;
@@ -50,6 +54,27 @@ describe('Notifications', function() {
 
     it('will display correct number of sections', function() {
       assert.equal(notifications.find('.list').children().length, 3);
+    });
+  });
+
+  describe('will open sections correctly', function() {
+    beforeEach(function () {
+      wrapper = shallow(
+        <Notifications user={{ id: 1 }} project={testProject} />,
+      );
+      wrapper.setState({ expanded: 'project-1234' });
+      wrapper.instance().groupNotifications(testNotifications);
+      notifications = shallow(wrapper.instance().renderNotifications())
+    });
+
+    it('will open the active project', function() {
+      let activeProject = notifications.find('CollapsableSection').filterWhere(n => n.prop('section') === 'project-1234');
+      assert.equal(activeProject.prop('expanded'), true);
+    });
+
+    it('will keep other projects closed', function() {
+      let activeProject = notifications.find('CollapsableSection').filterWhere(n => n.prop('section') === 'project-4321');
+      assert.equal(activeProject.prop('expanded'), false);
     });
   });
 });

--- a/app/pages/notifications.spec.js
+++ b/app/pages/notifications.spec.js
@@ -20,10 +20,6 @@ const testNotifications = [
   }
 ];
 
-const testProject = {
-  id: '1234'
-};
-
 describe('Notifications', function() {
   let wrapper, notifications;
 
@@ -60,7 +56,7 @@ describe('Notifications', function() {
   describe('will open sections correctly', function() {
     beforeEach(function () {
       wrapper = shallow(
-        <Notifications user={{ id: 1 }} project={testProject} />,
+        <Notifications user={{ id: 1 }} />,
       );
       wrapper.setState({ expanded: 'project-1234' });
       wrapper.instance().groupNotifications(testNotifications);

--- a/app/talk/lib/notifications-link.cjsx
+++ b/app/talk/lib/notifications-link.cjsx
@@ -24,7 +24,11 @@ module.exports = React.createClass
   render: ->
     return null unless @props.user and @context.unreadNotificationsCount?
 
+    {owner, name} = @props.params
     linkProps = @props.linkProps
     linkProps['aria-label'] = @ariaLabel()
 
-    <Link to="/notifications" {...linkProps}>{@label()}</Link>
+    if owner and name
+      <Link to="/projects/#{owner}/#{name}/notifications" {...linkProps}>{@label()}</Link>
+    else
+      <Link to="/notifications" {...linkProps}>{@label()}</Link>

--- a/css/notification-section.styl
+++ b/css/notification-section.styl
@@ -54,7 +54,7 @@
     float: right
 
 .notifications-title
-  margin: 0 10%
+  margin: 0 10% 1em 10%
   padding: 1em 0 0.75em 0
   text-align: center
 

--- a/css/notification-section.styl
+++ b/css/notification-section.styl
@@ -54,6 +54,7 @@
     float: right
 
 .notifications-title
+  margin: 0 10%
   padding: 1em 0 0.75em 0
   text-align: center
 


### PR DESCRIPTION
Describe your changes.
This adds back the route to a project specific notifications page based on user feedback. The project specific page does two things: 

- Double checks that the project notifications are present, if available.

- Automatically opens the section associated with that project.

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [X] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)

https://open-section.pfe-preview.zooniverse.org/

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?