### PR TITLE
Add first-to-classify subject split testing

### DIFF
--- a/app/classifier/classification-summary.cjsx
+++ b/app/classifier/classification-summary.cjsx
@@ -1,4 +1,6 @@
 React = require 'react'
+apiClient = require 'panoptes-client/lib/api-client'
+{TextSplit} = require 'seven-ten'
 tasks = require './tasks'
 
 module.exports = React.createClass
@@ -7,9 +9,20 @@ module.exports = React.createClass
   getDefaultProps: ->
     workflow: null
     classification: null
+    classificationCount: null
 
   render: ->
+    # first time the subject was classified
+    firstTimeClassified = @props.classificationCount? and @props.classificationCount is 0
+
     <div className="classification-summary">
+      {if firstTimeClassified
+        <TextSplit splitKey="subject.first-to-classify"
+          textKey="message"
+          splits={this.props.splits}
+          default={''}
+          elementType={"p"} />}
+
       {if @props.classification.annotations.length is 0
         'No annotations'
       else

--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -101,11 +101,23 @@ Classifier = React.createClass
     if @props.project.experimental_tools?.indexOf('expert comparison summary') > -1
       @getExpertClassification @props.workflow, @props.subject
 
+    @loadClassificationsCount subject
+
     preloadSubject subject
       .then =>
         if @props.subject is subject # The subject could have changed while we were loading.
           @setState subjectLoading: false
           @props.onLoad?()
+
+  loadClassificationsCount: (subject) ->
+    if @props.splits?['subject.first-to-classify']
+      query =
+        workflow_id: @props.workflow.id
+        subject_id: subject.id
+
+      apiClient.type('subject_workflow_statuses').get(query).then ([sws]) =>
+        classificationCount = sws?.classifications_count or 0
+        @setState {classificationCount}
 
   getExpertClassification: (workflow, subject) ->
     awaitExpertClassification = Promise.resolve do =>
@@ -359,7 +371,12 @@ Classifier = React.createClass
           else
             'Your classification:'}
         </strong>
-        <ClassificationSummary workflow={@props.workflow} classification={classification} />
+        <ClassificationSummary
+          workflow={@props.workflow}
+          classification={classification}
+          classificationCount={@state.classificationCount}
+          splits={@props.splits}
+        />
       </div>
 
       <hr />


### PR DESCRIPTION
Adds a 7-10 message for the first user to classify a subject.

Staged at https://first-to-classify.pfe-preview.zooniverse.org/projects/parrish/a-project/classify

We should also take care that this gets picked up in #3319

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [x] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?