### PR TITLE
Add segmented freehand tools, refactor existing freehand tools to return points array

### DIFF
--- a/app/classifier/drawing-tools/freehand-helpers.coffee
+++ b/app/classifier/drawing-tools/freehand-helpers.coffee
@@ -1,0 +1,8 @@
+createPathFromCoords = (coordsArray) ->
+  [firstCoord, otherCoords...] = coordsArray
+  path = "M #{firstCoord.x},#{firstCoord.y} "
+  path += "L #{x},#{y} " for {x, y} in otherCoords
+  path
+
+module.exports = 
+  createPathFromCoords: createPathFromCoords

--- a/app/classifier/drawing-tools/freehand-line.cjsx
+++ b/app/classifier/drawing-tools/freehand-line.cjsx
@@ -56,9 +56,10 @@ module.exports = React.createClass
     path = createPathFromCoords points
 
     <DrawingToolRoot tool={this}>
-      <path d={path} 
+      <path d={path}
         strokeWidth={GRAB_STROKE_WIDTH / ((@props.scale.horizontal + @props.scale.vertical) / 2)}
-        strokeOpacity="0" 
+        strokeOpacity="0"
+        fill="none"
         className="clickable" />
       <path d={path} fill="none" className="clickable" />
 

--- a/app/classifier/drawing-tools/freehand-segment-line.cjsx
+++ b/app/classifier/drawing-tools/freehand-segment-line.cjsx
@@ -35,6 +35,11 @@ module.exports = React.createClass
 
     isComplete: (mark) ->
       !mark._inProgress
+
+    forceComplete: (mark) ->
+      mark._inProgress = false
+      mark._currentlyDrawing = false
+      mark.auto_closed = true
     
   componentDidMount: ->
     document.addEventListener 'mousemove', @handleMouseMove
@@ -58,6 +63,7 @@ module.exports = React.createClass
   handleFinishClick: ->
     document.removeEventListener 'mousemove', @handleMouseMove
     @props.mark._inProgress = false
+    @props.mark._currentlyDrawing = false
     @props.onChange @props.mark
 
   handleFinishHover: (e) ->
@@ -107,27 +113,27 @@ module.exports = React.createClass
             getScreenCurrentTransformationMatrix={@props.getScreenCurrentTransformationMatrix} />
         </g>}
 
-        {if _inProgress and points.length and @state.mouseWithinViewer
-          <line className="guideline" 
-            x1={lastPoint.x} 
-            y1={lastPoint.y} 
-            x2={@state.mouseX} 
-            y2={@state.mouseY} />}
+      {if @props.selected and _inProgress and points.length and @state.mouseWithinViewer
+        <line className="guideline" 
+          x1={lastPoint.x} 
+          y1={lastPoint.y} 
+          x2={@state.mouseX} 
+          y2={@state.mouseY} />}
 
-        {if _inProgress and not _currentlyDrawing
-          averageScale = (@props.scale.horizontal + @props.scale.vertical) / 2
-          <g>
-            {if @state.lastPointHover
-              <circle r={FINISHER_RADIUS / averageScale} cx={lastPoint.x} cy={lastPoint.y} />}
-              
-            <circle className="clickable" 
-              r={POINT_RADIUS / averageScale} 
-              cx={lastPoint.x} 
-              cy={lastPoint.y} 
-              onClick={@handleFinishClick} 
-              onMouseEnter={@handleFinishHover} 
-              onMouseLeave={@handleFinishHover} 
-              fill="currentColor" />
-          </g>}
+      {if @props.selected and _inProgress and not _currentlyDrawing
+        averageScale = (@props.scale.horizontal + @props.scale.vertical) / 2
+        <g>
+          {if @state.lastPointHover
+            <circle r={FINISHER_RADIUS / averageScale} cx={lastPoint.x} cy={lastPoint.y} />}
+            
+          <circle className="clickable" 
+            r={POINT_RADIUS / averageScale} 
+            cx={lastPoint.x} 
+            cy={lastPoint.y} 
+            onClick={@handleFinishClick} 
+            onMouseEnter={@handleFinishHover} 
+            onMouseLeave={@handleFinishHover} 
+            fill="currentColor" />
+        </g>}
       }
     </DrawingToolRoot>

--- a/app/classifier/drawing-tools/freehand-segment-line.cjsx
+++ b/app/classifier/drawing-tools/freehand-segment-line.cjsx
@@ -1,0 +1,133 @@
+React = require 'react'
+DrawingToolRoot = require './root'
+deleteIfOutOfBounds = require './delete-if-out-of-bounds'
+DeleteButton = require './delete-button'
+{createPathFromCoords} = require './freehand-helpers'
+
+BUFFER = 16
+DELETE_BUTTON_WIDTH = 8
+FINISHER_RADIUS = 8
+GRAB_STROKE_WIDTH = 6
+MINIMUM_LENGTH = 20
+POINT_RADIUS = 4
+
+module.exports = React.createClass
+  displayName: 'FreehandSegmentLineTool'
+
+  statics:
+    initCoords: null
+
+    defaultValues: ->
+      points: []
+      _inProgress: false
+      _currentlyDrawing: false
+
+    initStart: ({x, y}, mark) ->
+      mark.points.push {x, y}
+      _inProgress: true
+      _currentlyDrawing: true
+
+    initMove: ({x, y}, mark) ->
+      mark.points.push {x, y}
+
+    initRelease: ->
+      _currentlyDrawing: false
+
+    isComplete: (mark) ->
+      !mark._inProgress
+    
+  componentDidMount: ->
+    document.addEventListener 'mousemove', @handleMouseMove
+
+  componentWillMount: ->
+    @setState
+      mouseX: @props.mark.points[0].x
+      mouseY: @props.mark.points[0].y
+      mouseWithinViewer: true
+
+  componentWillUnmount: ->
+    document.removeEventListener 'mousemove', @handleMouseMove
+
+  getDeletePosition: ([startCoords, otherCoords...]) ->
+    scale = (@props.scale.horizontal + @props.scale.vertical) / 2
+    mod = (BUFFER / scale)
+    x = startCoords.x - mod
+    x: if not @outOfBounds(x, scale) then x else startCoords.x + mod
+    y: startCoords.y
+
+  handleFinishClick: ->
+    document.removeEventListener 'mousemove', @handleMouseMove
+    @props.mark._inProgress = false
+    @props.onChange @props.mark
+
+  handleFinishHover: (e) ->
+    if e.type == 'mouseenter'
+      @setState lastPointHover: true
+    else if e.type == 'mouseleave'
+      @setState lastPointHover: false
+
+  handleMouseMove: (e) ->
+    newCoord = @props.getEventOffset(e)
+
+    mouseWithinViewer = if e.pageX < @props.containerRect.left || e.pageX > @props.containerRect.right
+      false
+    else if e.pageY < @props.containerRect.top || e.pageY > @props.containerRect.bottom
+      false
+    else
+      true
+
+    @setState
+      mouseX: newCoord.x 
+      mouseY: newCoord.y
+      mouseWithinViewer: mouseWithinViewer
+
+  outOfBounds: (deleteBtnX, scale) ->
+    deleteBtnX - (DELETE_BUTTON_WIDTH / scale) < 0
+
+  render: ->
+    { _inProgress, _currentlyDrawing, points } = @props.mark
+    path = createPathFromCoords points
+
+    <DrawingToolRoot tool={this}>
+      <path d={path} 
+        fill="none" 
+        strokeWidth={GRAB_STROKE_WIDTH / ((@props.scale.horizontal + @props.scale.vertical) / 2)}
+        stroke="transparent" 
+        className="clickable" />
+      <path d={path} fill="none" className="clickable" />
+
+      {if @props.selected
+        deletePosition = @getDeletePosition points
+        [..., lastPoint] = points
+
+        <g>
+          <DeleteButton tool={this} 
+            x={deletePosition.x} 
+            y={deletePosition.y} 
+            getScreenCurrentTransformationMatrix={@props.getScreenCurrentTransformationMatrix} />
+        </g>}
+
+        {if _inProgress and points.length and @state.mouseWithinViewer
+          <line className="guideline" 
+            x1={lastPoint.x} 
+            y1={lastPoint.y} 
+            x2={@state.mouseX} 
+            y2={@state.mouseY} />}
+
+        {if _inProgress and not _currentlyDrawing
+          averageScale = (@props.scale.horizontal + @props.scale.vertical) / 2
+          <g>
+            {if @state.lastPointHover
+              <circle r={FINISHER_RADIUS / averageScale} cx={lastPoint.x} cy={lastPoint.y} />}
+              
+            <circle className="clickable" 
+              r={POINT_RADIUS / averageScale} 
+              cx={lastPoint.x} 
+              cy={lastPoint.y} 
+              onClick={@handleFinishClick} 
+              onMouseEnter={@handleFinishHover} 
+              onMouseLeave={@handleFinishHover} 
+              fill="currentColor" />
+          </g>}
+      }
+    </DrawingToolRoot>

--- a/app/classifier/drawing-tools/freehand-segment-shape.cjsx
+++ b/app/classifier/drawing-tools/freehand-segment-shape.cjsx
@@ -35,6 +35,11 @@ module.exports = React.createClass
     isComplete: (mark) ->
       !mark._inProgress
     
+    forceComplete: (mark) ->
+      mark._inProgress = false
+      mark._currentlyDrawing = false
+      mark.auto_closed = true
+
   componentDidMount: ->
     document.addEventListener 'mousemove', @handleMouseMove
 
@@ -106,27 +111,27 @@ module.exports = React.createClass
             getScreenCurrentTransformationMatrix={@props.getScreenCurrentTransformationMatrix} />
         </g>}
 
-        {if _inProgress and points.length and @state.mouseWithinViewer
-          <line className="guideline" 
-            x1={lastPoint.x} 
-            y1={lastPoint.y} 
-            x2={@state.mouseX} 
-            y2={@state.mouseY} />}
+      {if @props.selected and _inProgress and points.length and @state.mouseWithinViewer
+        <line className="guideline" 
+          x1={lastPoint.x} 
+          y1={lastPoint.y} 
+          x2={@state.mouseX} 
+          y2={@state.mouseY} />}
 
-        {if _inProgress and not _currentlyDrawing
-          averageScale = (@props.scale.horizontal + @props.scale.vertical) / 2
-          <g>
-            {if @state.firstPointHover
-              <circle r={FINISHER_RADIUS / averageScale} cx={firstPoint.x} cy={firstPoint.y} />}
-              
-            <circle className="clickable" 
-              r={POINT_RADIUS / averageScale} 
-              cx={firstPoint.x} 
-              cy={firstPoint.y} 
-              onClick={@handleFinishClick} 
-              onMouseEnter={@handleFinishHover} 
-              onMouseLeave={@handleFinishHover} 
-              fill="currentColor" />
-          </g>}
+      {if @props.selected and _inProgress and not _currentlyDrawing
+        averageScale = (@props.scale.horizontal + @props.scale.vertical) / 2
+        <g>
+          {if @state.firstPointHover
+            <circle r={FINISHER_RADIUS / averageScale} cx={firstPoint.x} cy={firstPoint.y} />}
+            
+          <circle className="clickable" 
+            r={POINT_RADIUS / averageScale} 
+            cx={firstPoint.x} 
+            cy={firstPoint.y} 
+            onClick={@handleFinishClick} 
+            onMouseEnter={@handleFinishHover} 
+            onMouseLeave={@handleFinishHover} 
+            fill="currentColor" />
+        </g>}
       }
     </DrawingToolRoot>

--- a/app/classifier/drawing-tools/freehand-segment-shape.cjsx
+++ b/app/classifier/drawing-tools/freehand-segment-shape.cjsx
@@ -1,0 +1,132 @@
+React = require 'react'
+DrawingToolRoot = require './root'
+deleteIfOutOfBounds = require './delete-if-out-of-bounds'
+DeleteButton = require './delete-button'
+{createPathFromCoords} = require './freehand-helpers'
+
+BUFFER = 16
+DELETE_BUTTON_WIDTH = 8
+FINISHER_RADIUS = 8
+MINIMUM_LENGTH = 20
+POINT_RADIUS = 4
+
+module.exports = React.createClass
+  displayName: 'FreehandSegmentShapeTool'
+
+  statics:
+    initCoords: null
+
+    defaultValues: ->
+      points: []
+      _inProgress: false
+      _currentlyDrawing: false
+
+    initStart: ({x, y}, mark) ->
+      mark.points.push {x, y}
+      _inProgress: true
+      _currentlyDrawing: true
+
+    initMove: ({x, y}, mark) ->
+      mark.points.push {x, y}
+
+    initRelease: ->
+      _currentlyDrawing: false
+
+    isComplete: (mark) ->
+      !mark._inProgress
+    
+  componentDidMount: ->
+    document.addEventListener 'mousemove', @handleMouseMove
+
+  componentWillMount: ->
+    @setState
+      mouseX: @props.mark.points[0].x
+      mouseY: @props.mark.points[0].y
+      mouseWithinViewer: true
+
+  componentWillUnmount: ->
+    document.removeEventListener 'mousemove', @handleMouseMove
+
+  getDeletePosition: ([startCoords, otherCoords...]) ->
+    scale = (@props.scale.horizontal + @props.scale.vertical) / 2
+    mod = (BUFFER / scale)
+    x = startCoords.x - mod
+    x: if not @outOfBounds(x, scale) then x else startCoords.x + mod
+    y: startCoords.y
+
+  handleFinishClick: ->
+    document.removeEventListener 'mousemove', @handleMouseMove
+    @props.mark.points.push @props.mark.points[0]
+    @props.mark._inProgress = false
+    @props.onChange @props.mark
+
+  handleFinishHover: (e) ->
+    if e.type == 'mouseenter'
+      @setState firstPointHover: true
+    else if e.type == 'mouseleave'
+      @setState firstPointHover: false
+
+  handleMouseMove: (e) ->
+    newCoord = @props.getEventOffset(e)
+
+    mouseWithinViewer = if e.pageX < @props.containerRect.left || e.pageX > @props.containerRect.right
+      false
+    else if e.pageY < @props.containerRect.top || e.pageY > @props.containerRect.bottom
+      false
+    else
+      true
+
+    @setState
+      mouseX: newCoord.x 
+      mouseY: newCoord.y
+      mouseWithinViewer: mouseWithinViewer
+
+  outOfBounds: (deleteBtnX, scale) ->
+    deleteBtnX - (DELETE_BUTTON_WIDTH / scale) < 0
+
+  render: ->
+    { _currentlyDrawing, _inProgress, points } = @props.mark
+    path = createPathFromCoords points
+    fill = if _inProgress then 'none' else @props.color
+
+    <DrawingToolRoot tool={this}>
+      <path d={path} 
+        fill={fill} 
+        fillOpacity="0.2" 
+        className="clickable" />
+
+      {if @props.selected
+        [firstPoint, ..., lastPoint] = points
+        deletePosition = @getDeletePosition points
+
+        <g>
+          <DeleteButton tool={this} 
+            x={deletePosition.x} 
+            y={deletePosition.y} 
+            getScreenCurrentTransformationMatrix={@props.getScreenCurrentTransformationMatrix} />
+        </g>}
+
+        {if _inProgress and points.length and @state.mouseWithinViewer
+          <line className="guideline" 
+            x1={lastPoint.x} 
+            y1={lastPoint.y} 
+            x2={@state.mouseX} 
+            y2={@state.mouseY} />}
+
+        {if _inProgress and not _currentlyDrawing
+          averageScale = (@props.scale.horizontal + @props.scale.vertical) / 2
+          <g>
+            {if @state.firstPointHover
+              <circle r={FINISHER_RADIUS / averageScale} cx={firstPoint.x} cy={firstPoint.y} />}
+              
+            <circle className="clickable" 
+              r={POINT_RADIUS / averageScale} 
+              cx={firstPoint.x} 
+              cy={firstPoint.y} 
+              onClick={@handleFinishClick} 
+              onMouseEnter={@handleFinishHover} 
+              onMouseLeave={@handleFinishHover} 
+              fill="currentColor" />
+          </g>}
+      }
+    </DrawingToolRoot>

--- a/app/classifier/drawing-tools/index.coffee
+++ b/app/classifier/drawing-tools/index.coffee
@@ -4,6 +4,8 @@ module.exports =
   column: require './column-rectangle'
   ellipse: require './ellipse'
   freehandLine: require './freehand-line'
+  freehandSegmentLine: require './freehand-segment-line'
+  freehandSegmentShape: require './freehand-segment-shape'
   freehandShape: require './freehand-shape'
   grid: require './grid'
   line: require './line'

--- a/app/classifier/tasks/drawing/icons.cjsx
+++ b/app/classifier/tasks/drawing/icons.cjsx
@@ -54,3 +54,11 @@ module.exports =
   freehandShape: <svg viewBox="0 0 100 100">
     <path d="M20,60 C10,10,80,10,50,50 C20,90 90,90 80,40 z" />
   </svg>
+
+  freehandSegmentLine: <svg viewBox="0 0 100 100">
+    <path d="M10,50 Q25,10,50,50,75,90,90,50" fill={'none'} />
+  </svg>
+
+  freehandSegmentShape: <svg viewBox="0 0 100 100">
+    <path d="M20,60 C10,10,80,10,50,50 C20,90 90,90 80,40 z" />
+  </svg>

--- a/app/classifier/tasks/generic-editor.cjsx
+++ b/app/classifier/tasks/generic-editor.cjsx
@@ -122,13 +122,17 @@ module.exports = React.createClass
                         Type{' '}
                         <select name="#{@props.taskPrefix}.#{choicesKey}.#{index}.type" value={choice.type} onChange={handleChange}>
                           {for toolKey of drawingTools
-                            <option key={toolKey} value={toolKey}>{toolKey}</option> unless toolKey in ["grid", "freehandLine", "freehandShape"]}
+                            <option key={toolKey} value={toolKey}>{toolKey}</option> unless toolKey in ["grid", "freehandLine", "freehandShape", "freehandSegmentLine", "freehandSegmentShape"]}
                           {if @canUse("grid")
                             <option key="grid" value="grid">grid</option>}
                           {if @canUse("freehandLine")
                             <option key="freehandLine" value="freehandLine">freehand line</option>}
                           {if @canUse("freehandShape")
                             <option key="freehandShape" value="freehandShape">freehand shape</option>}
+                          {if @canUse("freehandSegmentLine")
+                            <option key="freehandSegmentLine" value="freehandSegmentLine">freehand segment line</option>}
+                          {if @canUse("freehandSegmentShape")
+                            <option key="freehandSegmentShape" value="freehandSegmentShape">freehand segment shape</option>}
                         </select>
                       </AutoSave>
                     </div>

--- a/app/pages/admin/project-status/experimental-features.jsx
+++ b/app/pages/admin/project-status/experimental-features.jsx
@@ -20,7 +20,9 @@ const experimentalFeatures = [
   'export classifications by workflow',
   'freehandLine',
   'freehandShape',
-  'enable subject flags'
+  'freehandSegmentLine',
+  'freehandSegmentShape',
+  'enable subject flags',
 ];
 
 class ExperimentalFeatures extends Component {
@@ -51,7 +53,6 @@ class ExperimentalFeatures extends Component {
     if (this.props.project) {
       return this.props.project.experimental_tools || [];
     }
-
     return [];
   }
 

--- a/app/pages/dev-classifier/mock-data.coffee
+++ b/app/pages/dev-classifier/mock-data.coffee
@@ -127,6 +127,8 @@ workflow = apiClient.type('workflows').create
         {type: 'grid', label: 'Grid', color: 'purple'}
         {type: 'freehandLine', label: 'Freehand Line', color: 'deepskyblue'}
         {type: 'freehandShape', label: 'Freehand Shape', color: 'darkseagreen'}
+        {type: 'freehandSegmentLine', label: 'Freehand Segment Line', color: 'gold'}
+        {type: 'freehandSegmentShape', label: 'Freehand Segment Shape', color: 'goldenrod'}
         
 
       ]


### PR DESCRIPTION
Adds multi-step freehand drawing tools for larger freehand shapes, and refactors the existing ones to return an array of coordinates instead of a path string to make them consistent with the existing drawing tools.

The tools can be tested out at https://freehand-segment.pfe-preview.zooniverse.org/projects/rogerhutchings/etch-a-cell

cc @hrspiers 


# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch? https://freehand-segment.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?