### PR TITLE
Frame Annotator Rewrite into ES6

### DIFF
--- a/app/classifier/drawing-tools/point.cjsx
+++ b/app/classifier/drawing-tools/point.cjsx
@@ -5,10 +5,10 @@ Draggable = require '../../lib/draggable'
 DeleteButton = require './delete-button'
 isInBounds = require '../../lib/is-in-bounds'
 
-RADIUS = 
+RADIUS =
   large: 10
   small: 2
-SELECTED_RADIUS = 
+SELECTED_RADIUS =
   large: 20
   small: 10
 CROSSHAIR_SPACE = 0.2
@@ -35,12 +35,12 @@ module.exports = React.createClass
 
     initRelease: ->
       _inProgress: false
-    
+
     options: ['size']
 
   getDefaultProps: ->
     size: 'large'
-  
+
   getDeleteButtonPosition: ->
     theta = (DELETE_BUTTON_ANGLE) * (Math.PI / 180)
     x: (SELECTED_RADIUS.large / @props.scale.horizontal) * Math.cos theta
@@ -76,6 +76,5 @@ module.exports = React.createClass
   handleDrag: (e, d) ->
     difference = @props.normalizeDifference(e,d)
     @props.mark.x += difference.x
-    @props.mark.y += difference.y 
+    @props.mark.y += difference.y
     @props.onChange @props.mark
-    

--- a/app/classifier/drawing-tools/rectangle.cjsx
+++ b/app/classifier/drawing-tools/rectangle.cjsx
@@ -115,7 +115,7 @@ module.exports = React.createClass
 
   handleBottomLeftDrag: (e, d) ->
     difference = @props.normalizeDifference(e, d)
-    @props.mark.x += difference.x 
+    @props.mark.x += difference.x
     @props.mark.width -= difference.x
     @props.mark.height += difference.y
     @props.onChange @props.mark

--- a/app/classifier/frame-annotator.jsx
+++ b/app/classifier/frame-annotator.jsx
@@ -42,7 +42,7 @@ export default class FrameAnnotator extends React.Component {
       bottom += pageYOffset;
       return { left, right, top, bottom, width, height };
     }
-    return null;
+    return { left: 0, right: 0, top: 0, bottom: 0, width: 0, height: 0 };
   }
 
   getScale() {

--- a/app/classifier/frame-annotator.jsx
+++ b/app/classifier/frame-annotator.jsx
@@ -31,7 +31,7 @@ export default class FrameAnnotator extends React.Component {
   }
 
   getSizeRect() {
-    const clientRect = this.refs.sizeRect && this.refs.sizeRect.getBoundingClientRect();
+    const clientRect = this.sizeRect && this.sizeRect.getBoundingClientRect();
 
     if (clientRect) {
       const { width, height } = clientRect;
@@ -199,7 +199,7 @@ export default class FrameAnnotator extends React.Component {
 
           <svg ref="svgSubjectArea" className="subject" style={svgStyle} viewBox={createdViewBox} {...svgProps}>
             <g ref="transformationContainer" transform={this.props.transform}>
-              <rect ref="sizeRect" width={this.props.naturalWidth} height={this.props.naturalHeight} fill="rgba(0, 0, 0, 0.01)" fillOpacity="0.01" stroke="none" />
+              <rect ref={(rect) => { this.sizeRect = rect; }} width={this.props.naturalWidth} height={this.props.naturalHeight} fill="rgba(0, 0, 0, 0.01)" fillOpacity="0.01" stroke="none" />
               {type === 'image' && (
                 <Draggable onDrag={this.props.panByDrag} disabled={this.props.disabled}>
                   <SVGImage className={this.props.panEnabled ? 'pan-active' : ''} src={src} width={this.props.naturalWidth} height={this.props.naturalHeight} modification={this.props.modification} />

--- a/app/classifier/frame-annotator.jsx
+++ b/app/classifier/frame-annotator.jsx
@@ -181,12 +181,7 @@ export default class FrameAnnotator extends React.Component {
     Object.keys(tasks).map((task) => {
       const Component = tasks[task];
       if (Component.getSVGProps) {
-        const props = Component.getSVGProps(hookProps);
-        if (props) {
-          Object.keys(props).map((key) => {
-            svgProps[key] = props[key];
-          });
-        }
+        Object.assign(svgProps, Component.getSVGProps(hookProps));
       }
     });
 
@@ -194,7 +189,7 @@ export default class FrameAnnotator extends React.Component {
       <div className="frame-annotator">
         <div className="subject-area">
 
-          {BeforeSubject && (
+          {!!BeforeSubject && (
             <BeforeSubject {...hookProps} />)}
 
           <svg ref="svgSubjectArea" className="subject" style={svgStyle} viewBox={createdViewBox} {...svgProps}>
@@ -206,7 +201,7 @@ export default class FrameAnnotator extends React.Component {
                 </Draggable>
               )}
 
-              {(InsideSubject && !this.props.panEnabled) && (
+              {(!!InsideSubject && !this.props.panEnabled) && (
                 <InsideSubject {...hookProps} />
               )}
 
@@ -222,11 +217,11 @@ export default class FrameAnnotator extends React.Component {
 
           {this.props.children}
 
-          {warningBanner && (
+          {!!warningBanner && (
             warningBanner
           )}
 
-          {AfterSubject && (
+          {!!AfterSubject && (
             <AfterSubject {...hookProps} />)}
         </div>
       </div>

--- a/app/classifier/frame-annotator.jsx
+++ b/app/classifier/frame-annotator.jsx
@@ -23,158 +23,210 @@ export default class FrameAnnotator extends React.Component {
     if (nextProps.annotation !== this.props.annotation)
       this.handleAnnotationChange(this.props.annotation, nextProps.annotation)
   }
+
+  handleAnnotationChange(oldAnnotation, currentAnnotation) {
+    if (oldAnnotation) {
+      const lastTask = this.props.workflow.tasks[oldAnnotation.task];
+      const LastTaskComponent = tasks[lastTask.type];
+      if (LastTaskComponent.onLeaveAnnotation !== undefined) {
+        LastTaskComponent.onLeaveAnnotation(lastTask, oldAnnotation);
+      }
+    }
+  }
+
+  getSizeRect() {
+    const clientRect = this.refs.sizeRect && this.refs.sizeRect.getBoundingClientRect();
+
+    if (clientRect) {
+      const {left, right, top, bottom, width, height} = clientRect;
+      left += pageXOffset
+      right += pageXOffset
+      top += pageYOffset
+      bottom += pageYOffset
+      return {left, right, top, bottom, width, height}
+    }
+    return null;
+  }
+
+  getScale() {
+    const sizeRect = this.getSizeRect();
+    const horizontal = sizeRect ? sizeRect.width / this.props.naturalWidth : 0;
+    const vertical = sizeRect ? sizeRect.height / this.props.naturalHeight : 0;
+
+    return {horizontal, vertical};
+  }
+
+  // get current transformation matrix
+  getScreenCurrentTransformationMatrix() {
+    const svg = this.refs.svgSubjectArea;
+    return svg.getScreenCTM();
+  }
+
+  // transforms the event coordinates
+  // to points in the SVG coordinate system
+  eventCoordsToSVGCoords(x, y) {
+    const svg = this.refs.svgSubjectArea;
+    const newPoint = svg.createSVGPoint();
+    newPoint.x = x;
+    newPoint.y = y;
+    const matrixForWindowCoordsToSVGUserSpaceCoords = this.getMatrixForWindowCoordsToSVGUserSpaceCoords();
+    return newPoint.matrixTransform(matrixForWindowCoordsToSVGUserSpaceCoords);
+  }
+
+  // find the original matrix for the SVG coordinate system
+  getMatrixForWindowCoordsToSVGUserSpaceCoords() {
+    transformationContainer = this.refs.transformationContainer;
+    transformationContainer.getScreenCTM().inverse();
+  }
+
+  // transforms the difference between two event coordinates
+  // into the difference as represent in the SVG coordinate system
+  normalizeDifference(e, d) {
+    const difference = {}
+    const normalizedPoint1 = this.eventCoordsToSVGCoords(e.pageX - d.x, e.pageY - d.y);
+    const normalizedPoint2 = this.eventCoordsToSVGCoords(e.pageX, e.pageY);
+    difference.x =  normalizedPoint2.x - normalizedPoint1.x;
+    difference.y =  normalizedPoint2.y - normalizedPoint1.y;
+    return difference;
+  }
+
+  // get the offset of event coordiantes in terms of the SVG coordinate system
+  getEventOffset(e) {
+    return eventCoordsToSVGCoords(e.clientX, e.clientY);
+  }
+
+  render() {
+    let warningBanner;
+    let taskDescription;
+    let TaskComponent;
+
+    if (this.props.annotation) {
+      taskDescription = this.props.workflow.tasks[this.props.annotation.task];
+      TaskComponent = tasks[taskDescription.type];
+    }
+
+    if (this.state.alreadySeen) {
+      warningBanner = (
+        <WarningBanner label="Already seen!">
+          <p>Our records show that you’ve already seen this image. We might have run out of data for you in this workflow!</p>
+          <p>Try choosing a different workflow or contributing to a different project.</p>
+        </WarningBanner>
+      )
+    } else if (this.props.subject.retired) {
+      warningBanner = (
+        <WarningBanner label="Finished!">
+          <p>This subject already has enough classifications, so yours won’t be used in its analysis!</p>
+          <p>If you’re looking to help, try choosing a different workflow or contributing to a different project.</p>
+        </WarningBanner>
+    )}
+
+    const {type, format, src} = getSubjectLocation(this.props.subject, this.props.frame);
+    const createdViewBox = `${this.props.viewBoxDimensions.x} ${this.props.viewBoxDimensions.y} ${this.props.viewBoxDimensions.width} ${this.props.viewBoxDimensions.height}`;
+
+    const svgStyle = {}
+    if (type === 'image' && !props.loading) {
+      // Images are rendered again within the SVG itself.
+      // When cropped right next to the edge of the image,
+      // the original tag can show through, so fill the SVG to cover it.
+      svgStyle.background = 'black';
+
+      // Allow touch scrolling on subject for mobile and tablets
+      if (taskDescription) {
+        unless (taskDescription.type === 'drawing' || taskDescription.type === 'crop')
+          svgStyle.pointerEvents = 'none';
+      }
+      if (this.props.panEnabled === true) {
+        svgStyle.pointerEvents = 'all';
+      }
+    }
+
+    const svgProps = {};
+
+    if (TaskComponent) {
+      const {BeforeSubject, InsideSubject, AfterSubject} = TaskComponent;
+    }
+
+    const hookProps = {
+      taskTypes: tasks,
+      workflow: this.props.workflow,
+      task: taskDescription,
+      classification: this.props.classification,
+      annotation: this.props.annotation,
+      frame: this.props.frame,
+      scale: this.getScale(),
+      naturalWidth: this.props.naturalWidth,
+      naturalHeight: this.props.naturalHeight,
+      containerRect: this.getSizeRect(),
+      getEventOffset: this.getEventOffset,
+      onChange: this.props.onChange,
+      preferences: this.props.preferences,
+      normalizeDifference: this.normalizeDifference,
+      getScreenCurrentTransformationMatrix: this.getScreenCurrentTransformationMatrix
+    }
+
+    for (const task in tasks) {
+      const Component = tasks[task];
+      if (Component.getSVGProps !== null) {
+        const ref = Component.getSVGProps(hookProps);
+        for (const key in ref) {
+          const value = ref[key];
+          svgProps[key] = value;
+        }
+      }
+    }
+
+    return (
+      <div className="frame-annotator">
+        <div className="subject-area">
+
+          {BeforeSubject && (
+            <BeforeSubject {...hookProps} />)}
+
+            <svg ref="svgSubjectArea" className="subject" style={svgStyle} viewBox={createdViewBox} {...svgProps}>
+              <g ref="transformationContainer" transform={this.props.transform}>
+                <rect ref="sizeRect" width={this.props.naturalWidth} height={this.props.naturalHeight} fill="rgba(0, 0, 0, 0.01)" fillOpacity="0.01" stroke="none" />
+                {type === 'image' && (
+                  <Draggable onDrag={this.props.panByDrag} disabled={this.props.disabled}>
+                    <SVGImage className={this.props.panEnabled ? "pan-active" : ''} src={src} width={this.props.naturalWidth} height={this.props.naturalHeight} modification={this.props.modification} />
+                  </Draggable>
+                )}
+
+              {(InsideSubject && !this.props.panEnabled) && (
+                <InsideSubject {...hookProps} />
+              )}
+
+              {tasks.map((anyTaskName) => {
+                const PersistInsideSubject = tasks[anyTaskName];
+                if (PersistInsideSubject) {
+                  return <PersistInsideSubject key={anyTaskName} {...hookProps} />;
+                }
+              })}
+
+              </g>
+            </svg>
+
+            {this.props.children}
+
+            {WarningBanner && (
+              WarningBanner
+            )}
+
+            {AfterSubject && (
+              <AfterSubject {...hookProps} />)}
+            </div>
+          </div>
+    )
+  }
 }
 
-  getDefaultProps: ->
-    user: null
-    project: null
-    subject: null
-    workflow: null
-    classification: null
-    annotation: null
-    onLoad: Function.prototype
-    frame: 0
-    onChange: Function.prototype
-
-  handleAnnotationChange: (oldAnnotation, currentAnnotation) ->
-    if oldAnnotation?
-      lastTask = @props.workflow.tasks[oldAnnotation.task]
-      LastTaskComponent = tasks[lastTask.type]
-      if LastTaskComponent.onLeaveAnnotation?
-        LastTaskComponent.onLeaveAnnotation lastTask, oldAnnotation
-
-  getSizeRect: ->
-    clientRect = @refs.sizeRect?.getBoundingClientRect() # Read only
-    return null unless clientRect?
-    {left, right, top, bottom, width, height} = clientRect
-    left += pageXOffset
-    right += pageXOffset
-    top += pageYOffset
-    bottom += pageYOffset
-    {left, right, top, bottom, width, height}
-
-  getScale: ->
-    sizeRect = @getSizeRect()
-    horizontal = sizeRect?.width / @props.naturalWidth || 0
-    vertical = sizeRect?.height / @props.naturalHeight || 0
-    {horizontal, vertical}
-
-  # get current transformation matrix
-  getScreenCurrentTransformationMatrix: ()->
-    svg = @refs.svgSubjectArea
-    matrix = svg.getScreenCTM()
-
-  # transforms the event coordinates
-  # to points in the SVG coordinate system
-  eventCoordsToSVGCoords: (x, y) ->
-    svg = @refs.svgSubjectArea
-    newPoint = svg.createSVGPoint()
-    newPoint.x = x
-    newPoint.y = y
-    matrixForWindowCoordsToSVGUserSpaceCoords = @getMatrixForWindowCoordsToSVGUserSpaceCoords()
-    pointForSVGSystem = newPoint.matrixTransform(matrixForWindowCoordsToSVGUserSpaceCoords)
-    pointForSVGSystem
-
-  # find the original matrix for the SVG coordinate system
-  getMatrixForWindowCoordsToSVGUserSpaceCoords: ->
-    transformationContainer = @refs.transformationContainer
-    transformationContainer.getScreenCTM().inverse()
-
-  # transforms the difference between two event coordinates
-  # into the difference as represent in the SVG coordinate system
-  normalizeDifference: (e, d) ->
-    difference = {}
-    normalizedPoint1 = @eventCoordsToSVGCoords(e.pageX - d.x, e.pageY - d.y)
-    normalizedPoint2 = @eventCoordsToSVGCoords(e.pageX, e.pageY)
-    difference.x =  normalizedPoint2.x - normalizedPoint1.x
-    difference.y =  normalizedPoint2.y - normalizedPoint1.y
-    difference
-
-  # get the offset of event coordiantes in terms of the SVG coordinate system
-  getEventOffset: (e) ->
-    eventOffset = @eventCoordsToSVGCoords(e.clientX, e.clientY)
-
-  render: ->
-    taskDescription = @props.workflow.tasks[@props.annotation?.task]
-    TaskComponent = tasks[taskDescription?.type]
-    {type, format, src} = getSubjectLocation @props.subject, @props.frame
-
-    createdViewBox = "#{@props.viewBoxDimensions.x} #{@props.viewBoxDimensions.y} #{@props.viewBoxDimensions.width} #{@props.viewBoxDimensions.height}"
-
-    svgStyle = {}
-    if type is 'image' and not @props.loading
-      # Images are rendered again within the SVG itself.
-      # When cropped right next to the edge of the image,
-      # the original tag can show through, so fill the SVG to cover it.
-      svgStyle.background = 'black'
-
-      # Allow touch scrolling on subject for mobile and tablets
-      unless taskDescription?.type is 'drawing' or taskDescription?.type is 'crop'
-        svgStyle.pointerEvents = 'none'
-      if @props.panEnabled is true
-        svgStyle.pointerEvents = 'all'
-
-    svgProps = {}
-
-    if TaskComponent?
-      {BeforeSubject, InsideSubject, AfterSubject} = TaskComponent
-
-    hookProps =
-      taskTypes: tasks
-      workflow: @props.workflow
-      task: taskDescription
-      classification: @props.classification
-      annotation: @props.annotation
-      frame: @props.frame
-      scale: @getScale()
-      naturalWidth: @props.naturalWidth
-      naturalHeight: @props.naturalHeight
-      containerRect: @getSizeRect()
-      getEventOffset: this.getEventOffset
-      onChange: @props.onChange
-      preferences: @props.preferences
-      normalizeDifference: @normalizeDifference
-      getScreenCurrentTransformationMatrix: @getScreenCurrentTransformationMatrix
-
-    for task, Component of tasks when Component.getSVGProps?
-      for key, value of Component.getSVGProps hookProps
-        svgProps[key] = value
-
-    <div className="frame-annotator">
-      <div className="subject-area">
-        {if BeforeSubject?
-          <BeforeSubject {...hookProps} />}
-        <svg ref="svgSubjectArea" className="subject" style=svgStyle viewBox={createdViewBox} {...svgProps}>
-          <g ref="transformationContainer" transform={@props.transform} >
-            <rect ref="sizeRect" width={@props.naturalWidth} height={@props.naturalHeight} fill="rgba(0, 0, 0, 0.01)" fillOpacity="0.01" stroke="none" />
-            {if type is 'image'
-              <Draggable onDrag={@props.panByDrag} disabled={@props.disabled}>
-                <SVGImage className={"pan-active" if @props.panEnabled} src={src} width={@props.naturalWidth} height={@props.naturalHeight} modification={@props.modification} />
-              </Draggable>
-            }
-
-            {if InsideSubject? && !@props.panEnabled
-              <InsideSubject {...hookProps} />}
-
-            {for anyTaskName, {PersistInsideSubject} of tasks when PersistInsideSubject?
-              <PersistInsideSubject key={anyTaskName} {...hookProps} />}
-          </g>
-        </svg>
-        {@props.children}
-        {if @state.alreadySeen
-          <WarningBanner label="Already seen!">
-            <p>Our records show that you’ve already seen this image. We might have run out of data for you in this workflow!</p>
-            <p>Try choosing a different workflow or contributing to a different project.</p>
-          </WarningBanner>
-
-        else if @props.subject.retired
-          <WarningBanner label="Finished!">
-            <p>This subject already has enough classifications, so yours won’t be used in its analysis!</p>
-            <p>If you’re looking to help, try choosing a different workflow or contributing to a different project.</p>
-          </WarningBanner>
-        }
-
-        {if AfterSubject?
-          <AfterSubject {...hookProps} />}
-      </div>
-    </div>
+FrameAnnotator.defaultProps = {
+  user: null,
+  project: null,
+  subject: null,
+  workflow: null,
+  classification: null,
+  annotation: null,
+  onLoad: () => {},
+  frame: 0,
+  onChange: () => {}
+};

--- a/app/classifier/frame-annotator.jsx
+++ b/app/classifier/frame-annotator.jsx
@@ -1,13 +1,29 @@
-React = require 'react'
-Draggable = require '../lib/draggable'
-tasks = require './tasks'
-seenThisSession = require '../lib/seen-this-session'
-getSubjectLocation = require '../lib/get-subject-location'
-WarningBanner = require './warning-banner'
-`import SVGImage from '../components/svg-image';`
+import React from 'react';
+import Draggable from '../lib/draggable';
+import tasks from './tasks';
+import seenThisSession from '../lib/seen-this-session';
+import getSubjectLocation from '../lib/get-subject-location';
+import WarningBanner from './warning-banner';
+import SVGImage from '../components/svg-image';
 
-module.exports = React.createClass
-  displayName: 'FrameAnnotator'
+export default class FrameAnnotator extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      alreadySeen: false,
+      showWarning: false
+    };
+  }
+
+  componentDidMount() {
+    this.setState({ alreadySeen: this.props.subject.already_seen || seenThisSession.check(this.props.workflow, this.props.subject) });
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.annotation !== this.props.annotation)
+      this.handleAnnotationChange(this.props.annotation, nextProps.annotation)
+  }
+}
 
   getDefaultProps: ->
     user: null
@@ -19,17 +35,6 @@ module.exports = React.createClass
     onLoad: Function.prototype
     frame: 0
     onChange: Function.prototype
-
-  getInitialState: ->
-    alreadySeen: false
-    showWarning: false
-
-  componentDidMount: ->
-    @setState alreadySeen: @props.subject.already_seen or seenThisSession.check @props.workflow, @props.subject
-
-  componentWillReceiveProps: (nextProps) ->
-    if nextProps.annotation isnt @props.annotation
-      @handleAnnotationChange @props.annotation, nextProps.annotation
 
   handleAnnotationChange: (oldAnnotation, currentAnnotation) ->
     if oldAnnotation?
@@ -59,7 +64,7 @@ module.exports = React.createClass
     svg = @refs.svgSubjectArea
     matrix = svg.getScreenCTM()
 
-  # transforms the event coordinates 
+  # transforms the event coordinates
   # to points in the SVG coordinate system
   eventCoordsToSVGCoords: (x, y) ->
     svg = @refs.svgSubjectArea

--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -1,7 +1,6 @@
 React = require 'react'
 apiClient = require 'panoptes-client/lib/api-client'
 ChangeListener = require '../components/change-listener'
-FrameAnnotator = require './frame-annotator'
 SubjectViewer = require '../components/subject-viewer'
 ClassificationSummary = require './classification-summary'
 {Link} = require 'react-router'
@@ -18,6 +17,7 @@ Intervention = require '../lib/intervention'
 experimentsClient = require '../lib/experiments-client'
 interventionMonitor = require '../lib/intervention-monitor'
 Shortcut = require './tasks/shortcut'
+`import FrameAnnotator from './frame-annotator';`
 `import TutorialButton from './tutorial-button';`
 `import MiniCourseButton from './mini-course-button';`
 `import CacheClassification from '../components/cache-classification';`

--- a/app/classifier/tasks/crop/initializer.cjsx
+++ b/app/classifier/tasks/crop/initializer.cjsx
@@ -30,10 +30,10 @@ module.exports = React.createClass
           </Draggable>
 
           <g style={color: 'white'}>
-            <DragHandle x={x} y={y + (height / 2)} scale={@props.scale} onStart={@handleStartHandle} onDrag={@handleDragNear.bind this, 'x'}  style={cursor: 'ew-resize'} />
-            <DragHandle x={x + width} y={y + (height / 2)} scale={@props.scale} onStart={@handleStartHandle} onDrag={@handleDragFar.bind this, 'x'} style={cursor: 'ew-resize'} />
-            <DragHandle x={x + (width / 2)} y={y} scale={@props.scale} onStart={@handleStartHandle} onDrag={@handleDragNear.bind this, 'y'} style={cursor: 'ns-resize'} />
-            <DragHandle x={x + (width / 2)} y={y + height} scale={@props.scale} onStart={@handleStartHandle} onDrag={@handleDragFar.bind this, 'y'} style={cursor: 'ns-resize'} />
+            <DragHandle x={x} y={y + (height / 2)} scale={@props.scale} onStart={@handleStartHandle} onDrag={@handleDragNear.bind this, 'x'} getScreenCurrentTransformationMatrix={@props.getScreenCurrentTransformationMatrix} style={cursor: 'ew-resize'} />
+            <DragHandle x={x + width} y={y + (height / 2)} scale={@props.scale} onStart={@handleStartHandle} onDrag={@handleDragFar.bind this, 'x'} getScreenCurrentTransformationMatrix={@props.getScreenCurrentTransformationMatrix} style={cursor: 'ew-resize'} />
+            <DragHandle x={x + (width / 2)} y={y} scale={@props.scale} onStart={@handleStartHandle} onDrag={@handleDragNear.bind this, 'y'} getScreenCurrentTransformationMatrix={@props.getScreenCurrentTransformationMatrix} style={cursor: 'ns-resize'} />
+            <DragHandle x={x + (width / 2)} y={y + height} scale={@props.scale} onStart={@handleStartHandle} onDrag={@handleDragFar.bind this, 'y'} getScreenCurrentTransformationMatrix={@props.getScreenCurrentTransformationMatrix} style={cursor: 'ns-resize'} />
           </g>
         </g>}
     </g>
@@ -56,10 +56,11 @@ module.exports = React.createClass
     @props.classification.update 'annotation'
 
   handleBoxDrag: (e, d) ->
+    difference = @props.normalizeDifference(e, d)
     maxX = (@props.containerRect.width / @props.scale.horizontal) - @props.annotation.value.width
     maxY = (@props.containerRect.height / @props.scale.vertical) - @props.annotation.value.height
-    @props.annotation.value.x = Math.max 0, Math.min maxX, @props.annotation.value.x + d.x
-    @props.annotation.value.y = Math.max 0, Math.min maxY, @props.annotation.value.y + d.y
+    @props.annotation.value.x = Math.max 0, Math.min maxX, @props.annotation.value.x += difference.x
+    @props.annotation.value.y = Math.max 0, Math.min maxY, @props.annotation.value.y += difference.y
     @props.classification.update 'annotations'
 
   handleStartHandle: (e) ->

--- a/app/classifier/tasks/drawing/icons.cjsx
+++ b/app/classifier/tasks/drawing/icons.cjsx
@@ -43,8 +43,8 @@ module.exports =
   </svg>
 
   triangle: <svg viewBox="0 0 100 100">
-    <polygon class="shape" points="50, 12 95, 90 5,90 "/>
-    <ellipse class="shape" cx="50" cy="64" rx="17" ry="9"/>
+    <polygon className="shape" points="50, 12 95, 90 5,90 "/>
+    <ellipse className="shape" cx="50" cy="64" rx="17" ry="9"/>
   </svg>
 
   freehandLine: <svg viewBox="0 0 100 100">


### PR DESCRIPTION
Describe your changes.
This rewrites the `FrameAnnotator` component into ES6. There were a few bugs that arose while writing this code that are also addressed in this PR. Those include:

- **Crop Tool**: Making the tool visible and scale correctly for drag functionality

- There was a bug in the classifier concerning drawing tools. If you make a mark on a subject with a drawing tool, navigate away from the classifier, and return to the same workflow and subject, the classifier will hang because the `getSizeRect()` is returning null, and the mark you made previously doesn't know the width, height, x, y, etc. of null.

- **Triangle Tool**: The dev classifier used `class` instead of `className` for this icon.

# Review Checklist

- [X] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [X] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [X] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)

https://frame-rewrite.pfe-preview.zooniverse.org/

## Optional

- [X] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
A couple warnings persist, but they appear minor.
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?