### PR TITLE
Fix another 'cannot read property split of undefined' bug

### DIFF
--- a/app/talk/discussion-preview.cjsx
+++ b/app/talk/discussion-preview.cjsx
@@ -5,7 +5,8 @@ LatestCommentLink = require './latest-comment-link'
 apiClient = require 'panoptes-client/lib/api-client'
 getSubjectLocation = require '../lib/get-subject-location'
 
-`import Thumbnail from '../components/thumbnail';`
+# `import Thumbnail from '../components/thumbnail';`
+Thumbnail = require('../components/thumbnail').default
 
 module.exports = React.createClass
   displayName: 'TalkDiscussionPreview'

--- a/app/talk/discussion-preview.cjsx
+++ b/app/talk/discussion-preview.cjsx
@@ -16,6 +16,9 @@ module.exports = React.createClass
 
   contextTypes:
     geordi: React.PropTypes.object
+  
+  getDefaultProps: ->
+    project: {}
 
   getInitialState: ->
     subject: null

--- a/app/talk/discussion-preview.cjsx
+++ b/app/talk/discussion-preview.cjsx
@@ -43,7 +43,7 @@ module.exports = React.createClass
       {owner, name} = @props.params
       "/projects/#{owner}/#{name}/talk/#{discussion.board_id}/#{discussion.id}"
 
-    else if @props.project # otherwise fetch from project
+    else if @props.project.slug # otherwise fetch from project
       [owner, name] = @props.project.slug.split('/')
       "/projects/#{owner}/#{name}/talk/#{discussion.board_id}/#{discussion.id}"
 

--- a/app/talk/discussion-preview.spec.js
+++ b/app/talk/discussion-preview.spec.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import assert from 'assert';
+import {Link} from 'react-router';
+import { shallow } from 'enzyme';
+import DiscussionPreview from './discussion-preview';
+
+const validProject = {
+  id: 34,
+  slug: 'test/project'
+};
+
+const discussion = {
+  id: 42,
+  board_id: 3456,
+  latest_comment: 1234
+};
+
+describe('DiscussionPreview', function(){
+  it('should link to /talk without a project', () => {
+    const wrapper = shallow(<DiscussionPreview discussion={discussion} />);
+    assert.equal(wrapper.find(Link).prop('to'), '/talk/3456/42');
+  });
+  it('should link to /talk with an empty project', () => {
+    const project = {};
+    const wrapper = shallow(<DiscussionPreview project={project} discussion={discussion} />);
+    assert.equal(wrapper.find(Link).prop('to'), '/talk/3456/42');
+  });
+  it('should link to a project slug if present', () => {
+    const wrapper = shallow(<DiscussionPreview project={validProject} discussion={discussion} />);
+    assert.equal(wrapper.find(Link).prop('to'), '/projects/test/project/talk/3456/42');
+  });
+});


### PR DESCRIPTION
Fixes search on top-level Zoo Talk, where project slugs are undefined.