### PR TITLE
Fix Collections Error Handling

### DIFF
--- a/app/collections/create-form.cjsx
+++ b/app/collections/create-form.cjsx
@@ -32,12 +32,12 @@ module.exports = React.createClass
     }
 
     apiClient.type('collections').create(collection).save()
-      .catch (e) =>
-        @setState error: e
       .then (collection) =>
         @refs.name.value = ''
         @refs.private.value = true
         @props.onSubmit collection
+      .catch (e) =>
+        @setState error: e
 
   handleNameInputChange: ->
     @setState collectionNameLength: @refs.name.value.length


### PR DESCRIPTION
Fixes #3433  .

Describe your changes.
It looks like everything was already set up to show the error on the front end. I think the problem was that the `.then` statement would always be returned (even if there was an error) causing the modal to close without the error being seen. Moving the `.catch` to the end of the API call will keep the modal open when an error is returned.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [X] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)

https://fix-3433.pfe-preview.zooniverse.org/

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?