### PR TITLE
Increase Size of Label in Survey Projects

### DIFF
--- a/css/survey-task.styl
+++ b/css/survey-task.styl
@@ -9,9 +9,9 @@ $survey-task-pill-button
   border-radius: 3px
   color: white
   display: inline-block
-  font-size: 10px
+  font-size: 12px
   font-weight: bold
-  padding: 0 0.5em
+  padding: 0.25em 0.75em
 
 .survey-identification-remove
   @extends $reset-button


### PR DESCRIPTION
Fixes #3360  .

Describe your changes.
This is a pretty simple CSS change to increase the label size in survey projects. I just increased the label a bit so that it's more obvious without obstructing the subject.

# Review Checklist

- [X] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [X] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [X] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)

https://fix-3360.pfe-preview.zooniverse.org/

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?