### PR TITLE
convert warning-banner to es6 and add a test

### DIFF
--- a/app/classifier/warning-banner.cjsx
+++ b/app/classifier/warning-banner.cjsx
@@ -1,7 +1,0 @@
-React = require 'react'
-TriggeredModalForm = require 'modal-form/triggered'
-
-module.exports = (props) ->
-    <TriggeredModalForm trigger={props.label} triggerProps={className: 'warning-banner'}>
-      {props.children}
-    </TriggeredModalForm>

--- a/app/classifier/warning-banner.jsx
+++ b/app/classifier/warning-banner.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import TriggeredModalForm from 'modal-form/triggered';
+
+const WarningBanner = (props) => {
+  return (
+    <TriggeredModalForm trigger={props.label} triggerProps={{ className: 'warning-banner' }}>
+      {props.children}
+    </TriggeredModalForm>
+  );
+};
+
+WarningBanner.propTypes = {
+  label: React.PropTypes.string.isRequired,
+  children: React.PropTypes.node.isRequired
+};
+
+export default WarningBanner;

--- a/app/classifier/warning-banner.spec.js
+++ b/app/classifier/warning-banner.spec.js
@@ -1,0 +1,27 @@
+/* eslint prefer-arrow-callback: 0, func-names: 0, 'react/jsx-boolean-value': ['error', 'always'] */
+/* global describe, it, beforeEach */
+import React from 'react';
+import WarningBanner from './warning-banner';
+import assert from 'assert';
+import { shallow } from 'enzyme';
+
+describe('WarningBanner', function () {
+  let wrapper;
+
+  beforeEach(function () {
+    wrapper = shallow(
+      <WarningBanner label="testing">
+        <p>Some test text.</p>
+      </WarningBanner>
+    );
+  });
+
+  it('should render without crashing', function () {
+  });
+
+  it('should pass label and children to TriggeredModalForm', function () {
+    assert.equal(wrapper.node.props.trigger, 'testing');
+    assert.equal(wrapper.node.props.children.type, 'p');
+    assert.equal(wrapper.node.props.children.props.children, 'Some test text.');
+  });
+});


### PR DESCRIPTION
Converts the classifier's `warning-banner` to ES6 and adds tests.  These are the "Already seen!" and "Finished!" banners that show up on the top left of an image.  This is split off from #3319.

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://convert-warning-banner.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [x] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?