### PR TITLE
Restore the updated projects list to news section

### DIFF
--- a/app/pages/home-for-user/index.jsx
+++ b/app/pages/home-for-user/index.jsx
@@ -320,7 +320,7 @@ export default class HomePageForUser extends React.Component {
               </div>
             </button>
 
-            <NewsSection updatedProjects={this.state.updatedProjects} toggleNews={this.toggleNews} showNews={this.state.showNews} />
+            <NewsSection updatedProjects={this.state.ribbonData.slice(0,3)} toggleNews={this.toggleNews} showNews={this.state.showNews} />
 
           </Pullout>
         </div>

--- a/app/pages/home-for-user/index.jsx
+++ b/app/pages/home-for-user/index.jsx
@@ -320,7 +320,7 @@ export default class HomePageForUser extends React.Component {
               </div>
             </button>
 
-            <NewsSection updatedProjects={this.state.ribbonData.slice(0,3)} toggleNews={this.toggleNews} showNews={this.state.showNews} />
+            <NewsSection updatedProjects={this.state.ribbonData} toggleNews={this.toggleNews} showNews={this.state.showNews} />
 
           </Pullout>
         </div>

--- a/app/pages/home-for-user/news-pullout.jsx
+++ b/app/pages/home-for-user/news-pullout.jsx
@@ -91,7 +91,7 @@ const NewsSection = React.createClass({
     const timestamp = moment(new Date(project.updated_at)).fromNow();
     return (<div key={project.id} className="home-page-news-pullout news-section__link">
       <a href={link}>
-        <h5 className="home-page-news-pullout news-section__title">{project.name} </h5>
+        <h5 className="home-page-news-pullout news-section__title">{project.display_name} </h5>
         <h5> has been updated! </h5>
         <p className="home-page-news-pullout news-section__timestamp">{timestamp}</p>
       </a>

--- a/app/pages/home-for-user/news-pullout.jsx
+++ b/app/pages/home-for-user/news-pullout.jsx
@@ -101,6 +101,10 @@ const NewsSection = React.createClass({
   render() {
     const projLink = `${window.location.origin}/projects/${this.state.newestProject.slug}`;
     const avatarSrc = !!this.state.newestAvatar ? this.state.newestAvatar.src : null;
+    const recentProjects = 
+      this.props.updatedProjects
+      .sort((a, b) => { return new Date(b.updated_at) - new Date(a.updated_at); })
+      .slice(0,3);
 
     return (
       <div className={"home-page-news-pullout news-main" + (this.props.showNews ? " active" : "")}>
@@ -119,7 +123,7 @@ const NewsSection = React.createClass({
 
           <div className="home-page-news-pullout news-section">
             <h4> Participated Project Updates </h4>
-            {this.props.updatedProjects.map((project) => {
+            {recentProjects.map((project) => {
               return this.renderUpdatedProjects(project);
             })}
           </div>


### PR DESCRIPTION
This section is blank at the moment, because `state.updatedProjects` was removed in #3321 