### PR TITLE
Bugfix: sort a copy of the updated projects list

### DIFF
--- a/app/pages/home-for-user/news-pullout.jsx
+++ b/app/pages/home-for-user/news-pullout.jsx
@@ -103,6 +103,7 @@ const NewsSection = React.createClass({
     const avatarSrc = !!this.state.newestAvatar ? this.state.newestAvatar.src : null;
     const recentProjects = 
       this.props.updatedProjects
+      .slice()
       .sort((a, b) => { return new Date(b.updated_at) - new Date(a.updated_at); })
       .slice(0,3);
 


### PR DESCRIPTION
Recent projects is broken on the home page now: projects are listed in the wrong order because the news pullout is re-sorting the array. This fixes that by forcing the news pullout to make a copy of the projects array before sorting it.