### PR TITLE
Adding in line about how to get your allowance uploaded

### DIFF
--- a/app/pages/lab/subject-set.cjsx
+++ b/app/pages/lab/subject-set.cjsx
@@ -132,15 +132,16 @@ EditSubjectSetPage = React.createClass
     "The project has " + project_subject_count + " uploaded subjects. " +
     "You have uploaded " + user.uploaded_subjects_count + " subjects from an " +
     "allowance of " + user.subject_limit + ". Your uploaded subject count is the tally of all subjects " +
-    "(including those deleted) that your account has uploaded through the project builder or Zooniverse API." +
-    "Please <a href='https://www.zooniverse.org/about/contact'> contact us</a> to request changes to your allowance."
-    
+    "(including those deleted) that your account has uploaded through the project builder or Zooniverse API."
+
   render: ->
     <div>
       <h3>{@props.subjectSet.display_name} #{@props.subjectSet.id}</h3>
       <p className="form-help">A subject is a unit of data to be analyzed. A subject can include one or more images that will be analyzed at the same time by volunteers. A subject set consists of a list of subjects (the “manifest”) defining their properties, and the images themselves.</p>
       <p className="form-help">Feel free to group subjects into sets in the way that is most useful for your research. Many projects will find it’s best to just have all their subjects in 1 set, but not all.</p>
-      <p className="form-help">{@subjectLimitMessage(@props.project.subjects_count, @props.user)} </p>
+      <p className="form-help">
+        {@subjectLimitMessage(@props.project.subjects_count, @props.user)} Please <a href='https://www.zooniverse.org/about/contact'> contact us</a> to request changes to your allowance.
+      </p>
       <p className="form-help"><strong>We strongly recommend uploading subjects in batches of 500 - 1,000 at a time.</strong></p>
 
       <form onSubmit={@handleSubmit}>

--- a/app/pages/lab/subject-set.cjsx
+++ b/app/pages/lab/subject-set.cjsx
@@ -131,8 +131,10 @@ EditSubjectSetPage = React.createClass
   subjectLimitMessage: (project_subject_count, user) ->
     "The project has " + project_subject_count + " uploaded subjects. " +
     "You have uploaded " + user.uploaded_subjects_count + " subjects from an " +
-    "allowance of " + user.subject_limit + ". Your uploaded subject count is the tally of all subjects (including those deleted) that your account has uploaded through the project builder or Zooniverse API."
-
+    "allowance of " + user.subject_limit + ". Your uploaded subject count is the tally of all subjects " +
+    "(including those deleted) that your account has uploaded through the project builder or Zooniverse API." +
+    "If you would like to upload more subjects than your allowance, please <a href="https://www.zooniverse.org/about/contact"> get in touch</a>."
+    
   render: ->
     <div>
       <h3>{@props.subjectSet.display_name} #{@props.subjectSet.id}</h3>

--- a/app/pages/lab/subject-set.cjsx
+++ b/app/pages/lab/subject-set.cjsx
@@ -133,7 +133,7 @@ EditSubjectSetPage = React.createClass
     "You have uploaded " + user.uploaded_subjects_count + " subjects from an " +
     "allowance of " + user.subject_limit + ". Your uploaded subject count is the tally of all subjects " +
     "(including those deleted) that your account has uploaded through the project builder or Zooniverse API." +
-    "Please <a href="https://www.zooniverse.org/about/contact"> contact us</a> to request changes to your allowance."
+    "Please <a href='https://www.zooniverse.org/about/contact'> contact us</a> to request changes to your allowance."
     
   render: ->
     <div>

--- a/app/pages/lab/subject-set.cjsx
+++ b/app/pages/lab/subject-set.cjsx
@@ -133,7 +133,7 @@ EditSubjectSetPage = React.createClass
     "You have uploaded " + user.uploaded_subjects_count + " subjects from an " +
     "allowance of " + user.subject_limit + ". Your uploaded subject count is the tally of all subjects " +
     "(including those deleted) that your account has uploaded through the project builder or Zooniverse API." +
-    "If you would like to upload more subjects than your allowance, please <a href="https://www.zooniverse.org/about/contact"> get in touch</a>."
+    "To increase your allowance, please <a href="https://www.zooniverse.org/about/contact"> get in touch</a>."
     
   render: ->
     <div>

--- a/app/pages/lab/subject-set.cjsx
+++ b/app/pages/lab/subject-set.cjsx
@@ -133,7 +133,7 @@ EditSubjectSetPage = React.createClass
     "You have uploaded " + user.uploaded_subjects_count + " subjects from an " +
     "allowance of " + user.subject_limit + ". Your uploaded subject count is the tally of all subjects " +
     "(including those deleted) that your account has uploaded through the project builder or Zooniverse API." +
-    "To increase your allowance, please <a href="https://www.zooniverse.org/about/contact"> get in touch</a>."
+    "Please <a href="https://www.zooniverse.org/about/contact"> contact us</a> to request changes to your allowance."
     
   render: ->
     <div>


### PR DESCRIPTION
Adding in a line about how to contact the Zooniverse team to get your subject upload allowance increased. I had gotten an email from an astronomer interested in using the Zooniverse project builder, but didn't know how to get the allowance increased, so adding a line here like what is on the policies page asking the project owner to contact the Zoonvierse team so it's clear. Not sure if I did the href correctly.
