### PR TITLE
Fix taskTypes require

### DIFF
--- a/app/classifier/tasks/combo/index.cjsx
+++ b/app/classifier/tasks/combo/index.cjsx
@@ -20,7 +20,7 @@ ComboTask = React.createClass
         Object.assign task: childTaskKey, defaultAnnotation
 
     isAnnotationComplete: (taskDescription, annotation, workflow) ->
-      taskTypes = require '..'
+      taskTypes = require('..').default
 
       method = if taskDescription.loosen_requirements
         'some'


### PR DESCRIPTION
Fixes the broken combo task introduced in #3456 

Test with dev classifier or with:
https://fix-combo-task.pfe-preview.zooniverse.org/projects/zooniverse/notes-from-nature/classify?reload=1&workflow=3068&env=production

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?