### PR TITLE
[WIP] Frame annotator tweaks

### DIFF
--- a/app/classifier/frame-annotator.jsx
+++ b/app/classifier/frame-annotator.jsx
@@ -10,8 +10,7 @@ export default class FrameAnnotator extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      alreadySeen: false,
-      showWarning: false
+      alreadySeen: false
     };
     this.getScreenCurrentTransformationMatrix = this.getScreenCurrentTransformationMatrix.bind(this);
     this.getEventOffset = this.getEventOffset.bind(this);
@@ -55,14 +54,12 @@ export default class FrameAnnotator extends React.Component {
 
   // get current transformation matrix
   getScreenCurrentTransformationMatrix() {
-    const svg = this.refs.svgSubjectArea;
-    return svg.getScreenCTM();
+    return this.svgSubjectArea.getScreenCTM();
   }
 
   // find the original matrix for the SVG coordinate system
   getMatrixForWindowCoordsToSVGUserSpaceCoords() {
-    const transformationContainer = this.refs.transformationContainer;
-    return transformationContainer.getScreenCTM().inverse();
+    return this.transformationContainer.getScreenCTM().inverse();
   }
 
   // get the offset of event coordiantes in terms of the SVG coordinate system
@@ -84,8 +81,7 @@ export default class FrameAnnotator extends React.Component {
   // transforms the event coordinates
   // to points in the SVG coordinate system
   eventCoordsToSVGCoords(x, y) {
-    const svg = this.refs.svgSubjectArea;
-    const newPoint = svg.createSVGPoint();
+    const newPoint = this.svgSubjectArea.createSVGPoint();
     newPoint.x = x;
     newPoint.y = y;
     const matrixForWindowCoordsToSVGUserSpaceCoords = this.getMatrixForWindowCoordsToSVGUserSpaceCoords();
@@ -155,7 +151,7 @@ export default class FrameAnnotator extends React.Component {
     const svgProps = {};
 
     if (TaskComponent) {
-      ({BeforeSubject, InsideSubject, AfterSubject} = TaskComponent);
+      ({ BeforeSubject, InsideSubject, AfterSubject } = TaskComponent);
     }
 
     const hookProps = {
@@ -190,8 +186,8 @@ export default class FrameAnnotator extends React.Component {
           {!!BeforeSubject && (
             <BeforeSubject {...hookProps} />)}
 
-          <svg ref="svgSubjectArea" className="subject" style={svgStyle} viewBox={createdViewBox} {...svgProps}>
-            <g ref="transformationContainer" transform={this.props.transform}>
+          <svg ref={(svg) => { this.svgSubjectArea = svg; }} className="subject" style={svgStyle} viewBox={createdViewBox} {...svgProps}>
+            <g ref={(g) => { this.transformationContainer = g; }} transform={this.props.transform}>
               <rect ref={(rect) => { this.sizeRect = rect; }} width={this.props.naturalWidth} height={this.props.naturalHeight} fill="rgba(0, 0, 0, 0.01)" fillOpacity="0.01" stroke="none" />
               {type === 'image' && (
                 <Draggable onDrag={this.props.panByDrag} disabled={this.props.disabled}>

--- a/app/classifier/frame-annotator.jsx
+++ b/app/classifier/frame-annotator.jsx
@@ -1,26 +1,18 @@
 import React from 'react';
 import Draggable from '../lib/draggable';
 import tasks from './tasks';
-import seenThisSession from '../lib/seen-this-session';
 import getSubjectLocation from '../lib/get-subject-location';
-import WarningBanner from './warning-banner';
 import SVGImage from '../components/svg-image';
 
 export default class FrameAnnotator extends React.Component {
   constructor(props) {
     super(props);
-    this.state = {
-      alreadySeen: false
-    };
+
     this.getScreenCurrentTransformationMatrix = this.getScreenCurrentTransformationMatrix.bind(this);
     this.getEventOffset = this.getEventOffset.bind(this);
     this.normalizeDifference = this.normalizeDifference.bind(this);
     this.eventCoordsToSVGCoords = this.eventCoordsToSVGCoords.bind(this);
     this.handleAnnotationChange = this.handleAnnotationChange.bind(this);
-  }
-
-  componentWillMount() {
-    this.setState({ alreadySeen: this.props.subject.already_seen || seenThisSession.check(this.props.workflow, this.props.subject) });
   }
 
   componentWillReceiveProps(nextProps) {
@@ -54,12 +46,14 @@ export default class FrameAnnotator extends React.Component {
 
   // get current transformation matrix
   getScreenCurrentTransformationMatrix() {
-    return this.svgSubjectArea.getScreenCTM();
+    const svgSubjectArea = this.svgSubjectArea;
+    return svgSubjectArea.getScreenCTM();
   }
 
   // find the original matrix for the SVG coordinate system
   getMatrixForWindowCoordsToSVGUserSpaceCoords() {
-    return this.transformationContainer.getScreenCTM().inverse();
+    const transformationContainer = this.transformationContainer;
+    return transformationContainer.getScreenCTM().inverse();
   }
 
   // get the offset of event coordiantes in terms of the SVG coordinate system
@@ -81,7 +75,8 @@ export default class FrameAnnotator extends React.Component {
   // transforms the event coordinates
   // to points in the SVG coordinate system
   eventCoordsToSVGCoords(x, y) {
-    const newPoint = this.svgSubjectArea.createSVGPoint();
+    const svgSubjectArea = this.svgSubjectArea;
+    const newPoint = svgSubjectArea.createSVGPoint();
     newPoint.x = x;
     newPoint.y = y;
     const matrixForWindowCoordsToSVGUserSpaceCoords = this.getMatrixForWindowCoordsToSVGUserSpaceCoords();
@@ -100,7 +95,6 @@ export default class FrameAnnotator extends React.Component {
   }
 
   render() {
-    let warningBanner;
     let taskDescription;
     let TaskComponent;
     let BeforeSubject;
@@ -112,22 +106,6 @@ export default class FrameAnnotator extends React.Component {
     if (this.props.annotation) {
       taskDescription = this.props.workflow.tasks[this.props.annotation.task];
       TaskComponent = tasks[taskDescription.type];
-    }
-
-    if (this.state.alreadySeen) {
-      warningBanner = (
-        <WarningBanner label="Already seen!">
-          <p>Our records show that you’ve already seen this image. We might have run out of data for you in this workflow!</p>
-          <p>Try choosing a different workflow or contributing to a different project.</p>
-        </WarningBanner>
-      );
-    } else if (this.props.subject.retired) {
-      warningBanner = (
-        <WarningBanner label="Finished!">
-          <p>This subject already has enough classifications, so yours won’t be used in its analysis!</p>
-          <p>If you’re looking to help, try choosing a different workflow or contributing to a different project.</p>
-        </WarningBanner>
-      );
     }
 
     const svgStyle = {};
@@ -186,7 +164,7 @@ export default class FrameAnnotator extends React.Component {
           {!!BeforeSubject && (
             <BeforeSubject {...hookProps} />)}
 
-          <svg ref={(svg) => { this.svgSubjectArea = svg; }} className="subject" style={svgStyle} viewBox={createdViewBox} {...svgProps}>
+          <svg ref={(svg) => { if (svg !== null) { this.svgSubjectArea = svg; } }} className="subject" style={svgStyle} viewBox={createdViewBox} {...svgProps}>
             <g ref={(g) => { this.transformationContainer = g; }} transform={this.props.transform}>
               <rect ref={(rect) => { this.sizeRect = rect; }} width={this.props.naturalWidth} height={this.props.naturalHeight} fill="rgba(0, 0, 0, 0.01)" fillOpacity="0.01" stroke="none" />
               {type === 'image' && (
@@ -210,10 +188,6 @@ export default class FrameAnnotator extends React.Component {
           </svg>
 
           {this.props.children}
-
-          {!!warningBanner && (
-            warningBanner
-          )}
 
           {!!AfterSubject && (
             <AfterSubject {...hookProps} />)}

--- a/css/classify.styl
+++ b/css/classify.styl
@@ -117,6 +117,7 @@
     text-transform: uppercase
     top: 0
     transform: rotate(-15deg)
+    z-index: 10
 
   > .task-area
     flex: 0 0 60ch


### PR DESCRIPTION
Moves the `<WarningBanner />` component out of the frame annotator and into the subject viewer where it better fits to make testing a bit more scoped to what the frame annotator actually does. Also fixes a few linter issues.

My test project only has a couple of subjects, so you can get an 'Already Seen' warning quickly: https://frame-annotator-tweaks.pfe-preview.zooniverse.org/projects/srallen086/srallen-testing/classify

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [x] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?