### PR TITLE
Remove PromiseRenderer from subject-set.cjsx

### DIFF
--- a/app/pages/lab/subject-set.cjsx
+++ b/app/pages/lab/subject-set.cjsx
@@ -17,6 +17,9 @@ VALID_SUBJECT_EXTENSIONS = ['.jpg', '.jpeg', '.png', '.gif', '.svg']
 INVALID_FILENAME_CHARS = ['/', '\\', ':', ',']
 MAX_FILE_SIZE = 600 * 1024
 
+announceSetChange = ->
+  apiClient.type('subject_sets').emit 'add-or-remove'
+
 SubjectSetListingRow = React.createClass
   displayName: 'SubjectSetListingRow'
 
@@ -124,6 +127,7 @@ SubjectSetListing = React.createClass
   removeSubject: (subject) ->
     @props.subjectSet.removeLink('subjects', subject.id).then =>
       @setSubjectResources(@props.subjectSet.id, @state.page)
+      announceSetChange()
 
 EditSubjectSetPage = React.createClass
   displayName: 'EditSubjectSetPage'
@@ -320,6 +324,7 @@ EditSubjectSetPage = React.createClass
           creationErrors: errors
           manifests: {}
           files: {}
+        announceSetChange()
 
   deleteSubjectSet: ->
     @setState deletionError: null
@@ -331,6 +336,7 @@ EditSubjectSetPage = React.createClass
 
       this.props.subjectSet.delete()
         .then =>
+          announceSetChange()
           @props.project.uncacheLink 'subject_sets'
           @context.router.push "/lab/#{@props.project.id}"
         .catch (error) =>

--- a/app/pages/lab/subject-set.cjsx
+++ b/app/pages/lab/subject-set.cjsx
@@ -331,9 +331,33 @@ module.exports = React.createClass
   getDefaultProps: ->
     params: null
 
+  getInitialState: ->
+    subject_set: null
+
+  componentWillReceiveProps: (nextProps) ->
+    if nextProps.params.subjectSetID isnt @props.params.subjectSetID
+      @setSubjectSet(nextProps.params.subjectSetID)
+
+
+  componentWillMount: ->
+    @setSubjectSet(@props.params.subjectSetID)
+
+
+  setSubjectSet: (subjectSetId) ->
+    subject_set = apiClient.type('subject_sets').get subjectSetId
+
+    subject_set.then( (subject_set) =>
+      @setState subject_set: subject_set
+    ).catch( (error) =>
+      console.log error
+    )
+
   render: ->
-    <PromiseRenderer promise={apiClient.type('subject_sets').get @props.params.subjectSetID}>{(subjectSet) =>
+    if @state.subject_set
+      subjectSet = @state.subject_set
       <ChangeListener target={subjectSet}>{=>
         <EditSubjectSetPage {...@props} subjectSet={subjectSet} />
       }</ChangeListener>
-    }</PromiseRenderer>
+    else
+      null
+

--- a/app/pages/lab/subject-set.cjsx
+++ b/app/pages/lab/subject-set.cjsx
@@ -71,8 +71,7 @@ SubjectSetListing = React.createClass
     subjects: null
 
   componentWillReceiveProps: (nextProps) ->
-    if @props.subjectSet.id isnt nextProps.subjectSet.id
-      @setSubjectResources(nextProps.subjectSet.id, "1")
+    @setSubjectResources(nextProps.subjectSet.id, "1")
       
   componentWillMount: ->
     @setSubjectResources(@props.subjectSet.id, @state.page)

--- a/app/pages/lab/subject-set.cjsx
+++ b/app/pages/lab/subject-set.cjsx
@@ -109,7 +109,7 @@ SubjectSetListing = React.createClass
       <div>
         <SubjectSetListingTable subjects={@state.subjects} onPreview={@previewSubject} onRemove={@removeSubject} />
         <nav className="pagination">
-          Page <select value={@props.page} disabled={@state.pageCount < 2 or isNaN @state.pageCount} onChange={(e) => @newPage(e.target.value, @state.pageCount)}>
+          Page <select value={@props.page} disabled={@state.pageCount < 2 or isNaN @state.pageCount} onChange={(e) => @newPage(e.target.value)}>
             {if isNaN @state.pageCount
               <option>?</option>
             else

--- a/app/pages/lab/subject-set.cjsx
+++ b/app/pages/lab/subject-set.cjsx
@@ -127,6 +127,7 @@ SubjectSetListing = React.createClass
 
   removeSubject: (subject) ->
     @props.subjectSet.removeLink('subjects', subject.id).then =>
+      @setSubjectResources(@props.subjectSet.id, @state.page)
       announceSetChange()
 
 EditSubjectSetPage = React.createClass

--- a/app/pages/lab/subject-set.cjsx
+++ b/app/pages/lab/subject-set.cjsx
@@ -48,7 +48,7 @@ SubjectSetListingRow = React.createClass
     @props.onRemove @props.subject
 
 SubjectSetListingTable = React.createClass
-  displayName: 'SubjectSetListing'
+  displayName: 'SubjectSetListingTable'
 
   getDefaultProps: ->
     subjects: []

--- a/app/pages/lab/subject-set.cjsx
+++ b/app/pages/lab/subject-set.cjsx
@@ -17,9 +17,6 @@ VALID_SUBJECT_EXTENSIONS = ['.jpg', '.jpeg', '.png', '.gif', '.svg']
 INVALID_FILENAME_CHARS = ['/', '\\', ':', ',']
 MAX_FILE_SIZE = 600 * 1024
 
-announceSetChange = ->
-  apiClient.type('subject_sets').emit 'add-or-remove'
-
 SubjectSetListingRow = React.createClass
   displayName: 'SubjectSetListingRow'
 
@@ -128,7 +125,6 @@ SubjectSetListing = React.createClass
   removeSubject: (subject) ->
     @props.subjectSet.removeLink('subjects', subject.id).then =>
       @setSubjectResources(@props.subjectSet.id, @state.page)
-      announceSetChange()
 
 EditSubjectSetPage = React.createClass
   displayName: 'EditSubjectSetPage'
@@ -325,7 +321,6 @@ EditSubjectSetPage = React.createClass
           creationErrors: errors
           manifests: {}
           files: {}
-        announceSetChange()
 
   deleteSubjectSet: ->
     @setState deletionError: null
@@ -337,7 +332,6 @@ EditSubjectSetPage = React.createClass
 
       this.props.subjectSet.delete()
         .then =>
-          announceSetChange()
           @props.project.uncacheLink 'subject_sets'
           @context.router.push "/lab/#{@props.project.id}"
         .catch (error) =>


### PR DESCRIPTION
Removes the PromiseRenderer from subject-set.cjsx, related to #3216. Staged [here](https://subject-set-remove-promise-render.pfe-preview.zooniverse.org/).

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?