### PR TITLE
add tests for single task summary

### DIFF
--- a/app/classifier/tasks/single.spec.js
+++ b/app/classifier/tasks/single.spec.js
@@ -1,6 +1,8 @@
+/* eslint prefer-arrow-callback: 0, func-names: 0, 'react/jsx-boolean-value': ['error', 'always'], 'react/jsx-filename-extension': 0 */
+/* global describe, it, beforeEach */
+import { mount } from 'enzyme';
 import React from 'react';
 import assert from 'assert';
-import { mount } from 'enzyme';
 import SingleTask from './single';
 
 const task = {
@@ -25,49 +27,125 @@ describe('SingleChoiceTask', function () {
 
   it('should render without crashing', function () {
   });
-  
+
   it('should have a question', function () {
     const question = wrapper.find('.question');
     assert.equal(question.length, 1);
   });
-  
+
   it('should have answers', function () {
     const answers = wrapper.find('.answer');
     assert.equal(answers.length, task.answers.length);
   });
-  
-  it('should have the supplied annotation checked', function(){
-    assert.equal(wrapper.find('input[type="radio"]').find({checked: true, value: 1}).length, 1);
-  });
-  
-  it('other answers should not be checked', function(){
-    assert.equal(wrapper.find('input[type="radio"]').find({checked: false, value: 0}).length, 1);
+
+  it('should have the supplied annotation checked', function () {
+    assert.equal(wrapper.find('input[type="radio"]').find({ checked: true, value: 1 }).length, 1);
   });
 
-  describe('static methods', function(){
-    it('should be complete', function(){
+  it('other answers should not be checked', function () {
+    assert.equal(wrapper.find('input[type="radio"]').find({ checked: false, value: 0 }).length, 1);
+  });
+
+  describe('static methods', function () {
+    it('should be complete', function () {
       assert.equal(SingleTask.isAnnotationComplete(task, annotation), true);
     });
 
-    it('should be complete when value is 0 (i.e. falsy)', function(){
+    it('should be complete when value is 0 (i.e. falsy)', function () {
       assert.equal(SingleTask.isAnnotationComplete(task, { value: 0 }), true);
     });
 
-    it('should not be complete when value is null', function(){
+    it('should not be complete when value is null', function () {
       assert.equal(SingleTask.isAnnotationComplete(task, { value: null }), false);
     });
 
-    it('should be complete when task is not required', function(){
+    it('should be complete when task is not required', function () {
       assert.equal(SingleTask.isAnnotationComplete(Object.assign({}, task, { required: false }), { value: null }), true);
     });
 
-    it('should have the correct question text', function(){
+    it('should have the correct question text', function () {
       assert.equal(SingleTask.getTaskText(task), task.question);
     });
 
-    it('the default annotation should be null', function(){
+    it('the default annotation should be null', function () {
       assert.equal(SingleTask.getDefaultAnnotation().value, null);
     });
   });
+});
 
+describe('SingleChoiceSummary', function () {
+  let summary;
+
+  beforeEach(function () {
+    summary = mount(<SingleTask.Summary task={task} annotation={annotation} />);
+  });
+
+  it('should render without crashing', function () {
+  });
+
+  it('should have a question', function () {
+    const question = summary.find('.question');
+    assert.equal(question.length, 1);
+  });
+
+  it('the default expanded state should be false', function () {
+    assert.equal(summary.state().expanded, false);
+  });
+
+  it('should have one answer when collapsed', function () {
+    const answers = summary.find('.answer');
+    assert.equal(answers.length, 1);
+  });
+
+  it('should have the correct answer label when the value if falsy (i.e. 0)', function () {
+    summary = mount(<SingleTask.Summary task={task} annotation={{ value: 0 }} />);
+    const answers = summary.find('.answer');
+    assert.notEqual(answers.text(), 'No answer');
+  });
+
+  it('should return "No answer" when annotation is null', function () {
+    summary = mount(<SingleTask.Summary task={task} annotation={{ value: null }} />);
+    const answers = summary.find('.answer');
+    assert.equal(answers.text(), 'No answer');
+  });
+
+  it('button should read "More" when not expanded', function () {
+    const button = summary.find('button');
+    assert.equal(button.text(), 'More');
+  });
+
+  describe('when summary is expanded', function () {
+    beforeEach(function () {
+      summary.find('button').simulate('click');
+    });
+
+    it('should set expanded to true in state', function () {
+      assert.equal(summary.state().expanded, true);
+    });
+
+    it('should show all answers', function () {
+      const answers = summary.find('.answer');
+      assert.equal(answers.length, task.answers.length);
+    });
+
+    it('should have one answer selected', function () {
+      const checks = summary.find('.fa-check-circle-o');
+      assert.equal(checks.length, 1);
+    });
+
+    it('should have the correct number of non-selected answers', function () {
+      const unchecks = summary.find('.fa-circle-o');
+      assert.equal(unchecks.length, task.answers.length - 1);
+    });
+
+    it('button should read "Less"', function () {
+      const button = summary.find('button');
+      assert.equal(button.text(), 'Less');
+    });
+
+    it('clicking the button should set expanded to false in state', function () {
+      summary.find('button').simulate('click');
+      assert.equal(summary.state().expanded, false);
+    });
+  });
 });


### PR DESCRIPTION
This adds some tests for the single task summary (and removes eslint warnings).

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?