### PR TITLE
fix 3431

### DIFF
--- a/app/pages/project/stats/stats.jsx
+++ b/app/pages/project/stats/stats.jsx
@@ -245,6 +245,7 @@ export class WorkflowProgress extends React.Component {
     let eta;
     let total;
     let retiredDiv;
+    let classificationDiv;
     let completeness = this.props.workflow.completeness;
     if (this.props.workflow.retirement.criteria !== 'never_retire') {
       retiredDiv = (
@@ -273,10 +274,16 @@ export class WorkflowProgress extends React.Component {
           />
         );
       }
-      classificationsString += ` / ${total.toLocaleString()}`;
       if (this.props.workflow.configuration) {
         if (this.props.workflow.configuration.stats_completeness_type === 'classification') {
           completeness = this.props.workflow.classifications_count / total;
+          classificationsString += ` / ${total.toLocaleString()}`;
+          classificationDiv = (
+            <div>
+              <span className="progress-stats-label">Classifications:</span>
+              {classificationsString}
+            </div>
+          );
         }
       }
     }
@@ -288,10 +295,7 @@ export class WorkflowProgress extends React.Component {
             {retirement}
           </div>
           {retiredDiv}
-          <div>
-            <span className="progress-stats-label">Classifications:</span>
-            {classificationsString}
-          </div>
+          {classificationDiv}
           {eta}
           <Progress progress={completeness} />
         </div>


### PR DESCRIPTION
Fixes #3431.

This removes the "Classification counts" when a workflow's visibility is set to "Retirement count".

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://fix-3431.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?