### PR TITLE
Fix import for subtask in workflow editor

### DIFF
--- a/app/classifier/tasks/drawing-task-details-editor.cjsx
+++ b/app/classifier/tasks/drawing-task-details-editor.cjsx
@@ -82,7 +82,7 @@ module.exports = React.createClass
   handleAddTask: (task) ->
     switch task
       when 'single'
-        TaskChoice = require './single'
+        TaskChoice = require('./single').default
       when 'text'
         TaskChoice = require './text'
     @props.task.tools[@props.toolIndex].details.push TaskChoice.getDefaultTask()


### PR DESCRIPTION
Fixes a bug where the question subtask wouldn't show up in the workflow editor.

Describe your changes.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://subtask-fix.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?