### PR TITLE
Frame Annotator tests

### DIFF
--- a/app/classifier/frame-annotator.spec.js
+++ b/app/classifier/frame-annotator.spec.js
@@ -150,5 +150,23 @@ describe('<FrameAnnotator />', function() {
     it('renders AfterSubject hook', function() {
       assert.equal(wrapper.find(TaskComponent.AfterSubject).length, 1);
     });
+
+    it('renders PersistInsideSubject hook', function() {
+      const drawingAnnotation = { task: 'draw' };
+      TaskComponent = tasks['drawing'];
+      wrapper = shallow(
+        <FrameAnnotator
+          annotation={drawingAnnotation}
+          classification={classification}
+          loading={false}
+          naturalHeight={naturalHeight}
+          naturalWidth={naturalWidth}
+          subject={subject}
+          viewBoxDimensions={viewBoxDimensions}
+          workflow={workflow}
+        />);
+
+      assert.equal(wrapper.find(TaskComponent.PersistInsideSubject).length, 1)
+    });
   });
 });

--- a/app/classifier/frame-annotator.spec.js
+++ b/app/classifier/frame-annotator.spec.js
@@ -1,0 +1,52 @@
+// "Passing arrow functions (“lambdas”) to Mocha is discouraged" - https://mochajs.org/#arrow-functions
+/* eslint prefer-arrow-callback: 0, func-names: 0, 'react/jsx-boolean-value': ['error', 'always'] */
+/* global describe, it, beforeEach */
+
+import React from 'react';
+import assert from 'assert';
+import sinon from 'sinon';
+import { shallow, mount } from 'enzyme';
+import FrameAnnotator from './frame-annotator';
+import SVGImage from '../components/svg-image';
+import { classification, workflow, subject, preferences } from '../pages/dev-classifier/mock-data';
+
+const annotation = {
+  task: 'init'
+};
+
+const viewBoxDimensions = {
+  height: 0,
+  width: 0,
+  x: 0,
+  y: 0
+};
+
+const naturalHeight = 0;
+const naturalWidth = 0;
+
+describe('FrameAnnotator', function() {
+  let wrapper;
+  beforeEach(function() {
+    wrapper = shallow(
+      <FrameAnnotator
+        annotation={annotation}
+        classification={classification}
+        loading={false}
+        naturalHeight={naturalHeight}
+        naturalWidth={naturalWidth}
+        subject={subject}
+        viewBoxDimensions={viewBoxDimensions}
+        workflow={workflow}
+      />);
+  });
+
+  it('should render without crashing', function() {
+    return wrapper;
+  });
+
+  describe('if subject type is an image', function() {
+    it('renders the <SVGImage /> if subject type is an image', function() {
+      assert.equal(wrapper.find(SVGImage).length, 1);
+    });
+  })
+});

--- a/app/classifier/frame-annotator.spec.js
+++ b/app/classifier/frame-annotator.spec.js
@@ -41,6 +41,21 @@ describe('<FrameAnnotator />', function() {
       />);
   });
 
+  it('should render children nodes', function() {
+    const wrapper = shallow(
+      <FrameAnnotator
+        annotation={annotation}
+        classification={classification}
+        loading={false}
+        naturalHeight={naturalHeight}
+        naturalWidth={naturalWidth}
+        subject={subject}
+        viewBoxDimensions={viewBoxDimensions}
+        workflow={workflow}
+      ><span>child</span></FrameAnnotator>);
+    assert.equal(wrapper.find('span').length, 1);
+  });
+
   describe('<SVGImage />', function() {
     let wrapper;
     before(function() {

--- a/app/classifier/frame-annotator.spec.js
+++ b/app/classifier/frame-annotator.spec.js
@@ -1,13 +1,15 @@
 // "Passing arrow functions (“lambdas”) to Mocha is discouraged" - https://mochajs.org/#arrow-functions
 /* eslint prefer-arrow-callback: 0, func-names: 0, 'react/jsx-boolean-value': ['error', 'always'] */
-/* global describe, it, beforeEach */
+/* global describe, it, beforeEach, before */
 
 import React from 'react';
 import assert from 'assert';
 import sinon from 'sinon';
 import { shallow, mount } from 'enzyme';
 import FrameAnnotator from './frame-annotator';
+import tasks from './tasks';
 import SVGImage from '../components/svg-image';
+import WarningBanner from './warning-banner';
 import { classification, workflow, subject, preferences } from '../pages/dev-classifier/mock-data';
 
 const annotation = {
@@ -24,10 +26,9 @@ const viewBoxDimensions = {
 const naturalHeight = 0;
 const naturalWidth = 0;
 
-describe('FrameAnnotator', function() {
-  let wrapper;
-  beforeEach(function() {
-    wrapper = shallow(
+describe('<FrameAnnotator />', function() {
+  it('should render without crashing', function() {
+    return shallow(
       <FrameAnnotator
         annotation={annotation}
         classification={classification}
@@ -40,13 +41,114 @@ describe('FrameAnnotator', function() {
       />);
   });
 
-  it('should render without crashing', function() {
-    return wrapper;
-  });
+  describe('<SVGImage />', function() {
+    let wrapper;
+    before(function() {
+      wrapper = shallow(
+        <FrameAnnotator
+          annotation={annotation}
+          classification={classification}
+          loading={false}
+          naturalHeight={naturalHeight}
+          naturalWidth={naturalWidth}
+          subject={subject}
+          viewBoxDimensions={viewBoxDimensions}
+          workflow={workflow}
+        />);
+    });
 
-  describe('if subject type is an image', function() {
-    it('renders the <SVGImage /> if subject type is an image', function() {
+    it('renders if subject type is an image', function() {
       assert.equal(wrapper.find(SVGImage).length, 1);
     });
-  })
+
+    it('does not render if type is not an image', function() {
+      subject.locations = [{ 'video/mp4': 'video.mp4' }];
+      wrapper.setProps({ subject });
+
+      assert.equal(wrapper.find(SVGImage).length, 0);
+    });
+  });
+
+  describe('<WarningBanner />', function() {
+    let wrapper;
+    beforeEach(function() {
+      subject.already_seen = false;
+      subject.retired = false;
+      wrapper = shallow(
+        <FrameAnnotator
+          annotation={annotation}
+          classification={classification}
+          loading={false}
+          naturalHeight={naturalHeight}
+          naturalWidth={naturalWidth}
+          subject={subject}
+          viewBoxDimensions={viewBoxDimensions}
+          workflow={workflow}
+        />);
+    });
+
+    it('renders if subject is already seen', function() {
+      subject.already_seen = true;
+      // Recalling the shallow mounting was needed to trigger componentWillMount.
+      // Couldn't get wrapper.unmount() and wrapper.mount() to work
+      wrapper = shallow(
+        <FrameAnnotator
+          annotation={annotation}
+          classification={classification}
+          loading={false}
+          naturalHeight={naturalHeight}
+          naturalWidth={naturalWidth}
+          subject={subject}
+          viewBoxDimensions={viewBoxDimensions}
+          workflow={workflow}
+        />);
+
+      assert.equal(wrapper.find(WarningBanner).length, 1);
+    });
+
+    it('renders if subject is retired', function() {
+      subject.retired = true;
+      wrapper.setProps({ subject });
+
+      assert.equal(wrapper.find(WarningBanner).length, 1);
+    });
+
+    it('does not render renders for normal subjects', function() {
+      assert.equal(wrapper.find(WarningBanner).length, 0);
+    });
+  });
+
+  describe('task hooks', function() {
+    let TaskComponent;
+    let wrapper;
+
+    before(function() {
+      // combo task has BeforeSubject, InsideSubject, and AfterSubject hooks
+      const comboAnnotation = { task: 'combo' };
+      TaskComponent = tasks[comboAnnotation.task];
+      wrapper = shallow(
+        <FrameAnnotator
+          annotation={comboAnnotation}
+          classification={classification}
+          loading={false}
+          naturalHeight={naturalHeight}
+          naturalWidth={naturalWidth}
+          subject={subject}
+          viewBoxDimensions={viewBoxDimensions}
+          workflow={workflow}
+        />);
+    });
+
+    it('renders BeforeSubject hook', function() {
+      assert.equal(wrapper.find(TaskComponent.BeforeSubject).length, 1);
+    });
+
+    it('renders InsideSubject hook', function() {
+      assert.equal(wrapper.find(TaskComponent.InsideSubject).length, 1);
+    });
+
+    it('renders AfterSubject hook', function() {
+      assert.equal(wrapper.find(TaskComponent.AfterSubject).length, 1);
+    });
+  });
 });


### PR DESCRIPTION
This is a start to testing the frame annotator. I've mostly covered what is rendered, but there should be additional tests added later to test the SVG matrix transformations and other class methods. 

Staged at https://fa-tests.pfe-preview.zooniverse.org/

I'm refocusing on the organizations lab this week, so I wanted to get this at least reviewed and merged.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?