### PR TITLE
Indicate When Project is Under Beta Review

### DIFF
--- a/app/pages/project/index.cjsx
+++ b/app/pages/project/index.cjsx
@@ -12,6 +12,7 @@ getWorkflowsInOrder = require '../../lib/get-workflows-in-order'
 isAdmin = require '../../lib/is-admin'
 {Split} = require('seven-ten')
 Thumbnail = require('../../components/thumbnail').default
+classnames = require 'classnames'
 
 counterpart.registerTranslations 'en',
   project:
@@ -232,10 +233,10 @@ ProjectPage = React.createClass
 
   renderProjectName: (betaApproved) ->
     if betaApproved
-      <span>
+      <div>
         <p>Under Review</p>
         {@props.project.display_name}
-      </span>
+      </div>
     else
       @props.project.display_name
 
@@ -243,6 +244,9 @@ ProjectPage = React.createClass
     betaApproved = @props.project.beta_approved
     projectPath = "/projects/#{@props.project.slug}"
     onHomePage = projectPath is @props.location.pathname
+    avatarClasses = classnames('tabbed-content-tab', {
+      'beta-approved': betaApproved
+    })
 
     pages = [{}, @state.pages...].reduce (map, page) =>
       map[page.url_key] = page
@@ -273,7 +277,7 @@ ProjectPage = React.createClass
             Visit {@props.project.display_name}
           </a>
         else
-          <IndexLink to="#{projectPath}" activeClassName="active" className="tabbed-content-tab #{('beta-approved' if betaApproved) ? ''}" onClick={logClick?.bind this, 'project.nav.home'}>
+          <IndexLink to="#{projectPath}" activeClassName="active" className={avatarClasses} onClick={logClick?.bind this, 'project.nav.home'}>
             {if @state.avatar?
               <Thumbnail src={@state.avatar.src} className="avatar" width={AVATAR_SIZE} height={AVATAR_SIZE} />}
             {if @props.loading
@@ -477,11 +481,11 @@ ProjectPageController = React.createClass
   render: ->
     slug = @props.params.owner + '/' + @props.params.name
     betaApproved = @state.project?.beta_approved
+    wrapperClasses = classnames('project-page-wrapper', {
+      'beta-border': betaApproved
+    })
 
-    <div className="project-page-wrapper">
-
-      {if betaApproved
-        <div className="beta-border"></div>}
+    <div className={wrapperClasses}>
 
       {if @state.project? and @state.owner?
         <ProjectPage

--- a/app/pages/project/index.cjsx
+++ b/app/pages/project/index.cjsx
@@ -476,8 +476,13 @@ ProjectPageController = React.createClass
 
   render: ->
     slug = @props.params.owner + '/' + @props.params.name
+    betaApproved = @state.project?.beta_approved
 
     <div className="project-page-wrapper">
+
+      {if betaApproved
+        <div className="beta-border"></div>}
+
       {if @state.project? and @state.owner?
         <ProjectPage
           {...@props}

--- a/app/pages/project/index.cjsx
+++ b/app/pages/project/index.cjsx
@@ -481,11 +481,11 @@ ProjectPageController = React.createClass
   render: ->
     slug = @props.params.owner + '/' + @props.params.name
     betaApproved = @state.project?.beta_approved
-    wrapperClasses = classnames('project-page-wrapper', {
-      'beta-border': betaApproved
-    })
 
-    <div className={wrapperClasses}>
+    <div className="project-page-wrapper">
+
+      {if betaApproved
+        <div className="beta-border"></div>}
 
       {if @state.project? and @state.owner?
         <ProjectPage

--- a/app/pages/project/index.cjsx
+++ b/app/pages/project/index.cjsx
@@ -230,7 +230,17 @@ ProjectPage = React.createClass
     getUserRoles.then (userRoles) =>
       isAdmin() or 'owner' in userRoles or 'collaborator' in userRoles
 
+  renderProjectName: (betaApproved) ->
+    if betaApproved
+      <span>
+        <p>Under Review</p>
+        {@props.project.display_name}
+      </span>
+    else
+      @props.project.display_name
+
   render: ->
+    betaApproved = @props.project.beta_approved
     projectPath = "/projects/#{@props.project.slug}"
     onHomePage = projectPath is @props.location.pathname
 
@@ -263,13 +273,13 @@ ProjectPage = React.createClass
             Visit {@props.project.display_name}
           </a>
         else
-          <IndexLink to="#{projectPath}" activeClassName="active" className="tabbed-content-tab" onClick={logClick?.bind this, 'project.nav.home'}>
+          <IndexLink to="#{projectPath}" activeClassName="active" className="tabbed-content-tab #{('beta-approved' if betaApproved) ? ''}" onClick={logClick?.bind this, 'project.nav.home'}>
             {if @state.avatar?
               <Thumbnail src={@state.avatar.src} className="avatar" width={AVATAR_SIZE} height={AVATAR_SIZE} />}
             {if @props.loading
               'Loading...'
             else
-              @props.project.display_name}
+              @renderProjectName(betaApproved)}
           </IndexLink>}
 
         <br className='responsive-break' />

--- a/app/pages/project/index.cjsx
+++ b/app/pages/project/index.cjsx
@@ -337,7 +337,7 @@ ProjectPage = React.createClass
         projectIsComplete: @state.projectIsComplete
         splits: @props.splits}
 
-      {unless @props.project.launch_approved or @props.project.beta_approved
+      {unless @props.project.launch_approved
         <Translate component="p" className="project-disclaimer" content="project.disclaimer" />}
 
       {unless @props.location.pathname is projectPath

--- a/css/project-page.styl
+++ b/css/project-page.styl
@@ -50,6 +50,17 @@
   background: FOREGROUND
   color: BACKGROUND
 
+.beta-border
+  border: 0.3em solid TEAL_MID
+  box-sizing: border-box
+  height: 100%
+  left: 0
+  pointer-events: none
+  position: fixed
+  top: 0
+  width: 100%
+  z-index: 2
+
 .project-page
   color: white
   display: flex

--- a/css/tabbed-content.styl
+++ b/css/tabbed-content.styl
@@ -32,6 +32,24 @@
     @media (max-width: 400px)
       display: block
 
+  .beta-approved
+    img
+      border: 3px solid TEAL_MID
+      border-radius: 100%
+
+    p
+      color: TEAL_MID
+      font-size: 0.8em
+      margin: 0
+
+    span
+      display: inherit
+      font-size: 1em
+      font-weight: 300
+      line-height: 1.25em
+      line-spacing: 0.25em
+      vertical-align: middle
+
 .tabbed-content-tab
   @extends $reset-button
   border-bottom: 3px solid transparent

--- a/css/tabbed-content.styl
+++ b/css/tabbed-content.styl
@@ -42,7 +42,7 @@
       font-size: 0.8em
       margin: 0
 
-    div
+    div, span
       display: inherit
       font-size: 1em
       font-weight: 300

--- a/css/tabbed-content.styl
+++ b/css/tabbed-content.styl
@@ -42,7 +42,7 @@
       font-size: 0.8em
       margin: 0
 
-    span
+    div
       display: inherit
       font-size: 1em
       font-weight: 300


### PR DESCRIPTION
Fixes #3404 
Fixes #3481 

Describe your changes.
Three main changes:

- Visual indicator on main project button when under beta review

- Border around page when project is under beta review

- Add the "not an official Zooniverse project" disclaimer for projects under beta review

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)

https://beta-review.pfe-preview.zooniverse.org/

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?