### PR TITLE
Fix text wrapping in field guide items

### DIFF
--- a/css/field-guide.styl
+++ b/css/field-guide.styl
@@ -85,7 +85,7 @@
 .field-guide-menu-item
   @extends $reset-button
   display: block
-  padding: 0.8em 1.6em
+  padding: 0.8em 1.6em 0.8em 6em
   text-align: left
   width: 100%
 
@@ -97,6 +97,8 @@
   background: rgba(gray, 0.3)
   vertical-align: middle
   margin-right: 1em
+  margin-left: -5em
 
 .field-guide-menu-item-title
+  display: inline-block
   font-weight: bold


### PR DESCRIPTION
Fixes #3485 .

Describe your changes.
Adds some padding to field guide item text, to avoid awkward text wrapping for long item titles.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch? https://field-guide-style.pfe-preview.zooniverse.org/projects/marckuchner/backyard-worlds-planet-9/classify?env=production
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?