### PR TITLE
Collection Contributions

### DIFF
--- a/app/collections/collaborators.cjsx
+++ b/app/collections/collaborators.cjsx
@@ -9,6 +9,7 @@ ID_PREFIX = 'COLLECTION_COLLABORATORS_PAGE_'
 POSSIBLE_ROLES = [
   "owner",
   "collaborator",
+  "contributor",
   "viewer"
 ]
 
@@ -19,6 +20,9 @@ ROLES_INFO =
   collaborator:
     label: "Collaborator"
     description: "Collaborators have full access to add and remove subjects from the collection."
+  contributor:
+    label: "Contributor"
+    description: "Contributors can add subjects to the collection, but not edit or delete from them."
   viewer:
     label: "Viewer"
     description: "Viewers can see this collection even if it's private."

--- a/app/collections/collaborators.cjsx
+++ b/app/collections/collaborators.cjsx
@@ -22,7 +22,7 @@ ROLES_INFO =
     description: "Collaborators have full access to add and remove subjects from the collection."
   contributor:
     label: "Contributor"
-    description: "Contributors can add subjects to the collection, but not edit or delete from them."
+    description: "Contributors can only add subjects to the collection."
   viewer:
     label: "Viewer"
     description: "Viewers can see this collection even if it's private."

--- a/app/components/collection-search.cjsx
+++ b/app/components/collection-search.cjsx
@@ -12,7 +12,7 @@ module.exports = React.createClass
   getDefaultProps: ->
     multi: false
     project: null
-  
+
   getInitialState: ->
     collections: []
 
@@ -23,7 +23,7 @@ module.exports = React.createClass
     query =
       page_size: 20
       favorite: false
-      current_user_roles: 'owner,collaborator'
+      current_user_roles: 'owner,collaborator,contributor'
     query.search = "#{value}" unless value is ''
 
     apiClient.type('collections').get query

--- a/app/main.cjsx
+++ b/app/main.cjsx
@@ -32,3 +32,6 @@ require('./lib/log-deployed-commit')()
 window?.zooAPI = require 'panoptes-client/lib/api-client'
 window?.talkAPI = require 'panoptes-client/lib/talk-client'
 require('./lib/split-config')
+
+# zooAPI.root = 'http://localhost:3000/api'
+# talkAPI.root = 'http://localhost:3001'

--- a/app/main.cjsx
+++ b/app/main.cjsx
@@ -32,6 +32,3 @@ require('./lib/log-deployed-commit')()
 window?.zooAPI = require 'panoptes-client/lib/api-client'
 window?.talkAPI = require 'panoptes-client/lib/talk-client'
 require('./lib/split-config')
-
-# zooAPI.root = 'http://localhost:3000/api'
-# talkAPI.root = 'http://localhost:3001'

--- a/app/pages/collections/collection-card.jsx
+++ b/app/pages/collections/collection-card.jsx
@@ -64,8 +64,11 @@ export default class CollectionCard extends React.Component {
               <span>{this.props.collection.display_name}</span>
               {this.props.collection.private ? <i className="fa fa-lock" /> : null}
             </div>
-            {!this.props.skipOwner ?
-              <div className="owner">{this.props.collection.links.owner.display_name}</div> : null}
+              <div className="owner">
+                {this.props.shared ?
+                  <i className="fa fa-users"></i> : null}
+                {this.props.collection.links.owner.display_name}
+              </div>
           </div>
         </div>
       </FlexibleLink>
@@ -84,6 +87,7 @@ CollectionCard.propTypes = {
   linkTo: React.PropTypes.string.isRequired,
   skipOwner: React.PropTypes.bool,
   subjectCount: React.PropTypes.number,
+  shared: React.PropTypes.bool,
   translationObjectName: React.PropTypes.string.isRequired,
 };
 

--- a/app/pages/collections/collection-card.jsx
+++ b/app/pages/collections/collection-card.jsx
@@ -66,7 +66,7 @@ export default class CollectionCard extends React.Component {
             </div>
               <div className="owner">
                 {this.props.shared ?
-                  <i className="fa fa-users"></i> : null}
+                  <span><i className="fa fa-users"></i>{" "}</span> : null}
                 {this.props.collection.links.owner.display_name}
               </div>
           </div>
@@ -85,7 +85,6 @@ CollectionCard.propTypes = {
   }).isRequired,
   imagePromise: React.PropTypes.any,
   linkTo: React.PropTypes.string.isRequired,
-  skipOwner: React.PropTypes.bool,
   subjectCount: React.PropTypes.number,
   shared: React.PropTypes.bool,
   translationObjectName: React.PropTypes.string.isRequired,
@@ -95,7 +94,6 @@ CollectionCard.defaultProps = {
   collection: {},
   imagePromise: null,
   linkTo: '',
-  skipOwner: false,
   subjectCount: 0,
   translationObjectName: '',
 };

--- a/app/pages/collections/list.cjsx
+++ b/app/pages/collections/list.cjsx
@@ -72,7 +72,7 @@ List = React.createClass
         @setState {collections}
 
   shared: (collection) ->
-    if (@props.params.collection_owner is @props.user.login) or (@props.params.profile_name is @props.user.login)
+    if (@props.params.collection_owner is @props.user?.login) or (@props.params.profile_name is @props.user?.login)
       @props.user?.id isnt collection.links.owner.id
 
   render: ->

--- a/app/pages/collections/list.cjsx
+++ b/app/pages/collections/list.cjsx
@@ -49,10 +49,16 @@ List = React.createClass
 
   listCollections: (props) ->
     query = {}
-    if props.params?.collection_owner?
+    if props.params.collection_owner is props.user?.login
       query.current_user_roles = "owner,contributor,collaborator"
-    else if props.params?.profile_name?
+    else if props.params.collection_owner?
+      query.owner = props.params.collection_owner
+
+    if props.params.profile_name is props.user?.login
+      query.current_user_roles = "owner,contributor,collaborator"
+    else if props.params.profile_name?
       query.owner = props.params.profile_name
+
     if props.project?
       query.project_ids = props.project.id
     query.favorite = props.favorite
@@ -66,7 +72,8 @@ List = React.createClass
         @setState {collections}
 
   shared: (collection) ->
-    @props.params?.collection_owner? and @props.params?.collection_owner isnt collection.links.owner.display_name
+    if (@props.params.collection_owner is @props.user.login) or (@props.params.profile_name is @props.user.login)
+      @props.user?.id isnt collection.links.owner.id
 
   render: ->
     {location} = @props

--- a/app/pages/collections/list.cjsx
+++ b/app/pages/collections/list.cjsx
@@ -20,7 +20,7 @@ List = React.createClass
         translationObjectName = "project#{translationObjectName}"
       Object.assign({}, props, {favorite: favorite, translationObjectName:"#{translationObjectName}"})
   }
-  
+
   getInitialState: ->
     collections: null # has to be null initially, rather than [], in order to display the loading message
 
@@ -30,7 +30,7 @@ List = React.createClass
 
   componentWillUnmount: ->
     document.documentElement.classList.remove 'on-secondary-page'
-  
+
   componentWillReceiveProps: (newProps) ->
     @listCollections newProps
 
@@ -50,7 +50,7 @@ List = React.createClass
   listCollections: (props) ->
     query = {}
     if props.params?.collection_owner?
-      query.owner = props.params.collection_owner
+      query.current_user_roles = "owner,contributor,collaborator"
     else if props.params?.profile_name?
       query.owner = props.params.profile_name
     if props.project?
@@ -64,6 +64,9 @@ List = React.createClass
       .get query
       .then (collections) =>
         @setState {collections}
+
+  shared: (collection) ->
+    @props.params?.collection_owner? and @props.params?.collection_owner isnt collection.links.owner.display_name
 
   render: ->
     {location} = @props
@@ -137,7 +140,7 @@ List = React.createClass
                    linkTo={@cardLink(collection)}
                    translationObjectName={@props.translationObjectName}
                    subjectCount={collection.links.subjects?.length}
-                   skipOwner={@props.params?.collection_owner?} />}
+                   shared={@shared(collection)} /> }
             </div>
             <nav>
               {if meta

--- a/app/pages/home-for-user/recent-collections.jsx
+++ b/app/pages/home-for-user/recent-collections.jsx
@@ -32,6 +32,10 @@ const RecentCollectionsSection = React.createClass({
     }
   },
 
+  shared(collection) {
+    return this.context.user.id !== collection.links.owner.id
+  },
+
   fetchCollections(user) {
     this.setState({
       loading: true,
@@ -40,10 +44,11 @@ const RecentCollectionsSection = React.createClass({
       collections: [],
     });
 
-    user.get('collections', {
+    apiClient.type('collections').get({
       page_size: 8,
       sort: '-updated_at',
       favorite: false,
+      current_user_roles: "owner,contributor,collaborator",
     })
     .then((collections) => {
       this.setState({ collections });
@@ -102,7 +107,7 @@ const RecentCollectionsSection = React.createClass({
         <div className="collections-card-list">
           {this.state.collections.map((collection) => {
             const subjectCount = collection.links.subjects ? collection.links.subjects.length : 0;
-            return <CollectionCard key={collection.id} subjectCount={subjectCount} collection={collection} imagePromise={this.state.images[collection.id]} linkTo={`/collections/${collection.slug}`} translationObjectName="collectionsPage" />;
+            return <CollectionCard key={collection.id} shared={this.shared(collection)} subjectCount={subjectCount} collection={collection} imagePromise={this.state.images[collection.id]} linkTo={`/collections/${collection.slug}`} translationObjectName="collectionsPage" />;
           })}
         </div>
       </HomePageSection>


### PR DESCRIPTION
Fixes #3263  .

Collections now have a `contributor` role that allows a user to add new subjects to a collection and nothing more. This is accessible from the collection's collaboration settings by the owner. 

* Logged in users looking at their own collection lists now see all of the collections that they are either an owner, collaborator, or contributor to. 
* If the collection is not owned by the logged in user, there's a little icon near the owner's name when viewing their own list.
* All owner names are now visible.

Staged at https://collab-collections.pfe-preview.zooniverse.org/

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?