### PR TITLE
Allow a default frame to be set for flipbooks

### DIFF
--- a/app/components/subject-viewer.cjsx
+++ b/app/components/subject-viewer.cjsx
@@ -50,7 +50,7 @@ module.exports = React.createClass
   getInitialState: ->
     loading: true
     playing: false
-    frame: @props.frame ? 0
+    frame: @props.frame ? parseInt(@props.subject.metadata.default_frame, 10) ? 0
     frameDimensions: {}
     inFlipbookMode: @props.allowFlipbook
     promptingToSignIn: false

--- a/app/components/subject-viewer.cjsx
+++ b/app/components/subject-viewer.cjsx
@@ -48,18 +48,22 @@ module.exports = React.createClass
     workflow: null
 
   getInitialState: ->
-    initialFrame = if @props.frame
-        @props.frame 
-      else if @props.allowFlipbook and @props.subject.metadata.default_frame? and @props.subject.metadata.default_frame <= @props.subject.locations.length
-          parseInt(@props.subject.metadata.default_frame, 10) - 1 
-      else 0
-
     loading: true
     playing: false
-    frame: initialFrame
+    frame: @getInitialFrame()
     frameDimensions: {}
     inFlipbookMode: @props.allowFlipbook
     promptingToSignIn: false
+
+  getInitialFrame: ->
+    {frame, allowFlipbook, subject} = @props
+    default_frame = parseInt(subject.metadata.default_frame, 10)
+    initialFrame = 0
+    if frame?
+      initialFrame = frame
+    else if allowFlipbook and typeof default_frame is 'number' and !isNaN(default_frame) and default_frame > 0 and default_frame <= subject.locations.length
+      initialFrame = default_frame - 1 
+    initialFrame
 
   componentWillReceiveProps: (nextProps) ->
     unless nextProps.subject is @props.subject

--- a/app/components/subject-viewer.cjsx
+++ b/app/components/subject-viewer.cjsx
@@ -48,9 +48,15 @@ module.exports = React.createClass
     workflow: null
 
   getInitialState: ->
+    initialFrame = if @props.frame
+        @props.frame 
+      else if @props.allowFlipbook and @props.subject.metadata.default_frame? and @props.subject.metadata.default_frame <= @props.subject.locations.length
+          parseInt(@props.subject.metadata.default_frame, 10) - 1 
+      else 0
+
     loading: true
     playing: false
-    frame: @props.frame ? parseInt(@props.subject.metadata.default_frame, 10) - 1 ? 0
+    frame: initialFrame
     frameDimensions: {}
     inFlipbookMode: @props.allowFlipbook
     promptingToSignIn: false

--- a/app/components/subject-viewer.cjsx
+++ b/app/components/subject-viewer.cjsx
@@ -50,7 +50,7 @@ module.exports = React.createClass
   getInitialState: ->
     loading: true
     playing: false
-    frame: @props.frame ? parseInt(@props.subject.metadata.default_frame, 10) ? 0
+    frame: @props.frame ? parseInt(@props.subject.metadata.default_frame, 10) - 1 ? 0
     frameDimensions: {}
     inFlipbookMode: @props.allowFlipbook
     promptingToSignIn: false

--- a/app/components/subject-viewer.cjsx
+++ b/app/components/subject-viewer.cjsx
@@ -217,7 +217,7 @@ module.exports = React.createClass
       @nextFrame()
       @_playingInterval = setInterval @nextFrame, @props.playFrameDuration
 
-      autoStopDelay = @props.subject.locations.length * @props.playFrameDuration * @props.playIterations
+      autoStopDelay = (@props.subject.locations.length * @props.playFrameDuration * @props.playIterations) - @props.playFrameDuration
       unless @props.playIterations is ''
         @_autoStop = setTimeout @setPlaying.bind(this, false), autoStopDelay
     else


### PR DESCRIPTION
Fixes #3464.

Respects a `default_frame` property if set in a multi-frame subject's metadata so the flipbook starts on that frame.

Also fixes a bug where flipbook loops would finish on the next frame, not the current frame.

Can be tested at https://default_frame.pfe-preview.zooniverse.org/projects/rogerhutchings/default-frame-test/classify, default frame should be ~~4~~ 3, now the property is 1-indexed

cc @hrspiers 

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://default_frame.pfe-preview.zooniverse.org/projects/rogerhutchings/default-frame-test/classify
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?