### PR TITLE
edit options and optionsKey

### DIFF
--- a/app/classifier/tasks/dropdown/index.spec.js
+++ b/app/classifier/tasks/dropdown/index.spec.js
@@ -153,7 +153,10 @@ describe('DropdownTask', function () {
         countrySelectInput.simulate('change', { target: { value: 'test Country' }});
         countrySelectInput.simulate('keyDown', { keyCode: 13, which: 13, key: 'Enter' });
 
-        assert.equal(annotation.value.length, 0);
+        const countryOption = annotation.value[0].option;
+        const countryValue = annotation.value[0].value;
+        assert.equal(countryValue, null);
+        assert.equal(countryOption, false);
       });
     });
     describe('and first annotation provided (Country),', function () {


### PR DESCRIPTION
Related to #3497.

- Not sure this helps, but pulls out `optionsKey` craziness to it's own function.
- Removes magical `@syncAnnotations` that didn't belong, related to... 
- `getDisabledAttribute` refactored. `getDisabledAttribute` shows the input as enabled or disabled, which for select's with `allowCreate = true` we want always enabled, but for select's with `allowCreate = false` we only want enabled if condition answered with a provided answer (`option = true`).
- edits test to reflect initial `annotation.value` array of null/false answers after mount

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? - https://dropdown-option-keys-mb.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?