### PR TITLE
Request comment authors and subjects in batches

### DIFF
--- a/app/talk/comment.cjsx
+++ b/app/talk/comment.cjsx
@@ -10,7 +10,6 @@ CommentLink = require './comment-link'
 upvotedByCurrentUser = require './lib/upvoted-by-current-user'
 {Link} = require 'react-router'
 {timestamp} = require './lib/time'
-apiClient = require 'panoptes-client/lib/api-client'
 talkClient = require 'panoptes-client/lib/talk-client'
 Avatar = require '../partials/avatar'
 SubjectViewer = require '../components/subject-viewer'
@@ -47,7 +46,6 @@ module.exports = React.createClass
     editing: false
     commentValidationErrors: []
     replies: []
-    roles: []
 
   contextTypes:
     geordi: React.PropTypes.object
@@ -55,18 +53,7 @@ module.exports = React.createClass
   logItemClick: (itemClick) ->
     @context.geordi?.logEvent
       type: itemClick
-
-  componentWillMount: ->
-
-    talkClient
-      .type 'roles'
-      .get
-        user_id: @props.data.user_id
-        section: ['zooniverse', @props.data.section]
-        is_shown: true
-        page_size: 100
-      .then (roles) =>
-        @setState {roles}
+    
 
   componentDidMount: ->
     if @props.active
@@ -187,7 +174,7 @@ module.exports = React.createClass
           <Link to={profile_link}>{@props.data.user_display_name}</Link>
           <div className="user-mention-name">@{@props.data.user_login}</div>
         </div>
-        <DisplayRoles roles={@state.roles} section={@props.data.section} />
+        <DisplayRoles roles={@props.roles} section={@props.data.section} />
       </div>
 
       <div className="talk-comment-body">

--- a/app/talk/comment.cjsx
+++ b/app/talk/comment.cjsx
@@ -47,9 +47,7 @@ module.exports = React.createClass
     editing: false
     commentValidationErrors: []
     replies: []
-    commentOwner: null
     roles: []
-    subject: null
 
   contextTypes:
     geordi: React.PropTypes.object
@@ -59,20 +57,6 @@ module.exports = React.createClass
       type: itemClick
 
   componentWillMount: ->
-    apiClient
-      .type 'users'
-      .get
-        id: @props.data.user_id
-      .index 0
-      .then (commentOwner) =>
-        @setState {commentOwner}
-    
-    if @props.data.focus_id
-      apiClient
-        .type 'subjects'
-        .get @props.data.focus_id
-        .then (subject) =>
-          @setState {subject}
 
     talkClient
       .type 'roles'
@@ -180,7 +164,7 @@ module.exports = React.createClass
   #   - it's not a focused discussion OR
   #   - it's a focused discussion and this comment's focus is different
   shouldShowFocus: ->
-    return false unless @state.subject?
+    return false unless @props.subject?
     return false if @props.hideFocus
 
     notInDiscussion = not @props.index
@@ -198,7 +182,7 @@ module.exports = React.createClass
       profile_link = "/projects/#{@props.project.slug}#{profile_link}"
     <div className="talk-comment #{activeClass} #{isDeleted}">
       <div className="talk-comment-author">
-        {<Avatar user={@state.commentOwner} /> if @state.commentOwner?}
+        {<Avatar user={@props.author} /> if @props.author?}
         <div>
           <Link to={profile_link}>{@props.data.user_display_name}</Link>
           <div className="user-mention-name">@{@props.data.user_login}</div>
@@ -236,9 +220,9 @@ module.exports = React.createClass
 
             {if @shouldShowFocus()
               <div className="polaroid-image">
-                {@commentSubjectTitle(@props.data, @state.subject)}
+                {@commentSubjectTitle(@props.data, @props.subject)}
                 <SubjectViewer
-                  subject={@state.subject}
+                  subject={@props.subject}
                   user={@props.user}
                   project={@props.project}
                   linkToFullImage={true}

--- a/app/talk/discussion.cjsx
+++ b/app/talk/discussion.cjsx
@@ -38,6 +38,7 @@ module.exports = React.createClass
     boards: []
     authors: {}
     subjects: {}
+    author_roles: {}
 
   getDefaultProps: ->
     location: query: page: 1
@@ -103,6 +104,7 @@ module.exports = React.createClass
     author_ids = []
     authors = {}
     subjects = {}
+    author_roles = {}
     @commentsRequest(page)
       .then (comments) =>
         if comments.length
@@ -126,6 +128,19 @@ module.exports = React.createClass
             .then (comment_subjects) =>
               comment_subjects.map (subject) -> subjects[subject.id] = subject
               @setState {subjects}
+
+          talkClient
+            .type 'roles'
+            .get
+              user_id: author_ids
+              section: ['zooniverse', @state.discussion.section]
+              is_shown: true
+              page_size: 100
+            .then (roles) =>
+              roles.map (role) ->
+                author_roles[role.user_id] ?= []
+                author_roles[role.user_id].push role
+              @setState {author_roles}
 
           @setState {comments, commentsMeta}, =>
             if @shouldScrollToBottom
@@ -216,6 +231,7 @@ module.exports = React.createClass
       data={data}
       author={@state.authors[data.user_id]}
       subject={@state.subjects[data.focus_id]}
+      roles={@state.author_roles[data.user_id]}
       active={+data.id is +@props.location.query?.comment}
       user={@props.user}
       locked={@state.discussion?.locked}

--- a/app/talk/recents.cjsx
+++ b/app/talk/recents.cjsx
@@ -127,9 +127,9 @@ module.exports = React.createClass
       project={@props.project}
       key={comment.id}
       data={comment}
-      author={@state.authors[data.user_id]}
-      subject={@state.subjects[data.focus_id]}
-      roles={@state.author_roles[data.user_id]}
+      author={@state.authors[comment.user_id]}
+      subject={@state.subjects[comment.focus_id]}
+      roles={@state.author_roles[comment.user_id]}
       user={@props.user}
       project={@props.project} />
 

--- a/app/talk/recents.cjsx
+++ b/app/talk/recents.cjsx
@@ -15,6 +15,8 @@ module.exports = React.createClass
 
   getInitialState: ->
     comments: []
+    authors: {}
+    subjects: {}
     boardTitle: null
     loading: true
 
@@ -57,6 +59,30 @@ module.exports = React.createClass
       boardTitle = comments[0].board_title if @props.params.board
       loading = false
       @setState {comments, boardTitle, meta, loading}
+      
+      author_ids = []
+      subject_ids = []
+      authors = {}
+      subjects = {}
+      comments.map (comment) =>
+        author_ids.push comment.user_id
+        subject_ids.push comment.focus_id if comment.focus_id.length
+
+      apiClient
+        .type 'users'
+        .get
+          id: author_ids
+        .then (users) =>
+          users.map (user) -> authors[user.id] = user
+          @setState {authors}
+
+      apiClient
+        .type 'subjects'
+        .get
+          id: subject_ids
+        .then (comment_subjects) =>
+          comment_subjects.map (subject) -> subjects[subject.id] = subject
+          @setState {subjects}
 
   toggleNotes: ->
     # Always reset to first page when toggling
@@ -84,6 +110,8 @@ module.exports = React.createClass
       project={@props.project}
       key={comment.id}
       data={comment}
+      author={@state.authors[data.user_id]}
+      subject={@state.subjects[data.focus_id]}
       user={@props.user}
       project={@props.project} />
 


### PR DESCRIPTION
Fixes load on the API caused by requests for users, subjects and user roles from the `Comment` component.

Describe your changes.
Moves the queries for comment authors, subjects and roles up to their parent components.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch? https://talk-comments-api.pfe-preview.zooniverse.org/?env=production
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?