### PR TITLE
Use flip count instead of timer to handle flipbook playing

### DIFF
--- a/app/components/subject-viewer.cjsx
+++ b/app/components/subject-viewer.cjsx
@@ -223,19 +223,22 @@ module.exports = React.createClass
 
   setPlaying: (playing) ->
     @setState {playing}
-    if playing
-      @nextFrame()
-      @_playingInterval = setInterval @nextFrame, @props.playFrameDuration
+    totalFrames = @props.subject.locations.length
+    flips = totalFrames * @props.playIterations
+    infiniteLoop = @props.playIterations is ''
+    counter = 0
 
-      autoStopDelay = (@props.subject.locations.length * @props.playFrameDuration * @props.playIterations) - @props.playFrameDuration
-      unless @props.playIterations is ''
-        @_autoStop = setTimeout @setPlaying.bind(this, false), autoStopDelay
-    else
-      clearInterval @_playingInterval
-      clearTimeout @_autoStop
+    flip = =>
+      if @state.playing and (counter < flips or infiniteLoop)
+        counter++
+        @handleFrameChange (@state.frame + 1) %% totalFrames
+        setTimeout flip, @props.playFrameDuration
+        if counter is flips and !infiniteLoop
+          @setPlaying false
+      else @setPlaying false
 
-  nextFrame: ->
-    @handleFrameChange (@state.frame + 1) %% @props.subject.locations.length
+    if playing 
+      setTimeout flip, 0
 
   handleFrameChange: (frame) ->
     @setState {frame}

--- a/app/components/subject-viewer.cjsx
+++ b/app/components/subject-viewer.cjsx
@@ -229,15 +229,15 @@ module.exports = React.createClass
     counter = 0
 
     flip = =>
-      if @state.playing and (counter < flips or infiniteLoop)
+      if @state.playing is on and (counter < flips or infiniteLoop is on)
         counter++
         @handleFrameChange (@state.frame + 1) %% totalFrames
         setTimeout flip, @props.playFrameDuration
-        if counter is flips and !infiniteLoop
+        if counter is flips and infiniteLoop is off
           @setPlaying false
       else @setPlaying false
 
-    if playing 
+    if playing is on
       setTimeout flip, 0
 
   handleFrameChange: (frame) ->


### PR DESCRIPTION
While doing #3498, @shaunanoordin discovered that different browsers handle the timeouts for the flipbook slightly differently, causing them to not complete a full loop in some cases. This uses a recursive function instead.

https://flipbook_counter.pfe-preview.zooniverse.org/projects/rogerhutchings/default-frame-test/classify

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://flipbook_counter.pfe-preview.zooniverse.org
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?