### PR TITLE
Consolidate Talk board and discussion previews

### DIFF
--- a/app/talk/board-preview.cjsx
+++ b/app/talk/board-preview.cjsx
@@ -36,7 +36,14 @@ module.exports = React.createClass
 
         <p>{@props.data.description}</p>
 
-        <LatestCommentLink {...@props} title={true} project={@props.project} discussion={@props.data.latest_discussion} comment={@props.comment} />
+        <LatestCommentLink {...@props}
+          title={true}
+          project={@props.project}
+          discussion={@props.data.latest_discussion}
+          comment={@props.comment}
+          author={@props.author}
+          roles={@props.roles}
+        />
       </div>
 
       <div className="preview-stats">

--- a/app/talk/board.cjsx
+++ b/app/talk/board.cjsx
@@ -34,6 +34,7 @@ module.exports = React.createClass
   getInitialState: ->
     discussions: []
     authors: {}
+    author_roles: {}
     subjects: {}
     board: {}
     discussionsMeta: {}
@@ -81,6 +82,19 @@ module.exports = React.createClass
               @setState (prevState, props) ->
                 prevState.authors[user.id] = user
 
+        talkClient
+          .type 'roles'
+          .get
+            user_id: author_ids
+            section: ['zooniverse', @props.section]
+            is_shown: true
+            page_size: 100
+          .then (roles) =>
+            roles.map (role) =>
+              @setState (prevState, props) ->
+                prevState.author_roles[role.user_id] ?= []
+                prevState.author_roles[role.user_id].push role
+
         apiClient
           .type 'subjects'
           .get
@@ -107,12 +121,15 @@ module.exports = React.createClass
     @setDiscussions()
 
   discussionPreview: (discussion, i) ->
+    roles = @state.author_roles[discussion.latest_comment.user_id]
+    roles ?= []
     <DiscussionPreview
       {...@props}
       key={i}
       discussion={discussion}
       subject={@state.subjects[discussion.focus_id]}
       author={@state.authors[discussion.latest_comment.user_id]}
+      roles={roles}
     />
 
   onClickDeleteBoard: ->

--- a/app/talk/discussion-preview.cjsx
+++ b/app/talk/discussion-preview.cjsx
@@ -60,7 +60,14 @@ module.exports = React.createClass
           </Link>
         </h1>
 
-        <LatestCommentLink {...@props} project={@props.project} discussion={discussion} comment={@props.comment} preview={true} />
+        <LatestCommentLink
+          {...@props}
+          project={@props.project}
+          discussion={discussion}
+          comment={@props.comment}
+          author={@props.author}
+          preview={true}
+        />
 
       </div>
       <div className="preview-stats">

--- a/app/talk/discussion-preview.cjsx
+++ b/app/talk/discussion-preview.cjsx
@@ -2,7 +2,6 @@ React = require 'react'
 {Link} = require 'react-router'
 resourceCount = require './lib/resource-count'
 LatestCommentLink = require './latest-comment-link'
-apiClient = require 'panoptes-client/lib/api-client'
 getSubjectLocation = require '../lib/get-subject-location'
 
 # `import Thumbnail from '../components/thumbnail';`
@@ -19,22 +18,6 @@ module.exports = React.createClass
   
   getDefaultProps: ->
     project: {}
-
-  getInitialState: ->
-    subject: null
-
-  componentDidMount: ->
-    @updateSubject @props.discussion
-
-  componentWillReceiveProps: (newProps) ->
-    @updateSubject newProps.discussion if newProps.discussion isnt @props.discussion
-
-  updateSubject: (discussion)->
-    if discussion.focus_id and discussion.focus_type is 'Subject'
-      apiClient.type 'subjects'
-        .get discussion.focus_id
-        .then (subject) =>
-          @setState {subject}
 
   logDiscussionClick: ->
     @context.geordi?.logEvent
@@ -61,8 +44,8 @@ module.exports = React.createClass
     <div className="talk-discussion-preview">
       <div className="preview-content">
 
-        {if @state.subject?
-          subject = getSubjectLocation(@state.subject)
+        {if @props.subject?
+          subject = getSubjectLocation(@props.subject)
           <div className="subject-preview">
             <Link to={@discussionLink()} onClick={@logDiscussionClick.bind null, this}>
               <Thumbnail src={subject.src} format={subject.format} width={100} height={150} controls={false} />

--- a/app/talk/discussion-preview.cjsx
+++ b/app/talk/discussion-preview.cjsx
@@ -66,6 +66,7 @@ module.exports = React.createClass
           discussion={discussion}
           comment={@props.comment}
           author={@props.author}
+          roles={@props.roles}
           preview={true}
         />
 

--- a/app/talk/init.cjsx
+++ b/app/talk/init.cjsx
@@ -1,6 +1,7 @@
 React = require 'react'
 BoardPreview = require './board-preview'
 ActiveUsers = require './active-users'
+apiClient = require 'panoptes-client/lib/api-client'
 talkClient = require 'panoptes-client/lib/talk-client'
 HandlePropChanges = require '../lib/handle-prop-changes'
 Moderation = require './lib/moderation'
@@ -37,6 +38,8 @@ module.exports = React.createClass
 
   getInitialState: ->
     boards: []
+    authors: {}
+    author_roles: {}
     boardsMeta: {}
     loading: true
     moderationOpen: false
@@ -49,13 +52,46 @@ module.exports = React.createClass
       @setBoards({}, nextProps)
 
   setBoards: (propValue, props = @props) ->
+    author_ids = []
     talkClient.type('boards').get(section: props.section, page_size: 20, page: props.location.query.page)
       .then (boards) =>
         boardsMeta = boards[0]?.getMeta()
         @setState {boards, boardsMeta, loading: false}
+        boards.map (board) ->
+          author_ids.push board.latest_discussion.user_id
+
+        apiClient
+          .type 'users'
+          .get
+            id: author_ids
+          .then (users) =>
+            users.map (user) => 
+              @setState (prevState, props) ->
+                prevState.authors[user.id] = user
+
+        talkClient
+          .type 'roles'
+          .get
+            user_id: author_ids
+            section: ['zooniverse', @props.section]
+            is_shown: true
+            page_size: 100
+          .then (roles) =>
+            roles.map (role) =>
+              @setState (prevState, props) ->
+                prevState.author_roles[role.user_id] ?= []
+                prevState.author_roles[role.user_id].push role
 
   boardPreview: (data, i) ->
-    <BoardPreview {...@props} key={i} data={data} />
+    roles = @state.author_roles[data.latest_discussion.user_id]
+    roles ?= []
+    <BoardPreview
+      {...@props}
+      key={i}
+      data={data}
+      author={@state.authors[data.latest_discussion.user_id]}
+      roles={roles}
+    />
 
   boardOrders: ->
     <DragReorderable

--- a/app/talk/init.cjsx
+++ b/app/talk/init.cjsx
@@ -58,7 +58,7 @@ module.exports = React.createClass
         boardsMeta = boards[0]?.getMeta()
         @setState {boards, boardsMeta, loading: false}
         boards.map (board) ->
-          author_ids.push board.latest_discussion.user_id
+          author_ids.push board.latest_discussion.latest_comment.user_id
 
         apiClient
           .type 'users'
@@ -83,13 +83,13 @@ module.exports = React.createClass
                 prevState.author_roles[role.user_id].push role
 
   boardPreview: (data, i) ->
-    roles = @state.author_roles[data.latest_discussion.user_id]
+    roles = @state.author_roles[data.latest_discussion.latest_comment.user_id]
     roles ?= []
     <BoardPreview
       {...@props}
       key={i}
       data={data}
-      author={@state.authors[data.latest_discussion.user_id]}
+      author={@state.authors[data.latest_discussion.latest_comment.user_id]}
       roles={roles}
     />
 

--- a/app/talk/latest-comment-link.cjsx
+++ b/app/talk/latest-comment-link.cjsx
@@ -1,5 +1,4 @@
 React = require 'react'
-apiClient = require 'panoptes-client/lib/api-client'
 talkClient = require 'panoptes-client/lib/talk-client'
 {timeAgo} = require './lib/time'
 DisplayRoles = require './lib/display-roles'
@@ -31,9 +30,7 @@ module.exports = React.createClass
     preview: false
 
   getInitialState: ->
-    commentUser: null
     latestCommentText: ''
-    roles: []
 
   logProfileClick: (profileItem) ->
     @context.geordi?.logEvent
@@ -44,32 +41,6 @@ module.exports = React.createClass
 
   lastPage: ->
     Math.ceil @props.discussion.comments_count / PAGE_SIZE
-
-  componentWillMount: ->
-    comment = @props.comment or @props.discussion?.latest_comment
-    return unless comment?
-    if @props.roles
-      @setState {roles: @props.roles}
-    else
-      @updateRoles comment
-    if @props.author
-      @setState {commentUser: @props.author}
-    else
-      apiClient.type('users').get(comment.user_id).then (commentUser) =>
-        @setState {commentUser}
-
-  componentWillReceiveProps: (newProps) ->
-    oldComment = @props.comment or @props.discussion?.latest_comment
-    comment = newProps.comment or newProps.discussion?.latest_comment
-    if newProps.roles
-      @setState {roles: newProps.roles}
-    else
-      @updateRoles comment
-    if newProps.author
-      @setState {commentUser: newProps.author}
-    else
-      apiClient.type('users').get(comment.user_id).then (commentUser) =>
-        @setState {commentUser}
 
   componentDidMount: ->
     latestCommentText = @refs?.markdownText?.textContent
@@ -88,17 +59,6 @@ module.exports = React.createClass
     <Link className={className} onClick={logClick?.bind(this, childtext)} to={@context.router.createHref(locationObject)}>
       {childtext}
     </Link>
-
-  updateRoles: (comment) ->
-    talkClient
-      .type 'roles'
-      .get
-        user_id: comment.user_id
-        section: ['zooniverse', comment.section]
-        is_shown: true
-        page_size: 100
-      .then (roles) =>
-        @setState {roles}
 
   render: ->
     {discussion} = @props
@@ -120,13 +80,13 @@ module.exports = React.createClass
           <Markdown content={comment.body} />
         </div>
 
-        {if @state.commentUser?
-          <Link className="user-profile-link" to="#{baseLink}users/#{@state.commentUser.login}" onClick={@logProfileClick.bind this, 'view-profile-author'}>
-            <Avatar user={@state.commentUser} />{' '}{@state.commentUser.display_name}
+        {if @props.author?
+          <Link className="user-profile-link" to="#{baseLink}users/#{@props.author.login}" onClick={@logProfileClick.bind this, 'view-profile-author'}>
+            <Avatar user={@props.author} />{' '}{@props.author.display_name}
           </Link>}
 
         {' '}
-        <DisplayRoles roles={@state.roles} section={comment.section} />
+        <DisplayRoles roles={@props.roles} section={comment.section} />
 
         <span>
           {if discussion.title and @props.title

--- a/app/talk/latest-comment-link.cjsx
+++ b/app/talk/latest-comment-link.cjsx
@@ -49,16 +49,22 @@ module.exports = React.createClass
     comment = @props.comment or @props.discussion?.latest_comment
     return unless comment?
     @updateRoles comment
-    apiClient.type('users').get(comment.user_id).then (commentUser) =>
-      @setState {commentUser}
+    if @props.author
+      @setState {commentUser: @props.author}
+    else
+      apiClient.type('users').get(comment.user_id).then (commentUser) =>
+        @setState {commentUser}
 
   componentWillReceiveProps: (newProps) ->
     oldComment = @props.comment or @props.discussion?.latest_comment
     comment = newProps.comment or newProps.discussion?.latest_comment
     return if comment is oldComment or not comment?
     @updateRoles comment
-    apiClient.type('users').get(comment.user_id).then (commentUser) =>
-      @setState {commentUser}
+    if newProps.author
+      @setState {commentUser: newProps.author}
+    else
+      apiClient.type('users').get(comment.user_id).then (commentUser) =>
+        @setState {commentUser}
 
   componentDidMount: ->
     latestCommentText = @refs?.markdownText?.textContent

--- a/app/talk/latest-comment-link.cjsx
+++ b/app/talk/latest-comment-link.cjsx
@@ -48,7 +48,10 @@ module.exports = React.createClass
   componentWillMount: ->
     comment = @props.comment or @props.discussion?.latest_comment
     return unless comment?
-    @updateRoles comment
+    if @props.roles
+      @setState {roles: @props.roles}
+    else
+      @updateRoles comment
     if @props.author
       @setState {commentUser: @props.author}
     else
@@ -58,8 +61,10 @@ module.exports = React.createClass
   componentWillReceiveProps: (newProps) ->
     oldComment = @props.comment or @props.discussion?.latest_comment
     comment = newProps.comment or newProps.discussion?.latest_comment
-    return if comment is oldComment or not comment?
-    @updateRoles comment
+    if newProps.roles
+      @setState {roles: newProps.roles}
+    else
+      @updateRoles comment
     if newProps.author
       @setState {commentUser: newProps.author}
     else


### PR DESCRIPTION
Consolidates the individual API requests for board  and discussion previews into single requests in their parent containers.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch? https://talk-boards-api.pfe-preview.zooniverse.org/?env=production
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?