### PR TITLE
add componentWillReceiveProps to stats index

### DIFF
--- a/app/pages/project/stats/index.jsx
+++ b/app/pages/project/stats/index.jsx
@@ -10,6 +10,7 @@ class ProjectStatsPageController extends React.Component {
     this.handleGraphChange = this.handleGraphChange.bind(this);
     this.handleWorkflowChange = this.handleWorkflowChange.bind(this);
     this.handleRangeChange = this.handleRangeChange.bind(this);
+    this.getWorkflows = this.getWorkflows.bind(this);
 
     this.state = {
       workflowList: [],
@@ -17,6 +18,16 @@ class ProjectStatsPageController extends React.Component {
   }
 
   componentDidMount() {
+    this.getWorkflows(this.project);
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (this.props.project !== nextProps.project) {
+      this.getWorkflows(nextProps.project);
+    }
+  }
+
+  getWorkflows(project) {
     const fields = [
       'classifications_count',
       'completeness',
@@ -29,7 +40,7 @@ class ProjectStatsPageController extends React.Component {
       active: true,
       fields: fields.join(','),
     };
-    getWorkflowsInOrder(this.props.project, query)
+    getWorkflowsInOrder(project, query)
       .then((workflows) => {
         const workflowsSetToBeVisible =
           workflows.filter((workflow) => { 


### PR DESCRIPTION
This fixes the issues where if you click on a link to another project's stats page from talk it will load the wrong workflows (e.g. Grants link in this post on the NfN talk https://www.zooniverse.org/projects/zooniverse/notes-from-nature/talk/484/70346?comment=322033).

This PR adds a `componentWillReceiveProps` to the stats page so it properly handles that change in project context.

I have set up a test case for this on the staged link: https://project-stats-context.pfe-preview.zooniverse.org/projects/cmk24/test-project-2/talk/149/234?comment=1241
This talk post links to a different project's stats page.

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://project-stats-context.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?