### PR TITLE
Use Thumbnail for small avatars

### DIFF
--- a/app/pages/project/index.cjsx
+++ b/app/pages/project/index.cjsx
@@ -11,6 +11,7 @@ classNames = require 'classnames'
 getWorkflowsInOrder = require '../../lib/get-workflows-in-order'
 isAdmin = require '../../lib/is-admin'
 {Split} = require('seven-ten')
+Thumbnail = require('../../components/thumbnail').default
 
 counterpart.registerTranslations 'en',
   project:
@@ -257,13 +258,13 @@ ProjectPage = React.createClass
         {if @props.project.redirect
           <a href={@props.project.redirect} className="tabbed-content-tab" target="_blank">
             {if @state.avatar?
-              <img src={@state.avatar.src} className="avatar" />}
+              <Thumbnail src={@state.avatar.src} className="avatar" width={48} height={48} />}
             Visit {@props.project.display_name}
           </a>
         else
           <IndexLink to="#{projectPath}" activeClassName="active" className="tabbed-content-tab" onClick={logClick?.bind this, 'project.nav.home'}>
             {if @state.avatar?
-              <img src={@state.avatar.src} className="avatar" />}
+              <Thumbnail src={@state.avatar.src} className="avatar" width={48} height={48} />}
             {if @props.loading
               'Loading...'
             else

--- a/app/pages/project/index.cjsx
+++ b/app/pages/project/index.cjsx
@@ -38,6 +38,7 @@ SOCIAL_ICONS =
   'youtu.be/': 'youtube'
   'youtube.com/': 'youtube'
 
+AVATAR_SIZE = 100
 
 ProjectPage = React.createClass
   contextTypes:
@@ -258,13 +259,13 @@ ProjectPage = React.createClass
         {if @props.project.redirect
           <a href={@props.project.redirect} className="tabbed-content-tab" target="_blank">
             {if @state.avatar?
-              <Thumbnail src={@state.avatar.src} className="avatar" width={48} height={48} />}
+              <Thumbnail src={@state.avatar.src} className="avatar" width={AVATAR_SIZE} height={AVATAR_SIZE} />}
             Visit {@props.project.display_name}
           </a>
         else
           <IndexLink to="#{projectPath}" activeClassName="active" className="tabbed-content-tab" onClick={logClick?.bind this, 'project.nav.home'}>
             {if @state.avatar?
-              <Thumbnail src={@state.avatar.src} className="avatar" width={48} height={48} />}
+              <Thumbnail src={@state.avatar.src} className="avatar" width={AVATAR_SIZE} height={AVATAR_SIZE} />}
             {if @props.loading
               'Loading...'
             else


### PR DESCRIPTION
Fixes #3501

Describe your changes.
Uses the `Thumbnail` component to resize small avatars to 48px square.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch? https://project-avatars.pfe-preview.zooniverse.org/projects/sweenkl/steller-watch?env=production
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?