### PR TITLE
Add fields filter to project index workflows request

### DIFF
--- a/app/pages/project/index.cjsx
+++ b/app/pages/project/index.cjsx
@@ -137,7 +137,7 @@ ProjectPage = React.createClass
       .then (pages) =>
         @setState {pages}
 
-  getAllWorkflows: (project, query = { active: true, fields: "active,completeness,configuration,display_name,finished_at,retirement,created_at" }) ->
+  getAllWorkflows: (project, query = { active: true, fields: "active,configuration,display_name" }) ->
     @setState { loadingSelectedWorkflow: true }
     getWorkflowsInOrder(project, query)
       .then (activeWorkflows) =>
@@ -179,10 +179,17 @@ ProjectPage = React.createClass
       @state.activeWorkflows[randomIndex].id
 
   getWorkflow: (selectedWorkflowIndex) ->
-    @setState {
-      selectedWorkflow: @state.activeWorkflows[selectedWorkflowIndex],
-      loadingSelectedWorkflow: false
-    }
+    apiClient.type('workflows').get({ id: "#{@state.activeWorkflows[selectedWorkflowIndex].id}" })
+      .catch (error) =>
+        console.error error
+        @setState {
+          loadingSelectedWorkflow: false
+        }
+      .then ([workflow]) =>
+        @setState {
+          selectedWorkflow: workflow,
+          loadingSelectedWorkflow: false
+        }
 
   isWorkflowInactive: (project, selectedWorkflowID) ->
     selectedWorkflowIndex = @state.activeWorkflows.findIndex (workflow, index) ->

--- a/app/pages/project/index.cjsx
+++ b/app/pages/project/index.cjsx
@@ -137,7 +137,7 @@ ProjectPage = React.createClass
       .then (pages) =>
         @setState {pages}
 
-  getAllWorkflows: (project, query = { active: true }) ->
+  getAllWorkflows: (project, query = { active: true, fields: "active,completeness,configuration,display_name,finished_at,retirement,created_at" }) ->
     @setState { loadingSelectedWorkflow: true }
     getWorkflowsInOrder(project, query)
       .then (activeWorkflows) =>

--- a/app/pages/project/index.cjsx
+++ b/app/pages/project/index.cjsx
@@ -137,7 +137,7 @@ ProjectPage = React.createClass
       .then (pages) =>
         @setState {pages}
 
-  getAllWorkflows: (project, query = { active: true, fields: "active,configuration,display_name" }) ->
+  getAllWorkflows: (project, query = { active: true, fields: "active,completeness,configuration,display_name" }) ->
     @setState { loadingSelectedWorkflow: true }
     getWorkflowsInOrder(project, query)
       .then (activeWorkflows) =>


### PR DESCRIPTION
Improves workflows response size on project index.

- edits `getAllWorkflows` to add `fields` filter to get only workflow attributes needed for index, home, home-workflow-buttons and home-workflow-button
- edits `getWorkflow` to get selected, uncached, workflow

Not sure this is the best solution, and as an integral part of the volunteer/classification process this will need thorough review.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? - https://add-fields-workflow.pfe-preview.zooniverse.org/
- [x] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?