### PR TITLE
[WIP][Grant-bot hack day] add a newsletter submission page to lab

### DIFF
--- a/app/pages/lab/newsletter.jsx
+++ b/app/pages/lab/newsletter.jsx
@@ -1,0 +1,91 @@
+import React from 'react';
+
+const PreviousLetter = (props) => {
+  // this makes use of the talk comment styling
+  return (
+    <div>
+      <div className="talk-comment-body">
+        {props.text}
+      </div>
+    </div>
+  );
+};
+
+PreviousLetter.propTypes = {
+  text: React.PropTypes.string
+};
+
+export default class NewsletterPage extends React.Component {
+  constructor(props) {
+    super(props);
+    this.handleChange = this.handleChange.bind(this);
+    this.handleSubmit = this.handleSubmit.bind(this);
+    this.state = {
+      newsletter: '',
+      busy: false,
+      previousNewsletters: []
+    };
+  }
+
+  componentDidMount() {
+    // Make API call to grab previously submitted newsletters
+  }
+
+  handleChange(e) {
+    this.setState({ newsletter: e.target.value });
+  }
+
+  handleSubmit() {
+    // Make the submit API call when that exists
+    // will have to parse the markdown into plan text
+    // or we could use a normal <input> box to avoid that
+    this.setState({ busy: true }, () => {
+      const previousNewsletters = this.state.previousNewsletters.slice();
+      previousNewsletters.push(this.state.newsletter);
+      this.setState({
+        newsletter: '',
+        previousNewsletters,
+        busy: false
+      });
+    });
+  }
+
+  render() {
+    let previousList = [<span key="no-letters">You have not sent any newsletters yet</span>];
+    if (this.state.previousNewsletters.length > 0) {
+      previousList = this.state.previousNewsletters.map((p, idx) => { return <PreviousLetter text={p} key={`previous-letter-${idx}`} />; });
+    }
+    return (
+      <div>
+        <span className="form-label">Newsletter</span>
+        <br />
+        <textarea
+          className="full"
+          rows="15"
+          cols="150"
+          value={this.state.newsletter}
+          onChange={this.handleChange}
+        />
+        <br />
+        <small className="form-help">Send a newsletter to your volunteers.  When you use the submit button below your newsletter will be reviewed by the Zooniverse before being sent out to your uses.</small>
+        <button
+          type="button"
+          className="major-button"
+          disabled={this.state.busy}
+          onClick={this.handleSubmit}
+        >
+          Submit
+        </button>
+        <hr />
+        <span className="form-label">Previous newsletters</span>
+        <div className="talk">
+          {previousList}
+        </div>
+      </div>
+    );
+  }
+}
+
+NewsletterPage.propTypes = {
+  project: React.PropTypes.object.isRequired
+};

--- a/app/pages/lab/newsletter.jsx
+++ b/app/pages/lab/newsletter.jsx
@@ -2,6 +2,9 @@ import React from 'react';
 
 const PreviousLetter = (props) => {
   // this makes use of the talk comment styling
+  // depanding on what data is saved on the API this should also display information
+  // about the "status" of the newsletter (e.g. accepted, pending, rejected)
+  // and metadata such as data sent out.
   return (
     <div>
       <div className="talk-comment-body">
@@ -37,8 +40,7 @@ export default class NewsletterPage extends React.Component {
 
   handleSubmit() {
     // Make the submit API call when that exists
-    // will have to parse the markdown into plan text
-    // or we could use a normal <input> box to avoid that
+    // the textarea style should be extracted to css
     this.setState({ busy: true }, () => {
       const previousNewsletters = this.state.previousNewsletters.slice();
       previousNewsletters.push(this.state.newsletter);
@@ -62,12 +64,13 @@ export default class NewsletterPage extends React.Component {
         <textarea
           className="full"
           rows="15"
-          cols="150"
+          style={{ width: '100%' }}
           value={this.state.newsletter}
           onChange={this.handleChange}
         />
         <br />
         <small className="form-help">Send a newsletter to your volunteers.  When you use the submit button below your newsletter will be reviewed by the Zooniverse before being sent out to your uses.</small>
+        <br />
         <button
           type="button"
           className="major-button"

--- a/app/pages/lab/project.cjsx
+++ b/app/pages/lab/project.cjsx
@@ -86,6 +86,9 @@ EditProjectPage = React.createClass
           <li><Link to={@labPath('/talk')} activeClassName='active' className="nav-list-item" title="Setup project specific discussion boards">
             Talk
           </Link></li>
+          <li><Link to={@labPath('/newsletter')} activeClassName='active' className="nav-list-item" title="Send a newsletter to your volunteers">
+            Newsletter
+          </Link></li>
           <li><Link to={@labPath('/data-exports')} activeClassName='active' className="nav-list-item" title="Get your project's data exports">
             Data Exports
           </Link></li>

--- a/app/router.cjsx
+++ b/app/router.cjsx
@@ -14,6 +14,7 @@ React = require 'react'
 `import EditMediaPage from './pages/lab/media';`
 `import UserProfilePage from './pages/profile/index';`
 `import NotificationsPage from './pages/notifications';`
+`import NewsletterPage from './pages/lab/newsletter';`
 
 # <Redirect from="home" to="/" /> doesn't work.
 ONE_UP_REDIRECT = React.createClass
@@ -193,6 +194,7 @@ module.exports =
       <Route path="visibility" component={require './pages/lab/visibility'} />
       <Route path="talk" component={require './pages/lab/talk'} />
       <Route path="data-exports" component={require './pages/lab/data-dumps'} />
+      <Route path="newsletter" component={NewsletterPage} />
       <Route path="tutorial" component={require './pages/lab/tutorial'} />
       <Route path="guide" component={require './pages/lab/field-guide'} />
       <Route path="mini-course" component={require './pages/lab/mini-course'} />


### PR DESCRIPTION
This adds the front-end component where project builders and submit text for a newsletter that can be sent to their users.

There is currently no back-end in place to hook this component up to.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?