### PR TITLE
Validate project before allowing beta application

### DIFF
--- a/app/pages/lab/visibility.cjsx
+++ b/app/pages/lab/visibility.cjsx
@@ -32,14 +32,17 @@ module.exports = React.createClass
 
   isReviewable: ->
     not @props.project.private and
-    @props.project.live and not
-    @state.setting.beta_requested and not
-    @props.project.beta_requested and not
-    @props.project.beta_approved and
+    @props.project.live and 
+    not @state.setting.beta_requested and 
+    not @props.project.beta_requested and 
+    not @props.project.beta_approved
+
+  isValidProject: ->
     @props.project.subject_count >= 100
 
   canApplyForReview: ->
     @isReviewable() and
+    @isValidProject() and
     @state.labPolicyReviewed and
     @state.bestPracticesReviewed and
     @state.feedbackReviewed

--- a/app/pages/lab/visibility.cjsx
+++ b/app/pages/lab/visibility.cjsx
@@ -38,7 +38,9 @@ module.exports = React.createClass
     not @props.project.beta_approved
 
   isValidProject: ->
-    @props.project.subject_count >= 100
+    activeWorkflows = @state.workflows?.filter (workflow) -> workflow.active
+    @props.project.subject_count >= 100 and
+    (activeWorkflows and activeWorkflows.length > 0)
 
   canApplyForReview: ->
     @isReviewable() and

--- a/app/pages/lab/visibility.cjsx
+++ b/app/pages/lab/visibility.cjsx
@@ -35,7 +35,8 @@ module.exports = React.createClass
     @props.project.live and not
     @state.setting.beta_requested and not
     @props.project.beta_requested and not
-    @props.project.beta_approved
+    @props.project.beta_approved and
+    @props.project.subject_count >= 100
 
   canApplyForReview: ->
     @isReviewable() and


### PR DESCRIPTION
Now requires the following statements to be true about a project before an owner can apply for beta:

- Must have an active workflow
- Must have all about pages filled in (doesn't check very hard, just to see how many pages are attached to a project; you can circumvent this by entering some content and deleting it again :/ )
- ~~Must have at least 100 subjects in active workflows~~ [see below](https://github.com/zooniverse/Panoptes-Front-End/pull/3523#issuecomment-282685877)

@mrniaboc 

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://validate-project.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?