### PR TITLE
Fix display of empty discussions

### DIFF
--- a/app/talk/board.cjsx
+++ b/app/talk/board.cjsx
@@ -72,7 +72,7 @@ module.exports = React.createClass
         @setState {discussions, discussionsMeta, loading: false}
         discussions.map (discussion) ->
           subject_ids.push discussion.focus_id if discussion.focus_id and discussion.focus_type is 'Subject'
-          author_ids.push discussion.latest_comment.user_id
+          author_ids.push discussion.latest_comment.user_id if discussion.latest_comment?
 
         apiClient
           .type 'users'
@@ -122,14 +122,15 @@ module.exports = React.createClass
     @setDiscussions()
 
   discussionPreview: (discussion, i) ->
-    roles = @state.author_roles[discussion.latest_comment.user_id]
+    user_id = discussion.latest_comment?.user_id
+    roles = @state.author_roles[user_id]
     roles ?= []
     <DiscussionPreview
       {...@props}
       key={i}
       discussion={discussion}
       subject={@state.subjects[discussion.focus_id]}
-      author={@state.authors[discussion.latest_comment.user_id]}
+      author={@state.authors[user_id]}
       roles={roles}
     />
 

--- a/app/talk/init.cjsx
+++ b/app/talk/init.cjsx
@@ -59,7 +59,8 @@ module.exports = React.createClass
         boardsMeta = boards[0]?.getMeta()
         @setState {boards, boardsMeta, loading: false}
         boards.map (board) ->
-          author_ids.push board.latest_discussion.latest_comment.user_id
+          user_id = board.latest_discussion?.latest_comment.user_id
+          author_ids.push user_id if user_id?
 
         apiClient
           .type 'users'
@@ -84,13 +85,14 @@ module.exports = React.createClass
                 prevState.author_roles[role.user_id].push role
 
   boardPreview: (data, i) ->
-    roles = @state.author_roles[data.latest_discussion.latest_comment.user_id]
+    user_id = data.latest_discussion?.latest_comment.user_id
+    roles = @state.author_roles[user_id]
     roles ?= []
     <BoardPreview
       {...@props}
       key={i}
       data={data}
-      author={@state.authors[data.latest_discussion.latest_comment.user_id]}
+      author={@state.authors[user_id]}
       roles={roles}
     />
 


### PR DESCRIPTION
Fixes: Gravity Spy Talk currently fails to load because they have a new, empty discussion.

Describe your changes.
Check for latest discussion (and latest comment) before rendering authors and roles.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://talk-load-empty-discussions.pfe-preview.zooniverse.org/projects/zooniverse/gravity-spy/talk?env=production
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?