### PR TITLE
Validate project before allowing beta submission

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -28,6 +28,13 @@
       "plugins": [
         ["transform-react-jsx"]
       ]
+    },
+    "test": {
+      "plugins": [
+        ["babel-plugin-rewire"],
+        ["transform-react-jsx"],
+        ["typecheck"]        
+      ] 
     }
   }
 }

--- a/app/pages/lab/apply-for-beta-form.jsx
+++ b/app/pages/lab/apply-for-beta-form.jsx
@@ -17,9 +17,9 @@ const projectHasMinimumActiveSubjects = (workflows) => {
   const activeWorkflows = workflows.filter((workflow) => {
     return workflow.active;
   });
-  const uniqueSetIDs = uniq(activeWorkflows.map((workflow) => {
-    return workflow.links.subject_sets;
-  }));
+  const uniqueSetIDs = activeWorkflows.reduce((sets, workflow) => {
+    return uniq(sets.concat(workflow.links.subject_sets));
+  }, []);
   // Second parameter is an empty object to prevent request caching.
   return apiClient.type('subject_sets', {})
     .get(uniqueSetIDs)
@@ -64,7 +64,7 @@ const renderValidationErrors = (errors) => {
     return (
       <div>
         <p className="form-help">The following errors need to be fixed:</p>
-        <ul className="form-help error-messages">
+        <ul className="form-help error error-messages">
           {errors.map((error) => {
             return <li key={error}>{error}</li>;
           })}
@@ -245,6 +245,8 @@ class ApplyForBetaForm extends React.Component {
         </ul>
         <p className="form-help">These will be checked when you click &quot;Apply for review&quot;.</p>
 
+        {renderValidationErrors(this.state.validationErrors)}
+
         <button
           type="button"
           className="standard-button"
@@ -253,8 +255,6 @@ class ApplyForBetaForm extends React.Component {
         >
           Apply for review
         </button>
-
-        {renderValidationErrors(this.state.validationErrors)}
 
       </div>
     );

--- a/app/pages/lab/apply-for-beta-form.jsx
+++ b/app/pages/lab/apply-for-beta-form.jsx
@@ -1,0 +1,243 @@
+import React from 'react';
+import uniq from 'lodash.uniq';
+import apiClient from 'panoptes-client/lib/api-client';
+
+const MINIMUM_SUBJECT_COUNT = 100;
+const REQUIRED_PAGES = ['Research', 'FAQ'];
+
+class ApplyForBetaForm extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.attemptApplyForBeta = this.attemptApplyForBeta.bind(this);
+    this.canApplyForReview = this.canApplyForReview.bind(this);
+    this.createCheckbox = this.createCheckbox.bind(this);
+    this.projectHasActiveWorkflows = this.projectHasActiveWorkflows.bind(this);
+    this.projectHasMinimumActiveSubjects = this.projectHasMinimumActiveSubjects.bind(this);
+    this.projectHasRequiredContent = this.projectHasRequiredContent.bind(this);
+    this.projectIsLive = this.projectIsLive.bind(this);
+    this.projectIsPublic = this.projectIsPublic.bind(this);
+    this.renderValidationErrors = this.renderValidationErrors.bind(this);
+    this.testAsyncValidations = this.testAsyncValidations.bind(this);
+    this.toggleValidation = this.toggleValidation.bind(this);
+    this.updateValidationsFromProps = this.updateValidationsFromProps.bind(this);
+    
+    this.state = {
+      validations: {
+        projectIsPublic: this.projectIsPublic(props.project),
+        projectIsLive: this.projectIsLive(props.project),
+        projectHasActiveWorkflows: this.projectHasActiveWorkflows(props.workflows),
+        labPolicyReviewed: false,
+        bestPracticesReviewed: false,
+        feedbackReviewed: false,
+      },
+      validationErrors: [],
+      doingAsyncValidation: false,
+    };
+  }
+
+  attemptApplyForBeta() {
+    this.testAsyncValidations()
+      .then(() => {
+        this.props.applyFn();
+      })
+      .catch(errors => {
+        this.setState({
+          validationErrors: errors,
+        });
+      });
+  }
+
+  projectHasMinimumActiveSubjects(workflows) { 
+    const activeWorkflows = workflows.filter(workflow => workflow.active);
+    const uniqueSetIDs = uniq(activeWorkflows.map(workflow => workflow.links.subject_sets));
+    // Second parameter is an empty object to prevent request caching.
+    return apiClient.type('subject_sets', {})
+      .get(uniqueSetIDs)
+      .then(sets => {
+        const subjectCount = sets.reduce((count, set) => count + set.set_member_subjects_count, 0);
+        return (subjectCount >= MINIMUM_SUBJECT_COUNT) ? true : `The project only has ${subjectCount} of ${MINIMUM_SUBJECT_COUNT} required subjects`;
+      });
+  }
+  
+  projectHasRequiredContent(project) { 
+    // Second parameter is an empty object to prevent request caching.
+    return apiClient.type('projects')
+      .get(project.id)
+      .get('pages', {})
+      .then(projectPages => {
+        const missingPages = REQUIRED_PAGES.reduce((accumulator, requiredPage) => {
+          const pagePresent = projectPages.find(page => requiredPage === page.title);
+          if (!pagePresent || (pagePresent.content === null || pagePresent.content === ''))
+            accumulator.push(requiredPage);
+          return accumulator;
+        }, []);
+        return (missingPages.length === 0) ? true : 'The following pages are missing content: ' + missingPages.join(', ');
+      });
+  }
+
+  testAsyncValidations() {
+    // Resolves to true if everything passes, else rejects with an array of
+    // error messages.
+    this.setState({ doingAsyncValidation: true });
+    return Promise.all([
+      this.projectHasMinimumActiveSubjects(this.props.workflows),
+      this.projectHasRequiredContent(this.props.project),
+    ])
+    .catch(error => console.error('Error requesting project data', error))
+    .then(results => {
+      this.setState({ doingAsyncValidation: false });
+      if (results.every(result => typeof result === 'boolean' && result === true)) {
+        return true;
+      }
+      const errors = results.filter(result => typeof result !== 'boolean');
+      return Promise.reject(errors);
+    })
+  }
+
+  projectIsPublic(project) {
+    return project.private === false;
+  }
+
+  projectIsLive(project) {
+    return project.live === true;
+  }
+
+  projectHasActiveWorkflows(workflows) {
+    return workflows.some(workflow => workflow.active);
+  }
+
+  toggleValidation(validationName, event) {
+    const validations = Object.assign({}, this.state.validations);
+    validations[validationName] = event.target.checked;
+    this.setState({ validations });
+  }
+
+  canApplyForReview() {
+    const { validations } = this.state;
+    const values = Object.keys(validations)
+      .map(key => validations[key]);
+    return values.every(value => value === true);
+  }
+
+  createCheckbox(validationName, content, disabled = false) {
+    // If it's a non-user controlled checkbox, we don't want to trigger anything 
+    // on change, so we use Function.prototype as a noop.
+    const changeFn = (disabled) ? Function.prototype : this.toggleValidation.bind(this, validationName);
+    return (
+      <label style={{ display: 'block' }}>
+        <input type="checkbox"
+          onChange={changeFn}
+          checked={this.state.validations[validationName] === true}
+          disabled={disabled}
+          />
+          {content}
+      </label>
+    );
+  }
+
+  componentWillUpdate(nextProps) {
+    this.updateValidationsFromProps(nextProps);
+  }
+
+  updateValidationsFromProps(props) {
+    // We need to do a props comparison, otherwise we get a loop where props
+    // update state -> updates state repeatedly.
+    // 
+    // Unfortunately, we have to do it by comparing the new props against the 
+    // current state, instead of using shouldComponentUpdate. This is because 
+    // the project prop passed down is mutable, which breaks the props/nextProps 
+    // comparison used by shouldComponentUpdate.
+    const validations = Object.assign({}, this.state.validations);
+
+    const newValues = {
+      projectIsPublic: this.projectIsPublic(props.project),
+      projectIsLive: this.projectIsLive(props.project),
+      projectHasActiveWorkflows: this.projectHasActiveWorkflows(props.workflows),
+    };
+
+    for (let key in newValues) {
+      if (validations[key] !== newValues[key])
+        validations[key] = newValues[key];
+    }
+
+    if (!shallowCompare(validations, this.state.validations))
+      this.setState({ validations });
+  }
+
+  renderValidationErrors(errors) {
+    if (errors.length) {
+      return (
+        <div>
+          <p className="form-help">The following errors need to be fixed:</p>
+          <ul className="form-help error-messages">
+            {errors.map(error => <li key={error}>{error}</li>)}
+          </ul>
+        </div>
+      );
+    }
+    return null;
+  }
+
+  render() {
+    const applyButtonDisabled = !this.canApplyForReview() || 
+      this.state.doingAsyncValidation;
+    
+    return (
+      <div>
+
+        {this.createCheckbox('projectIsPublic', <span>Project is public</span>, true)}  
+
+        {this.createCheckbox('projectIsLive', <span>Project is live</span>, true)}
+
+        {this.createCheckbox('projectHasActiveWorkflows', <span>Project has at least one active workflow</span>, true)}
+
+        {this.createCheckbox('labPolicyReviewed', <span>I have reviewed the <a href="/lab-policies" target="_blank">policies</a></span>)}
+
+        {this.createCheckbox('bestPracticesReviewed', <span>I have reviewed the <a href="/lab-best-practices" target="_blank">best practices</a></span>)}
+
+        {this.createCheckbox('feedbackReviewed', <span>I have reviewed the sample <a href="https://docs.google.com/a/zooniverse.org/forms/d/1o7yTqpytWWhSOqQhJYiKaeHIaax7xYVUyTOaG3V0xA4/viewform" target="_blank">project review feedback form</a></span>)}
+
+        <p className="form-help">To be eligible for beta review, projects also require:</p>
+        <ul className="form-help">
+          <li>at least {MINIMUM_SUBJECT_COUNT} subjects in active workflows</li>
+          <li>content on the Research and FAQ pages in the About page</li>
+        </ul>
+        <p className="form-help">These will be checked when you click "Apply for review".</p>
+
+        <button
+          type="button"
+          className="standard-button"
+          disabled={applyButtonDisabled}
+          onClick={this.attemptApplyForBeta}
+        >
+          Apply for review
+        </button>
+
+        {this.renderValidationErrors(this.state.validationErrors)}
+
+      </div>
+    );
+
+  }
+}
+
+ApplyForBetaForm.defaultProps = {
+  project: {},
+  workflows: [],
+}
+
+export default ApplyForBetaForm;
+
+// Helper function for comparing objects
+const shallowCompare = (a, b) => {
+  for (let key in a) {
+    if (!(key in b) || a[key] !== b[key])
+      return false;
+  }
+  for (let key in b) {
+    if(!(key in a) || a[key] !== b[key])
+      return false;
+  }
+  return true;
+}

--- a/app/pages/lab/apply-for-beta-form.spec.js
+++ b/app/pages/lab/apply-for-beta-form.spec.js
@@ -1,0 +1,362 @@
+import React from 'react';
+import assert from 'assert';
+import { shallow, mount } from 'enzyme';
+import sinon from 'sinon';
+import ApplyForBetaForm from './apply-for-beta-form';
+
+const MINIMUM_SUBJECT_COUNT = 100;
+const REQUIRED_PAGES = ['Research', 'FAQ'];
+
+const createProjectProp = (properties) => {
+  return Object.assign({}, {
+    id: 1234,
+    private: false,
+    live: true,
+  }, properties);
+};
+
+const assertLabelAndCheckboxExist = function(label, checkbox) {
+  assert.ok(label.length, 'Label exists');
+  assert.ok(checkbox.length, 'Checkbox exists');
+};
+
+const assertCheckboxDisabled = function(checkbox, disabled = true) {
+  const message = `Checkbox is ${disabled ? 'disabled' : 'enabled'}`;
+  assert.ok(checkbox.prop('disabled') === disabled, message);
+};
+
+const assertCheckboxChecked = function(checkbox, checked = true) {
+  const message = `Checkbox is ${checked ? 'checked' : 'unchecked'}`;
+  assert.ok(checkbox.prop('checked') === checked, message);
+};
+
+describe('ApplyForBeta component:', function() {
+
+  let project = {};
+  let workflows = [];
+  let applyFn = Function.prototype;
+  let wrapper = Function.prototype;
+  let label = Function.prototype;
+  let checkbox = Function.prototype;
+  let mockPages = [];
+  let mockSubjectSets = [];
+
+  const testSetup = function() {
+    project = createProjectProp();
+    workflows = [1, 2, 3].map(i => ({
+      id: i.toString(),
+      active: false,
+      links: {
+        subject_sets: [(i + 3).toString()],
+      },
+    }));
+    applyFn = sinon.spy();
+    mockPages = [];
+    mockSubjectSets = [
+      { id: "0", set_member_subjects_count: 98 },
+    ];
+  };
+
+  ApplyForBetaForm.__Rewire__('apiClient', {
+    type: (type) => ({
+      get: () => {
+        let result = null;
+        const resolver = (value) => new Promise(resolve => resolve(value));
+        if (type === 'projects') {
+          result = {
+            get: () => resolver(mockPages),
+          };  
+        } else if (type === 'subject_sets') {
+          result = resolver(mockSubjectSets);
+        }
+        return result;
+      },
+    }),
+  });
+
+  it('should render without crashing', function() {
+    testSetup();
+    shallow(<ApplyForBetaForm project={project} />);
+  });
+
+  describe('checkbox validation:', function() {
+
+    const setWrappers = function(labelText) {
+      wrapper = shallow(<ApplyForBetaForm project={project} workflows={workflows} />);
+      label = wrapper.findWhere(function(node) {
+        return node.type() === 'label' && node.text() === labelText;
+      }).first();
+      checkbox = label.find('input[type="checkbox"]').first();
+    }
+
+    describe('disabled checkboxes:', function() {
+      describe('public status checkbox:', function() {
+        const setPublicStatusWrappers = function() {
+          setWrappers('Project is public');
+        }
+
+        beforeEach(testSetup);
+
+        it('should exist', function() { 
+          setPublicStatusWrappers();
+          assertLabelAndCheckboxExist(label, checkbox);
+        });
+
+        it('should be disabled', function() {
+          setPublicStatusWrappers();
+          assertCheckboxDisabled(checkbox);
+        });
+
+        it('should be unchecked if the project is private', function() {
+          project.private = true;
+          setPublicStatusWrappers();
+          assertCheckboxChecked(checkbox, false);
+        });
+
+        it('should be checked if the project is public', function() {
+          setPublicStatusWrappers();
+          assertCheckboxChecked(checkbox);
+        });
+      });
+
+      describe('live status checkbox:', function() {
+        const setLiveStatusWrappers = function() {
+          setWrappers('Project is live');
+        }
+
+        beforeEach(testSetup);
+
+        it('should exist', function() {
+          setLiveStatusWrappers();
+          assertLabelAndCheckboxExist(label, checkbox);
+        });
+
+        it('should be disabled', function() {
+          setLiveStatusWrappers();
+          assertCheckboxDisabled(checkbox);
+        });
+
+        it('should be unchecked if the project is in development', function() {
+          project.live = false;
+          setLiveStatusWrappers();
+          assertCheckboxChecked(checkbox, false);
+        });
+
+        it('should be checked if the project is live', function() {
+          setLiveStatusWrappers();
+          assertCheckboxChecked(checkbox);
+        });
+      });
+
+      describe('active workflow checkbox:', function() {
+        const setActiveWorkflowStatusWrappers = function() {
+          setWrappers('Project has at least one active workflow');
+        }
+
+        beforeEach(testSetup);
+
+        it('should exist', function() { 
+          setActiveWorkflowStatusWrappers();
+          assertLabelAndCheckboxExist(label, checkbox);
+        });
+
+        it('should be disabled', function() {
+          setActiveWorkflowStatusWrappers();
+          assertCheckboxDisabled(checkbox);
+        });
+
+        it('should be unchecked if the project has no active workflows', function() {
+          setActiveWorkflowStatusWrappers();
+          assertCheckboxChecked(checkbox, false);
+        });
+
+        it('should be checked if the project has at least one active workflow', function() {
+          workflows[0].active = true;
+          setActiveWorkflowStatusWrappers();
+          assertCheckboxChecked(checkbox);
+        });
+      });
+    });
+
+    describe('enabled checkboxes:', function() {
+      describe('lab policies checkbox:', function() {
+        const setLabPoliciesWrappers = function() {
+          setWrappers('I have reviewed the policies');
+        };
+
+        beforeEach(testSetup);
+
+        it('should exist', function() {
+          setLabPoliciesWrappers();
+          assertLabelAndCheckboxExist(label, checkbox);
+        });
+
+        it('should be enabled', function() {
+          setLabPoliciesWrappers();
+          assertCheckboxDisabled(checkbox, false);
+        });
+      });
+
+      describe('best practices checkbox:', function() {
+        const setBestPracticesWrappers = function() {
+          setWrappers('I have reviewed the best practices');
+        };
+
+        beforeEach(testSetup);
+
+        it('should exist', function() {
+          setBestPracticesWrappers();
+          assertLabelAndCheckboxExist(label, checkbox);
+        });
+
+        it('should be enabled', function() {
+          setBestPracticesWrappers();
+          assertCheckboxDisabled(checkbox, false);
+        });
+      });
+
+      describe('feedback form checkbox:', function() {
+        const setFeedbackFormWrappers = function() {
+          setWrappers('I have reviewed the sample project review feedback form');
+        };
+        
+        beforeEach(testSetup);
+
+        it('should exist', function() {
+          setFeedbackFormWrappers();
+          assertLabelAndCheckboxExist(label, checkbox);
+        });
+
+        it('should be enabled', function() {
+          setFeedbackFormWrappers();
+          assertCheckboxDisabled(checkbox, false);
+        });
+      });
+    });
+  });
+
+  describe('async validation:', function() {
+    const testForErrorMessage = (regex, result, condition, done) => {
+      workflows[0].active = true;
+      wrapper = mount(<ApplyForBetaForm project={project} workflows={workflows} />);
+      wrapper.find('input[type="checkbox"]').forEach(checkbox => {
+        checkbox.simulate('change', { target: { checked: true }});
+      });
+      wrapper.find('button.standard-button').first().simulate('click');
+      setTimeout(() => {
+        const errorMessages = wrapper.find('ul.form-help').at(1).text();
+        const containsError = regex.test(errorMessages);
+        assert.ok(containsError === result, condition);
+        done();
+      }, 0)
+    };
+
+    describe('content page checks:', function () {
+      REQUIRED_PAGES.map(function (pageTitle) {
+        beforeEach(testSetup);
+
+        const pattern = 'The following pages are missing content:(.+?)' + pageTitle;
+        const regex = new RegExp(pattern);
+
+        it(`should show an error if ${pageTitle} doesn't exist`, function(done) {
+          testForErrorMessage(regex, true, `${pageTitle} page doesn't exist`, done);
+        });
+
+        it(`should show an error if ${pageTitle} doesn't have any content`, function(done) {
+          mockPages.push({
+            title: pageTitle,
+            content: '',
+          });
+          testForErrorMessage(regex, true, `${pageTitle} page doesn't contain any content`, done);
+        });        
+
+        it(`shouldn't show an error if ${pageTitle} exists and has content`, function(done) {
+          mockPages.push({
+            title: pageTitle,
+            content: 'foobar',
+          });
+          testForErrorMessage(regex, false, `${pageTitle} page doesn't contain any content`, done);
+        });  
+      });
+    });
+
+    describe('subject set checks:', function () {
+      beforeEach(testSetup);
+
+      const pattern = 'The project only has (\\d+?) of ' + MINIMUM_SUBJECT_COUNT + ' required subjects';
+      const regex = new RegExp(pattern);
+
+      it(`should show an error if there are less than ${MINIMUM_SUBJECT_COUNT} subjects`, function(done) {
+        testForErrorMessage(regex, true, `Project contains less than ${MINIMUM_SUBJECT_COUNT} subjects`, done);
+      });
+
+      it(`shouldn't show an error if there are ${MINIMUM_SUBJECT_COUNT} subjects`, function(done) {
+        mockSubjectSets.push({
+          id: "1", 
+          set_member_subjects_count: 98,
+        });
+        testForErrorMessage(regex, false, `Project contains ${MINIMUM_SUBJECT_COUNT} subjects`, done);
+      });
+
+      it(`shouldn't show an error if there are more than ${MINIMUM_SUBJECT_COUNT} subjects`, function(done) {
+        mockSubjectSets.push({
+          id: "1", 
+          set_member_subjects_count: 98,
+        }, {
+          id: "2", 
+          set_member_subjects_count: 1,
+        });
+        testForErrorMessage(regex, false, `Project contains ${MINIMUM_SUBJECT_COUNT} subjects`, done);
+      });
+    });
+  });
+
+  describe('apply button behaviour:', function() {
+    beforeEach(testSetup);
+
+    it('should exist', function() {
+      wrapper = shallow(<ApplyForBetaForm project={project} workflows={workflows} />);
+      const button = wrapper.find('button.standard-button').first();
+      assert(button.length > 0, 'Button exists');
+    });
+
+    it('should be disabled unless all checkboxes are checked', function() {
+      workflows[0].active = true;
+      wrapper = mount(<ApplyForBetaForm project={project} workflows={workflows} />);
+      const checkboxes = wrapper.find('input[type="checkbox"]');
+      checkboxes.forEach(function(checkbox, index) {
+        if (index < (checkboxes.length - 1))
+          checkbox.simulate('change', { target: { checked: true }});
+      })
+      const button = wrapper.find('button.standard-button').first();
+      assert(button.prop('disabled') === true, 'Button is disabled');
+    });
+
+    it('should call the applyFn prop on click if all validations pass', function(done) {
+      workflows[0].active = true;
+      mockPages.push({
+        title: 'Research', 
+        content: 'foobar', 
+      }, {
+        title: 'FAQ', 
+        content: 'foobar', 
+      });
+      mockSubjectSets.push({
+        id: "1", 
+        set_member_subjects_count: 2,
+      });
+
+      wrapper = mount(<ApplyForBetaForm project={project} workflows={workflows} applyFn={applyFn} />);
+      wrapper.find('input[type="checkbox"]').forEach(function(checkbox) {
+        checkbox.simulate('change', { target: { checked: true }});
+      })
+      wrapper.find('button.standard-button').first().simulate('click');
+      
+      setTimeout(function() {
+        assert.ok(applyFn.calledOnce, 'applyFn has been called');
+        done();
+      }, 0);
+    });
+  });
+
+});

--- a/app/pages/lab/visibility.cjsx
+++ b/app/pages/lab/visibility.cjsx
@@ -1,8 +1,11 @@
 React = require 'react'
+apiClient = require 'panoptes-client/lib/api-client'
 WorkflowToggle = require '../../components/workflow-toggle'
 SetToggle = require '../../lib/set-toggle'
-Dialog = require 'modal-form/dialog'
 getWorkflowsInOrder = require '../../lib/get-workflows-in-order'
+uniq = require 'lodash.uniq'
+
+`import ApplyForBetaForm from './apply-for-beta-form';`
 
 module.exports = React.createClass
   displayName: 'EditProjectVisibility'
@@ -10,61 +13,34 @@ module.exports = React.createClass
   getDefaultProps: ->
     project: null
 
-  getInitialState: -> {
-    error: null,
-    setting: {
-      private: false,
-      beta_requested: false,
-      launch_requested: false,
-    },
-    workflows: null 
-  }
+  getInitialState: -> 
+    error: null
+    setting:
+      private: false
+      beta_requested: false
+      launch_requested: false
+    workflows: []
+    loadingWorkflows: false
 
   mixins: [SetToggle]
 
   setterProperty: 'project'
 
   componentDidMount: ->
-    getWorkflowsInOrder(@props.project, fields: 'display_name,active,configuration')
-      .then((workflows) =>
-        @setState({ workflows })
-      )
-
-  isReviewable: ->
-    not @props.project.private and
-    @props.project.live and not
-    @state.setting.beta_requested and not
-    @props.project.beta_requested and not
-    @props.project.beta_approved
-
-  canApplyForReview: ->
-    @isReviewable() and
-    @state.labPolicyReviewed and
-    @state.bestPracticesReviewed and
-    @state.feedbackReviewed
+    @setState { loadingWorkflows: true }
+    getWorkflowsInOrder @props.project
+      .then (workflows) =>
+        @setState
+          workflows: workflows
+          loadingWorkflows: false
 
   setRadio: (property, value) ->
     @set property, value
-    unless @isReviewable()
-      @setState
-        labPolicyReviewed: false
-        bestPracticesReviewed: false
-        feedbackReviewed: false
 
   toggleCheckbox: (checkbox) ->
     change = { }
     change[checkbox] = @refs?[checkbox]?.checked
     @setState change
-
-  showFeedbackForm: ->
-    Dialog.alert(
-      <div>
-        <h3>Review Feedback</h3>
-        <p>During review, a feedback form will be provided to volunteers that will help you improve your project.</p>
-        <p>A <a href="https://docs.google.com/a/zooniverse.org/forms/d/1o7yTqpytWWhSOqQhJYiKaeHIaax7xYVUyTOaG3V0xA4/viewform" target="_blank">sample of the form</a> is provided for your consideration.</p>
-      </div>,
-      closeButton: true
-    )
 
   handleWorkflowSettingChange: (workflow, e) ->
     checked = e.target.checked
@@ -131,51 +107,10 @@ module.exports = React.createClass
 
       <p className="form-help">All workflows can be edited during development, and subjects will never retire. In a live project, active workflows are locked and can no longer be edited, and classifications count toward subject retirement.</p>
 
-      <div style={looksDisabled if @props.project.private or not @props.project.live}>
+      <div>
         <hr />
 
-        <div>
-          {if @isReviewable()
-            <fieldset className="lab-visibility__policy-reviews">
-              <label>
-                <input type="checkbox" ref="labPolicyReviewed" onChange={@toggleCheckbox.bind this, 'labPolicyReviewed'} />
-                I have reviewed the <a href="/lab-policies" target="_blank">policies</a>
-              </label>
-
-              <br />
-
-              <label>
-                <input type="checkbox" ref="bestPracticesReviewed" onChange={@toggleCheckbox.bind this, 'bestPracticesReviewed'} />
-                I have reviewed the <a href="/lab-best-practices" target="_blank">best practices</a>
-              </label>
-
-              <br />
-
-              <label>
-                <input type="checkbox" ref="feedbackReviewed" onChange={@toggleCheckbox.bind this, 'feedbackReviewed'} />
-                I have reviewed the <button className="link-button" onClick={@showFeedbackForm}>review feedback form</button>
-              </label>
-            </fieldset>}
-
-          <p>
-            <button
-              type="button"
-              className="standard-button"
-              disabled={not @canApplyForReview()}
-              onClick={@set.bind this, 'beta_requested', true}
-            >Apply for review</button>{' '}
-
-            {if @props.project.private
-              <span>Only <strong>public projects</strong> can apply for review.</span>
-            else if not @props.project.live
-              <span>Only <strong>live projects</strong> can apply for review.</span>
-            else if @props.project.beta_requested
-              <span>Review status has been applied for. <button type="button" disabled={@state.setting.beta_requested} onClick={@set.bind this, 'beta_requested', false}>Cancel application</button></span>}
-          </p>
-        </div>
-
-        {unless @props.project.beta_approved
-          <p className="form-help">Pending approval, expose this project to users who have opted in to help test new projects.</p>}
+        <p className="form-label">Beta status</p>
 
         {if @props.project.beta_approved
           <span>
@@ -193,45 +128,18 @@ module.exports = React.createClass
           <div className="approval-status">
             <span>Beta Approval Status: </span>
             <span className="color-label orange">Pending</span>
-          </div>}
+          </div>
+          <span>Review status has been applied for. <button type="button" disabled={@state.setting.beta_requested} onClick={@set.bind this, 'beta_requested', false}>Cancel application</button></span>
+        else
+          <ApplyForBetaForm project={@props.project} workflows={@state.workflows} applyFn={@set.bind this, 'beta_requested', true} />
+        }
 
-        <div style={looksDisabled unless @props.project.beta_approved}>
-          <hr />
-
-          <p>
-            <button type="button" className="standard-button" disabled={not @props.project.beta_approved or @state.setting.launch_requested or @props.project.launch_requested} onClick={@set.bind this, 'launch_requested', true}>Apply for full launch</button>{' '}
-
-            {unless @props.project.beta_approved
-              <span>Only <strong>projects in review</strong> can apply for a full launch.</span>}
-
-            {if @props.project.launch_approved
-              <span>
-              <div className="approval-status">
-                <span>Launch Approval Status: </span>
-                <span className="color-label green">Approved</span>
-              </div>
-                This project is available to the whole Zooniverse!
-              </span>
-            else if @props.project.launch_requested
-              <span>
-                <div className="approval-status">
-                  <span>Launch Approval Status: </span>
-                  <span className="color-label orange">Pending</span>
-                </div>
-                Launch is awaiting Zooniverse approval. <button type="button" disabled={@state.setting.launch_requested} onClick={@set.bind this, 'launch_requested', false}>Cancel application</button>
-              </span>}
-          </p>
-
-          {unless @props.project.launch_approved
-            <p className="form-help">Pending approval, expose this project to the entire Zooniverse through the main projects listing.</p>}
-
-        </div>
       </div>
 
       <hr/>
 
       <p className="form-label">Workflow Settings</p>
-      {if @state.workflows is null
+      {if @state.loadingWorkflows is true
         <div className="workflow-status-list">Loading workflows...</div>
       else if @state.workflows.length is 0
         <div className="workflow-status-list">No workflows found</div>

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "babel-loader": "~6.2.4",
     "babel-plugin-add-module-exports": "~0.2.1",
     "babel-plugin-react-transform": "~2.0.2",
+    "babel-plugin-rewire": "~1.0.0",
     "babel-plugin-transform-object-assign": "~6.8.0",
     "babel-plugin-transform-react-jsx": "~6.7.5",
     "babel-plugin-typecheck": "~3.9.0",
@@ -111,6 +112,6 @@
     "stage-with-docker": "./bin/run-through-docker.sh 'npm run stage'",
     "_deploy": "export PATH_ROOT=www.zooniverse.org; npm run _build && npm run _publish",
     "deploy": "export NODE_ENV=production; npm run _deploy",
-    "test": "export NODE_ENV=development; mocha test/setup.js $(find app -name *.spec.js) --reporter nyan --compilers js:babel-core/register,coffee:coffee-script/register,cjsx:coffee-react/register"
+    "test": "NODE_ENV=development BABEL_ENV=test mocha test/setup.js $(find app -name *.spec.js) --reporter nyan --compilers js:babel-core/register,coffee:coffee-script/register,cjsx:coffee-react/register || true"
   }
 }


### PR DESCRIPTION
Following on from a first crack at this in #3523, this adds validation before allowing a beta review submission. It uses `set_member_subjects_count` which is known to be wrong for some projects (zooniverse/Panoptes#2155), ~~so this PR is blocked until that bug is fixed~~ but we're ignoring it for now.

Adds the babel-rewire plugin to allow mocking the `apiClient`, so will need an `npm install` before testing locally.

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://validate-project-subjects.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?