### PR TITLE
Toggle for persist annotations in the dev classifier

### DIFF
--- a/app/pages/dev-classifier/index.cjsx
+++ b/app/pages/dev-classifier/index.cjsx
@@ -23,6 +23,10 @@ ClassificationViewer = React.createClass
     unless "#{key}".charAt(0) is '_'
       value
 
+  togglePersistAnnotations: (e) ->
+    @props.classification._workflow.configuration.persist_annotations = e.target.checked
+    @forceUpdate()
+
   render: ->
     showing =  if @state.showOnlyLast
       @props.classification.annotations[@props.classification.annotations.length - 1]
@@ -43,6 +47,11 @@ ClassificationViewer = React.createClass
       <label>
         <input type="checkbox" checked={@state.showThrowaways} onChange={(e) => @setState showThrowaways: e.target.checked} />{' '}
         Show throwaway properties
+      </label>
+      &ensp;
+      <label>
+        <input type="checkbox" checked={@props.classification._workflow.configuration.persist_annotations} onChange={@togglePersistAnnotations} />{' '}
+        Persist Annotations
       </label>
       <br />
       <pre>{JSON.stringify showing, replacer, 2}</pre>

--- a/app/pages/dev-classifier/mock-data.coffee
+++ b/app/pages/dev-classifier/mock-data.coffee
@@ -32,7 +32,7 @@ workflow = apiClient.type('workflows').create
     enable_switching_flipbook_and_separate: true
     multi_image_layout: 'grid3'
     invert_subject: true
-    persist_annotations: true
+    persist_annotations: false
     pan_and_zoom: true
 
   first_task: 'init'


### PR DESCRIPTION
Adds a quick and simple toggle for setting the workflow config for persist annotations in the dev classifier. Few projects use this experimental feature, so having it defaulted to off and having a toggle is probably better for manual testing. 

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [x] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?