### PR TITLE
Add "App Status" banner

### DIFF
--- a/app/partials/app-status.jsx
+++ b/app/partials/app-status.jsx
@@ -6,6 +6,7 @@ import fetch from 'isomorphic-fetch';
 //const APP_STATUS_URL = 'https://www.theguardian.com/uk/rss';
 //const APP_STATUS_URL = 'http://localhost:3735/favicon.ico';
 const APP_STATUS_URL = 'https://static.zooniverse.org/variants.shakespearesworld.org/sake.txt';
+//const APP_STATUS_URL = 'https://static.zooniverse.org/index.html';
 
 export default class AppStatus extends React.Component {
   constructor(props) {
@@ -70,7 +71,7 @@ export default class AppStatus extends React.Component {
     return (
       <div className="app-status">
         <button className="fa fa-close" onClick={this.hide.bind(this)}></button>
-        <div className="message">{this.state.message}</div>
+        <div className="message" dangerouslySetInnerHTML={{ __html: this.state.message }}></div>
       </div>
     );
   }

--- a/app/partials/app-status.jsx
+++ b/app/partials/app-status.jsx
@@ -60,7 +60,6 @@ export default class AppStatus extends React.Component {
           show: true,
           message: text,
         });
-        if (this.button) { this.button.focus(); }  //<button autofocus=true/> won't work, so we'll manually trigger it.
       }
     })
     .catch((err) => {
@@ -74,7 +73,7 @@ export default class AppStatus extends React.Component {
     
     return (
       <div className="app-status">
-        <button ref={b=>this.button=b} className="fa fa-close" onClick={this.hide.bind(this)}></button>
+        <button className="fa fa-close" onClick={this.hide.bind(this)} autoFocus={true}></button>
         <div className="message">{this.state.message}</div>
       </div>
     );

--- a/app/partials/app-status.jsx
+++ b/app/partials/app-status.jsx
@@ -33,6 +33,7 @@ const APP_STATUS_URL = 'https://static.zooniverse.org/zooniverse.org-status.txt'
 export default class AppStatus extends React.Component {
   constructor(props) {
     super(props);
+    this.button = null;
     
     this.state = {
       show: false,
@@ -58,7 +59,8 @@ export default class AppStatus extends React.Component {
         this.setState({
           show: true,
           message: text,
-        });  
+        });
+        if (this.button) { this.button.focus(); }
       }
     })
     .catch((err) => {
@@ -72,7 +74,7 @@ export default class AppStatus extends React.Component {
     
     return (
       <div className="app-status">
-        <button className="fa fa-close" onClick={this.hide.bind(this)}></button>
+        <button ref={b=>this.button=b} className="fa fa-close" onClick={this.hide.bind(this)} autofocus={true}></button>
         <div className="message">{this.state.message}</div>
       </div>
     );

--- a/app/partials/app-status.jsx
+++ b/app/partials/app-status.jsx
@@ -15,8 +15,9 @@ Expected Input/Output:
 * static file found, is empty => don't show status banner
 * static file not found (403, 404, etc) => don't show status banner
 
-Assumption: the static "status message" resource is stored on a reliable,
-scalable host.
+Assumptions:
+* the static "status message" resource is stored on a reliable, scalable host.
+* fetch() polyfill is available.
 
 See https://github.com/zooniverse/Panoptes-Front-End/issues/3530 for initial
 feature specs.

--- a/app/partials/app-status.jsx
+++ b/app/partials/app-status.jsx
@@ -1,12 +1,7 @@
 import React from 'react';
 import fetch from 'isomorphic-fetch';
 
-//const APP_STATUS_URL = 'http://static.zooniverse.org/everybody_panic.txt';
-//const APP_STATUS_URL = 'http://shaunanoordin.com/feed/';
-//const APP_STATUS_URL = 'https://www.theguardian.com/uk/rss';
-//const APP_STATUS_URL = 'http://localhost:3735/favicon.ico';
-const APP_STATUS_URL = 'https://static.zooniverse.org/variants.shakespearesworld.org/sake.txt';
-//const APP_STATUS_URL = 'https://static.zooniverse.org/index.html';
+const APP_STATUS_URL = 'https://static.zooniverse.org/zooniverse.org-status.txt';
 
 export default class AppStatus extends React.Component {
   constructor(props) {

--- a/app/partials/app-status.jsx
+++ b/app/partials/app-status.jsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import fetch from 'isomorphic-fetch';
+
+//const APP_STATUS_URL = 'http://static.zooniverse.org/everybody_panic.txt';
+//const APP_STATUS_URL = 'http://shaunanoordin.com/feed/';
+//const APP_STATUS_URL = 'https://www.theguardian.com/uk/rss';
+//const APP_STATUS_URL = 'http://localhost:3735/favicon.ico';
+const APP_STATUS_URL = 'https://static.zooniverse.org/variants.shakespearesworld.org/sake.txt';
+
+export default class AppStatus extends React.Component {
+  constructor(props) {
+    super(props);
+    
+    this.state = {
+      show: false,
+      message: '',
+    };
+  }
+  
+  componentDidMount() {
+    /**/
+    var request = new XMLHttpRequest();
+    request.onreadystatechange = () => {
+      if (request.readyState === 4 && request.status === 200) {
+        console.log('AppStatus: Received status data from ' + APP_STATUS_URL + '.');
+        if (!request.responseText || request.responseText === '') console.log('AppStatus: Nothing to report.');
+        this.setState({
+          show: true,
+          message: request.responseText,
+        });
+      } else if (request.readyState === 4) {
+        console.log('AppStatus: No status data from ' + APP_STATUS_URL + '. Assuming everything is OK.');
+      }
+    };
+    request.open("GET", APP_STATUS_URL, true);
+    request.send();
+    /**/
+    
+    /*
+    fetch(APP_STATUS_URL, {
+      mode: 'cors',
+      method: 'GET',
+    })
+    .then((dataStream) => {
+      if (!dataStream) return;
+      
+      let dataText = '', chunk;
+      
+      dataStream.on('end', function() {
+        this.setState({
+          show: true,
+          message: dataText,
+        });
+      });
+      
+      dataStream.on('readable', () => {
+        while ((chunk = dataStream.read()) !== null) { dataText += chunk; }
+      });
+    })
+    .catch((err) => {
+      console.error('AppStatus ERROR: ', err);
+    });
+    /**/
+  }
+  
+  render() {
+    if (!this.state.show) return null;
+    if (!this.state.message || this.state.message === '') return null;
+    
+    return (
+      <div className="app-status">
+        <button className="fa fa-close" onClick={this.hide.bind(this)}></button>
+        <div className="message">{this.state.message}</div>
+      </div>
+    );
+  }
+  
+  hide() {
+    this.setState({
+      show: false,
+    });
+  }
+}

--- a/app/partials/app-status.jsx
+++ b/app/partials/app-status.jsx
@@ -60,7 +60,7 @@ export default class AppStatus extends React.Component {
           show: true,
           message: text,
         });
-        if (this.button) { this.button.focus(); }
+        if (this.button) { this.button.focus(); }  //<button autofocus=true/> won't work, so we'll manually trigger it.
       }
     })
     .catch((err) => {
@@ -74,7 +74,7 @@ export default class AppStatus extends React.Component {
     
     return (
       <div className="app-status">
-        <button ref={b=>this.button=b} className="fa fa-close" onClick={this.hide.bind(this)} autofocus={true}></button>
+        <button ref={b=>this.button=b} className="fa fa-close" onClick={this.hide.bind(this)}></button>
         <div className="message">{this.state.message}</div>
       </div>
     );

--- a/app/partials/app.cjsx
+++ b/app/partials/app.cjsx
@@ -1,5 +1,6 @@
 React = require 'react'
 auth = require 'panoptes-client/lib/auth'
+`import AppStatus from './app-status';`
 IOStatus = require './io-status'
 AppLayout = require('../layout').default
 GeordiLogger = require '../lib/geordi-logger'
@@ -70,6 +71,7 @@ PanoptesApp = React.createClass
 
   render: ->
     <div className="panoptes-main">
+      <AppStatus />
       <IOStatus />
       <AppLayout {...@props}>
         {React.cloneElement @props.children, user: @state.user}

--- a/css/app-status.styl
+++ b/css/app-status.styl
@@ -1,0 +1,17 @@
+.app-status
+  background: BACKGROUND
+  border: 1px solid ZOONIVERSE_TEAL
+  border-radius: 1em
+  padding: 0.5em 1em
+  position: fixed
+  left: 50%
+  bottom: 1em
+  transform: translateX(-50%);
+  width: 80%
+  max-width: 40em
+  z-index: 1000
+  box-shadow: 0 0 0.5em BACKGROUND
+
+  button.fa-close
+    float: right
+    cursor: pointer

--- a/css/main.styl
+++ b/css/main.styl
@@ -37,6 +37,7 @@
 @require './search'
 @require './subject-viewer'
 @require './frame-annotator'
+@require './app-status'
 
 // Home page
 @require "./home-page"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "drag-reorderable": "~0.1.0",
     "engine.io-client": "~1.8.2",
     "events": "~1.1.1",
-    "isomorphic-fetch": "^2.2.1",
     "he": "~1.1.0",
     "jsplumb": "1.7.9",
     "lodash.intersection": "~3.2.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "drag-reorderable": "~0.1.0",
     "engine.io-client": "~1.8.2",
     "events": "~1.1.1",
+    "isomorphic-fetch": "^2.2.1",
     "he": "~1.1.0",
     "jsplumb": "1.7.9",
     "lodash.intersection": "~3.2.0",


### PR DESCRIPTION
## PR Overview
Closes #3530

* New feature: a "status banner" is displayed on zooniverse.org, if PFE detects a status message on a secondary location.
* Mechanism: PFE checks static.zooniverse.org for a static resource (expecting to find a simple .txt or .html file). If the resource exists, the status banner appears and displays the contents of the file to the user. (Final static resource URL not finalised: see Notes)
* Zooniverse admins will need to manually add/edit the static resource. (e.g. via the AWS CLI) We're going for _a simple and primitive, but reliable_ solution.
* The static "app status" resource will be hosted on static.zooniverse.org, as that would make it scalable to the number of PFE users. (Each active user will ping the resource once per loading of Zooniverse.org, whether or not there's a status message.)

Tagging @marten as request originator.

## Notes
* Open dev question: **should we only allow text for the status update message, or are we going to allow HTML and JavaScript to be part of the message?** (Shaun: leaning towards HTML+JS)
* Open dev question: XMLHttpRequest or fetch()? (Shaun: I have both working, but I like XMLHttpRequest since nothing else is using fetch(), and we don't need that extra `isomorphic-fetch` package.json dependency.)
* **Current dev issue:** setting up the static "status message" resource on static.zooniverse.org - along with the necessary CORS settings - is as easy as pulling out teeth. _And not through the mouth._
* Future plans: a more advanced implementation that uses WebSockets and Amazon Lambda to more consistently monitor changes to the status update resource. (Tagging @rogerhutchings for the idea.)

![screen shot 2017-03-01 at 15 52 11](https://cloud.githubusercontent.com/assets/13952701/23467870/16de36ce-fe97-11e6-979f-c3bbd2f8d555.png)
_Behold, the status banner. At the bottom of the screen. With a nonsense message._

## Status
WORK IN PROGRESS - please don't merge, but feedback is welcome (2017.03.01)

## Preview
URL: https://status-banner.pfe-preview.zooniverse.org/
What you're expected to see:
* The status banner should appear at the bottom of the screen, with gibberish text.

## Review Checklist
- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)
