### PR TITLE
Tutorials don't need to create preferences

### DIFF
--- a/app/components/tutorial.cjsx
+++ b/app/components/tutorial.cjsx
@@ -109,10 +109,6 @@ module.exports = React.createClass
 
     if @props.user?
       projectPreferences = @props.preferences
-      projectPreferences ?= apiClient.type('project_preferences').create
-        links:
-          project: project.id
-        preferences: {}
       # Build this manually. Having an index (even as a strings) keys creates an array.
       projectPreferences.preferences ?= {}
       projectPreferences.preferences.tutorials_completed_at ?= {}


### PR DESCRIPTION
This should have been a part of #3455. This removes a bit of code where the tutorial would create preferences, however, this is not necessary since the project index started handling preference fetch/creation. Bug found while working on the workflow selection refactor.

https://tutorial-preferences.pfe-preview.zooniverse.org/

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?