### PR TITLE
Extract renderExpertOptions to an ExpertOptions component

### DIFF
--- a/app/classifier/expert-options.jsx
+++ b/app/classifier/expert-options.jsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import TriggeredModalForm from 'modal-form/triggered';
+import isAdmin from '../lib/is-admin';
+
+function ExpertOptions(props) {
+  function handleGoldStandardChange(e) {
+    props.classification.update({ gold_standard: e.target.checked || undefined });
+  }
+
+  function handleDemoModeChange(e) {
+    props.onChangeDemoMode(e.target.checked);
+  }
+
+  return (
+    <TriggeredModalForm
+      trigger={<i className="fa fa-cog fa-fw" />}
+    >
+      {(props.userRoles.includes('owner') || props.userRoles.includes('expert')) &&
+        <p>
+          <label>
+            <input type="checkbox" checked={props.classification.gold_standard} onChange={handleGoldStandardChange} />{' '}
+            Gold standard mode
+          </label>{' '}
+          <TriggeredModalForm
+            trigger={<i className="fa fa-question-circle" />}
+          >
+            <p>A “gold standard” classification is one that is known to be completely accurate. We’ll compare other classifications against it during aggregation.</p>
+          </TriggeredModalForm>
+        </p>
+      }
+
+      {(isAdmin() || props.userRoles.includes('owner') || props.userRoles.includes('collaborator')) &&
+        <p>
+          <label>
+            <input type="checkbox" checked={props.demoMode} onChange={handleDemoModeChange} />{' '}
+            Demo mode
+          </label>{' '}
+          <TriggeredModalForm
+            trigger={<i className="fa fa-question-circle" />}
+          >
+            <p>In demo mode, classifications <strong>will not be saved</strong>. Use this for quick, inaccurate demos of the classification interface.</p>
+          </TriggeredModalForm>
+        </p>
+      }
+    </TriggeredModalForm>
+  );
+}
+
+ExpertOptions.propTypes = {
+  classification: React.PropTypes.shape({
+    update: React.PropTypes.func,
+    gold_standard: React.PropTypes.bool
+  }),
+  demoMode: React.PropTypes.bool,
+  onChangeDemoMode: React.PropTypes.func,
+  userRoles: React.PropTypes.arrayOf(React.PropTypes.string)
+};
+
+export default ExpertOptions;

--- a/app/classifier/expert-options.jsx
+++ b/app/classifier/expert-options.jsx
@@ -18,7 +18,7 @@ function ExpertOptions(props) {
       {(props.userRoles.includes('owner') || props.userRoles.includes('expert')) &&
         <p>
           <label>
-            <input type="checkbox" checked={props.classification.gold_standard} onChange={handleGoldStandardChange} />{' '}
+            <input type="checkbox" checked={!!props.classification.gold_standard} onChange={handleGoldStandardChange} />{' '}
             Gold standard mode
           </label>{' '}
           <TriggeredModalForm

--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -13,13 +13,14 @@ workflowAllowsSeparateFrames = require '../lib/workflow-allows-separate-frames'
 `import FrameAnnotator from './frame-annotator';`
 `import CacheClassification from '../components/cache-classification';`
 MetadataBasedFeedback = require './metadata-based-feedback'
-`import Task from './task';`
 { VisibilitySplit } = require('seven-ten');
 `import RestartButton from './restart-button';`
 MiniCourse = require '../components/mini-course'
 Tutorial = require '../components/tutorial'
 interventionMonitor = require '../lib/intervention-monitor'
 experimentsClient = require '../lib/experiments-client'
+Task = require('./task').default
+TaskNav = require('./task-nav').default
 ExpertOptions = require('./expert-options').default
 
 # For easy debugging
@@ -166,22 +167,32 @@ Classifier = React.createClass
       <div className="task-area">
         {unless currentClassification.completed
           <Task
-            expertClassifier={@props.expertClassifier}
             preferences={@props.preferences}
             user={@props.user}
-            userRoles={@props.userRoles}
             project={@props.project}
             workflow={@props.workflow}
-            subject={@props.subject}
             classification={currentClassification}
             task={currentTask}
             annotation={currentAnnotation}
-            completeClassification={@completeClassification}
-            renderExpertOptions={@renderExpertOptions}
             subjectLoading={@state.subjectLoading}
-            demoMode={@props.demoMode}
-            onChangeDemoMode={@props.onChangeDemoMode}
           >
+            <TaskNav
+              annotation={currentAnnotation}
+              classification={currentClassification}
+              completeClassification={@completeClassification}
+              project={@props.project}
+              subject={@props.subject}
+              task={currentTask}
+              workflow={@props.workflow}
+            >
+              {if @props.expertClassifier
+                <ExpertOptions
+                  classification={currentClassification}
+                  userRoles={@props.userRoles}
+                  demoMode={@props.demoMode}
+                  onChangeDemoMode={@props.onChangeDemoMode}
+                />}
+            </TaskNav>
             <p>
               <small>
                 <strong>
@@ -219,6 +230,33 @@ Classifier = React.createClass
                 </strong>
               </small>
             </p>
+
+            {if @props.demoMode
+              <p style={{ textAlign: 'center' }}>
+                <i className="fa fa-trash" />{' '}
+                <small>
+                  <strong>Demo mode:</strong>
+                  <br />
+                  No classifications are being recorded.{' '}
+                  <button type="button" className="secret-button" onClick={@props.onChangeDemoMode.bind(this, false)}>
+                    <u>Disable</u>
+                  </button>
+                </small>
+              </p>
+            }
+            {if currentClassification.gold_standard
+              <p style={{ textAlign: 'center' }}>
+                <i className="fa fa-star" />{' '}
+                <small>
+                  <strong>Gold standard mode:</strong>
+                  <br />
+                  Please ensure this classification is completely accurate.{' '}
+                  <button type="button" className="secret-button" onClick={currentClassification.update.bind(currentClassification, { gold_standard: undefined })}>
+                    <u>Disable</u>
+                  </button>
+                </small>
+              </p>
+            }
           </Task>
         else if @subjectIsGravitySpyGoldStandard()
           @renderGravitySpyGoldStandard currentClassification

--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -238,7 +238,7 @@ Classifier = React.createClass
                   <strong>Demo mode:</strong>
                   <br />
                   No classifications are being recorded.{' '}
-                  <button type="button" className="secret-button" onClick={@props.onChangeDemoMode.bind(this, false)}>
+                  <button type="button" className="secret-button" onClick={@changeDemoMode.bind(this, false)}>
                     <u>Disable</u>
                   </button>
                 </small>
@@ -408,6 +408,9 @@ Classifier = React.createClass
 
   toggleExpertClassification: (value) ->
     @setState showingExpertClassification: value
+  
+  changeDemoMode: (demoMode) ->
+    @props.onChangeDemoMode demoMode
 
   subjectIsGravitySpyGoldStandard: ->
     @props.workflow.configuration?.gravity_spy_gold_standard and @props.subject.metadata?['#Type'] is 'Gold'

--- a/app/classifier/task.jsx
+++ b/app/classifier/task.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import tasks from './tasks';
+import ExpertOptions from './expert-options';
 import Intervention from '../lib/intervention';
 import Shortcut from './tasks/shortcut';
 import TaskNav from './task-nav';
@@ -99,10 +100,45 @@ class Task extends React.Component {
             task={task}
             workflow={workflow}
           >
-            {this.props.renderExpertOptions()}
+            {!!this.props.expertClassifier &&
+            <ExpertOptions
+              classification={classification}
+              userRoles={this.props.userRoles}
+              demoMode={this.props.demoMode}
+              onChangeDemoMode={this.props.onChangeDemoMode}
+            />}
           </TaskNav>
 
           {this.props.children}
+
+          {this.props.demoMode ?
+            <p style={{ textAlign: 'center' }}>
+              <i className="fa fa-trash" />{' '}
+              <small>
+                <strong>Demo mode:</strong>
+                <br />
+                No classifications are being recorded.{' '}
+                <button type="button" className="secret-button" onClick={this.props.onChangeDemoMode.bind(this, false)}>
+                  <u>Disable</u>
+                </button>
+              </small>
+            </p> :
+            null
+          }
+          {classification.gold_standard ?
+            <p style={{ textAlign: 'center' }}>
+              <i className="fa fa-star" />{' '}
+              <small>
+                <strong>Gold standard mode:</strong>
+                <br />
+                Please ensure this classification is completely accurate.{' '}
+                <button type="button" className="secret-button" onClick={classification.update.bind(classification, { gold_standard: undefined })}>
+                  <u>Disable</u>
+                </button>
+              </small>
+            </p> :
+            null
+          }
         </div>
       </div>
     );
@@ -126,7 +162,8 @@ Task.propTypes = {
   project: React.PropTypes.shape({
     id: React.PropTypes.string
   }),
-  renderExpertOptions: React.PropTypes.func,
+  expertClassifier: React.PropTypes.bool,
+  onChangeDemoMode: React.PropTypes.func,
   subject: React.PropTypes.shape({
     id: React.PropTypes.string
   }),
@@ -137,6 +174,7 @@ Task.propTypes = {
   user: React.PropTypes.shape({
     id: React.PropTypes.string
   }),
+  userRoles: React.PropTypes.arrayOf(React.PropTypes.string),
   workflow: React.PropTypes.shape({
     id: React.PropTypes.string
   })

--- a/app/classifier/task.jsx
+++ b/app/classifier/task.jsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import tasks from './tasks';
-import ExpertOptions from './expert-options';
 import Intervention from '../lib/intervention';
 import Shortcut from './tasks/shortcut';
-import TaskNav from './task-nav';
 
 class Task extends React.Component {
   constructor(props) {
@@ -90,55 +88,8 @@ class Task extends React.Component {
               classification={classification}
             />}
 
-          <TaskNav
-            annotation={annotation}
-            classification={classification}
-            completeClassification={this.props.completeClassification}
-            demoMode={this.props.demoMode}
-            project={this.props.project}
-            subject={this.props.subject}
-            task={task}
-            workflow={workflow}
-          >
-            {!!this.props.expertClassifier &&
-            <ExpertOptions
-              classification={classification}
-              userRoles={this.props.userRoles}
-              demoMode={this.props.demoMode}
-              onChangeDemoMode={this.props.onChangeDemoMode}
-            />}
-          </TaskNav>
-
           {this.props.children}
 
-          {this.props.demoMode ?
-            <p style={{ textAlign: 'center' }}>
-              <i className="fa fa-trash" />{' '}
-              <small>
-                <strong>Demo mode:</strong>
-                <br />
-                No classifications are being recorded.{' '}
-                <button type="button" className="secret-button" onClick={this.props.onChangeDemoMode.bind(this, false)}>
-                  <u>Disable</u>
-                </button>
-              </small>
-            </p> :
-            null
-          }
-          {classification.gold_standard ?
-            <p style={{ textAlign: 'center' }}>
-              <i className="fa fa-star" />{' '}
-              <small>
-                <strong>Gold standard mode:</strong>
-                <br />
-                Please ensure this classification is completely accurate.{' '}
-                <button type="button" className="secret-button" onClick={classification.update.bind(classification, { gold_standard: undefined })}>
-                  <u>Disable</u>
-                </button>
-              </small>
-            </p> :
-            null
-          }
         </div>
       </div>
     );
@@ -154,17 +105,10 @@ Task.propTypes = {
   classification: React.PropTypes.shape({
     id: React.PropTypes.string
   }),
-  completeClassification: React.PropTypes.func,
-  demoMode: React.PropTypes.bool,
   preferences: React.PropTypes.shape({
     id: React.PropTypes.string
   }),
   project: React.PropTypes.shape({
-    id: React.PropTypes.string
-  }),
-  expertClassifier: React.PropTypes.bool,
-  onChangeDemoMode: React.PropTypes.func,
-  subject: React.PropTypes.shape({
     id: React.PropTypes.string
   }),
   subjectLoading: React.PropTypes.bool,
@@ -174,7 +118,6 @@ Task.propTypes = {
   user: React.PropTypes.shape({
     id: React.PropTypes.string
   }),
-  userRoles: React.PropTypes.arrayOf(React.PropTypes.string),
   workflow: React.PropTypes.shape({
     id: React.PropTypes.string
   })


### PR DESCRIPTION
Part of #3522. Forked to make reviewing changes easier. Removes `renderExpertOptions` from the classifier, in favour of an `ExpertOptions` functional component.

Staged at https://classifier-expert-options.pfe-preview.zooniverse.org/

Describe your changes.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?