### PR TITLE
Refactor tutorial media requests

### DIFF
--- a/app/components/mini-course.cjsx
+++ b/app/components/mini-course.cjsx
@@ -17,7 +17,7 @@ module.exports = React.createClass
     find: (workflow) ->
       # Prefer fetching the tutorial for the workflow, so we know which one to fetch if multiple exist.
       if workflow?
-        apiClient.type('tutorials').get workflow_id: workflow.id, kind: "mini-course"
+        apiClient.type('tutorials').get workflow_id: workflow.id, kind: "mini-course", include: 'attached_images'
           .then ([minicourse]) ->
             minicourse
       else
@@ -26,15 +26,18 @@ module.exports = React.createClass
     start: (minicourse, projectPreferences, user, geordi) ->
       MiniCourseComponent = this
       if minicourse.steps.length isnt 0
-        awaitMiniCourseMedia = minicourse.get 'attached_images'
-          .catch ->
-            # Checking for attached images throws if there are none.
-            []
-          .then (mediaResources) ->
-            mediaByID = {}
-            for mediaResource in mediaResources
-              mediaByID[mediaResource.id] = mediaResource
-            mediaByID
+        if minicourse.links.attached_images.ids?.length
+          awaitMiniCourseMedia = apiClient.type('media').get(minicourse.links.attached_images.ids)
+              .catch ->
+                # Checking for attached images throws if there are none.
+                []
+              .then (mediaResources) ->
+                mediaByID = {}
+                for mediaResource in mediaResources
+                  mediaByID[mediaResource.id] = mediaResource
+                mediaByID
+        else
+          awaitMiniCourseMedia = Promise.resolve()
 
         awaitMiniCourseMedia.then (mediaByID) =>
           Dialog.alert(<MiniCourseComponent projectPreferences={projectPreferences} user={user} minicourse={minicourse} media={mediaByID} geordi={geordi} />, {
@@ -159,4 +162,3 @@ module.exports = React.createClass
         minicourseCompletedAt: datetime
       }
     }
-

--- a/app/components/mini-course.cjsx
+++ b/app/components/mini-course.cjsx
@@ -26,7 +26,7 @@ module.exports = React.createClass
     start: (minicourse, projectPreferences, user, geordi) ->
       MiniCourseComponent = this
       if minicourse.steps.length isnt 0
-        if minicourse.links.attached_images.ids?.length
+        if minicourse.links.attached_images.ids? and minicourse.links.attached_images.ids.length isnt 0
           awaitMiniCourseMedia = apiClient.type('media').get(minicourse.links.attached_images.ids)
               .catch ->
                 # Checking for attached images throws if there are none.

--- a/app/components/mini-course.cjsx
+++ b/app/components/mini-course.cjsx
@@ -17,7 +17,7 @@ module.exports = React.createClass
     find: (workflow) ->
       # Prefer fetching the tutorial for the workflow, so we know which one to fetch if multiple exist.
       if workflow?
-        apiClient.type('tutorials').get workflow_id: workflow.id, kind: "mini-course", include: 'attached_images'
+        apiClient.type('tutorials').get workflow_id: workflow.id, kind: "mini-course", include: ['attached_images']
           .then ([minicourse]) ->
             minicourse
       else

--- a/app/components/tutorial.cjsx
+++ b/app/components/tutorial.cjsx
@@ -42,7 +42,7 @@ module.exports = React.createClass
       TutorialComponent = this
 
       if tutorial.steps.length isnt 0
-        if tutorial.links.attached_images.ids?.length
+        if tutorial.links.attached_images.ids? and tutorial.links.attached_images.ids.length isnt 0
           awaitTutorialMedia = apiClient.type('media').get(tutorial.links.attached_images?.ids)
             .catch ->
               # Checking for attached images throws if there are none.

--- a/app/components/tutorial.cjsx
+++ b/app/components/tutorial.cjsx
@@ -16,7 +16,7 @@ module.exports = React.createClass
     find: (workflow) ->
       # Prefer fetching the tutorial for the workflow, if a workflow is given.
       if workflow?
-        apiClient.type('tutorials').get workflow_id: workflow.id
+        apiClient.type('tutorials').get workflow_id: workflow.id, include: 'attached_images'
           .then (tutorials) ->
             # Backwards compatibility for null kind values. We assume these are standard tutorials.
             onlyStandardTutorials = tutorials.filter (tutorial) ->

--- a/app/components/tutorial.cjsx
+++ b/app/components/tutorial.cjsx
@@ -16,7 +16,7 @@ module.exports = React.createClass
     find: (workflow) ->
       # Prefer fetching the tutorial for the workflow, if a workflow is given.
       if workflow?
-        apiClient.type('tutorials').get workflow_id: workflow.id, include: 'attached_images'
+        apiClient.type('tutorials').get workflow_id: workflow.id, include: ['attached_images']
           .then (tutorials) ->
             # Backwards compatibility for null kind values. We assume these are standard tutorials.
             onlyStandardTutorials = tutorials.filter (tutorial) ->

--- a/app/components/tutorial.cjsx
+++ b/app/components/tutorial.cjsx
@@ -42,15 +42,18 @@ module.exports = React.createClass
       TutorialComponent = this
 
       if tutorial.steps.length isnt 0
-        awaitTutorialMedia = apiClient.type('media').get(tutorial.links.attached_images?.ids)
-          .catch ->
-            # Checking for attached images throws if there are none.
-            []
-          .then (mediaResources) ->
-            mediaByID = {}
-            for mediaResource in mediaResources
-              mediaByID[mediaResource.id] = mediaResource
-            mediaByID
+        if tutorial.links.attached_images.ids?.length
+          awaitTutorialMedia = apiClient.type('media').get(tutorial.links.attached_images?.ids)
+            .catch ->
+              # Checking for attached images throws if there are none.
+              []
+            .then (mediaResources) ->
+              mediaByID = {}
+              for mediaResource in mediaResources
+                mediaByID[mediaResource.id] = mediaResource
+              mediaByID
+        else
+          awaitTutorialMedia = Promise.resolve()
 
         awaitTutorialMedia.then (mediaByID) =>
           Dialog.alert(<TutorialComponent tutorial={tutorial} media={mediaByID} preferences={preferences} user={user} geordi={geordi} />, {

--- a/app/components/tutorial.cjsx
+++ b/app/components/tutorial.cjsx
@@ -42,7 +42,7 @@ module.exports = React.createClass
       TutorialComponent = this
 
       if tutorial.steps.length isnt 0
-        awaitTutorialMedia = tutorial.get 'attached_images'
+        awaitTutorialMedia = apiClient.type('media').get(tutorial.links.attached_images?.ids)
           .catch ->
             # Checking for attached images throws if there are none.
             []


### PR DESCRIPTION
Addresses the tutorial and mini-course portion of #3492.

- adds `include: 'attached_images'` to tutorial/mini-course request
- on start checks if there are `attached_images`, else resolves Promise
- gets `attached_images` based on `include` cache in apiClient, not stringed `.get` on tutorial/mini-course resource like previously

this [test project](https://refactor-tutorial-media-requests.pfe-preview.zooniverse.org/projects/markb-panoptes/nfn-test-mb)'s workflows 1 and 2 have separate tutorials and mini-courses with media, workflow 3 has no media. 

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? - https://refactor-tutorial-media-requests.pfe-preview.zooniverse.org
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?