### PR TITLE
Fix classifier mount

### DIFF
--- a/app/classifier/frame-annotator.jsx
+++ b/app/classifier/frame-annotator.jsx
@@ -28,6 +28,9 @@ export default class FrameAnnotator extends React.Component {
     if (nextProps.annotation !== this.props.annotation) {
       this.handleAnnotationChange(this.props.annotation, nextProps.annotation);
     }
+    if (nextProps.subject !== this.props.subject) {
+      this.setState({ alreadySeen: nextProps.subject.already_seen || seenThisSession.check(nextProps.workflow, nextProps.subject) });
+    }
   }
 
   getSizeRect() {

--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -77,11 +77,18 @@ Classifier = React.createClass
 
   componentWillReceiveProps: (nextProps) ->
     if nextProps.subject isnt @props.subject
-      @loadSubject subject
-    if nextProps.classification isnt @props.classification
-      @prepareToClassify nextProps.classification
+      @loadSubject nextProps.subject
     if @props.subject isnt nextProps.subject or !@context.geordi?.keys["subjectID"]?
       @context.geordi?.remember subjectID: nextProps.subject?.id
+    
+    if nextProps.classification isnt @props.classification
+      @props.classification.stopListening 'change', =>
+        {annotations} = @props.classification
+        @setState {annotations}
+      nextProps.classification.listen 'change', =>
+        {annotations} = nextProps.classification
+        @setState {annotations}
+      @prepareToClassify nextProps.classification
 
   componentWillMount: () ->
     interventionMonitor.setProjectSlug @props.project.slug
@@ -619,9 +626,7 @@ module.exports = React.createClass
       @loadClassification nextProps.classification
 
   loadClassification: (classification) ->
-    @setState subject: null
-
-    # TODO: These underscored references are temporary stopgaps.
+# TODO: These underscored references are temporary stopgaps.
 
     Promise.resolve(classification._subjects ? classification.get 'subjects').then ([subject]) =>
       # We'll only handle one subject per classification right now.

--- a/app/collections/favorites-button.cjsx
+++ b/app/collections/favorites-button.cjsx
@@ -56,6 +56,12 @@ module.exports = React.createClass
       .then (favorited) =>
         @setState {favorited}
 
+  componentDidUpdate: (prevProps) ->
+    if prevProps.subject isnt @props.subject
+      @findSubjectInCollection(@state.favorites)
+      .then (favorited) =>
+        @setState {favorited}
+
   addSubjectTo: (collection) ->
     @setState favorited: true
     collection.addLink('subjects', [@props.subject.id.toString()])

--- a/app/collections/favorites-button.cjsx
+++ b/app/collections/favorites-button.cjsx
@@ -44,7 +44,7 @@ module.exports = React.createClass
       favorites.get('subjects', id: @props.subject.id)
         .then ([subject]) -> subject?
     else
-      false
+      Promise.resolve false
 
   componentWillMount: ->
     # see if the subject is in the project's favorites collection


### PR DESCRIPTION
Fixes #3543  .

Describe your changes.
Mounts the Classifier once, then reacts to subject and classification changes when props change.

There could be components that relied on the old behaviour, so there may still be component code, dotted through the classifier components, that needs to be changed to run on `componentWillReceiveProps` or `componentDidUpdate` as well as on `componentWillMount` or `componentDidMount`.

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch? https://fix-classifier-mount.pfe-preview.zooniverse.org/
- [x] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [x] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [x] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [x] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?