### PR TITLE
increase lab subject_sets request page_size

### DIFF
--- a/app/pages/lab/project.cjsx
+++ b/app/pages/lab/project.cjsx
@@ -125,7 +125,7 @@ EditProjectPage = React.createClass
           <li>
             <br />
             <div className="nav-list-header">Subject sets</div>
-            <PromiseRenderer promise={@props.project.get 'subject_sets', sort: 'display_name', page_size: 100}>{(subjectSets) =>
+            <PromiseRenderer promise={@props.project.get 'subject_sets', sort: 'display_name', page_size: 250}>{(subjectSets) =>
               <ul className="nav-list">
                 {renderSubjectSetListItem = (subjectSet) ->
                   subjectSetListLabel = subjectSet.display_name || <i>{'Untitled subject set'}</i>

--- a/app/pages/lab/workflow.cjsx
+++ b/app/pages/lab/workflow.cjsx
@@ -72,7 +72,7 @@ EditWorkflowPage = React.createClass
 
     stats_completeness_type = @props.workflow.configuration.stats_completeness_type ? 'retirement'
 
-    disabledIfLive = if @props.project.live and @props.workflow.active 
+    disabledIfLive = if @props.project.live and @props.workflow.active
                        {opacity: 0.4, pointerEvents: 'none'}
                      else
                        {}
@@ -450,8 +450,8 @@ EditWorkflowPage = React.createClass
 
   renderSubjectSets: ->
     projectAndWorkflowSubjectSets = Promise.all [
-      @props.project.get 'subject_sets', sort: 'display_name', page_size: 100
-      @props.workflow.get 'subject_sets', sort: 'display_name', page_size: 100
+      @props.project.get 'subject_sets', sort: 'display_name', page_size: 250
+      @props.workflow.get 'subject_sets', sort: 'display_name', page_size: 250
     ]
 
     <PromiseRenderer promise={projectAndWorkflowSubjectSets}>{([projectSubjectSets, workflowSubjectSets]) =>


### PR DESCRIPTION
Backyard Worlds and Gravity Spy have over 100 subject sets. In the Project Builder the list of subject sets in the side nav and in the workflow editor needs to be increased from 100 until better UI/UX is established. 

This PR changes the related `subject_sets` API requests' `page_size` from `100` to `250`.

Better pagination and improved UI/UX as it relates to the areas of the Project Builder noted have been identified as a post SGL priority. See #2852.

Rationale of 250 - Backyard Worlds has over 100 subject sets in less than 3 weeks. While it won't continue at the same rate post initial launch, it's estimated a `page_size` of 250 will give enough room to work with until a better solution can be implemented within the near future.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? - https://lab-subject-sets-request.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?