### PR TITLE
Fix 'seen this session'

### DIFF
--- a/app/lib/seen-this-session.coffee
+++ b/app/lib/seen-this-session.coffee
@@ -6,9 +6,9 @@ auth.listen 'change', ->
   subjectsSeenThisSession.splice 0
 
 module.exports =
-  add: (workflow, subjects) ->
-    for subject in subjects
-      subjectsSeenThisSession.push "#{workflow.id}/#{subject.id}"
+  add: (workflow_id, subject_ids) ->
+    for subject_id in subject_ids
+      subjectsSeenThisSession.push "#{workflow_id}/#{subject_id}"
 
   check: (workflow, subject) ->
     "#{workflow.id}/#{subject.id}" in subjectsSeenThisSession

--- a/app/pages/project/classify.cjsx
+++ b/app/pages/project/classify.cjsx
@@ -287,10 +287,9 @@ module.exports = React.createClass
         else
           console?.log 'Saved classification', classification.id
           Split.classificationCreated(classification)
-          classification.get('subjects')
-            .then (subjects) =>
-              seenThisSession.add @props.workflow, subjects
-              classification.destroy()
+          {workflow, subjects} = classification.links
+          seenThisSession.add workflow, subjects
+          classification.destroy()
         @saveAllQueuedClassifications()
       .catch (error) =>
         console?.warn 'Failed to save classification:', error


### PR DESCRIPTION
Don't fetch the subject when we already have its ID.

Fixes #2158 .

Describe your changes.
Removes the subjects API call after classifying, since we already have the subject ID for the seens array.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://fix-subject-seens.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?