### PR TITLE
Falls back to using ID if collection slug is malformed

### DIFF
--- a/app/collections/show.jsx
+++ b/app/collections/show.jsx
@@ -175,6 +175,17 @@ const CollectionPageWrapper = React.createClass({
         { include: ['owner'] }
       )
       .then(([collection]) => {
+        if (collection) {
+          return [collection]
+        } else {
+          return apiClient.type('collections')
+          .get({
+            id: this.props.params.collection_name,
+            include: ['owner']
+          })
+        }
+      })
+      .then(([collection]) => {
         return apiClient.type('collection_roles')
           .get({
             collection_id: collection.id,

--- a/app/pages/collections/collection-card.jsx
+++ b/app/pages/collections/collection-card.jsx
@@ -46,9 +46,10 @@ export default class CollectionCard extends React.Component {
     }
     const [owner, name] = this.props.collection.slug.split('/');
     const dataText = `view-${translationObjectName}`;
+    const linkTo = name ? this.props.linkTo : `${this.props.linkTo}${this.props.collection.id}`;
 
     const linkProps = {
-      to: this.props.linkTo,
+      to: linkTo,
       geordiHandler: 'profile-menu',
       logText: dataText,
       params: { owner, name },


### PR DESCRIPTION
Fixes #3519 .

Describe your changes.
Some collections have display names that don't produce URL slugs eg. ??? or !!!.

This PR falls back to using collection ID if the name part of the slug is empty.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://workaround-collection-slugs.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?