### PR TITLE
Prevent inactive workflows on live projects from being set as default

### DIFF
--- a/app/pages/lab/workflow.cjsx
+++ b/app/pages/lab/workflow.cjsx
@@ -14,6 +14,7 @@ FileButton = require '../../components/file-button'
 WorkflowCreateForm = require './workflow-create-form'
 workflowActions = require './actions/workflow'
 ShortcutEditor = require '../../components/shortcut-editor'
+classnames = require 'classnames'
 
 DEMO_SUBJECT_SET_ID = if process.env.NODE_ENV is 'production'
   '6' # Cats
@@ -72,10 +73,11 @@ EditWorkflowPage = React.createClass
 
     stats_completeness_type = @props.workflow.configuration.stats_completeness_type ? 'retirement'
 
-    disabledIfLive = if @props.project.live and @props.workflow.active
-                       {opacity: 0.4, pointerEvents: 'none'}
-                     else
-                       {}
+    projectLiveWorkflowActive = @props.project.live and @props.workflow.active
+    projectLiveWorkflowInactive = @props.project.live and !@props.workflow.active
+    disabledIfLive = classnames({ 'disabled-section': projectLiveWorkflowActive })
+    disabledIfWorkflowInactive = classnames({ 'disabled-section': projectLiveWorkflowInactive })
+    taskEditorClasses = classnames({'column': true, 'disabled-section': projectLiveWorkflowActive})
 
     <div className="edit-workflow-page">
       <h3>{@props.workflow.display_name} #{@props.workflow.id}{' '}
@@ -103,7 +105,7 @@ EditWorkflowPage = React.createClass
 
             <br />
 
-            <div style={disabledIfLive}>
+            <div className={disabledIfLive}>
               <div className="nav-list standalone">
                 <span className="nav-list-header">Tasks</span>
                 <br />
@@ -247,10 +249,11 @@ EditWorkflowPage = React.createClass
               <hr />
             </div>}
 
-          <div>
+          <div className={disabledIfWorkflowInactive}>
             <AutoSave resource={@props.project}>
               <span className="form-label">Set as default</span><br />
               <small className="form-help">If you have more than one workflow, you can set which should be default. Only one can be default.</small>
+              {<span><br /><small className="form-help">Inactive workflows on live projects cannot be made default.</small></span> if projectLiveWorkflowInactive}
               <br />
               <label>
                 <input ref="defaultWorkflow" type="checkbox" checked={@props.project.configuration?.default_workflow is @props.workflow.id} onChange={@handleDefaultWorkflowToggle} />
@@ -399,7 +402,7 @@ EditWorkflowPage = React.createClass
 
           <hr />
 
-          <div style={disabledIfLive}>
+          <div className={disabledIfLive}>
             <small>
               <button type="button" className="minor-button" disabled={@state.deletionInProgress} data-busy={@state.deletionInProgress || null} onClick={@handleDelete}>
                 Delete this workflow
@@ -410,7 +413,7 @@ EditWorkflowPage = React.createClass
           </div>
         </div>
 
-        <div className="column" style={disabledIfLive}>
+        <div className={taskEditorClasses}>
           {if @state.selectedTaskKey? and @props.workflow.tasks[@state.selectedTaskKey]?
             TaskEditorComponent = tasks[@props.workflow.tasks[@state.selectedTaskKey].type].Editor
             <div>

--- a/app/pages/lab/workflow.cjsx
+++ b/app/pages/lab/workflow.cjsx
@@ -256,7 +256,7 @@ EditWorkflowPage = React.createClass
               {<span><br /><small className="form-help">Inactive workflows on live projects cannot be made default.</small></span> if projectLiveWorkflowInactive}
               <br />
               <label>
-                <input ref="defaultWorkflow" type="checkbox" checked={@props.project.configuration?.default_workflow is @props.workflow.id} onChange={@handleDefaultWorkflowToggle} />
+                <input ref="defaultWorkflow" type="checkbox" disabled={projectLiveWorkflowInactive} checked={@props.project.configuration?.default_workflow is @props.workflow.id} onChange={@handleDefaultWorkflowToggle} />
                 Default workflow
               </label>
             </AutoSave>

--- a/css/lab.styl
+++ b/css/lab.styl
@@ -85,3 +85,7 @@
     > [draggable]
       >td:first-of-type
         border-left: 1ch solid rgba(gray, 0.2)
+
+.disabled-section
+  pointer-events: none
+  opacity: 0.4


### PR DESCRIPTION
This disables the checkbox for setting a workflow as default for live projects and inactive workflows. I can't think of a scenario where a project builder would want to do this purposely and it also breaks the workflow selection causing an infinite loop attempt to fetching a workflow that isn't active. 

I also added `classnames` to manage this and the inline styles added in #3517 

https://inactive-default-workflows.pfe-preview.zooniverse.org/

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?