### PR TITLE
Don't use Link for external project URLs on the home page

### DIFF
--- a/app/components/flexible-link.jsx
+++ b/app/components/flexible-link.jsx
@@ -10,27 +10,28 @@ export default class FlexibleLink extends React.Component {
     }
 
     if (this.props.to.indexOf('http') > -1) {
-      return (<a href={this.props.to}>{this.props.children}</a>);
+      return (<a className={this.props.className} href={this.props.to}>{this.props.children}</a>);
     }
 
-    return (<Link to={this.props.to} onClick={clickHandler.bind(this, this.props.logText)}>{this.props.children}</Link>);
+    return (<Link className={this.props.className} to={this.props.to} onClick={clickHandler.bind(this, this.props.logText)}>{this.props.children}</Link>);
   }
 }
 
 FlexibleLink.contextTypes = {
-  geordi: React.PropTypes.object,
+  geordi: React.PropTypes.object
 };
 
 FlexibleLink.propTypes = {
   children: React.PropTypes.node,
+  className: React.PropTypes.string,
   geordiHandler: React.PropTypes.string,
   logText: React.PropTypes.string,
-  to: React.PropTypes.string.isRequired,
+  to: React.PropTypes.string.isRequired
 };
 
 FlexibleLink.defaultProps = {
   children: null,
   geordiHandler: null,
   logText: null,
-  to: '',
+  to: ''
 };

--- a/app/pages/home-not-logged-in/promoted.cjsx
+++ b/app/pages/home-not-logged-in/promoted.cjsx
@@ -1,7 +1,7 @@
 React = require 'react'
 ReactDOM = require 'react-dom'
-{Link} = require 'react-router'
 apiClient = require 'panoptes-client/lib/api-client'
+FlexibleLink = require('../../components/flexible-link').default
 ZooniverseLogo = require '../../partials/zooniverse-logo'
 FEATURED_PROJECTS = require '../../lib/featured-projects'
 loadImage = require '../../lib/load-image'
@@ -80,7 +80,7 @@ module.exports = React.createClass
             <i className="controls angles fa fa-angle-left" onClick={=> @switchTo(projectIndex - 1)} />
             <i className="controls angles fa fa-angle-right" onClick={=> @switchTo(projectIndex + 1)} />
 
-            <Link to={if project.redirect then project.redirect else "/projects/#{project.slug}"} className="standard-button">Join Our Team</Link>
+            <FlexibleLink to={if project.redirect then project.redirect else "/projects/#{project.slug}"} className="standard-button">Join Our Team</FlexibleLink>
 
             <div className="controls circles">
               {for _, controlIndex in @state.projects


### PR DESCRIPTION
Fixes #3557

Describe your changes.
Replaces `Link` with `FlexibleLink` in the promoted projects component.

Updates `FlexibleLink` to accept an optional `className` property.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://featured-project-links.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?