### PR TITLE
Filter out dupe coords

### DIFF
--- a/app/classifier/drawing-tools/freehand-helpers.coffee
+++ b/app/classifier/drawing-tools/freehand-helpers.coffee
@@ -4,5 +4,13 @@ createPathFromCoords = (coordsArray) ->
   path += "L #{x},#{y} " for {x, y} in otherCoords
   path
 
-module.exports = 
+filterDupeCoords = (coordsArray) ->
+  coordsArray.reduce (filtered, current, index) ->
+    previous = coordsArray[index - 1] or false
+    filtered.push current unless previous and (previous.x is current.x and previous.y is current.y)
+    filtered
+  , []
+
+module.exports =
   createPathFromCoords: createPathFromCoords
+  filterDupeCoords: filterDupeCoords

--- a/app/classifier/drawing-tools/freehand-line.cjsx
+++ b/app/classifier/drawing-tools/freehand-line.cjsx
@@ -3,14 +3,14 @@ DrawingToolRoot = require './root'
 deleteIfOutOfBounds = require './delete-if-out-of-bounds'
 DeleteButton = require './delete-button'
 {svgPathProperties} = require 'svg-path-properties'
-{createPathFromCoords} = require './freehand-helpers'
+{createPathFromCoords, filterDupeCoords} = require './freehand-helpers'
 
 BUFFER = 16
 DELETE_BUTTON_WIDTH = 8
 GRAB_STROKE_WIDTH = 6
 MINIMUM_LENGTH = 20
 SELECTED_STROKE_WIDTH = 6
-STROKE_WIDTH = 
+STROKE_WIDTH =
 
 module.exports = React.createClass
   displayName: 'FreehandLineTool'
@@ -27,7 +27,8 @@ module.exports = React.createClass
     initMove: ({x, y}, mark) ->
       mark.points.push {x, y}
 
-    initRelease: ->
+    initRelease: (coords, mark) ->
+      points: filterDupeCoords mark.points
       _inProgress: false
 
     initValid: (mark) ->
@@ -66,9 +67,9 @@ module.exports = React.createClass
       {if @props.selected
         deletePosition = @getDeletePosition points
         <g>
-          <DeleteButton tool={this} 
-            x={deletePosition.x} 
-            y={deletePosition.y} 
+          <DeleteButton tool={this}
+            x={deletePosition.x}
+            y={deletePosition.y}
             getScreenCurrentTransformationMatrix={@props.getScreenCurrentTransformationMatrix} />
         </g>}
     </DrawingToolRoot>

--- a/app/classifier/drawing-tools/freehand-segment-line.cjsx
+++ b/app/classifier/drawing-tools/freehand-segment-line.cjsx
@@ -2,7 +2,7 @@ React = require 'react'
 DrawingToolRoot = require './root'
 deleteIfOutOfBounds = require './delete-if-out-of-bounds'
 DeleteButton = require './delete-button'
-{createPathFromCoords} = require './freehand-helpers'
+{createPathFromCoords, filterDupeCoords} = require './freehand-helpers'
 
 BUFFER = 16
 DELETE_BUTTON_WIDTH = 8
@@ -30,17 +30,19 @@ module.exports = React.createClass
     initMove: ({x, y}, mark) ->
       mark.points.push {x, y}
 
-    initRelease: ->
+    initRelease: (coords, mark) ->
       _currentlyDrawing: false
+      points: filterDupeCoords mark.points
 
     isComplete: (mark) ->
       !mark._inProgress
 
     forceComplete: (mark) ->
+      mark.points = filterDupeCoords mark.points
       mark._inProgress = false
       mark._currentlyDrawing = false
       mark.auto_closed = true
-    
+
   componentDidMount: ->
     document.addEventListener 'mousemove', @handleMouseMove
 
@@ -83,7 +85,7 @@ module.exports = React.createClass
       true
 
     @setState
-      mouseX: newCoord.x 
+      mouseX: newCoord.x
       mouseY: newCoord.y
       mouseWithinViewer: mouseWithinViewer
 
@@ -95,10 +97,10 @@ module.exports = React.createClass
     path = createPathFromCoords points
 
     <DrawingToolRoot tool={this}>
-      <path d={path} 
-        fill="none" 
+      <path d={path}
+        fill="none"
         strokeWidth={GRAB_STROKE_WIDTH / ((@props.scale.horizontal + @props.scale.vertical) / 2)}
-        stroke="transparent" 
+        stroke="transparent"
         className="clickable" />
       <path d={path} fill="none" className="clickable" />
 
@@ -107,17 +109,17 @@ module.exports = React.createClass
         [..., lastPoint] = points
 
         <g>
-          <DeleteButton tool={this} 
-            x={deletePosition.x} 
-            y={deletePosition.y} 
+          <DeleteButton tool={this}
+            x={deletePosition.x}
+            y={deletePosition.y}
             getScreenCurrentTransformationMatrix={@props.getScreenCurrentTransformationMatrix} />
         </g>}
 
       {if @props.selected and _inProgress and points.length and @state.mouseWithinViewer
-        <line className="guideline" 
-          x1={lastPoint.x} 
-          y1={lastPoint.y} 
-          x2={@state.mouseX} 
+        <line className="guideline"
+          x1={lastPoint.x}
+          y1={lastPoint.y}
+          x2={@state.mouseX}
           y2={@state.mouseY} />}
 
       {if @props.selected and _inProgress and not _currentlyDrawing
@@ -125,14 +127,14 @@ module.exports = React.createClass
         <g>
           {if @state.lastPointHover
             <circle r={FINISHER_RADIUS / averageScale} cx={lastPoint.x} cy={lastPoint.y} />}
-            
-          <circle className="clickable" 
-            r={POINT_RADIUS / averageScale} 
-            cx={lastPoint.x} 
-            cy={lastPoint.y} 
-            onClick={@handleFinishClick} 
-            onMouseEnter={@handleFinishHover} 
-            onMouseLeave={@handleFinishHover} 
+
+          <circle className="clickable"
+            r={POINT_RADIUS / averageScale}
+            cx={lastPoint.x}
+            cy={lastPoint.y}
+            onClick={@handleFinishClick}
+            onMouseEnter={@handleFinishHover}
+            onMouseLeave={@handleFinishHover}
             fill="currentColor" />
         </g>}
       }

--- a/app/classifier/drawing-tools/freehand-segment-shape.cjsx
+++ b/app/classifier/drawing-tools/freehand-segment-shape.cjsx
@@ -2,7 +2,7 @@ React = require 'react'
 DrawingToolRoot = require './root'
 deleteIfOutOfBounds = require './delete-if-out-of-bounds'
 DeleteButton = require './delete-button'
-{createPathFromCoords} = require './freehand-helpers'
+{createPathFromCoords, filterDupeCoords} = require './freehand-helpers'
 
 BUFFER = 16
 DELETE_BUTTON_WIDTH = 8
@@ -29,13 +29,15 @@ module.exports = React.createClass
     initMove: ({x, y}, mark) ->
       mark.points.push {x, y}
 
-    initRelease: ->
+    initRelease: (coords, mark) ->
       _currentlyDrawing: false
+      points: filterDupeCoords mark.points
 
     isComplete: (mark) ->
       !mark._inProgress
-    
+
     forceComplete: (mark) ->
+      mark.points = filterDupeCoords mark.points
       mark._inProgress = false
       mark._currentlyDrawing = false
       mark.auto_closed = true
@@ -82,7 +84,7 @@ module.exports = React.createClass
       true
 
     @setState
-      mouseX: newCoord.x 
+      mouseX: newCoord.x
       mouseY: newCoord.y
       mouseWithinViewer: mouseWithinViewer
 
@@ -95,9 +97,9 @@ module.exports = React.createClass
     fill = if _inProgress then 'none' else @props.color
 
     <DrawingToolRoot tool={this}>
-      <path d={path} 
-        fill={fill} 
-        fillOpacity="0.2" 
+      <path d={path}
+        fill={fill}
+        fillOpacity="0.2"
         className="clickable" />
 
       {if @props.selected
@@ -105,17 +107,17 @@ module.exports = React.createClass
         deletePosition = @getDeletePosition points
 
         <g>
-          <DeleteButton tool={this} 
-            x={deletePosition.x} 
-            y={deletePosition.y} 
+          <DeleteButton tool={this}
+            x={deletePosition.x}
+            y={deletePosition.y}
             getScreenCurrentTransformationMatrix={@props.getScreenCurrentTransformationMatrix} />
         </g>}
 
       {if @props.selected and _inProgress and points.length and @state.mouseWithinViewer
-        <line className="guideline" 
-          x1={lastPoint.x} 
-          y1={lastPoint.y} 
-          x2={@state.mouseX} 
+        <line className="guideline"
+          x1={lastPoint.x}
+          y1={lastPoint.y}
+          x2={@state.mouseX}
           y2={@state.mouseY} />}
 
       {if @props.selected and _inProgress and not _currentlyDrawing
@@ -123,14 +125,14 @@ module.exports = React.createClass
         <g>
           {if @state.firstPointHover
             <circle r={FINISHER_RADIUS / averageScale} cx={firstPoint.x} cy={firstPoint.y} />}
-            
-          <circle className="clickable" 
-            r={POINT_RADIUS / averageScale} 
-            cx={firstPoint.x} 
-            cy={firstPoint.y} 
-            onClick={@handleFinishClick} 
-            onMouseEnter={@handleFinishHover} 
-            onMouseLeave={@handleFinishHover} 
+
+          <circle className="clickable"
+            r={POINT_RADIUS / averageScale}
+            cx={firstPoint.x}
+            cy={firstPoint.y}
+            onClick={@handleFinishClick}
+            onMouseEnter={@handleFinishHover}
+            onMouseLeave={@handleFinishHover}
             fill="currentColor" />
         </g>}
       }

--- a/app/classifier/drawing-tools/freehand-shape.cjsx
+++ b/app/classifier/drawing-tools/freehand-shape.cjsx
@@ -3,7 +3,7 @@ DrawingToolRoot = require './root'
 deleteIfOutOfBounds = require './delete-if-out-of-bounds'
 DeleteButton = require './delete-button'
 {svgPathProperties} = require 'svg-path-properties'
-{createPathFromCoords} = require './freehand-helpers'
+{createPathFromCoords, filterDupeCoords} = require './freehand-helpers'
 
 BUFFER = 16
 DELETE_BUTTON_WIDTH = 8
@@ -26,6 +26,7 @@ module.exports = React.createClass
 
     initRelease: (coords, mark) ->
       mark.points.push mark.points[0]
+      mark.points = filterDupeCoords mark.points
       _inProgress: false
 
     initValid: (mark) ->
@@ -49,17 +50,17 @@ module.exports = React.createClass
     fill = if _inProgress then 'none' else @props.color
 
     <DrawingToolRoot tool={this}>
-      <path d={path} 
-        fill={fill} 
-        fillOpacity="0.2" 
+      <path d={path}
+        fill={fill}
+        fillOpacity="0.2"
         className="clickable" />
 
       {if !_inProgress and @props.selected
         deletePosition = @getDeletePosition points
         <g>
-          <DeleteButton tool={this} 
-            x={deletePosition.x} 
-            y={deletePosition.y} 
+          <DeleteButton tool={this}
+            x={deletePosition.x}
+            y={deletePosition.y}
             getScreenCurrentTransformationMatrix={@props.getScreenCurrentTransformationMatrix} />
         </g>}
     </DrawingToolRoot>


### PR DESCRIPTION
Related to #3551, removes duplicate coordinates from freehand annotations.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?