### PR TITLE
Improve keyboard control for survey task choices

### DIFF
--- a/app/classifier/tasks/survey/choice.cjsx
+++ b/app/classifier/tasks/survey/choice.cjsx
@@ -96,7 +96,7 @@ module.exports = React.createClass
                   <ImageFlipper images={@props.task.images[filename] for filename in otherChoice.images} />
                   <Markdown content={choice.confusions[otherChoiceID]} />
                   <div className="survey-task-choice-confusion-buttons" style={textAlign: 'center'}>
-                    <button type="submit" autoFocus={true} className="major-button identfiy">Dismiss</button>
+                    <button type="submit" autoFocus={true and otherChoice.images.length < 2} className="major-button identfiy">Dismiss</button>
                     {' '}
                     <button type="button" className="standard-button cancel" onClick={@props.onSwitch.bind null, otherChoiceID}>I think it’s this</button>
                   </div>

--- a/app/classifier/tasks/survey/choice.cjsx
+++ b/app/classifier/tasks/survey/choice.cjsx
@@ -26,10 +26,9 @@ ImageFlipper = React.createClass
       <div className="survey-task-image-flipper-pips">
         {unless @props.images.length is 1
           for index in [0...@props.images.length]
-            <span key={@props.images[index]}>
-              <button type="button" className="survey-task-image-flipper-pip" disabled={index is @state.frame} onClick={@handleFrameChange.bind this, index}>{index + 1}</button>
-              {' '}
-            </span>}
+            <label key={@props.images[index]}  className="survey-task-image-flipper-pip #{if index is @state.frame then 'active' else ''}">
+              <input type="radio" name="image-flipper" autoFocus={index is 0} checked={index is @state.frame} onChange={@handleFrameChange.bind this, index} />{index + 1}
+            </label>}
       </div>
     </span>
 
@@ -97,7 +96,7 @@ module.exports = React.createClass
                   <ImageFlipper images={@props.task.images[filename] for filename in otherChoice.images} />
                   <Markdown content={choice.confusions[otherChoiceID]} />
                   <div className="survey-task-choice-confusion-buttons" style={textAlign: 'center'}>
-                    <button type="submit" className="major-button identfiy">Dismiss</button>
+                    <button type="submit" autoFocus={true} className="major-button identfiy">Dismiss</button>
                     {' '}
                     <button type="button" className="standard-button cancel" onClick={@props.onSwitch.bind null, otherChoiceID}>I think it’s this</button>
                   </div>

--- a/app/classifier/tasks/survey/choice.cjsx
+++ b/app/classifier/tasks/survey/choice.cjsx
@@ -53,6 +53,7 @@ module.exports = React.createClass
 
   getInitialState: ->
     answers: {}
+    focusedAnswer: ''
 
   checkFilledIn: ->
     # if there are no questions, don't make them fill one in
@@ -122,9 +123,10 @@ module.exports = React.createClass
                   answerID in (@state.answers[questionID] ? [])
                 else
                   answerID is @state.answers[questionID]
+                isFocused = @state.focusedAnswer is "#{questionID}/#{answerID}"
                 <span key={answerID}>
-                  <label className="survey-task-choice-answer" data-checked={isChecked || null}>
-                    <input ref={questionID} name={questionID} type={inputType} checked={isChecked} onChange={@handleAnswer.bind this, questionID, answerID} />
+                  <label className="survey-task-choice-answer" data-checked={isChecked || null} data-focused={isFocused || null}>
+                    <input ref={questionID} name={questionID} type={inputType} checked={isChecked} onChange={@handleAnswer.bind this, questionID, answerID} onFocus={@handleFocus.bind this, questionID, answerID} onBlur={@handleFocus.bind this, null, null} />
                     {answer.label}
                   </label>
                   {' '}
@@ -157,6 +159,12 @@ module.exports = React.createClass
       else
         @state.answers[questionID] = answerID
     @setState answers: @state.answers
+
+  handleFocus: (questionID, answerID, e) ->
+    if questionID and answerID
+      @setState focusedAnswer: "#{questionID}/#{answerID}"
+    else
+      @setState focusedAnswer: ''
 
   handleIdentification: ->
     @props.onConfirm @props.choiceID, @state.answers

--- a/css/survey-task.styl
+++ b/css/survey-task.styl
@@ -313,6 +313,10 @@ $survey-task-pill-button
     background: MAIN_HIGHLIGHT
     color: white
 
+  &[data-focused]
+    background: SECOND_HIGHLIGHT
+    color: white
+
   span
     cursor: pointer
 

--- a/css/survey-task.styl
+++ b/css/survey-task.styl
@@ -205,13 +205,19 @@ $survey-task-pill-button
   border-radius: 50%
   color: white
   display: inline-block
-  height: 1em
+  height: .5em
   overflow: hidden
   text-indent: 1em
-  width: 1em
+  width: .5em
+  
+  input[type=radio]
+    position: absolute
+    height: 0
+    width: 0
+    left: -100px
 
   &.active
-    background: white
+    opacity: .3
 
 .survey-task-choice
   background:  #f7f7f7


### PR DESCRIPTION
Towards #2132 

Describe your changes.
Autofocus the survey image flipper when the choice first mounts, allowing images to be changed with the cursor keys.
Autofocus the confusions popup when that opens, so that it can be dismissed from the keyboard if required.
Add a visual style to question answers when those radio buttons have focus.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://survey-choice-keyboard.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?