### PR TITLE
update label for recent classifications

### DIFF
--- a/app/pages/project/stats/stats.jsx
+++ b/app/pages/project/stats/stats.jsx
@@ -390,7 +390,7 @@ export class ProjectStatsPage extends React.Component {
             </div>
             <div className="project-metadata-stat">
               <div>{this.props.currentClassifications.toLocaleString()}</div>
-              <div>Recent Classifications</div>
+              <div>Classifications Yesterday</div>
             </div>
           </div>
           <hr />


### PR DESCRIPTION
This replaces the project stats page label for `Recent Classifications` to `Classifications Yesterday` to better reflect what that number is.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?