### PR TITLE
Only retry fetching workflow if selected_workflow exists

### DIFF
--- a/app/pages/project/index.cjsx
+++ b/app/pages/project/index.cjsx
@@ -102,7 +102,7 @@ ProjectPage = React.createClass
       else
         @getAllWorkflows(nextProps.project)
 
-    if nextProps.preferences?.preferences? and @state.selectedWorkflow?
+    if nextProps.preferences?.preferences?.selected_workflow? and @state.selectedWorkflow?
       if nextProps.preferences?.preferences.selected_workflow isnt @state.selectedWorkflow.id
         @getSelectedWorkflow(nextProps.project, nextProps.preferences)
 
@@ -404,15 +404,12 @@ ProjectPageController = React.createClass
 
   fetchProjectData: (ownerName, projectName, user) ->
     @listenToPreferences null
-    @setState
-      background: null
-      error: null
-      loading: true
-      owner: null
-      pages: null
-      preferences: null
-      projectAvatar: null
-      projectRoles: null
+    @setState({ 
+      error: null,
+      loading: true,
+      preferences: null,
+    })
+
 
     slug = ownerName + '/' + projectName
 


### PR DESCRIPTION
Fixes #3561. I changed the conditional slightly to check if the `selected_workflow` property exists first before trying to refetch for the workflow. Also fixed a bug introduced in #3545 where certain resources that weren't changing between sign in/out like the project, its background, avatar, etc were being set back to null when fetching the new project data. I've reverted it back to the old behavior. This is still not ideal since on user change we should probably just be fetching for just the preferences, not all the project data, but I'll change that in a separate PR.

Fix can be tested with this test project: https://fix-3561.pfe-preview.zooniverse.org/projects/cmk24/test-project-2/classify

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?