### PR TITLE
Optimize API call on Collection Cards

### DIFF
--- a/app/lib/get-collection-covers.js
+++ b/app/lib/get-collection-covers.js
@@ -1,0 +1,26 @@
+import apiClient from 'panoptes-client/lib/api-client';
+
+function getCollectionCovers(collections) {
+  const subjectIDs = collections.reduce(((ids, collection) => {
+    if (collection.links.subjects) {
+      ids.push(collection.links.subjects[0]);
+    }
+    return ids;
+  }), []);
+  return apiClient.type('subjects').get({ id: subjectIDs })
+    .then((subjects) => {
+      const subjectSrcs = subjects.reduce(((ids, subject) => {
+        const firstKey = Object.keys(subject.locations[0])[0];
+        ids[subject.id] = subject.locations[0][firstKey];
+        return ids;
+      }), {});
+      return collections.reduce(((covers, collection) => {
+        if (collection.links.subjects) {
+          covers[collection.id] = subjectSrcs[collection.links.subjects[0]];
+        }
+        return covers;
+      }), {});
+    });
+}
+
+export default getCollectionCovers;

--- a/app/pages/collections/collection-card.jsx
+++ b/app/pages/collections/collection-card.jsx
@@ -10,12 +10,12 @@ export default class CollectionCard extends React.Component {
   }
 
   componentDidMount() {
-    this.refreshImage(this.props.imagePromise);
+    this.refreshImage(this.props.coverSrc);
   }
 
   componentWillReceiveProps(nextProps) {
-    if (nextProps.imagePromise !== this.props.imagePromise) {
-      this.refreshImage(nextProps.imagePromise);
+    if (nextProps.coverSrc !== this.props.coverSrc) {
+      this.refreshImage(nextProps.coverSrc);
     }
   }
 
@@ -23,20 +23,12 @@ export default class CollectionCard extends React.Component {
     apiClient.type(this.props.collection.links.owner.type).get(this.props.collection.links.owner.id);
   }
 
-  refreshImage(promise) {
-    Promise.resolve(promise)
-      .then((src) => {
-        if (src) {
-          this.collectionCard.style.backgroundImage = `url('${src}')`;
-          this.collectionCard.style.backgroundPosition = 'initial';
-          this.collectionCard.style.backgroundRepeat = "no-repeat";
-          this.collectionCard.style.backgroundSize = "cover";
-        } else {
-          this.collectionCard.style.backgroundImage = "url('/assets/simple-pattern.png')";
-        }
-      }).catch(() => {
-        return null; // We don't care if there is an error. Default pattern in styles will show.
-      });
+  refreshImage(src) {
+    const source = src.includes('.mp4') ? '/assets/simple-pattern.png' : src;
+    this.collectionCard.style.backgroundImage = `url('${source}')`;
+    this.collectionCard.style.backgroundPosition = 'initial';
+    this.collectionCard.style.backgroundRepeat = 'no-repeat';
+    this.collectionCard.style.backgroundSize = 'cover';
   }
 
   render() {
@@ -52,7 +44,7 @@ export default class CollectionCard extends React.Component {
       to: linkTo,
       geordiHandler: 'profile-menu',
       logText: dataText,
-      params: { owner, name },
+      params: { owner, name }
     };
 
     return (
@@ -65,11 +57,11 @@ export default class CollectionCard extends React.Component {
               <span>{this.props.collection.display_name}</span>
               {this.props.collection.private ? <i className="fa fa-lock" /> : null}
             </div>
-              <div className="owner">
-                {this.props.shared ?
-                  <span><i className="fa fa-users"></i>{" "}</span> : null}
-                {this.props.collection.links.owner.display_name}
-              </div>
+            <div className="owner">
+              {this.props.shared ?
+                <span><i className="fa fa-users" />{' '}</span> : null}
+              {this.props.collection.links.owner.display_name}
+            </div>
           </div>
         </div>
       </FlexibleLink>
@@ -80,21 +72,22 @@ export default class CollectionCard extends React.Component {
 CollectionCard.propTypes = {
   collection: React.PropTypes.shape({
     display_name: React.PropTypes.string,
+    id: React.PropTypes.string,
     links: React.PropTypes.object,
     private: React.PropTypes.bool,
-    slug: React.PropTypes.string,
+    slug: React.PropTypes.string
   }).isRequired,
-  imagePromise: React.PropTypes.any,
+  coverSrc: React.PropTypes.string,
   linkTo: React.PropTypes.string.isRequired,
   subjectCount: React.PropTypes.number,
   shared: React.PropTypes.bool,
-  translationObjectName: React.PropTypes.string.isRequired,
+  translationObjectName: React.PropTypes.string.isRequired
 };
 
 CollectionCard.defaultProps = {
   collection: {},
-  imagePromise: null,
+  coverSrc: '/assets/simple-pattern.png',
   linkTo: '',
   subjectCount: 0,
-  translationObjectName: '',
+  translationObjectName: ''
 };

--- a/app/pages/home-for-user/recent-collections.jsx
+++ b/app/pages/home-for-user/recent-collections.jsx
@@ -3,14 +3,15 @@ import apiClient from 'panoptes-client/lib/api-client';
 import { Link } from 'react-router';
 import HomePageSection from './generic-section';
 import CollectionCard from '../collections/collection-card';
+import getCollectionCovers from '../../lib/get-collection-covers';
 
 const RecentCollectionsSection = React.createClass({
   propTypes: {
-    onClose: React.PropTypes.func,
+    onClose: React.PropTypes.func
   },
 
   contextTypes: {
-    user: React.PropTypes.object.isRequired,
+    user: React.PropTypes.object.isRequired
   },
 
   getInitialState() {
@@ -18,7 +19,7 @@ const RecentCollectionsSection = React.createClass({
       loading: false,
       error: null,
       collections: [],
-      images: {},
+      images: {}
     };
   },
 
@@ -33,7 +34,7 @@ const RecentCollectionsSection = React.createClass({
   },
 
   shared(collection) {
-    return this.context.user.id !== collection.links.owner.id
+    return this.context.user.id !== collection.links.owner.id;
   },
 
   fetchCollections(user) {
@@ -41,47 +42,29 @@ const RecentCollectionsSection = React.createClass({
       loading: true,
       error: null,
       images: {},
-      collections: [],
+      collections: []
     });
 
     apiClient.type('collections').get({
       page_size: 8,
       sort: '-updated_at',
       favorite: false,
-      current_user_roles: "owner,contributor,collaborator",
+      current_user_roles: "owner,contributor,collaborator"
     })
     .then((collections) => {
       this.setState({ collections });
-
-      return Promise.all(collections.map((collection) => {
-        return apiClient.type('subjects').get({
-          collection_id: collection.id,
-          page_size: 1,
-        })
-        .then(([subject]) => {
-          let imageSrc;
-          if (subject !== undefined) {
-            const firstLocationKey = Object.keys(subject.locations[0])[0];
-            imageSrc = subject.locations[0][firstLocationKey];
-          } else {
-            imageSrc = '/simple-avatar.png';
-          }
-          const imageState = Object.assign({}, this.state.images);
-          imageState[collection.id] = imageSrc;
-          this.setState({
-            images: imageState,
-          });
-        });
-      }));
+      getCollectionCovers(collections).then((images) => {
+        this.setState({ images });
+      });
     })
     .catch((error) => {
       this.setState({
-        error: error,
+        error: error
       });
     })
     .then(() => {
       this.setState({
-        loading: false,
+        loading: false
       });
     });
   },
@@ -107,12 +90,12 @@ const RecentCollectionsSection = React.createClass({
         <div className="collections-card-list">
           {this.state.collections.map((collection) => {
             const subjectCount = collection.links.subjects ? collection.links.subjects.length : 0;
-            return <CollectionCard key={collection.id} shared={this.shared(collection)} subjectCount={subjectCount} collection={collection} imagePromise={this.state.images[collection.id]} linkTo={`/collections/${collection.slug}`} translationObjectName="collectionsPage" />;
+            return <CollectionCard key={collection.id} shared={this.shared(collection)} subjectCount={subjectCount} collection={collection} coverSrc={this.state.images[collection.id]} linkTo={`/collections/${collection.slug}`} translationObjectName="collectionsPage" />;
           })}
         </div>
       </HomePageSection>
     );
-  },
+  }
 });
 
 export default RecentCollectionsSection;


### PR DESCRIPTION
Fixes #3550  .

Describe your changes.
Fix the subject call on collections to use an array or ids instead of making an API call for each subject. Also fixed some linter warnings on the components that were changed.

https://collections-promise.pfe-preview.zooniverse.org/

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?