### PR TITLE
Updating the help text for live active workflows

### DIFF
--- a/app/pages/lab/workflow.cjsx
+++ b/app/pages/lab/workflow.cjsx
@@ -90,7 +90,7 @@ EditWorkflowPage = React.createClass
       <p className="form-help">A workflow is the sequence of tasks that you’re asking volunteers to perform. For example, you might want to ask volunteers to answer questions about your images, or to mark features in your images, or both.</p>
       <p className="form-help">If you have multiple workflows you can rearrange the order in which they are listed on your project's front page by clicking and dragging on the left gray tab next to each workflow title in the left menu bar.</p>
       {if @props.project.live and @props.workflow.active
-        <p className="form-help warning"><strong>You cannot edit an active workflow if the project is live.</strong></p>}
+        <p className="form-help warning"><strong>If the project is live, you cannot edit tasks in an active workflow, but other workflow settings can be changed.</strong></p>}
       <div className="columns-container">
         <div className="column">
           <div>


### PR DESCRIPTION
modifying the help text for active worflows for live projects so people know they can swap subject sets and retirement rules