### PR TITLE
Fix shortcut defaults

### DIFF
--- a/app/classifier/tasks/shortcut.cjsx
+++ b/app/classifier/tasks/shortcut.cjsx
@@ -41,10 +41,14 @@ module.exports = React.createClass
       value: null
 
   getDefaultProps: ->
-    annotation: null
+    annotation: 
+      task: null
+      value: null
     classification: null
-    task: null
-    workflow: null
+    task:
+      unlinkedTask: null
+    workflow:
+      tasks:[]
 
   getInitialState: ->
     index: null
@@ -63,7 +67,8 @@ module.exports = React.createClass
     @props.classification.update 'annotations'
 
   render: ->
-    options = @props.workflow.tasks[@props.task.unlinkedTask].answers
+    options = @props.workflow.tasks[@props.task.unlinkedTask]?.answers
+    options ?= []
 
     <div>
 

--- a/app/classifier/tasks/shortcut.spec.js
+++ b/app/classifier/tasks/shortcut.spec.js
@@ -1,0 +1,21 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import assert from 'assert';
+import Shortcut from './shortcut';
+
+describe('Shortcut', function() {
+  let wrapper;
+  let annotation = {
+    task: 'T0',
+    value: 'something'
+  }
+  
+  it('should render with default props', function() {
+    wrapper = shallow(<Shortcut />);
+  });
+  
+  it('should update on annotation change', function() {
+    wrapper = shallow(<Shortcut />);
+    wrapper.setProps({annotation});
+  });
+});


### PR DESCRIPTION
Fixes broken task rendering for Backyard Worlds, which is throwing an error for an undefined value in the shortcut task.

Describe your changes.
Adds a test for the bug.
Sets default props for task, workflow and annotation.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://fix-shortcut-defaults.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?