### PR TITLE
Use subject.favorite to get favourited status

### DIFF
--- a/app/collections/favorites-button.cjsx
+++ b/app/collections/favorites-button.cjsx
@@ -39,18 +39,29 @@ module.exports = React.createClass
       .get({project_ids: @props.project?.id, favorite: true, owner: @props.user.login})
       .then ([favorites]) -> if favorites? then favorites else null
 
+  findSubjectInCollection: (favorites) ->
+    if @props.subject.hasOwnProperty 'favorite'
+      Promise.resolve @props.subject.favorite
+    else if favorites?
+      favorites.get('subjects', id: @props.subject.id)
+        .then ([subject]) -> subject?
+    else
+      Promise.resolve false
+
   componentWillMount: ->
-    favorited = @props.subject.favorite
-    @setState {favorited}
     @findFavoriteCollection()
       .then (favorites) =>
         @setState {favorites}
+        @findSubjectInCollection(favorites)
+        .then (favorited) =>
+          @setState {favorited}
 
 
   componentDidUpdate: (prevProps) ->
     if prevProps.subject isnt @props.subject
-      favorited = @props.subject.favorite
-      @setState {favorited}
+      @findSubjectInCollection(@state.favorites)
+      .then (favorited) =>
+        @setState {favorited}
 
   addSubjectTo: (collection) ->
     @setState favorited: true

--- a/app/collections/favorites-button.cjsx
+++ b/app/collections/favorites-button.cjsx
@@ -39,28 +39,18 @@ module.exports = React.createClass
       .get({project_ids: @props.project?.id, favorite: true, owner: @props.user.login})
       .then ([favorites]) -> if favorites? then favorites else null
 
-  findSubjectInCollection: (favorites) ->
-    if favorites?
-      favorites.get('subjects', id: @props.subject.id)
-        .then ([subject]) -> subject?
-    else
-      Promise.resolve false
-
   componentWillMount: ->
-    # see if the subject is in the project's favorites collection
-    # to see if it's favorites
+    favorited = @props.subject.favorite
+    @setState {favorited}
     @findFavoriteCollection()
       .then (favorites) =>
         @setState {favorites}
-        @findSubjectInCollection(favorites)
-      .then (favorited) =>
-        @setState {favorited}
+
 
   componentDidUpdate: (prevProps) ->
     if prevProps.subject isnt @props.subject
-      @findSubjectInCollection(@state.favorites)
-      .then (favorited) =>
-        @setState {favorited}
+      favorited = @props.subject.favorite
+      @setState {favorited}
 
   addSubjectTo: (collection) ->
     @setState favorited: true


### PR DESCRIPTION
Fixes #3494  .

Describe your changes.
Uses the `subject.favorite` flag to set favourited status.
Removes API call to check for subject in collection.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://subject-favorite-flag.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?