### PR TITLE
Move field guide to classifier

### DIFF
--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -271,6 +271,7 @@ Classifier = React.createClass
         else if not @props.workflow.configuration?.hide_classification_summaries # Classification is complete; show summary if enabled
           @renderSummary currentClassification}
       </div>
+      <PotentialFieldGuide guide={@props.guide} guideIcons={@props.guideIcons} />
     </div>
 
   renderSummary: (classification) ->
@@ -462,9 +463,14 @@ module.exports = React.createClass
   getInitialState: ->
     subject: null
     expertClassifier: null
+    guide: null
+    guideIcons: null
     userRoles: []
     tutorial: null
     minicourse: null
+
+  componentWillMount: ->
+    @loadFieldGuide(@props.project.id)
 
   componentDidMount: ->
     @checkExpertClassifier()
@@ -495,6 +501,16 @@ module.exports = React.createClass
 
     unless nextProps.classification is @props.classification
       @loadClassification nextProps.classification
+
+  loadFieldGuide: (projectId) ->
+    apiClient.type('field_guides').get(project_id: projectId).then ([guide]) =>
+      @setState {guide}
+      guide?.get('attached_images', page_size: 100)?.then (images) =>
+        guideIcons = {}
+        for image in images
+          guideIcons[image.id] = image
+        @setState {guideIcons}
+
 
   loadClassification: (classification) ->
 # TODO: These underscored references are temporary stopgaps.
@@ -552,6 +568,8 @@ module.exports = React.createClass
           userRoles={@state.userRoles}
           tutorial={@state.tutorial}
           minicourse={@state.minicourse}
+          guide={@state.guide}
+          guideIcons={@state.guideIcons}
           onComplete={@onComplete}
           onCompleteAndLoadAnotherSubject={@onCompleteAndLoadAnotherSubject}
         />

--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -23,6 +23,7 @@ Task = require('./task').default
 TaskNav = require('./task-nav').default
 ExpertOptions = require('./expert-options').default
 `import CustomSignInPrompt from './custom-sign-in-prompt';`
+PotentialFieldGuide = require '../components/potential-field-guide'
 
 # For easy debugging
 window.cachedClassification = CacheClassification

--- a/app/components/field-guide.cjsx
+++ b/app/components/field-guide.cjsx
@@ -3,6 +3,8 @@ React = require 'react'
 CroppedImage = require './cropped-image'
 
 module.exports = React.createClass
+  displayName: 'FieldGuide'
+
   getDefaultProps: ->
     title: null
     content: null

--- a/app/components/potential-field-guide.cjsx
+++ b/app/components/potential-field-guide.cjsx
@@ -4,6 +4,8 @@ Pullout = require 'react-pullout'
 FieldGuide = require './field-guide'
 
 module.exports = React.createClass
+  displayName: 'PotentialFieldGuide'
+
   getDefaultProps: ->
     project: null
 

--- a/app/components/potential-field-guide.cjsx
+++ b/app/components/potential-field-guide.cjsx
@@ -30,7 +30,7 @@ module.exports = React.createClass
     apiClient.type('field_guides').get project_id: project.id
       .then ([guide]) =>
         @setState {guide}
-        guide?.get('attached_images')?.then (images) =>
+        guide?.get('attached_images', page_size: 50)?.then (images) =>
           icons = {}
           for image in images
             icons[image.id] = image

--- a/app/components/potential-field-guide.cjsx
+++ b/app/components/potential-field-guide.cjsx
@@ -1,7 +1,7 @@
 React = require 'react'
 apiClient = require 'panoptes-client/lib/api-client'
 Pullout = require 'react-pullout'
-FieldGuide = require '../../components/field-guide'
+FieldGuide = require './field-guide'
 
 module.exports = React.createClass
   getDefaultProps: ->

--- a/app/components/potential-field-guide.cjsx
+++ b/app/components/potential-field-guide.cjsx
@@ -8,35 +8,14 @@ module.exports = React.createClass
 
   getDefaultProps: ->
     project: null
+    guide: null
+    guideIcons: null
 
   getInitialState: ->
-    guide: null
-    icons: {}
-    revealed: true
+    revealed: false
 
   contextTypes:
     geordi: React.PropTypes.object
-
-  componentDidMount: ->
-    @fetchGuide @props.project
-
-  componentWillReceiveProps: (nextProps) ->
-    unless nextProps.project is @props.project
-      @fetchGuide nextProps.project
-
-  fetchGuide: (project) ->
-    @setState
-      guide: null
-      icons: {}
-      revealed: false
-    apiClient.type('field_guides').get project_id: project.id
-      .then ([guide]) =>
-        @setState {guide}
-        guide?.get('attached_images', page_size: 50)?.then (images) =>
-          icons = {}
-          for image in images
-            icons[image.id] = image
-          @setState {icons}
 
   logClick: (type) ->
     @context?.geordi?.logEvent
@@ -51,12 +30,12 @@ module.exports = React.createClass
     @setState revealed: not @state.revealed
 
   render: ->
-    if @state.guide? and @state.guide.items.length isnt 0
+    if @props.guide? and @props.guide.items.length isnt 0 and @props.guideIcons?
       <Pullout className="field-guide-pullout" side="right" open={@state.revealed}>
         <button type="button" className="field-guide-pullout-toggle" onClick={@toggleFieldGuide}>
           <strong>Field guide</strong>
         </button>
-        <FieldGuide items={@state.guide.items} icons={@state.icons} onClickClose={@toggleFieldGuide} />
+        <FieldGuide items={@props.guide.items} icons={@props.guideIcons} onClickClose={@toggleFieldGuide} />
       </Pullout>
     else
       null

--- a/app/pages/lab/field-guide/index.cjsx
+++ b/app/pages/lab/field-guide/index.cjsx
@@ -50,7 +50,7 @@ FieldGuideEditor = React.createClass
 
   fetchIcons: (guide) ->
     guide.uncacheLink 'attached_images'
-    guide.get 'attached_images'
+    guide.get 'attached_images', page_size: 50
       .then (images) =>
         icons = {}
         images.forEach (image) ->

--- a/app/pages/project/project-page.cjsx
+++ b/app/pages/project/project-page.cjsx
@@ -3,7 +3,6 @@ React = require 'react'
 Translate = require 'react-translate-component'
 {IndexLink, Link} = require 'react-router'
 {Markdown} = require 'markdownz'
-PotentialFieldGuide = require './potential-field-guide'
 {sugarClient} = require 'panoptes-client/lib/sugar'
 Thumbnail = require('../../components/thumbnail').default
 classnames = require 'classnames'
@@ -217,9 +216,6 @@ ProjectPage = React.createClass
 
       {unless @props.project.launch_approved
         <Translate component="p" className="project-disclaimer" content="project.disclaimer" />}
-
-      {unless @props.location.pathname is projectPath
-        <PotentialFieldGuide project={@props.project} />}
     </div>
 
 module.exports = ProjectPage


### PR DESCRIPTION
This PR addresses the field guide portion of #3492 and replaces PR #3535.

**Describe your changes.**
The PotentialFieldGuide component is now required in the `/classifier/index` instead of the `pages/project/index`.

The request for the field_guide has been moved to the ClassifierWrapper (see `loadFieldGuide()`), where the field_guide data and icons are set in state and passed to the Classifier and PotentialFieldGuide as props.

The icons for the field guide are not requested via an `include` on the original request because of the page_size issue identified in #3535. I've set the page_size on the request for the field guide, but I wasn't sure what number to specify. Any input on what the page size should be?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://move-field-guide-to-classifier.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?