### PR TITLE
[WIP] Use user.avatar_src instead of fetching seperately

### DIFF
--- a/app/partials/avatar.cjsx
+++ b/app/partials/avatar.cjsx
@@ -33,14 +33,7 @@ module.exports = React.createClass
     @props.user.stopListening 'change', @handleResourceChange
 
   handleResourceChange: (user = @props.user) ->
-    @setState loading: true
-    user.get 'avatar'
-      .then ([avatar]) =>
-        @setState src: avatar.src
-      .catch =>
-        @setState src: DEFAULT_AVATAR
-      .then =>
-        @setState loading: false
+    @setState src: (user.avatar_src || DEFAULT_AVATAR)
 
   handleError: ->
     @setState src: DEFAULT_AVATAR
@@ -50,7 +43,6 @@ module.exports = React.createClass
       src={@state.src}
       alt="Avatar for #{@props.user.display_name}"
       className={"avatar #{@props.className}".trim()}
-      data-loading={@state.loading || null}
       style={
         height: @props.size
         width: @props.size


### PR DESCRIPTION
**Needs Panoptes to be deployed first.**

Panoptes will start emitting the avatar src directly as a field in the user json. This PR takes advantage of that, removing one API call for most page-loads (fetching the current user's avatar), and removing lots of API calls on talk discussion pages (to load each individual user's avatar).

Tagging @camallen who will coordinate the deploy of this feature to Panoptes production on Monday, and is happy to merge this afterwards (if approved).

Closes https://github.com/zooniverse/Panoptes/issues/2204

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?