### PR TITLE
fix onChange context for taskHookProps

### DIFF
--- a/app/classifier/task.jsx
+++ b/app/classifier/task.jsx
@@ -47,7 +47,7 @@ class Task extends React.Component {
       taskTypes: tasks,
       workflow,
       classification,
-      onChange: classification.update
+      onChange: (...args) => classification.update(args)
     };
 
     return (


### PR DESCRIPTION
Fixes #3578.

The wrong onChange context was being passed into the `taskHookProps`.

This can be tested out with the `Bars` or `Spiral` workflows for this project: https://fix-hide-previous-marks.pfe-preview.zooniverse.org/projects/klmasters/galaxy-zoo-3d/?env=production

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?