### PR TITLE
Remove demoMode and gold_standard on signout

### DIFF
--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -61,12 +61,18 @@ Classifier = React.createClass
     @loadSubject @props.subject
 
   componentWillReceiveProps: (nextProps) ->
+    if nextProps.user isnt @props.user
+      if @props.demoMode
+        @props.onChangeDemoMode false
+      if @props.classification.gold_standard
+        @props.classification.update gold_standard: undefined
+
     if nextProps.subject isnt @props.subject
       @loadSubject nextProps.subject
 
     if @props.subject isnt nextProps.subject or !@context.geordi?.keys["subjectID"]?
       @context.geordi?.remember subjectID: nextProps.subject?.id
-    
+
     if nextProps.classification isnt @props.classification
       @props.classification.stopListening 'change', =>
         {annotations} = @props.classification
@@ -251,7 +257,7 @@ Classifier = React.createClass
                   <strong>Gold standard mode:</strong>
                   <br />
                   Please ensure this classification is completely accurate.{' '}
-                  <button type="button" className="secret-button" onClick={currentClassification.update.bind(currentClassification, { gold_standard: undefined })}>
+                  <button type="button" className="secret-button" onClick={@handleGoldStandardChange}>
                     <u>Disable</u>
                   </button>
                 </small>
@@ -264,7 +270,6 @@ Classifier = React.createClass
           @renderSummary currentClassification}
       </div>
     </div>
-    
 
   renderSummary: (classification) ->
     disableTalk = @props.classification.metadata.subject_flagged?
@@ -385,8 +390,8 @@ Classifier = React.createClass
     changes["metadata.subject_dimensions.#{frameIndex}"] = {naturalWidth, naturalHeight, clientWidth, clientHeight}
     @props.classification.update changes
 
-  handleAnnotationChange: (classification, newAnnotation) ->		
-    classification.annotations[classification.annotations.length - 1] = newAnnotation		
+  handleAnnotationChange: (classification, newAnnotation) ->
+    classification.annotations[classification.annotations.length - 1] = newAnnotation
     classification.update 'annotations'
 
   completeClassification: ->
@@ -408,7 +413,7 @@ Classifier = React.createClass
 
   toggleExpertClassification: (value) ->
     @setState showingExpertClassification: value
-  
+
   changeDemoMode: (demoMode) ->
     @props.onChangeDemoMode demoMode
 

--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -257,7 +257,7 @@ Classifier = React.createClass
                   <strong>Gold standard mode:</strong>
                   <br />
                   Please ensure this classification is completely accurate.{' '}
-                  <button type="button" className="secret-button" onClick={@handleGoldStandardChange}>
+                  <button type="button" className="secret-button" onClick={currentClassification.update.bind(currentClassification, { gold_standard: undefined })}>
                     <u>Disable</u>
                   </button>
                 </small>
@@ -341,7 +341,7 @@ Classifier = React.createClass
           />}
       </nav>
     </div>
-    
+
 
   renderGravitySpyGoldStandard: (classification) ->
     disableTalk = @props.classification.metadata.subject_flagged?


### PR DESCRIPTION
Fixes #3582 

Describe your changes.
Removes demoMode and gold_standard props on projects when user signs out.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)

https://fix-3582.pfe-preview.zooniverse.org/

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?