### PR TITLE
Make it clear the username is public

### DIFF
--- a/app/partials/register-form.cjsx
+++ b/app/partials/register-form.cjsx
@@ -14,6 +14,7 @@ counterpart.registerTranslations 'en',
     required: 'Required'
     looksGood: 'Looks good'
     userName: 'User name'
+    whyUserName: 'You’ll use this name to log in. It will be shown publicly.'
     badChars: "Only letters, numbers, '.', '_', and '-'."
     nameConflict: 'That username is taken'
     forgotPassword: 'Forget your password?'
@@ -77,6 +78,7 @@ module.exports = React.createClass
               </span>}
         </span>
         <input type="text" ref="name" className="standard-input full" disabled={@props.user?} autoFocus onChange={@handleNameChange} maxLength="255" />
+        <Translate component="span" className="form-help info" content="registerForm.whyUserName" />
       </label>
 
       <br />


### PR DESCRIPTION
Adds a node to the registration form making it clear that the username is public.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?