### PR TITLE
move subjectDimensions to state and add to the classification in the TaskNav componenet

### DIFF
--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -388,7 +388,6 @@ Classifier = React.createClass
     @context.geordi?.remember subjectID: @props.subject?.id
 
     {naturalWidth, naturalHeight, clientWidth, clientHeight} = e.target
-    changes = {}
     subjectDimensions = @state.subjectDimensions.slice()
     subjectDimensions["#{frameIndex}"] = {naturalWidth, naturalHeight, clientWidth, clientHeight}
     @setState({ subjectDimensions })

--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -55,6 +55,7 @@ Classifier = React.createClass
     selectedExpertAnnotation: -1
     showingExpertClassification: false
     subjectLoading: false
+    subjectDimensions: []
     annotations: []
 
   componentDidMount: ->
@@ -86,6 +87,11 @@ Classifier = React.createClass
       @setState {annotations}
     try
       @context.geordi?.forget ['subjectID']
+
+  shouldComponentUpdate: (nextProps, nextState) ->
+    if nextState.subjectDimensions isnt @state.subjectDimensions
+      return false
+    return true
 
   loadSubject: (subject) ->
     @setState
@@ -182,6 +188,7 @@ Classifier = React.createClass
               completeClassification={@completeClassification}
               project={@props.project}
               subject={@props.subject}
+              subjectDimensions={@state.subjectDimensions}
               task={currentTask}
               workflow={@props.workflow}
             >
@@ -382,8 +389,9 @@ Classifier = React.createClass
 
     {naturalWidth, naturalHeight, clientWidth, clientHeight} = e.target
     changes = {}
-    changes["metadata.subject_dimensions.#{frameIndex}"] = {naturalWidth, naturalHeight, clientWidth, clientHeight}
-    @props.classification.update changes
+    subjectDimensions = @state.subjectDimensions.slice()
+    subjectDimensions["#{frameIndex}"] = {naturalWidth, naturalHeight, clientWidth, clientHeight}
+    @setState({ subjectDimensions })
 
   handleAnnotationChange: (classification, newAnnotation) ->		
     classification.annotations[classification.annotations.length - 1] = newAnnotation		

--- a/app/classifier/task-nav.jsx
+++ b/app/classifier/task-nav.jsx
@@ -63,6 +63,7 @@ class TaskNav extends React.Component {
     });
     classification.update({
       completed: true,
+      'metadata.subject_dimensions': this.props.subjectDimensions,
       'metadata.session': getSessionID(),
       'metadata.finished_at': (new Date()).toISOString(),
       'metadata.viewport': {
@@ -209,6 +210,7 @@ TaskNav.propTypes = {
   subject: React.PropTypes.shape({
     id: React.PropTypes.string
   }),
+  subjectDimensions: React.PropTypes.array,
   task: React.PropTypes.object,
   workflow: React.PropTypes.object
 };


### PR DESCRIPTION
Fixes #3591.

This sets the `subjectDimensions` as `state` on the classifier so it does not trigger a race condition when updated the `classification` object.  The `subjectDimensions`are passed as a prop down to the `TaskNav` component, and are added to the `classification` object with the rest of the `metadata`.

The original race condition only triggered when a users subject queue was empty and the subject on the classification page started to load before `TaskNav` but finished loading after `TaskNav`.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://fix-3591.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?