### PR TITLE
Update TaskNav component when props change

### DIFF
--- a/app/classifier/task-nav.jsx
+++ b/app/classifier/task-nav.jsx
@@ -21,14 +21,13 @@ class TaskNav extends React.Component {
     };
   }
 
-  componentWillMount() {
+  componentDidUpdate() {
     const { workflow, classification } = this.props;
     classification.annotations = classification.annotations ? classification.annotations : [];
     if (classification.annotations.length === 0) {
       this.addAnnotationForTask(workflow.first_task);
     }
   }
-
   // Next (or first question)
   addAnnotationForTask(taskKey) {
     const { workflow, classification } = this.props;

--- a/app/classifier/task-nav.jsx
+++ b/app/classifier/task-nav.jsx
@@ -5,7 +5,7 @@ import tasks from './tasks';
 import CacheClassification from '../components/cache-classification';
 import GridTool from './drawing-tools/grid';
 
-const BackButtonWarning = (props) =>
+const BackButtonWarning = props =>
   <p className="back-button-warning" >Going back will clear your work for the current task.</p>;
 
 class TaskNav extends React.Component {
@@ -201,15 +201,30 @@ TaskNav.propTypes = {
     value: React.PropTypes.any.isRequired
   }),
   children: React.PropTypes.node,
-  classification: React.PropTypes.object,
+  classification: React.PropTypes.shape({
+    annotations: React.PropTypes.array,
+    gold_standard: React.PropTypes.bool,
+    id: React.PropTypes.string,
+    metadata: React.PropTypes.object
+  }),
   completeClassification: React.PropTypes.func,
   demoMode: React.PropTypes.bool,
-  project: React.PropTypes.object,
+  project: React.PropTypes.shape({
+    id: React.PropTypes.string,
+    slug: React.PropTypes.string
+  }),
   subject: React.PropTypes.shape({
     id: React.PropTypes.string
   }),
-  task: React.PropTypes.object,
-  workflow: React.PropTypes.object
+  task: React.PropTypes.shape({
+    type: React.PropTypes.string
+  }),
+  workflow: React.PropTypes.shape({
+    id: React.PropTypes.string,
+    configuration: React.PropTypes.object,
+    first_task: React.PropTypes.string,
+    tasks: React.PropTypes.object
+  })
 };
 
 export default TaskNav;


### PR DESCRIPTION
Fixes #3591 .

Describe your changes.
Updates the Task Nav component when the classification prop changes, rather than on first mount.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://fix-3591a.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?