### PR TITLE
Wait for workflow before loading tutorials

### DIFF
--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -423,6 +423,9 @@ Classifier = React.createClass
 module.exports = React.createClass
   displayName: 'ClassifierWrapper'
 
+  contextTypes:
+    geordi: React.PropTypes.object
+
   propTypes:
     classification: React.PropTypes.object
     onLoad: React.PropTypes.func

--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -445,12 +445,32 @@ module.exports = React.createClass
     subject: null
     expertClassifier: null
     userRoles: []
+    tutorial: null
+    minicourse: null
 
   componentDidMount: ->
     @checkExpertClassifier()
     @loadClassification @props.classification
+    Tutorial.find @props.workflow
+    .then (tutorial) =>
+      {user, preferences} = @props
+      Tutorial.startIfNecessary tutorial, user, preferences, @context.geordi
+      @setState {tutorial}
+    MiniCourse.find @props.workflow
+    .then (minicourse) =>
+      @setState {minicourse}
 
   componentWillReceiveProps: (nextProps) ->
+    if nextProps.workflow isnt @props.workflow
+      Tutorial.find nextProps.workflow
+      .then (tutorial) =>
+        {user, preferences} = nextProps
+        Tutorial.startIfNecessary tutorial, user, preferences, @context.geordi
+        @setState {tutorial}
+      MiniCourse.find nextProps.workflow
+      .then (minicourse) =>
+        @setState {minicourse}
+
     if @props.user isnt nextProps.user
       @setState expertClassifier: null
       @checkExpertClassifier nextProps
@@ -489,6 +509,9 @@ module.exports = React.createClass
         workflow={@props.workflow}
         subject={@state.subject}
         expertClassifier={@state.expertClassifier}
-        userRoles={@state.userRoles} />
+        userRoles={@state.userRoles}
+        tutorial={@state.tutorial}
+        minicourse={@state.minicourse}
+      />
     else
       <span>Loading classifier...</span>

--- a/app/pages/project/classify.cjsx
+++ b/app/pages/project/classify.cjsx
@@ -10,8 +10,6 @@ seenThisSession = require '../../lib/seen-this-session'
 `import CustomSignInPrompt from './custom-sign-in-prompt';`
 `import WorkflowAssignmentDialog from '../../components/workflow-assignment-dialog';`
 experimentsClient = require '../../lib/experiments-client'
-Tutorial = require '../../components/tutorial'
-MiniCourse = require '../../components/mini-course'
 {Split} = require('seven-ten')
 {VisibilitySplit} = require('seven-ten')
 
@@ -82,32 +80,14 @@ module.exports = React.createClass
     demoMode: sessionDemoMode
     promptWorkflowAssignmentDialog: false
     rejected: null
-    tutorial: null
 
   componentDidMount: () ->
     Split.classifierVisited();
     if @props.workflow and not @props.loadingSelectedWorkflow
       @loadAppropriateClassification(@props)
-    Tutorial.find @props.workflow
-    .then (tutorial) =>
-      {user, preferences} = @props
-      Tutorial.startIfNecessary tutorial, user, preferences, @context.geordi
-      @setState {tutorial}
-    MiniCourse.find @props.workflow
-    .then (minicourse) =>
-      @setState {minicourse}
 
   componentWillUpdate: (nextProps, nextState) ->
     @context.geordi.remember workflowID: nextProps?.workflow?.id
-    if nextProps.workflow isnt @props.workflow
-      Tutorial.find nextProps.workflow
-      .then (tutorial) =>
-        {user, preferences} = nextProps
-        Tutorial.startIfNecessary tutorial, user, preferences, @context.geordi
-        @setState {tutorial}
-      MiniCourse.find nextProps.workflow
-      .then (minicourse) =>
-        @setState {minicourse}
 
   componentWillUnmount: () ->
     @context.geordi?.forget ['workflowID']
@@ -248,8 +228,6 @@ module.exports = React.createClass
           onCompleteAndLoadAnotherSubject={@saveClassificationAndLoadAnotherSubject}
           onClickNext={@loadAnotherSubject}
           splits={@props.splits}
-          tutorial={@state.tutorial}
-          minicourse={@state.minicourse}
         />
       else if @state.rejected?.classification?
         <code>Please try again. Something went wrong: {@state.rejected.classification.toString()}</code>


### PR DESCRIPTION
Fixes #3598 

Describe your changes.
Moves the tutorial load into classifier index, after workflow selection has finished.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://fix-multiple-tutorials.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?