### PR TITLE
Edit Access to Collaborated Collections

### DIFF
--- a/app/collections/collaborators.cjsx
+++ b/app/collections/collaborators.cjsx
@@ -150,11 +150,11 @@ RoleRow = React.createClass
       @props.roleSet.delete()
 
     promise
-      .catch (error) =>
-        @setState { error }
       .then =>
         callback =>
-          @setState saving: false
+        @setState saving: false
+      .catch (error) =>
+        @setState { error }
 
   render: ->
     { owner } = @state

--- a/app/collections/collaborators.cjsx
+++ b/app/collections/collaborators.cjsx
@@ -151,7 +151,7 @@ RoleRow = React.createClass
 
     promise
       .then =>
-        callback =>
+        callback()
         @setState saving: false
       .catch (error) =>
         @setState { error }

--- a/app/collections/show.jsx
+++ b/app/collections/show.jsx
@@ -69,6 +69,17 @@ const CollectionPage = React.createClass({
     document.documentElement.classList.remove('on-collection-page');
   },
 
+  canCollaborate() {
+    if (!this.props.user) return false;
+
+    return this.props.roles.some((role) => {
+      const idMatch = (role.links.owner.id === this.props.user.id);
+      const isOwner = role.roles.includes('owner');
+      const isCollaborator = role.roles.includes('collaborator');
+      return ((isOwner && idMatch) || (isCollaborator && idMatch));
+    });
+  },
+
   render() {
     if (!this.state.owner) {
       return null;
@@ -81,7 +92,6 @@ const CollectionPage = React.createClass({
     }
     const baseCollectionLink = `${baseLink}/collections/${this.props.collection.slug}`;
     const baseCollectionsLink = `${baseLink}/${baseType}/${this.state.owner.login}`;
-    const isOwner = !!this.props.user && this.props.user.id === this.state.owner.id;
     const profileLink = `${baseLink}/users/${this.state.owner.login}`;
     const collectionsLinkMessageKey = `collectionPage.${baseType}Link`;
 
@@ -92,7 +102,7 @@ const CollectionPage = React.createClass({
             <Avatar user={this.state.owner} />
             {this.props.collection.display_name}
           </IndexLink>
-          {isOwner ?
+          {this.canCollaborate() ?
             <span>
               <Link to={`${baseCollectionLink}/settings`} activeClassName="active" className="tabbed-content-tab" onClick={!!this.logClick ? this.logClick.bind(this, 'settings-collection') : null}>
                 <Translate content="collectionPage.settings" />

--- a/app/collections/show.jsx
+++ b/app/collections/show.jsx
@@ -76,7 +76,7 @@ const CollectionPage = React.createClass({
       const idMatch = (role.links.owner.id === this.props.user.id);
       const isOwner = role.roles.includes('owner');
       const isCollaborator = role.roles.includes('collaborator');
-      return ((isOwner && idMatch) || (isCollaborator && idMatch));
+      return (isOwner || isCollaborator) && idMatch;
     });
   },
 

--- a/app/components/collection-search.cjsx
+++ b/app/components/collection-search.cjsx
@@ -23,7 +23,7 @@ module.exports = React.createClass
     query =
       page_size: 20
       favorite: false
-      current_user_roles: 'owner,collaborator,contributor,viewer'
+      current_user_roles: 'owner,collaborator,contributor'
     query.search = "#{value}" unless value is ''
 
     apiClient.type('collections').get query

--- a/app/components/collection-search.cjsx
+++ b/app/components/collection-search.cjsx
@@ -23,7 +23,7 @@ module.exports = React.createClass
     query =
       page_size: 20
       favorite: false
-      current_user_roles: 'owner,collaborator,contributor'
+      current_user_roles: 'owner,collaborator,contributor,viewer'
     query.search = "#{value}" unless value is ''
 
     apiClient.type('collections').get query

--- a/app/pages/collections/list.cjsx
+++ b/app/pages/collections/list.cjsx
@@ -34,6 +34,9 @@ List = React.createClass
     document.documentElement.classList.remove 'on-secondary-page'
 
   componentWillReceiveProps: (nextProps) ->
+    if nextProps.user isnt @props.user
+      @listCollections nextProps
+
     if nextProps.location.query.page isnt @props.location.query.page
       @listCollections nextProps
 
@@ -46,12 +49,12 @@ List = React.createClass
   listCollections: (props) ->
     query = {}
     if props.params.collection_owner is props.user?.login
-      query.current_user_roles = "owner,contributor,collaborator"
+      query.current_user_roles = "owner,contributor,collaborator,viewer"
     else if props.params.collection_owner?
       query.owner = props.params.collection_owner
 
     if props.params.profile_name is props.user?.login
-      query.current_user_roles = "owner,contributor,collaborator"
+      query.current_user_roles = "owner,contributor,collaborator,viewer"
     else if props.params.profile_name?
       query.owner = props.params.profile_name
 

--- a/app/pages/home-for-user/recent-collections.jsx
+++ b/app/pages/home-for-user/recent-collections.jsx
@@ -49,7 +49,7 @@ const RecentCollectionsSection = React.createClass({
       page_size: 8,
       sort: '-updated_at',
       favorite: false,
-      current_user_roles: "owner,contributor,collaborator"
+      current_user_roles: 'owner,contributor,collaborator,viewer'
     })
     .then((collections) => {
       this.setState({ collections });


### PR DESCRIPTION
Fixes #3435 

Describe your changes.
Allows collection collaborators to also have access to "Settings" and "Collaborators" tabs of collections.

_Also changes the functionality of other user roles on collections_:
**Viewer**: can view a collection (even if private) but cannot add to the collection.
**Contributor**: can add to/view a collection but cannot edit settings
**Collaborator**: can add to/view/edit a collection
**Owner**: owns the collection and can do everything

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)

https://edit-access-collections.pfe-preview.zooniverse.org/

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?