### PR TITLE
Revert "Wait for workflow before loading tutorials"

### DIFF
--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -423,9 +423,6 @@ Classifier = React.createClass
 module.exports = React.createClass
   displayName: 'ClassifierWrapper'
 
-  contextTypes:
-    geordi: React.PropTypes.object
-
   propTypes:
     classification: React.PropTypes.object
     onLoad: React.PropTypes.func
@@ -448,32 +445,12 @@ module.exports = React.createClass
     subject: null
     expertClassifier: null
     userRoles: []
-    tutorial: null
-    minicourse: null
 
   componentDidMount: ->
     @checkExpertClassifier()
     @loadClassification @props.classification
-    Tutorial.find @props.workflow
-    .then (tutorial) =>
-      {user, preferences} = @props
-      Tutorial.startIfNecessary tutorial, user, preferences, @context.geordi
-      @setState {tutorial}
-    MiniCourse.find @props.workflow
-    .then (minicourse) =>
-      @setState {minicourse}
 
   componentWillReceiveProps: (nextProps) ->
-    if nextProps.workflow isnt @props.workflow
-      Tutorial.find nextProps.workflow
-      .then (tutorial) =>
-        {user, preferences} = nextProps
-        Tutorial.startIfNecessary tutorial, user, preferences, @context.geordi
-        @setState {tutorial}
-      MiniCourse.find nextProps.workflow
-      .then (minicourse) =>
-        @setState {minicourse}
-
     if @props.user isnt nextProps.user
       @setState expertClassifier: null
       @checkExpertClassifier nextProps
@@ -512,9 +489,6 @@ module.exports = React.createClass
         workflow={@props.workflow}
         subject={@state.subject}
         expertClassifier={@state.expertClassifier}
-        userRoles={@state.userRoles}
-        tutorial={@state.tutorial}
-        minicourse={@state.minicourse}
-      />
+        userRoles={@state.userRoles} />
     else
       <span>Loading classifier...</span>

--- a/app/pages/project/classify.cjsx
+++ b/app/pages/project/classify.cjsx
@@ -10,6 +10,8 @@ seenThisSession = require '../../lib/seen-this-session'
 `import CustomSignInPrompt from './custom-sign-in-prompt';`
 `import WorkflowAssignmentDialog from '../../components/workflow-assignment-dialog';`
 experimentsClient = require '../../lib/experiments-client'
+Tutorial = require '../../components/tutorial'
+MiniCourse = require '../../components/mini-course'
 {Split} = require('seven-ten')
 {VisibilitySplit} = require('seven-ten')
 
@@ -80,14 +82,32 @@ module.exports = React.createClass
     demoMode: sessionDemoMode
     promptWorkflowAssignmentDialog: false
     rejected: null
+    tutorial: null
 
   componentDidMount: () ->
     Split.classifierVisited();
     if @props.workflow and not @props.loadingSelectedWorkflow
       @loadAppropriateClassification(@props)
+    Tutorial.find @props.workflow
+    .then (tutorial) =>
+      {user, preferences} = @props
+      Tutorial.startIfNecessary tutorial, user, preferences, @context.geordi
+      @setState {tutorial}
+    MiniCourse.find @props.workflow
+    .then (minicourse) =>
+      @setState {minicourse}
 
   componentWillUpdate: (nextProps, nextState) ->
     @context.geordi.remember workflowID: nextProps?.workflow?.id
+    if nextProps.workflow isnt @props.workflow
+      Tutorial.find nextProps.workflow
+      .then (tutorial) =>
+        {user, preferences} = nextProps
+        Tutorial.startIfNecessary tutorial, user, preferences, @context.geordi
+        @setState {tutorial}
+      MiniCourse.find nextProps.workflow
+      .then (minicourse) =>
+        @setState {minicourse}
 
   componentWillUnmount: () ->
     @context.geordi?.forget ['workflowID']
@@ -228,6 +248,8 @@ module.exports = React.createClass
           onCompleteAndLoadAnotherSubject={@saveClassificationAndLoadAnotherSubject}
           onClickNext={@loadAnotherSubject}
           splits={@props.splits}
+          tutorial={@state.tutorial}
+          minicourse={@state.minicourse}
         />
       else if @state.rejected?.classification?
         <code>Please try again. Something went wrong: {@state.rejected.classification.toString()}</code>


### PR DESCRIPTION
Reverts zooniverse/Panoptes-Front-End#3599

I missed this, but moving the mini-course the classifier index state breaks launching it. These lines needed to be moved/reworked with it: https://github.com/zooniverse/Panoptes-Front-End/blob/master/app/pages/project/classify.cjsx#L315-L320