### PR TITLE
Only show the collaboration icon to logged in users

### DIFF
--- a/app/pages/collections/list.cjsx
+++ b/app/pages/collections/list.cjsx
@@ -74,7 +74,7 @@ List = React.createClass
 
   shared: (collection) ->
     if (@props.params.collection_owner is @props.user?.login) or (@props.params.profile_name is @props.user?.login)
-      @props.user?.id isnt collection.links.owner.id
+      @props.user and @props.user?.id isnt collection.links.owner.id
 
   render: ->
     {location} = @props


### PR DESCRIPTION
Fixes #3606 .

The way the conditional was written was evaluating as true when no user was logged in. Added a check for user so the intended boolean value is returned.

https://fix-3606.pfe-preview.zooniverse.org/

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?