### PR TITLE
Modal focus

### DIFF
--- a/app/classifier/drawing-tools/root.cjsx
+++ b/app/classifier/drawing-tools/root.cjsx
@@ -1,5 +1,6 @@
 React = require 'react'
 StickyModalForm = require 'modal-form/sticky'
+ModalFocus = require('../../components/modal-focus').default
 
 STROKE_WIDTH = 1.5
 SELECTED_STROKE_WIDTH = 2.5
@@ -62,14 +63,16 @@ module.exports = React.createClass
             true
 
         <StickyModalForm ref="detailsForm" style={SEMI_MODAL_FORM_STYLE} underlayStyle={SEMI_MODAL_UNDERLAY_STYLE} onSubmit={@handleDetailsFormClose} onCancel={@handleDetailsFormClose}>
-          {for detailTask, i in toolProps.details
-            detailTask._key ?= Math.random()
-            TaskComponent = tasks[detailTask.type]
-            <TaskComponent autoFocus={i is 0} key={detailTask._key} task={detailTask} annotation={toolProps.mark.details[i]} onChange={@handleDetailsChange.bind this, i} />}
-          <hr />
-          <p style={textAlign: 'center'}>
-            <button type="submit" className="standard-button" disabled={not detailsAreComplete}>OK</button>
-          </p>
+          <ModalFocus onEscape={@handleDetailsFormClose}>
+            {for detailTask, i in toolProps.details
+              detailTask._key ?= Math.random()
+              TaskComponent = tasks[detailTask.type]
+              <TaskComponent autoFocus={i is 0} key={detailTask._key} task={detailTask} annotation={toolProps.mark.details[i]} onChange={@handleDetailsChange.bind this, i} />}
+            <hr />
+            <p style={textAlign: 'center'}>
+              <button autoFocus type="submit" className="standard-button" disabled={not detailsAreComplete}>OK</button>
+            </p>
+          </ModalFocus>
         </StickyModalForm>}
     </g>
 

--- a/app/classifier/drawing-tools/root.cjsx
+++ b/app/classifier/drawing-tools/root.cjsx
@@ -70,7 +70,7 @@ module.exports = React.createClass
               <TaskComponent autoFocus={i is 0} key={detailTask._key} task={detailTask} annotation={toolProps.mark.details[i]} onChange={@handleDetailsChange.bind this, i} />}
             <hr />
             <p style={textAlign: 'center'}>
-              <button autoFocus type="submit" className="standard-button" disabled={not detailsAreComplete}>OK</button>
+              <button autoFocus={toolProps.details[0].type in ['single', 'multiple']} type="submit" className="standard-button" disabled={not detailsAreComplete}>OK</button>
             </p>
           </ModalFocus>
         </StickyModalForm>}

--- a/app/classifier/drawing-tools/root.cjsx
+++ b/app/classifier/drawing-tools/root.cjsx
@@ -63,7 +63,7 @@ module.exports = React.createClass
             true
 
         <StickyModalForm ref="detailsForm" style={SEMI_MODAL_FORM_STYLE} underlayStyle={SEMI_MODAL_UNDERLAY_STYLE} onSubmit={@handleDetailsFormClose} onCancel={@handleDetailsFormClose}>
-          <ModalFocus onEscape={@handleDetailsFormClose}>
+          <ModalFocus onEscape={@handleDetailsFormClose} preserveFocus={false}>
             {for detailTask, i in toolProps.details
               detailTask._key ?= Math.random()
               TaskComponent = tasks[detailTask.type]

--- a/app/classifier/tasks/generic.jsx
+++ b/app/classifier/tasks/generic.jsx
@@ -13,12 +13,13 @@ export default class GenericTask extends React.Component {
 
   showHelp() {
     alert(
-      <div className="content-container">
-        <Markdown className="classification-task-help">
-          {this.props.help}
-        </Markdown>
-        <button autoFocus className="standard-button" onClick={this.reject}>Close</button>
-      </div>
+      (resolve, reject) =>
+        <div className="content-container">
+          <Markdown className="classification-task-help">
+            {this.props.help}
+          </Markdown>
+          <button autoFocus={true} className="standard-button" onClick={reject}>Close</button>
+        </div>
     );
   }
 

--- a/app/classifier/tasks/generic.jsx
+++ b/app/classifier/tasks/generic.jsx
@@ -17,6 +17,7 @@ export default class GenericTask extends React.Component {
         <Markdown className="classification-task-help">
           {this.props.help}
         </Markdown>
+        <button autoFocus className="standard-button" onClick={this.reject}>Close</button>
       </div>
     );
   }

--- a/app/components/dialog.cjsx
+++ b/app/components/dialog.cjsx
@@ -1,10 +1,6 @@
 React = require 'react'
 ReactDOM = require 'react-dom'
-
-FOCUSABLES = "a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), iframe, object, embed, *[tabindex], *[contenteditable]"
-
-ESC_KEY = 27
-TAB_KEY = 9
+ModalFocus = require('./modal-focus').default
 
 # NOTE: This component probably shouldn't be used directly.
 # See the function at ../lib/alert.
@@ -13,7 +9,7 @@ module.exports = React.createClass
   displayName: 'Dialog'
 
   render: ->
-    <div className="dialog-underlay" onKeyDown={@handleKeyDown}>
+    <ModalFocus className="dialog-underlay" onEscape={@props.onEscape}>
       <div aria-role='dialog' className="dialog">
         <div className="dialog-controls">
           <div className="wrapper">{@props.controls}</div>
@@ -24,20 +20,5 @@ module.exports = React.createClass
           </div>
         </div>
       </div>
-    </div>
-
-  handleKeyDown: (e) ->
-    switch e.keyCode
-      when ESC_KEY
-        @props.onEscape? e
-
-      when TAB_KEY
-        {shiftKey} = e # Save this; React recycles the event object.
-        focusables = ReactDOM.findDOMNode(@).querySelectorAll FOCUSABLES
-        if shiftKey and document.activeElement == focusables[0]
-          focusables[focusables.length - 1]?.focus()
-          e.preventDefault()
-        else if !shiftKey and document.activeElement == focusables[focusables.length - 1]
-          focusables[0]?.focus()
-          e.preventDefault()
+    </ModalFocus>
 

--- a/app/components/modal-focus.jsx
+++ b/app/components/modal-focus.jsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+const FOCUSABLES = 'a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), iframe, object, embed, *[tabindex], *[contenteditable]';
+
+const ESC_KEY = 27;
+const TAB_KEY = 9;
+
+class ModalFocus extends React.Component {
+  constructor(props) {
+    super(props);
+    this.focusables = [];
+    this.previousActiveElement = document.activeElement;
+    this.handleKeyDown = this.handleKeyDown.bind(this);
+  }
+
+  componentDidMount() {
+    this.focusables = ReactDOM.findDOMNode(this).querySelectorAll(FOCUSABLES);
+  }
+
+  componentWillUnmount() {
+    !!this.previousActiveElement && this.previousActiveElement.focus();
+  }
+
+  handleKeyDown(e) {
+    const { shiftKey, target } = e;
+    const { focusables } = this;
+    switch (e.keyCode) {
+      case ESC_KEY:
+        this.props.onEscape();
+        break;
+      case TAB_KEY:
+        if (shiftKey && target === focusables[0]) {
+          focusables[focusables.length - 1].focus();
+          e.preventDefault();
+        } else if (!shiftKey && target === focusables[focusables.length - 1]) {
+          focusables[0].focus();
+          e.preventDefault();
+        }
+        break;
+      default:
+        break;
+    }
+  }
+
+  render() {
+    return (
+      <div className={this.props.className} onKeyDown={this.handleKeyDown}>
+        {this.props.children}
+      </div>
+    );
+  }
+}
+
+ModalFocus.propTypes = {
+  children: React.PropTypes.node,
+  className: React.PropTypes.string,
+  onEscape: React.PropTypes.func
+};
+
+ModalFocus.defaultProps = {
+  onEscape: () => null
+};
+
+export default ModalFocus;

--- a/app/components/modal-focus.jsx
+++ b/app/components/modal-focus.jsx
@@ -19,7 +19,7 @@ class ModalFocus extends React.Component {
   }
 
   componentWillUnmount() {
-    !!this.previousActiveElement && this.previousActiveElement.focus();
+    !!this.props.preserveFocus && !!this.previousActiveElement && this.previousActiveElement.focus();
   }
 
   handleKeyDown(e) {
@@ -55,11 +55,13 @@ class ModalFocus extends React.Component {
 ModalFocus.propTypes = {
   children: React.PropTypes.node,
   className: React.PropTypes.string,
-  onEscape: React.PropTypes.func
+  onEscape: React.PropTypes.func,
+  preserveFocus: React.PropTypes.bool
 };
 
 ModalFocus.defaultProps = {
-  onEscape: () => null
+  onEscape: () => null,
+  preserveFocus: true
 };
 
 export default ModalFocus;

--- a/app/lib/alert.cjsx
+++ b/app/lib/alert.cjsx
@@ -18,8 +18,6 @@ module.exports = (message) ->
   container.classList.add 'dialog-container'
   document.body.appendChild container
 
-  previousActiveElement = document.activeElement
-
   closeButton = <button aria-label='Close' onClick={defer.resolve}>&times;</button>
   ReactDOM.render <Dialog className="alert" controls={closeButton} onEscape={defer.resolve}>
     {message}
@@ -28,7 +26,6 @@ module.exports = (message) ->
   unmount = ->
     ReactDOM.unmountComponentAtNode container
     container.parentNode.removeChild container
-    previousActiveElement?.focus()
 
   promise.then unmount, unmount
   promise


### PR DESCRIPTION
Fixes #3613  .

Describe your changes.
Reopens #3533 but allows drawing details forms to lose document focus when they close. Not a great solution, but it's what they do at present so doesn't change current behaviour.

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://modal-focus.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?