### PR TITLE
Add simple filter for already seens

### DIFF
--- a/app/pages/project/classify.cjsx
+++ b/app/pages/project/classify.cjsx
@@ -185,7 +185,9 @@ module.exports = React.createClass
               setTimeout fetchSubjectsAgain, 2000
         .then (subjects) ->
           nonLoadedSubjects = (newSubject for newSubject in subjects when newSubject isnt subjectToLoad)
-          upcomingSubjects.forWorkflow[workflow.id].push nonLoadedSubjects...
+          filteredSubjects = nonLoadedSubjects.filter((subject) => subject if !subject.already_seen)
+          subjectsToLoad = if filteredSubjects.length > 0 then filteredSubjects else nonLoadedSubjects
+          upcomingSubjects.forWorkflow[workflow.id].push subjectsToLoad...
 
       # If we're filling this list for the first time, we won't have a subject selected, so try again.
       subject ?= fetchSubjects.then ->


### PR DESCRIPTION
This adds a simple filter to the subjects array to remove the already seens. If the array is empty, then it falls back to the original response. This is a step toward a more intelligent handling of the subject queue. I still want to take some time to think about when the subject queue end point should be requested again.

https://skip-already-seen.pfe-preview.zooniverse.org/

and in production: https://skip-already-seen.pfe-preview.zooniverse.org/projects/zooniverse/gravity-spy/classify?env=production

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?