### PR TITLE
Set loadingSelectedWorkflow flag on preference change.

### DIFF
--- a/app/pages/project/classify.cjsx
+++ b/app/pages/project/classify.cjsx
@@ -165,7 +165,7 @@ module.exports = React.createClass
 
     # If there aren't any left (or there weren't any to begin with), refill the list.
     if upcomingSubjects.forWorkflow[workflow.id].length is 0
-      # console.log 'Fetching subjects'
+      # console.log 'Fetching subjects', workflow.id
       @maybePromptWorkflowAssignmentDialog(@props)
       subjectQuery =
         workflow_id: workflow.id

--- a/app/pages/project/index.cjsx
+++ b/app/pages/project/index.cjsx
@@ -104,6 +104,7 @@ ProjectPage = React.createClass
 
     if nextProps.preferences?.preferences?.selected_workflow? and @state.selectedWorkflow?
       if nextProps.preferences?.preferences.selected_workflow isnt @state.selectedWorkflow.id
+        @setState { loadingSelectedWorkflow: true }
         @getSelectedWorkflow(nextProps.project, nextProps.preferences)
 
   resizeBackground: ->


### PR DESCRIPTION
Fixes #3619 

Describe your changes.
Sets the `loadingSelectedWorkflow` flag back to true on preference change, before loading the workflow. This signals to child components not to load subjects, launch tutorials etc.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://fix-3619.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?