### PR TITLE
Remove API call for user avatar in favor of using user.avatar_src

### DIFF
--- a/app/pages/home-for-user/circle-ribbon.jsx
+++ b/app/pages/home-for-user/circle-ribbon.jsx
@@ -13,12 +13,14 @@ const CircleRibbon = React.createClass({
     size: React.PropTypes.string,
     weight: React.PropTypes.number,
     gap: React.PropTypes.number,
-    image: React.PropTypes.string,
     loading: React.PropTypes.bool,
     data: React.PropTypes.array,
     hrefTemplate: React.PropTypes.func,
     onClick: React.PropTypes.func,
-    user: React.PropTypes.object.isRequired,
+    user: React.PropTypes.shape({
+      avatar_src: React.PropTypes.string,
+      login: React.PropTypes.string
+    }).isRequired
   },
 
   getDefaultProps() {
@@ -26,11 +28,11 @@ const CircleRibbon = React.createClass({
       size: '10em',
       weight: 10,
       gap: 2,
-      image: '//lorempixel.com/100/100/animals/1',
       loading: false,
       data: [],
       hrefTemplate: defaultHREFTemplate,
       onClick: () => {},
+      user: { avatar_src: '/assets/simple-avatar.png' }
     };
   },
 
@@ -168,6 +170,8 @@ const CircleRibbon = React.createClass({
       tooltipPosition = this.getTooltipPoint(hoveredArc, 50);
     }
 
+    const avatar = this.props.user.avatar_src ? this.props.user.avatar_src : '/assets/simple-avatar.png';
+
     return (
       <div ref="container" className="circle-ribbon" style={{ position: 'relative' }}>
         <svg ref="svg" viewBox="0 0 100 100" width={this.props.size} height={this.props.size}>
@@ -177,19 +181,17 @@ const CircleRibbon = React.createClass({
             </clipPath>
           </defs>
 
-          {!!this.props.image && (
-            <SVGLink to={`/users/${this.props.user.login}/stats`} aria-label={`${this.props.user.login} stats`}>
-              <image
-                xlinkHref={this.props.image}
-                x={this.props.weight + this.props.gap}
-                y={this.props.weight + this.props.gap}
-                width={imageSize}
-                height={imageSize}
-                clipPath={`url('#circle-ribbon-clip-${this.id}')`}
-                className={`url('#circle-ribbon-shadow-${this.id}')`}
-              />
-            </SVGLink>
-          )}
+          <SVGLink to={`/users/${this.props.user.login}/stats`} aria-label={`${this.props.user.login} stats`}>
+            <image
+              xlinkHref={avatar}
+              x={this.props.weight + this.props.gap}
+              y={this.props.weight + this.props.gap}
+              width={imageSize}
+              height={imageSize}
+              clipPath={`url('#circle-ribbon-clip-${this.id}')`}
+              className={`url('#circle-ribbon-shadow-${this.id}')`}
+            />
+          </SVGLink>
 
           <g ref="arcGroup" fill="none" stroke="none" transform="translate(50, 50)">
             {this.props.loading && (

--- a/app/pages/home-for-user/index.jsx
+++ b/app/pages/home-for-user/index.jsx
@@ -27,7 +27,6 @@ export default class HomePageForUser extends React.Component {
 
     this.state = {
       backgroundSrc: '',
-      avatarSrc: '',
       showNews: false,
       totalClassifications: 0,
       ribbonData: [],
@@ -96,19 +95,6 @@ export default class HomePageForUser extends React.Component {
       if (profileHeader) {
         this.setState({
           backgroundSrc: profileHeader.src
-        });
-      }
-    });
-
-    user.get('avatar')
-    .catch((error) => {
-      console.log('Something went wrong. Error: ', error);
-    })
-    .then((avatars) => {
-      const avatar = [].concat(avatars)[0];
-      if (avatar) {
-        this.setState({
-          avatarSrc: avatar.src
         });
       }
     });
@@ -265,11 +251,6 @@ export default class HomePageForUser extends React.Component {
   render() {
     if (!this.props.user) return null;
 
-    let avatarSrc = this.state.avatarSrc;
-    if (!avatarSrc) {
-      avatarSrc = '/assets/simple-avatar.png';
-    }
-    
     const {OpenSectionComponent} = this.state;
 
     return (
@@ -293,7 +274,7 @@ export default class HomePageForUser extends React.Component {
           )}
 
           <div className="home-page-for-user__content" style={{ position: 'relative', zIndex: 1 }}>
-            <CircleRibbon user={this.props.user} loading={this.state.loading} image={avatarSrc} data={this.state.ribbonData} hrefTemplate={this.findProjectLink} />
+            <CircleRibbon user={this.props.user} loading={this.state.loading} data={this.state.ribbonData} hrefTemplate={this.findProjectLink} />
 
             <div className="home-page-for-user__welcome">
               Hello {this.props.user.display_name},<br />


### PR DESCRIPTION
As a follow up to #3576, this removes the separate user avatar API call that was on the signed in home page. 

https://remove-avatar-fetch.pfe-preview.zooniverse.org/

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?