### PR TITLE
More survey task keyboard improvements

### DIFF
--- a/app/classifier/tasks/survey/choice.cjsx
+++ b/app/classifier/tasks/survey/choice.cjsx
@@ -74,9 +74,11 @@ module.exports = React.createClass
     canIdentify = answerProvided.every (answer) -> answer is true
 
   render: ->
+    hasFocus = false
     choice = @props.task.choices[@props.choiceID]
     <div className="survey-task-choice">
       {unless choice.images.length is 0
+        hasFocus = choice.images.length > 1
         <ImageFlipper images={@props.task.images[filename] for filename in choice.images} />}
       <div className="survey-task-choice-content">
         <div className="survey-task-choice-label">{choice.label}</div>
@@ -86,14 +88,19 @@ module.exports = React.createClass
           <div className="survey-task-choice-confusions">
             Often confused with
             {' '}
-            {for otherChoiceID in choice.confusionsOrder
+            {for otherChoiceID, i in choice.confusionsOrder
               otherChoice = @props.task.choices[otherChoiceID]
               <span key={otherChoiceID}>
-                <TriggeredModalForm className="survey-task-confusions-modal" trigger={
-                  <span className="survey-task-choice-confusion">
-                    {otherChoice.label}
-                  </span>
-                } style={maxWidth: '60ch'}>
+                <TriggeredModalForm
+                  className="survey-task-confusions-modal"
+                  triggerProps={autoFocus: not hasFocus and i is 0}
+                  trigger={
+                    <span className="survey-task-choice-confusion">
+                      {otherChoice.label}
+                      </span>
+                  }
+                  style={maxWidth: '60ch'}
+                >
                   <ImageFlipper images={@props.task.images[filename] for filename in otherChoice.images} />
                   <Markdown content={choice.confusions[otherChoiceID]} />
                   <div className="survey-task-choice-confusion-buttons" style={textAlign: 'center'}>
@@ -103,6 +110,7 @@ module.exports = React.createClass
                   </div>
                 </TriggeredModalForm>
                 {' '}
+                {hasFocus = true}
               </span>}
           </div>}
 
@@ -117,7 +125,7 @@ module.exports = React.createClass
               'radio'
             <div key={questionID} className="survey-task-choice-question" data-multiple={question.multiple || null}>
               <div className="survey-task-choice-question-label">{question.label}</div>
-              {for answerID in question.answersOrder
+              {for answerID, i in question.answersOrder
                 answer = question.answers[answerID]
                 isChecked = if question.multiple
                   answerID in (@state.answers[questionID] ? [])
@@ -126,10 +134,20 @@ module.exports = React.createClass
                 isFocused = @state.focusedAnswer is "#{questionID}/#{answerID}"
                 <span key={answerID}>
                   <label className="survey-task-choice-answer" data-checked={isChecked || null} data-focused={isFocused || null}>
-                    <input ref={questionID} name={questionID} type={inputType} checked={isChecked} onChange={@handleAnswer.bind this, questionID, answerID} onFocus={@handleFocus.bind this, questionID, answerID} onBlur={@handleFocus.bind this, null, null} />
+                    <input
+                      ref={questionID}
+                      name={questionID}
+                      type={inputType}
+                      autoFocus={not hasFocus and i is 0}
+                      checked={isChecked}
+                      onChange={@handleAnswer.bind this, questionID, answerID}
+                      onFocus={@handleFocus.bind this, questionID, answerID}
+                      onBlur={@handleFocus.bind this, null, null}
+                    />
                     {answer.label}
                   </label>
                   {' '}
+                  {hasFocus=true}
                 </span>}
             </div>}
 
@@ -137,7 +155,7 @@ module.exports = React.createClass
           <hr />}
       </div>
       <div style={textAlign: 'center'}>
-        <button type="button" className="minor-button" onClick={@props.onCancel}>Cancel</button>
+        <button type="button" autoFocus={not hasFocus} className="minor-button" onClick={@props.onCancel}>Cancel</button>
         {' '}
         <button type="button" className="standard-button" disabled={not @checkFilledIn()} onClick={@handleIdentification}>
           <strong>Identify</strong>

--- a/app/classifier/tasks/survey/chooser.cjsx
+++ b/app/classifier/tasks/survey/chooser.cjsx
@@ -80,12 +80,12 @@ module.exports = React.createClass
 
     <div className="survey-task-chooser">
       <div className="survey-task-chooser-characteristics">
-        {for characteristicID in @props.task.characteristicsOrder
+        {for characteristicID, i in @props.task.characteristicsOrder
           characteristic = @props.task.characteristics[characteristicID]
           selectedValue = characteristic.values[@props.filters[characteristicID]]
           hasBeenAutoFocused = false
 
-          <TriggeredModalForm key={characteristicID} ref="#{characteristicID}-dropdown" className="survey-task-chooser-characteristic-menu" trigger={
+          <TriggeredModalForm key={characteristicID} ref="#{characteristicID}-dropdown" className="survey-task-chooser-characteristic-menu" triggerProps={autoFocus: i is 0 and not @props.focusedChoice} trigger={
             <span className="survey-task-chooser-characteristic" data-is-active={selectedValue? || null}>
               <span className="survey-task-chooser-characteristic-label">{selectedValue?.label ? characteristic.label}</span>
             </span>

--- a/app/classifier/tasks/survey/chooser.cjsx
+++ b/app/classifier/tasks/survey/chooser.cjsx
@@ -78,7 +78,16 @@ module.exports = React.createClass
                 if autoFocus
                   hasBeenAutoFocused = true
 
-                <button key={valueID} type="submit" title={value.label} className="survey-task-chooser-characteristic-value" disabled={disabled} data-selected={selected} autoFocus={autoFocus} onClick={@handleFilter.bind this, characteristicID, valueID}>
+                <button
+                  key={valueID}
+                  type="submit"
+                  title={value.label}
+                  className="survey-task-chooser-characteristic-value"
+                  disabled={disabled}
+                  data-selected={selected}
+                  autoFocus={autoFocus}
+                  onClick={@handleFilter.bind this, characteristicID, valueID}
+                >
                   {if value.image?
                     <img src={@props.task.images[value.image]} alt={value.label} className="survey-task-chooser-characteristic-value-icon" />}
                 </button>}
@@ -110,7 +119,14 @@ module.exports = React.createClass
           for choiceID, i in sortedFilteredChoices
             choice = @props.task.choices[choiceID]
             chosenAlready = choiceID in selectedChoices
-            <button autoFocus={choiceID is @props.focusedChoice} key={choiceID + i} type="button" className="survey-task-chooser-choice-button #{'survey-task-chooser-choice-button-chosen' if chosenAlready}" onClick={@props.onChoose.bind null, choiceID} onKeyDown={@handleKeyDown.bind(this, choiceID)}>
+            <button
+              autoFocus={choiceID is @props.focusedChoice}
+              key={choiceID + i}
+              type="button"
+              className="survey-task-chooser-choice-button #{'survey-task-chooser-choice-button-chosen' if chosenAlready}"
+              onClick={@props.onChoose.bind null, choiceID}
+              onKeyDown={@handleKeyDown.bind(this, choiceID)}
+            >
               <span className="survey-task-chooser-choice">
                 {if choice.images?.length > 0
                   thumbnailSrc = @props.task.images[choice.images[0]]

--- a/app/classifier/tasks/survey/chooser.cjsx
+++ b/app/classifier/tasks/survey/chooser.cjsx
@@ -16,6 +16,10 @@ module.exports = React.createClass
     onFilter: Function.prototype
     onChoose: Function.prototype
 
+  componentWillMount: ->
+    # refs for the choices
+    @choiceButtons = []
+
   getFilteredChoices: ->
     for choiceID in @props.task.choicesOrder
       choice = @props.task.choices[choiceID]
@@ -48,6 +52,8 @@ module.exports = React.createClass
       3
 
   render: ->
+    @choiceButtons = []
+
     filteredChoices = @getFilteredChoices()
 
     thumbnailSize = @whatSizeThumbnails filteredChoices
@@ -122,6 +128,7 @@ module.exports = React.createClass
             <button
               autoFocus={choiceID is @props.focusedChoice}
               key={choiceID + i}
+              ref={(button) => @choiceButtons.push button}
               type="button"
               className="survey-task-chooser-choice-button #{'survey-task-chooser-choice-button-chosen' if chosenAlready}"
               onClick={@props.onChoose.bind null, choiceID}
@@ -155,6 +162,17 @@ module.exports = React.createClass
     switch e.which
       when 8
         @props.onRemove choiceID
+      when 38
+        index = @choiceButtons.indexOf document.activeElement
+        newIndex = index - 1
+        if newIndex is -1 then newIndex = @choiceButtons.length - 1
+        @choiceButtons[newIndex].focus()
+        e.preventDefault()
+      when 40
+        index = @choiceButtons.indexOf document.activeElement
+        newIndex = (index + 1) % @choiceButtons.length
+        @choiceButtons[newIndex].focus()
+        e.preventDefault()
       else
         true
     

--- a/app/classifier/tasks/survey/chooser.cjsx
+++ b/app/classifier/tasks/survey/chooser.cjsx
@@ -27,16 +27,15 @@ module.exports = React.createClass
    @sortChoiceButtons()
 
   sortChoiceButtons: ->
-    # overrides default DOM focus order by sorting the buttons in alphabetical order
-    @choiceButtons = @choiceButtons
+    # overrides default DOM focus order by sorting the buttons according to task.choicesOrder
+    newChoiceButtons = []
+    @choiceButtons
       .filter Boolean
-      .sort (a, b) =>
-        order = 0
-        if a.textContent < b.textContent
-          order = -1
-        if a.textContent > b.textContent
-          order = 1
-        order
+      .map (button) =>
+        choiceID = button.getAttribute 'data-choiceID'
+        index = @props.task.choicesOrder.indexOf choiceID
+        newChoiceButtons[index] = button
+    @choiceButtons = newChoiceButtons.filter Boolean
 
   getFilteredChoices: ->
     for choiceID in @props.task.choicesOrder
@@ -145,7 +144,8 @@ module.exports = React.createClass
             chosenAlready = choiceID in selectedChoices
             <button
               autoFocus={choiceID is @props.focusedChoice}
-              key={choiceID + i}
+              key={choiceID}
+              data-choiceID={choiceID}
               ref={(button) => @choiceButtons.push button}
               type="button"
               className="survey-task-chooser-choice-button #{'survey-task-chooser-choice-button-chosen' if chosenAlready}"

--- a/app/classifier/tasks/survey/chooser.cjsx
+++ b/app/classifier/tasks/survey/chooser.cjsx
@@ -2,6 +2,11 @@ React = require 'react'
 TriggeredModalForm = require 'modal-form/triggered'
 sortIntoColumns = require 'sort-into-columns'
 
+# key codes
+BACKSPACE = 8
+UP = 38
+DOWN = 40
+
 module.exports = React.createClass
   displayName: 'Chooser'
 
@@ -105,7 +110,7 @@ module.exports = React.createClass
           for choiceID, i in sortedFilteredChoices
             choice = @props.task.choices[choiceID]
             chosenAlready = choiceID in selectedChoices
-            <button autoFocus={choiceID is @props.focusedChoice} key={choiceID + i} type="button" className="survey-task-chooser-choice-button #{'survey-task-chooser-choice-button-chosen' if chosenAlready}" onClick={@props.onChoose.bind null, choiceID}>
+            <button autoFocus={choiceID is @props.focusedChoice} key={choiceID + i} type="button" className="survey-task-chooser-choice-button #{'survey-task-chooser-choice-button-chosen' if chosenAlready}" onClick={@props.onChoose.bind null, choiceID} onKeyDown={@handleKeyDown.bind(this, choiceID)}>
               <span className="survey-task-chooser-choice">
                 {if choice.images?.length > 0
                   thumbnailSrc = @props.task.images[choice.images[0]]
@@ -129,3 +134,11 @@ module.exports = React.createClass
   handleClearFilters: ->
     for characteristicID in @props.task.characteristicsOrder
       @props.onFilter characteristicID, undefined
+
+  handleKeyDown: (choiceID, e) ->
+    switch e.which
+      when 8
+        @props.onRemove choiceID
+      else
+        true
+    

--- a/app/classifier/tasks/survey/chooser.cjsx
+++ b/app/classifier/tasks/survey/chooser.cjsx
@@ -180,6 +180,7 @@ module.exports = React.createClass
     switch e.which
       when BACKSPACE
         @props.onRemove choiceID
+        e.preventDefault()
       when UP
         index = @choiceButtons.indexOf document.activeElement
         newIndex = index - 1

--- a/app/classifier/tasks/survey/chooser.cjsx
+++ b/app/classifier/tasks/survey/chooser.cjsx
@@ -20,6 +20,24 @@ module.exports = React.createClass
     # refs for the choices
     @choiceButtons = []
 
+  componentDidMount: ->
+    @sortChoiceButtons()
+
+  componentDidUpdate: ->
+   @sortChoiceButtons()
+
+  sortChoiceButtons: ->
+    # overrides default DOM focus order by sorting the buttons in alphabetical order
+    @choiceButtons = @choiceButtons
+      .filter Boolean
+      .sort (a, b) =>
+        order = 0
+        if a.textContent < b.textContent
+          order = -1
+        if a.textContent > b.textContent
+          order = 1
+        order
+
   getFilteredChoices: ->
     for choiceID in @props.task.choicesOrder
       choice = @props.task.choices[choiceID]

--- a/app/classifier/tasks/survey/chooser.cjsx
+++ b/app/classifier/tasks/survey/chooser.cjsx
@@ -105,7 +105,7 @@ module.exports = React.createClass
           for choiceID, i in sortedFilteredChoices
             choice = @props.task.choices[choiceID]
             chosenAlready = choiceID in selectedChoices
-            <button key={choiceID + i} type="button" className="survey-task-chooser-choice-button #{'survey-task-chooser-choice-button-chosen' if chosenAlready}" onClick={@props.onChoose.bind null, choiceID}>
+            <button autoFocus={choiceID is @props.focusedChoice} key={choiceID + i} type="button" className="survey-task-chooser-choice-button #{'survey-task-chooser-choice-button-chosen' if chosenAlready}" onClick={@props.onChoose.bind null, choiceID}>
               <span className="survey-task-chooser-choice">
                 {if choice.images?.length > 0
                   thumbnailSrc = @props.task.images[choice.images[0]]

--- a/app/classifier/tasks/survey/chooser.cjsx
+++ b/app/classifier/tasks/survey/chooser.cjsx
@@ -178,15 +178,15 @@ module.exports = React.createClass
 
   handleKeyDown: (choiceID, e) ->
     switch e.which
-      when 8
+      when BACKSPACE
         @props.onRemove choiceID
-      when 38
+      when UP
         index = @choiceButtons.indexOf document.activeElement
         newIndex = index - 1
         if newIndex is -1 then newIndex = @choiceButtons.length - 1
         @choiceButtons[newIndex].focus()
         e.preventDefault()
-      when 40
+      when DOWN
         index = @choiceButtons.indexOf document.activeElement
         newIndex = (index + 1) % @choiceButtons.length
         @choiceButtons[newIndex].focus()

--- a/app/classifier/tasks/survey/index.cjsx
+++ b/app/classifier/tasks/survey/index.cjsx
@@ -41,11 +41,12 @@ module.exports = React.createClass
   getInitialState: ->
     filters: {}
     selectedChoiceID: ''
+    focusedChoice: ''
 
   render: ->
     <div className="survey-task">
       {if @state.selectedChoiceID is ''
-        <Chooser task={@props.task} filters={@state.filters} onFilter={@handleFilter} onChoose={@handleChoice} annotation={@props.annotation} />
+        <Chooser task={@props.task} filters={@state.filters} onFilter={@handleFilter} onChoose={@handleChoice} annotation={@props.annotation} focusedChoice={@state.focusedChoice} />
       else
         <Choice task={@props.task} choiceID={@state.selectedChoiceID} onSwitch={@handleChoice} onCancel={@clearSelection} onConfirm={@handleAnnotation} />}
     </div>
@@ -67,7 +68,9 @@ module.exports = React.createClass
     @setState filters: {}
 
   clearSelection: ->
-    @setState selectedChoiceID: ''
+    @setState 
+      selectedChoiceID: ''
+      focusedChoice: @state.selectedChoiceID
     newAnnotation = Object.assign {}, @props.annotation, _choiceInProgress: false
     @props.onChange newAnnotation
 

--- a/app/classifier/tasks/survey/index.cjsx
+++ b/app/classifier/tasks/survey/index.cjsx
@@ -46,7 +46,7 @@ module.exports = React.createClass
   render: ->
     <div className="survey-task">
       {if @state.selectedChoiceID is ''
-        <Chooser task={@props.task} filters={@state.filters} onFilter={@handleFilter} onChoose={@handleChoice} annotation={@props.annotation} focusedChoice={@state.focusedChoice} />
+        <Chooser task={@props.task} filters={@state.filters} onFilter={@handleFilter} onChoose={@handleChoice} onRemove={@handleRemove} annotation={@props.annotation} focusedChoice={@state.focusedChoice} />
       else
         <Choice task={@props.task} choiceID={@state.selectedChoiceID} onSwitch={@handleChoice} onCancel={@clearSelection} onConfirm={@handleAnnotation} />}
     </div>
@@ -62,6 +62,13 @@ module.exports = React.createClass
   handleChoice: (choiceID) ->
     @setState selectedChoiceID: choiceID
     newAnnotation = Object.assign {}, @props.annotation, _choiceInProgress: true
+    @props.onChange newAnnotation
+
+  handleRemove: (choiceID) ->
+    selectedChoices = (item.choice for item in @props.annotation.value)
+    index = selectedChoices.indexOf choiceID
+    @props.annotation.value.splice index, 1
+    newAnnotation = Object.assign {}, @props.annotation
     @props.onChange newAnnotation
 
   clearFilters: ->


### PR DESCRIPTION
Describe your changes.
If a choice has been chosen, focus that button when the chooser mounts.

Add backspace to remove the currently selected choice.

Add up/down keys to navigate the choice list, when focused.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://survey-choice-keyboard.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?