### PR TITLE
We dont need to fetch the workflow for nextProps location queries

### DIFF
--- a/app/pages/project/index.cjsx
+++ b/app/pages/project/index.cjsx
@@ -59,9 +59,6 @@ ProjectPageController = React.createClass
       @setupSplits nextProps
 
   componentWillUpdate: (nextProps, nextState) ->
-    if nextState.project? and nextState.preferences? and nextProps.location.query?.workflow? and @canFetchWorkflowByQuery(nextState.project, nextProps.user)
-      @getSelectedWorkflow(nextState.project, nextState.preferences) unless nextState.loadingSelectedWorkflow
-
     if nextState.preferences?.preferences?.selected_workflow? and @state.workflow?
       if nextState.preferences?.preferences.selected_workflow isnt @state.workflow.id
         @getSelectedWorkflow(nextState.project, nextState.preferences) unless nextState.loadingSelectedWorkflow


### PR DESCRIPTION
Fixes #3625.

https://fix-3625.pfe-preview.zooniverse.org/projects/zooniverse/notes-from-nature/classify?workflow=2808&reload=true&env=production

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?