### PR TITLE
Add Pagination to Collections Page

### DIFF
--- a/app/collections/show-list.cjsx
+++ b/app/collections/show-list.cjsx
@@ -22,7 +22,7 @@ SubjectNode = React.createClass
 
   getInitialState: ->
     project: null
-  
+
   componentWillMount: ->
     @fetchProject(@props.subject)
       .then (project) =>
@@ -58,7 +58,7 @@ SubjectNode = React.createClass
           </Link>
       </SubjectViewer>
     </div>
-    
+
 module.exports = React.createClass
   displayName: 'CollectionShowList'
 
@@ -105,7 +105,7 @@ module.exports = React.createClass
     index = subjects.indexOf subject
     subjects.splice index, 1
     @setState {subjects}
-    
+
     @props.collection.removeLink 'subjects', [subject.id.toString()]
       .then =>
         @props.collection.uncacheLink 'subjects'

--- a/app/pages/collections/list.cjsx
+++ b/app/pages/collections/list.cjsx
@@ -11,6 +11,9 @@ Paginator = require '../../talk/lib/paginator'
 List = React.createClass
   displayName: 'List'
 
+  contextTypes:
+    router: React.PropTypes.object.isRequired
+
   statics: {
     getPropsForList: (props,favorite)->
       translationObjectName = "collectionsPage"
@@ -109,7 +112,6 @@ List = React.createClass
           baseType={@props.baseType} />}
         {if @state.collections?.length > 0
           meta = @state.collections[0].getMeta()
-          console.log meta
           <div>
             <div className="resource-results-counter collection-results-counter">
               <p>
@@ -166,19 +168,10 @@ List = React.createClass
                 }
                 <nav className="pagination">
                   <Paginator
+                    className='talk'
                     page={meta.page}
                     onPageChange={@onPageChange}
                     pageCount={meta.page_count} />
-                  {for page in [1..meta.page_count]
-                    active = (page is +location.query.page) or (page is 1 and not location.search)
-                    <Link
-                      key={page}
-                      to={"#{@props.location.pathname}?page=#{page}"}
-                      activeClassName="active"
-                      className={buttonClasses}
-                      style={border: "2px solid" if active}>
-                      {page}
-                    </Link>}
                 </nav>}
             </nav>
           </div>

--- a/app/pages/collections/list.cjsx
+++ b/app/pages/collections/list.cjsx
@@ -5,6 +5,7 @@ Translate = require 'react-translate-component'
 {Link} = require 'react-router'
 CollectionsNav = require './nav'
 classNames = require 'classnames'
+Paginator = require '../../talk/lib/paginator'
 `import getCollectionCovers from '../../lib/get-collection-covers';`
 
 List = React.createClass
@@ -45,6 +46,12 @@ List = React.createClass
     if @props.project?
       baseLink += "projects/#{@props.project.slug}/"
     "#{baseLink}collections/#{collection.slug}"
+
+  onPageChange: (page) ->
+    nextQuery = Object.assign {}, @props.location.query, { page }
+    @context.router.push
+      pathname: @props.location.pathname
+      query: nextQuery
 
   listCollections: (props) ->
     query = {}
@@ -102,6 +109,7 @@ List = React.createClass
           baseType={@props.baseType} />}
         {if @state.collections?.length > 0
           meta = @state.collections[0].getMeta()
+          console.log meta
           <div>
             <div className="resource-results-counter collection-results-counter">
               <p>
@@ -157,6 +165,10 @@ List = React.createClass
                   "project-pill-button": @props.project?
                 }
                 <nav className="pagination">
+                  <Paginator
+                    page={meta.page}
+                    onPageChange={@onPageChange}
+                    pageCount={meta.page_count} />
                   {for page in [1..meta.page_count]
                     active = (page is +location.query.page) or (page is 1 and not location.search)
                     <Link

--- a/css/paginator.styl
+++ b/css/paginator.styl
@@ -6,6 +6,7 @@
 
   .paginator-page-selector
     display: inline-block
+    margin: 0 0.25em
 
     > select, > select > option
       color: black


### PR DESCRIPTION
Fixes # .

Describe your changes.
The collections page doesn't use a paginator, and each page is listed as a link. This takes up space and is bad UI. I also added some margins to the page selector in the paginator because it was butting up against the buttons.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)

https://collections-pagination.pfe-preview.zooniverse.org/

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?