### PR TITLE
add fields param to lab-visibility workflows request

### DIFF
--- a/app/pages/lab/visibility.cjsx
+++ b/app/pages/lab/visibility.cjsx
@@ -13,7 +13,7 @@ module.exports = React.createClass
   getDefaultProps: ->
     project: null
 
-  getInitialState: -> 
+  getInitialState: ->
     error: null
     setting:
       private: false
@@ -28,7 +28,7 @@ module.exports = React.createClass
 
   componentDidMount: ->
     @setState { loadingWorkflows: true }
-    getWorkflowsInOrder @props.project
+    getWorkflowsInOrder @props.project, fields: 'active,configuration,display_name'
       .then (workflows) =>
         @setState
           workflows: workflows
@@ -56,7 +56,7 @@ module.exports = React.createClass
 
   handleSetStatsCompletenessType: (workflow, e) ->
     workflow.update({ 'configuration.stats_completeness_type': e.target.value }).save()
-      .catch((error) => 
+      .catch((error) =>
         @setState {error}
       ).then(() => @forceUpdate())
 
@@ -241,7 +241,7 @@ module.exports = React.createClass
       <p className="form-help">
         When using "Retirement Count" the completeness will increase after each image retires (note: this value is re-calculated once an hour).
         {' '}Since the images are shown to users in a random order, this completeness estimate will be slow to increase until the project is close to being finished.
-        {' '}If your project does not have a constant retirement limit (e.g. it uses a custom retiment rule) and/or subject sets 
+        {' '}If your project does not have a constant retirement limit (e.g. it uses a custom retiment rule) and/or subject sets
         {' '}have been unlinked from a live workflow, this estimate will be the most accurate.
       </p>
       <p className="form-label">Statistics Visbiility</p>


### PR DESCRIPTION
Adds `fields: active,display_name,configuration` param to workflows request for Project Builder Visibility section. `configuration.stats_completeness_type` and `configuration.stats_hidden` handles **Completeness statistic** and **Statistic visibility** columns in Visibility section, respectively.

Fixes long load-time for NfN Project Builder Visibility section.

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? - https://refactor-lab-vis-workflow-req.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?