### PR TITLE
Bump panoptes-client to 2.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "markdownz": "~7.0",
     "modal-form": "~2.4",
     "moment": "~2.9.0",
-    "panoptes-client": "~2.5.0",
+    "panoptes-client": "~2.6",
     "papaparse": "mholt/PapaParse#cada171",
     "pusher-js": "~3.2.1",
     "qs": "~6.0.2",


### PR DESCRIPTION
Describe your changes.
This makes HTTP status codes available with API errors, as `error.status`.

During SGL, this should allow us to put up a `service unavailable` message for endpoints that are temporarily offline (returning 503 status codes.)

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://api-client-errors.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?