### PR TITLE
fix owner/collab access to inactive workflow via "Test workflow" button

### DIFF
--- a/app/pages/project/index.cjsx
+++ b/app/pages/project/index.cjsx
@@ -84,7 +84,7 @@ ProjectPageController = React.createClass
       @context.geordi?.forget ['experiment','cohort']
 
   fetchProjectData: (ownerName, projectName, user) ->
-    @setState({ 
+    @setState({
       error: null,
       loading: true,
       preferences: null,
@@ -120,7 +120,7 @@ ProjectPageController = React.createClass
             awaitProjectCompleteness,
             awaitProjectRoles,
             awaitPreferences
-          ]).then(([background, owner, pages, projectAvatar, projectIsComplete, projectRoles, preferences]) => 
+          ]).then(([background, owner, pages, projectAvatar, projectIsComplete, projectRoles, preferences]) =>
               @setState({ background, owner, pages, projectAvatar, projectIsComplete, projectRoles, preferences })
               @getSelectedWorkflow(project, preferences)
             ).catch((error) => @setState({ error }); console.error(error); );
@@ -201,7 +201,7 @@ ProjectPageController = React.createClass
       linkedWorkflows[randomIndex]
 
   getWorkflow: (selectedWorkflowID) ->
-    apiClient.type('workflows').get({ active: true, id: "#{selectedWorkflowID}", project_id: @state.project.id })
+    apiClient.type('workflows').get({ id: "#{selectedWorkflowID}", project_id: @state.project.id })
       .catch (error) =>
         console.error error
         # TODO: Handle 404 once json-api-client error handling is fixed.

--- a/app/pages/project/index.cjsx
+++ b/app/pages/project/index.cjsx
@@ -201,7 +201,12 @@ ProjectPageController = React.createClass
       linkedWorkflows[randomIndex]
 
   getWorkflow: (selectedWorkflowID) ->
-    apiClient.type('workflows').get({ id: "#{selectedWorkflowID}", project_id: @state.project.id })
+    query =
+      id: "#{selectedWorkflowID}",
+      project_id: @state.project.id
+    unless @checkUserRoles(@state.project, @props.user)
+      query['active'] = 'true'
+    apiClient.type('workflows').get(query)
       .catch (error) =>
         console.error error
         # TODO: Handle 404 once json-api-client error handling is fixed.


### PR DESCRIPTION
"Test workflow" button from inactive workflow lab goes to classify page that doesn't load due to `active: true` param on workflow request in project/index.cjsx.

This adds conditional where unless user is owner/collab `active: true` is added to workflow request, if they are owner/collab, it does not add `active: true` to workflow request.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? - https://test-workflow-fix.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?