### PR TITLE
Fix App Status component - better colours on Project Page and no more 'empty' text

### DIFF
--- a/app/partials/app-status.jsx
+++ b/app/partials/app-status.jsx
@@ -53,13 +53,13 @@ export default class AppStatus extends React.Component {
     })
     .then((text) => {
       console.log('AppStatus: Received status data from ' + APP_STATUS_URL + '.');
-      const cleanedtext = text.trim();  //If text is just white space or newlines...
-      if (!cleanedtext || cleanedtext === '') {  //...ignore it.
+      const cleanedText = (text) ? text.trim() : '';  //If text is just white space or newlines...
+      if (cleanedText === '') {  //...ignore it.
         console.log('AppStatus: Nothing to report.');
       } else {
         this.setState({
           show: true,
-          message: cleanedtext,
+          message: cleanedText,
         });
       }
     })

--- a/app/partials/app-status.jsx
+++ b/app/partials/app-status.jsx
@@ -53,12 +53,13 @@ export default class AppStatus extends React.Component {
     })
     .then((text) => {
       console.log('AppStatus: Received status data from ' + APP_STATUS_URL + '.');
-      if (!text || text === '') {
+      const cleanedtext = text.trim();  //If text is just white space or newlines...
+      if (!cleanedtext || cleanedtext === '') {  //...ignore it.
         console.log('AppStatus: Nothing to report.');
       } else {
         this.setState({
           show: true,
-          message: text,
+          message: cleanedtext,
         });
       }
     })

--- a/app/partials/app-status.jsx
+++ b/app/partials/app-status.jsx
@@ -28,7 +28,9 @@ feature specs.
 
 import React from 'react';
 
-const APP_STATUS_URL = 'https://static.zooniverse.org/zooniverse.org-status.txt';
+const APP_STATUS_URL = (process.env.NODE_ENV === 'staging' || process.env.NODE_ENV === 'development')
+  ? 'https://static.zooniverse.org/zooniverse.org-status-TEST.txt'
+  : 'https://static.zooniverse.org/zooniverse.org-status.txt';
 
 export default class AppStatus extends React.Component {
   constructor(props) {

--- a/css/app-status.styl
+++ b/css/app-status.styl
@@ -1,5 +1,6 @@
 .app-status
   background: BACKGROUND
+  color: FOREGROUND
   border: 1px solid ZOONIVERSE_TEAL
   border-radius: 1em
   padding: 0.5em 1em


### PR DESCRIPTION
## PR Overview
* There are two issues, reported by @astopy on Slack at 8am today (GMT+0):
  * The App Status component is unreadable on individual Project pages, as the text becomes white.
  * If the [status text file](https://static.zooniverse.org/zooniverse.org-status.txt) consists of only a newline, the App Status component thinks there's a message.
<img width="427" alt="screen shot 2017-03-23 at 08 13 00" src="https://cloud.githubusercontent.com/assets/13952701/24251210/4772d560-0fd1-11e7-8724-f782aa88bb41.png">
* This PR fixes both issues by...
  * _overriding the colour overrides_ on Project pages.
  * `trim()`-ing any text the App Status compo receives - this eliminates not just stray newlines, but any sort of whitespace that serves no purpose.
![screen shot 2017-03-23 at 13 49 30](https://cloud.githubusercontent.com/assets/13952701/24251332/bba98e6a-0fd1-11e7-85f0-6255d5abe9c4.png)
* Tested with OSX+Chrome - but note that due to the external resource (a text file on `zooniverse-static`), testing had to be done under localhost conditions with an [external test file.](https://static.zooniverse.org/zooniverse.org-status-TEST.txt)

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)
