### PR TITLE
SIM subject classification summary notification

### DIFF
--- a/app/classifier/classification-summary.jsx
+++ b/app/classifier/classification-summary.jsx
@@ -84,7 +84,7 @@ class ClassificationSummary extends React.Component {
             { this.state.showExpert ? 'Expert Classification:' : 'Your classification:' }
           </strong>
           {this.props.workflow.configuration.sim_notification && this.props.subject.metadata['#sim'] &&
-            <p>This was a simulated planet. We include these to help calibrate the project. Keep going to discover a real planet!</p>}
+            <p style={{fontWeight: 'bold'}}>This was a simulated planet. We include these to help calibrate the project. Keep going to discover a real planet!</p>}
           <DefaultClassificationSummary
             workflow={this.props.workflow}
             classification={this.state.showExpert ? this.props.expertClassification : this.props.classification}

--- a/app/classifier/classification-summary.jsx
+++ b/app/classifier/classification-summary.jsx
@@ -83,6 +83,8 @@ class ClassificationSummary extends React.Component {
           <strong>
             { this.state.showExpert ? 'Expert Classification:' : 'Your classification:' }
           </strong>
+          {this.props.workflow.configuration.sim_notification && this.props.subject.metadata['#sim'] &&
+            <p>This was simulated data that we show volunteers in order to calibrate the project.</p>}
           <DefaultClassificationSummary
             workflow={this.props.workflow}
             classification={this.state.showExpert ? this.props.expertClassification : this.props.classification}
@@ -96,8 +98,12 @@ class ClassificationSummary extends React.Component {
 }
 
 ClassificationSummary.propTypes = {
-  project: React.PropTypes.object.isRequired,
-  workflow: React.PropTypes.object.isRequired,
+  project: React.PropTypes.shape({
+    experimental_tools: React.PropTypes.array
+  }).isRequired,
+  workflow: React.PropTypes.shape({
+    configuration: React.PropTypes.object
+  }).isRequired,
   subject: React.PropTypes.object.isRequired,
   classification: React.PropTypes.object.isRequired,
   expertClassification: React.PropTypes.object,

--- a/app/classifier/classification-summary.jsx
+++ b/app/classifier/classification-summary.jsx
@@ -84,7 +84,7 @@ class ClassificationSummary extends React.Component {
             { this.state.showExpert ? 'Expert Classification:' : 'Your classification:' }
           </strong>
           {this.props.workflow.configuration.sim_notification && this.props.subject.metadata['#sim'] &&
-            <p>This was simulated data that we show volunteers in order to calibrate the project.</p>}
+            <p>This was a simulated planet. We include these to help calibrate the project. Keep going to discover a real planet!</p>}
           <DefaultClassificationSummary
             workflow={this.props.workflow}
             classification={this.state.showExpert ? this.props.expertClassification : this.props.classification}

--- a/app/pages/admin/project-status/experimental-features.jsx
+++ b/app/pages/admin/project-status/experimental-features.jsx
@@ -23,6 +23,7 @@ const experimentalFeatures = [
   'freehandSegmentLine',
   'freehandSegmentShape',
   'enable subject flags',
+  'sim notification'
 ];
 
 class ExperimentalFeatures extends Component {

--- a/app/pages/lab/workflow.cjsx
+++ b/app/pages/lab/workflow.cjsx
@@ -293,6 +293,25 @@ EditWorkflowPage = React.createClass
               <hr />
             </div>}
 
+          {if 'sim notification' in @props.project.experimental_tools
+            <div>
+              <div>
+                <AutoSave resource={@props.workflow}>
+                  <span className="form-label">Simulation subject notification</span><br />
+                  <small className="form-help">Simulation subject notification will display a small message in the classification summary that lets the volunteer know the subject is a simulation:</small><br /><br />
+                  <small className="form-help">This was simulated data that we show volunteers in order to calibrate the project.</small><br /><br />
+                  <small className="form-help">For this feature to work, it requires hidden subject metadata with the column label <code>{'#sim'}</code> and the value set to <code>true</code> or <code>false.</code></small>
+                  <br />
+                  <label>
+                    <input type="checkbox" checked={@props.workflow.configuration.sim_notification} onChange={@handleSetSimNotification} />
+                    Simluation subject notification
+                  </label>
+                </AutoSave>
+              </div>
+
+              <hr />
+            </div>}
+
           {if 'Gravity Spy Gold Standard' in @props.project.experimental_tools
             <div>
               <div>
@@ -551,6 +570,10 @@ EditWorkflowPage = React.createClass
   handlePersistAnnotationsToggle: (e) ->
     @props.workflow.update
       'configuration.persist_annotations': e.target.checked
+
+  handleSetSimNotification: (e) ->
+    @props.workflow.update
+      'configuration.sim_notification': e.target.checked
 
   handleSetInvert: (e) ->
     @props.workflow.update

--- a/app/pages/lab/workflow.cjsx
+++ b/app/pages/lab/workflow.cjsx
@@ -298,8 +298,7 @@ EditWorkflowPage = React.createClass
               <div>
                 <AutoSave resource={@props.workflow}>
                   <span className="form-label">Simulation subject notification</span><br />
-                  <small className="form-help">Simulation subject notification will display a small message in the classification summary that lets the volunteer know the subject is a simulation:</small><br /><br />
-                  <small className="form-help">This was simulated data that we show volunteers in order to calibrate the project.</small><br /><br />
+                  <small className="form-help">Simulation subject notification will display a small message in the classification summary that lets the volunteer know the subject is a simulation.</small><br /><br />
                   <small className="form-help">For this feature to work, it requires hidden subject metadata with the column label <code>{'#sim'}</code> and the value set to <code>true</code> or <code>false.</code></small>
                   <br />
                   <label>


### PR DESCRIPTION
This is for the SGL planet hunters project. They have sim subjects and want to notify the volunteers in the summary that it was a sim. 

https://sgl-planets-metadata-feedback.pfe-preview.zooniverse.org/projects/srallen086/sgl-tester/classify

The flower subject is the only subject with metadata for a true sim. The hurricane is sim false. The others are missing that subject metadata.

~~It's WIP because I need to put in the messaging they actually want.~~ At some point in the future, we may want an interface in the lab so projects and put in the message they want.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?