### PR TITLE
revert test worklfow fixes

### DIFF
--- a/app/pages/project/index.cjsx
+++ b/app/pages/project/index.cjsx
@@ -201,12 +201,7 @@ ProjectPageController = React.createClass
       linkedWorkflows[randomIndex]
 
   getWorkflow: (selectedWorkflowID) ->
-    query =
-      id: "#{selectedWorkflowID}",
-      project_id: @state.project.id
-    unless @checkUserRoles(@state.project, @props.user)
-      query['active'] = 'true'
-    apiClient.type('workflows').get(query)
+    apiClient.type('workflows').get({ active: true, id: "#{selectedWorkflowID}", project_id: @state.project.id })
       .catch (error) =>
         console.error error
         # TODO: Handle 404 once json-api-client error handling is fixed.
@@ -234,11 +229,10 @@ ProjectPageController = React.createClass
       Promise.resolve(null)
 
   checkUserRoles: (project, user) ->
-    if user
-      currentUserRoleSets = @state.projectRoles.filter((roleSet) => roleSet.links.owner.id is user.id)
-      roles = currentUserRoleSets[0].roles
+    currentUserRoleSets = @state.projectRoles.filter((roleSet) => roleSet.links.owner.id is user.id)
+    roles = currentUserRoleSets[0].roles
 
-      isAdmin() or 'owner' in roles or 'collaborator' in roles
+    isAdmin() or 'owner' in roles or 'collaborator' in roles
 
   listenToPreferences: (preferences) ->
     @_listenedToPreferences?.stopListening 'change', @_boundForceUpdate


### PR DESCRIPTION
Fixes issue loading classification interface.

Reverting `getWorkflow` to before "Test Workflow" button edits.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? - https://revert-test-workflow-fix.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?