### PR TITLE
Edit workflow request when queried depending on role or project setting

### DIFF
--- a/app/pages/project/index.cjsx
+++ b/app/pages/project/index.cjsx
@@ -109,7 +109,7 @@ ProjectPageController = React.createClass
 
           awaitProjectCompleteness = Promise.resolve(project.completeness > 0.99)
 
-          awaitProjectRoles = apiClient.type('project_roles').get({ project_id: project.id, user_id: user?.id }).catch((error) => console.error(error))
+          awaitProjectRoles = apiClient.type('project_roles').get({ project_id: project.id, page_size: 50 }).catch((error) => console.error(error))
 
           awaitPreferences = @getUserProjectPreferences(project, user)
 

--- a/app/pages/project/index.cjsx
+++ b/app/pages/project/index.cjsx
@@ -109,7 +109,7 @@ ProjectPageController = React.createClass
 
           awaitProjectCompleteness = Promise.resolve(project.completeness > 0.99)
 
-          awaitProjectRoles = apiClient.type('project_roles').get(project.links.project_roles).catch((error) => console.error(error))
+          awaitProjectRoles = apiClient.type('project_roles').get({ project_id: project.id, user_id: user?.id, page_size: 50 }).catch((error) => console.error(error))
 
           awaitPreferences = @getUserProjectPreferences(project, user)
 
@@ -239,7 +239,7 @@ ProjectPageController = React.createClass
       Promise.resolve(null)
 
   checkUserRoles: (project, user) ->
-    currentUserRoleSets = @state.projectRoles.filter((roleSet) => roleSet.links.owner.id is user.id)
+    currentUserRoleSets = @state.projectRoles.filter((roleSet) => roleSet.links.owner.id is user?.id)
     roles = currentUserRoleSets[0]?.roles or []
 
     isAdmin() or 'owner' in roles or 'collaborator' in roles

--- a/app/pages/project/index.cjsx
+++ b/app/pages/project/index.cjsx
@@ -13,6 +13,7 @@ ProjectPageController = React.createClass
   contextTypes:
     geordi: React.PropTypes.object
     initialLoadComplete: React.PropTypes.bool
+    router: React.PropTypes.object.isRequired
 
   propTypes:
     params: React.PropTypes.object
@@ -143,10 +144,6 @@ ProjectPageController = React.createClass
       .then =>
         @setState loading: false
 
-  canFetchWorkflowByQuery: (project, user) ->
-    if project?
-      'allow workflow query' in project.experimental_tools or @checkUserRoles(project, user)
-
   getUserProjectPreferences: (project, user) ->
     @listenToPreferences null
 
@@ -173,9 +170,15 @@ ProjectPageController = React.createClass
 
   getSelectedWorkflow: (project, preferences) ->
     @setState({ loadingSelectedWorkflow: true })
-    # preference workflow query, then user selected workflow, then project owner set workflow, then default workflow
+    # preference workflow query by admin/owner/collab, then workflow query if in project settings, then user selected workflow, then project owner set workflow, then default workflow
     # if none of those are set, select random workflow
-    if @props.location.query?.workflow? and @canFetchWorkflowByQuery(project, @props.user)
+    activeFilter = true
+    if @props.location.query?.workflow? and @checkUserRoles(project, @props.user)
+      selectedWorkflowID = @props.location.query.workflow
+      activeFilter = false
+      unless preferences?.preferences.selected_workflow is selectedWorkflowID
+        @handlePreferencesChange('preferences.selected_workflow', selectedWorkflowID)
+    else if @props.location.query?.workflow? and 'allow workflow query' in project?.experimental_tools
       selectedWorkflowID = @props.location.query.workflow
       unless preferences?.preferences.selected_workflow is selectedWorkflowID
         @handlePreferencesChange('preferences.selected_workflow', selectedWorkflowID)
@@ -188,7 +191,7 @@ ProjectPageController = React.createClass
     else
       selectedWorkflowID = @selectRandomWorkflow(project)
 
-    @getWorkflow(selectedWorkflowID)
+    @getWorkflow(selectedWorkflowID, activeFilter)
 
   selectRandomWorkflow: (project) ->
     linkedWorkflows = project.links.workflows
@@ -200,8 +203,13 @@ ProjectPageController = React.createClass
       # console.log 'Chose random workflow', linkedWorkflows[randomIndex]
       linkedWorkflows[randomIndex]
 
-  getWorkflow: (selectedWorkflowID) ->
-    apiClient.type('workflows').get({ active: true, id: "#{selectedWorkflowID}", project_id: @state.project.id })
+  getWorkflow: (selectedWorkflowID, activeFilter = true) ->
+    query =
+      id: "#{selectedWorkflowID}",
+      project_id: @state.project.id
+    if activeFilter
+      query['active'] = true
+    apiClient.type('workflows').get(query)
       .catch (error) =>
         console.error error
         # TODO: Handle 404 once json-api-client error handling is fixed.
@@ -211,6 +219,8 @@ ProjectPageController = React.createClass
           @setState({ loadingSelectedWorkflow: false, workflow })
         else
           console.log "No workflow #{selectedWorkflowID} for project #{@state.project.id}"
+          if @props.location.query?.workflow?
+            @context.router.push "/projects/#{@state.project.slug}/classify"
           @clearInactiveWorkflow(selectedWorkflowID)
             .then(@getSelectedWorkflow(@state.project, @state.preferences))
 
@@ -230,7 +240,7 @@ ProjectPageController = React.createClass
 
   checkUserRoles: (project, user) ->
     currentUserRoleSets = @state.projectRoles.filter((roleSet) => roleSet.links.owner.id is user.id)
-    roles = currentUserRoleSets[0].roles
+    roles = currentUserRoleSets[0]?.roles or []
 
     isAdmin() or 'owner' in roles or 'collaborator' in roles
 

--- a/app/pages/project/index.cjsx
+++ b/app/pages/project/index.cjsx
@@ -109,7 +109,7 @@ ProjectPageController = React.createClass
 
           awaitProjectCompleteness = Promise.resolve(project.completeness > 0.99)
 
-          awaitProjectRoles = apiClient.type('project_roles').get({ project_id: project.id, user_id: user?.id, page_size: 50 }).catch((error) => console.error(error))
+          awaitProjectRoles = apiClient.type('project_roles').get({ project_id: project.id, user_id: user?.id }).catch((error) => console.error(error))
 
           awaitPreferences = @getUserProjectPreferences(project, user)
 


### PR DESCRIPTION
**Temporary Alternative**: see branch [`disable-test-workflow`](https://github.com/zooniverse/Panoptes-Front-End/compare/disable-test-workflow)

Fixes broken Test Workflow button from workflow editor in lab.

If a workflow query in url and admin/owner/collaborator remove `active: true` from workflow request to allow viewing of inactive workflow, i.e. via Test Workflow button from lab.

If a workflow query in url and project settings allow workflow queries, try to get requested workflow, but if inactive then remove query and proceed through other workflow determining steps.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? - https://test-workflow-fix.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?