### PR TITLE
Create Workflow and Subject Set Lab Pages

### DIFF
--- a/app/components/subject-sets.jsx
+++ b/app/components/subject-sets.jsx
@@ -1,0 +1,120 @@
+import React from 'react';
+import apiClient from 'panoptes-client/lib/api-client';
+import SubjectSetsPage from '../pages/lab/subject-sets';
+
+const DEFAULT_SUBJECT_SET_NAME = 'Untitled subject set';
+
+export default class SubjectSetsContainer extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      loading: true,
+      subjectSetCreationError: null,
+      subjectSetCreationInProgress: false,
+      subjectSets: []
+    };
+
+    this.onPageChange = this.onPageChange.bind(this);
+    this.labPath = this.labPath.bind(this);
+    this.createNewSubjectSet = this.createNewSubjectSet.bind(this);
+  }
+
+  componentDidMount() {
+    this._isMounted = true;
+
+    const page = this.props.location.query.page || 1;
+    this.getSubjectSets(page);
+  }
+
+  componentWillReceiveProps(nextProps) {
+    const newPage = nextProps.location.query.page;
+    if (newPage !== this.props.location.query.page) {
+      this.getSubjectSets(newPage);
+    }
+  }
+
+  componentWillUnmount() {
+    this._isMounted = false;
+  }
+
+  onPageChange(page) {
+    const nextQuery = Object.assign({}, this.props.location.query, { page });
+    this.context.router.push({
+      pathname: this.props.location.pathname,
+      query: nextQuery
+    });
+  }
+
+  getSubjectSets(page = 1) {
+    this.props.project.get('subject_sets', { sort: 'display_name', page })
+    .then((subjectSets) => {
+      this.setState({ subjectSets, loading: false });
+    });
+  }
+
+  createNewSubjectSet() {
+    const subjectSet = apiClient.type('subject_sets').create({
+      display_name: DEFAULT_SUBJECT_SET_NAME,
+      links:
+        { project: this.props.project.id }
+    });
+
+    this.setState({
+      subjectSetCreationError: null,
+      subjectSetCreationInProgress: true
+    });
+
+    subjectSet.save()
+      .then(() => {
+        this.context.router.push(`/lab/${this.props.project.id}/subject-set/${subjectSet.id}`);
+      })
+      .catch((error) => {
+        this.setState({ subjectSetCreationError: error });
+      })
+      .then(() => {
+        this.props.project.uncacheLink('subject_sets');
+        if (this._isMounted) {
+          this.setState({ subjectSetCreationInProgress: false });
+        }
+      });
+  }
+
+  labPath(postFix = '') {
+    return `/lab/${this.props.project.id}${postFix}`;
+  }
+
+  render() {
+    return (
+      <SubjectSetsPage
+        createNewSubjectSet={this.createNewSubjectSet}
+        labPath={this.labPath}
+        loading={this.state.loading}
+        onPageChange={this.onPageChange}
+        project={this.props.project}
+        error={this.state.subjectSetCreationError}
+        creationInProgress={this.state.subjectSetCreationInProgress}
+        subjectSets={this.state.subjectSets}
+      />
+    );
+  }
+}
+
+SubjectSetsContainer.contextTypes = {
+  router: React.PropTypes.object.isRequired
+};
+
+SubjectSetsContainer.defaultProps = {
+  project: {}
+};
+
+SubjectSetsContainer.propTypes = {
+  location: React.PropTypes.shape({
+    pathname: React.PropTypes.string,
+    query: React.PropTypes.object
+  }),
+  project: React.PropTypes.shape({
+    get: React.PropTypes.func,
+    id: React.PropTypes.string,
+    uncacheLink: React.PropTypes.func
+  })
+};

--- a/app/pages/lab/project.cjsx
+++ b/app/pages/lab/project.cjsx
@@ -90,6 +90,12 @@ EditProjectPage = React.createClass
           <li><Link to={@labPath('/data-exports')} activeClassName='active' className="nav-list-item" title="Get your project's data exports">
             Data Exports
           </Link></li>
+          <li><Link to={@labPath('/workflows')} activeClassName='active' className="nav-list-item" title="View your project's workflows">
+            Workflows
+          </Link></li>
+          <li><Link to={@labPath('/subjectsets')} activeClassName='active' className="nav-list-item" title="View your project's subject sets">
+            Subject Sets
+          </Link></li>
 
           <li>
             <br />

--- a/app/pages/lab/project.cjsx
+++ b/app/pages/lab/project.cjsx
@@ -77,7 +77,7 @@ EditProjectPage = React.createClass
           <li><Link to={@labPath('/workflows')} activeClassName='active' className="nav-list-item" title="View your project's workflows">
             Workflows
           </Link></li>
-          <li><Link to={@labPath('/subjectsets')} activeClassName='active' className="nav-list-item" title="View your project's subject sets">
+          <li><Link to={@labPath('/subject-sets')} activeClassName='active' className="nav-list-item" title="View your project's subject sets">
             Subject Sets
           </Link></li>
 

--- a/app/pages/lab/project.cjsx
+++ b/app/pages/lab/project.cjsx
@@ -28,8 +28,6 @@ EditProjectPage = React.createClass
     workflowActions: workflowActions
 
   getInitialState: ->
-    subjectSetCreationError: null
-    subjectSetCreationInProgress: false
     deletionError: null
     deletionInProgress: false
 
@@ -85,32 +83,6 @@ EditProjectPage = React.createClass
 
           <li>
             <br />
-            <div className="nav-list-header">Subject sets</div>
-            <PromiseRenderer promise={@props.project.get 'subject_sets', sort: 'display_name', page_size: 250}>{(subjectSets) =>
-              <ul className="nav-list">
-                {renderSubjectSetListItem = (subjectSet) ->
-                  subjectSetListLabel = subjectSet.display_name || <i>{'Untitled subject set'}</i>
-                  <li key={subjectSet.id}>
-                    <Link to={@labPath("/subject-set/#{subjectSet.id}")} activeClassName="active" className="nav-list-item" title="A subject is an image (or group of images) to be analyzed.">{subjectSetListLabel}</Link>
-                  </li>}
-
-                {for subjectSet in subjectSets
-                  <ChangeListener key={subjectSet.id} target={subjectSet} eventName="save" handler={renderSubjectSetListItem.bind this, subjectSet} />}
-
-                <li className="nav-list-item">
-                  <button type="button" onClick={@createNewSubjectSet} disabled={@state.subjectSetCreationInProgress} title="A subject is an image (or group of images) to be analyzed.">
-                    New subject set{' '}
-                    <LoadingIndicator off={not @state.subjectSetCreationInProgress} />
-                  </button>{' '}
-                  {if @state.subjectSetCreationError?
-                    <div className="form-help error">{@state.subjectSetCreationError.message}</div>}
-                </li>
-              </ul>
-            }</PromiseRenderer>
-          </li>
-
-          <li>
-            <br />
             <div className="nav-list-header">Need some help?</div>
             <ul className="nav-list">
               <li>
@@ -144,26 +116,6 @@ EditProjectPage = React.createClass
         } />
       </div>
     </div>
-
-  createNewSubjectSet: ->
-    subjectSet = apiClient.type('subject_sets').create
-      display_name: DEFAULT_SUBJECT_SET_NAME
-      links:
-        project: @props.project.id
-
-    @setState
-      subjectSetCreationError: null
-      subjectSetCreationInProgress: true
-
-    subjectSet.save()
-      .then =>
-        @context.router.push "/lab/#{@props.project.id}/subject-set/#{subjectSet.id}"
-      .catch (error) =>
-        @setState subjectSetCreationError: error
-      .then =>
-        @props.project.uncacheLink 'subject_sets'
-        if @isMounted()
-          @setState subjectSetCreationInProgress: false
 
   deleteProject: ->
     @setState deletionError: null

--- a/app/pages/lab/subject-set.cjsx
+++ b/app/pages/lab/subject-set.cjsx
@@ -130,7 +130,7 @@ SubjectSetListing = React.createClass
     lastSubjectOnPage = (@state.subjects.length % 20 is 1)
 
     pageValue = @props.page
-    
+
     # if the removed subject is the last subject on the page,
     # set the page number to the previous page
     if lastSubjectOnPage
@@ -404,4 +404,3 @@ module.exports = React.createClass
       }</ChangeListener>
     else
       null
-

--- a/app/pages/lab/subject-sets-container.jsx
+++ b/app/pages/lab/subject-sets-container.jsx
@@ -20,8 +20,6 @@ export default class SubjectSetsContainer extends React.Component {
   }
 
   componentDidMount() {
-    this._isMounted = true;
-
     const page = this.props.location.query.page || 1;
     this.getSubjectSets(page);
   }
@@ -31,10 +29,6 @@ export default class SubjectSetsContainer extends React.Component {
     if (newPage !== this.props.location.query.page) {
       this.getSubjectSets(newPage);
     }
-  }
-
-  componentWillUnmount() {
-    this._isMounted = false;
   }
 
   onPageChange(page) {
@@ -66,16 +60,16 @@ export default class SubjectSetsContainer extends React.Component {
 
     subjectSet.save()
       .then(() => {
-        this.context.router.push(`/lab/${this.props.project.id}/subject-set/${subjectSet.id}`);
+        this.context.router.push(`/lab/${this.props.project.id}/subject-sets/${subjectSet.id}`);
       })
       .catch((error) => {
-        this.setState({ subjectSetCreationError: error });
+        this.setState({
+          subjectSetCreationError: error,
+          subjectSetCreationInProgress: false
+        });
       })
       .then(() => {
         this.props.project.uncacheLink('subject_sets');
-        if (this._isMounted) {
-          this.setState({ subjectSetCreationInProgress: false });
-        }
       });
   }
 
@@ -87,9 +81,9 @@ export default class SubjectSetsContainer extends React.Component {
     return (
       <SubjectSetsPage
         createNewSubjectSet={this.createNewSubjectSet}
+        defaultSubjectSetName={DEFAULT_SUBJECT_SET_NAME}
         labPath={this.labPath}
         onPageChange={this.onPageChange}
-        project={this.props.project}
         {...this.state}
       />
     );

--- a/app/pages/lab/subject-sets-container.jsx
+++ b/app/pages/lab/subject-sets-container.jsx
@@ -23,21 +23,13 @@ export default class SubjectSetsContainer extends React.Component {
     this.getSubjectSets(page);
   }
 
-  componentWillReceiveProps(nextProps) {
-    const newPath = nextProps.location.pathname !== this.props.location.pathname;
-    const newPage = nextProps.location.query.page;
-    const pageChange = newPage !== this.props.location.query.page;
-    if (newPath || pageChange) {
-      this.getSubjectSets(newPage);
-    }
-  }
-
   onPageChange(page) {
     const nextQuery = Object.assign({}, this.props.location.query, { page });
     this.context.router.push({
       pathname: this.props.location.pathname,
       query: nextQuery
     });
+    this.getSubjectSets(page);
   }
 
   getSubjectSets(page = 1) {
@@ -74,6 +66,7 @@ export default class SubjectSetsContainer extends React.Component {
       })
       .then(() => {
         this.props.project.uncacheLink('subject_sets');
+        this.getSubjectSets();
       });
   }
 

--- a/app/pages/lab/subject-sets-container.jsx
+++ b/app/pages/lab/subject-sets-container.jsx
@@ -24,8 +24,10 @@ export default class SubjectSetsContainer extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
+    const newPath = nextProps.location.pathname !== this.props.location.pathname;
     const newPage = nextProps.location.query.page;
-    if (newPage !== this.props.location.query.page) {
+    const pageChange = newPage !== this.props.location.query.page;
+    if (newPath || pageChange) {
       this.getSubjectSets(newPage);
     }
   }
@@ -59,6 +61,9 @@ export default class SubjectSetsContainer extends React.Component {
 
     subjectSet.save()
       .then(() => {
+        this.setState({
+          subjectSetCreationInProgress: false
+        });
         this.context.router.push(`/lab/${this.props.project.id}/subject-sets/${subjectSet.id}`);
       })
       .catch((error) => {

--- a/app/pages/lab/subject-sets-container.jsx
+++ b/app/pages/lab/subject-sets-container.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import apiClient from 'panoptes-client/lib/api-client';
-import SubjectSetsPage from './subject-sets';
 
 const DEFAULT_SUBJECT_SET_NAME = 'Untitled subject set';
 
@@ -78,14 +77,19 @@ export default class SubjectSetsContainer extends React.Component {
   }
 
   render() {
+    const hookProps = {
+      createNewSubjectSet: this.createNewSubjectSet,
+      defaultSubjectSetName: DEFAULT_SUBJECT_SET_NAME,
+      labPath: this.labPath,
+      onPageChange: this.onPageChange
+    };
+
+    const allProps = Object.assign({}, this.state, this.props, hookProps);
+
     return (
-      <SubjectSetsPage
-        createNewSubjectSet={this.createNewSubjectSet}
-        defaultSubjectSetName={DEFAULT_SUBJECT_SET_NAME}
-        labPath={this.labPath}
-        onPageChange={this.onPageChange}
-        {...this.state}
-      />
+      <div>
+        {React.cloneElement(this.props.children, allProps)}
+      </div>
     );
   }
 }
@@ -99,6 +103,7 @@ SubjectSetsContainer.defaultProps = {
 };
 
 SubjectSetsContainer.propTypes = {
+  children: React.PropTypes.node,
   location: React.PropTypes.shape({
     pathname: React.PropTypes.string,
     query: React.PropTypes.object

--- a/app/pages/lab/subject-sets-container.jsx
+++ b/app/pages/lab/subject-sets-container.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import apiClient from 'panoptes-client/lib/api-client';
-import SubjectSetsPage from '../pages/lab/subject-sets';
+import SubjectSetsPage from './subject-sets';
 
 const DEFAULT_SUBJECT_SET_NAME = 'Untitled subject set';
 
@@ -88,12 +88,9 @@ export default class SubjectSetsContainer extends React.Component {
       <SubjectSetsPage
         createNewSubjectSet={this.createNewSubjectSet}
         labPath={this.labPath}
-        loading={this.state.loading}
         onPageChange={this.onPageChange}
         project={this.props.project}
-        error={this.state.subjectSetCreationError}
-        creationInProgress={this.state.subjectSetCreationInProgress}
-        subjectSets={this.state.subjectSets}
+        {...this.state}
       />
     );
   }

--- a/app/pages/lab/subject-sets.jsx
+++ b/app/pages/lab/subject-sets.jsx
@@ -29,7 +29,7 @@ const SubjectSetsPage = (props) => {
         })}
 
         {(props.subjectSets.length === 0 && props.loading === false) && (
-          <p id="no-subject-set">No subject sets are currently associated with this project.</p>
+          <p>No subject sets are currently associated with this project.</p>
         )}
 
         <li className="nav-list-item">

--- a/app/pages/lab/subject-sets.jsx
+++ b/app/pages/lab/subject-sets.jsx
@@ -64,7 +64,7 @@ export default class SubjectSetsPage extends React.Component {
                   activeClassName="active"
                   className="nav-list-item"
                   title="A subject is an image (or group of images) to be analyzed."
-                  to={this.labPath('/subject-set/#{subjectSet.id}')}
+                  to={this.labPath(`/subject-set/${subjectSet.id}`)}
                 >
                   {subjectSetListLabel}
                 </Link>

--- a/app/pages/lab/subject-sets.jsx
+++ b/app/pages/lab/subject-sets.jsx
@@ -57,7 +57,7 @@ export default class SubjectSetsPage extends React.Component {
     const subjectSet = apiClient.type('subject_sets').create({
       display_name: DEFAULT_SUBJECT_SET_NAME,
       links:
-        { project: 999999999999 }
+        { project: this.props.project.id }
     });
 
     this.setState({
@@ -108,11 +108,16 @@ export default class SubjectSetsPage extends React.Component {
           })}
 
           {(this.state.subjectSets.length === 0 && this.state.loading === false) && (
-            <p> No subject sets are currently associated with this project. </p>
+            <p>No subject sets are currently associated with this project.</p>
           )}
 
           <li className="nav-list-item">
-            <button type="button" onClick={this.createNewSubjectSet} disabled={this.state.subjectSetCreationInProgress} title="A subject is an image (or group of images) to be analyzed.">
+            <button
+              type="button"
+              onClick={this.createNewSubjectSet}
+              disabled={this.state.subjectSetCreationInProgress}
+              title="A subject is an image (or group of images) to be analyzed."
+            >
               New subject set{' '}
               <LoadingIndicator off={!this.state.subjectSetCreationInProgress} />
             </button>{' '}

--- a/app/pages/lab/subject-sets.jsx
+++ b/app/pages/lab/subject-sets.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Link } from 'react-router';
 import apiClient from 'panoptes-client/lib/api-client';
 import LoadingIndicator from '../../components/loading-indicator';
+import Paginator from '../../talk/lib/paginator';
 
 const DEFAULT_SUBJECT_SET_NAME = 'Untitled subject set';
 
@@ -9,16 +10,46 @@ export default class SubjectSetsPage extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
+      loading: true,
       subjectSetCreationError: null,
       subjectSetCreationInProgress: false,
       subjectSets: []
     };
+
+    this.onPageChange = this.onPageChange.bind(this);
+    this.createNewSubjectSet = this.createNewSubjectSet.bind(this);
   }
 
-  componentWillMount() {
-    this.props.project.get('subject_sets', { sort: 'display_name', page_size: 250 })
+  componentDidMount() {
+    this._isMounted = true;
+
+    const page = this.props.location.query.page || 1;
+    this.getSubjectSets(page);
+  }
+
+  componentWillReceiveProps(nextProps) {
+    const newPage = nextProps.location.query.page;
+    if (newPage !== this.props.location.query.page) {
+      this.getSubjectSets(newPage);
+    }
+  }
+
+  componentWillUnmount() {
+    this._isMounted = false;
+  }
+
+  onPageChange(page) {
+    const nextQuery = Object.assign({}, this.props.location.query, { page });
+    this.context.router.push({
+      pathname: this.props.location.pathname,
+      query: nextQuery
+    });
+  }
+
+  getSubjectSets(page = 1) {
+    this.props.project.get('subject_sets', { sort: 'display_name', page })
     .then((subjectSets) => {
-      this.setState({ subjectSets });
+      this.setState({ subjectSets, loading: false });
     });
   }
 
@@ -26,7 +57,7 @@ export default class SubjectSetsPage extends React.Component {
     const subjectSet = apiClient.type('subject_sets').create({
       display_name: DEFAULT_SUBJECT_SET_NAME,
       links:
-        { project: this.props.project.id }
+        { project: 999999999999 }
     });
 
     this.setState({
@@ -43,7 +74,9 @@ export default class SubjectSetsPage extends React.Component {
       })
       .then(() => {
         this.props.project.uncacheLink('subject_sets');
-        this.setState({ subjectSetCreationInProgress: false });
+        if (this._isMounted) {
+          this.setState({ subjectSetCreationInProgress: false });
+        }
       });
   }
 
@@ -52,9 +85,11 @@ export default class SubjectSetsPage extends React.Component {
   }
 
   render() {
+    const meta = this.state.subjectSets.length ? this.state.subjectSets[0].getMeta() : {};
+
     return (
       <div>
-        <div className="nav-list-header">Subject sets</div>
+        <div className="form-label">Subject sets</div>
         <ul className="nav-list">
           {this.state.subjectSets.map((subjectSet) => {
             const subjectSetListLabel = subjectSet.display_name || <i>{'Untitled subject set'}</i>;
@@ -71,6 +106,11 @@ export default class SubjectSetsPage extends React.Component {
               </li>
             );
           })}
+
+          {(this.state.subjectSets.length === 0 && this.state.loading === false) && (
+            <p> No subject sets are currently associated with this project. </p>
+          )}
+
           <li className="nav-list-item">
             <button type="button" onClick={this.createNewSubjectSet} disabled={this.state.subjectSetCreationInProgress} title="A subject is an image (or group of images) to be analyzed.">
               New subject set{' '}
@@ -81,6 +121,16 @@ export default class SubjectSetsPage extends React.Component {
             )}
           </li>
         </ul>
+
+        {this.state.subjectSets.length > 0 && (
+          <Paginator
+            className="talk"
+            page={meta.page}
+            onPageChange={this.onPageChange}
+            pageCount={meta.page_count}
+          />
+        )}
+
       </div>
     );
   }
@@ -95,6 +145,10 @@ SubjectSetsPage.defaultProps = {
 };
 
 SubjectSetsPage.propTypes = {
+  location: React.PropTypes.shape({
+    pathname: React.PropTypes.string,
+    query: React.PropTypes.object
+  }),
   project: React.PropTypes.shape({
     get: React.PropTypes.func,
     id: React.PropTypes.string,

--- a/app/pages/lab/subject-sets.jsx
+++ b/app/pages/lab/subject-sets.jsx
@@ -29,7 +29,7 @@ const SubjectSetsPage = (props) => {
         })}
 
         {(props.subjectSets.length === 0 && props.loading === false) && (
-          <p>No subject sets are currently associated with this project.</p>
+          <p id="no-subject-set">No subject sets are currently associated with this project.</p>
         )}
 
         <li className="nav-list-item">

--- a/app/pages/lab/subject-sets.jsx
+++ b/app/pages/lab/subject-sets.jsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { Link } from 'react-router';
+import apiClient from 'panoptes-client/lib/api-client';
+import LoadingIndicator from '../../components/loading-indicator';
+
+const DEFAULT_SUBJECT_SET_NAME = 'Untitled subject set';
+
+export default class SubjectSetsPage extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      subjectSetCreationError: null,
+      subjectSetCreationInProgress: false,
+      subjectSets: []
+    };
+  }
+
+  componentWillMount() {
+    this.props.project.get('subject_sets', { sort: 'display_name', page_size: 250 })
+    .then((subjectSets) => {
+      this.setState({ subjectSets });
+    });
+  }
+
+  createNewSubjectSet() {
+    const subjectSet = apiClient.type('subject_sets').create({
+      display_name: DEFAULT_SUBJECT_SET_NAME,
+      links:
+        { project: this.props.project.id }
+    });
+
+    this.setState({
+      subjectSetCreationError: null,
+      subjectSetCreationInProgress: true
+    });
+
+    subjectSet.save()
+      .then(() => {
+        this.context.router.push(`/lab/${this.props.project.id}/subject-set/${subjectSet.id}`);
+      })
+      .catch((error) => {
+        this.setState({ subjectSetCreationError: error });
+      })
+      .then(() => {
+        this.props.project.uncacheLink('subject_sets');
+        this.setState({ subjectSetCreationInProgress: false });
+      });
+  }
+
+  labPath(postFix = '') {
+    return `/lab/${this.props.project.id}${postFix}`;
+  }
+
+  render() {
+    return (
+      <div>
+        <div className="nav-list-header">Subject sets</div>
+        <ul className="nav-list">
+          {this.state.subjectSets.map((subjectSet) => {
+            const subjectSetListLabel = subjectSet.display_name || <i>{'Untitled subject set'}</i>;
+            return (
+              <li key={subjectSet.id}>
+                <Link
+                  activeClassName="active"
+                  className="nav-list-item"
+                  title="A subject is an image (or group of images) to be analyzed."
+                  to={this.labPath('/subject-set/#{subjectSet.id}')}
+                >
+                  {subjectSetListLabel}
+                </Link>
+              </li>
+            );
+          })}
+          <li className="nav-list-item">
+            <button type="button" onClick={this.createNewSubjectSet} disabled={this.state.subjectSetCreationInProgress} title="A subject is an image (or group of images) to be analyzed.">
+              New subject set{' '}
+              <LoadingIndicator off={!this.state.subjectSetCreationInProgress} />
+            </button>{' '}
+            {this.state.subjectSetCreationError && (
+              <div className="form-help error">{this.state.subjectSetCreationError.message}</div>
+            )}
+          </li>
+        </ul>
+      </div>
+    );
+  }
+}
+
+SubjectSetsPage.contextTypes = {
+  router: React.PropTypes.object.isRequired
+};
+
+SubjectSetsPage.defaultProps = {
+  project: {}
+};
+
+SubjectSetsPage.propTypes = {
+  project: React.PropTypes.shape({
+    get: React.PropTypes.func,
+    id: React.PropTypes.string,
+    uncacheLink: React.PropTypes.func
+  })
+};

--- a/app/pages/lab/subject-sets.jsx
+++ b/app/pages/lab/subject-sets.jsx
@@ -9,16 +9,19 @@ const SubjectSetsPage = (props) => {
   return (
     <div>
       <div className="form-label">Subject sets</div>
+      <small>
+        Subject sets are a group of data presented to volunteers in a project. A subject is typically
+        an image, graph, photo, audio recording, video, or a collection of these different things.
+      </small>
       <ul className="nav-list">
         {props.subjectSets.map((subjectSet) => {
-          const subjectSetListLabel = subjectSet.display_name || <i>{'Untitled subject set'}</i>;
+          const subjectSetListLabel = subjectSet.display_name || <i>{props.defaultSubjectSetName}</i>;
           return (
             <li key={subjectSet.id}>
               <Link
                 activeClassName="active"
                 className="nav-list-item"
-                title="A subject is an image (or group of images) to be analyzed."
-                to={props.labPath(`/subject-set/${subjectSet.id}`)}
+                to={props.labPath(`/subject-sets/${subjectSet.id}`)}
               >
                 {subjectSetListLabel}
               </Link>
@@ -34,14 +37,13 @@ const SubjectSetsPage = (props) => {
           <button
             type="button"
             onClick={props.createNewSubjectSet}
-            disabled={props.creationInProgress}
-            title="A subject is an image (or group of images) to be analyzed."
+            disabled={props.subjectSetCreationInProgress}
           >
             New subject set{' '}
-            <LoadingIndicator off={!props.creationInProgress} />
+            <LoadingIndicator off={!props.subjectSetCreationInProgress} />
           </button>{' '}
-          {props.error && (
-            <div className="form-help error">{props.error.message}</div>
+          {props.subjectSetCreationError && (
+            <div className="form-help error">{props.subjectSetCreationError.message}</div>
           )}
         </li>
       </ul>
@@ -65,13 +67,14 @@ SubjectSetsPage.defaultProps = {
 
 SubjectSetsPage.propTypes = {
   createNewSubjectSet: React.PropTypes.func,
-  creationInProgress: React.PropTypes.bool,
+  defaultSubjectSetName: React.PropTypes.string,
   labPath: React.PropTypes.func,
   loading: React.PropTypes.bool,
-  error: React.PropTypes.shape({
+  onPageChange: React.PropTypes.func,
+  subjectSetCreationError: React.PropTypes.shape({
     message: React.PropTypes.string
   }),
-  onPageChange: React.PropTypes.func,
+  subjectSetCreationInProgress: React.PropTypes.bool,
   subjectSets: React.PropTypes.arrayOf(React.PropTypes.object)
 };
 

--- a/app/pages/lab/subject-sets.jsx
+++ b/app/pages/lab/subject-sets.jsx
@@ -3,14 +3,14 @@ import { Link } from 'react-router';
 import LoadingIndicator from '../../components/loading-indicator';
 import Paginator from '../../talk/lib/paginator';
 
-const SubjectSetsPage = ({ onPageChange, createNewSubjectSet, subjectSets, error, creationInProgress, labPath, loading }) => {
-  const meta = subjectSets.length ? subjectSets[0].getMeta() : {};
+const SubjectSetsPage = (props) => {
+  const meta = props.subjectSets.length ? props.subjectSets[0].getMeta() : {};
 
   return (
     <div>
       <div className="form-label">Subject sets</div>
       <ul className="nav-list">
-        {subjectSets.map((subjectSet) => {
+        {props.subjectSets.map((subjectSet) => {
           const subjectSetListLabel = subjectSet.display_name || <i>{'Untitled subject set'}</i>;
           return (
             <li key={subjectSet.id}>
@@ -18,7 +18,7 @@ const SubjectSetsPage = ({ onPageChange, createNewSubjectSet, subjectSets, error
                 activeClassName="active"
                 className="nav-list-item"
                 title="A subject is an image (or group of images) to be analyzed."
-                to={labPath(`/subject-set/${subjectSet.id}`)}
+                to={props.labPath(`/subject-set/${subjectSet.id}`)}
               >
                 {subjectSetListLabel}
               </Link>
@@ -26,31 +26,31 @@ const SubjectSetsPage = ({ onPageChange, createNewSubjectSet, subjectSets, error
           );
         })}
 
-        {(subjectSets.length === 0 && loading === false) && (
+        {(props.subjectSets.length === 0 && props.loading === false) && (
           <p>No subject sets are currently associated with this project.</p>
         )}
 
         <li className="nav-list-item">
           <button
             type="button"
-            onClick={createNewSubjectSet}
-            disabled={creationInProgress}
+            onClick={props.createNewSubjectSet}
+            disabled={props.creationInProgress}
             title="A subject is an image (or group of images) to be analyzed."
           >
             New subject set{' '}
-            <LoadingIndicator off={!creationInProgress} />
+            <LoadingIndicator off={!props.creationInProgress} />
           </button>{' '}
-          {error && (
-            <div className="form-help error">{error.message}</div>
+          {props.error && (
+            <div className="form-help error">{props.error.message}</div>
           )}
         </li>
       </ul>
 
-      {subjectSets.length > 0 && (
+      {props.subjectSets.length > 0 && (
         <Paginator
           className="talk"
           page={meta.page}
-          onPageChange={onPageChange}
+          onPageChange={props.onPageChange}
           pageCount={meta.page_count}
         />
       )}
@@ -70,9 +70,6 @@ SubjectSetsPage.propTypes = {
   loading: React.PropTypes.bool,
   error: React.PropTypes.shape({
     message: React.PropTypes.string
-  }),
-  project: React.PropTypes.shape({
-    id: React.PropTypes.string
   }),
   onPageChange: React.PropTypes.func,
   subjectSets: React.PropTypes.arrayOf(React.PropTypes.object)

--- a/app/pages/lab/subject-sets.jsx
+++ b/app/pages/lab/subject-sets.jsx
@@ -8,11 +8,10 @@ const SubjectSetsPage = (props) => {
 
   return (
     <div>
-      <div className="form-label">Subject sets</div>
-      <small>
-        Subject sets are a group of data presented to volunteers in a project. A subject is typically
-        an image, graph, photo, audio recording, video, or a collection of these different things.
-      </small>
+      <header className="form-label">Subject sets</header>
+      <p>
+        Subject sets are a group of data presented to volunteers in a project.
+      </p>
       <ul className="nav-list">
         {props.subjectSets.map((subjectSet) => {
           const subjectSetListLabel = subjectSet.display_name || <i>{props.defaultSubjectSetName}</i>;

--- a/app/pages/lab/subject-sets.spec.js
+++ b/app/pages/lab/subject-sets.spec.js
@@ -13,17 +13,18 @@ const subjectSets = [
   { id: '2', display_name: 'Cool Subject Set', getMeta: meta }
 ];
 
-const context = { router: {}};
-
 describe('SubjectSetsPage', function () {
   let wrapper;
+  const newShortcut = sinon.spy();
 
   before(function () {
     wrapper = shallow(
-      <SubjectSetsPage />,
-      { disableLifecycleMethods: true, context }
+      <SubjectSetsPage
+        labPath={(url) => { return url; }}
+        createNewSubjectSet={newShortcut}
+      />
     );
-    wrapper.setState({ loading: false });
+    wrapper.setProps({ loading: false });
   });
 
   it('will display a message when no subject sets are present', function () {
@@ -32,20 +33,16 @@ describe('SubjectSetsPage', function () {
   });
 
   it('will display the correct amount of subject sets', function () {
-    wrapper.setState({ subjectSets });
+    wrapper.setProps({ subjectSets });
     assert.equal(wrapper.find('Link').length, 2);
   });
 
-  it('will display a paginator', function () {
-    wrapper.setState({ subjectSets });
-    assert.equal(wrapper.find('Paginator').length, 1);
+  it('should call the subject set create handler', function () {
+    wrapper.find('button').simulate('click');
+    sinon.assert.called(newShortcut);
   });
 
-  it('will allow for the creation of a new subject set', function () {
-    const newSubjectStub = sinon.stub(wrapper.instance(), 'createNewSubjectSet');
-    wrapper.instance().forceUpdate();
-    wrapper.update();
-    wrapper.find('button').simulate('click');
-    sinon.assert.called(newSubjectStub);
+  it('will display a paginator', function () {
+    assert.equal(wrapper.find('Paginator').length, 1);
   });
 });

--- a/app/pages/lab/subject-sets.spec.js
+++ b/app/pages/lab/subject-sets.spec.js
@@ -29,7 +29,7 @@ describe('SubjectSetsPage', function () {
 
   it('will display a message when no subject sets are present', function () {
     const message = 'No subject sets are currently associated with this project.';
-    assert.equal(wrapper.find('p').text(), message);
+    assert.equal(wrapper.find('#no-subject-set').text(), message);
   });
 
   it('will display the correct amount of subject sets', function () {

--- a/app/pages/lab/subject-sets.spec.js
+++ b/app/pages/lab/subject-sets.spec.js
@@ -2,7 +2,6 @@ import React from 'react';
 import assert from 'assert';
 import sinon from 'sinon';
 import { shallow } from 'enzyme';
-import Paginator from '../../talk/lib/paginator';
 import SubjectSetsPage from './subject-sets';
 
 const meta = () => {
@@ -39,7 +38,7 @@ describe('SubjectSetsPage', function () {
 
   it('will display a paginator', function () {
     wrapper.setState({ subjectSets });
-    assert.equal(wrapper.find(Paginator).length, 1);
+    assert.equal(wrapper.find('Paginator').length, 1);
   });
 
   it('will allow for the creation of a new subject set', function () {

--- a/app/pages/lab/subject-sets.spec.js
+++ b/app/pages/lab/subject-sets.spec.js
@@ -15,13 +15,13 @@ const subjectSets = [
 
 describe('SubjectSetsPage', function () {
   let wrapper;
-  const newShortcut = sinon.spy();
+  const newSubjectSet = sinon.spy();
 
   before(function () {
     wrapper = shallow(
       <SubjectSetsPage
         labPath={(url) => { return url; }}
-        createNewSubjectSet={newShortcut}
+        createNewSubjectSet={newSubjectSet}
       />
     );
     wrapper.setProps({ loading: false });
@@ -39,7 +39,7 @@ describe('SubjectSetsPage', function () {
 
   it('should call the subject set create handler', function () {
     wrapper.find('button').simulate('click');
-    sinon.assert.called(newShortcut);
+    sinon.assert.called(newSubjectSet);
   });
 
   it('will display a paginator', function () {

--- a/app/pages/lab/subject-sets.spec.js
+++ b/app/pages/lab/subject-sets.spec.js
@@ -29,7 +29,7 @@ describe('SubjectSetsPage', function () {
 
   it('will display a message when no subject sets are present', function () {
     const message = 'No subject sets are currently associated with this project.';
-    assert.equal(wrapper.find('#no-subject-set').text(), message);
+    assert.equal(wrapper.contains(<p>{message}</p>), true);
   });
 
   it('will display the correct amount of subject sets', function () {

--- a/app/pages/lab/subject-sets.spec.js
+++ b/app/pages/lab/subject-sets.spec.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import assert from 'assert';
+import sinon from 'sinon';
+import { shallow } from 'enzyme';
+import Paginator from '../../talk/lib/paginator';
+import SubjectSetsPage from './subject-sets';
+
+const meta = () => {
+  return { meta: { page: 1, page_size: 1 }};
+};
+
+const subjectSets = [
+  { id: '1', display_name: 'Rad Subject Set', getMeta: meta },
+  { id: '2', display_name: 'Cool Subject Set', getMeta: meta }
+];
+
+const context = { router: {}};
+
+describe('SubjectSetsPage', function () {
+  let wrapper;
+
+  before(function () {
+    wrapper = shallow(
+      <SubjectSetsPage />,
+      { disableLifecycleMethods: true, context }
+    );
+    wrapper.setState({ loading: false });
+  });
+
+  it('will display a message when no subject sets are present', function () {
+    const message = 'No subject sets are currently associated with this project.';
+    assert.equal(wrapper.find('p').text(), message);
+  });
+
+  it('will display the correct amount of subject sets', function () {
+    wrapper.setState({ subjectSets });
+    assert.equal(wrapper.find('Link').length, 2);
+  });
+
+  it('will display a paginator', function () {
+    wrapper.setState({ subjectSets });
+    assert.equal(wrapper.find(Paginator).length, 1);
+  });
+
+  it('will allow for the creation of a new subject set', function () {
+    const newSubjectStub = sinon.stub(wrapper.instance(), 'createNewSubjectSet');
+    wrapper.instance().forceUpdate();
+    wrapper.update();
+    wrapper.find('button').simulate('click');
+    sinon.assert.called(newSubjectStub);
+  });
+});

--- a/app/pages/lab/workflow-viewer/index.cjsx
+++ b/app/pages/lab/workflow-viewer/index.cjsx
@@ -44,7 +44,7 @@ module.exports = React.createClass
   displayName: 'WorkflowVisPageWrapper'
 
   propTypes:
-    params: React.PropTypes.shape({projectId: React.PropTypes.string, workflowId: React.PropTypes.string})
+    params: React.PropTypes.shape({projectID: React.PropTypes.string, workflowID: React.PropTypes.string})
 
   render: ->
     <PromiseRenderer promise={apiClient.type('workflows').get @props.params.workflowID}>{(workflow) =>

--- a/app/pages/lab/workflow.cjsx
+++ b/app/pages/lab/workflow.cjsx
@@ -53,7 +53,7 @@ EditWorkflowPage = React.createClass
 
   handleWorkflowCreation: (workflow) ->
     @hideCreateWorkflow()
-    newLocation = Object.assign {}, @props.location, pathname: "/lab/#{@props.project.id}/workflow/#{workflow.id}"
+    newLocation = Object.assign {}, @props.location, pathname: "/lab/#{@props.project.id}/workflows/#{workflow.id}"
     @context.router.push newLocation
     @props.project.uncacheLink 'workflows'
     @props.project.uncacheLink 'subject_sets' # An "expert" subject set is automatically created with each workflow.

--- a/app/pages/lab/workflow.cjsx
+++ b/app/pages/lab/workflow.cjsx
@@ -415,7 +415,7 @@ EditWorkflowPage = React.createClass
           <hr />
 
           <div>
-            <Link to="/lab/#{@props.project.id}/workflow/#{@props.workflow.id}/visualize" className="standard-button" params={workflowID: @props.workflow.id, projectID: @props.project.id} title="A workflow is the sequence of tasks that you’re asking volunteers to perform.">Visualize this workflow</Link>
+            <Link to="/lab/#{@props.project.id}/workflows/#{@props.workflow.id}/visualize" className="standard-button" params={workflowID: @props.workflow.id, projectID: @props.project.id} title="A workflow is the sequence of tasks that you’re asking volunteers to perform.">Visualize this workflow</Link>
           </div>
 
           <hr />

--- a/app/pages/lab/workflows-container.jsx
+++ b/app/pages/lab/workflows-container.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import getWorkflowsInOrder from '../../lib/get-workflows-in-order';
-import WorkflowsPage from './workflows';
 
 export default class WorkflowsContainer extends React.Component {
   constructor(props) {
@@ -15,32 +14,15 @@ export default class WorkflowsContainer extends React.Component {
     this.handleWorkflowCreation = this.handleWorkflowCreation.bind(this);
     this.hideCreateWorkflow = this.hideCreateWorkflow.bind(this);
     this.showCreateWorkflow = this.showCreateWorkflow.bind(this);
-    this.onPageChange = this.onPageChange.bind(this);
     this.handleWorkflowReorder = this.handleWorkflowReorder.bind(this);
   }
 
   componentDidMount() {
-    const page = this.props.location.query.page || 1;
-    this.getWorkflowList(page);
+    this.getWorkflowList();
   }
 
-  componentWillReceiveProps(nextProps) {
-    const newPage = nextProps.location.query.page;
-    if (newPage !== this.props.location.query.page) {
-      this.getWorkflowList(newPage);
-    }
-  }
-
-  onPageChange(page) {
-    const nextQuery = Object.assign({}, this.props.location.query, { page });
-    this.context.router.push({
-      pathname: this.props.location.pathname,
-      query: nextQuery
-    });
-  }
-
-  getWorkflowList(page = 1) {
-    getWorkflowsInOrder(this.props.project, { fields: 'display_name', page_size: 20, page })
+  getWorkflowList() {
+    getWorkflowsInOrder(this.props.project, { fields: 'display_name' })
     .then((workflows) => {
       this.setState({ workflows, loading: false });
     });
@@ -82,13 +64,16 @@ export default class WorkflowsContainer extends React.Component {
       hideCreateWorkflow: this.hideCreateWorkflow,
       handleWorkflowCreation: this.handleWorkflowCreation,
       handleWorkflowReorder: this.handleWorkflowReorder,
-      onPageChange: this.onPageChange,
       showCreateWorkflow: this.showCreateWorkflow,
       labPath: this.labPath
     };
 
+    const allProps = Object.assign({}, this.props, this.state, hookProps);
+
     return (
-      <WorkflowsPage {...this.props} {...hookProps} {...this.state} />
+      <div>
+        {React.cloneElement(this.props.children, allProps)}
+      </div>
     );
   }
 }
@@ -104,6 +89,7 @@ WorkflowsContainer.defaultProps = {
 };
 
 WorkflowsContainer.propTypes = {
+  children: React.PropTypes.node,
   location: React.PropTypes.shape({
     pathname: React.PropTypes.string,
     query: React.PropTypes.object

--- a/app/pages/lab/workflows-container.jsx
+++ b/app/pages/lab/workflows-container.jsx
@@ -1,0 +1,117 @@
+import React from 'react';
+import getWorkflowsInOrder from '../../lib/get-workflows-in-order';
+import WorkflowsPage from './workflows';
+
+export default class WorkflowsContainer extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      loading: true,
+      workflowCreationInProgress: false,
+      workflows: []
+    };
+
+    this.labPath = this.labPath.bind(this);
+    this.handleWorkflowCreation = this.handleWorkflowCreation.bind(this);
+    this.hideCreateWorkflow = this.hideCreateWorkflow.bind(this);
+    this.showCreateWorkflow = this.showCreateWorkflow.bind(this);
+    this.onPageChange = this.onPageChange.bind(this);
+    this.handleWorkflowReorder = this.handleWorkflowReorder.bind(this);
+  }
+
+  componentDidMount() {
+    const page = this.props.location.query.page || 1;
+    this.getWorkflowList(page);
+  }
+
+  componentWillReceiveProps(nextProps) {
+    const newPage = nextProps.location.query.page;
+    if (newPage !== this.props.location.query.page) {
+      this.getWorkflowList(newPage);
+    }
+  }
+
+  onPageChange(page) {
+    const nextQuery = Object.assign({}, this.props.location.query, { page });
+    this.context.router.push({
+      pathname: this.props.location.pathname,
+      query: nextQuery
+    });
+  }
+
+  getWorkflowList(page = 1) {
+    getWorkflowsInOrder(this.props.project, { fields: 'display_name', page_size: 20, page })
+    .then((workflows) => {
+      this.setState({ workflows, loading: false });
+    });
+  }
+
+  labPath(postFix = '') {
+    return `/lab/${this.props.project.id}${postFix}`;
+  }
+
+  showCreateWorkflow() {
+    this.setState({ workflowCreationInProgress: true });
+  }
+
+  hideCreateWorkflow() {
+    this.setState({ workflowCreationInProgress: false });
+  }
+
+  handleWorkflowReorder(newOrder) {
+    const newOrderIDs = newOrder.map((workflow) => {
+      return workflow.id;
+    });
+    this.props.project.update({
+      'configuration.workflow_order': newOrderIDs
+    });
+    this.setState({ workflows: newOrder });
+    this.props.project.save();
+  }
+
+  handleWorkflowCreation(workflow) {
+    this.hideCreateWorkflow();
+    const newLocation = Object.assign({}, this.props.location, { pathname: `/lab/${this.props.project.id}/workflow/${workflow.id}` });
+    this.context.router.push(newLocation);
+    this.props.project.uncacheLink('workflows');
+    this.props.project.uncacheLink('subject_sets'); // An "expert" subject set is automatically created with each workflow.
+  }
+
+  render() {
+    const hookProps = {
+      hideCreateWorkflow: this.hideCreateWorkflow,
+      handleWorkflowCreation: this.handleWorkflowCreation,
+      handleWorkflowReorder: this.handleWorkflowReorder,
+      onPageChange: this.onPageChange,
+      showCreateWorkflow: this.showCreateWorkflow,
+      labPath: this.labPath
+    };
+
+    return (
+      <WorkflowsPage {...this.props} {...hookProps} {...this.state} />
+    );
+  }
+}
+
+WorkflowsContainer.contextTypes = {
+  router: React.PropTypes.object.isRequired
+};
+
+WorkflowsContainer.defaultProps = {
+  project: {
+    configuration: {}
+  }
+};
+
+WorkflowsContainer.propTypes = {
+  location: React.PropTypes.shape({
+    pathname: React.PropTypes.string,
+    query: React.PropTypes.object
+  }),
+  project: React.PropTypes.shape({
+    id: React.PropTypes.string,
+    save: React.PropTypes.func,
+    uncacheLink: React.PropTypes.func,
+    update: React.PropTypes.func
+  })
+};

--- a/app/pages/lab/workflows-container.jsx
+++ b/app/pages/lab/workflows-container.jsx
@@ -71,7 +71,7 @@ export default class WorkflowsContainer extends React.Component {
 
   handleWorkflowCreation(workflow) {
     this.hideCreateWorkflow();
-    const newLocation = Object.assign({}, this.props.location, { pathname: `/lab/${this.props.project.id}/workflow/${workflow.id}` });
+    const newLocation = Object.assign({}, this.props.location, { pathname: `/lab/${this.props.project.id}/workflows/${workflow.id}` });
     this.context.router.push(newLocation);
     this.props.project.uncacheLink('workflows');
     this.props.project.uncacheLink('subject_sets'); // An "expert" subject set is automatically created with each workflow.

--- a/app/pages/lab/workflows-container.jsx
+++ b/app/pages/lab/workflows-container.jsx
@@ -21,12 +21,6 @@ export default class WorkflowsContainer extends React.Component {
     this.getWorkflowList();
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (this.props.location !== nextProps.location) {
-      this.getWorkflowList();
-    }
-  }
-
   getWorkflowList() {
     getWorkflowsInOrder(this.props.project, { fields: 'display_name' })
     .then((workflows) => {
@@ -63,6 +57,7 @@ export default class WorkflowsContainer extends React.Component {
     this.context.router.push(newLocation);
     this.props.project.uncacheLink('workflows');
     this.props.project.uncacheLink('subject_sets'); // An "expert" subject set is automatically created with each workflow.
+    this.getWorkflowList();
   }
 
   render() {

--- a/app/pages/lab/workflows-container.jsx
+++ b/app/pages/lab/workflows-container.jsx
@@ -21,6 +21,12 @@ export default class WorkflowsContainer extends React.Component {
     this.getWorkflowList();
   }
 
+  componentWillReceiveProps(nextProps) {
+    if (this.props.location !== nextProps.location) {
+      this.getWorkflowList();
+    }
+  }
+
   getWorkflowList() {
     getWorkflowsInOrder(this.props.project, { fields: 'display_name' })
     .then((workflows) => {

--- a/app/pages/lab/workflows.jsx
+++ b/app/pages/lab/workflows.jsx
@@ -11,6 +11,7 @@ export default class WorkflowsPage extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
+      loading: true,
       workflowCreationInProgress: false,
       workflows: []
     };
@@ -23,7 +24,7 @@ export default class WorkflowsPage extends React.Component {
     this.handleWorkflowReorder = this.handleWorkflowReorder.bind(this);
   }
 
-  componentWillMount() {
+  componentDidMount() {
     const page = this.props.location.query.page || 1;
     this.getWorkflowList(page);
   }
@@ -46,7 +47,7 @@ export default class WorkflowsPage extends React.Component {
   getWorkflowList(page = 1) {
     getWorkflowsInOrder(this.props.project, { fields: 'display_name', page_size: 20, page })
     .then((workflows) => {
-      this.setState({ workflows });
+      this.setState({ workflows, loading: false });
     });
   }
 
@@ -99,12 +100,21 @@ export default class WorkflowsPage extends React.Component {
 
     return (
       <div>
-        <div className="nav-list-header">Workflows</div>
+        <div className="form-label">Workflows</div>
 
         <DragReorderable tag="ul" className="nav-list" items={this.state.workflows} render={this.renderWorkflow} onChange={this.handleWorkflowReorder} />
 
+        {(this.state.workflows.length === 0 && this.state.loading === false) && (
+          <p> No workflows are currently associated with this project. </p>
+        )}
+
         <div className="nav-list-item">
-          <button type="button" onClick={this.showCreateWorkflow} disabled={this.state.workflowCreationInProgress} title="A workflow is the sequence of tasks that you’re asking volunteers to perform.">
+          <button
+            type="button"
+            onClick={this.showCreateWorkflow}
+            disabled={this.state.workflowCreationInProgress}
+            title="A workflow is the sequence of tasks that you’re asking volunteers to perform."
+          >
             New workflow{' '}
             <LoadingIndicator off={!this.state.workflowCreationInProgress} />
           </button>
@@ -122,7 +132,7 @@ export default class WorkflowsPage extends React.Component {
           </ModalFormDialog>
         )}
 
-        {this.state.workflows.length && (
+        {this.state.workflows.length > 0 && (
           <Paginator
             className="talk"
             page={meta.page}

--- a/app/pages/lab/workflows.jsx
+++ b/app/pages/lab/workflows.jsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import { Link } from 'react-router';
 import DragReorderable from 'drag-reorderable';
+import ModalFormDialog from 'modal-form/dialog';
+import Paginator from '../../talk/lib/paginator';
+import WorkflowCreateForm from './workflow-create-form';
 import LoadingIndicator from '../../components/loading-indicator';
 import getWorkflowsInOrder from '../../lib/get-workflows-in-order';
 
@@ -12,11 +15,36 @@ export default class WorkflowsPage extends React.Component {
       workflows: []
     };
 
+    this.handleWorkflowCreation = this.handleWorkflowCreation.bind(this);
+    this.hideCreateWorkflow = this.hideCreateWorkflow.bind(this);
     this.showCreateWorkflow = this.showCreateWorkflow.bind(this);
+    this.onPageChange = this.onPageChange.bind(this);
+    this.renderWorkflow = this.renderWorkflow.bind(this);
+    this.handleWorkflowReorder = this.handleWorkflowReorder.bind(this);
   }
 
   componentWillMount() {
-    getWorkflowsInOrder(this.props.project, { fields: 'display_name' })
+    const page = this.props.location.query.page || 1;
+    this.getWorkflowList(page);
+  }
+
+  componentWillReceiveProps(nextProps) {
+    const newPage = nextProps.location.query.page;
+    if (newPage !== this.props.location.query.page) {
+      this.getWorkflowList(newPage);
+    }
+  }
+
+  onPageChange(page) {
+    const nextQuery = Object.assign({}, this.props.location.query, { page });
+    this.context.router.push({
+      pathname: this.props.location.pathname,
+      query: nextQuery
+    });
+  }
+
+  getWorkflowList(page = 1) {
+    getWorkflowsInOrder(this.props.project, { fields: 'display_name', page_size: 20, page })
     .then((workflows) => {
       this.setState({ workflows });
     });
@@ -30,21 +58,50 @@ export default class WorkflowsPage extends React.Component {
     this.setState({ workflowCreationInProgress: true });
   }
 
+  hideCreateWorkflow() {
+    this.setState({ workflowCreationInProgress: false });
+  }
+
+  handleWorkflowReorder(newOrder) {
+    const newOrderIDs = newOrder.map((workflow) => {
+      return workflow.id;
+    });
+    this.props.project.update({
+      'configuration.workflow_order': newOrderIDs
+    });
+    this.setState({ workflows: newOrder });
+    this.props.project.save();
+  }
+
+  handleWorkflowCreation(workflow) {
+    this.hideCreateWorkflow();
+    const newLocation = Object.assign({}, this.props.location, { pathname: `/lab/${this.props.project.id}/workflow/${workflow.id}` });
+    this.context.router.push(newLocation);
+    this.props.project.uncacheLink('workflows');
+    this.props.project.uncacheLink('subject_sets'); // An "expert" subject set is automatically created with each workflow.
+  }
+
+  renderWorkflow(workflow) {
+    return (
+      <li key={workflow.id}>
+        <Link key={workflow.id} to={this.labPath(`/workflow/${workflow.id}`)} className="nav-list-item" activeClassName="active">
+          {workflow.display_name}
+          {workflow.id === this.props.project.configuration.default_workflow && (
+            <span title="Default workflow">{' '}*{' '}</span>
+          )}
+        </Link>
+      </li>
+    );
+  }
+
   render() {
+    const meta = this.state.workflows.length ? this.state.workflows[0].getMeta() : {};
+
     return (
       <div>
         <div className="nav-list-header">Workflows</div>
 
-        {this.state.workflows.map((workflow) => {
-          return (
-            <Link to={this.labPath(`/workflow/${workflow.id}`)} className="nav-list-item" activeClassName="active">
-              {workflow.display_name}
-              {workflow.id === this.props.project.configuration.default_workflow && (
-                <span title="Default workflow">{' '}*{' '}</span>
-              )}
-            </Link>
-          );
-        })}
+        <DragReorderable tag="ul" className="nav-list" items={this.state.workflows} render={this.renderWorkflow} onChange={this.handleWorkflowReorder} />
 
         <div className="nav-list-item">
           <button type="button" onClick={this.showCreateWorkflow} disabled={this.state.workflowCreationInProgress} title="A workflow is the sequence of tasks that you’re asking volunteers to perform.">
@@ -52,6 +109,27 @@ export default class WorkflowsPage extends React.Component {
             <LoadingIndicator off={!this.state.workflowCreationInProgress} />
           </button>
         </div>
+
+        {this.state.workflowCreationInProgress && (
+          <ModalFormDialog tag="div">
+            <WorkflowCreateForm
+              onSubmit={this.props.workflowActions.createWorkflowForProject}
+              onCancel={this.hideCreateWorkflow}
+              onSuccess={this.handleWorkflowCreation}
+              projectID={this.props.project.id}
+              workflowActiveStatus={!this.props.project.live}
+            />
+          </ModalFormDialog>
+        )}
+
+        {this.state.workflows.length && (
+          <Paginator
+            className="talk"
+            page={meta.page}
+            onPageChange={this.onPageChange}
+            pageCount={meta.page_count}
+          />
+        )}
 
       </div>
     );
@@ -67,8 +145,19 @@ WorkflowsPage.defaultProps = {
 };
 
 WorkflowsPage.propTypes = {
+  location: React.PropTypes.shape({
+    pathname: React.PropTypes.string,
+    query: React.PropTypes.object
+  }),
   project: React.PropTypes.shape({
     configuration: React.PropTypes.object,
-    id: React.PropTypes.string
+    id: React.PropTypes.string,
+    live: React.PropTypes.bool,
+    save: React.PropTypes.func,
+    uncacheLink: React.PropTypes.func,
+    update: React.PropTypes.func
+  }),
+  workflowActions: React.PropTypes.shape({
+    createWorkflowForProject: React.PropTypes.func
   })
 };

--- a/app/pages/lab/workflows.jsx
+++ b/app/pages/lab/workflows.jsx
@@ -5,174 +5,96 @@ import ModalFormDialog from 'modal-form/dialog';
 import Paginator from '../../talk/lib/paginator';
 import WorkflowCreateForm from './workflow-create-form';
 import LoadingIndicator from '../../components/loading-indicator';
-import getWorkflowsInOrder from '../../lib/get-workflows-in-order';
 
-export default class WorkflowsPage extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      loading: true,
-      workflowCreationInProgress: false,
-      workflows: []
-    };
+const WorkflowsPage = (props) => {
+  const meta = props.workflows.length ? props.workflows[0].getMeta() : {};
 
-    this.handleWorkflowCreation = this.handleWorkflowCreation.bind(this);
-    this.hideCreateWorkflow = this.hideCreateWorkflow.bind(this);
-    this.showCreateWorkflow = this.showCreateWorkflow.bind(this);
-    this.onPageChange = this.onPageChange.bind(this);
-    this.renderWorkflow = this.renderWorkflow.bind(this);
-    this.handleWorkflowReorder = this.handleWorkflowReorder.bind(this);
-  }
-
-  componentDidMount() {
-    const page = this.props.location.query.page || 1;
-    this.getWorkflowList(page);
-  }
-
-  componentWillReceiveProps(nextProps) {
-    const newPage = nextProps.location.query.page;
-    if (newPage !== this.props.location.query.page) {
-      this.getWorkflowList(newPage);
-    }
-  }
-
-  onPageChange(page) {
-    const nextQuery = Object.assign({}, this.props.location.query, { page });
-    this.context.router.push({
-      pathname: this.props.location.pathname,
-      query: nextQuery
-    });
-  }
-
-  getWorkflowList(page = 1) {
-    getWorkflowsInOrder(this.props.project, { fields: 'display_name', page_size: 20, page })
-    .then((workflows) => {
-      this.setState({ workflows, loading: false });
-    });
-  }
-
-  labPath(postFix = '') {
-    return `/lab/${this.props.project.id}${postFix}`;
-  }
-
-  showCreateWorkflow() {
-    this.setState({ workflowCreationInProgress: true });
-  }
-
-  hideCreateWorkflow() {
-    this.setState({ workflowCreationInProgress: false });
-  }
-
-  handleWorkflowReorder(newOrder) {
-    const newOrderIDs = newOrder.map((workflow) => {
-      return workflow.id;
-    });
-    this.props.project.update({
-      'configuration.workflow_order': newOrderIDs
-    });
-    this.setState({ workflows: newOrder });
-    this.props.project.save();
-  }
-
-  handleWorkflowCreation(workflow) {
-    this.hideCreateWorkflow();
-    const newLocation = Object.assign({}, this.props.location, { pathname: `/lab/${this.props.project.id}/workflow/${workflow.id}` });
-    this.context.router.push(newLocation);
-    this.props.project.uncacheLink('workflows');
-    this.props.project.uncacheLink('subject_sets'); // An "expert" subject set is automatically created with each workflow.
-  }
-
-  renderWorkflow(workflow) {
+  const renderWorkflow = ((workflow) => {
     return (
       <li key={workflow.id}>
-        <Link key={workflow.id} to={this.labPath(`/workflow/${workflow.id}`)} className="nav-list-item" activeClassName="active">
+        <Link key={workflow.id} to={props.labPath(`/workflow/${workflow.id}`)} className="nav-list-item" activeClassName="active">
           {workflow.display_name}
-          {workflow.id === this.props.project.configuration.default_workflow && (
+          {workflow.id === props.project.configuration.default_workflow && (
             <span title="Default workflow">{' '}*{' '}</span>
           )}
         </Link>
       </li>
     );
-  }
+  });
 
-  render() {
-    const meta = this.state.workflows.length ? this.state.workflows[0].getMeta() : {};
+  return (
+    <div>
+      <div className="form-label">Workflows</div>
 
-    return (
-      <div>
-        <div className="form-label">Workflows</div>
+      <DragReorderable tag="ul" className="nav-list" items={props.workflows} render={renderWorkflow} onChange={props.handleWorkflowReorder} />
 
-        <DragReorderable tag="ul" className="nav-list" items={this.state.workflows} render={this.renderWorkflow} onChange={this.handleWorkflowReorder} />
+      {(props.workflows.length === 0 && props.loading === false) && (
+        <p>No workflows are currently associated with this project.</p>
+      )}
 
-        {(this.state.workflows.length === 0 && this.state.loading === false) && (
-          <p>No workflows are currently associated with this project.</p>
-        )}
-
-        <div className="nav-list-item">
-          <button
-            type="button"
-            onClick={this.showCreateWorkflow}
-            disabled={this.state.workflowCreationInProgress}
-            title="A workflow is the sequence of tasks that you’re asking volunteers to perform."
-          >
-            New workflow{' '}
-            <LoadingIndicator off={!this.state.workflowCreationInProgress} />
-          </button>
-        </div>
-
-        {this.state.workflowCreationInProgress && (
-          <ModalFormDialog tag="div">
-            <WorkflowCreateForm
-              onSubmit={this.props.workflowActions.createWorkflowForProject}
-              onCancel={this.hideCreateWorkflow}
-              onSuccess={this.handleWorkflowCreation}
-              projectID={this.props.project.id}
-              workflowActiveStatus={!this.props.project.live}
-            />
-          </ModalFormDialog>
-        )}
-
-        {this.state.workflows.length > 0 && (
-          <Paginator
-            className="talk"
-            page={meta.page}
-            onPageChange={this.onPageChange}
-            pageCount={meta.page_count}
-          />
-        )}
-
+      <div className="nav-list-item">
+        <button
+          type="button"
+          onClick={props.showCreateWorkflow}
+          disabled={props.workflowCreationInProgress}
+          title="A workflow is the sequence of tasks that you’re asking volunteers to perform."
+        >
+          New workflow{' '}
+          <LoadingIndicator off={!props.workflowCreationInProgress} />
+        </button>
       </div>
-    );
-  }
-}
 
-WorkflowsPage.contextTypes = {
-  router: React.PropTypes.object.isRequired
+      {props.workflowCreationInProgress && (
+        <ModalFormDialog tag="div">
+          <WorkflowCreateForm
+            onSubmit={props.workflowActions.createWorkflowForProject}
+            onCancel={props.hideCreateWorkflow}
+            onSuccess={props.handleWorkflowCreation}
+            projectID={props.project.id}
+            workflowActiveStatus={!props.project.live}
+          />
+        </ModalFormDialog>
+      )}
+
+      {props.workflows.length > 0 && (
+        <Paginator
+          className="talk"
+          page={meta.page}
+          onPageChange={props.onPageChange}
+          pageCount={meta.page_count}
+        />
+      )}
+
+    </div>
+  );
 };
 
 WorkflowsPage.defaultProps = {
-  project: {
-    configuration: {}
-  },
+  labPath: () => {},
+  workflows: [],
   workflowActions: {
     createWorkflowForProject: () => {}
   }
 };
 
 WorkflowsPage.propTypes = {
-  location: React.PropTypes.shape({
-    pathname: React.PropTypes.string,
-    query: React.PropTypes.object
-  }),
+  hideCreateWorkflow: React.PropTypes.func,
+  handleWorkflowCreation: React.PropTypes.func,
+  handleWorkflowReorder: React.PropTypes.func,
+  labPath: React.PropTypes.func,
+  loading: React.PropTypes.bool,
+  onPageChange: React.PropTypes.func,
   project: React.PropTypes.shape({
     configuration: React.PropTypes.object,
     id: React.PropTypes.string,
-    live: React.PropTypes.bool,
-    save: React.PropTypes.func,
-    uncacheLink: React.PropTypes.func,
-    update: React.PropTypes.func
+    live: React.PropTypes.bool
   }),
+  showCreateWorkflow: React.PropTypes.func,
+  workflows: React.PropTypes.arrayOf(React.PropTypes.object),
   workflowActions: React.PropTypes.shape({
     createWorkflowForProject: React.PropTypes.func
-  })
+  }),
+  workflowCreationInProgress: React.PropTypes.bool
 };
+
+export default WorkflowsPage;

--- a/app/pages/lab/workflows.jsx
+++ b/app/pages/lab/workflows.jsx
@@ -21,10 +21,10 @@ const WorkflowsPage = (props) => {
 
   return (
     <div>
-      <div className="form-label">Workflows</div>
+      <header className="form-label">Workflows</header>
 
-      <small>A workflow is the sequence of tasks that you’re asking volunteers to perform.</small> <br />
-      <small> An asterisk (*) denotes a default workflow. </small>
+      <p>A workflow is the sequence of tasks that you’re asking volunteers to perform.</p> <br />
+      <p> An asterisk (*) denotes a default workflow. </p>
 
       <DragReorderable tag="ul" className="nav-list" items={props.workflows} render={renderWorkflow} onChange={props.handleWorkflowReorder} />
 

--- a/app/pages/lab/workflows.jsx
+++ b/app/pages/lab/workflows.jsx
@@ -29,7 +29,7 @@ const WorkflowsPage = (props) => {
       <DragReorderable tag="ul" className="nav-list" items={props.workflows} render={renderWorkflow} onChange={props.handleWorkflowReorder} />
 
       {(props.workflows.length === 0 && props.loading === false) && (
-        <p>No workflows are currently associated with this project.</p>
+        <p id="no-workflows">No workflows are currently associated with this project.</p>
       )}
 
       <div className="nav-list-item">

--- a/app/pages/lab/workflows.jsx
+++ b/app/pages/lab/workflows.jsx
@@ -2,17 +2,14 @@ import React from 'react';
 import { Link } from 'react-router';
 import DragReorderable from 'drag-reorderable';
 import ModalFormDialog from 'modal-form/dialog';
-import Paginator from '../../talk/lib/paginator';
 import WorkflowCreateForm from './workflow-create-form';
 import LoadingIndicator from '../../components/loading-indicator';
 
 const WorkflowsPage = (props) => {
-  const meta = props.workflows.length ? props.workflows[0].getMeta() : {};
-
   const renderWorkflow = ((workflow) => {
     return (
       <li key={workflow.id}>
-        <Link key={workflow.id} to={props.labPath(`/workflow/${workflow.id}`)} className="nav-list-item" activeClassName="active">
+        <Link key={workflow.id} to={props.labPath(`/workflows/${workflow.id}`)} className="nav-list-item" activeClassName="active">
           {workflow.display_name}
           {workflow.id === props.project.configuration.default_workflow && (
             <span title="Default workflow">{' '}*{' '}</span>
@@ -26,6 +23,9 @@ const WorkflowsPage = (props) => {
     <div>
       <div className="form-label">Workflows</div>
 
+      <small>A workflow is the sequence of tasks that you’re asking volunteers to perform.</small> <br />
+      <small> An asterisk (*) denotes a default workflow. </small>
+
       <DragReorderable tag="ul" className="nav-list" items={props.workflows} render={renderWorkflow} onChange={props.handleWorkflowReorder} />
 
       {(props.workflows.length === 0 && props.loading === false) && (
@@ -37,7 +37,6 @@ const WorkflowsPage = (props) => {
           type="button"
           onClick={props.showCreateWorkflow}
           disabled={props.workflowCreationInProgress}
-          title="A workflow is the sequence of tasks that you’re asking volunteers to perform."
         >
           New workflow{' '}
           <LoadingIndicator off={!props.workflowCreationInProgress} />
@@ -54,15 +53,6 @@ const WorkflowsPage = (props) => {
             workflowActiveStatus={!props.project.live}
           />
         </ModalFormDialog>
-      )}
-
-      {props.workflows.length > 0 && (
-        <Paginator
-          className="talk"
-          page={meta.page}
-          onPageChange={props.onPageChange}
-          pageCount={meta.page_count}
-        />
       )}
 
     </div>
@@ -83,7 +73,6 @@ WorkflowsPage.propTypes = {
   handleWorkflowReorder: React.PropTypes.func,
   labPath: React.PropTypes.func,
   loading: React.PropTypes.bool,
-  onPageChange: React.PropTypes.func,
   project: React.PropTypes.shape({
     configuration: React.PropTypes.object,
     id: React.PropTypes.string,

--- a/app/pages/lab/workflows.jsx
+++ b/app/pages/lab/workflows.jsx
@@ -105,7 +105,7 @@ export default class WorkflowsPage extends React.Component {
         <DragReorderable tag="ul" className="nav-list" items={this.state.workflows} render={this.renderWorkflow} onChange={this.handleWorkflowReorder} />
 
         {(this.state.workflows.length === 0 && this.state.loading === false) && (
-          <p> No workflows are currently associated with this project. </p>
+          <p>No workflows are currently associated with this project.</p>
         )}
 
         <div className="nav-list-item">

--- a/app/pages/lab/workflows.jsx
+++ b/app/pages/lab/workflows.jsx
@@ -23,13 +23,13 @@ const WorkflowsPage = (props) => {
     <div>
       <header className="form-label">Workflows</header>
 
-      <p>A workflow is the sequence of tasks that you’re asking volunteers to perform.</p> <br />
+      <p>A workflow is the sequence of tasks that you’re asking volunteers to perform.</p>
       <p> An asterisk (*) denotes a default workflow. </p>
 
       <DragReorderable tag="ul" className="nav-list" items={props.workflows} render={renderWorkflow} onChange={props.handleWorkflowReorder} />
 
       {(props.workflows.length === 0 && props.loading === false) && (
-        <p id="no-workflows">No workflows are currently associated with this project.</p>
+        <p>No workflows are currently associated with this project.</p>
       )}
 
       <div className="nav-list-item">

--- a/app/pages/lab/workflows.jsx
+++ b/app/pages/lab/workflows.jsx
@@ -153,6 +153,9 @@ WorkflowsPage.contextTypes = {
 WorkflowsPage.defaultProps = {
   project: {
     configuration: {}
+  },
+  workflowActions: {
+    createWorkflowForProject: () => {}
   }
 };
 

--- a/app/pages/lab/workflows.jsx
+++ b/app/pages/lab/workflows.jsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { Link } from 'react-router';
+import DragReorderable from 'drag-reorderable';
+import LoadingIndicator from '../../components/loading-indicator';
+import getWorkflowsInOrder from '../../lib/get-workflows-in-order';
+
+export default class WorkflowsPage extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      workflowCreationInProgress: false,
+      workflows: []
+    };
+
+    this.showCreateWorkflow = this.showCreateWorkflow.bind(this);
+  }
+
+  componentWillMount() {
+    getWorkflowsInOrder(this.props.project, { fields: 'display_name' })
+    .then((workflows) => {
+      this.setState({ workflows });
+    });
+  }
+
+  labPath(postFix = '') {
+    return `/lab/${this.props.project.id}${postFix}`;
+  }
+
+  showCreateWorkflow() {
+    this.setState({ workflowCreationInProgress: true });
+  }
+
+  render() {
+    return (
+      <div>
+        <div className="nav-list-header">Workflows</div>
+
+        {this.state.workflows.map((workflow) => {
+          return (
+            <Link to={this.labPath(`/workflow/${workflow.id}`)} className="nav-list-item" activeClassName="active">
+              {workflow.display_name}
+              {workflow.id === this.props.project.configuration.default_workflow && (
+                <span title="Default workflow">{' '}*{' '}</span>
+              )}
+            </Link>
+          );
+        })}
+
+        <div className="nav-list-item">
+          <button type="button" onClick={this.showCreateWorkflow} disabled={this.state.workflowCreationInProgress} title="A workflow is the sequence of tasks that you’re asking volunteers to perform.">
+            New workflow{' '}
+            <LoadingIndicator off={!this.state.workflowCreationInProgress} />
+          </button>
+        </div>
+
+      </div>
+    );
+  }
+}
+
+WorkflowsPage.contextTypes = {
+  router: React.PropTypes.object.isRequired
+};
+
+WorkflowsPage.defaultProps = {
+  project: {}
+};
+
+WorkflowsPage.propTypes = {
+  project: React.PropTypes.shape({
+    configuration: React.PropTypes.object,
+    id: React.PropTypes.string
+  })
+};

--- a/app/pages/lab/workflows.jsx
+++ b/app/pages/lab/workflows.jsx
@@ -151,7 +151,9 @@ WorkflowsPage.contextTypes = {
 };
 
 WorkflowsPage.defaultProps = {
-  project: {}
+  project: {
+    configuration: {}
+  }
 };
 
 WorkflowsPage.propTypes = {

--- a/app/pages/lab/workflows.jsx
+++ b/app/pages/lab/workflows.jsx
@@ -11,7 +11,7 @@ const WorkflowsPage = (props) => {
       <li key={workflow.id}>
         <Link key={workflow.id} to={props.labPath(`/workflows/${workflow.id}`)} className="nav-list-item" activeClassName="active">
           {workflow.display_name}
-          {workflow.id === props.project.configuration.default_workflow && (
+          {(props.project.configuration && workflow.id === props.project.configuration.default_workflow) && (
             <span title="Default workflow">{' '}*{' '}</span>
           )}
         </Link>

--- a/app/pages/lab/workflows.spec.js
+++ b/app/pages/lab/workflows.spec.js
@@ -13,18 +13,21 @@ const workflows = [
   { id: '2', display_name: 'Cool Workflow', getMeta: meta }
 ];
 
-const context = { router: {}};
+const project = { id: '1', configuration: {}};
 
-describe('SubjectSetsPage', function () {
+const createHref = function(channel) { return { bind: function(event, callback) { } }};
+const isActive = function(channel) { return { bind: function(event, callback) { } }};
+const context = { router: { createHref, isActive }};
+
+describe('WorkflowsPage', function () {
   let wrapper;
 
   before(function () {
-    sinon.stub(WorkflowsPage.prototype, 'componentDidMount');
-    wrapper = mount(
+    wrapper = shallow(
       <WorkflowsPage />,
       { disableLifecycleMethods: true, context }
     );
-    wrapper.setState({ loading: false, workflows });
+    wrapper.setState({ loading: false });
   });
 
   it('will display a message when no workflows are present', function () {
@@ -33,9 +36,6 @@ describe('SubjectSetsPage', function () {
   });
 
   // it('will display the correct number of workflows', function () {
-  //   wrapper.setState({ workflows });
-  //   console.log(wrapper.find('button'));
-  //   assert.equal(wrapper.find('a').length, 2);
   // });
   //
   // it('will display workflows as a link', function () {
@@ -43,4 +43,21 @@ describe('SubjectSetsPage', function () {
   //
   // it('will allow for the creation of a new sworkflow', function () {
   // });
+});
+
+describe('WorkflowsPage', function () {
+  let wrapper;
+
+  before(function () {
+    sinon.stub(WorkflowsPage.prototype, 'componentDidMount');
+    wrapper = mount(
+      <WorkflowsPage />,
+      { context }
+    );
+    wrapper.setState({ workflows, loading: false });
+  });
+
+  it('will display a message when no workflows are present', function () {
+    const message = 'No workflows are currently associated with this project.';
+  });
 });

--- a/app/pages/lab/workflows.spec.js
+++ b/app/pages/lab/workflows.spec.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import assert from 'assert';
-import { shallow, mount } from 'enzyme';
-import sinon from 'sinon';
+import { shallow } from 'enzyme';
 import WorkflowsPage from './workflows';
 
 const meta = () => {
@@ -35,29 +34,17 @@ describe('WorkflowsPage', function () {
     assert.equal(wrapper.find('p').text(), message);
   });
 
-  // it('will display the correct number of workflows', function () {
-  // });
-  //
-  // it('will display workflows as a link', function () {
-  // });
-  //
-  // it('will allow for the creation of a new sworkflow', function () {
-  // });
-});
-
-describe('WorkflowsPage', function () {
-  let wrapper;
-
-  before(function () {
-    sinon.stub(WorkflowsPage.prototype, 'componentDidMount');
-    wrapper = mount(
-      <WorkflowsPage />,
-      { context }
-    );
+  it('will display the correct amount of workflows', function () {
     wrapper.setState({ workflows, loading: false });
+    assert.equal(wrapper.find('DragReorderable').render().find('li').length, 2);
   });
 
-  it('will display a message when no workflows are present', function () {
-    const message = 'No workflows are currently associated with this project.';
+  it('will display a form to create a new workflow', function () {
+    wrapper.find('button').simulate('click');
+    assert.equal(wrapper.find('WorkflowCreateForm').length, 1);
+  });
+
+  it('will display a paginator', function () {
+    assert.equal(wrapper.find('Paginator').length, 1);
   });
 });

--- a/app/pages/lab/workflows.spec.js
+++ b/app/pages/lab/workflows.spec.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import assert from 'assert';
+import WorkflowsPage from './workflows';
+import { shallow } from 'enzyme';
+
+const meta = () => {
+  return { meta: { page: 1, page_size: 1 }};
+};
+
+const workflows = [
+  { id: '1', display_name: 'Rad Workflow', getMeta: meta },
+  { id: '2', display_name: 'Cool Workflow', getMeta: meta }
+];
+
+const context = { router: {}};
+
+describe('SubjectSetsPage', function () {
+  let wrapper;
+
+  before(function () {
+    wrapper = shallow(
+      <WorkflowsPage />,
+      { disableLifecycleMethods: true, context }
+    );
+    wrapper.setState({ loading: false });
+  });
+
+  it('will display a message when no workflows are present', function () {
+    const message = 'No workflows are currently associated with this project.';
+    assert.equal(wrapper.find('p').text(), message);
+  });
+
+  it('will display the correct number of workflows', function () {
+    wrapper.setState({ workflows });
+    console.log(wrapper.find('button'));
+    assert.equal(wrapper.find('Link').length, 2);
+  });
+  //
+  // it('will display workflows as a link', function () {
+  // });
+  //
+  // it('will allow for the creation of a new sworkflow', function () {
+  // });
+});

--- a/app/pages/lab/workflows.spec.js
+++ b/app/pages/lab/workflows.spec.js
@@ -47,8 +47,4 @@ describe('WorkflowsPage', function () {
     wrapper.find('button').simulate('click');
     sinon.assert.called(newWorkflow);
   });
-
-  it('will display a paginator', function () {
-    assert.equal(wrapper.find('Paginator').length, 1);
-  });
 });

--- a/app/pages/lab/workflows.spec.js
+++ b/app/pages/lab/workflows.spec.js
@@ -35,7 +35,7 @@ describe('WorkflowsPage', function () {
 
   it('will display a message when no workflows are present', function () {
     const message = 'No workflows are currently associated with this project.';
-    assert.equal(wrapper.find('p').text(), message);
+    assert.equal(wrapper.find('#no-workflows').text(), message);
   });
 
   it('will display the correct amount of workflows', function () {

--- a/app/pages/lab/workflows.spec.js
+++ b/app/pages/lab/workflows.spec.js
@@ -12,11 +12,10 @@ const workflows = [
   { id: '2', display_name: 'Cool Workflow', getMeta: meta }
 ];
 
-const project = { id: '1', configuration: {}};
-
-const createHref = function(channel) { return { bind: function(event, callback) { } }};
-const isActive = function(channel) { return { bind: function(event, callback) { } }};
-const context = { router: { createHref, isActive }};
+const context = { router: {
+  createHref: () => {},
+  isActive: () => {}
+}};
 
 describe('WorkflowsPage', function () {
   let wrapper;

--- a/app/pages/lab/workflows.spec.js
+++ b/app/pages/lab/workflows.spec.js
@@ -35,7 +35,7 @@ describe('WorkflowsPage', function () {
 
   it('will display a message when no workflows are present', function () {
     const message = 'No workflows are currently associated with this project.';
-    assert.equal(wrapper.find('#no-workflows').text(), message);
+    assert.equal(wrapper.contains(<p>{message}</p>), true);
   });
 
   it('will display the correct amount of workflows', function () {

--- a/app/pages/lab/workflows.spec.js
+++ b/app/pages/lab/workflows.spec.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import assert from 'assert';
 import { shallow } from 'enzyme';
+import sinon from 'sinon';
 import WorkflowsPage from './workflows';
 
 const meta = () => {
@@ -12,20 +13,24 @@ const workflows = [
   { id: '2', display_name: 'Cool Workflow', getMeta: meta }
 ];
 
-const context = { router: {
-  createHref: () => {},
-  isActive: () => {}
-}};
+const project = {
+  configuration: {}
+};
 
 describe('WorkflowsPage', function () {
   let wrapper;
+  const newWorkflow = sinon.spy();
 
   before(function () {
     wrapper = shallow(
-      <WorkflowsPage />,
-      { disableLifecycleMethods: true, context }
+      <WorkflowsPage
+        labPath={(url) => { return url; }}
+        handleWorkflowReorder={() => {}}
+        project={project}
+        showCreateWorkflow={newWorkflow}
+      />
     );
-    wrapper.setState({ loading: false });
+    wrapper.setProps({ loading: false });
   });
 
   it('will display a message when no workflows are present', function () {
@@ -34,13 +39,13 @@ describe('WorkflowsPage', function () {
   });
 
   it('will display the correct amount of workflows', function () {
-    wrapper.setState({ workflows, loading: false });
+    wrapper.setProps({ workflows });
     assert.equal(wrapper.find('DragReorderable').render().find('li').length, 2);
   });
 
-  it('will display a form to create a new workflow', function () {
+  it('should call the workflow create handler', function () {
     wrapper.find('button').simulate('click');
-    assert.equal(wrapper.find('WorkflowCreateForm').length, 1);
+    sinon.assert.called(newWorkflow);
   });
 
   it('will display a paginator', function () {

--- a/app/pages/lab/workflows.spec.js
+++ b/app/pages/lab/workflows.spec.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import assert from 'assert';
+import { shallow, mount } from 'enzyme';
+import sinon from 'sinon';
 import WorkflowsPage from './workflows';
-import { shallow } from 'enzyme';
 
 const meta = () => {
   return { meta: { page: 1, page_size: 1 }};
@@ -18,11 +19,12 @@ describe('SubjectSetsPage', function () {
   let wrapper;
 
   before(function () {
-    wrapper = shallow(
+    sinon.stub(WorkflowsPage.prototype, 'componentDidMount');
+    wrapper = mount(
       <WorkflowsPage />,
       { disableLifecycleMethods: true, context }
     );
-    wrapper.setState({ loading: false });
+    wrapper.setState({ loading: false, workflows });
   });
 
   it('will display a message when no workflows are present', function () {
@@ -30,11 +32,11 @@ describe('SubjectSetsPage', function () {
     assert.equal(wrapper.find('p').text(), message);
   });
 
-  it('will display the correct number of workflows', function () {
-    wrapper.setState({ workflows });
-    console.log(wrapper.find('button'));
-    assert.equal(wrapper.find('Link').length, 2);
-  });
+  // it('will display the correct number of workflows', function () {
+  //   wrapper.setState({ workflows });
+  //   console.log(wrapper.find('button'));
+  //   assert.equal(wrapper.find('a').length, 2);
+  // });
   //
   // it('will display workflows as a link', function () {
   // });

--- a/app/router.cjsx
+++ b/app/router.cjsx
@@ -19,7 +19,9 @@ React = require 'react'
 `import WorkflowsPage from './pages/lab/workflows';`
 `import SubjectSetsPage from './components/subject-sets';`
 `import WorkflowsContainer from './pages/lab/workflows-container';`
+`import WorkflowsList from './pages/lab/workflows';`
 `import SubjectSetsContainer from './pages/lab/subject-sets-container';`
+`import SubjectSetsList from './pages/lab/subject-sets';`
 
 # <Redirect from="home" to="/" /> doesn't work.
 ONE_UP_REDIRECT = React.createClass
@@ -197,16 +199,18 @@ module.exports =
       <Route path="data-exports" component={require './pages/lab/data-dumps'} />
       <Route path="tutorial" component={require './pages/lab/tutorial'} />
       <Route path="guide" component={require './pages/lab/field-guide'} />
-      <Route path="workflows" component={WorkflowsContainer} />
-      <Route path="workflows/:workflowID" component={require './pages/lab/workflow'} />
-      <Route path="workflows/:workflowID/visualize" component={require './pages/lab/workflow-viewer'} />
-      <Route path="workflows/:workflowID/visualise" component={require './pages/lab/workflow-viewer'} />
-      <Redirect from="workflow/:workflowID" to="workflows/:workflowID" />
-      <Redirect from="workflow/:workflowID/visualize" to="workflows/:workflowID/visualize" />
-      <Redirect from="workflow/:workflowID/visualise" to="workflows/:workflowID/visualise" />
-      <Route path="subject-sets" component={SubjectSetsContainer} />
-      <Route path="subject-sets/:subjectSetID" component={require './pages/lab/subject-set'} />
-      <Redirect from="subject-set/:subjectSetID" to="subject-sets/:subjectSetID" />
+      <Redirect from="workflow/*" to="workflows/*" />
+      <Route path="workflows" component={WorkflowsContainer}>
+        <IndexRoute component={WorkflowsList} />
+        <Route path=":workflowID" component={require './pages/lab/workflow'} />
+        <Route path=":workflowID/visualize" component={require './pages/lab/workflow-viewer'} />
+        <Route path=":workflowID/visualise" component={require './pages/lab/workflow-viewer'} />
+      </Route>
+      <Redirect from="subject-set/*" to="subject-sets/*" />
+      <Route path="subject-sets" component={SubjectSetsContainer}>
+        <IndexRoute component={SubjectSetsList} />
+        <Route path=":subjectSetID" component={require './pages/lab/subject-set'} />
+      </Route>
       <Route path="mini-course" component={require './pages/lab/mini-course'} />
     </Route>
     <Route path="lab-policies" component={require './pages/lab/help/lab-policies'} />

--- a/app/router.cjsx
+++ b/app/router.cjsx
@@ -192,17 +192,21 @@ module.exports =
       </Route>
       <Route path="collaborators" component={require './pages/lab/collaborators'} />
       <Route path="media" component={EditMediaPage} />
-      <Route path="workflows/:workflowID" component={require './pages/lab/workflow'} />
-      <Route path="workflow/:workflowID/visualize" component={require './pages/lab/workflow-viewer'} />
-      <Route path="workflow/:workflowID/visualise" component={require './pages/lab/workflow-viewer'} />
-      <Route path="subject-sets/:subjectSetID" component={require './pages/lab/subject-set'} />
       <Route path="visibility" component={require './pages/lab/visibility'} />
       <Route path="talk" component={require './pages/lab/talk'} />
       <Route path="data-exports" component={require './pages/lab/data-dumps'} />
       <Route path="tutorial" component={require './pages/lab/tutorial'} />
       <Route path="guide" component={require './pages/lab/field-guide'} />
       <Route path="workflows" component={WorkflowsContainer} />
+      <Route path="workflows/:workflowID" component={require './pages/lab/workflow'} />
+      <Route path="workflows/:workflowID/visualize" component={require './pages/lab/workflow-viewer'} />
+      <Route path="workflows/:workflowID/visualise" component={require './pages/lab/workflow-viewer'} />
+      <Redirect from="workflow/:workflowID" to="workflows/:workflowID" />
+      <Redirect from="workflow/:workflowID/visualize" to="workflows/:workflowID/visualize" />
+      <Redirect from="workflow/:workflowID/visualise" to="workflows/:workflowID/visualise" />
       <Route path="subject-sets" component={SubjectSetsContainer} />
+      <Route path="subject-sets/:subjectSetID" component={require './pages/lab/subject-set'} />
+      <Redirect from="subject-set/:subjectSetID" to="subject-sets/:subjectSetID" />
       <Route path="mini-course" component={require './pages/lab/mini-course'} />
     </Route>
     <Route path="lab-policies" component={require './pages/lab/help/lab-policies'} />

--- a/app/router.cjsx
+++ b/app/router.cjsx
@@ -192,17 +192,17 @@ module.exports =
       </Route>
       <Route path="collaborators" component={require './pages/lab/collaborators'} />
       <Route path="media" component={EditMediaPage} />
-      <Route path="workflow/:workflowID" component={require './pages/lab/workflow'} />
+      <Route path="workflows/:workflowID" component={require './pages/lab/workflow'} />
       <Route path="workflow/:workflowID/visualize" component={require './pages/lab/workflow-viewer'} />
       <Route path="workflow/:workflowID/visualise" component={require './pages/lab/workflow-viewer'} />
-      <Route path="subject-set/:subjectSetID" component={require './pages/lab/subject-set'} />
+      <Route path="subject-sets/:subjectSetID" component={require './pages/lab/subject-set'} />
       <Route path="visibility" component={require './pages/lab/visibility'} />
       <Route path="talk" component={require './pages/lab/talk'} />
       <Route path="data-exports" component={require './pages/lab/data-dumps'} />
       <Route path="tutorial" component={require './pages/lab/tutorial'} />
       <Route path="guide" component={require './pages/lab/field-guide'} />
       <Route path="workflows" component={WorkflowsContainer} />
-      <Route path="subjectsets" component={SubjectSetsContainer} />
+      <Route path="subject-sets" component={SubjectSetsContainer} />
       <Route path="mini-course" component={require './pages/lab/mini-course'} />
     </Route>
     <Route path="lab-policies" component={require './pages/lab/help/lab-policies'} />

--- a/app/router.cjsx
+++ b/app/router.cjsx
@@ -16,6 +16,8 @@ React = require 'react'
 `import UserProfilePage from './pages/profile/index';`
 `import NotificationsPage from './pages/notifications';`
 `import SubjectPageController from './subjects';`
+`import WorkflowsPage from './pages/lab/workflows';`
+`import SubjectSetsPage from './pages/lab/subject-sets';`
 
 # <Redirect from="home" to="/" /> doesn't work.
 ONE_UP_REDIRECT = React.createClass
@@ -197,6 +199,8 @@ module.exports =
       <Route path="data-exports" component={require './pages/lab/data-dumps'} />
       <Route path="tutorial" component={require './pages/lab/tutorial'} />
       <Route path="guide" component={require './pages/lab/field-guide'} />
+      <Route path="workflows" component={WorkflowsPage} />
+      <Route path="subjectsets" component={SubjectSetsPage} />
       <Route path="mini-course" component={require './pages/lab/mini-course'} />
     </Route>
     <Route path="lab-policies" component={require './pages/lab/help/lab-policies'} />

--- a/app/router.cjsx
+++ b/app/router.cjsx
@@ -18,6 +18,8 @@ React = require 'react'
 `import SubjectPageController from './subjects';`
 `import WorkflowsPage from './pages/lab/workflows';`
 `import SubjectSetsPage from './components/subject-sets';`
+`import WorkflowsContainer from './pages/lab/workflows-container';`
+`import SubjectSetsContainer from './pages/lab/subject-sets-container';`
 
 # <Redirect from="home" to="/" /> doesn't work.
 ONE_UP_REDIRECT = React.createClass
@@ -199,8 +201,8 @@ module.exports =
       <Route path="data-exports" component={require './pages/lab/data-dumps'} />
       <Route path="tutorial" component={require './pages/lab/tutorial'} />
       <Route path="guide" component={require './pages/lab/field-guide'} />
-      <Route path="workflows" component={WorkflowsPage} />
-      <Route path="subjectsets" component={SubjectSetsPage} />
+      <Route path="workflows" component={WorkflowsContainer} />
+      <Route path="subjectsets" component={SubjectSetsContainer} />
       <Route path="mini-course" component={require './pages/lab/mini-course'} />
     </Route>
     <Route path="lab-policies" component={require './pages/lab/help/lab-policies'} />

--- a/app/router.cjsx
+++ b/app/router.cjsx
@@ -17,7 +17,7 @@ React = require 'react'
 `import NotificationsPage from './pages/notifications';`
 `import SubjectPageController from './subjects';`
 `import WorkflowsPage from './pages/lab/workflows';`
-`import SubjectSetsPage from './pages/lab/subject-sets';`
+`import SubjectSetsPage from './components/subject-sets';`
 
 # <Redirect from="home" to="/" /> doesn't work.
 ONE_UP_REDIRECT = React.createClass

--- a/app/router.cjsx
+++ b/app/router.cjsx
@@ -17,7 +17,6 @@ React = require 'react'
 `import NotificationsPage from './pages/notifications';`
 `import SubjectPageController from './subjects';`
 `import WorkflowsPage from './pages/lab/workflows';`
-`import SubjectSetsPage from './components/subject-sets';`
 `import WorkflowsContainer from './pages/lab/workflows-container';`
 `import WorkflowsList from './pages/lab/workflows';`
 `import SubjectSetsContainer from './pages/lab/subject-sets-container';`


### PR DESCRIPTION
Fixes #3268 

Describe your changes.
This creates standalone lab pages for workflows and subject sets rather than having them on the left sidebar. It also adds pagination for both pages. Tests included.

https://new-lab-pages.pfe-preview.zooniverse.org/

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [x] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [x] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?