### PR TITLE
Stop cursor from changing to pointer while drawing freehand

### DIFF
--- a/app/classifier/drawing-tools/freehand-line.cjsx
+++ b/app/classifier/drawing-tools/freehand-line.cjsx
@@ -56,13 +56,17 @@ module.exports = React.createClass
     {_inProgress, points} = @props.mark
     path = createPathFromCoords points
 
+    lineClass = if _inProgress then 'drawing' else 'clickable'
+
     <DrawingToolRoot tool={this}>
       <path d={path}
         strokeWidth={GRAB_STROKE_WIDTH / ((@props.scale.horizontal + @props.scale.vertical) / 2)}
         strokeOpacity="0"
         fill="none"
-        className="clickable" />
-      <path d={path} fill="none" className="clickable" />
+        className={lineClass} />
+      <path d={path}
+        fill="none"
+        className={lineClass} />
 
       {if @props.selected
         deletePosition = @getDeletePosition points

--- a/app/classifier/drawing-tools/freehand-segment-line.cjsx
+++ b/app/classifier/drawing-tools/freehand-segment-line.cjsx
@@ -95,14 +95,15 @@ module.exports = React.createClass
   render: ->
     { _inProgress, _currentlyDrawing, points } = @props.mark
     path = createPathFromCoords points
+    lineClass = if _inProgress then 'drawing' else 'clickable'
 
     <DrawingToolRoot tool={this}>
       <path d={path}
         fill="none"
         strokeWidth={GRAB_STROKE_WIDTH / ((@props.scale.horizontal + @props.scale.vertical) / 2)}
         stroke="transparent"
-        className="clickable" />
-      <path d={path} fill="none" className="clickable" />
+        className={lineClass} />
+      <path d={path} fill="none" className={lineClass} />
 
       {if @props.selected
         deletePosition = @getDeletePosition points

--- a/app/classifier/drawing-tools/freehand-segment-shape.cjsx
+++ b/app/classifier/drawing-tools/freehand-segment-shape.cjsx
@@ -95,12 +95,13 @@ module.exports = React.createClass
     { _currentlyDrawing, _inProgress, points } = @props.mark
     path = createPathFromCoords points
     fill = if _inProgress then 'none' else @props.color
+    lineClass = if _inProgress then 'drawing' else 'clickable'
 
     <DrawingToolRoot tool={this}>
       <path d={path}
         fill={fill}
         fillOpacity="0.2"
-        className="clickable" />
+        className={lineClass} />
 
       {if @props.selected
         [firstPoint, ..., lastPoint] = points

--- a/app/classifier/drawing-tools/freehand-shape.cjsx
+++ b/app/classifier/drawing-tools/freehand-shape.cjsx
@@ -48,12 +48,13 @@ module.exports = React.createClass
     {_inProgress, points} = @props.mark
     path = createPathFromCoords points
     fill = if _inProgress then 'none' else @props.color
+    lineClass = if _inProgress then 'drawing' else 'clickable'
 
     <DrawingToolRoot tool={this}>
       <path d={path}
         fill={fill}
         fillOpacity="0.2"
-        className="clickable" />
+        className={lineClass} />
 
       {if !_inProgress and @props.selected
         deletePosition = @getDeletePosition points

--- a/css/drawing-tool.styl
+++ b/css/drawing-tool.styl
@@ -13,6 +13,9 @@
     opacity: 0
     transform: scale(0.1)
 
+  .drawing
+    cursor: crosshair
+
   .clickable
     cursor: pointer
 


### PR DESCRIPTION
When using the freehand tools, the cursor could flip rapidly between pointer and crosshair. This forces the cursor to crosshair while actively drawing.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://freehand-tool-tweaks.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?