### PR TITLE
Add "Lab Status" banner

### DIFF
--- a/app/pages/lab/index.cjsx
+++ b/app/pages/lab/index.cjsx
@@ -4,6 +4,7 @@ apiClient = require 'panoptes-client/lib/api-client'
 ModalFormDialog = require 'modal-form/dialog'
 projectActions = require './actions/project'
 LandingPage = require './landing-page'
+`import LabStatus from '../../partials/lab-status.jsx';`
 
 ProjectLink = React.createClass
   getDefaultProps: ->
@@ -233,6 +234,7 @@ module.exports = React.createClass
   render: ->
     if @props.user?
       <div>
+        <LabStatus />
         <ProjectList
           title="Your projects"
           page={@props.location.query['owned-page']}

--- a/app/pages/lab/project.cjsx
+++ b/app/pages/lab/project.cjsx
@@ -11,6 +11,7 @@ workflowActions = require './actions/workflow'
 isAdmin = require '../../lib/is-admin'
 getWorkflowsInOrder = require '../../lib/get-workflows-in-order'
 DragReorderable = require 'drag-reorderable'
+`import LabStatus from '../../partials/lab-status.jsx';`
 
 DEFAULT_SUBJECT_SET_NAME = 'Untitled subject set'
 DELETE_CONFIRMATION_PHRASE = 'I AM DELETING THIS PROJECT'
@@ -175,6 +176,7 @@ EditProjectPage = React.createClass
       <hr />
 
       <div className="column">
+        <LabStatus />
         <ChangeListener target={@props.project} handler={=>
           propsWithoutChildren = Object.assign {}, @props
           delete propsWithoutChildren.children

--- a/app/partials/lab-status.jsx
+++ b/app/partials/lab-status.jsx
@@ -1,0 +1,72 @@
+/*
+"Lab Status" Banner
+===================
+
+A spin-off of the AppStatus component, for the Lab page.
+
+(shaun.a.noordin 20170327)
+********************************************************************************
+ */
+
+import React from 'react';
+
+const APP_STATUS_URL = (process.env.NODE_ENV === 'staging' || process.env.NODE_ENV === 'development')
+  ? 'https://static.zooniverse.org/zooniverse.org-lab-status-TEST.txt'
+  : 'https://static.zooniverse.org/zooniverse.org-lab-status.txt';
+
+export default class LabStatus extends React.Component {
+  constructor(props) {
+    super(props);
+    this.button = null;
+    
+    this.state = {
+      show: false,
+      message: '',
+    };
+  }
+  
+  componentDidMount() {  //Display only first time user loads zooniverse.org
+    fetch(APP_STATUS_URL, { mode: 'cors' })
+    .then((response) => {
+      if (!response.ok) {
+        console.error('LabStatus: ERROR')
+        throw Error(response.statusText);
+      }
+      
+      return response.text();
+    })
+    .then((text) => {
+      console.log('LabStatus: Received status data from ' + APP_STATUS_URL + '.');
+      const cleanedText = (text) ? text.trim() : '';  //If text is just white space or newlines...
+      if (cleanedText === '') {  //...ignore it.
+        console.log('LabStatus: Nothing to report.');
+      } else {
+        this.setState({
+          show: true,
+          message: cleanedText,
+        });
+      }
+    })
+    .catch((err) => {
+      console.error('LabStatus: No status data from ' + APP_STATUS_URL + '. ', err);
+    });
+  }
+  
+  render() {
+    if (!this.state.show) return null;
+    if (!this.state.message || this.state.message === '') return null;
+    
+    return (
+      <div className="lab-status">
+        <button className="fa fa-close" onClick={this.hide.bind(this)} autoFocus={true}></button>
+        <div className="message">{this.state.message}</div>
+      </div>
+    );
+  }
+  
+  hide() {
+    this.setState({
+      show: false,
+    });
+  }
+}

--- a/app/partials/lab-status.jsx
+++ b/app/partials/lab-status.jsx
@@ -58,7 +58,14 @@ export default class LabStatus extends React.Component {
     
     return (
       <div className="lab-status">
+        {/*
         <button className="fa fa-close" onClick={this.hide.bind(this)} autoFocus={true}></button>
+        //Unlike App Status, we prevent the closing of the message since we
+        //can't get a consistent 'state' across every instance of Lab Status,
+        //meaning users will get annoyed if they close the message on Project 13
+        //but the message pops up again in Project 15. Removing the option to
+        //close will remove the expectation (-shaun 20170327)
+        */}
         <div className="message">{this.state.message}</div>
       </div>
     );

--- a/css/app-status.styl
+++ b/css/app-status.styl
@@ -16,3 +16,19 @@
   button.fa-close
     float: right
     cursor: pointer
+
+.lab-status
+  background: BACKGROUND
+  color: FOREGROUND
+  border: 0.2em solid BURNT_ORANGE
+  border-radius: 1em
+  padding: 0.5em 1em
+  margin: 1em auto
+  width: 40em
+  max-width: 80%
+  z-index: 1000
+  box-shadow: 0 0 0.5em BACKGROUND
+
+  button.fa-close
+    float: right
+    cursor: pointer

--- a/css/app-status.styl
+++ b/css/app-status.styl
@@ -27,7 +27,7 @@
   width: 40em
   max-width: 80%
   z-index: 1000
-  box-shadow: 0 0 0.5em BACKGROUND
+  box-shadow: 0 0.2em 0.4em FOREGROUND
 
   button.fa-close
     float: right

--- a/css/app-status.styl
+++ b/css/app-status.styl
@@ -27,7 +27,7 @@
   width: 40em
   max-width: 80%
   z-index: 1000
-  box-shadow: 0 0.2em 0.4em FOREGROUND
+  box-shadow: 0 0.15em 0.2em FOREGROUND
 
   button.fa-close
     float: right


### PR DESCRIPTION
## PR Overview
* New feature: a "status banner" is displayed on zooniverse.org's **Lab (aka Build a Project) page**, if PFE detects a status message on a secondary location.
* This is a spinoff to the App Status message in #3531 
* The message for the Lab Status banner is taken from a specific file in the `zooniverse-static` AWS bucket.
  * [https://static.zooniverse.org/zooniverse.org-lab-status.txt](https://static.zooniverse.org/zooniverse.org-lab-status.txt) for production.
  * [https://static.zooniverse.org/zooniverse.org-lab-status-TEST.txt](https://static.zooniverse.org/zooniverse.org-lab-status-TEST.txt) for staging/development.
* As with #3531, devs can change this message by manually replacing the 

## Dev Notes
* I may need to roll App Status and Lab Status into a single component... I dunno, I'm open to suggestions.
* The Lab Status banner and the App Status banner might _(will absolutely)_ benefit from designer feedback. As a background, Grant mentioned that he barely noticed our maintenance message on the App Status compo today. This is why the Lab Status design is different from App Status; it's more prominent.

## Status
Ready for feedback and review. Tagging @mcbouslog because he gave useful ideas when writing the feature specs. Thanks Mark!

## Preview
URL: https://lab-status.pfe-preview.zooniverse.org/lab
What you expect to see:
* (Assuming you're logged in) When you go to the Lab (aka Build a Project) page, a message should appear saying "We're undergoing maintenance" 
![screen shot 2017-03-27 at 16 26 07](https://cloud.githubusercontent.com/assets/13952701/24364516/e557a4cc-130a-11e7-901e-c4306ee299d0.png)

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)
