### PR TITLE
revert tutorial media request back to non-cached request

### DIFF
--- a/app/components/mini-course.cjsx
+++ b/app/components/mini-course.cjsx
@@ -17,7 +17,7 @@ module.exports = React.createClass
     find: (workflow) ->
       # Prefer fetching the tutorial for the workflow, so we know which one to fetch if multiple exist.
       if workflow?
-        apiClient.type('tutorials').get workflow_id: workflow.id, kind: "mini-course", include: ['attached_images']
+        apiClient.type('tutorials').get workflow_id: workflow.id, kind: "mini-course"
           .then ([minicourse]) ->
             minicourse
       else
@@ -26,18 +26,15 @@ module.exports = React.createClass
     start: (minicourse, projectPreferences, user, geordi) ->
       MiniCourseComponent = this
       if minicourse.steps.length isnt 0
-        if minicourse.links.attached_images.ids? and minicourse.links.attached_images.ids.length isnt 0
-          awaitMiniCourseMedia = apiClient.type('media').get(minicourse.links.attached_images.ids)
-              .catch ->
-                # Checking for attached images throws if there are none.
-                []
-              .then (mediaResources) ->
-                mediaByID = {}
-                for mediaResource in mediaResources
-                  mediaByID[mediaResource.id] = mediaResource
-                mediaByID
-        else
-          awaitMiniCourseMedia = Promise.resolve()
+        awaitMiniCourseMedia = minicourse.get 'attached_images'
+            .catch ->
+              # Checking for attached images throws if there are none.
+              []
+            .then (mediaResources) ->
+              mediaByID = {}
+              for mediaResource in mediaResources
+                mediaByID[mediaResource.id] = mediaResource
+              mediaByID
 
         awaitMiniCourseMedia.then (mediaByID) =>
           Dialog.alert(<MiniCourseComponent projectPreferences={projectPreferences} user={user} minicourse={minicourse} media={mediaByID} geordi={geordi} />, {

--- a/app/components/tutorial.cjsx
+++ b/app/components/tutorial.cjsx
@@ -16,7 +16,7 @@ module.exports = React.createClass
     find: (workflow) ->
       # Prefer fetching the tutorial for the workflow, if a workflow is given.
       if workflow?
-        apiClient.type('tutorials').get workflow_id: workflow.id, include: ['attached_images']
+        apiClient.type('tutorials').get workflow_id: workflow.id
           .then (tutorials) ->
             # Backwards compatibility for null kind values. We assume these are standard tutorials.
             onlyStandardTutorials = tutorials.filter (tutorial) ->
@@ -42,18 +42,15 @@ module.exports = React.createClass
       TutorialComponent = this
 
       if tutorial.steps.length isnt 0
-        if tutorial.links.attached_images.ids? and tutorial.links.attached_images.ids.length isnt 0
-          awaitTutorialMedia = apiClient.type('media').get(tutorial.links.attached_images?.ids)
-            .catch ->
-              # Checking for attached images throws if there are none.
-              []
-            .then (mediaResources) ->
-              mediaByID = {}
-              for mediaResource in mediaResources
-                mediaByID[mediaResource.id] = mediaResource
-              mediaByID
-        else
-          awaitTutorialMedia = Promise.resolve()
+        awaitTutorialMedia = tutorial.get 'attached_images'
+          .catch ->
+            # Checking for attached images throws if there are none.
+            []
+          .then (mediaResources) ->
+            mediaByID = {}
+            for mediaResource in mediaResources
+              mediaByID[mediaResource.id] = mediaResource
+            mediaByID
 
         awaitTutorialMedia.then (mediaByID) =>
           Dialog.alert(<TutorialComponent tutorial={tutorial} media={mediaByID} preferences={preferences} user={user} geordi={geordi} />, {


### PR DESCRIPTION
Fixes tutorial and mini-course images not loading.

Will update with reference to Panoptes issue once created momentarily, but due to `apiClient.type('tutorials').get workflow_id: workflow.id, kind: "mini-course", include: ['attached_images']` returning all project `attached_images`, not just related tutorial `attached_images`, which with Gravity Spy is more than the 20 returned by default, and doesn't include the requested tutorial media, that media wasn't loading.

Revert back to requesting media not from cache.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? - https://tutorial-media-revert.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?