### PR TITLE
Strip static.zooniverse.org/ from thumbnail paths

### DIFF
--- a/app/components/thumbnail.jsx
+++ b/app/components/thumbnail.jsx
@@ -15,7 +15,8 @@ export default class Thumbnail extends React.Component {
   }
 
   getThumbnailSrc({ origin, width, height, src }) {
-    const srcPath = src.split('//').pop();
+    let srcPath = src.split('//').pop();
+    srcPath = srcPath.replace('static.zooniverse.org/', '');
     return (`${origin}/${width}x${height}/${srcPath}`);
   }
 


### PR DESCRIPTION
Fixes # .

Describe your changes.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?