### PR TITLE
Dedupe author and subject IDs in Talk queries

### DIFF
--- a/app/talk/board.cjsx
+++ b/app/talk/board.cjsx
@@ -73,6 +73,8 @@ module.exports = React.createClass
         discussions.map (discussion) ->
           subject_ids.push discussion.focus_id if discussion.focus_id and discussion.focus_type is 'Subject'
           author_ids.push discussion.latest_comment.user_id if discussion.latest_comment?
+        author_ids = author_ids.filter (id, i) -> author_ids.indexOf(id) is i
+        subject_ids = subject_ids.filter (id, i) -> subject_ids.indexOf(id) is i
 
         apiClient
           .type 'users'

--- a/app/talk/discussion.cjsx
+++ b/app/talk/discussion.cjsx
@@ -112,6 +112,8 @@ module.exports = React.createClass
           comments.map (comment) ->
             author_ids.push comment.user_id
             subject_ids.push comment.focus_id if comment.focus_id
+          author_ids = author_ids.filter (id, i) -> author_ids.indexOf(id) is i
+          subject_ids = subject_ids.filter (id, i) -> subject_ids.indexOf(id) is i
 
           apiClient
             .type 'users'

--- a/app/talk/recents.cjsx
+++ b/app/talk/recents.cjsx
@@ -71,6 +71,8 @@ module.exports = React.createClass
       comments.map (comment) =>
         author_ids.push comment.user_id
         subject_ids.push comment.focus_id if comment.focus_id.length
+      author_ids = author_ids.filter (id, i) -> author_ids.indexOf(id) is i
+      subject_ids = subject_ids.filter (id, i) -> subject_ids.indexOf(id) is i
 
       apiClient
         .type 'users'


### PR DESCRIPTION
Fixes # .

Describe your changes.
Ensures subject and user IDs are unique in Talk API calls for lists of resources by ID.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://dedupe-queries.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?