### PR TITLE
Check for subject in favorites that belongs to logged in user

### DIFF
--- a/app/subjects/index.cjsx
+++ b/app/subjects/index.cjsx
@@ -43,7 +43,7 @@ module.exports = React.createClass
       .then (collections) =>
         isFavorite = false
         if collections and @props.user?
-          favoriteCollection = collections.filter((collection) => collection.favorite and @props.project.id in collection.links.projects)
+          favoriteCollection = collections.filter((collection) => collection.favorite and collection.links.owner.id is @props.user.id and @props.project.id in collection.links.projects)
           isFavorite = subject.id in favoriteCollection[0].links.subjects if favoriteCollection.length > 0
         @setState {collections, isFavorite}
 


### PR DESCRIPTION
This wasn't caught by me in the previous fav button work since I was working with my own favorites collections on staging. If you browse the subject talk page in admin mode, you can get back other users' fav collections and the fav button was showing as a fav'ed when I had not favorited the subject. This fixes this by making sure the favorite collection found actually belongs to the logged in user. 

check it out: https://only-fav-for-logged-in-user.pfe-preview.zooniverse.org/projects/skymap/planet-9/talk/subjects/8360430?env=production

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?