### PR TITLE
Link project home subjects to Talk

### DIFF
--- a/app/pages/project/home/project-home.jsx
+++ b/app/pages/project/home/project-home.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router';
 import { Markdown } from 'markdownz';
 import getSubjectLocation from '../../../lib/get-subject-location.coffee';
 import Thumbnail from '../../../components/thumbnail';
@@ -37,14 +38,16 @@ const ProjectHomePage = (props) => {
             const location = getSubjectLocation(subject);
             return (
               <div className="project-home-page__talk-image" key={subject.id}>
-                <Thumbnail
-                  alt=""
-                  controls={false}
-                  format={location.format}
-                  height={300}
-                  src={location.src}
-                  width={600}
-                />
+                <Link to={`/projects/${props.project.slug}/talk/subjects/${subject.id}`} >
+                  <Thumbnail
+                    alt=""
+                    controls={false}
+                    format={location.format}
+                    height={300}
+                    src={location.src}
+                    width={600}
+                  />
+                </Link>
               </div>
             );
           })}

--- a/css/project-page.styl
+++ b/css/project-page.styl
@@ -151,7 +151,7 @@
   font-size: 14px
   justify-content: center
 
-  button, a
+  button, a.standard-button
     background: white
     border: 2px solid #00979d
     border-radius: .5em


### PR DESCRIPTION
Describe your changes.
Does what it says on the can. For @mrniaboc 

Scopes button link styles just to those links.

Adds links to the Talk preview subjects on the project home page.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://project-home-links.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?