### PR TITLE
add more left padding to charts on the stats page

### DIFF
--- a/app/pages/project/stats/charts.jsx
+++ b/app/pages/project/stats/charts.jsx
@@ -284,6 +284,12 @@ Graph.defaultProps = {
     axisY: {
       onlyInteger: true,
     },
+    chartPadding: {
+      top: 15,
+      right: 15,
+      bottom: 5,
+      left: 15
+    },
   },
   optionsSmall: {
     axisX: {


### PR DESCRIPTION
This prevents the y-axis of the charts on the stats page from getting cut off when there are more than 1,000,000 classifications in a day.

Describe your changes.
Adds left padding to the Chartist.js graph (changed from the default 10px to 15px).

This can be tested by looking at the planet 9 stats page on the staging branch: https://stats-chart-padding.pfe-preview.zooniverse.org/projects/skymap/planet-9/stats/?env=production

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://stats-chart-padding.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?