### PR TITLE
Cache active users in a shared store.

### DIFF
--- a/app/talk/active-users.cjsx
+++ b/app/talk/active-users.cjsx
@@ -3,6 +3,7 @@ apiClient = require 'panoptes-client/lib/api-client'
 {sugarApiClient} = require 'panoptes-client/lib/sugar'
 {Link} = require 'react-router'
 Paginator = require './lib/paginator'
+activeUserCache = require('./lib/active-user-cache').default
 
 module.exports = React.createClass
   displayName: 'ActiveUsers'
@@ -11,7 +12,7 @@ module.exports = React.createClass
     geordi: React.PropTypes.object
 
   getInitialState: ->
-    userRecords: { }
+    userRecords: activeUserCache
     users: []
     total: 0
     pageCount: 0
@@ -33,16 +34,16 @@ module.exports = React.createClass
 
       @fetchUncachedUsers(onPage).then(@cacheUsers).then (users) =>
         activeUsers = (@state.userRecords[id] for id in onPage when @state.userRecords[id]?)
-        @setState userRecords: @state.userRecords, users: activeUsers, page: page, pageCount: pageCount, total: userIds.length
+        @setState userRecords: activeUserCache, users: activeUsers, page: page, pageCount: pageCount, total: userIds.length
         @restartTimer()
       .catch =>
         @restartTimer()
 
   cacheUsers: (users) ->
-    @state.userRecords[user.id] = user for user in users
+    activeUserCache[user.id] = user for user in users
 
   fetchUncachedUsers: (ids) ->
-    cachedIds = Object.keys @state.userRecords
+    cachedIds = Object.keys activeUserCache
     uncachedIds = (id for id in ids when id not in cachedIds)
 
     if uncachedIds.length > 0

--- a/app/talk/lib/active-user-cache.js
+++ b/app/talk/lib/active-user-cache.js
@@ -1,0 +1,3 @@
+const activeUserCache = {};
+
+export default activeUserCache;


### PR DESCRIPTION
Fixes: ActiveUsers component spamming Panoptes to look up users

Describe your changes.
Uses a shared variable to store the user cache.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://active-user-cache.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?