### PR TITLE
Fix fetch for iOS webview on App Status

### DIFF
--- a/app/partials/app-status.jsx
+++ b/app/partials/app-status.jsx
@@ -3,7 +3,7 @@
 ===================
 
 The AppStatus banner has one job: it displays a static message to the users, if
-it detects a non-empty "status message" file at a specified static URL. 
+it detects a non-empty 'status message' file at a specified static URL. 
 (The static resource is defined by the hardcoded APP_STATUS_URL.)
 
 Intended use: Zooniverse admins can manually change the status file (e.g. via
@@ -36,22 +36,23 @@ export default class AppStatus extends React.Component {
   constructor(props) {
     super(props);
     this.button = null;
-    
+
     this.state = {
       show: false,
-      message: '',
+      message: ''
     };
+    this.hide = this.hide.bind(this);
   }
-  
-  componentDidMount() {  //Display only first time user loads zooniverse.org
-    if (typeof fetch === 'function'){ //conditional required to support webview on iOS < 10.3
+
+  componentDidMount() {  // Display only first time user loads zooniverse.org
+    if (typeof fetch === 'function') { // conditional required to support webview on iOS < 10.3
       fetch(APP_STATUS_URL, { mode: 'cors' })
       .then((response) => {
         if (!response.ok) {
           console.error('AppStatus: ERROR')
           throw Error(response.statusText);
         }
-        
+
         return response.text();
       })
       .then((text) => {
@@ -62,7 +63,7 @@ export default class AppStatus extends React.Component {
         console.error('AppStatus: No status data from ' + APP_STATUS_URL + '. ', err);
       });
     } else {
-      var request = new XMLHttpRequest();
+      const request = new XMLHttpRequest();
       request.onreadystatechange = () => {
         if (request.readyState === 4 && request.status === 200) {
           this.setStatus(request.responseText);
@@ -70,38 +71,38 @@ export default class AppStatus extends React.Component {
           console.log('AppStatus: No status data from ' + APP_STATUS_URL + '. Assuming everything is OK.');
         }
       };
-      request.open("GET", APP_STATUS_URL, true);
+      request.open('GET', APP_STATUS_URL, true);
       request.send();
     }
   }
-  
+
   setStatus(text) {
-    const cleanedText = (text) ? text.trim() : '';  //If text is just white space or newlines...
-    if (cleanedText === '') {  //...ignore it.
+    const cleanedText = (text) ? text.trim() : '';  // If text is just white space or newlines...
+    if (cleanedText === '') {  // ...ignore it.
       console.log('AppStatus: Nothing to report.');
     } else {
       this.setState({
         show: true,
-        message: cleanedText,
+        message: cleanedText
       });
     }
+  }
+
+  hide() {
+    this.setState({
+      show: false
+    });
   }
 
   render() {
     if (!this.state.show) return null;
     if (!this.state.message || this.state.message === '') return null;
-    
+
     return (
       <div className="app-status">
-        <button className="fa fa-close" onClick={this.hide.bind(this)} autoFocus={true}></button>
+        <button className="fa fa-close" onClick={this.hide} autoFocus={true} />
         <div className="message">{this.state.message}</div>
       </div>
     );
-  }
-  
-  hide() {
-    this.setState({
-      show: false,
-    });
   }
 }

--- a/app/partials/app-status.jsx
+++ b/app/partials/app-status.jsx
@@ -44,32 +44,49 @@ export default class AppStatus extends React.Component {
   }
   
   componentDidMount() {  //Display only first time user loads zooniverse.org
-    fetch(APP_STATUS_URL, { mode: 'cors' })
-    .then((response) => {
-      if (!response.ok) {
-        console.error('AppStatus: ERROR')
-        throw Error(response.statusText);
-      }
-      
-      return response.text();
-    })
-    .then((text) => {
-      console.log('AppStatus: Received status data from ' + APP_STATUS_URL + '.');
-      const cleanedText = (text) ? text.trim() : '';  //If text is just white space or newlines...
-      if (cleanedText === '') {  //...ignore it.
-        console.log('AppStatus: Nothing to report.');
-      } else {
-        this.setState({
-          show: true,
-          message: cleanedText,
-        });
-      }
-    })
-    .catch((err) => {
-      console.error('AppStatus: No status data from ' + APP_STATUS_URL + '. ', err);
-    });
+    if (typeof fetch === 'function'){ //conditional required to support webview on iOS < 10.3
+      fetch(APP_STATUS_URL, { mode: 'cors' })
+      .then((response) => {
+        if (!response.ok) {
+          console.error('AppStatus: ERROR')
+          throw Error(response.statusText);
+        }
+        
+        return response.text();
+      })
+      .then((text) => {
+        console.log('AppStatus: Received status data from ' + APP_STATUS_URL + '.');
+        this.setStatus(text);
+      })
+      .catch((err) => {
+        console.error('AppStatus: No status data from ' + APP_STATUS_URL + '. ', err);
+      });
+    } else {
+      var request = new XMLHttpRequest();
+      request.onreadystatechange = () => {
+        if (request.readyState === 4 && request.status === 200) {
+          this.setStatus(request.responseText);
+        } else if (request.readyState === 4) {
+          console.log('AppStatus: No status data from ' + APP_STATUS_URL + '. Assuming everything is OK.');
+        }
+      };
+      request.open("GET", APP_STATUS_URL, true);
+      request.send();
+    }
   }
   
+  setStatus(text) {
+    const cleanedText = (text) ? text.trim() : '';  //If text is just white space or newlines...
+    if (cleanedText === '') {  //...ignore it.
+      console.log('AppStatus: Nothing to report.');
+    } else {
+      this.setState({
+        show: true,
+        message: cleanedText,
+      });
+    }
+  }
+
   render() {
     if (!this.state.show) return null;
     if (!this.state.message || this.state.message === '') return null;

--- a/app/partials/app-status.jsx
+++ b/app/partials/app-status.jsx
@@ -17,7 +17,8 @@ Expected Input/Output:
 
 Assumptions:
 * the static "status message" resource is stored on a reliable, scalable host.
-* fetch() polyfill is available.
+* fetch() polyfill is available in most browsers, except for
+*   on iOS UIWebview < 10.3.  In this case XHR is used instead.
 
 See https://github.com/zooniverse/Panoptes-Front-End/issues/3530 for initial
 feature specs.


### PR DESCRIPTION
Fixes #3668 and https://github.com/zooniverse/mobile/issues/104

  *  Add a test to check if the fetch() function exists, needed to display in the mobile app webview, for iOS < 10.3.  If fetch() doesn't exist it will perform an XHR instead.
  *  Clean up some linter issues (separate commit)

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?