### PR TITLE
Type checking for sim metadata

### DIFF
--- a/app/classifier/classification-summary.jsx
+++ b/app/classifier/classification-summary.jsx
@@ -24,6 +24,18 @@ class ClassificationSummary extends React.Component {
     this.hasExpert = !!this.props.expertClassification;
   }
 
+  isSubjectASim() {
+    const simMetadataField = this.props.subject.metadata['#sim'];
+
+    if (typeof simMetadataField === 'string') {
+      return simMetadataField.toLowerCase() === 'true';
+    } else if (typeof simMetadataField === 'boolean') {
+      return simMetadataField;
+    }
+
+    return false;
+  }
+
   render() {
     const tools = this.props.project.experimental_tools || [];
 
@@ -83,8 +95,8 @@ class ClassificationSummary extends React.Component {
           <strong>
             { this.state.showExpert ? 'Expert Classification:' : 'Your classification:' }
           </strong>
-          {this.props.workflow.configuration.sim_notification && this.props.subject.metadata['#sim'] &&
-            <p style={{fontWeight: 'bold'}}>This was a simulated planet. We include these to help calibrate the project. Keep going to discover a real planet!</p>}
+          {this.props.workflow.configuration.sim_notification && this.isSubjectASim() &&
+            <p style={{ fontWeight: 'bold' }}>This was a simulated planet. We include these to help calibrate the project. Keep going to discover a real planet!</p>}
           <DefaultClassificationSummary
             workflow={this.props.workflow}
             classification={this.state.showExpert ? this.props.expertClassification : this.props.classification}

--- a/app/classifier/classification-summary.jsx
+++ b/app/classifier/classification-summary.jsx
@@ -92,11 +92,11 @@ class ClassificationSummary extends React.Component {
           </div> : '' }
 
         <div>
+          {this.props.workflow.configuration.sim_notification && this.isSubjectASim() &&
+            <p style={{ fontWeight: 'bold' }}>This was a simulated planet. We include these to help calibrate the project. Keep going to discover a real planet!</p>}
           <strong>
             { this.state.showExpert ? 'Expert Classification:' : 'Your classification:' }
           </strong>
-          {this.props.workflow.configuration.sim_notification && this.isSubjectASim() &&
-            <p style={{ fontWeight: 'bold' }}>This was a simulated planet. We include these to help calibrate the project. Keep going to discover a real planet!</p>}
           <DefaultClassificationSummary
             workflow={this.props.workflow}
             classification={this.state.showExpert ? this.props.expertClassification : this.props.classification}


### PR DESCRIPTION
The ABC SGL project subject metadata is using a string instead of a boolean for the sim metadata. This adds in a bit of type checking. 

https://sim-feedback-type-bug.pfe-preview.zooniverse.org/projects/ianc2/exoplanet-explorers/classify?env=production

And on staging (flower subject is a sim with a boolean value of true):
https://sim-feedback-type-bug.pfe-preview.zooniverse.org/projects/srallen086/sgl-tester/classify

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?