### PR TITLE
Update Lab Status to match App Status + improve App Status style

### DIFF
--- a/app/partials/lab-status.jsx
+++ b/app/partials/lab-status.jsx
@@ -23,7 +23,6 @@ export default class LabStatus extends React.Component {
       show: false,
       message: ''
     };
-    this.hide = this.hide.bind(this);
   }
 
   componentDidMount() {  // Display only first time user loads zooniverse.org
@@ -68,12 +67,6 @@ export default class LabStatus extends React.Component {
         message: cleanedText
       });
     }
-  }
-
-  hide() {
-    this.setState({
-      show: false
-    });
   }
 
   render() {

--- a/css/app-status.styl
+++ b/css/app-status.styl
@@ -1,9 +1,12 @@
-.app-status
+.app-status, .lab-status
   background: BACKGROUND
   color: FOREGROUND
-  border: 1px solid ZOONIVERSE_TEAL
+  border: 0.2em solid BURNT_ORANGE
   border-radius: 1em
   padding: 0.5em 1em
+  box-shadow: 0 0.15em 0.2em FOREGROUND
+
+.app-status
   position: fixed
   left: 50%
   bottom: 1em
@@ -11,24 +14,12 @@
   width: 80%
   max-width: 40em
   z-index: 1000
-  box-shadow: 0 0 0.5em BACKGROUND
-
+  
   button.fa-close
     float: right
     cursor: pointer
 
 .lab-status
-  background: BACKGROUND
-  color: FOREGROUND
-  border: 0.2em solid BURNT_ORANGE
-  border-radius: 1em
-  padding: 0.5em 1em
   margin: 1em auto
   width: 40em
   max-width: 80%
-  z-index: 1000
-  box-shadow: 0 0.15em 0.2em FOREGROUND
-
-  button.fa-close
-    float: right
-    cursor: pointer


### PR DESCRIPTION
## PR Overview
* Follows up on #3670 
* The code for Lab Status has been updated to match App Status, in that it uses XMLHttpRequest as a fallback. Logically, we shouldn't need to worry about the Lab being used in an iOS native app environment(...?) but hey, we should keep the code consistent.
* Also, the style for the App Status message has been made more prominent.
![screen shot 2017-03-29 at 22 52 03](https://cloud.githubusercontent.com/assets/13952701/24478333/6872a1b8-14d2-11e7-879c-669b28f83eae.png)

In the case of the alert messages, @beckyrother if you have some spare time, I'm keen to know your thoughts about standardising the UI/UX design for 'alert messages', 'info messages', and similar popups/modulars. (Or whatever those component types are called.)

You can see an example of one alert message here on the homepage - https://update-app-status-lab-status.pfe-preview.zooniverse.org/ - and an alert message on the Build a Project/Lab page - https://update-app-status-lab-status.pfe-preview.zooniverse.org/lab

(If you don't have time, no worries, we'll use the current styles for now and revisit the visual design another day.)

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)
