### PR TITLE
Only show the sim feedback if subject is a sim

### DIFF
--- a/app/classifier/classification-summary.jsx
+++ b/app/classifier/classification-summary.jsx
@@ -81,6 +81,12 @@ class ClassificationSummary extends React.Component {
       );
     }
 
+    if (this.props.workflow.configuration && this.props.workflow.configuration.sim_notification && this.isSubjectASim()) {
+      return (
+        <p style={{ fontWeight: 'bold' }}>This was a simulated planet. We include these to help calibrate the project. Keep going to discover a real planet!</p>
+      );
+    }
+
     return (
       <div>
         { this.hasExpert ?
@@ -92,8 +98,6 @@ class ClassificationSummary extends React.Component {
           </div> : '' }
 
         <div>
-          {this.props.workflow.configuration.sim_notification && this.isSubjectASim() &&
-            <p style={{ fontWeight: 'bold' }}>This was a simulated planet. We include these to help calibrate the project. Keep going to discover a real planet!</p>}
           <strong>
             { this.state.showExpert ? 'Expert Classification:' : 'Your classification:' }
           </strong>


### PR DESCRIPTION
This changes the sim feedback to only show that message and not also the default classification summary. ~~There's a chance that the message itself might change, so I've marked this as WIP.~~ 

https://only-show-sim-feedback.pfe-preview.zooniverse.org/projects/srallen086/sgl-tester/classify

https://only-show-sim-feedback.pfe-preview.zooniverse.org/projects/ianc2/exoplanet-explorers/classify?env=production

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?