### PR TITLE
Fetch authors and roles for subject comment lists

### DIFF
--- a/app/subjects/comment-list.cjsx
+++ b/app/subjects/comment-list.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+apiClient = require 'panoptes-client/lib/api-client'
 talkClient = require 'panoptes-client/lib/talk-client'
 Comment = require '../talk/comment'
 Paginator = require '../talk/lib/paginator'
@@ -19,6 +20,8 @@ module.exports = React.createClass
 
   getInitialState: ->
     meta: { }
+    authors: {}
+    author_roles: {}
 
   getComments: (page = @props.location.query.page) ->
     query =
@@ -29,8 +32,35 @@ module.exports = React.createClass
       sort: '-created_at'
 
     talkClient.type('comments').get(query).then (comments) =>
+        author_ids = []
+        authors = {}
+        author_roles = {}
         meta = comments[0]?.getMeta() or { }
         @setState {comments, meta}
+        comments.map (comment) ->
+          author_ids.push comment.user_id
+        author_ids = author_ids.filter (id, i) -> author_ids.indexOf(id) is i
+
+        apiClient
+          .type 'users'
+          .get
+            id: author_ids
+          .then (users) =>
+            users.map (user) -> authors[user.id] = user
+            @setState {authors}
+
+        talkClient
+          .type 'roles'
+          .get
+            user_id: author_ids
+            section: ['zooniverse', @props.section]
+            is_shown: true
+            page_size: 100
+          .then (roles) =>
+            roles.map (role) ->
+              author_roles[role.user_id] ?= []
+              author_roles[role.user_id].push role
+            @setState {author_roles}
 
   render: ->
     return <Loading /> unless @state.comments
@@ -40,7 +70,16 @@ module.exports = React.createClass
         <h2>Comments:</h2>
         <div>
           {for comment in @state.comments
-            <Comment {...@props} key={"comment-#{comment.id}"} data={comment} locked={true} linked={true} hideFocus={true} />}
+            <Comment
+              {...@props}
+              key={"comment-#{comment.id}"}
+              data={comment}
+              author={@state.authors[comment.user_id]}
+              roles={@state.author_roles[comment.user_id]}
+              locked={true}
+              linked={true}
+              hideFocus={true}
+            />}
         </div>
 
         {if +@state.meta.page_count > 1


### PR DESCRIPTION
Fixes #3677.

Describe your changes.
Fetches comment authors and roles in the comment list component.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://subject-comment-authors.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?