### PR TITLE
Load the next subject when clicking Talk link

### DIFF
--- a/app/classifier/task-nav.jsx
+++ b/app/classifier/task-nav.jsx
@@ -197,6 +197,7 @@ class TaskNav extends React.Component {
           }
           {completed &&
             <Link
+              onClick={this.props.nextSubject}
               to={`/projects/${this.props.project.slug}/talk/subjects/${this.props.subject.id}`}
               className="talk standard-button"
             >

--- a/app/pages/project/classify.cjsx
+++ b/app/pages/project/classify.cjsx
@@ -247,15 +247,15 @@ module.exports = React.createClass
     else
       classification.save()
 
+    Split.classificationCreated(classification)
+    {workflow, subjects} = classification.links
+    seenThisSession.add workflow, subjects
     savingClassification
       .then (classification) =>
         if @state.demoMode
           console?.log 'Demo mode: Did NOT save classification'
         else
           console?.log 'Saved classification', classification.id
-          Split.classificationCreated(classification)
-          {workflow, subjects} = classification.links
-          seenThisSession.add workflow, subjects
           classification.destroy()
         @saveAllQueuedClassifications()
       .catch (error) =>

--- a/app/pages/project/classify.cjsx
+++ b/app/pages/project/classify.cjsx
@@ -230,7 +230,7 @@ module.exports = React.createClass
 
   saveClassificationAndLoadAnotherSubject: ->
     @saveClassification()
-      .then @loadAnotherSubject()
+    @loadAnotherSubject()
 
   saveClassification: ->
     if @context.geordi.keys["experiment"]?


### PR DESCRIPTION
Fixes a bug where navigating to Talk leaves a completed classification stored in the project page state, which breaks the classify component on mount.

Describe your changes.
Adds an event handler to the Talk link so that it behaves exactly like the Next button.

Also takes a bunch of code that was waiting on `classification.save()` and runs it immediately instead.

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://fix-summary-nav.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?