### PR TITLE
Move subject_workflow_statuses get call back into conditional

### DIFF
--- a/app/classifier/classifier.jsx
+++ b/app/classifier/classifier.jsx
@@ -116,14 +116,15 @@ export default class Classifier extends React.Component {
         workflow_id: this.props.workflow.id,
         subject_id: subject.id
       };
-    }
+    
 
-    apiClient.type('subject_workflow_statuses')
-    .get(query)
-    .then(([sws]) => {
-      const classificationCount = sws.classifications_count ? sws.classifications_count : 0;
-      this.setState({ classificationCount });
-    });
+      apiClient.type('subject_workflow_statuses')
+      .get(query)
+      .then(([sws]) => {
+        const classificationCount = sws.classifications_count ? sws.classifications_count : 0;
+        this.setState({ classificationCount });
+      });
+    }
   }
 
   loadSubject(subject) {


### PR DESCRIPTION
Moves the API call back into the conditional for the experiment.

https://fix-load-count-bug.pfe-preview.zooniverse.org/

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?