### PR TITLE
Fix 3676

### DIFF
--- a/app/components/frame-viewer.cjsx
+++ b/app/components/frame-viewer.cjsx
@@ -50,7 +50,7 @@ module.exports = React.createClass
         <TextViewer  src={src} type={type} format={format} frame={@props.frame} onLoad={@handleLoad} /> 
 
     if FrameWrapper
-      <PanZoom ref="panZoom" enabled={zoomEnabled} frameDimensions={@state.frameDimensions}>
+      <PanZoom ref="panZoom" enabled={zoomEnabled} frameType={type} frameDimensions={@state.frameDimensions}>
         <FrameWrapper 
           frame={frame} 
           naturalWidth={@state.frameDimensions?.width or 0} 

--- a/app/components/pan-zoom.jsx
+++ b/app/components/pan-zoom.jsx
@@ -42,19 +42,19 @@ const PanZoom = React.createClass({
   componentDidMount() {
     // these events enable a user to navigate an image using arrows, +, and - keys,
     // while the user is in pan and zoom mode.
-    if (this.props.enabled && this.props.frameType === "image") {
+    if (this.props.enabled && this.props.frameType === 'image') {
       addEventListener('keydown', this.frameKeyPan);
       addEventListener('wheel', this.frameKeyPan);
     }
   },
 
-  componentWillReceiveProps(nextProps){
+  componentWillReceiveProps(nextProps) {
     if (nextProps.enabled) {
-      if (nextProps.frameType === "image"){
+      if (nextProps.frameType === 'image') {
         // when the frame is an image, add the pan-zoom event listeners
         addEventListener('keydown', this.frameKeyPan);
         addEventListener('wheel', this.frameKeyPan);
-      } else if (!(nextProps.frameType === "image") && this.props.frameType === "image"){
+      } else if (!(nextProps.frameType === 'image') && this.props.frameType === 'image') {
         // when switching from an image frame to an non-image frame, remove the pan-zoom event listeners
         removeEventListener('keydown', this.frameKeyPan);
         removeEventListener('wheel', this.frameKeyPan);
@@ -92,7 +92,7 @@ const PanZoom = React.createClass({
     return (
       <div>
         {children}
-        {(this.props.enabled && this.props.frameType === "image") ?
+        {(this.props.enabled && this.props.frameType === 'image') ?
           <div className="pan-zoom-controls" >
             <div className="draw-pan-toggle" >
               <div className={this.state.panEnabled ? '' : 'active'} >
@@ -153,7 +153,7 @@ const PanZoom = React.createClass({
   },
 
   cannotResetZoomRotate() {
-    return this.cannotZoomOut() && this.state.rotation === 0
+    return this.cannotZoomOut() && this.state.rotation === 0;
   },
 
   continuousZoom(change) {

--- a/app/components/pan-zoom.jsx
+++ b/app/components/pan-zoom.jsx
@@ -42,9 +42,23 @@ const PanZoom = React.createClass({
   componentDidMount() {
     // these events enable a user to navigate an image using arrows, +, and - keys,
     // while the user is in pan and zoom mode.
-    if (this.props.enabled) {
+    if (this.props.enabled && this.props.frameType === "image") {
       addEventListener('keydown', this.frameKeyPan);
       addEventListener('wheel', this.frameKeyPan);
+    }
+  },
+
+  componentWillReceiveProps(nextProps){
+    if (nextProps.enabled) {
+      if (nextProps.frameType === "image"){
+        // when the frame is an image, add the pan-zoom event listeners
+        addEventListener('keydown', this.frameKeyPan);
+        addEventListener('wheel', this.frameKeyPan);
+      } else if (!(nextProps.frameType === "image") && this.props.frameType === "image"){
+        // when switching from an image frame to an non-image frame, remove the pan-zoom event listeners
+        removeEventListener('keydown', this.frameKeyPan);
+        removeEventListener('wheel', this.frameKeyPan);
+      }
     }
   },
 

--- a/app/components/pan-zoom.jsx
+++ b/app/components/pan-zoom.jsx
@@ -6,6 +6,7 @@ const PanZoom = React.createClass({
   propTypes: {
     children: React.PropTypes.node,
     enabled: React.PropTypes.bool,
+    frameType: React.PropTypes.string.isRequired,
     frameDimensions: React.PropTypes.shape({
       height: React.PropTypes.number,
       width: React.PropTypes.number
@@ -77,7 +78,7 @@ const PanZoom = React.createClass({
     return (
       <div>
         {children}
-        {this.props.enabled ?
+        {(this.props.enabled && this.props.frameType === "image") ?
           <div className="pan-zoom-controls" >
             <div className="draw-pan-toggle" >
               <div className={this.state.panEnabled ? '' : 'active'} >

--- a/app/components/pan-zoom.spec.js
+++ b/app/components/pan-zoom.spec.js
@@ -13,7 +13,7 @@ describe('PanZoom', function () {
     let wrapper;
 
     beforeEach(function () {
-      wrapper = shallow(<PanZoom enabled={true} />);
+      wrapper = shallow(<PanZoom enabled={true} frameType={"image"} />);
     });
 
     it('should render a zoom-in, a zoom-out, rotate, and reset button', function () {
@@ -40,7 +40,7 @@ describe('PanZoom', function () {
       let zoomInButton;
 
       beforeEach(function () {
-        wrapper = mount(<PanZoom enabled={true} />);
+        wrapper = mount(<PanZoom enabled={true} frameType={"image"} />);
         zoomInButton = wrapper.find('button.zoom-in');
         wrapper.instance().handleFocus('zoomIn');
       });
@@ -59,7 +59,7 @@ describe('PanZoom', function () {
       const originalFrameDimensions = { width: 100, height: 100, x: 0, y: 0 };
 
       beforeEach(function () {
-        wrapper = mount(<PanZoom enabled={true} frameDimensions={originalFrameDimensions} />);
+        wrapper = mount(<PanZoom enabled={true} frameType={"image"} frameDimensions={originalFrameDimensions} />);
       });
 
       it('returns false if there is room to zoom out', function () {
@@ -80,7 +80,7 @@ describe('PanZoom', function () {
       const originalFrameDimensions = { width: 100, height: 100, x: 0, y: 0 };
 
       beforeEach(function () {
-        wrapper = mount(<PanZoom enabled={true} frameDimensions={originalFrameDimensions} />);
+        wrapper = mount(<PanZoom enabled={true} frameType={"image"} frameDimensions={originalFrameDimensions} />);
       });
 
       it('returns false if state.rotation is not 0', function () {
@@ -108,7 +108,7 @@ describe('PanZoom', function () {
       let zoomSpy;
 
       beforeEach(function () {
-        wrapper = mount(<PanZoom enabled={true} />);
+        wrapper = mount(<PanZoom enabled={true} frameType={"image"} />);
         clearZoomingTimeout = sinon.spy(wrapper.instance(), 'clearZoomingTimeout');
         zoomSpy = sinon.spy(wrapper.instance(), 'zoom');
       });
@@ -145,7 +145,7 @@ describe('PanZoom', function () {
     describe('#keyDownZoomButton()', function () {
       it('it should call #zoom()', function () {
         const originalFrameDimensions = { width: 100, height: 100, x: 0, y: 0 };
-        const wrapper = mount(<PanZoom enabled={true} frameDimensions={originalFrameDimensions} />);
+        const wrapper = mount(<PanZoom enabled={true} frameType={"image"} frameDimensions={originalFrameDimensions} />);
         const zoomSpy = sinon.spy(wrapper.instance(), 'zoom');
         const change = 10;
         const keyEvent = { which: 13, preventDefault() { return 'This is a mock'; } };
@@ -161,7 +161,7 @@ describe('PanZoom', function () {
 
     describe('#stopZoom()', function () {
       it('should set this.state.zooming to false', function () {
-        const wrapper = mount(<PanZoom enabled={true} />);
+        const wrapper = mount(<PanZoom enabled={true} frameType={"image"} />);
         const clickEvent = { stopPropagation() { return 'This is a mock'; } };
         const continuousZoomSpy = sinon.spy(wrapper.instance(), 'continuousZoom');
         wrapper.setState({ zooming: true });
@@ -175,7 +175,7 @@ describe('PanZoom', function () {
     describe('#zoomReset()', function () {
       it('should reset the viewBoxDimensions to the orignal frame dimensions', function () {
         const originalFrameDimensions = { width: 100, height: 100, x: 0, y: 0 };
-        const wrapper = mount(<PanZoom enabled={true} frameDimensions={originalFrameDimensions} />);
+        const wrapper = mount(<PanZoom enabled={true} frameType={"image"} frameDimensions={originalFrameDimensions} />);
         wrapper.setState({ viewBoxDimensions: { width: 50, heigth: 50, x: 25, y: 25 } });
         wrapper.instance().zoomReset();
 
@@ -185,7 +185,7 @@ describe('PanZoom', function () {
 
     describe('#togglePanOn()', function () {
       it('should set this.state.panEnabled to true', function () {
-        const wrapper = mount(<PanZoom enabled={true} />);
+        const wrapper = mount(<PanZoom enabled={true} frameType={"image"} />);
         wrapper.instance().togglePanOn();
 
         assert.equal(wrapper.state('panEnabled'), true);
@@ -194,7 +194,7 @@ describe('PanZoom', function () {
 
     describe('#togglePanOff()', function () {
       it('should set this.state.panEnabled to false', function () {
-        const wrapper = mount(<PanZoom enabled={true} />);
+        const wrapper = mount(<PanZoom enabled={true} frameType={"image"} />);
         wrapper.instance().togglePanOff();
 
         assert.equal(wrapper.state('panEnabled'), false);
@@ -205,7 +205,7 @@ describe('PanZoom', function () {
       let wrapper;
 
       beforeEach(function () {
-        wrapper = mount(<PanZoom enabled={true} />);
+        wrapper = mount(<PanZoom enabled={true} frameType={"image"} />);
       });
 
       it('should change the this.state.keyPanZoomEnabled from true to false', function () {
@@ -229,7 +229,7 @@ describe('PanZoom', function () {
       const zoomedViewBoxDimensions = { width: 50, height: 50, x: 25, y: 25 };
 
       beforeEach(function () {
-        wrapper = mount(<PanZoom enabled={true} frameDimensions={originalFrameDimensions} />);
+        wrapper = mount(<PanZoom enabled={true} frameType={"image"} frameDimensions={originalFrameDimensions} />);
         wrapper.setState({ viewBoxDimensions: zoomedViewBoxDimensions, panEnabled: true });
       });
 
@@ -252,7 +252,7 @@ describe('PanZoom', function () {
       let wrapper;
 
       beforeEach(function () {
-        wrapper = mount(<PanZoom enabled={true} frameDimensions={originalFrameDimensions} />);
+        wrapper = mount(<PanZoom enabled={true} frameType={"image"} frameDimensions={originalFrameDimensions} />);
         panHorizontalSpy = sinon.spy(wrapper.instance(), 'panHorizontal');
         panVerticalSpy = sinon.spy(wrapper.instance(), 'panVertical');
         zoomSpy = sinon.spy(wrapper.instance(), 'zoom');
@@ -348,7 +348,7 @@ describe('PanZoom', function () {
 
       beforeEach(function () {
         originalFrameDimensions = { width: 100, height: 100, x: 0, y: 0 };
-        wrapper = mount(<PanZoom enabled={true} frameDimensions={originalFrameDimensions} />);
+        wrapper = mount(<PanZoom enabled={true} frameType={"image"} frameDimensions={originalFrameDimensions} />);
         wrapper.setState({ viewBoxDimensions: { width: 50, height: 50, x: 25, y: 25 } });
       });
 
@@ -384,7 +384,7 @@ describe('PanZoom', function () {
 
       beforeEach(function () {
         originalFrameDimensions = { width: 100, height: 100, x: 0, y: 0 };
-        wrapper = mount(<PanZoom enabled={true} frameDimensions={originalFrameDimensions} />);
+        wrapper = mount(<PanZoom enabled={true} frameType={"image"} frameDimensions={originalFrameDimensions} />);
         wrapper.setState({ viewBoxDimensions: { width: 50, height: 50, x: 25, y: 25 } });
       });
 
@@ -420,7 +420,7 @@ describe('PanZoom', function () {
 
       beforeEach(function () {
         originalFrameDimensions = { width: 100, height: 100, x: 0, y: 0 };
-        wrapper = mount(<PanZoom enabled={true} frameDimensions={originalFrameDimensions} />);
+        wrapper = mount(<PanZoom enabled={true} frameType={"image"} frameDimensions={originalFrameDimensions} />);
       });
 
       it('should add 90 to this.state.rotation', function () {

--- a/app/components/text-viewer.jsx
+++ b/app/components/text-viewer.jsx
@@ -10,6 +10,7 @@ class TextViewer extends Component {
     this.state = {
       content: '',
     };
+    this.onLoadForText = this.onLoadForText.bind(this);
   }
 
   componentWillMount() {
@@ -45,8 +46,7 @@ class TextViewer extends Component {
   }
 
   onLoadForText(element) {
-    // mock event for frame-viewer
-    // sometimes element is null, not sure why
+    // mock event for frame-viewer's #handleLoad() method
     if (!element === null) {
       let e = {
         target: {

--- a/app/components/text-viewer.jsx
+++ b/app/components/text-viewer.jsx
@@ -19,20 +19,11 @@ class TextViewer extends Component {
     })
     .then((content) => {
       this.setState({ content });
-      ReactDOM.findDOMNode(this).dispatchEvent(new Event('load'));
     })
     .catch((e) => {
       const content = e.message;
       this.setState({ content });
     });
-  }
-
-  componentDidMount() {
-    ReactDOM.findDOMNode(this).addEventListener('load', this.props.onLoad);
-  }
-
-  componentWillUnmount() {
-    ReactDOM.findDOMNode(this).removeEventListener('load', this.props.onLoad);
   }
 
   render() {
@@ -47,10 +38,26 @@ class TextViewer extends Component {
       content = `Unsupported format: ${this.props.format}`;
     }
     return (
-      <div className="text-viewer" >
+      <div ref={(element) => {this.onLoadForText(element);}} className="text-viewer" >
         { content }
       </div>
     );
+  }
+
+  onLoadForText(element) {
+    // mock event for frame-viewer
+    // sometimes element is null, not sure why
+    if (!element === null) {
+      let e = {
+        target: {
+          naturalWidth: 0,
+          naturalHeight: 0
+        }
+      };
+      e.target.naturalWidth = element.getBoundingClientRect().width;
+      e.target.naturalHeight = element.getBoundingClientRect().height;
+      this.props.onLoad(e);
+    }
   }
 }
 

--- a/app/components/text-viewer.jsx
+++ b/app/components/text-viewer.jsx
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-import ReactDOM from 'react-dom';
 
 const SUPPORTED_TYPES = ['text'];
 const SUPPORTED_FORMATS = ['plain'];
@@ -8,7 +7,7 @@ class TextViewer extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      content: '',
+      content: ''
     };
     this.onLoadForText = this.onLoadForText.bind(this);
   }
@@ -27,24 +26,6 @@ class TextViewer extends Component {
     });
   }
 
-  render() {
-    let { content } = this.state;
-    if (content === "") {
-      return null;
-    }
-    if (SUPPORTED_TYPES.indexOf(this.props.type) === -1) {
-      content = `Unsupported type: ${this.props.type}`;
-    }
-    if (SUPPORTED_FORMATS.indexOf(this.props.format) === -1) {
-      content = `Unsupported format: ${this.props.format}`;
-    }
-    return (
-      <div ref={(element) => {this.onLoadForText(element);}} className="text-viewer" >
-        { content }
-      </div>
-    );
-  }
-
   onLoadForText(element) {
     // mock event for frame-viewer's #handleLoad() method
     if (!element === null) {
@@ -59,19 +40,37 @@ class TextViewer extends Component {
       this.props.onLoad(e);
     }
   }
+
+  render() {
+    let { content } = this.state;
+    if (content === '') {
+      return null;
+    }
+    if (SUPPORTED_TYPES.indexOf(this.props.type) === -1) {
+      content = `Unsupported type: ${this.props.type}`;
+    }
+    if (SUPPORTED_FORMATS.indexOf(this.props.format) === -1) {
+      content = `Unsupported format: ${this.props.format}`;
+    }
+    return (
+      <div ref={(element) => { this.onLoadForText(element); }} className="text-viewer" >
+        { content }
+      </div>
+    );
+  }
 }
 
 TextViewer.propTypes = {
   src: React.PropTypes.string.isRequired,
   type: React.PropTypes.string,
   format: React.PropTypes.string,
-  onLoad: React.PropTypes.func,
+  onLoad: React.PropTypes.func
 };
 
 TextViewer.defaultProps = {
   type: 'text',
   format: 'plain',
-  onLoad: (e) => { console.log('text loaded', e); },
+  onLoad: (e) => { console.log('text loaded', e); }
 };
 
 export default TextViewer;


### PR DESCRIPTION

Fixes #3676. 

Describe your changes.
- The PanZoom buttons and eventListeners only render for subject frames of the type 'image'.
- For the TextViewer, `#onLoad()` is now called using a `ref`. In `componentDidMount` and `componentWillMount`, `ReactDOM.findDOMNode(this)` was returning null. The error from [`ReactDOM.findDOMNode(this).addEventListener('load', this.props.onLoad)` on line 31](https://github.com/zooniverse/Panoptes-Front-End/compare/fix-3676?expand=1#diff-f8270d0c4ee56789ba85382262b11d88L31) prevented classification submission for text subject frames.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch? https://fix-3676.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?