### PR TITLE
Add webpack dashboard

### DIFF
--- a/dev-server.js
+++ b/dev-server.js
@@ -4,11 +4,13 @@ import webpack from 'webpack';
 import webpackMiddleware from 'webpack-dev-middleware';
 import webpackHotMiddleware from 'webpack-hot-middleware';
 import config from './webpack.dev.js';
+import DashboardPlugin from 'webpack-dashboard/plugin';
 
 const port = process.env.PORT || 3735;
 
 const app = express();
 const compiler = webpack(config);
+compiler.apply(new DashboardPlugin());
 const middleware = webpackMiddleware(compiler, {
   publicPath: config.output.publicPath,
   noInfo: true,

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "stylus": "~0.54.5",
     "stylus-loader": "~2.1.0",
     "webpack": "~1.13.0",
+    "webpack-dashboard": "~0.3.0",
     "webpack-dev-middleware": "~1.6.1",
     "webpack-hot-middleware": "~2.10.0",
     "webpack-split-by-path": "0.0.8"
@@ -101,7 +102,7 @@
   "license": "Apache-2.0",
   "repository": "zooniverse/Panoptes-Front-End",
   "scripts": {
-    "start": "export NODE_ENV=development; check-engines && check-dependencies && babel-node ./dev-server.js",
+    "start": "export NODE_ENV=development; check-engines && check-dependencies && webpack-dashboard -- babel-node ./dev-server.js",
     "_build": "export HEAD_COMMIT=$(git rev-parse --short HEAD); check-engines && check-dependencies && rimraf dist; webpack --config ./webpack.build.js --progress --profile --colors",
     "serve-static": "export NODE_ENV=staging; check-engines && check-dependencies && npm run _build && node ./static-server.js",
     "serve-hot": "export BABEL_ENV=hot-reload; npm start",

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -4,6 +4,7 @@ var path = require('path');
 var webpack = require('webpack');
 var HtmlWebpackPlugin = require('html-webpack-plugin');
 var CopyWebpackPlugin = require('copy-webpack-plugin');
+var DashboardPlugin = require('webpack-dashboard/plugin');
 
 var config = {
   devtool: 'eval-source-map',
@@ -28,7 +29,8 @@ var config = {
       template: 'views/index.ejs',
       inject: 'body',
       filename: 'index.html'
-    })
+    }),
+    new DashboardPlugin({ port: 3736 })
   ],
   resolve: {
     extensions: ['', '.js', '.jsx', '.cjsx', '.coffee', '.styl', '.css'],


### PR DESCRIPTION
For more information with our webpack use in development. 

Take note to get scrolling to work: 
> OS X Terminal.app users: Make sure that View → Allow Mouse Reporting is enabled, otherwise scrolling through logs and modules won't work. If your version of Terminal.app doesn't have this feature, you may want to check out an alternative such as iTerm2.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?