### PR TITLE
Add annotation check to exoplanets feedback

### DIFF
--- a/app/classifier/classification-summary.jsx
+++ b/app/classifier/classification-summary.jsx
@@ -91,7 +91,7 @@ class ClassificationSummary extends React.Component {
 
     if (this.showExoplanetSimFeedback()) {
       return (
-        <p style={{ fontWeight: 'bold' }}>This was a simulated planet. We include these to help calibrate the project. Keep going to discover a real planet!</p>
+        <p style={{ fontWeight: 'bold' }}>Well done! You've found a simulated planet. We include these to help calibrate the project. Keep going to discover a real planet!</p>
       );
     }
 

--- a/app/classifier/classification-summary.jsx
+++ b/app/classifier/classification-summary.jsx
@@ -36,6 +36,14 @@ class ClassificationSummary extends React.Component {
     return false;
   }
 
+  showExoplanetSimFeedback() {
+    return (this.props.workflow.configuration &&
+      this.props.workflow.configuration.sim_notification &&
+      this.isSubjectASim() &&
+      this.props.classification.annotations[0].value === 0
+    );
+  }
+
   render() {
     const tools = this.props.project.experimental_tools || [];
 
@@ -81,7 +89,7 @@ class ClassificationSummary extends React.Component {
       );
     }
 
-    if (this.props.workflow.configuration && this.props.workflow.configuration.sim_notification && this.isSubjectASim()) {
+    if (this.showExoplanetSimFeedback()) {
       return (
         <p style={{ fontWeight: 'bold' }}>This was a simulated planet. We include these to help calibrate the project. Keep going to discover a real planet!</p>
       );


### PR DESCRIPTION
Describe your changes.
Adds an annotation check so that SGL exoplanets feedback only shows depending on the answer to the question.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?