### PR TITLE
[Wait to Merge]Add Collection functionality to add-delete multiple items

### DIFF
--- a/app/collections/create-form.cjsx
+++ b/app/collections/create-form.cjsx
@@ -31,8 +31,6 @@ module.exports = React.createClass
     links.project = +@props.project if @props.project?
     links.subjects = @props.subjectIDs if @props.subjectIDs.length > 0
 
-    console.log links
-
     collection = {
       display_name: displayName
       private: notPublic

--- a/app/collections/create-form.cjsx
+++ b/app/collections/create-form.cjsx
@@ -15,6 +15,12 @@ module.exports = React.createClass
     error: null
     collectionNameLength: 0
 
+  getDefaultProps: ->
+    subjectIDs: []
+
+  propTypes:
+    subjectIDs: React.PropTypes.array
+
   onSubmit: (e) ->
     e.preventDefault()
 
@@ -23,7 +29,9 @@ module.exports = React.createClass
 
     links = {}
     links.project = +@props.project if @props.project?
-    links.subjects = [+@props.subject] if @props.subject?
+    links.subjects = @props.subjectIDs if @props.subjectIDs.length > 0
+
+    console.log links
 
     collection = {
       display_name: displayName

--- a/app/collections/manager-icon.cjsx
+++ b/app/collections/manager-icon.cjsx
@@ -28,6 +28,6 @@ module.exports = React.createClass
 
       {if @state.open
         <Dialog tag="div" closeButton={true} onCancel={@close}>
-          <CollectionsManager user={@props.user} project={@props.project} subject={@props.subject} onSuccess={@close} />
+          <CollectionsManager user={@props.user} project={@props.project} subjectIDs={[@props.subject?.id]} onSuccess={@close} />
         </Dialog>}
     </button>

--- a/app/collections/manager.cjsx
+++ b/app/collections/manager.cjsx
@@ -11,9 +11,10 @@ module.exports = React.createClass
 
   getDefaultProps: ->
     project: null
+    subjectIDs: []
 
   propTypes:
-    subject: React.PropTypes.object
+    subjectIDs: React.PropTypes.array
     project: React.PropTypes.object
 
   addToCollections: ->
@@ -21,7 +22,7 @@ module.exports = React.createClass
     return unless collections.length > 0
 
     promises = for { collection } in collections
-      collection.addLink('subjects', [@props.subject?.id])
+      collection.addLink('subjects', @props.subjectIDs)
 
     Promise.all(promises)
       .then =>
@@ -48,5 +49,5 @@ module.exports = React.createClass
       <hr />
 
       <div className="form-help">Or Create a new Collection</div>
-      <CollectionsCreateForm project={@props.project?.id} subject={@props.subject?.id} onSubmit={@props.onSuccess} />
+      <CollectionsCreateForm project={@props.project?.id} subjectIDs={@props.subjectIDs} onSubmit={@props.onSuccess} />
     </div>

--- a/app/collections/manager.cjsx
+++ b/app/collections/manager.cjsx
@@ -21,7 +21,7 @@ module.exports = React.createClass
     return unless collections.length > 0
 
     promises = for { collection } in collections
-      collection.addLink('subjects', [@props.subject.id])
+      collection.addLink('subjects', [@props.subject?.id])
 
     Promise.all(promises)
       .then =>
@@ -48,5 +48,5 @@ module.exports = React.createClass
       <hr />
 
       <div className="form-help">Or Create a new Collection</div>
-      <CollectionsCreateForm project={@props.project?.id} subject={@props.subject.id} onSubmit={@props.onSuccess} />
+      <CollectionsCreateForm project={@props.project?.id} subject={@props.subject?.id} onSubmit={@props.onSuccess} />
     </div>

--- a/app/collections/show-list.cjsx
+++ b/app/collections/show-list.cjsx
@@ -74,21 +74,26 @@ SubjectNode = React.createClass
     logClick = @context.geordi?.makeHandler? 'about-menu'
     <div className="collection-subject-viewer">
       <SubjectViewer defaultStyle={false} subject={@props.subject} user={@props.user} project={@state.project} isFavorite={@state.isFavorite}>
-          <Link className="subject-link" to={"/projects/#{@state.project?.slug}/talk/subjects/#{@props.subject.id}"} onClick={logClick?.bind(this, 'view-favorite')}>
-            <span></span>
-          </Link>
+          {if !@props.selecting
+            <Link className="subject-link" to={"/projects/#{@state.project?.slug}/talk/subjects/#{@props.subject.id}"} onClick={logClick?.bind(this, 'view-favorite')}>
+              <span></span>
+            </Link>}
           {if @isOwnerOrCollaborator() and !@props.selecting
             <button type="button" className="collection-subject-viewer-delete-button" onClick={@props.onDelete}>
               <i className="fa fa-close" />
             </button>}
           {if @props.selecting and !@props.selected
-            <button className="collection-subject-viewer-circle-open" onClick={@handleSelect.bind @, 'add'}>
-              <i className="fa fa-circle-o" />
-            </button>}
+            <div className="collection-subject-viewer-selecting">
+              <button className="collection-subject-viewer-select" onClick={@handleSelect.bind @, 'add'}>
+                <i className="fa fa-circle-o" />
+              </button>
+            </div>}
           {if @props.selecting and @props.selected
-            <button className="collection-subject-viewer-circle-open" onClick={@handleSelect.bind @, 'delete'}>
+            <div className="collection-subject-viewer-selecting">
+              <button className="collection-subject-viewer-select" onClick={@handleSelect.bind @, 'delete'}>
               <i className="fa fa-check" />
-            </button>}
+              </button>
+            </div>}
       </SubjectViewer>
     </div>
 

--- a/app/collections/show-list.cjsx
+++ b/app/collections/show-list.cjsx
@@ -4,6 +4,7 @@ Translate = require 'react-translate-component'
 apiClient = require 'panoptes-client/lib/api-client'
 intersection = require 'lodash.intersection'
 pick = require 'lodash.pick'
+classNames = require 'classnames'
 counterpart = require 'counterpart'
 alert = require '../lib/alert'
 Paginator = require '../talk/lib/paginator'
@@ -64,6 +65,11 @@ SubjectNode = React.createClass
 
   render: ->
     logClick = @context.geordi?.makeHandler? 'about-menu'
+    subjectSelectClasses = classNames({
+      "collection-subject-viewer-circle": true,
+      "fa fa-check-circle": !!@props.selected,
+      "fa fa-circle-o": !@props.selected
+    })
     <div className="collection-subject-viewer">
       <SubjectViewer defaultStyle={false} subject={@props.subject} user={@props.user} project={@state.project} isFavorite={@state.isFavorite}>
           {if !@props.selecting
@@ -77,7 +83,7 @@ SubjectNode = React.createClass
           {if @props.selecting
             <label className="collection-subject-viewer-select">
               <input type="checkbox" checked={@props.selected} onChange={@toggleSelect}/>
-              <i className={"collection-subject-viewer-circle " + if @props.selected then "fa fa-check-circle" else "fa fa-circle-o"} />
+              <i className={subjectSelectClasses} />
             </label>}
       </SubjectViewer>
     </div>
@@ -150,9 +156,7 @@ module.exports = React.createClass
 
   promptCollectionManager: ->
     alert (resolve) =>
-      <CollectionsManager user={@props.user} project={@props.project} subjectIDs={@state.selected} onSuccess={resolve} />
-
-    @toggleSelecting()
+      <CollectionsManager user={@props.user} project={@props.project} subjectIDs={@state.selected} onSuccess={() => @toggleSelecting(); resolve();} />
 
   handleDeleteSubject: (subject) ->
     subjects = @state.subjects
@@ -187,18 +191,25 @@ module.exports = React.createClass
           {if @state.selecting
             <div className="collection-buttons-container">
               <button
-                className="select-images-button"
+                type="button"
+                className="select-subjects-button"
                 onClick={@promptCollectionManager}
                 disabled={@state.selected.length < 1}>
                 Add to Collection
               </button>
               {if @props.canCollaborate
-                <button className="select-images-button" onClick={@deleteSubjects} disabled={@state.selected.length < 1}>Remove from Collection</button>}
-              <button className="select-images-button" onClick={@toggleSelecting}>Cancel</button>
+                <button
+                  type="button"
+                  className="select-subjects-button"
+                  onClick={@deleteSubjects}
+                  disabled={@state.selected.length < 1}>
+                  Remove from Collection
+                </button>}
+              <button type="button" className="select-subjects-button" onClick={@toggleSelecting}>Cancel</button>
             </div>
-          else
+          else if @props.user?
             <div className="collection-buttons-container">
-              <button className="select-images-button" onClick={@toggleSelecting}>Select Subjects</button>
+              <button type="button" className="select-subjects-button" onClick={@toggleSelecting}>Select Subjects</button>
             </div>
           }
             <div>

--- a/app/collections/show-list.cjsx
+++ b/app/collections/show-list.cjsx
@@ -77,12 +77,20 @@ SubjectNode = React.createClass
               <span></span>
             </Link>}
           {if @props.canCollaborate and !@props.selecting
-            <button type="button" className="collection-subject-viewer-delete-button" onClick={@props.onDelete}>
+            <button
+              type="button"
+              aria-label="Delete"
+              className="collection-subject-viewer-delete-button"
+              onClick={@props.onDelete}>
               <i className="fa fa-close" />
             </button>}
           {if @props.selecting
             <label className="collection-subject-viewer-select">
-              <input type="checkbox" checked={@props.selected} onChange={@toggleSelect}/>
+              <input
+                aria-label={if @props.selected then "Selected" else "Not Selected"}
+                type="checkbox"
+                checked={@props.selected}
+                onChange={@toggleSelect}/>
               <i className={subjectSelectClasses} />
             </label>}
       </SubjectViewer>
@@ -168,7 +176,16 @@ module.exports = React.createClass
       .then =>
         @props.collection.uncacheLink 'subjects'
 
-  deleteSubjects: () ->
+  confirmDeleteSubjects: ->
+    alert (resolve) =>
+      <div className="confirm-delete-dialog content-container">
+        <p>Are you sure you want to delete {@state.selected.length} subjects from this collection? This action is irreversible!</p>
+        <button className="minor-button" autoFocus={true} onClick={resolve}>No, don&apos;t delete the subjects.</button>
+        {' '}
+        <button className="major-button" onClick={() => @deleteSubjects(); resolve();}>Yes, delete the subjects selected!</button>
+      </div>
+
+  deleteSubjects: ->
     subjects = @state.subjects.filter((subject) => @state.selected.indexOf(subject.id) is -1)
     @setState {subjects}
 
@@ -201,7 +218,7 @@ module.exports = React.createClass
                 <button
                   type="button"
                   className="select-subjects-button"
-                  onClick={@deleteSubjects}
+                  onClick={@confirmDeleteSubjects}
                   disabled={@state.selected.length < 1}>
                   Remove from Collection
                 </button>}

--- a/app/collections/show-list.cjsx
+++ b/app/collections/show-list.cjsx
@@ -76,8 +76,8 @@ SubjectNode = React.createClass
             </button>}
           {if @props.selecting
             <label className="collection-subject-viewer-select">
-              <i className={"collection-subject-viewer-circle " + if @props.selected then "fa fa-check-circle" else "fa fa-circle-o"} />
               <input type="checkbox" checked={@props.selected} onChange={@toggleSelect}/>
+              <i className={"collection-subject-viewer-circle " + if @props.selected then "fa fa-check-circle" else "fa fa-circle-o"} />
             </label>}
       </SubjectViewer>
     </div>

--- a/app/collections/show-list.cjsx
+++ b/app/collections/show-list.cjsx
@@ -69,13 +69,16 @@ SubjectNode = React.createClass
     logClick = @context.geordi?.makeHandler? 'about-menu'
     <div className="collection-subject-viewer">
       <SubjectViewer defaultStyle={false} subject={@props.subject} user={@props.user} project={@state.project} isFavorite={@state.isFavorite}>
-        {if @isOwnerOrCollaborator()
-          <button type="button" className="collection-subject-viewer-delete-button" onClick={@props.onDelete}>
-            <i className="fa fa-close" />
-          </button>}
           <Link className="subject-link" to={"/projects/#{@state.project?.slug}/talk/subjects/#{@props.subject.id}"} onClick={logClick?.bind(this, 'view-favorite')}>
             <span></span>
           </Link>
+          {if @isOwnerOrCollaborator()
+            <button type="button" className="collection-subject-viewer-delete-button" onClick={@props.onDelete}>
+              <i className="fa fa-close" />
+            </button>}
+          <button className="collection-subject-viewer-circle-open" onClick={@props.selectSubject}>
+            <i className="fa fa-circle-o" />
+          </button>
       </SubjectViewer>
     </div>
 
@@ -89,6 +92,7 @@ module.exports = React.createClass
   getInitialState: ->
     subjects: null
     error: null
+    selecting: false
 
   componentWillMount: ->
     @fetchCollectionSubjects pick @props.location.query, VALID_COLLECTION_MEMBER_SUBJECTS_PARAMS
@@ -120,6 +124,9 @@ module.exports = React.createClass
       pathname: @props.location.pathname
       query: nextQuery
 
+  toggleSelect: ->
+    @setState selecting: !@state.selecting
+
   handleDeleteSubject: (subject) ->
     subjects = @state.subjects
     index = subjects.indexOf subject
@@ -129,6 +136,9 @@ module.exports = React.createClass
     @props.collection.removeLink 'subjects', [subject.id.toString()]
       .then =>
         @props.collection.uncacheLink 'subjects'
+
+  selectSubject: (subject) ->
+    console.log subject
 
   render: ->
     if @state.subjects?
@@ -140,6 +150,17 @@ module.exports = React.createClass
           meta = @state.subjects[0].getMeta()
 
           <div>
+          {if @state.selecting
+            <div className="collection-buttons-container">
+              <button className="select-images-button">Add to Collection</button>
+              <button className="select-images-button">Remove from Collection</button>
+              <button className="select-images-button" onClick={@toggleSelect}>Cancel</button>
+            </div>
+          else
+            <div className="collection-buttons-container">
+              <button className="select-images-button" onClick={@toggleSelect}>Select Images</button>
+            </div>
+          }
             <div className="collection-subjects-list">
               {@state.subjects.map (subject) =>
                 <SubjectNode
@@ -149,6 +170,7 @@ module.exports = React.createClass
                   user={@props.user}
                   roles={@props.roles}
                   onDelete={@handleDeleteSubject.bind @, subject}
+                  selectSubject={@selectSubject.bind @, subject}
                 />
               }
             </div>

--- a/app/collections/show-list.cjsx
+++ b/app/collections/show-list.cjsx
@@ -83,17 +83,13 @@ SubjectNode = React.createClass
               <i className="fa fa-close" />
             </button>}
           {if @props.selecting and !@props.selected
-            <div className="collection-subject-viewer-selecting">
-              <button className="collection-subject-viewer-select" onClick={@handleSelect.bind @, 'add'}>
-                <i className="fa fa-circle-o" />
-              </button>
-            </div>}
+            <button className="collection-subject-viewer-select-button" onClick={@handleSelect.bind @, 'add'}>
+              <i className="fa fa-circle-o collection-subject-viewer-circle" />
+            </button>}
           {if @props.selecting and @props.selected
-            <div className="collection-subject-viewer-selecting">
-              <button className="collection-subject-viewer-select" onClick={@handleSelect.bind @, 'delete'}>
-              <i className="fa fa-check" />
-              </button>
-            </div>}
+            <button className="collection-subject-viewer-select-button" onClick={@handleSelect.bind @, 'delete'}>
+              <i className="fa fa-check-circle collection-subject-viewer-circle" />
+            </button>}
       </SubjectViewer>
     </div>
 
@@ -222,7 +218,7 @@ module.exports = React.createClass
               <button className="select-images-button" onClick={@toggleSelect}>Select Images</button>
             </div>
           }
-            <div className="collection-subjects-list">
+            <div>
               {@state.subjects.map (subject) =>
                 <SubjectNode
                   key={subject.id}

--- a/app/collections/show-list.cjsx
+++ b/app/collections/show-list.cjsx
@@ -179,10 +179,12 @@ module.exports = React.createClass
   confirmDeleteSubjects: ->
     alert (resolve) =>
       <div className="confirm-delete-dialog content-container">
-        <p>Are you sure you want to delete {@state.selected.length} subjects from this collection? This action is irreversible!</p>
-        <button className="minor-button" autoFocus={true} onClick={resolve}>No, don&apos;t delete the subjects.</button>
+        <p>Are you sure you want to remove {@state.selected.length} subjects from this collection?</p>
+        <div style={{ textAlign: "center" }}>
+          <button className="minor-button" autoFocus={true} onClick={resolve}>Cancel</button>
         {' '}
-        <button className="major-button" onClick={() => @deleteSubjects(); resolve();}>Yes, delete the subjects selected!</button>
+          <button className="major-button" onClick={() => @deleteSubjects(); resolve();}>Yes</button>
+        </div>
       </div>
 
   deleteSubjects: ->

--- a/app/collections/show-list.cjsx
+++ b/app/collections/show-list.cjsx
@@ -1,15 +1,15 @@
 React = require 'react'
 {Link} = require 'react-router'
+Translate = require 'react-translate-component'
 apiClient = require 'panoptes-client/lib/api-client'
 intersection = require 'lodash.intersection'
 pick = require 'lodash.pick'
-Translate = require 'react-translate-component'
 counterpart = require 'counterpart'
+alert = require '../lib/alert'
 Paginator = require '../talk/lib/paginator'
 SubjectViewer = require '../components/subject-viewer'
 Loading = require '../components/loading-indicator'
 CollectionsManager = require './manager'
-Dialog = require 'modal-form/dialog'
 
 VALID_COLLECTION_MEMBER_SUBJECTS_PARAMS = ['page', 'page_size']
 
@@ -143,13 +143,6 @@ module.exports = React.createClass
 
     return hasPermission
 
-  openCollectionsManager: ->
-    @setState {collectionsManaging: true}
-
-  closeCollectionsManager: ->
-    @setState {collectionsManaging: false}
-    @toggleSelect()
-
   toggleSelect: ->
     @setState selecting: !@state.selecting, selected: []
 
@@ -165,6 +158,12 @@ module.exports = React.createClass
       index = selected.indexOf subjectID
       selected.splice index, 1
       @setState {selected}
+
+  promptCollectionManager: ->
+    alert (resolve) =>
+      <CollectionsManager user={@props.user} project={@props.project} subjectIDs={@state.selected} onSuccess={resolve} />
+
+    @toggleSelect()
 
   handleDeleteSubject: (subject) ->
     subjects = @state.subjects
@@ -200,14 +199,10 @@ module.exports = React.createClass
             <div className="collection-buttons-container">
               <button
                 className="select-images-button"
-                onClick={@openCollectionsManager}
+                onClick={@promptCollectionManager}
                 disabled={@state.selected.length < 1}>
                 Add to Collection
               </button>
-              {if @state.collectionsManaging
-                <Dialog tag="div" closeButton={true} onCancel={@closeCollectionsManager}>
-                <CollectionsManager user={@props.user} project={@props.project} subjectIDs={@state.selected} onSuccess={@closeCollectionsManager} />
-                </Dialog>}
               {if @isOwnerOrCollaborator()
                 <button className="select-images-button" onClick={@deleteSubjects} disabled={@state.selected.length < 1}>Remove from Collection</button>}
               <button className="select-images-button" onClick={@toggleSelect}>Cancel</button>

--- a/app/collections/show-list.cjsx
+++ b/app/collections/show-list.cjsx
@@ -106,6 +106,12 @@ module.exports = React.createClass
     selected: []
     collectionsManaging: false
 
+  getDefaultProps: ->
+    project: null
+
+  propTypes:
+    project: React.PropTypes.object
+
   componentWillMount: ->
     @fetchCollectionSubjects pick @props.location.query, VALID_COLLECTION_MEMBER_SUBJECTS_PARAMS
       .then (subjects) =>
@@ -171,10 +177,6 @@ module.exports = React.createClass
       .then =>
         @props.collection.uncacheLink 'subjects'
 
-  addSubjects: () ->
-
-    console.log 'add subjects ', @state.selected
-
   deleteSubjects: () ->
     subjects = @state.subjects.filter((subject) => @state.selected.indexOf(subject.id) is -1)
     @setState {subjects}
@@ -199,14 +201,15 @@ module.exports = React.createClass
             <div className="collection-buttons-container">
               <button
                 className="select-images-button"
-                onClick={@openCollectionsManager}>
-                <span>Add stuff</span>
+                onClick={@openCollectionsManager}
+                disabled={@state.selected.length < 1}>
+                <span>Add to Collection</span>
               </button>
               {if @state.collectionsManaging
                 <Dialog tag="div" closeButton={true} onCancel={@closeCollectionsManager}>
-                <CollectionsManager user={@props.user} project={@props.project} subject={undefined} onSuccess={@closeCollectionsManager} />
+                <CollectionsManager user={@props.user} project={@props.project} subjectIDs={@state.selected} onSuccess={@closeCollectionsManager} />
                 </Dialog>}
-              <button className="select-images-button" onClick={@deleteSubjects}>Remove from Collection</button>
+              <button className="select-images-button" onClick={@deleteSubjects} disabled={@state.selected.length < 1}>Remove from Collection</button>
               <button className="select-images-button" onClick={@toggleSelect}>Cancel</button>
             </div>
           else

--- a/app/collections/show.jsx
+++ b/app/collections/show.jsx
@@ -100,9 +100,12 @@ const CollectionPage = React.createClass({
     const profileLink = `${baseLink}/users/${this.state.owner.login}`;
     const collectionsLinkMessageKey = `collectionPage.${baseType}Link`;
 
-    const userRole = this.props.roles.filter((collectionRole) => {
-      return collectionRole.links.owner.id === this.props.user.id;
-    });
+    let userRole = [];
+    if (!!this.props.user) {
+      userRole = this.props.roles.filter((collectionRole) => {
+        return collectionRole.links.owner.id === this.props.user.id;
+      });
+    }
 
     return (
       <div className="collections-page">

--- a/app/collections/show.jsx
+++ b/app/collections/show.jsx
@@ -71,15 +71,18 @@ const CollectionPage = React.createClass({
 
   canCollaborate() {
     let canCollaborate;
-    if (!this.props.user) { canCollaborate = false; }
+    if (!this.props.user) {
+      canCollaborate = false;
+    } else {
+      canCollaborate = this.props.roles.some((role) => {
+        const idMatch = (role.links.owner.id === this.props.user.id);
+        const isOwner = role.roles.includes('owner');
+        const isCollaborator = role.roles.includes('collaborator');
+        return (isOwner || isCollaborator) && idMatch;
+      });
+    }
 
-    this.props.roles.some((role) => {
-      const idMatch = (role.links.owner.id === this.props.user.id);
-      const isOwner = role.roles.includes('owner');
-      const isCollaborator = role.roles.includes('collaborator');
-      canCollaborate = (isOwner || isCollaborator) && idMatch;
-      this.setState({ canCollaborate });
-    });
+    this.setState({ canCollaborate });
   },
 
   render() {

--- a/app/collections/show.jsx
+++ b/app/collections/show.jsx
@@ -129,9 +129,10 @@ const CollectionPage = React.createClass({
         <div className="talk">
           {React.cloneElement(this.props.children, {
             canCollaborate: this.state.canCollaborate,
+            user: this.props.user,
+            project: this.props.project,
             collection: this.props.collection,
-            roles: this.props.roles,
-            user: this.props.user
+            roles: this.props.roles
           })}
         </div>
       </div>

--- a/app/collections/show.jsx
+++ b/app/collections/show.jsx
@@ -121,7 +121,7 @@ const CollectionPage = React.createClass({
             </Link>
           </div>
           <nav className="collection-nav">
-            {isOwner ?
+            {this.state.canCollaborate ?
               <span>
                 <Link to={`${baseCollectionLink}/settings`} className="collection-nav-item" onClick={!!this.logClick ? this.logClick.bind(this, 'settings-collection') : null}>
                   <Translate content="collectionPage.settings" />

--- a/app/collections/show.jsx
+++ b/app/collections/show.jsx
@@ -1,24 +1,22 @@
 import React from 'react';
-import apiClient from 'panoptes-client/lib/api-client';
 import { IndexLink, Link } from 'react-router';
 import Translate from 'react-translate-component';
+import apiClient from 'panoptes-client/lib/api-client';
+import classNames from 'classnames';
 import counterpart from 'counterpart';
-import Avatar from '../partials/avatar';
 import Loading from '../components/loading-indicator';
 import TitleMixin from '../lib/title-mixin';
-import classNames from 'classnames';
 
 counterpart.registerTranslations('en', {
   collectionPage: {
-    settings: 'Settings',
+    settings: 'Collection Settings',
     collaborators: 'Collaborators',
     collectionsLink: '%(user)s\'s Collections',
-    favoritesLink: '%(user)s\'s Favorites',
-    userLink: '%(user)s\'s Profile',
+    favoritesLink: '%(user)s\'s Favorites'
   },
   collectionsPageWrapper: {
-    error: 'There was an error retrieving this collection.',
-  },
+    error: 'There was an error retrieving this collection.'
+  }
 });
 
 const CollectionPage = React.createClass({
@@ -28,16 +26,16 @@ const CollectionPage = React.createClass({
     collection: React.PropTypes.object.isRequired,
     project: React.PropTypes.object,
     children: React.PropTypes.node,
-    roles: React.PropTypes.array,
+    roles: React.PropTypes.array
   },
 
   contextTypes: {
-    geordi: React.PropTypes.object,
+    geordi: React.PropTypes.object
   },
 
   getDefaultProps() {
     return {
-      collection: null,
+      collection: null
     };
   },
 
@@ -101,30 +99,34 @@ const CollectionPage = React.createClass({
 
     return (
       <div className="collections-page">
-        <nav className="collection-nav tabbed-content-tabs">
-          <IndexLink to={baseCollectionLink} activeClassName="active" className="tabbed-content-tab" onClick={!!this.logClick ? this.logClick.bind(this, 'view-collection') : null}>
-            <Avatar user={this.state.owner} />
-            {this.props.collection.display_name}
-          </IndexLink>
-          {this.state.canCollaborate ?
-            <span>
-              <Link to={`${baseCollectionLink}/settings`} activeClassName="active" className="tabbed-content-tab" onClick={!!this.logClick ? this.logClick.bind(this, 'settings-collection') : null}>
-                <Translate content="collectionPage.settings" />
-              </Link>
-              <Link to={`${baseCollectionLink}/collaborators`} activeClassName="active" className="tabbed-content-tab" onClick={!!this.logClick ? this.logClick.bind(this, 'collab-collection') : null}>
-                <Translate content="collectionPage.collaborators" />
-              </Link>
-            </span> :
-            null
-          }
-          <Link to={baseCollectionsLink} className="tabbed-content-tab">
-            <Translate content={collectionsLinkMessageKey} user={this.state.owner.display_name} />
-          </Link>
-          <Link to={profileLink} activeClassName="active" className="tabbed-content-tab">
-            <Translate content="collectionPage.userLink" user={this.state.owner.display_name} />
-          </Link>
-        </nav>
-        <div className="collection-container talk">
+        <div className="collection-header">
+          <div>
+            <IndexLink to={baseCollectionLink} className="collection-title">
+              {this.props.collection.display_name}
+            </IndexLink>
+            <br />
+            <Link to={profileLink} className="collection-owner">
+              BY {this.state.owner.display_name}
+            </Link>
+          </div>
+          <nav className="collection-nav">
+            {isOwner ?
+              <span>
+                <Link to={`${baseCollectionLink}/settings`} className="collection-nav-item" onClick={!!this.logClick ? this.logClick.bind(this, 'settings-collection') : null}>
+                  <Translate content="collectionPage.settings" />
+                </Link>
+                <Link to={`${baseCollectionLink}/collaborators`} className="collection-nav-item" onClick={!!this.logClick ? this.logClick.bind(this, 'collab-collection') : null}>
+                  <Translate content="collectionPage.collaborators" />
+                </Link>
+              </span> :
+              null
+            }
+            <Link to={baseCollectionsLink} className="collection-nav-item">
+              <Translate content={collectionsLinkMessageKey} user={this.state.owner.display_name} />
+            </Link>
+          </nav>
+        </div>
+        <div className="talk">
           {React.cloneElement(this.props.children, {
             canCollaborate: this.state.canCollaborate,
             collection: this.props.collection,
@@ -134,7 +136,7 @@ const CollectionPage = React.createClass({
         </div>
       </div>
     );
-  },
+  }
 });
 
 const CollectionPageWrapper = React.createClass({

--- a/app/collections/show.jsx
+++ b/app/collections/show.jsx
@@ -97,14 +97,9 @@ const CollectionPage = React.createClass({
     const profileLink = `${baseLink}/users/${this.state.owner.login}`;
     const collectionsLinkMessageKey = `collectionPage.${baseType}Link`;
 
-    let roles;
-    if (this.props.roles.some(collectionRole => collectionRole.links.owner.id === this.props.user.id)) {
-      const userRole = this.props.roles.filter(collectionRole =>
-      collectionRole.links.owner.id === this.props.user.id);
-      roles = userRole[0].roles;
-    } else {
-      roles = [];
-    }
+    const userRole = this.props.roles.filter((collectionRole) => {
+      return collectionRole.links.owner.id === this.props.user.id;
+    });
 
     return (
       <div className="collections-page">
@@ -113,7 +108,7 @@ const CollectionPage = React.createClass({
             <IndexLink to={baseCollectionLink} className="collection-title">
               {this.props.collection.display_name}
             </IndexLink>
-            {(roles.length > 0) ? <span> [ {roles.join(', ')} ] </span> : null
+            {(userRole.length > 0) ? <span> [ {userRole[0].roles.join(', ')} ] </span> : null
             }
             <br />
             <Link to={profileLink} className="collection-owner">

--- a/app/collections/show.jsx
+++ b/app/collections/show.jsx
@@ -42,7 +42,7 @@ const CollectionPage = React.createClass({
   getInitialState() {
     return {
       canCollaborate: false,
-      owner: null,
+      owner: null
     };
   },
 
@@ -113,9 +113,7 @@ const CollectionPage = React.createClass({
             <IndexLink to={baseCollectionLink} className="collection-title">
               {this.props.collection.display_name}
             </IndexLink>
-            {(roles.length > 0) ?
-              <span> [ {roles.join(', ')} ] </span> :
-              null
+            {(roles.length > 0) ? <span> [ {roles.join(', ')} ] </span> : null
             }
             <br />
             <Link to={profileLink} className="collection-owner">
@@ -162,7 +160,7 @@ const CollectionPageWrapper = React.createClass({
     user: React.PropTypes.object,
     params: React.PropTypes.shape({
       collection_owner: React.PropTypes.string,
-      collection_name: React.PropTypes.string,
+      collection_name: React.PropTypes.string
     })
   },
 

--- a/app/collections/show.jsx
+++ b/app/collections/show.jsx
@@ -103,7 +103,7 @@ const CollectionPage = React.createClass({
       collectionRole.links.owner.id === this.props.user.id);
       roles = userRole[0].roles;
     } else {
-      roles = []
+      roles = [];
     }
 
     return (
@@ -163,12 +163,12 @@ const CollectionPageWrapper = React.createClass({
     params: React.PropTypes.shape({
       collection_owner: React.PropTypes.string,
       collection_name: React.PropTypes.string,
-    }),
+    })
   },
 
   getDefaultProps() {
     return {
-      params: null,
+      params: null
     };
   },
 
@@ -177,7 +177,7 @@ const CollectionPageWrapper = React.createClass({
       collection: null,
       roles: null,
       error: false,
-      loading: false,
+      loading: false
     };
   },
 
@@ -206,7 +206,7 @@ const CollectionPageWrapper = React.createClass({
 
   fetchCollection() {
     this.setState({
-      loading: true,
+      loading: true
     });
 
     apiClient.type('collections')
@@ -216,13 +216,13 @@ const CollectionPageWrapper = React.createClass({
       )
       .then(([collection]) => {
         if (collection) {
-          return [collection]
+          return [collection];
         } else {
           return apiClient.type('collections')
           .get({
             id: this.props.params.collection_name,
             include: ['owner']
-          })
+          });
         }
       })
       .then(([collection]) => {
@@ -230,21 +230,21 @@ const CollectionPageWrapper = React.createClass({
 
         return apiClient.type('collection_roles')
           .get({
-            collection_id: collection.id,
+            collection_id: collection.id
           })
           .then((roles) => {
             this.setState({
               error: false,
               loading: false,
               collection,
-              roles,
+              roles
             });
           });
       })
       .catch((e) => {
         this.setState({
           error: e,
-          loading: false,
+          loading: false
         });
       });
   },
@@ -252,15 +252,15 @@ const CollectionPageWrapper = React.createClass({
   render() {
     const classes = classNames({
       'content-container': true,
-      'collection-page-with-project-context': !!this.props.project,
+      'collection-page-with-project-context': !!this.props.project
     });
     const { project, user } = this.props;
     let output = null;
     if (this.state.collection) {
-      output =
+      output = (
         <CollectionPage project={project} user={user} collection={this.state.collection} roles={this.state.roles}>
           {this.props.children}
-        </CollectionPage>;
+        </CollectionPage>);
     }
     if (this.state.error) {
       output = <Translate component="p" content="collectionsPageWrapper.error" />;
@@ -273,7 +273,7 @@ const CollectionPageWrapper = React.createClass({
         {output}
       </div>
     );
-  },
+  }
 });
 
 export default CollectionPageWrapper;

--- a/app/collections/show.jsx
+++ b/app/collections/show.jsx
@@ -90,6 +90,7 @@ const CollectionPage = React.createClass({
       return null;
     }
 
+    const title = `${this.props.collection.display_name} (${this.props.collection.links.subjects ? this.props.collection.links.subjects.length : null})`;
     const baseType = this.props.collection.favorite ? 'favorites' : 'collections';
     let baseLink = '';
     if (!!this.props.project) {
@@ -107,32 +108,37 @@ const CollectionPage = React.createClass({
       });
     }
 
+    let displayRole = '';
+    if (userRole.length > 0) {
+      if (userRole[0].roles.includes('owner')) {
+        displayRole = ` (you're the ${userRole[0].roles.join(', ')})`;
+      } else {
+        displayRole = ` (you're a ${userRole[0].roles.join(', ')})`;
+      }
+    }
+
     return (
       <div className="collections-page">
         <div className="collection-header">
           <div>
             <IndexLink to={baseCollectionLink} className="collection-title">
-              {this.props.collection.display_name}
+              {title}
             </IndexLink>
-            {(userRole.length > 0) ? <span> [ {userRole[0].roles.join(', ')} ] </span> : null
-            }
             <br />
             <Link to={profileLink} className="collection-owner">
               BY {this.state.owner.display_name}
             </Link>
+            {displayRole}
           </div>
           <nav className="collection-nav">
             {this.state.canCollaborate ?
-              <span>
-                <Link to={`${baseCollectionLink}/settings`} className="collection-nav-item" onClick={!!this.logClick ? this.logClick.bind(this, 'settings-collection') : null}>
-                  <Translate content="collectionPage.settings" />
-                </Link>
-                <Link to={`${baseCollectionLink}/collaborators`} className="collection-nav-item" onClick={!!this.logClick ? this.logClick.bind(this, 'collab-collection') : null}>
+              <Link to={`${baseCollectionLink}/settings`} activeClassName="active" className="collection-nav-item" onClick={!!this.logClick ? this.logClick.bind(this, 'settings-collection') : null}>
+                <Translate content="collectionPage.settings" />
+              </Link> : null}
+            {this.state.canCollaborate ?
+                <Link to={`${baseCollectionLink}/collaborators`} activeClassName="active" className="collection-nav-item" onClick={!!this.logClick ? this.logClick.bind(this, 'collab-collection') : null}>
                   <Translate content="collectionPage.collaborators" />
-                </Link>
-              </span> :
-              null
-            }
+                </Link> : null}
             <Link to={baseCollectionsLink} className="collection-nav-item">
               <Translate content={collectionsLinkMessageKey} user={this.state.owner.display_name} />
             </Link>

--- a/app/collections/show.jsx
+++ b/app/collections/show.jsx
@@ -114,7 +114,7 @@ const CollectionPage = React.createClass({
               {this.props.collection.display_name}
             </IndexLink>
             {(roles.length > 0) ?
-              <span> [ {roles.toString()} ] </span> :
+              <span> [ {roles.join(', ')} ] </span> :
               null
             }
             <br />

--- a/app/collections/show.jsx
+++ b/app/collections/show.jsx
@@ -97,6 +97,15 @@ const CollectionPage = React.createClass({
     const profileLink = `${baseLink}/users/${this.state.owner.login}`;
     const collectionsLinkMessageKey = `collectionPage.${baseType}Link`;
 
+    let roles;
+    if (this.props.roles.some(collectionRole => collectionRole.links.owner.id === this.props.user.id)) {
+      const userRole = this.props.roles.filter(collectionRole =>
+      collectionRole.links.owner.id === this.props.user.id);
+      roles = userRole[0].roles;
+    } else {
+      roles = []
+    }
+
     return (
       <div className="collections-page">
         <div className="collection-header">
@@ -104,6 +113,10 @@ const CollectionPage = React.createClass({
             <IndexLink to={baseCollectionLink} className="collection-title">
               {this.props.collection.display_name}
             </IndexLink>
+            {(roles.length > 0) ?
+              <span> [ {roles.toString()} ] </span> :
+              null
+            }
             <br />
             <Link to={profileLink} className="collection-owner">
               BY {this.state.owner.display_name}

--- a/css/collections-page.styl
+++ b/css/collections-page.styl
@@ -3,17 +3,60 @@
   flex: 1 0 auto
   flex-direction: column
 
-  .collection-container
-    padding: 0 3vw
+  .collection-header
+    display: flex
+    flex: 1 0 auto
+    margin-bottom: 3em
+    font-size: 0.8em
+    color: COPY
+    justify-content: space-between
 
-  .collection-settings-tab
-    max-width: 800px
-    margin: 0 auto
+  .collection-title
+    @extends $reset-button
+    font-size: 1.5em
+    font-weight: bold
+
+  .collection-owner
+    @extends $reset-button
+    text-transform: uppercase
+
+  .collection-nav
+    display: flex
+    align-items: flex-end
+    justify-content: space-between
+
+  .collection-nav-item
+    @extends $reset-button
+    margin-left: 1.5em
+    text-transform: uppercase
 
   .collections-show
-    flex-wrap: wrap
-    max-width: 1200px
     margin: 0 auto
+
+    .collection-buttons-container
+      display: flex
+      justify-content: flex-end
+      margin-bottom: 2em
+
+    .select-images-button
+      @extends $reset-button
+      margin-left: 1.5em
+      min-width: 10em
+      border-radius: 2px
+      border: HIGHLIGHT_COLOR
+      background-color: transparent
+      padding: 0.6em 1.2em
+      text-align: center
+      font-size: 0.8em
+
+      &:focus,
+      &:hover
+        background-color: HIGHLIGHT_COLOR
+        color: white
+
+    .collection-subjects-list
+      display: flex
+      flex-flow: row wrap
 
     .collection-subject-viewer
       width: 18em
@@ -38,40 +81,20 @@
       top: 0
       left: 0
 
-    .collection-subject-viewer-delete-button
-      background: white
-      border: none
-      border-bottom-left-radius: 50%
-      cursor: pointer
-      display: flex
-      height: 1.3em
-      margin-left: -2px
-      position: absolute
-      right: -0.3em
-      top: -0.3em
-      width: 1.3em
-      z-index: 1
+    // .collection-subject-viewer-delete-button
 
-      &:hover
-        color: red
+    // .collection-subject-viewer-circle-open
+
+    // .collection-subject-viewer-circle-checked
+
+  .collection-settings-tab
+    max-width: 800px
+    margin: 0 auto
 
   .helpful-tip
     color: #777
     font-style: italic
     text-align: center
-
-.collection-nav
-  margin-left: 0
-  margin-top: 2em
-  text-align: left
-
-  .tabbed-content-tab
-    position: relative
-
-  .avatar
-    height: 4em
-    vertical-align: middle
-    margin: -2em 1vw -2em 0px
 
 .collections-manager
   h1

--- a/css/collections-page.styl
+++ b/css/collections-page.styl
@@ -133,6 +133,9 @@
     text-align: center
 
 .collections-manager
+  margin: 1em 1em
+  padding: 1em 1em
+
   h1
     margin-bottom: 20px
 

--- a/css/collections-page.styl
+++ b/css/collections-page.styl
@@ -62,13 +62,18 @@
       width: 18em
       border: 1px solid #cdcdcd
       border-radius: 5px
+      position: relative
       margin: 0 1.66em 1.66em 0
       text-align: center
-      display: inline-block
-      position: relative
+      display: flex
+      flex-direction: column
+      justify-content: center
 
       .subject-video-controls
         display: initial
+
+      .subject-image-frame
+        margin: auto
 
     img
       width: 100%
@@ -81,11 +86,39 @@
       top: 0
       left: 0
 
-    // .collection-subject-viewer-delete-button
+    .collection-subject-viewer-delete-button
+      background: white
+      border: none
+      border-bottom-left-radius: 50%
+      cursor: pointer
+      display: flex
+      height: 1.3em
+      margin-left: -2px
+      position: absolute
+      right: -0.3em
+      top: -0.3em
+      width: 1.3em
+      z-index: 1
 
-    // .collection-subject-viewer-circle-open
+      &:hover
+        color: red
 
-    // .collection-subject-viewer-circle-checked
+    .collection-subject-viewer-selecting
+      height: 100%
+      width: 100%
+      position: absolute
+      top: 0
+      left: 0
+      display: flex
+      justify-content: center
+      align-content: center
+
+      .collection-subject-viewer-select
+        color: white
+        background: transparent
+        font-size: 3em
+        border: none
+        width: 100%
 
   .collection-settings-tab
     max-width: 800px

--- a/css/collections-page.styl
+++ b/css/collections-page.styl
@@ -124,10 +124,13 @@
         position: absolute
         left: -9999px
 
+        &:focus + i
+          text-shadow: 0 0 25px COBOLT_BLUE
+
       .collection-subject-viewer-circle
         color: white
         font-size: 6em
-        text-shadow: 1px 1px 25px COPY
+        text-shadow: 0 0 25px COPY
 
   .collection-settings-tab
     max-width: 800px

--- a/css/collections-page.styl
+++ b/css/collections-page.styl
@@ -104,21 +104,27 @@
       &:hover
         color: red
 
-    .collection-subject-viewer-select-button
+    .collection-subject-viewer-select
       height: 100%
       width: 100%
       position: absolute
       top: 0
       left: 0
       border: none
-      text-align: center
       background: transparent
+      display: flex
+      flex-direction: column
+      justify-content: center
 
       &:hover
         background-color: transparent
+        cursor: pointer
+
+      input
+        position: absolute
+        left: -9999px
 
       .collection-subject-viewer-circle
-        vertical-align: middle
         color: white
         font-size: 6em
         text-shadow: 1px 1px 25px COPY
@@ -133,8 +139,8 @@
     text-align: center
 
 .collections-manager
-  margin: 1em 1em
-  padding: 1em 1em
+  margin: 1em
+  padding: 1em
 
   h1
     margin-bottom: 20px

--- a/css/collections-page.styl
+++ b/css/collections-page.styl
@@ -58,19 +58,14 @@
       &:disabled
         opacity: 0.5
 
-    .collection-subjects-list
-      display: flex
-      flex-flow: row wrap
-
     .collection-subject-viewer
       width: 18em
       border: 1px solid #cdcdcd
       border-radius: 5px
       margin: 0 1.66em 1.66em 0
       text-align: center
-      display: flex
-      flex-direction: column
-      justify-content: center
+      display: inline-block
+      position: relative
 
       .subject-video-controls
         display: initial
@@ -106,22 +101,24 @@
       &:hover
         color: red
 
-    .collection-subject-viewer-selecting
+    .collection-subject-viewer-select-button
       height: 100%
       width: 100%
       position: absolute
       top: 0
       left: 0
-      display: flex
-      justify-content: center
-      align-content: center
+      border: none
+      text-align: center
+      background: transparent
 
-      .collection-subject-viewer-select
+      &:hover
+        background-color: transparent
+
+      .collection-subject-viewer-circle
+        vertical-align: middle
         color: white
-        background: transparent
-        font-size: 4em
-        border: none
-        width: 100%
+        font-size: 6em
+        text-shadow: 1px 1px 25px COPY
 
   .collection-settings-tab
     max-width: 800px

--- a/css/collections-page.styl
+++ b/css/collections-page.styl
@@ -51,8 +51,12 @@
 
       &:focus,
       &:hover
+        border: HIGHLIGHT_COLOR
         background-color: HIGHLIGHT_COLOR
         color: white
+
+      &:disabled
+        opacity: 0.5
 
     .collection-subjects-list
       display: flex
@@ -62,7 +66,6 @@
       width: 18em
       border: 1px solid #cdcdcd
       border-radius: 5px
-      position: relative
       margin: 0 1.66em 1.66em 0
       text-align: center
       display: flex
@@ -116,7 +119,7 @@
       .collection-subject-viewer-select
         color: white
         background: transparent
-        font-size: 3em
+        font-size: 4em
         border: none
         width: 100%
 

--- a/css/collections-page.styl
+++ b/css/collections-page.styl
@@ -6,10 +6,14 @@
   .collection-header
     display: flex
     flex: 1 0 auto
-    margin-bottom: 3em
+    margin-bottom: 2em
     font-size: 0.8em
     color: COPY
     justify-content: space-between
+
+    @media (max-width: 900px)
+      flex-direction: column
+      margin-bottom: 1em
 
   .collection-title
     @extends $reset-button
@@ -25,10 +29,22 @@
     align-items: flex-end
     justify-content: space-between
 
+    @media (max-width: 900px)
+      flex-direction: column
+      align-items: flex-start
+
   .collection-nav-item
     @extends $reset-button
     margin-left: 1.5em
     text-transform: uppercase
+    text-align: center
+
+    @media (max-width: 900px)
+      margin: 0.6em 0
+
+    &.active
+      border-bottom: 1px solid TEAL_MID
+      font-weight: bold
 
   .collections-show
     margin: 0 auto
@@ -37,6 +53,11 @@
       display: flex
       justify-content: flex-end
       margin-bottom: 2em
+
+      @media (max-width: 900px)
+        flex-direction: column
+        justify-content: center
+        align-content: center
 
     .select-subjects-button
       @extends $reset-button
@@ -48,6 +69,9 @@
       padding: 0.6em 1.2em
       text-align: center
       font-size: 0.8em
+
+      @media (max-width: 900px)
+        margin: 1em
 
       &:focus,
       &:hover
@@ -67,10 +91,14 @@
       display: inline-block
       position: relative
 
+      @media (max-width: 900px)
+        display: block
+        margin: 0 auto
+
       .subject-video-controls
         display: initial
 
-      .subject-media-frame
+      .subject-image-frame
         margin: auto
 
     img

--- a/css/collections-page.styl
+++ b/css/collections-page.styl
@@ -77,6 +77,9 @@
       width: 100%
       max-height: 250px
 
+    .subject-video-controls
+      z-index: 1
+
     .subject-link
       height: 100%
       width: 100%

--- a/css/collections-page.styl
+++ b/css/collections-page.styl
@@ -38,7 +38,7 @@
       justify-content: flex-end
       margin-bottom: 2em
 
-    .select-images-button
+    .select-subjects-button
       @extends $reset-button
       margin-left: 1.5em
       min-width: 10em
@@ -70,7 +70,7 @@
       .subject-video-controls
         display: initial
 
-      .subject-image-frame
+      .subject-media-frame
         margin: auto
 
     img


### PR DESCRIPTION
WAIT TO MERGE - wait for notice to be given to users before merging.

Fixes #3483.

Changes to general design of a collection.
Add functionality to select then add or remove multiple subjects in a collection.

I've been testing in this project's collections:
https://collections-add-delete-multi-subjects.pfe-preview.zooniverse.org/projects/markb-panoptes/test-project-mb/collections

Remaining Open Items:
- [x] card border
- [x] circle drop-shadow
- [x] test with video and flipbook subjects

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? - https://collections-add-delete-multi-subjects.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?