### PR TITLE
Fix null or undefined DOM node in text viewer

### DIFF
--- a/app/components/text-viewer.jsx
+++ b/app/components/text-viewer.jsx
@@ -35,7 +35,7 @@ class TextViewer extends Component {
       this.setState({ content: cachedContent });
     } else {
       this.setState({ content: 'Loading…' });
-      fetch(src, { mode: 'cors' })
+      fetch(src + '?=')
       .then((response) => {
         return response.text();
       })

--- a/app/components/text-viewer.jsx
+++ b/app/components/text-viewer.jsx
@@ -3,12 +3,14 @@ import React, { Component } from 'react';
 const SUPPORTED_TYPES = ['text'];
 const SUPPORTED_FORMATS = ['plain'];
 
+const cache = {};
+
 class TextViewer extends Component {
   constructor(props) {
     super(props);
     this.element = null;
     this.state = {
-      content: 'Loading…'
+      content: ''
     };
   }
 
@@ -19,7 +21,6 @@ class TextViewer extends Component {
 
   componentWillReceiveProps(newProps) {
     if (newProps.src !== this.props.src) {
-      this.setState({ content: 'Loading…' });
       this.loadText(newProps.src);
     }
   }
@@ -29,18 +30,25 @@ class TextViewer extends Component {
   }
 
   loadText(src) {
-    fetch(src, { mode: 'cors' })
-    .then((response) => {
-      return response.text();
-    })
-    .then((content) => {
-      this.setState({ content });
-      this.element.dispatchEvent(new Event('load'));
-    })
-    .catch((e) => {
-      const content = e.message;
-      this.setState({ content });
-    });
+    const cachedContent = cache[src];
+    if (cachedContent) {
+      this.setState({ content: cachedContent });
+    } else {
+      this.setState({ content: 'Loading…' });
+      fetch(src, { mode: 'cors' })
+      .then((response) => {
+        return response.text();
+      })
+      .then((content) => {
+        cache[src] = content;
+        this.setState({ content });
+        this.element.dispatchEvent(new Event('load'));
+      })
+      .catch((e) => {
+        const content = e.message;
+        this.setState({ content });
+      });
+    }
   }
 
   render() {

--- a/app/components/text-viewer.jsx
+++ b/app/components/text-viewer.jsx
@@ -53,6 +53,7 @@ class TextViewer extends Component {
 
   render() {
     let { content } = this.state;
+    const isLoading = (this.state.content === 'Loading…');
     if (SUPPORTED_TYPES.indexOf(this.props.type) === -1) {
       content = `Unsupported type: ${this.props.type}`;
     }
@@ -60,7 +61,7 @@ class TextViewer extends Component {
       content = `Unsupported format: ${this.props.format}`;
     }
     return (
-      <div ref={(element) => { this.element = element; }} className="text-viewer" >
+      <div ref={(element) => { this.element = element; }} className={isLoading ? 'text-viewer-loading' : 'text-viewer'} >
         { content }
       </div>
     );

--- a/app/components/text-viewer.jsx
+++ b/app/components/text-viewer.jsx
@@ -8,27 +8,25 @@ class TextViewer extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      content: '',
+      content: 'Loading…'
     };
   }
 
-  componentWillMount() {
+  componentDidMount() {
+    const root = ReactDOM.findDOMNode(this);
+    root.addEventListener('load', this.props.onLoad);
     fetch(this.props.src, { mode: 'cors' })
     .then((response) => {
       return response.text();
     })
     .then((content) => {
       this.setState({ content });
-      ReactDOM.findDOMNode(this).dispatchEvent(new Event('load'));
+      root.dispatchEvent(new Event('load'));
     })
     .catch((e) => {
       const content = e.message;
       this.setState({ content });
     });
-  }
-
-  componentDidMount() {
-    ReactDOM.findDOMNode(this).addEventListener('load', this.props.onLoad);
   }
 
   componentWillUnmount() {
@@ -37,9 +35,6 @@ class TextViewer extends Component {
 
   render() {
     let { content } = this.state;
-    if (content === "") {
-      return null;
-    }
     if (SUPPORTED_TYPES.indexOf(this.props.type) === -1) {
       content = `Unsupported type: ${this.props.type}`;
     }

--- a/app/components/text-viewer.jsx
+++ b/app/components/text-viewer.jsx
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-import ReactDOM from 'react-dom';
 
 const SUPPORTED_TYPES = ['text'];
 const SUPPORTED_FORMATS = ['plain'];
@@ -7,21 +6,21 @@ const SUPPORTED_FORMATS = ['plain'];
 class TextViewer extends Component {
   constructor(props) {
     super(props);
+    this.element = null;
     this.state = {
       content: 'Loading…'
     };
   }
 
   componentDidMount() {
-    const root = ReactDOM.findDOMNode(this);
-    root.addEventListener('load', this.props.onLoad);
+    this.element.addEventListener('load', this.props.onLoad);
     fetch(this.props.src, { mode: 'cors' })
     .then((response) => {
       return response.text();
     })
     .then((content) => {
       this.setState({ content });
-      root.dispatchEvent(new Event('load'));
+      this.element.dispatchEvent(new Event('load'));
     })
     .catch((e) => {
       const content = e.message;
@@ -30,7 +29,7 @@ class TextViewer extends Component {
   }
 
   componentWillUnmount() {
-    ReactDOM.findDOMNode(this).removeEventListener('load', this.props.onLoad);
+    this.element.removeEventListener('load', this.props.onLoad);
   }
 
   render() {
@@ -42,7 +41,7 @@ class TextViewer extends Component {
       content = `Unsupported format: ${this.props.format}`;
     }
     return (
-      <div className="text-viewer" >
+      <div ref={(element) => { this.element = element; }} className="text-viewer" >
         { content }
       </div>
     );
@@ -53,13 +52,13 @@ TextViewer.propTypes = {
   src: React.PropTypes.string.isRequired,
   type: React.PropTypes.string,
   format: React.PropTypes.string,
-  onLoad: React.PropTypes.func,
+  onLoad: React.PropTypes.func
 };
 
 TextViewer.defaultProps = {
   type: 'text',
   format: 'plain',
-  onLoad: (e) => { console.log('text loaded', e); },
+  onLoad: (e) => { console.log('text loaded', e); }
 };
 
 export default TextViewer;

--- a/app/components/text-viewer.jsx
+++ b/app/components/text-viewer.jsx
@@ -14,7 +14,22 @@ class TextViewer extends Component {
 
   componentDidMount() {
     this.element.addEventListener('load', this.props.onLoad);
-    fetch(this.props.src, { mode: 'cors' })
+    this.loadText(this.props.src);
+  }
+
+  componentWillReceiveProps(newProps) {
+    if (newProps.src !== this.props.src) {
+      this.setState({ content: 'Loading…' });
+      this.loadText(newProps.src);
+    }
+  }
+
+  componentWillUnmount() {
+    this.element.removeEventListener('load', this.props.onLoad);
+  }
+
+  loadText(src) {
+    fetch(src, { mode: 'cors' })
     .then((response) => {
       return response.text();
     })
@@ -26,10 +41,6 @@ class TextViewer extends Component {
       const content = e.message;
       this.setState({ content });
     });
-  }
-
-  componentWillUnmount() {
-    this.element.removeEventListener('load', this.props.onLoad);
   }
 
   render() {

--- a/css/subject-viewer.styl
+++ b/css/subject-viewer.styl
@@ -51,6 +51,7 @@
     .text-viewer
       background-color: #404040
       color: white
+      min-width: 30em
       padding: 2%
       white-space: pre-wrap
 

--- a/css/subject-viewer.styl
+++ b/css/subject-viewer.styl
@@ -51,7 +51,7 @@
     .text-viewer
       background-color: #404040
       color: white
-      min-width: 30em
+      width: 96%
       padding: 2%
       white-space: pre-wrap
 


### PR DESCRIPTION
Rewrites the text viewer to fix a bug where it manipulates the DOM before it has rendered.
Sets a minimum width of 30em for text subjects.
Adds content caching, by URL, for text subjects.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://fix-text-viewer.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?