### PR TITLE
Check collection owner for favourites

### DIFF
--- a/app/collections/show-list.cjsx
+++ b/app/collections/show-list.cjsx
@@ -49,8 +49,8 @@ SubjectNode = React.createClass
     return hasPermission
 
   isFavorite: (project) ->
-    if @props.collection.favorite
-      @setState isFavorite: @props.collection.favorite
+    if @props.collection.favorite and @props.collection.links.owner.id is @props.user.id
+      @setState isFavorite: true
     else if @props.user?
       query = {
         favorite: true


### PR DESCRIPTION
Fixes favourite button highlighting for any favourites collection, not just your own.

Describe your changes.
Add a check for collection owner when testing for favourites collections.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://fix-favourite-collections.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?