### PR TITLE
First to classify experiment

### DIFF
--- a/app/classifier/classifier.jsx
+++ b/app/classifier/classifier.jsx
@@ -111,24 +111,6 @@ export default class Classifier extends React.Component {
     this.setState({ annotations });
   }
 
-  loadClassificationsCount(subject) {
-    let query = {};
-    if (this.props.splits && this.props.splits['subject.first-to-classify']) {
-      query = {
-        workflow_id: this.props.workflow.id,
-        subject_id: subject.id
-      };
-    
-
-      apiClient.type('subject_workflow_statuses')
-      .get(query)
-      .then(([sws]) => {
-        const classificationCount = sws.classifications_count ? sws.classifications_count : 0;
-        this.setState({ classificationCount });
-      });
-    }
-  }
-
   loadSubject(subject) {
     this.setState({
       expertClassification: null,
@@ -140,8 +122,6 @@ export default class Classifier extends React.Component {
     if (this.props.project.experimental_tools && this.props.project.experimental_tools.indexOf('expert comparison summary') > -1) {
       this.getExpertClassification(this.props.workflow, this.props.subject);
     }
-
-    this.loadClassificationsCount(subject);
 
     preloadSubject(subject)
     .then(() => {
@@ -261,7 +241,7 @@ export default class Classifier extends React.Component {
               classification={currentClassification}
               expertClassification={this.state.expertClassification}
               splits={this.props.splits}
-              classificationCount={this.state.classificationCount}
+              classificationCount={this.props.classificationCount}
               hasGSGoldStandard={this.subjectIsGravitySpyGoldStandard()}
               toggleExpertClassification={this.toggleExpertClassification}
             />
@@ -369,6 +349,7 @@ Classifier.propTypes = {
     stopListening: React.PropTypes.func,
     update: React.PropTypes.func
   }),
+  classificationCount: React.PropTypes.number,
   demoMode: React.PropTypes.bool,
   expertClassifier: React.PropTypes.bool,
   minicourse: React.PropTypes.shape({
@@ -413,6 +394,7 @@ Classifier.propTypes = {
 
 Classifier.defaultProps = {
   classification: null,
+  classificationCount: 0,
   demoMode: false,
   minicourse: null,
   preferences: null,

--- a/app/classifier/custom-sign-in-prompt.jsx
+++ b/app/classifier/custom-sign-in-prompt.jsx
@@ -24,7 +24,7 @@ export default class CustomSignInPrompt extends React.Component {
   render() {
     if (!this.state.hidden) {
       return (
-        <div className="project-announcement-banner custom-sign-in-banner">
+        <div className="classify-announcement-banner custom-sign-in-banner">
           <span>
             <i className="fa fa-exclamation-circle" aria-hidden="true"></i>{' '}
             {this.props.children}

--- a/app/classifier/custom-sign-in-prompt.jsx
+++ b/app/classifier/custom-sign-in-prompt.jsx
@@ -24,7 +24,7 @@ export default class CustomSignInPrompt extends React.Component {
   render() {
     if (!this.state.hidden) {
       return (
-        <div className="classify-announcement-banner custom-sign-in-banner">
+        <div className="classifier-announcement-banner custom-sign-in-banner">
           <span>
             <i className="fa fa-exclamation-circle" aria-hidden="true"></i>{' '}
             {this.props.children}

--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -50,7 +50,7 @@ module.exports = React.createClass
     userRoles: []
     tutorial: null
     minicourse: null
-    classificationCount: 0
+    classificationCount: null
 
   componentDidMount: ->
     @checkExpertClassifier()

--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -151,7 +151,7 @@ module.exports = React.createClass
           <p>Please sign in or sign up to access more glitch types and classification options as well as our mini-course.</p>
         </CustomSignInPrompt>}
 
-      {if @state.classificationCount is 0 and (@props.splits['classifier.first-to-classify.visible']
+      {if @state.classificationCount is 0 and @props.splits['classifier.first-to-classify.visible']
         <VisibilitySplit splits={@props.splits} splitKey={'classifier.first-to-classify.visible'} elementKey={'div'}>
           <div className="classifier-announcement-banner classifier-announcement-banner--yellow">
             <p>You're the first person to see this subject!</p>

--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -141,7 +141,7 @@ module.exports = React.createClass
       apiClient.type('subject_workflow_statuses')
       .get(query)
       .then ([sws]) =>
-        classificationCount = if sws.classifications_count then sws.classifications_count else 0
+        classificationCount = if sws?.classifications_count then sws.classifications_count else 0
         @setState({ classificationCount });
 
   render: ->
@@ -151,7 +151,7 @@ module.exports = React.createClass
           <p>Please sign in or sign up to access more glitch types and classification options as well as our mini-course.</p>
         </CustomSignInPrompt>}
 
-      {if @state.classificationCount is 0 and @props.splits['subject.first-to-classify.visible']
+      {if @state.classificationCount is 0 and @props.splits?['subject.first-to-classify.visible']
         <VisibilitySplit splits={@props.splits} splitKey={'subject.first-to-classify.visible'} elementKey={'div'}>
           <div className="classifier-announcement-banner classifier-announcement-banner--yellow">
             <p>You're the first person to see this subject!</p>

--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -5,6 +5,7 @@ MiniCourse = require '../components/mini-course'
 Tutorial = require '../components/tutorial'
 `import CustomSignInPrompt from './custom-sign-in-prompt';`
 isAdmin = require '../lib/is-admin'
+{ VisibilitySplit } = require 'seven-ten'
 
 ###############################################################################
 # Page Wrapper Component
@@ -49,10 +50,12 @@ module.exports = React.createClass
     userRoles: []
     tutorial: null
     minicourse: null
+    classificationCount: 0
 
   componentDidMount: ->
     @checkExpertClassifier()
     @loadClassification @props.classification
+
     Tutorial.find @props.workflow
     .then (tutorial) =>
       {user, preferences} = @props
@@ -86,6 +89,8 @@ module.exports = React.createClass
     Promise.resolve(classification._subjects ? classification.get 'subjects').then ([subject]) =>
       # We'll only handle one subject per classification right now.
       # TODO: Support multi-subject classifications in the future.
+      @loadClassificationsCount(subject);
+
       @setState {subject}
 
   onCompleteAndLoadAnotherSubject: ->
@@ -122,12 +127,37 @@ module.exports = React.createClass
         expertClassifier = isAdmin() or 'owner' in userRoles or 'collaborator' in userRoles or 'expert' in userRoles
         @setState {expertClassifier, userRoles}
 
+  loadClassificationsCount: (subject) ->
+    query = {};
+    # Split 'classifier.first-to-classify.visible' is a visibility split on 
+    # a generic pre-classification notification banner on the classify page.
+    # Split 'subject.first-to-classify' is a text split in the classification summary.
+    # Projects need classification summarys visible for this to work.
+    if @props.splits and subject and (@props.splits['classifier.first-to-classify.visible'] or @props.splits['subject.first-to-classify'])
+      query =
+        workflow_id: @props.workflow.id,
+        subject_id: subject.id
+
+      apiClient.type('subject_workflow_statuses')
+      .get(query)
+      .then ([sws]) =>
+        classificationCount = if sws.classifications_count then sws.classifications_count else 0
+        @setState({ classificationCount });
+
   render: ->
     <div>
       {if @props.project.experimental_tools.indexOf('workflow assignment') > -1 and not @props.user # Gravity Spy
         <CustomSignInPrompt classificationsThisSession={classificationsThisSession}>
           <p>Please sign in or sign up to access more glitch types and classification options as well as our mini-course.</p>
         </CustomSignInPrompt>}
+
+      {if @state.classificationCount is 0 and (@props.splits['classifier.first-to-classify.visible']
+        <VisibilitySplit splits={@props.splits} splitKey={'classifier.first-to-classify.visible'} elementKey={'div'}>
+          <div className="classifier-announcement-banner classifier-announcement-banner--yellow">
+            <p>You're the first person to see this subject!</p>
+          </div>
+        </VisibilitySplit>}
+
       {if @props.workflow? and @state.subject?
         <Classifier {...@props}
           workflow={@props.workflow}
@@ -140,6 +170,7 @@ module.exports = React.createClass
           guideIcons={@state.guideIcons}
           onComplete={@onComplete}
           onCompleteAndLoadAnotherSubject={@onCompleteAndLoadAnotherSubject}
+          classificationCount={@state.classificationCount}
         />
       else
         <span>Loading classifier...</span>}

--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -129,11 +129,11 @@ module.exports = React.createClass
 
   loadClassificationsCount: (subject) ->
     query = {};
-    # Split 'classifier.first-to-classify.visible' is a visibility split on 
+    # Split 'subject.first-to-classify.visible' is a visibility split on 
     # a generic pre-classification notification banner on the classify page.
     # Split 'subject.first-to-classify' is a text split in the classification summary.
     # Projects need classification summarys visible for this to work.
-    if @props.splits and subject and (@props.splits['classifier.first-to-classify.visible'] or @props.splits['subject.first-to-classify'])
+    if @props.splits and subject and (@props.splits['subject.first-to-classify.visible'] or @props.splits['subject.first-to-classify'])
       query =
         workflow_id: @props.workflow.id,
         subject_id: subject.id
@@ -151,8 +151,8 @@ module.exports = React.createClass
           <p>Please sign in or sign up to access more glitch types and classification options as well as our mini-course.</p>
         </CustomSignInPrompt>}
 
-      {if @state.classificationCount is 0 and @props.splits['classifier.first-to-classify.visible']
-        <VisibilitySplit splits={@props.splits} splitKey={'classifier.first-to-classify.visible'} elementKey={'div'}>
+      {if @state.classificationCount is 0 and @props.splits['subject.first-to-classify.visible']
+        <VisibilitySplit splits={@props.splits} splitKey={'subject.first-to-classify.visible'} elementKey={'div'}>
           <div className="classifier-announcement-banner classifier-announcement-banner--yellow">
             <p>You're the first person to see this subject!</p>
           </div>

--- a/app/pages/project/classify.cjsx
+++ b/app/pages/project/classify.cjsx
@@ -9,8 +9,7 @@ Classifier = require '../../classifier'
 seenThisSession = require '../../lib/seen-this-session'
 `import WorkflowAssignmentDialog from '../../components/workflow-assignment-dialog';`
 experimentsClient = require '../../lib/experiments-client'
-{Split} = require('seven-ten')
-{VisibilitySplit} = require('seven-ten')
+{ Split } = require('seven-ten')
 
 
 FAILED_CLASSIFICATION_QUEUE_NAME = 'failed-classifications'

--- a/app/pages/project/index.cjsx
+++ b/app/pages/project/index.cjsx
@@ -84,6 +84,7 @@ ProjectPageController = React.createClass
           break
     else
       Split.clear()
+      @setState { splits: null }
       @context.geordi?.forget ['experiment','cohort']
 
   fetchProjectData: (ownerName, projectName, user) ->

--- a/css/classify.styl
+++ b/css/classify.styl
@@ -28,6 +28,22 @@
     @extends $reset-button
     text-decoration: underline
 
+.classify-page
+  .classifier-announcement-banner
+    @extends $announcement-banner
+    margin: 0 0 1.5em
+
+    &--yellow
+      background: HIGHLIGHT_COLOR
+
+    &.custom-sign-in-banner
+      display: flex
+      justify-content: space-between
+      margin: 0 0 3vh
+
+      p
+        display: inline-block
+
 .classifier
   display: flex
   justify-content: center

--- a/css/common.styl
+++ b/css/common.styl
@@ -119,6 +119,16 @@ $project-role
   padding: 0.1em 0.4em
   text-transform: uppercase
 
+$announcement-banner
+  border: 2px solid
+  border-radius: 0.2em
+  box-shadow: 0 2px 4px rgba(black, 0.3)
+  box-sizing: border-box
+  color: white
+  margin: 0 3vw
+  padding: 0 1.5vw
+  text-align: center
+
 .color-label
   display: inline
   border-radius: 2px

--- a/css/project-page.styl
+++ b/css/project-page.styl
@@ -118,22 +118,7 @@
     width: 4em
 
 .project-announcement-banner
-  border: 2px solid
-  border-radius: 0.2em
-  box-shadow: 0 2px 4px rgba(black, 0.3)
-  box-sizing: border-box
-  color: white
-  margin: 0 3vw
-  padding: 0 1.5vw
-  text-align: center
-
-  &.custom-sign-in-banner
-    display: flex
-    justify-content: space-between
-    margin: 0 0 3vh
-
-    p
-      display: inline-block
+  @extends $announcement-banner
 
   &.informational
     background: MAIN_HIGHLIGHT


### PR DESCRIPTION
Fixes #3466

This is the novelty experiment for Gravity Spy. Rather than remove the text split that was setup previously, this adds another kind of visibility split experiment that shows a banner informing the volunteer they are the first to see the subject prior to classification. Labeled as WIP since experiment still needs setting up on Seven-Ten staging. Will add staging link once it is working.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?