### PR TITLE
Reset state.annotations when a new classification loads.

### DIFF
--- a/app/classifier/classifier.jsx
+++ b/app/classifier/classifier.jsx
@@ -41,6 +41,7 @@ export default class Classifier extends React.Component {
       const { annotations } = this.props.classification;
       this.setState({ annotations });
     });
+    this.props.classification.update(); // reset state.annotations
   }
 
   componentDidMount() {
@@ -75,6 +76,7 @@ export default class Classifier extends React.Component {
         const { annotations } = nextProps.classification;
         this.setState({ annotations });
       });
+      nextProps.classification.update(); // reset state.annotations from the new classification
     }
   }
 


### PR DESCRIPTION
Fixes #3697 where stale annotations were stored in classifier state when a new classification loads.

Describe your changes.
Runs `updateAnnotations()` when a new classification loads, forcing the classifier to update `state.annotations`.

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://fix-3697.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?