### PR TITLE
only enable pan-zoom controls for images

### DIFF
--- a/app/components/frame-viewer.jsx
+++ b/app/components/frame-viewer.jsx
@@ -40,9 +40,9 @@ export default class FrameViewer extends React.Component {
   }
 
   render() {
-    const zoomEnabled = this.props.workflow && this.props.workflow.configuration.pan_and_zoom;
     const FrameWrapper = this.props.frameWrapper;
     const { type, format, src } = getSubjectLocation(this.props.subject, this.props.frame);
+    const zoomEnabled = this.props.workflow && this.props.workflow.configuration.pan_and_zoom && type === 'image';
 
     const frameDisplay = ((subject) => {
       switch (subject) {


### PR DESCRIPTION
Fixes #3676. The FrameViewer should only enabled the PanZoom controls if the frame type is image. Long term, the FrameViewer should only rendered the PanZoom component for image frames, which is being addressed in #3695.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://fix-3676.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?