### PR TITLE
allow inactive workflows to be shown on the stats page

### DIFF
--- a/app/pages/lab/visibility.cjsx
+++ b/app/pages/lab/visibility.cjsx
@@ -61,9 +61,9 @@ module.exports = React.createClass
       ).then(() => @forceUpdate())
 
   handleWorkflowStatsVisibility: (workflow, e) ->
-    checked = !e.target.checked
+    hidden = !e.target.checked
 
-    workflow.update({ 'configuration.stats_hidden': checked }).save()
+    workflow.update({ 'configuration.stats_hidden': hidden }).save()
       .catch((error) =>
         @setState { error }
       ).then(() => @forceUpdate())

--- a/app/pages/lab/visibility.cjsx
+++ b/app/pages/lab/visibility.cjsx
@@ -169,9 +169,9 @@ module.exports = React.createClass
             {@state.workflows.map (workflow) =>
               setting = workflow.active
               stats_completeness_type = workflow.configuration.stats_completeness_type ? 'retirement'
-              stats_visible = !workflow.configuration.stats_hidden
-              if !workflow.active
-                stats_visible = !(workflow.configuration.stats_hidden == undefined) && stats_visible
+              statsVisible = workflow.active
+              if workflow.configuration.stats_hidden != undefined
+                statsVisible = !workflow.configuration.stats_hidden
               <tr key={workflow.id}>
                 <td>
                   {workflow.id}
@@ -217,8 +217,8 @@ module.exports = React.createClass
                     <input
                       type="checkbox"
                       name="stats_hidden.#{workflow.id}"
-                      value={stats_visible}
-                      checked={stats_visible}
+                      value={statsVisible}
+                      checked={statsVisible}
                       onChange={@handleWorkflowStatsVisibility.bind(this, workflow)}
                     />
                     Show on Stats Page

--- a/app/pages/lab/visibility.cjsx
+++ b/app/pages/lab/visibility.cjsx
@@ -61,7 +61,7 @@ module.exports = React.createClass
       ).then(() => @forceUpdate())
 
   handleWorkflowStatsVisibility: (workflow, e) ->
-    checked = e.target.checked
+    checked = !e.target.checked
 
     workflow.update({ 'configuration.stats_hidden': checked }).save()
       .catch((error) =>
@@ -169,6 +169,9 @@ module.exports = React.createClass
             {@state.workflows.map (workflow) =>
               setting = workflow.active
               stats_completeness_type = workflow.configuration.stats_completeness_type ? 'retirement'
+              stats_visible = !workflow.configuration.stats_hidden
+              if !workflow.active
+                stats_visible = !(workflow.configuration.stats_hidden == undefined) && stats_visible
               <tr key={workflow.id}>
                 <td>
                   {workflow.id}
@@ -214,11 +217,11 @@ module.exports = React.createClass
                     <input
                       type="checkbox"
                       name="stats_hidden.#{workflow.id}"
-                      value={workflow.configuration.stats_hidden}
-                      checked={workflow.configuration.stats_hidden}
+                      value={stats_visible}
+                      checked={stats_visible}
                       onChange={@handleWorkflowStatsVisibility.bind(this, workflow)}
                     />
-                    Hide on Stats Page
+                    Show on Stats Page
                   </label>
                   &emsp;
                 </td>
@@ -246,6 +249,6 @@ module.exports = React.createClass
       </p>
       <p className="form-label">Statistics Visbiility</p>
       <p className="form-help">
-        Active workflows are visible on the project's statistics page by default. If there is a reason to hide an active workflow from the statistics page, such as a workflow being used in an a/b split experiment, then toggle the "Hide on Stats Page" checkbox.
+        Active workflows are visible on the project's statistics page by default, and inactive projects are hidden by default. If there is a reason to hide an active workflow from the statistics page, such as a workflow being used in an a/b split experiment, or a reason to show an inactive workflow, then toggle the "Show on Stats Page" checkbox.
       </p>
     </div>

--- a/app/pages/project/stats/index.jsx
+++ b/app/pages/project/stats/index.jsx
@@ -13,7 +13,7 @@ class ProjectStatsPageController extends React.Component {
     this.getWorkflows = this.getWorkflows.bind(this);
 
     this.state = {
-      workflowList: [],
+      workflowList: []
     };
   }
 
@@ -29,22 +29,32 @@ class ProjectStatsPageController extends React.Component {
 
   getWorkflows(project) {
     const fields = [
+      'active',
       'classifications_count',
       'completeness',
       'configuration',
       'display_name',
       'retired_set_member_subjects_count',
-      'retirement,subjects_count',
+      'retirement,subjects_count'
     ];
     const query = {
-      active: true,
-      fields: fields.join(','),
+      fields: fields.join(',')
     };
     getWorkflowsInOrder(project, query)
       .then((workflows) => {
         const workflowsSetToBeVisible =
-          workflows.filter((workflow) => { 
-            return (!workflow.configuration.stats_hidden ? workflow : null);
+          workflows.filter((workflow) => {
+            if (workflow.active) {
+              return (!workflow.configuration.stats_hidden ? workflow : null);
+            } else {
+              // if stats_hidden has never been set on an inactive workflow
+              // make it hidden by default.
+              if ((workflow.configuration.stats_hidden === undefined) || (workflow.configuration.stats_hidden)) {
+                return null;
+              } else {
+                return workflow;
+              }
+            }
         })
         this.setState({ workflowList: workflowsSetToBeVisible });
       });
@@ -96,7 +106,7 @@ class ProjectStatsPageController extends React.Component {
       totalVolunteers: this.props.project.classifiers_count,
       currentClassifications: this.props.project.activity,
       workflows: this.state.workflowList,
-      startDate: this.props.project.launch_date,
+      startDate: this.props.project.launch_date
     };
 
     return <ProjectStatsPage {...queryProps} />;
@@ -107,7 +117,7 @@ ProjectStatsPageController.contextTypes = { router: React.PropTypes.object };
 
 ProjectStatsPageController.propTypes = {
   project: React.PropTypes.object,
-  params: React.PropTypes.object,
+  params: React.PropTypes.object
 };
 
 module.exports = ProjectStatsPageController;

--- a/app/pages/project/stats/index.jsx
+++ b/app/pages/project/stats/index.jsx
@@ -44,10 +44,15 @@ class ProjectStatsPageController extends React.Component {
       .then((workflows) => {
         const workflowsSetToBeVisible =
           workflows.filter((workflow) => {
-            let statsVisible = !workflow.configuration.stats_hidden;
-            if (!workflow.active) {
-              statsVisible = !(workflow.configuration.stats_hidden === undefined) && statsVisible;
+            let statsVisible = workflow.active;
+            if (workflow.configuration.stats_hidden !== undefined) {
+              statsVisible = !workflow.configuration.stats_hidden;
             }
+            // statsVisible = statsVisible || !workflow.configuration.stats_hidden;
+            // let statsVisible = !workflow.configuration.stats_hidden;
+            // if (!workflow.active) {
+            //   statsVisible = !(workflow.configuration.stats_hidden === undefined) && statsVisible;
+            // }
             return (statsVisible ? workflow : null);
           });
         this.setState({ workflowList: workflowsSetToBeVisible });

--- a/app/pages/project/stats/index.jsx
+++ b/app/pages/project/stats/index.jsx
@@ -44,12 +44,12 @@ class ProjectStatsPageController extends React.Component {
       .then((workflows) => {
         const workflowsSetToBeVisible =
           workflows.filter((workflow) => {
-            let stats_visible = !workflow.configuration.stats_hidden
+            let statsVisible = !workflow.configuration.stats_hidden;
             if (!workflow.active) {
-              stats_visible = !(workflow.configuration.stats_hidden === undefined) && stats_visible
+              statsVisible = !(workflow.configuration.stats_hidden === undefined) && statsVisible;
             }
-            return (stats_visible ? workflow : null)
-        })
+            return (statsVisible ? workflow : null);
+          });
         this.setState({ workflowList: workflowsSetToBeVisible });
       });
   }

--- a/app/pages/project/stats/index.jsx
+++ b/app/pages/project/stats/index.jsx
@@ -44,17 +44,11 @@ class ProjectStatsPageController extends React.Component {
       .then((workflows) => {
         const workflowsSetToBeVisible =
           workflows.filter((workflow) => {
-            if (workflow.active) {
-              return (!workflow.configuration.stats_hidden ? workflow : null);
-            } else {
-              // if stats_hidden has never been set on an inactive workflow
-              // make it hidden by default.
-              if ((workflow.configuration.stats_hidden === undefined) || (workflow.configuration.stats_hidden)) {
-                return null;
-              } else {
-                return workflow;
-              }
+            let stats_visible = !workflow.configuration.stats_hidden
+            if (!workflow.active) {
+              stats_visible = !(workflow.configuration.stats_hidden === undefined) && stats_visible
             }
+            return (stats_visible ? workflow : null)
         })
         this.setState({ workflowList: workflowsSetToBeVisible });
       });


### PR DESCRIPTION
Fixes #3683.

This PR allows inactive workflows to be visible on a project's stats page by setting the visibility in the lab.  This also changes the check box on the lab visibility page from `Hide on Stats Page` to `Show on Stats Page`.  I have used the same `workflow.configuration.stats_hidden` parameters that was being used before, so this *should* not change the current look of any live project's stats pages.

Note: Some of the logic is a bit confusing since it defaults inactive workflows that don't have `workflow.configuration.stats_hidden` to be not visible.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://show-inactive-workflow-stats.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?