### PR TITLE
Don't use string comparison to figure out home page path

### DIFF
--- a/app/pages/project/project-page.cjsx
+++ b/app/pages/project/project-page.cjsx
@@ -117,7 +117,7 @@ ProjectPage = React.createClass
   render: ->
     betaApproved = @props.project.beta_approved
     projectPath = "/projects/#{@props.project.slug}"
-    onHomePage = projectPath is @props.location.pathname
+    onHomePage = @props.routes[2].path is undefined
     avatarClasses = classnames('tabbed-content-tab', {
       'beta-approved': betaApproved
     })


### PR DESCRIPTION
Fixes #3709 .

Describe your changes.
Uses React router to figure out if we're on a project home page, rather than comparing strings with the window location.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://fix-3709.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?