### PR TITLE
Replace slideshow buttons with radio buttons

### DIFF
--- a/app/components/subject-viewer.cjsx
+++ b/app/components/subject-viewer.cjsx
@@ -140,7 +140,7 @@ module.exports = React.createClass
           <span>
             <span className="subject-frame-pips">
               {for i in [0...@props.subject?.locations.length ? 0]
-                <label key={i} className="button subject-frame-pip #{if i is @state.frame then 'active' else ''}" ><input type="radio" name="frame" value="i" onChange={@handleFrameChange.bind this, i} />{i + 1}</label>}
+                <label key={i} className="button subject-frame-pip #{if i is @state.frame then 'active' else ''}" ><input type="radio" name="frame" value={i} onChange={@handleFrameChange.bind this, i} />{i + 1}</label>}
             </span>
         </span>}
         <span>

--- a/app/components/subject-viewer.cjsx
+++ b/app/components/subject-viewer.cjsx
@@ -140,7 +140,7 @@ module.exports = React.createClass
           <span>
             <span className="subject-frame-pips">
               {for i in [0...@props.subject?.locations.length ? 0]
-                <button type="button" key={i} className="subject-frame-pip #{if i is @state.frame then 'active' else ''}" value={i} onClick={@handleFrameChange.bind this, i}>{i + 1}</button>}
+                <label key={i} className="button subject-frame-pip #{if i is @state.frame then 'active' else ''}" ><input type="radio" name="frame" value="i", onChange={@handleFrameChange.bind this, i} />{i + 1}</label>}
             </span>
         </span>}
         <span>

--- a/app/components/subject-viewer.cjsx
+++ b/app/components/subject-viewer.cjsx
@@ -140,7 +140,7 @@ module.exports = React.createClass
           <span>
             <span className="subject-frame-pips">
               {for i in [0...@props.subject?.locations.length ? 0]
-                <label key={i} className="button subject-frame-pip #{if i is @state.frame then 'active' else ''}" ><input type="radio" name="frame" value="i", onChange={@handleFrameChange.bind this, i} />{i + 1}</label>}
+                <label key={i} className="button subject-frame-pip #{if i is @state.frame then 'active' else ''}" ><input type="radio" name="frame" value="i" onChange={@handleFrameChange.bind this, i} />{i + 1}</label>}
             </span>
         </span>}
         <span>

--- a/css/subject-viewer.styl
+++ b/css/subject-viewer.styl
@@ -14,9 +14,8 @@
 
       input[type=radio]
         position: absolute
+        opacity: 0.01
         left: -100px
-        height: 0
-        width: 0
 
       &.active
         font-weight: 700

--- a/css/subject-viewer.styl
+++ b/css/subject-viewer.styl
@@ -7,6 +7,17 @@
 
   .subject-frame-pips
     .subject-frame-pip
+      display: inline-block
+      overflow: hidden
+      position: relative
+      vertical-align: middle
+
+      input[type=radio]
+        position: absolute
+        left: -100px
+        height: 0
+        width: 0
+
       &.active
         font-weight: 700
 

--- a/css/survey-task.styl
+++ b/css/survey-task.styl
@@ -212,8 +212,7 @@ $survey-task-pill-button
   
   input[type=radio]
     position: absolute
-    height: 0
-    width: 0
+    opacity: 0.01
     left: -100px
 
   &.active

--- a/css/talk.styl
+++ b/css/talk.styl
@@ -89,7 +89,7 @@ COPY_GREY_LIGHT = #afaeae
     &:hover
       color: MAIN_HIGHLIGHT
 
-  a.button
+  .button
   button:not(.link-style)
     @extend .standard-button
     @extend .talk-module
@@ -470,8 +470,10 @@ COPY_GREY_LIGHT = #afaeae
       img
         max-width: 100%
     .subject-tools
-      span > button
-        margin-right: 2px
+      span > 
+        button
+        .button
+          margin-right: 2px
 
   .talk-comment-author
     @extend .talk-module


### PR DESCRIPTION
Fixes #3514.

Describe your changes.
Adds keyboard support by replacing buttons with named radio inputs, which can be controlled using the cursor keys.

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://subject-viewer-pips.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?