### PR TITLE
fixes sizing of text viewer after loading content

### DIFF
--- a/app/components/text-viewer.jsx
+++ b/app/components/text-viewer.jsx
@@ -59,11 +59,19 @@ class TextViewer extends Component {
     if (SUPPORTED_FORMATS.indexOf(this.props.format) === -1) {
       content = `Unsupported format: ${this.props.format}`;
     }
-    return (
-      <div ref={(element) => { this.element = element; }} className="text-viewer" >
-        { content }
-      </div>
-    );
+    if (content === 'Loading…') {
+      return(
+        <div ref={(element) => { this.element = element; }} className="text-viewer-loading" >
+          { content }
+        </div>
+      );
+    } else {
+      return (
+        <div ref={(element) => { this.element = element; }} className="text-viewer" >
+          { content }
+        </div>
+      );
+    }
   }
 }
 

--- a/css/subject-viewer.styl
+++ b/css/subject-viewer.styl
@@ -51,7 +51,6 @@
     .text-viewer
       background-color: #404040
       color: white
-      min-width: 30em
       padding: 2%
       white-space: pre-wrap
 


### PR DESCRIPTION
This is a work around to get the text-viewer to be the right size after loading the content of text frames. Setting a `min-width` property on the `text-viewer` is causing the subject to overlap the task area in Chrome, Safari, and Edge.

Describe your changes.
Instead of using `min-width` to control the size of the text-viewer, the text-viewer renders a different div when the content is loading than when the content is loaded. 

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [X] Did you deploy a staging branch? https://text-viewer-sizing-from-fix-text-viewer.pfe-preview.zooniverse.org
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?