### PR TITLE
Reset the default frame on subject change

### DIFF
--- a/app/components/subject-viewer.cjsx
+++ b/app/components/subject-viewer.cjsx
@@ -71,6 +71,10 @@ module.exports = React.createClass
       clearTimeout @signInAttentionTimeout
       @setState loading: true
 
+  componentDidUpdate: (prevProps) ->
+    if @props.subject isnt prevProps.subject
+      @setState frame: @getInitialFrame()
+
   logSubjClick: (logType) ->
     @context.geordi?.logEvent
       type: logType


### PR DESCRIPTION
Fixes #3700 .

Describe your changes.
Calls `getInitialFrame` if the subject changes in the subject viewer.

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://fix-3700.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?