### PR TITLE
Makes clearer that subjects don't get deleted

### DIFF
--- a/app/pages/lab/subject-set.cjsx
+++ b/app/pages/lab/subject-set.cjsx
@@ -241,7 +241,7 @@ EditSubjectSetPage = React.createClass
       <p>
         <small>
           <button type="button" className="minor-button" disabled={@state.deletionInProgress} onClick={@deleteSubjectSet}>
-            Delete this subject set and its {@props.subjectSet.set_member_subjects_count} subjects
+            Delete this subject set and unlink its {@props.subjectSet.set_member_subjects_count} subjects
           </button>
         </small>{' '}
         {if @state.deletionError?
@@ -353,7 +353,7 @@ EditSubjectSetPage = React.createClass
   deleteSubjectSet: ->
     @setState deletionError: null
 
-    confirmed = confirm 'Really delete this subject set and all its subjects?'
+    confirmed = confirm 'Really delete this subject set and unlink its subjects?\nNote that subjects will still be added to your user quota.'
 
     if confirmed
       @setState deletionInProgress: true


### PR DESCRIPTION
Follow up to https://github.com/zooniverse/Panoptes/issues/1037#issue-91752692

Makes the text on the subject-set delete button less ambiguous.
Also, adds a note to the alert box.

- [x] Did you deploy a staging branch? https://edit-subjectset-text.pfe-preview.zooniverse.org/