### PR TITLE
Render button even when file not specified

### DIFF
--- a/app/classifier/tasks/survey/chooser.cjsx
+++ b/app/classifier/tasks/survey/chooser.cjsx
@@ -112,7 +112,9 @@ module.exports = React.createClass
                   onClick={@handleFilter.bind this, characteristicID, valueID}
                 >
                   {if value.image?
-                    <img src={@props.task.images[value.image]} alt={value.label} className="survey-task-chooser-characteristic-value-icon" />}
+                    <img src={@props.task.images[value.image]} alt={value.label} className="survey-task-chooser-characteristic-value-icon" />
+                  else
+                    <img alt={value.label} className="survey-task-chooser-characteristic-value-icon" />}
                 </button>}
 
               <button type="submit" className="survey-task-chooser-characteristic-clear-button" disabled={characteristicID not of @props.filters} autoFocus={not hasBeenAutoFocused} onClick={@handleFilter.bind this, characteristicID, undefined}>

--- a/app/classifier/tasks/survey/chooser.cjsx
+++ b/app/classifier/tasks/survey/chooser.cjsx
@@ -114,7 +114,7 @@ module.exports = React.createClass
                   {if value.image?
                     <img src={@props.task.images[value.image]} alt={value.label} className="survey-task-chooser-characteristic-value-icon" />
                   else
-                    <img alt={value.label} className="survey-task-chooser-characteristic-value-icon" />}
+                    value.label}
                 </button>}
 
               <button type="submit" className="survey-task-chooser-characteristic-clear-button" disabled={characteristicID not of @props.filters} autoFocus={not hasBeenAutoFocused} onClick={@handleFilter.bind this, characteristicID, undefined}>


### PR DESCRIPTION
Fixes #2913 

Describe your changes.
Adds `else` block to make sure `img` attribute `alt-text` is rendered if file not specified/uploaded.

Test it here against production https://fix-2913.pfe-preview.zooniverse.org/projects/mrniaboc/zooniverse-go/classify