### PR TITLE
Remove React.createClass from VideoPlayer

### DIFF
--- a/app/components/video-player.jsx
+++ b/app/components/video-player.jsx
@@ -2,54 +2,48 @@ import React from 'react';
 
 const IS_IE = 'ActiveXObject' in window;
 
-const VideoPlayer = React.createClass({
+class VideoPlayer extends React.Component {
+  constructor(props) {
+    super(props);
 
-  propTypes: {
-    children: React.PropTypes.node,
-    format: React.PropTypes.string,
-    frame: React.PropTypes.number,
-    onLoad: React.PropTypes.func,
-    showControls: React.PropTypes.bool,
-    src: React.PropTypes.string,
-    type: React.PropTypes.string
-  },
+    this.player = null;
+    this.scrubber = null;
 
-  getDefaultProps() {
-    return {
-      showControls: true
-    };
-  },
+    this.endVideo = this.endVideo.bind(this);
+    this.playVideo = this.playVideo.bind(this);
+    this.seekVideo = this.seekVideo.bind(this);
+    this.setPlayRate = this.setPlayRate.bind(this);
+    this.updateScrubber = this.updateScrubber.bind(this);
 
-  getInitialState() {
-    return {
+    this.state = {
       playing: false,
       playbackRate: 1
     };
-  },
+  }
 
   componentDidMount() {
-    if (this.refs.videoScrubber) {
-      this.refs.videoScrubber.value = 0;
-      if (IS_IE) this.refs.videoScrubber.addEventListener('change', this.seekVideo);
+    if (this.scrubber) {
+      this.scrubber.value = 0;
+      if (IS_IE) this.scrubber.addEventListener('change', this.seekVideo);
     }
-  },
+  }
 
   componentDidUpdate() {
-    if (this.refs.videoPlayer) this.refs.videoPlayer.playbackRate = this.state.playbackRate;
-  },
+    if (this.player) this.player.playbackRate = this.state.playbackRate;
+  }
 
   componentWillUnmount() {
-    if (this.refs.videoScrubber && IS_IE) {
-      this.refs.videoScrubber.removeEventListener('change', this.seekVideo);
+    if (this.scrubber && IS_IE) {
+      this.scrubber.removeEventListener('change', this.seekVideo);
     }
-  },
+  }
 
   setPlayRate(e) {
     this.setState({ playbackRate: parseFloat(e.target.value) });
-  },
+  }
 
   playVideo(playing) {
-    const player = this.refs.videoPlayer;
+    const { player } = this;
     if (!player) return;
 
     this.setState({ playing });
@@ -59,41 +53,41 @@ const VideoPlayer = React.createClass({
     } else {
       player.pause();
     }
-  },
+  }
 
   seekVideo() {
-    const player = this.refs.videoPlayer;
-    const scrubber = this.refs.videoScrubber;
+    const { player, scrubber } = this;
     player.currentTime = scrubber.value;
-  },
+  }
 
   endVideo() {
     this.setState({ playing: false });
-  },
+  }
 
   updateScrubber() {
-    const player = this.refs.videoPlayer;
-    const scrubber = this.refs.videoScrubber;
+    const { player, scrubber } = this;
     if (!scrubber.getAttribute('max')) scrubber.setAttribute('max', player.duration);
     scrubber.value = player.currentTime;
-  },
+  }
 
   renderSpeedControls(rates) {
-    return rates.map((rate, i) => (
-      <label key={`rate-${i}`} className="secret-button">
-        <input
-          type="radio"
-          name={`playRate${this.props.frame}`}
-          value={rate}
-          checked={rate === this.state.playbackRate}
-          onChange={this.setPlayRate}
-        />
-        <span>
-          {rate}&times;
-        </span>
-      </label>),
-    );
-  },
+    return rates.map((rate, i) => {
+      return (
+        <label key={`rate-${i}`} className="secret-button">
+          <input
+            type="radio"
+            name={`playRate${this.props.frame}`}
+            value={rate}
+            checked={rate === this.state.playbackRate}
+            onChange={this.setPlayRate}
+          />
+          <span>
+            {rate}&times;
+          </span>
+        </label>
+      );
+    });
+  }
 
   render() {
     const rates = [0.25, 0.5, 1];
@@ -101,7 +95,7 @@ const VideoPlayer = React.createClass({
       <div className="subject-video-frame">
         <video
           className="subject"
-          ref="videoPlayer"
+          ref={(element) => { this.player = element; }}
           src={this.props.src}
           type={`${this.props.type}/${this.props.format}`}
           preload="auto"
@@ -138,7 +132,7 @@ const VideoPlayer = React.createClass({
             <input
               type="range"
               className="video-scrubber"
-              ref="videoScrubber"
+              ref={(element) => { this.scrubber = element; }}
               min="0"
               step="any"
               onChange={this.seekVideo}
@@ -153,6 +147,20 @@ const VideoPlayer = React.createClass({
     );
   }
 
-});
+}
+
+VideoPlayer.propTypes = {
+  children: React.PropTypes.node,
+  format: React.PropTypes.string,
+  frame: React.PropTypes.number,
+  onLoad: React.PropTypes.func,
+  showControls: React.PropTypes.bool,
+  src: React.PropTypes.string,
+  type: React.PropTypes.string
+};
+
+VideoPlayer.defaultProps = {
+  showControls: true
+};
 
 export default VideoPlayer;


### PR DESCRIPTION
Describe your changes.
Removes `React.createClass` and named refs from the video player component.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://video-create-class.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?