### PR TITLE
Disable TaskNav component while subject is loading.

### DIFF
--- a/app/classifier/classifier.jsx
+++ b/app/classifier/classifier.jsx
@@ -271,6 +271,7 @@ export default class Classifier extends React.Component {
             annotation={currentAnnotation}
             classification={currentClassification}
             completeClassification={this.completeClassification}
+            disabled={this.state.subjectLoading}
             nextSubject={this.props.onClickNext}
             project={this.props.project}
             subject={this.props.subject}

--- a/app/classifier/task-nav.jsx
+++ b/app/classifier/task-nav.jsx
@@ -124,7 +124,7 @@ class TaskNav extends React.Component {
     const onFirstAnnotation = !completed && (this.props.classification.annotations.indexOf(this.props.annotation) === 0);
 
     // Should we disable the "Next" or "Done" buttons?
-    let waitingForAnswer = false;
+    let waitingForAnswer = this.props.disabled;
     if (TaskComponent && TaskComponent.isAnnotationComplete && this.props.annotation) {
       waitingForAnswer = !this.props.annotation.shortcut && !TaskComponent.isAnnotationComplete(task, this.props.annotation, this.props.workflow);
     }
@@ -233,6 +233,7 @@ TaskNav.propTypes = {
     metadata: React.PropTypes.object
   }),
   completeClassification: React.PropTypes.func,
+  disabled: React.PropTypes.bool,
   nextSubject: React.PropTypes.func,
   demoMode: React.PropTypes.bool,
   project: React.PropTypes.shape({
@@ -251,6 +252,10 @@ TaskNav.propTypes = {
     first_task: React.PropTypes.string,
     tasks: React.PropTypes.object
   })
+};
+
+TaskNav.defaultProps = {
+  disabled: false
 };
 
 export default TaskNav;


### PR DESCRIPTION
Fixes: the Done button can be clicked, to submit a classification, while the subject is loading.

Describe your changes.
Adds a `disabled` prop to the `TaskNav` component, which disables the buttons. Sets that prop while the subject is loading.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?