### PR TITLE
Remove subject upload module if subject limit has been reached

### DIFF
--- a/app/pages/lab/subject-set.cjsx
+++ b/app/pages/lab/subject-set.cjsx
@@ -199,17 +199,19 @@ EditSubjectSetPage = React.createClass
 
       <hr />
 
-      <p>
-        <UploadDropTarget accept={"text/csv, text/tab-separated-values, image/*#{if isAdmin() then ', video/*' else ''}"} multiple onSelect={@handleFileSelection}>
-          <strong>Drag-and-drop or click to upload manifests and subject images here.</strong><br />
-          Manifests must be <code>.csv</code> or <code>.tsv</code>. The first row should define metadata headers. All other rows should include at least one reference to an image filename in the same directory as the manifest.<br />
-          Headers that begin with "#" or "//" denote private fields that will not be visible to classifiers in the main classification interface or in the Talk discussion tool.<br />
-          Headers that begin with "!" denote fields that <strong>will not</strong> be visible to classifiers in the main classification interface but <strong>will be </strong> visible after classification in the Talk discussion tool.<br />
-          Subject images can be up to {MAX_FILE_SIZE / 1024}KB and any of: {<span key={ext}><code>{ext}</code>{', ' if VALID_SUBJECT_EXTENSIONS[i + 1]?}</span> for ext, i in VALID_SUBJECT_EXTENSIONS}{' '}
-          and may not contain {<span key={char}><kbd>{char}</kbd>{', ' if INVALID_FILENAME_CHARS[i + 1]?}</span> for char, i in INVALID_FILENAME_CHARS}<br />
-        </UploadDropTarget>
-      </p>
-
+      {if @props.user.uploaded_subjects_count >= @props.user.subject_limit and !localStorage.adminFlag
+        <p>You've reached your subject upload limit. Please <a href='/about/contact'> contact us</a> to request changes to your allowance.'</p>
+      else
+        <p>
+          <UploadDropTarget accept={"text/csv, text/tab-separated-values, image/*#{if isAdmin() then ', video/*' else ''}"} multiple onSelect={@handleFileSelection}>
+            <strong>Drag-and-drop or click to upload manifests and subject images here.</strong><br />
+            Manifests must be <code>.csv</code> or <code>.tsv</code>. The first row should define metadata headers. All other rows should include at least one reference to an image filename in the same directory as the manifest.<br />
+            Headers that begin with "#" or "//" denote private fields that will not be visible to classifiers in the main classification interface or in the Talk discussion tool.<br />
+            Headers that begin with "!" denote fields that <strong>will not</strong> be visible to classifiers in the main classification interface but <strong>will be </strong> visible after classification in the Talk discussion tool.<br />
+            Subject images can be up to {MAX_FILE_SIZE / 1024}KB and any of: {<span key={ext}><code>{ext}</code>{', ' if VALID_SUBJECT_EXTENSIONS[i + 1]?}</span> for ext, i in VALID_SUBJECT_EXTENSIONS}{' '}
+            and may not contain {<span key={char}><kbd>{char}</kbd>{', ' if INVALID_FILENAME_CHARS[i + 1]?}</span> for char, i in INVALID_FILENAME_CHARS}<br />
+          </UploadDropTarget>
+        </p>}
       <div className="manifests-and-subjects">
         <ul>
           {subjectsToCreate = 0

--- a/app/pages/lab/subject-set.cjsx
+++ b/app/pages/lab/subject-set.cjsx
@@ -199,7 +199,7 @@ EditSubjectSetPage = React.createClass
 
       <hr />
 
-      {if @props.user.uploaded_subjects_count >= @props.user.subject_limit and !localStorage.adminFlag
+      {if @props.user.uploaded_subjects_count >= @props.user.subject_limit and !isAdmin()
         <p>You've reached your subject upload limit. Please <a href='/about/contact'> contact us</a> to request changes to your allowance.'</p>
       else
         <p>


### PR DESCRIPTION
Removes subject upload module if subject limit has been reached.
It's a way of getting around https://github.com/zooniverse/Panoptes-Front-End/issues/921

However, the current code means users over the limit need to reload the page to get the upload module back, which is less than ideal.

So, this an interim solution while I work on the refactor of the subject upload related files. Once the flow of props is clearer and `ChangeListener` removed, I believe we can update the view without manual refresh.

If this doesn't seem very helpful/necessary, feel free to close and I'll submit a new PR with the refactor.

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://disable-upload-when-limit-reached.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?