### PR TITLE
Default guideIcons to an empty object

### DIFF
--- a/app/pages/project/index.cjsx
+++ b/app/pages/project/index.cjsx
@@ -30,7 +30,7 @@ ProjectPageController = React.createClass
     background: null
     error: null
     guide: null
-    guideIcons: null
+    guideIcons: {}
     loading: false
     loadingSelectedWorkflow: false
     owner: null


### PR DESCRIPTION
Fixes: field guide disappears from project pages if there are no attached images.

Describe your changes.
Changes the default value of `guideIcons` from `null` to `{}`

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://fix-field-guide.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?