### PR TITLE
Fix default frame bug

### DIFF
--- a/app/components/subject-viewer.cjsx
+++ b/app/components/subject-viewer.cjsx
@@ -58,7 +58,7 @@ module.exports = React.createClass
 
   getInitialFrame: ->
     {frame, allowFlipbook, subject} = @props
-    default_frame = parseInt(subject.metadata.default_frame, 10)
+    default_frame = parseInt(subject.metadata?.default_frame, 10)
     initialFrame = 0
     if frame?
       initialFrame = frame


### PR DESCRIPTION
Fixing a bug found while doing collections work. Can be seen on master staging:
https://master.pfe-preview.zooniverse.org/collections/chrissnyder-test/test

Fix seen here:
https://fix-default-frame-bug.pfe-preview.zooniverse.org/collections/chrissnyder-test/test

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?