### PR TITLE
Adjust WWT Summary Tag

### DIFF
--- a/app/classifier/classification-summary.jsx
+++ b/app/classifier/classification-summary.jsx
@@ -77,7 +77,7 @@ class ClassificationSummary extends React.Component {
 
     if (this.props.workflow.configuration &&
         this.props.workflow.configuration.custom_summary &&
-        this.props.workflow.configuration.custom_summary.includes('worldwide telescope')) {
+        this.props.workflow.configuration.custom_summary.includes('world_wide_telescope')) {
       return (
         <strong>
           <WorldWideTelescope


### PR DESCRIPTION
Describe your changes.
When rendering a Worldwide Telescope summary, the classification-summary component was looking for the wrong tag. Because of this, the WWT link was not appearing in the summary.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)

https://fix-wwt-summary.pfe-preview.zooniverse.org/

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?