### PR TITLE
Add check for upload whitelist

### DIFF
--- a/app/pages/lab/subject-set.cjsx
+++ b/app/pages/lab/subject-set.cjsx
@@ -199,8 +199,8 @@ EditSubjectSetPage = React.createClass
 
       <hr />
 
-      {if @props.user.uploaded_subjects_count >= @props.user.subject_limit and !isAdmin()
-        <p>You've reached your subject upload limit. Please <a href='/about/contact'> contact us</a> to request changes to your allowance.'</p>
+      {if !isAdmin() and !@props.user.upload_whitelist and @props.user.uploaded_subjects_count >= @props.user.subject_limit
+        <p>You've reached your subject upload limit. Please <a href='/about/contact'> contact us</a> to request changes to your allowance.</p>
       else
         <p>
           <UploadDropTarget accept={"text/csv, text/tab-separated-values, image/*#{if isAdmin() then ', video/*' else ''}"} multiple onSelect={@handleFileSelection}>


### PR DESCRIPTION
Fixes #3731.

The subject upload drag and drop area shouldn't be hidden for users who have been whitelisted. 

@mschwamb can you upload using this staged link? https://upload-whitelist.pfe-preview.zooniverse.org/?env=production

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?