### PR TITLE
fix researcher word overflow

### DIFF
--- a/css/project-page.styl
+++ b/css/project-page.styl
@@ -264,6 +264,8 @@
     span
       font-size: 1.75em
       font-style: italic
+      overflow: auto
+      word-wrap: break-word
 
   @media (min-width: 1000px)
     &__researcher-words:before


### PR DESCRIPTION
Fixes an overflow problem for research quotes that contain long words without spaces, such as a url. 
<img width="624" alt="research quote overflows" src="https://cloud.githubusercontent.com/assets/7684729/25100062/63642678-2374-11e7-8522-3f741de05c0d.png">


Describe your changes.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://fix-overflow-researcher-quote.pfe-preview.zooniverse.org
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?