### PR TITLE
Text Highlighter Task

### DIFF
--- a/app/classifier/annotation-renderer/index.jsx
+++ b/app/classifier/annotation-renderer/index.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import SVGRenderer from './svg';
+import TextRenderer from './text';
 
 function DefaultRenderer(props) {
   return (
@@ -14,7 +15,8 @@ DefaultRenderer.propTypes = {
 };
 
 const VIEWERS = {
-  image: SVGRenderer
+  image: SVGRenderer,
+  text: TextRenderer
 };
 
 function AnnotationRenderer(props) {

--- a/app/classifier/annotation-renderer/svg.jsx
+++ b/app/classifier/annotation-renderer/svg.jsx
@@ -194,11 +194,11 @@ export default class SVGRenderer extends React.Component {
               </Draggable>
             )}
             {children}
-
             {(showFeedback) && (<SVGFeedbackViewer />)}
           </g>
         </svg>
         {(showFeedback) && (<SVGToolTipLayer getScreenCTM={this.getScreenCurrentTransformationMatrix} />)}
+        {this.props.children}
       </div>
     );
   }
@@ -208,6 +208,7 @@ SVGRenderer.propTypes = {
   annotation: React.PropTypes.shape({
     task: React.PropTypes.string
   }),
+  children: React.PropTypes.node,
   classification: React.PropTypes.shape({
     annotations: React.PropTypes.array,
     loading: React.PropTypes.bool

--- a/app/classifier/annotation-renderer/text.jsx
+++ b/app/classifier/annotation-renderer/text.jsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import tasks from '../tasks';
+import getSubjectLocation from '../../lib/get-subject-location';
+
+export default class TextRenderer extends React.Component {
+
+  render() {
+    let taskDescription;
+    let InsideSubject;
+    const { src } = getSubjectLocation(this.props.subject, this.props.frame);
+
+    if (this.props.annotation.task) {
+      taskDescription = this.props.workflow.tasks[this.props.annotation.task];
+      ({ InsideSubject } = tasks[taskDescription.type]);
+    }
+
+
+    const hookProps = {
+      taskTypes: tasks,
+      workflow: this.props.workflow,
+      task: taskDescription,
+      classification: this.props.classification,
+      annotation: this.props.annotation,
+      frame: this.props.frame,
+      onChange: this.props.onChange,
+      preferences: this.props.preferences
+    };
+
+    let children = [];
+    const isTextTask = taskDescription && (tasks[taskDescription.type].AnnotationRenderer === TextRenderer);
+    if (isTextTask && InsideSubject) {
+      children.push(<InsideSubject key="inside" src={src} {...hookProps} />);
+    }
+    const persistentHooks = Object
+      .keys(tasks)
+      .filter((key) => { return tasks[key].AnnotationRenderer === TextRenderer; })
+      .map((taskName) => {
+        const PersistInsideSubject = tasks[taskName].PersistInsideSubject;
+        if (PersistInsideSubject) {
+          return <PersistInsideSubject key={taskName} src={src} {...hookProps} />;
+        }
+        return null;
+      })
+      .filter(Boolean);
+    children = children.concat(persistentHooks);
+
+    return (
+      <div className="frame-annotator">
+        {children}
+      </div>
+    );
+  }
+}
+
+TextRenderer.propTypes = {
+  annotation: React.PropTypes.shape({
+    task: React.PropTypes.string
+  }),
+  classification: React.PropTypes.shape({
+    annotations: React.PropTypes.array,
+    loading: React.PropTypes.bool
+  }),
+  frame: React.PropTypes.number,
+  onChange: React.PropTypes.func,
+  preferences: React.PropTypes.object,
+  subject: React.PropTypes.shape({
+    already_seen: React.PropTypes.bool,
+    retired: React.PropTypes.bool
+  }),
+  workflow: React.PropTypes.shape({
+    tasks: React.PropTypes.object
+  })
+};
+
+TextRenderer.defaultProps = {
+  user: null,
+  project: null,
+  subject: null,
+  workflow: null,
+  classification: null,
+  annotation: null,
+  onLoad: () => {},
+  frame: 0,
+  onChange: () => {}
+};

--- a/app/classifier/annotation-renderer/text.jsx
+++ b/app/classifier/annotation-renderer/text.jsx
@@ -31,13 +31,22 @@ export default class TextRenderer extends React.Component {
     if (isTextTask && InsideSubject) {
       children.push(<InsideSubject key="inside" src={src} {...hookProps}>{this.props.children}</InsideSubject>);
     }
-    const persistentHooks = Object
-      .keys(tasks)
-      .filter((key) => { return tasks[key].AnnotationRenderer === TextRenderer; })
-      .map((taskName) => {
-        const PersistInsideSubject = tasks[taskName].PersistInsideSubject;
+    const persistentHooks = this.props.classification.annotations
+      .map((annotation) => { return this.props.workflow.tasks[annotation.task]; })
+      .filter((task) => { return tasks[task.type].AnnotationRenderer === TextRenderer; })
+      .map((task, i) => {
+        const { PersistInsideSubject } = tasks[task.type];
         if (PersistInsideSubject) {
-          return <PersistInsideSubject key={taskName} src={src} {...hookProps}>{this.props.children}</PersistInsideSubject>;
+          return (
+            <PersistInsideSubject
+              key={task.type}
+              src={src}
+              {...hookProps}
+              annotation={this.props.classification.annotations[i]}
+            >
+              {this.props.children}
+            </PersistInsideSubject>
+          );
         }
         return null;
       })

--- a/app/classifier/annotation-renderer/text.jsx
+++ b/app/classifier/annotation-renderer/text.jsx
@@ -29,17 +29,21 @@ export default class TextRenderer extends React.Component {
     let children = [];
     const isTextTask = taskDescription && (tasks[taskDescription.type].AnnotationRenderer === TextRenderer);
     const persistentHooks = this.props.classification.annotations
-      .map((annotation) => { return this.props.workflow.tasks[annotation.task]; })
-      .filter((task) => { return tasks[task.type].AnnotationRenderer === TextRenderer; })
+      .map(annotation => this.props.workflow.tasks[annotation.task])
+      .filter(task => tasks[task.type].AnnotationRenderer === TextRenderer)
       .map((task, i) => {
         const { PersistInsideSubject } = tasks[task.type];
+        const filteredAnnotations = this.props.classification.annotations.filter((annotation) => {
+          const currentTask = this.props.workflow.tasks[annotation.task];
+          return tasks[currentTask.type].AnnotationRenderer === TextRenderer;
+        });
         if (PersistInsideSubject) {
           return (
             <PersistInsideSubject
               key={task.type}
               src={src}
               {...hookProps}
-              annotation={this.props.classification.annotations[i]}
+              annotation={filteredAnnotations[i]}
             >
               {this.props.children}
             </PersistInsideSubject>

--- a/app/classifier/annotation-renderer/text.jsx
+++ b/app/classifier/annotation-renderer/text.jsx
@@ -52,6 +52,9 @@ export default class TextRenderer extends React.Component {
       })
       .filter(Boolean);
     children = children.concat(persistentHooks);
+    if (children.length === 0) {
+      ({ children } = this.props);
+    }
 
     return (
       <div className="frame-annotator">

--- a/app/classifier/annotation-renderer/text.jsx
+++ b/app/classifier/annotation-renderer/text.jsx
@@ -28,9 +28,6 @@ export default class TextRenderer extends React.Component {
 
     let children = [];
     const isTextTask = taskDescription && (tasks[taskDescription.type].AnnotationRenderer === TextRenderer);
-    if (isTextTask && InsideSubject) {
-      children.push(<InsideSubject key="inside" src={src} {...hookProps}>{this.props.children}</InsideSubject>);
-    }
     const persistentHooks = this.props.classification.annotations
       .map((annotation) => { return this.props.workflow.tasks[annotation.task]; })
       .filter((task) => { return tasks[task.type].AnnotationRenderer === TextRenderer; })
@@ -52,6 +49,9 @@ export default class TextRenderer extends React.Component {
       })
       .filter(Boolean);
     children = children.concat(persistentHooks);
+    if (isTextTask && InsideSubject) {
+      children = <InsideSubject key="inside" src={src} {...hookProps}>{children}</InsideSubject>;
+    }
     if (children.length === 0) {
       ({ children } = this.props);
     }

--- a/app/classifier/annotation-renderer/text.jsx
+++ b/app/classifier/annotation-renderer/text.jsx
@@ -37,7 +37,7 @@ export default class TextRenderer extends React.Component {
       .map((taskName) => {
         const PersistInsideSubject = tasks[taskName].PersistInsideSubject;
         if (PersistInsideSubject) {
-          return <PersistInsideSubject key={taskName} src={src} {...hookProps} />;
+          return <PersistInsideSubject key={taskName} src={src} {...hookProps}>{this.props.children}</PersistInsideSubject>;
         }
         return null;
       })

--- a/app/classifier/annotation-renderer/text.jsx
+++ b/app/classifier/annotation-renderer/text.jsx
@@ -29,7 +29,7 @@ export default class TextRenderer extends React.Component {
     let children = [];
     const isTextTask = taskDescription && (tasks[taskDescription.type].AnnotationRenderer === TextRenderer);
     if (isTextTask && InsideSubject) {
-      children.push(<InsideSubject key="inside" src={src} {...hookProps} />);
+      children.push(<InsideSubject key="inside" src={src} {...hookProps}>{this.props.children}</InsideSubject>);
     }
     const persistentHooks = Object
       .keys(tasks)
@@ -56,6 +56,7 @@ TextRenderer.propTypes = {
   annotation: React.PropTypes.shape({
     task: React.PropTypes.string
   }),
+  children: React.PropTypes.node,
   classification: React.PropTypes.shape({
     annotations: React.PropTypes.array,
     loading: React.PropTypes.bool

--- a/app/classifier/frame-annotator.jsx
+++ b/app/classifier/frame-annotator.jsx
@@ -91,9 +91,9 @@ export default class FrameAnnotator extends React.Component {
           {!!BeforeSubject && (
             <BeforeSubject {...hookProps} />)}
 
-          <AnnotationRenderer type={type} {...rendererProps} />
-
-          {this.props.children}
+          <AnnotationRenderer type={type} {...rendererProps}>
+            {this.props.children}
+          </AnnotationRenderer>
 
           {!!warningBanner && (
             warningBanner

--- a/app/classifier/tasks/generic-editor.cjsx
+++ b/app/classifier/tasks/generic-editor.cjsx
@@ -29,6 +29,7 @@ module.exports = React.createClass
       when 'crop' then ['instruction']
       when 'text' then ['instruction']
       when 'slider' then ['instruction']
+      when 'highlighter' then ['instruction', 'highlighterLabels']
 
     isAQuestion = @props.task.type in ['single', 'multiple']
     canBeRequired = @props.task.type in ['single', 'multiple', 'text']
@@ -117,6 +118,23 @@ module.exports = React.createClass
                         </AutoSave>
                       </div>
 
+                  when 'highlighter'
+                    <div className="workflow-choice-setting" >
+                      <AutoSave resource={@props.workflow} >
+                        Color{' '}
+                        <select name="#{@props.taskPrefix}.#{choicesKey}.#{index}.color" value={choice.color} onChange={handleChange}>
+                          <option value="#ff0000">Red</option>
+                          <option value="#ffff00">Yellow</option>
+                          <option value="#00ff00">Green</option>
+                          <option value="#00ffff">Cyan</option>
+                          <option value="#0000ff">Blue</option>
+                          <option value="#ff00ff">Magenta</option>
+                          <option value="#000000">Black</option>
+                          <option value="#ffffff">White</option>
+                        </select>
+                      </AutoSave>
+                    </div>
+
                   when 'drawing'
                     options = drawingTools[choice.type].options ? []
                     [<div key="type" className="workflow-choice-setting">
@@ -202,6 +220,10 @@ module.exports = React.createClass
                 <small className="form-help">The answers will be displayed next to each checkbox, so this text is as important as the main text and help text for guiding the volunteers. Keep your answers as minimal as possible -- any more than 5 answers can discourage new users.</small><br />
                 <small className="form-help">The “Next task” selection describes what task you want the volunteer to perform next after they give a particular answer. You can choose from among the tasks you’ve already defined. If you want to link a task to another you haven’t built yet, you can come back and do it later (don’t forget to save your changes).</small>
               </div>
+            when 'highlighterLabels'
+              <div> 
+                <small className="form-help"> Add labels for the highlighter tool.</small>
+              </div>
             when 'tools'
               <div>
                 <small className="form-help">Select which marks you want for this task, and what to call each of them. The tool name will be displayed on the classification page next to each marking option. Use the simplest tool that will give you the results you need for your research.</small><br />
@@ -248,10 +270,16 @@ module.exports = React.createClass
     switch type
       when 'answers' then @addAnswer()
       when 'tools' then @addTool()
+      when 'highlighterLabels' then @addHighlighterLabels()
 
   addAnswer: ->
     @props.task.answers.push
       label: 'Enter an answer'
+    @props.workflow.update 'tasks'
+
+  addHighlighterLabels: ->
+    @props.task.highlighterLabels.push
+      label: 'Enter label'
     @props.workflow.update 'tasks'
 
   addTool: ->

--- a/app/classifier/tasks/generic-editor.cjsx
+++ b/app/classifier/tasks/generic-editor.cjsx
@@ -123,12 +123,12 @@ module.exports = React.createClass
                       <AutoSave resource={@props.workflow} >
                         Color{' '}
                         <select name="#{@props.taskPrefix}.#{choicesKey}.#{index}.color" value={choice.color} onChange={handleChange}>
-                          <option value="#ff0000">Red</option>
-                          <option value="#ffff00">Yellow</option>
-                          <option value="#00ff00">Green</option>
+                          <option value="#ff6639">Red</option>
+                          <option value="#ffa539">Yellow</option>
+                          <option value="#38b978">Green</option>
+                          <option value="#43bcfd">Blue</option>
+                          <option value="#5364fd">Violet</option>
                           <option value="#00ffff">Cyan</option>
-                          <option value="#0000ff">Blue</option>
-                          <option value="#ff00ff">Magenta</option>
                           <option value="#000000">Black</option>
                           <option value="#ffffff">White</option>
                         </select>

--- a/app/classifier/tasks/highlighter/index.jsx
+++ b/app/classifier/tasks/highlighter/index.jsx
@@ -44,9 +44,10 @@ export default class Highlighter extends React.Component {
   }
 
   selectableArea(selection, range, offset, start, end){
+    const spansNodes = range.startContainer !== range.endContainer
     const noAreaSelected = start === end;
     const subjectSelection = selection.anchorNode.parentElement.parentElement.className === 'label-renderer';
-    const isSelectable = !noAreaSelected && subjectSelection;
+    const isSelectable = !spansNodes && !noAreaSelected && subjectSelection;
     return isSelectable;
   }
 

--- a/app/classifier/tasks/highlighter/index.jsx
+++ b/app/classifier/tasks/highlighter/index.jsx
@@ -31,7 +31,8 @@ export default class Highlighter extends React.Component {
     newAnnotation.value.push({
       labelInformation: labelInformation,
       start: start,
-      end: end
+      end: end,
+      text: range.toString()
     });
     this.props.onChange(newAnnotation);
     selection.collapseToEnd();

--- a/app/classifier/tasks/highlighter/index.jsx
+++ b/app/classifier/tasks/highlighter/index.jsx
@@ -53,16 +53,15 @@ export default class Highlighter extends React.Component {
     const { anchorNode } = selection;
     const { parentNode } = anchorNode;
     let start = 0;
-    let counting = true;
-    parentNode.childNodes.forEach((node) => {
+    for (const node of parentNode.childNodes) {
       // ignore comments (nodeType 8) when calculating offset distance
-      if (counting && node.nodeType !== 8 && node !== anchorNode) {
+      if (node.nodeType !== 8 && node !== anchorNode) {
         start += node.textContent.length;
       }
       if (node === anchorNode) {
-        counting = false;
+        break;
       }
-    });
+    }
     return start;
   }
 

--- a/app/classifier/tasks/highlighter/index.jsx
+++ b/app/classifier/tasks/highlighter/index.jsx
@@ -3,6 +3,7 @@ import { Markdown } from 'markdownz';
 import GenericTaskEditor from '../generic-editor';
 import GenericTask from '../generic';
 import LabelRenderer from './label-renderer';
+import HighlighterSummary from './summary';
 
 export default class Highlighter extends React.Component {
   constructor(props) {
@@ -66,6 +67,8 @@ export default class Highlighter extends React.Component {
 Highlighter.Editor = GenericTaskEditor;
 
 Highlighter.InsideSubject = LabelRenderer;
+
+Highlighter.Summary = HighlighterSummary;
 
 Highlighter.getDefaultTask = () => {
   return (

--- a/app/classifier/tasks/highlighter/index.jsx
+++ b/app/classifier/tasks/highlighter/index.jsx
@@ -12,6 +12,7 @@ export default class Highlighter extends React.Component {
     this.handleChange = this.handleChange.bind(this);
     this.createButtons = this.createButtons.bind(this);
     this.createLabelAnnotation = this.createLabelAnnotation.bind(this);
+    this.selectableArea = this.selectableArea.bind(this);
   }
 
   handleChange(toolIndex, e) {
@@ -27,15 +28,28 @@ export default class Highlighter extends React.Component {
     const end = offset + range.endOffset;
     const task = this.props.workflow.tasks[this.props.annotation.task];
     const labelInformation = task.highlighterLabels[toolIndex];
-    const newAnnotation = Object.assign({}, this.props.annotation, { _toolIndex: toolIndex });
-    newAnnotation.value.push({
-      labelInformation: labelInformation,
-      start: start,
-      end: end,
-      text: range.toString()
-    });
-    this.props.onChange(newAnnotation);
+    const selectable = this.selectableArea(selection, range, offset, start, end);
+    if (selectable) {
+      const newAnnotation = Object.assign({}, this.props.annotation, { _toolIndex: toolIndex });
+      newAnnotation.value.push({
+        labelInformation: labelInformation,
+        start: start,
+        end: end,
+        text: range.toString()
+      });
+      this.props.onChange(newAnnotation);
+    }
     selection.collapseToEnd();
+  }
+
+  selectableArea(selection, range, offset, start, end){
+    const noAreaSelected = start === end;
+    const subjectSelection = selection.anchorNode.parentElement.parentElement.className === 'label-renderer';
+    if (!noAreaSelected && subjectSelection) {
+      return true;
+    } else {
+      return false;
+    }
   }
 
   getOffset(selection) {

--- a/app/classifier/tasks/highlighter/index.jsx
+++ b/app/classifier/tasks/highlighter/index.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Markdown } from 'markdownz';
 import GenericTaskEditor from '../generic-editor';
 import GenericTask from '../generic';
+import LabelRenderer from './label-renderer';
 
 export default class Highlighter extends React.Component {
   constructor(props) {
@@ -11,6 +12,7 @@ export default class Highlighter extends React.Component {
   }
 
   handleChange(toolIndex, e) {
+    debugger;
     if (e.target.checked) {
       const newAnnotation = Object.assign({}, this.props.annotation, { _toolIndex: toolIndex });
       this.props.onChange(newAnnotation);
@@ -52,6 +54,8 @@ export default class Highlighter extends React.Component {
 }
 
 Highlighter.Editor = GenericTaskEditor;
+
+Highlighter.InsideSubject = LabelRenderer;
 
 Highlighter.getDefaultTask = () => {
   return (

--- a/app/classifier/tasks/highlighter/index.jsx
+++ b/app/classifier/tasks/highlighter/index.jsx
@@ -45,11 +45,8 @@ export default class Highlighter extends React.Component {
   selectableArea(selection, range, offset, start, end){
     const noAreaSelected = start === end;
     const subjectSelection = selection.anchorNode.parentElement.parentElement.className === 'label-renderer';
-    if (!noAreaSelected && subjectSelection) {
-      return true;
-    } else {
-      return false;
-    }
+    const isSelectable = !noAreaSelected && subjectSelection;
+    return isSelectable;
   }
 
   getOffset(selection) {

--- a/app/classifier/tasks/highlighter/index.jsx
+++ b/app/classifier/tasks/highlighter/index.jsx
@@ -101,12 +101,23 @@ export default class Highlighter extends React.Component {
 Highlighter.Editor = GenericTaskEditor;
 
 Highlighter.InsideSubject = (props) => {
-  const onClick = (e) => {
-    console.log(e.target)
+  function onClick(e) {
+    if (e.data && e.data.text) {
+      e.target.focus();
+    }
   }
   
+  function onKeyDown(e) {
+    if (e.data && e.data.text && e.which === 8) {
+      const index = props.annotation.value.indexOf(e.data);
+      props.annotation.value.splice(index, 1);
+      props.classification.update('annotations');
+      e.preventDefault();
+    }
+  }
+
   return(
-    <div onClick={onClick}>
+    <div onClick={onClick} onKeyDown={onKeyDown}>
       {props.children}
     </div>
   );

--- a/app/classifier/tasks/highlighter/index.jsx
+++ b/app/classifier/tasks/highlighter/index.jsx
@@ -100,6 +100,18 @@ export default class Highlighter extends React.Component {
 
 Highlighter.Editor = GenericTaskEditor;
 
+Highlighter.InsideSubject = (props) => {
+  const onClick = (e) => {
+    console.log(e.target)
+  }
+  
+  return(
+    <div onClick={onClick}>
+      {props.children}
+    </div>
+  );
+}
+
 Highlighter.PersistInsideSubject = LabelRenderer;
 
 Highlighter.Summary = HighlighterSummary;

--- a/app/classifier/tasks/highlighter/index.jsx
+++ b/app/classifier/tasks/highlighter/index.jsx
@@ -8,16 +8,30 @@ export default class Highlighter extends React.Component {
   constructor(props) {
     super(props);
     this.handleChange = this.handleChange.bind(this);
-    this.createLabels = this.createLabels.bind(this);
+    this.createButtons = this.createButtons.bind(this);
+    this.createLabelAnnotation = this.createLabelAnnotation.bind(this);
   }
 
   handleChange(toolIndex, e) {
-    if (e.target.checked) {
-      const newAnnotation = Object.assign({}, this.props.annotation, { _toolIndex: toolIndex });
-      this.props.onChange(newAnnotation);
-    }
+    let selection = document.getSelection();
+    this.createLabelAnnotation(selection, toolIndex);
   }
-  createLabels(option, index) {
+
+  createLabelAnnotation(selection, toolIndex) {
+    const anchorIndex = selection.anchorOffset;
+    const focusIndex = selection.focusOffset;
+    const task = this.props.workflow.tasks[this.props.annotation.task];
+    const labelInformation = task.highlighterLabels[toolIndex];
+    const newAnnotation = Object.assign({}, this.props.annotation, { _toolIndex: toolIndex });
+    newAnnotation.value.push({
+      labelInformation: labelInformation,
+      anchorIndex: anchorIndex,
+      focusIndex: focusIndex
+    });
+    this.props.onChange(newAnnotation);
+  }
+
+  createButtons(option, index) {
     const checked = index === this.props.annotation._toolIndex;
     let active = '';
     if (checked) {
@@ -25,19 +39,16 @@ export default class Highlighter extends React.Component {
     }
     return (
       <div>
-        <label htmlFor={option.label} >
-          <input id={option.label} type="checkbox" checked={checked} className="drawing-tool-button-input" value={option.label} autoFocus={this.props.autoFocus && index === 0} onChange={this.handleChange.bind(this.props.annotation._toolIndex, index)} />
-          <div className={`minor-button answer-button ${active}`} >
-            <i className="fa fa-i-cursor" aria-hidden="true" style={{ color: `${option.color}` }} />
-            <Markdown className="answer-button-label">{option.label}</Markdown>
-          </div>
-        </label>
+        <button className="minor-button answer-button" value={option.label} onClick={this.handleChange.bind(this.props.annotation._toolIndex, index)} >
+          <i className="fa fa-i-cursor" aria-hidden="true" style={{ color: `${option.color}` }} />
+          <Markdown className="answer-button-label">{option.label}</Markdown>
+        </button>
       </div>
     );
   }
   render() {
     if (this.props.task.highlighterLabels !== null) {
-      const labels = this.props.task.highlighterLabels.map(this.createLabels);
+      const labels = this.props.task.highlighterLabels.map(this.createButtons);
       return (
         <div>
           <GenericTask question={this.props.task.instruction} help={this.props.task.help} answers={labels} required={this.props.task.required} />

--- a/app/classifier/tasks/highlighter/index.jsx
+++ b/app/classifier/tasks/highlighter/index.jsx
@@ -1,24 +1,60 @@
 import React from 'react';
+import { Markdown } from 'markdownz';
 import GenericTaskEditor from '../generic-editor';
 import GenericTask from '../generic';
-import {Markdown} from 'markdownz';
 
 export default class Highlighter extends React.Component {
   constructor(props) {
     super(props);
+    this.handleChange = this.handleChange.bind(this);
+    this.createLabels = this.createLabels.bind(this);
   }
 
-  render(){
-    return(
-      <div className="highlighter-tool" />
+  handleChange(toolIndex, e) {
+    if (e.target.checked) {
+      const newAnnotation = Object.assign({}, this.props.annotation, { _toolIndex: toolIndex });
+      this.props.onChange(newAnnotation);
+    }
+  }
+  createLabels(option, index) {
+    const checked = index === this.props.annotation._toolIndex;
+    let active = '';
+    if (checked) {
+      active = 'active';
+    }
+    return (
+      <div>
+        <label htmlFor={option.label} >
+          <input id={option.label} type="checkbox" checked={checked} className="drawing-tool-button-input" value={option.label} autoFocus={this.props.autoFocus && index === 0} onChange={this.handleChange.bind(this.props.annotation._toolIndex, index)} />
+          <div className={`minor-button answer-button ${active}`} >
+            <i className="fa fa-i-cursor" aria-hidden="true" style={{ color: `${option.color}` }} />
+            <Markdown className="answer-button-label">{option.label}</Markdown>
+          </div>
+        </label>
+      </div>
     );
   }
+  render() {
+    if (this.props.task.highlighterLabels !== null) {
+      const labels = this.props.task.highlighterLabels.map(this.createLabels);
+      return (
+        <div>
+          <GenericTask question={this.props.task.instruction} help={this.props.task.help} answers={labels} required={this.props.task.required} />
+        </div>
+      );
+    } else {
+      return (
+        <div>{'No labels for the Highlighter Tool'}</div>
+      );
+    }
+  }
+
 }
 
 Highlighter.Editor = GenericTaskEditor;
 
 Highlighter.getDefaultTask = () => {
-  return(
+  return (
     {
       type: 'highlighter',
       instruction: 'Highlight the text',
@@ -29,15 +65,15 @@ Highlighter.getDefaultTask = () => {
 };
 
 Highlighter.getTaskText = (task) => {
-  return(task.instruction);
+  return (task.instruction);
 };
 
 Highlighter.getDefaultAnnotation = () => {
-  return({
+  return ({
     _toolIndex: 0,
     value: []
   });
-}
+};
 
 Highlighter.defaultProps = {
   task: {
@@ -53,6 +89,14 @@ Highlighter.propTypes = {
     type: React.PropTypes.string,
     instruction: React.PropTypes.string,
     help: React.PropTypes.string,
+    tools: React.PropTypes.array,
+    required: React.PropTypes.bool,
+    highlighterLabels: React.PropTypes.array
+  }),
+  onChange: React.PropTypes.func,
+  annotation: React.PropTypes.shape({
+    _toolIndex: React.PropTypes.number,
     tools: React.PropTypes.array
-  })
+  }),
+  autoFocus: React.PropTypes.bool
 };

--- a/app/classifier/tasks/highlighter/index.jsx
+++ b/app/classifier/tasks/highlighter/index.jsx
@@ -4,6 +4,7 @@ import GenericTaskEditor from '../generic-editor';
 import GenericTask from '../generic';
 import LabelRenderer from './label-renderer';
 import HighlighterSummary from './summary';
+import TextRenderer from '../../annotation-renderer/text';
 
 export default class Highlighter extends React.Component {
   constructor(props) {
@@ -72,6 +73,8 @@ Highlighter.Editor = GenericTaskEditor;
 Highlighter.InsideSubject = LabelRenderer;
 
 Highlighter.Summary = HighlighterSummary;
+
+Highlighter.AnnotationRenderer = TextRenderer;
 
 Highlighter.getDefaultTask = () => {
   return (

--- a/app/classifier/tasks/highlighter/index.jsx
+++ b/app/classifier/tasks/highlighter/index.jsx
@@ -56,7 +56,8 @@ export default class Highlighter extends React.Component {
     for (const node of parentNode.childNodes) {
       // ignore comments (nodeType 8) when calculating offset distance
       if (node.nodeType !== 8 && node !== anchorNode) {
-        start += node.textContent.length;
+        const text = node.getAttribute ? node.getAttribute('data-selection') : node.textContent;
+        start += text.length;
       }
       if (node === anchorNode) {
         break;
@@ -101,8 +102,11 @@ Highlighter.Editor = GenericTaskEditor;
 
 Highlighter.InsideSubject = (props) => {
   function onClick(e) {
-    if (e.data && e.data.text) {
-      e.target.focus();
+    if (e.data && e.data.text && e.target.className === "survey-identification-remove") {
+      const index = props.annotation.value.indexOf(e.data);
+      props.annotation.value.splice(index, 1);
+      props.classification.update('annotations');
+      e.preventDefault();
     }
   }
   
@@ -115,9 +119,15 @@ Highlighter.InsideSubject = (props) => {
     }
   }
 
+  const children = React.Children.map(props.children, (child) => {
+    return React.cloneElement(child, {
+      disabled: false
+    })
+  });
+
   return(
     <div onClick={onClick} onKeyDown={onKeyDown}>
-      {props.children}
+      {children}
     </div>
   );
 }

--- a/app/classifier/tasks/highlighter/index.jsx
+++ b/app/classifier/tasks/highlighter/index.jsx
@@ -70,7 +70,7 @@ export default class Highlighter extends React.Component {
 
 Highlighter.Editor = GenericTaskEditor;
 
-Highlighter.InsideSubject = LabelRenderer;
+Highlighter.PersistInsideSubject = LabelRenderer;
 
 Highlighter.Summary = HighlighterSummary;
 

--- a/app/classifier/tasks/highlighter/index.jsx
+++ b/app/classifier/tasks/highlighter/index.jsx
@@ -46,7 +46,7 @@ export default class Highlighter extends React.Component {
   selectableArea(selection, range, offset, start, end){
     const spansNodes = range.startContainer !== range.endContainer
     const noAreaSelected = start === end;
-    const subjectSelection = selection.anchorNode.parentElement.parentElement.className === 'label-renderer';
+    const subjectSelection = selection.anchorNode.parentNode.parentNode.className === 'label-renderer';
     const isSelectable = !spansNodes && !noAreaSelected && subjectSelection;
     return isSelectable;
   }
@@ -55,8 +55,9 @@ export default class Highlighter extends React.Component {
     const { anchorNode } = selection;
     const { parentNode } = anchorNode;
     let start = 0;
-    for (const node of parentNode.childNodes) {
-      // ignore comments (nodeType 8) when calculating offset distance
+    let nodeArray = parentNode.childNodes;
+    for (var i = 0; i < nodeArray.length; i++) {
+      let node = nodeArray[i];
       if (node.nodeType !== 8 && node !== anchorNode) {
         const text = node.getAttribute ? node.getAttribute('data-selection') : node.textContent;
         start += text.length;

--- a/app/classifier/tasks/highlighter/index.jsx
+++ b/app/classifier/tasks/highlighter/index.jsx
@@ -30,6 +30,7 @@ export default class Highlighter extends React.Component {
       focusIndex: focusIndex
     });
     this.props.onChange(newAnnotation);
+    selection.collapse(selection.achorNode, focusIndex);
   }
 
   createButtons(option, index) {

--- a/app/classifier/tasks/highlighter/index.jsx
+++ b/app/classifier/tasks/highlighter/index.jsx
@@ -22,8 +22,9 @@ export default class Highlighter extends React.Component {
   createLabelAnnotation(selection, toolIndex) {
     // currently we only deal with one selection at a time
     const range = selection.getRangeAt(0);
-    const start = range.startOffset;
-    const end = range.endOffset;
+    const offset = this.getOffset(selection);
+    const start = offset + range.startOffset;
+    const end = offset + range.endOffset;
     const task = this.props.workflow.tasks[this.props.annotation.task];
     const labelInformation = task.highlighterLabels[toolIndex];
     const newAnnotation = Object.assign({}, this.props.annotation, { _toolIndex: toolIndex });
@@ -34,6 +35,23 @@ export default class Highlighter extends React.Component {
     });
     this.props.onChange(newAnnotation);
     selection.collapseToEnd();
+  }
+
+  getOffset(selection) {
+    const { anchorNode } = selection;
+    const { parentNode } = anchorNode;
+    let start = 0;
+    let counting = true;
+    parentNode.childNodes.forEach((node) => {
+      // ignore comments (nodeType 8) when calculating offset distance
+      if (counting && node.nodeType !== 8 && node !== anchorNode) {
+        start += node.textContent.length;
+      }
+      if (node === anchorNode) {
+        counting = false;
+      }
+    });
+    return start;
   }
 
   createButtons(option, index) {

--- a/app/classifier/tasks/highlighter/index.jsx
+++ b/app/classifier/tasks/highlighter/index.jsx
@@ -19,18 +19,20 @@ export default class Highlighter extends React.Component {
   }
 
   createLabelAnnotation(selection, toolIndex) {
-    const anchorIndex = selection.anchorOffset;
-    const focusIndex = selection.focusOffset;
+    // currently we only deal with one selection at a time
+    const range = selection.getRangeAt(0);
+    const start = range.startOffset;
+    const end = range.endOffset;
     const task = this.props.workflow.tasks[this.props.annotation.task];
     const labelInformation = task.highlighterLabels[toolIndex];
     const newAnnotation = Object.assign({}, this.props.annotation, { _toolIndex: toolIndex });
     newAnnotation.value.push({
       labelInformation: labelInformation,
-      anchorIndex: anchorIndex,
-      focusIndex: focusIndex
+      start: start,
+      end: end
     });
     this.props.onChange(newAnnotation);
-    selection.collapse(selection.achorNode, focusIndex);
+    selection.collapseToEnd();
   }
 
   createButtons(option, index) {

--- a/app/classifier/tasks/highlighter/index.jsx
+++ b/app/classifier/tasks/highlighter/index.jsx
@@ -12,7 +12,6 @@ export default class Highlighter extends React.Component {
   }
 
   handleChange(toolIndex, e) {
-    debugger;
     if (e.target.checked) {
       const newAnnotation = Object.assign({}, this.props.annotation, { _toolIndex: toolIndex });
       this.props.onChange(newAnnotation);

--- a/app/classifier/tasks/highlighter/index.jsx
+++ b/app/classifier/tasks/highlighter/index.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Markdown } from 'markdownz';
 import GenericTaskEditor from '../generic-editor';
 import GenericTask from '../generic';
+import LabelEditor from './label-editor';
 import LabelRenderer from './label-renderer';
 import HighlighterSummary from './summary';
 import TextRenderer from '../../annotation-renderer/text';
@@ -100,37 +101,7 @@ export default class Highlighter extends React.Component {
 
 Highlighter.Editor = GenericTaskEditor;
 
-Highlighter.InsideSubject = (props) => {
-  function onClick(e) {
-    if (e.data && e.data.text && e.target.className === "survey-identification-remove") {
-      const index = props.annotation.value.indexOf(e.data);
-      props.annotation.value.splice(index, 1);
-      props.classification.update('annotations');
-      e.preventDefault();
-    }
-  }
-  
-  function onKeyDown(e) {
-    if (e.data && e.data.text && e.which === 8) {
-      const index = props.annotation.value.indexOf(e.data);
-      props.annotation.value.splice(index, 1);
-      props.classification.update('annotations');
-      e.preventDefault();
-    }
-  }
-
-  const children = React.Children.map(props.children, (child) => {
-    return React.cloneElement(child, {
-      disabled: false
-    })
-  });
-
-  return(
-    <div onClick={onClick} onKeyDown={onKeyDown}>
-      {children}
-    </div>
-  );
-}
+Highlighter.InsideSubject = LabelEditor;
 
 Highlighter.PersistInsideSubject = LabelRenderer;
 

--- a/app/classifier/tasks/highlighter/index.jsx
+++ b/app/classifier/tasks/highlighter/index.jsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import GenericTaskEditor from '../generic-editor';
+import GenericTask from '../generic';
+import {Markdown} from 'markdownz';
+
+export default class Highlighter extends React.Component {
+  constructor(props) {
+    super(props);
+  }
+
+  render(){
+    return(
+      <div className="highlighter-tool" />
+    );
+  }
+}
+
+Highlighter.Editor = GenericTaskEditor;
+
+Highlighter.getDefaultTask = () => {
+  return(
+    {
+      type: 'highlighter',
+      instruction: 'Highlight the text',
+      help: '',
+      highlighterLabels: []
+    }
+  );
+};
+
+Highlighter.getTaskText = (task) => {
+  return(task.instruction);
+};
+
+Highlighter.getDefaultAnnotation = () => {
+  return({
+    _toolIndex: 0,
+    value: []
+  });
+}
+
+Highlighter.defaultProps = {
+  task: {
+    type: 'highlighter',
+    instruction: 'Highlight the text',
+    help: '',
+    highlighterLabels: []
+  }
+};
+
+Highlighter.propTypes = {
+  task: React.PropTypes.shape({
+    type: React.PropTypes.string,
+    instruction: React.PropTypes.string,
+    help: React.PropTypes.string,
+    tools: React.PropTypes.array
+  })
+};

--- a/app/classifier/tasks/highlighter/label-editor.jsx
+++ b/app/classifier/tasks/highlighter/label-editor.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+
+export default function LabelEditor(props) {
+  function deleteAnnotation(annotation) {
+    const index = props.annotation.value.indexOf(annotation);
+    props.annotation.value.splice(index, 1);
+    props.classification.update('annotations');
+  }
+
+  function onClick(e) {
+    if (e.data && e.data.text && e.target.className === 'survey-identification-remove') {
+      deleteAnnotation(e.data);
+      e.preventDefault();
+    }
+  }
+
+  function onKeyDown(e) {
+    if (e.data && e.data.text && e.which === 8) {
+      deleteAnnotation(e.data);
+      e.preventDefault();
+    }
+  }
+
+  const children = React.Children.map(props.children, (child) => {
+    return React.cloneElement(child, {
+      disabled: false
+    });
+  });
+
+  return (
+    <div onClick={onClick} onKeyDown={onKeyDown}>
+      {children}
+    </div>
+  );
+}
+
+LabelEditor.propTypes = {
+  children: React.PropTypes.node
+};

--- a/app/classifier/tasks/highlighter/label-renderer.jsx
+++ b/app/classifier/tasks/highlighter/label-renderer.jsx
@@ -72,7 +72,7 @@ export default class LabelRenderer extends React.Component {
       padding: '2%',
       color: '#efefef',
       whiteSpace: 'pre-wrap',
-      width: '96%'
+      width: '40ch'
     };
     const children = React.Children.map(this.props.children, (child) => {
       return React.cloneElement(child, {

--- a/app/classifier/tasks/highlighter/label-renderer.jsx
+++ b/app/classifier/tasks/highlighter/label-renderer.jsx
@@ -20,8 +20,9 @@ export default class LabelRenderer extends React.Component {
   createNewContent(){
     let newContent = [];
     let lastFocusIndex = 0;
+    let i = 0;
     if (this.props.annotation.value && this.props.annotation.value.length > 0) {
-      for ( let i = 0; i < this.state.content.length; i++){
+      for ( i = 0; i < this.state.content.length; i++){
         for (let a = 0; a < this.props.annotation.value.length; a++) {
           let currentAnnotation = this.props.annotation.value[a];
           let annotationColor = currentAnnotation.labelInformation.color;
@@ -44,16 +45,13 @@ export default class LabelRenderer extends React.Component {
             lastFocusIndex = currentAnnotation.end;
           }
         }
-        // 4. if last character in the string, add the remaining content
-        if (i === (this.state.content.length - 1)) {
-          let endContent = this.state.content.slice(lastFocusIndex, i);
-          newContent.push(endContent);
-        }
       }
-      return(newContent);
-    } else {
-      return([this.state.content]);
+      // 4. if last character in the string, add the remaining content
+      const endContent = this.state.content.slice(lastFocusIndex, i);
+      newContent.push(endContent);
     }
+
+    return ( newContent.length === 0 ? this.state.content : newContent );
   }
 
   render() {

--- a/app/classifier/tasks/highlighter/label-renderer.jsx
+++ b/app/classifier/tasks/highlighter/label-renderer.jsx
@@ -1,0 +1,91 @@
+import React from 'react';
+
+export default class LabelRenderer extends React.Component {
+
+  constructor(props) {
+    super(props);
+    this.createLabelAnnotation = this.createLabelAnnotation.bind(this);
+    this.createNewContent = this.createNewContent.bind(this);
+  }
+
+  createLabelAnnotation() {
+    const selection = window.getSelection();
+    const anchorIndex = selection.anchorOffset;
+    const focusIndex = selection.focusOffset;
+    const task = this.props.classification._workflow.tasks[this.props.annotation.task];
+    const labelInformation = task.highlighterLabels[this.props.annotation._toolIndex];
+
+    this.props.annotation.value.push({
+      _toolIndex: this.props.annotation._toolIndex,
+      labelInformation: labelInformation,
+      anchorIndex: anchorIndex,
+      focusIndex: focusIndex
+    });
+    this.props.onChange(this.props.annotation);
+  }
+
+  createNewContent(){
+    let newContent = [];
+    let lastFocusIndex = 0;
+    const annotationValueLength = this.props.annotation.value.length;
+    if (annotationValueLength > 0) {
+      for ( let i = 0; i < this.props.content.length; i++){
+        for (let a = 0; a < this.props.annotation.value.length; a++) {
+          let currentAnnotation = this.props.annotation.value[a];
+          let annotationColor = currentAnnotation.labelInformation.color;
+          if (currentAnnotation.anchorIndex === i ) {
+            // 1. add text between last label and current label
+            let preContent = this.props.content.slice(lastFocusIndex, i);
+            newContent.push(preContent);
+            
+            // 2. add the highlighted content, push content to be labeled
+            let highlightedContent = this.props.content.slice(i, currentAnnotation.focusIndex);
+            let labelColor = currentAnnotation.labelInformation.color;
+
+            let newLabel = 
+              <span key={a} style={{background: `${labelColor}`}} >
+                {highlightedContent}
+              </span>;
+            newContent.push(newLabel);
+            
+            // 3. re-set last focusIndex with annotation index
+            lastFocusIndex = currentAnnotation.focusIndex;
+          }
+        }
+        // 4. if last character in the string, add the remaining content
+        if (i === (this.props.content.length - 1)) {
+          let endContent = this.props.content.slice(lastFocusIndex, i);
+          newContent.push(endContent);
+        }
+      }
+      return(newContent);
+    } else {
+      return([this.props.content]);
+    }
+  }
+
+  render() {
+    const labeledContent = this.createNewContent();
+    const divStyles = {      
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      padding: '2%',
+      color: 'transparent'
+    };
+    return(
+      <div>
+        <div>
+          {labeledContent}
+        </div>
+        <div style={divStyles} onMouseUp={this.createLabelAnnotation} >
+          {this.props.content}
+        </div>
+      </div>
+    );
+  }
+}
+
+LabelRenderer.propTypes = {
+  content: React.PropTypes.string
+};

--- a/app/classifier/tasks/highlighter/label-renderer.jsx
+++ b/app/classifier/tasks/highlighter/label-renderer.jsx
@@ -1,46 +1,20 @@
-import React from 'react';
-
-const cache = {}; 
+import React from 'react'; 
 
 export default class LabelRenderer extends React.Component {
 
   constructor(props) {
     super(props);
     this.createNewContent = this.createNewContent.bind(this);
+    this.onLoad = this.onLoad.bind(this);
     this.state = {
       content: ''
     }
   }
 
-  componentWillReceiveProps(newProps) {
-    if (newProps.src !== this.props.src) {
-      this.loadText(newProps.src);
-    }
-  }
-
-  componentDidMount(){
-    this.loadText(this.props.src);
-  }
-
-  loadText(src) {
-    const cachedContent = cache[src];
-    if (cachedContent) {
-      this.setState({ content: cachedContent });
-    } else {
-      this.setState({ content: 'Loading…' });
-      fetch(src + '?=')
-      .then((response) => {
-        return response.text();
-      })
-      .then((content) => {
-        cache[src] = content;
-        this.setState({ content });
-      })
-      .catch((e) => {
-        const content = e.message;
-        this.setState({ content });
-      });
-    }
+  onLoad(e) {
+    const content = e.data;
+    this.setState({ content });
+    this.props.onLoad(e);
   }
 
   createNewContent(){
@@ -101,19 +75,28 @@ export default class LabelRenderer extends React.Component {
       color: '#efefef',
       whiteSpace: 'pre-wrap'
     };
+    const children = React.Children.map(this.props.children, (child) => {
+      return React.cloneElement(child, {
+        style: invisibleDivStyles,
+        onLoad: this.onLoad
+      });
+    });
     return(
       <div className='label-renderer' >
         <div style={visibleDivStyles} >
           {labeledContent}
         </div>
-        <div style={invisibleDivStyles} >
-          {this.state.content}
-        </div>
+          {children}
       </div>
     );
   }
 }
 
 LabelRenderer.propTypes = {
+  onLoad: React.PropTypes.func,
   src: React.PropTypes.string
 };
+
+LabelRenderer.defaultProps = {
+  onLoad: () => { return true }
+}

--- a/app/classifier/tasks/highlighter/label-renderer.jsx
+++ b/app/classifier/tasks/highlighter/label-renderer.jsx
@@ -52,13 +52,13 @@ export default class LabelRenderer extends React.Component {
         for (let a = 0; a < this.props.annotation.value.length; a++) {
           let currentAnnotation = this.props.annotation.value[a];
           let annotationColor = currentAnnotation.labelInformation.color;
-          if (currentAnnotation.anchorIndex === i ) {
+          if (currentAnnotation.start === i ) {
             // 1. add text between last label and current label
             let preContent = this.state.content.slice(lastFocusIndex, i);
             newContent.push(preContent);
             
             // 2. add the highlighted content, push content to be labeled
-            let highlightedContent = this.state.content.slice(i, currentAnnotation.focusIndex);
+            let highlightedContent = this.state.content.slice(i, currentAnnotation.end);
             let labelColor = currentAnnotation.labelInformation.color;
 
             let newLabel = 
@@ -68,7 +68,7 @@ export default class LabelRenderer extends React.Component {
             newContent.push(newLabel);
             
             // 3. re-set last focusIndex with annotation index
-            lastFocusIndex = currentAnnotation.focusIndex;
+            lastFocusIndex = currentAnnotation.end;
           }
         }
         // 4. if last character in the string, add the remaining content

--- a/app/classifier/tasks/highlighter/label-renderer.jsx
+++ b/app/classifier/tasks/highlighter/label-renderer.jsx
@@ -1,4 +1,5 @@
-import React from 'react'; 
+import React from 'react';
+import Selection from './selection';
 
 export default class LabelRenderer extends React.Component {
 
@@ -32,13 +33,7 @@ export default class LabelRenderer extends React.Component {
             newContent.push(preContent);
             
             // 2. add the highlighted content, push content to be labeled
-            let highlightedContent = this.state.content.slice(i, currentAnnotation.end);
-            let labelColor = currentAnnotation.labelInformation.color;
-
-            let newLabel = 
-              <span key={a} style={{background: `${labelColor}`}} >
-                {highlightedContent}
-              </span>;
+            let newLabel = <Selection key={a} annotation={currentAnnotation} />
             newContent.push(newLabel);
             
             // 3. re-set last focusIndex with annotation index

--- a/app/classifier/tasks/highlighter/label-renderer.jsx
+++ b/app/classifier/tasks/highlighter/label-renderer.jsx
@@ -33,7 +33,7 @@ export default class LabelRenderer extends React.Component {
             newContent.push(preContent);
             
             // 2. add the highlighted content, push content to be labeled
-            let newLabel = <Selection key={a} annotation={currentAnnotation} />
+            let newLabel = <Selection key={a} annotation={currentAnnotation} disabled={this.props.disabled} />
             newContent.push(newLabel);
             
             // 3. re-set last focusIndex with annotation index
@@ -69,6 +69,7 @@ export default class LabelRenderer extends React.Component {
 }
 
 LabelRenderer.propTypes = {
+  disabled: React.PropTypes.bool,
   onLoad: React.PropTypes.func,
   src: React.PropTypes.string
 };
@@ -77,5 +78,6 @@ LabelRenderer.defaultProps = {
   annotation: {
     value: []
   },
+  disabled: true,
   onLoad: () => { return true }
 }

--- a/app/classifier/tasks/highlighter/label-renderer.jsx
+++ b/app/classifier/tasks/highlighter/label-renderer.jsx
@@ -56,31 +56,15 @@ export default class LabelRenderer extends React.Component {
 
   render() {
     const labeledContent = this.createNewContent();
-    const invisibleDivStyles = {
-      background: 'transparent',
-      position: 'absolute',
-      top: 0,
-      left: 0,
-      padding: '2%',
-      color: 'transparent',
-      whiteSpace: 'pre-wrap',
-      width: '96%'
-    };
-    const visibleDivStyles = {
-      padding: '2%',
-      color: '#efefef',
-      whiteSpace: 'pre-wrap',
-      width: '40ch'
-    };
     const children = React.Children.map(this.props.children, (child) => {
       return React.cloneElement(child, {
-        style: invisibleDivStyles,
+        className: 'invisible',
         onLoad: this.onLoad
       });
     });
     return(
       <div className='label-renderer' >
-        <div style={visibleDivStyles} >
+        <div >
           {labeledContent}
         </div>
           {children}

--- a/app/classifier/tasks/highlighter/label-renderer.jsx
+++ b/app/classifier/tasks/highlighter/label-renderer.jsx
@@ -6,7 +6,6 @@ export default class LabelRenderer extends React.Component {
 
   constructor(props) {
     super(props);
-    this.createLabelAnnotation = this.createLabelAnnotation.bind(this);
     this.createNewContent = this.createNewContent.bind(this);
     this.state = {
       content: ''
@@ -42,22 +41,6 @@ export default class LabelRenderer extends React.Component {
         this.setState({ content });
       });
     }
-  }
-
-  createLabelAnnotation() {
-    const selection = window.getSelection();
-    const anchorIndex = selection.anchorOffset;
-    const focusIndex = selection.focusOffset;
-    const task = this.props.classification._workflow.tasks[this.props.annotation.task];
-    const labelInformation = task.highlighterLabels[this.props.annotation._toolIndex];
-
-    this.props.annotation.value.push({
-      _toolIndex: this.props.annotation._toolIndex,
-      labelInformation: labelInformation,
-      anchorIndex: anchorIndex,
-      focusIndex: focusIndex
-    });
-    this.props.onChange(this.props.annotation);
   }
 
   createNewContent(){
@@ -119,11 +102,11 @@ export default class LabelRenderer extends React.Component {
       whiteSpace: 'pre-wrap'
     };
     return(
-      <div>
+      <div className='label-renderer' >
         <div style={visibleDivStyles} >
           {labeledContent}
         </div>
-        <div style={invisibleDivStyles} onMouseDown={this.createLabelAnnotation} >
+        <div style={invisibleDivStyles} >
           {this.state.content}
         </div>
       </div>

--- a/app/classifier/tasks/highlighter/label-renderer.jsx
+++ b/app/classifier/tasks/highlighter/label-renderer.jsx
@@ -20,8 +20,7 @@ export default class LabelRenderer extends React.Component {
   createNewContent(){
     let newContent = [];
     let lastFocusIndex = 0;
-    const annotationValueLength = this.props.annotation.value.length;
-    if (annotationValueLength > 0) {
+    if (this.props.annotation.value && this.props.annotation.value.length > 0) {
       for ( let i = 0; i < this.state.content.length; i++){
         for (let a = 0; a < this.props.annotation.value.length; a++) {
           let currentAnnotation = this.props.annotation.value[a];
@@ -59,21 +58,21 @@ export default class LabelRenderer extends React.Component {
 
   render() {
     const labeledContent = this.createNewContent();
-    const invisibleDivStyles = {      
+    const invisibleDivStyles = {
+      background: 'transparent',
       position: 'absolute',
       top: 0,
       left: 0,
       padding: '2%',
       color: 'transparent',
-      whiteSpace: 'pre-wrap'
+      whiteSpace: 'pre-wrap',
+      width: '96%'
     };
-    const visibleDivStyles = {      
-      position: 'absolute',
-      top: 0,
-      left: 0,
+    const visibleDivStyles = {
       padding: '2%',
       color: '#efefef',
-      whiteSpace: 'pre-wrap'
+      whiteSpace: 'pre-wrap',
+      width: '96%'
     };
     const children = React.Children.map(this.props.children, (child) => {
       return React.cloneElement(child, {
@@ -98,5 +97,8 @@ LabelRenderer.propTypes = {
 };
 
 LabelRenderer.defaultProps = {
+  annotation: {
+    value: []
+  },
   onLoad: () => { return true }
 }

--- a/app/classifier/tasks/highlighter/selection.jsx
+++ b/app/classifier/tasks/highlighter/selection.jsx
@@ -10,8 +10,15 @@ export default function Selection(props) {
   }
 
   return (
-    <span tabIndex={-1} style={{ background: `${props.annotation.labelInformation.color}` }} onClick={onClick} onKeyDown={onKeyDown}>
+    <span
+      style={{ background: `${props.annotation.labelInformation.color}` }}
+      data-selection={props.annotation.text}
+      onClick={onClick}
+      onKeyDown={onKeyDown}
+    >
       {props.annotation.text}
+      {' '}
+      {!props.disabled && <button className="survey-identification-remove" aria-label="Delete" title="Delete">&times;</button>}
     </span>
   );
 }
@@ -20,5 +27,10 @@ Selection.propTypes = {
   annotation: React.PropTypes.shape({
     labelInformation: React.PropTypes.object,
     text: React.PropTypes.string
-  })
+  }),
+  disabled: React.PropTypes.bool
 };
+
+Selection.defaultProps = {
+  disabled: true
+}

--- a/app/classifier/tasks/highlighter/selection.jsx
+++ b/app/classifier/tasks/highlighter/selection.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+export default function Selection(props) {
+  return (
+    <span style={{ background: `${props.annotation.labelInformation.color}` }} >
+      {props.annotation.text}
+    </span>
+  );
+}
+
+Selection.propTypes = {
+  annotation: React.PropTypes.shape({
+    labelInformation: React.PropTypes.object,
+    text: React.PropTypes.string
+  })
+};

--- a/app/classifier/tasks/highlighter/selection.jsx
+++ b/app/classifier/tasks/highlighter/selection.jsx
@@ -1,8 +1,16 @@
 import React from 'react';
 
 export default function Selection(props) {
+  function onClick(e) {
+    e.data = props.annotation;
+  }
+
+  function onKeyDown(e) {
+    e.data = props.annotation;
+  }
+
   return (
-    <span style={{ background: `${props.annotation.labelInformation.color}` }} >
+    <span tabIndex={-1} style={{ background: `${props.annotation.labelInformation.color}` }} onClick={onClick} onKeyDown={onKeyDown}>
       {props.annotation.text}
     </span>
   );

--- a/app/classifier/tasks/highlighter/summary.jsx
+++ b/app/classifier/tasks/highlighter/summary.jsx
@@ -9,7 +9,7 @@ export default class HighlighterSummary extends React.Component {
   createSummary(value, index){
     return(
       <div key={index} className="answer">
-        <p>{value.labelInformation.label} : {value.start} to {value.end}</p>
+      <p>{value.labelInformation.label} : {value.text} ({value.start} to {value.end})</p>
       </div>
     );
   }

--- a/app/classifier/tasks/highlighter/summary.jsx
+++ b/app/classifier/tasks/highlighter/summary.jsx
@@ -9,7 +9,7 @@ export default class HighlighterSummary extends React.Component {
   createSummary(value, index){
     return(
       <div key={index} className="answer">
-        <p>{value.labelInformation.label} : {value.anchorIndex} to {value.focusIndex}</p>
+        <p>{value.labelInformation.label} : {value.start} to {value.end}</p>
       </div>
     );
   }

--- a/app/classifier/tasks/highlighter/summary.jsx
+++ b/app/classifier/tasks/highlighter/summary.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Markdown } from 'markdownz';
+
+export default class HighlighterSummary extends React.Component {
+  constructor(props){
+    super(props);
+    this.createSummary = this.createSummary.bind(this);
+  }
+  createSummary(value, index){
+    return(
+      <div className="answer">
+        <p>{value.labelInformation.label} : {value.anchorIndex} to {value.focusIndex}</p>
+      </div>
+    );
+  }
+  render() {
+    const annotationSummaries = this.props.annotation.value.map(this.createSummary);
+    return(
+      <div>
+        {annotationSummaries}
+      </div>
+    );
+  }
+}
+

--- a/app/classifier/tasks/highlighter/summary.jsx
+++ b/app/classifier/tasks/highlighter/summary.jsx
@@ -8,7 +8,7 @@ export default class HighlighterSummary extends React.Component {
   }
   createSummary(value, index){
     return(
-      <div className="answer">
+      <div key={index} className="answer">
         <p>{value.labelInformation.label} : {value.anchorIndex} to {value.focusIndex}</p>
       </div>
     );

--- a/app/classifier/tasks/index.jsx
+++ b/app/classifier/tasks/index.jsx
@@ -8,6 +8,7 @@ import SliderTask from './slider/';
 import TextTask from './text/';
 import DropdownTask from './dropdown/';
 import ShortcutTask from './shortcut';
+import Highlighter from './highlighter/'
 
 const tasks = {
   combo: ComboTask,
@@ -19,7 +20,8 @@ const tasks = {
   slider: SliderTask,
   text: TextTask,
   dropdown: DropdownTask,
-  shortcut: ShortcutTask
+  shortcut: ShortcutTask,
+  highlighter: Highlighter
 };
 
 export default tasks;

--- a/app/components/file-viewer/index.jsx
+++ b/app/components/file-viewer/index.jsx
@@ -24,14 +24,13 @@ const VIEWERS = {
 };
 
 function subjectViewerSelector(props) {
-  if(Array.isArray(props.type)){
-    if(props.type.includes('audio')){
+  if (Array.isArray(props.type)) {
+    if (props.type.includes('audio')) {
       return VIEWERS.audio;
     }
     // ... add outher here if neccessary
   }
   return VIEWERS[props.type] || DefaultViewer;
-
 }
 
 function FileViewer(props) {
@@ -39,6 +38,8 @@ function FileViewer(props) {
 
   return (
     <Viewer
+      className={props.className}
+      style={props.style}
       src={props.src}
       type={props.type}
       format={props.format}
@@ -51,6 +52,7 @@ function FileViewer(props) {
 }
 
 FileViewer.propTypes = {
+  className: React.PropTypes.string,
   format: React.PropTypes.oneOfType([
     React.PropTypes.array,
     React.PropTypes.string
@@ -63,6 +65,7 @@ FileViewer.propTypes = {
     React.PropTypes.array,
     React.PropTypes.string
   ]),
+  style: React.PropTypes.object,
   type: React.PropTypes.oneOfType([
     React.PropTypes.array,
     React.PropTypes.string

--- a/app/components/file-viewer/text-viewer.jsx
+++ b/app/components/file-viewer/text-viewer.jsx
@@ -63,7 +63,7 @@ class TextViewer extends Component {
       content = `Unsupported format: ${this.props.format}`;
     }
     return (
-      <div ref={(element) => { this.element = element; }} className={isLoading ? 'text-viewer-loading' : 'text-viewer'} >
+      <div ref={(element) => { this.element = element; }} className={isLoading ? 'text-viewer-loading' : 'text-viewer'} style={this.props.style}>
         { content }
       </div>
     );
@@ -74,7 +74,8 @@ TextViewer.propTypes = {
   src: React.PropTypes.string.isRequired,
   type: React.PropTypes.string,
   format: React.PropTypes.string,
-  onLoad: React.PropTypes.func
+  onLoad: React.PropTypes.func,
+  style: React.PropTypes.object
 };
 
 TextViewer.defaultProps = {

--- a/app/components/file-viewer/text-viewer.jsx
+++ b/app/components/file-viewer/text-viewer.jsx
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import classnames from 'classnames';
 
 const SUPPORTED_TYPES = ['text'];
 const SUPPORTED_FORMATS = ['plain'];
@@ -65,8 +66,12 @@ class TextViewer extends Component {
     if (SUPPORTED_FORMATS.indexOf(this.props.format) === -1) {
       content = `Unsupported format: ${this.props.format}`;
     }
+    const className = classnames(this.props.className, {
+      'text-viewer-loading': isLoading,
+      'text-viewer': !isLoading
+    });
     return (
-      <div ref={(element) => { this.element = element; }} className={isLoading ? 'text-viewer-loading' : 'text-viewer'} style={this.props.style}>
+      <div ref={(element) => { this.element = element; }} className={className} style={this.props.style}>
         { content }
       </div>
     );

--- a/app/components/file-viewer/text-viewer.jsx
+++ b/app/components/file-viewer/text-viewer.jsx
@@ -42,7 +42,9 @@ class TextViewer extends Component {
       .then((content) => {
         cache[src] = content;
         this.setState({ content });
-        this.element.dispatchEvent(new Event('load'));
+        const e = new Event('load');
+        e.data = content;
+        this.element.dispatchEvent(e);
       })
       .catch((e) => {
         const content = e.message;

--- a/app/components/file-viewer/text-viewer.jsx
+++ b/app/components/file-viewer/text-viewer.jsx
@@ -33,6 +33,9 @@ class TextViewer extends Component {
     const cachedContent = cache[src];
     if (cachedContent) {
       this.setState({ content: cachedContent });
+      const e = new Event('load');
+      e.data = cachedContent;
+      this.element.dispatchEvent(e);
     } else {
       this.setState({ content: 'Loading…' });
       fetch(src + '?=')

--- a/app/components/frame-viewer.jsx
+++ b/app/components/frame-viewer.jsx
@@ -43,20 +43,18 @@ export default class FrameViewer extends React.Component {
     const FrameWrapper = this.props.frameWrapper;
     if(this.props.isAudioPlusImage){
       const subjectLocations = getSubjectLocations(this.props.subject);
-      var type = Object.keys(subjectLocations);
-      var format = Object.keys(subjectLocations).map((locationKey) => {
+      const type = Object.keys(subjectLocations);
+      const format = Object.keys(subjectLocations).map((locationKey) => {
         return subjectLocations[locationKey][0];
       });
-      var src = Object.keys(subjectLocations).map((locationKey) => {
+      const src = Object.keys(subjectLocations).map((locationKey) => {
         return subjectLocations[locationKey][1];
       });
     }else{
-      var { type, format, src } = getSubjectLocation(this.props.subject, this.props.frame);
+      const { type, format, src } = getSubjectLocation(this.props.subject, this.props.frame);
     }
     const zoomEnabled = this.props.workflow && this.props.workflow.configuration.pan_and_zoom && (type === 'image' || this.props.isAudioPlusImage);
-
     const ProgressMarker = this.props.progressMarker;
-
     if (FrameWrapper) {
       return (
         <PanZoom ref={(c) => { this.panZoom = c; }} enabled={zoomEnabled} frameDimensions={this.state.frameDimensions}>

--- a/app/components/frame-viewer.jsx
+++ b/app/components/frame-viewer.jsx
@@ -41,17 +41,20 @@ export default class FrameViewer extends React.Component {
 
   render() {
     const FrameWrapper = this.props.frameWrapper;
+    let type;
+    let format;
+    let src;
     if(this.props.isAudioPlusImage){
       const subjectLocations = getSubjectLocations(this.props.subject);
-      const type = Object.keys(subjectLocations);
-      const format = Object.keys(subjectLocations).map((locationKey) => {
+      type = Object.keys(subjectLocations);
+      format = Object.keys(subjectLocations).map((locationKey) => {
         return subjectLocations[locationKey][0];
       });
-      const src = Object.keys(subjectLocations).map((locationKey) => {
+      src = Object.keys(subjectLocations).map((locationKey) => {
         return subjectLocations[locationKey][1];
       });
     }else{
-      const { type, format, src } = getSubjectLocation(this.props.subject, this.props.frame);
+      ({ type, format, src } = getSubjectLocation(this.props.subject, this.props.frame));
     }
     const zoomEnabled = this.props.workflow && this.props.workflow.configuration.pan_and_zoom && (type === 'image' || this.props.isAudioPlusImage);
     const ProgressMarker = this.props.progressMarker;

--- a/app/lib/get-subject-location.coffee
+++ b/app/lib/get-subject-location.coffee
@@ -2,6 +2,7 @@ READABLE_FORMATS =
   image: ['jpeg', 'png', 'svg+xml', 'gif']
   video: ['mp4']
   audio: ['mp3', 'm4a', 'mpeg']
+  text: ['plain']
 
 module.exports = (subject, frame = 0) ->
   for mimeType, src of subject.locations[frame]

--- a/app/pages/admin/project-status/experimental-features.jsx
+++ b/app/pages/admin/project-status/experimental-features.jsx
@@ -25,6 +25,7 @@ const experimentalFeatures = [
   'sim notification',
   'general feedback',
   'slider',
+  'highlighter'
 ];
 
 class ExperimentalFeatures extends Component {

--- a/app/pages/lab/workflow.cjsx
+++ b/app/pages/lab/workflow.cjsx
@@ -177,13 +177,14 @@ EditWorkflowPage = React.createClass
                       <small><strong>Survey</strong></small>
                     </button>
                   </AutoSave>{' '}
-                  <AutoSave resource={@props.workflow}>
-                    <button type="submit" className="minor-button" onClick={@addNewTask.bind this, 'highlighter'} title="Highlighter: The volunteer can highlight piece of text.">
-                      <i className="fa fa-i-cursor fa-2x"></i>
-                      <br />
-                      <small><strong>Highlighter</strong></small>
-                    </button>
-                  </AutoSave>{' '}
+                  {if @canUseTask(@props.project, "highlighter")
+                    <AutoSave resource={@props.workflow}>
+                      <button type="submit" className="minor-button" onClick={@addNewTask.bind this, 'highlighter'} title="Highlighter: The volunteer can highlight piece of text.">
+                        <i className="fa fa-i-cursor fa-2x"></i>
+                        <br />
+                        <small><strong>Highlighter</strong></small>
+                      </button>
+                    </AutoSave>}{' '}
                   {if @canUseTask(@props.project, "crop")
                     <AutoSave resource={@props.workflow}>
                       <button type="submit" className="minor-button" onClick={@addNewTask.bind this, 'crop'} title="Crop tasks: the volunteer draws a rectangle around an area of interest, and the view of the subject is approximately cropped to that area.">

--- a/app/pages/lab/workflow.cjsx
+++ b/app/pages/lab/workflow.cjsx
@@ -132,7 +132,8 @@ EditWorkflowPage = React.createClass
                             when 'text' then <i className="fa fa-file-text-o fa-fw"></i>
                             when 'dropdown' then <i className="fa fa-list fa-fw"></i>
                             when 'combo' then <i className="fa fa-cubes fa-fw"></i>
-                            when 'slider' then <i className="fa fa-sliders fa-fw"></i>}
+                            when 'slider' then <i className="fa fa-sliders fa-fw"></i>
+                            when 'highlighter' then <i className="fa fa-i-cursor"></i>}
                           {' '}
                           {tasks[definition.type].getTaskText definition}
                           {if key is @props.workflow.first_task
@@ -174,6 +175,13 @@ EditWorkflowPage = React.createClass
                       <i className="fa fa-binoculars fa-2x"></i>
                       <br />
                       <small><strong>Survey</strong></small>
+                    </button>
+                  </AutoSave>{' '}
+                  <AutoSave resource={@props.workflow}>
+                    <button type="submit" className="minor-button" onClick={@addNewTask.bind this, 'highlighter'} title="Highlighter: The volunteer can highlight piece of text.">
+                      <i className="fa fa-i-cursor fa-2x"></i>
+                      <br />
+                      <small><strong>Highlighter</strong></small>
                     </button>
                   </AutoSave>{' '}
                   {if @canUseTask(@props.project, "crop")

--- a/css/highlighter-task.styl
+++ b/css/highlighter-task.styl
@@ -1,0 +1,15 @@
+.label-renderer
+  position: relative
+
+  > div
+    padding: 2%
+    color: #efefef
+    whitespace: pre-wrap
+    width: 40ch
+    
+    &.text-viewer.invisible
+      background: transparent
+      position: absolute
+      top: 0
+      left: 0
+      color: transparent

--- a/css/highlighter-task.styl
+++ b/css/highlighter-task.styl
@@ -8,8 +8,4 @@
     width: 40ch
     
     &.text-viewer.invisible
-      background: transparent
-      position: absolute
-      top: 0
-      left: 0
-      color: transparent
+      display: none;

--- a/css/main.styl
+++ b/css/main.styl
@@ -78,6 +78,7 @@
 @require './default-classification-summary'
 @require './world-wide-telescope'
 @require './classifier-feedback'
+@require './highlighter-task'
 
 // Lab
 @require './lab'


### PR DESCRIPTION
Work towards #3458.
Requesting feedback on this approach for a highlighting tool. [Example of the highlighting tool](https://highlighter-tool-v2.pfe-preview.zooniverse.org/projects/scribe-2/textsubjectproject/classify?reload=0&workflow=2831).

On the project above, a user highlights some text and then clicks that text selection to record the annotation. That is not a task flow we want in the end product. @eatyourgreens [suggested a task flow of 1) highlighting text, 2) selecting label for the highlighted text (like Diagnosis London)](https://github.com/zooniverse/Panoptes-Front-End/issues/3458). I am working on implementing this structure for the task. 

Describe your changes.
- Adds a highlighter task to the workflow editor. The highlighter task has a similar structure to the drawing task.
- Starts adding a highlighter tool to the /classify page. I tried to replicate some of the same structure of the drawing tools. For example, the highlighter's label-renderer is suppose to serve a similar function as the markings-renderer.

Todo List
- [x] Task flow of 1. select text, 2. select label for text
- [x] Support highlighting text both forward and backward. At the moment, a user can only highlight forward.
- [x] Use more accessible highlighting colors
- [x] Support selecting text by tapping on a touchscreen
- [x] Support selecting text by keyboard shortcut
- [x]  In the annotation, change `anchorIndex` and `focusIndex` to `start` and `end`, respectively
- [x] Delete selection annotations
- [x] Fix tests
- [x] The classification summary should display the selected words instead of the character indices
- [x] If the start index and end index of a selection are the same, the tool should not create an annotation.
- [x] Annotation values should only be created for selections of subject content, not selections from anywhere on the page.
- [x] Text can be selected from inside a highlighted phrase, causing a duplication of the selected text. 
- [ ] Labeling more than one selection at a time?
- [x] Access to this tool should be enabled under the admin flag (#3873)

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch? https://highlighter-tool-v2.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?