### PR TITLE
allow project builder to always show thumbnails for survey task

### DIFF
--- a/app/classifier/tasks/survey/chooser.cjsx
+++ b/app/classifier/tasks/survey/chooser.cjsx
@@ -57,6 +57,8 @@ module.exports = React.createClass
       'medium'
     else if length <= 20
       'small'
+    else if @props.task.alwaysShowThumbnails
+      'small'
     else
       'none'
 
@@ -196,4 +198,3 @@ module.exports = React.createClass
         e.preventDefault()
       else
         true
-    

--- a/app/classifier/tasks/survey/editor.cjsx
+++ b/app/classifier/tasks/survey/editor.cjsx
@@ -278,6 +278,15 @@ module.exports = React.createClass
           Require at least one identification
         </AutoSave>
       </label>
+
+      <hr />
+
+      <label>
+        <AutoSave resource={@props.workflow}>
+          <input type="checkbox" name="#{@props.taskPrefix}.alwaysShowThumbnails" checked={@props.task.alwaysShowThumbnails} onChange={handleInputChange.bind @props.workflow} />{' '}
+          Always show thumbnails
+        </AutoSave>
+      </label>
     </div>
 
   handleImportTabs: (tab) ->


### PR DESCRIPTION
Describe your changes.
Allows a project builder to set if thumbnails should always be shown for the options of a survey task.  Currently thumbnails are only shown if their are fewer than 20 survey options, a setting that makes sense for camera trap projects, but for other use cases small thumbnails might be fine.

Example case: https://always-show-thumbnail-suvey-task.pfe-preview.zooniverse.org/projects/cmk24/test-porject-1/classify?reload=0&workflow=2909
The thumbnails for this survey task are just colors assigned to various emotions.  The emotions are ordered by color, so if the thumbnails are not shown the order does not make much sense.

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://always-show-thumbnail-suvey-task.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?