### PR TITLE
Break out SVG annotations from frame annotations.

### DIFF
--- a/app/classifier/annotation-renderer/image.jsx
+++ b/app/classifier/annotation-renderer/image.jsx
@@ -1,0 +1,224 @@
+import React from 'react';
+import Draggable from '../../lib/draggable';
+import tasks from '../tasks';
+import getSubjectLocation from '../../lib/get-subject-location';
+import SVGImage from '../../components/svg-image';
+
+export default class ImageAnnotator extends React.Component {
+  constructor(props) {
+    super(props);
+    this.getScreenCurrentTransformationMatrix = this.getScreenCurrentTransformationMatrix.bind(this);
+    this.getEventOffset = this.getEventOffset.bind(this);
+    this.normalizeDifference = this.normalizeDifference.bind(this);
+    this.eventCoordsToSVGCoords = this.eventCoordsToSVGCoords.bind(this);
+  }
+
+  getSizeRect() {
+    const clientRect = this.sizeRect && this.sizeRect.getBoundingClientRect();
+
+    if (clientRect) {
+      const { width, height } = clientRect;
+      let { left, right, top, bottom } = clientRect;
+      left += pageXOffset;
+      right += pageXOffset;
+      top += pageYOffset;
+      bottom += pageYOffset;
+      return { left, right, top, bottom, width, height };
+    }
+    return { left: 0, right: 0, top: 0, bottom: 0, width: 0, height: 0 };
+  }
+
+  getScale() {
+    const sizeRect = this.getSizeRect();
+    const horizontal = sizeRect ? sizeRect.width / this.props.naturalWidth : 0;
+    const vertical = sizeRect ? sizeRect.height / this.props.naturalHeight : 0;
+
+    return { horizontal, vertical };
+  }
+
+  // get current transformation matrix
+  getScreenCurrentTransformationMatrix() {
+    const svg = this.refs.svgSubjectArea;
+    return svg.getScreenCTM();
+  }
+
+  // find the original matrix for the SVG coordinate system
+  getMatrixForWindowCoordsToSVGUserSpaceCoords() {
+    const transformationContainer = this.refs.transformationContainer;
+    return transformationContainer.getScreenCTM().inverse();
+  }
+
+  // get the offset of event coordiantes in terms of the SVG coordinate system
+  getEventOffset(e) {
+    return this.eventCoordsToSVGCoords(e.clientX, e.clientY);
+  }
+
+  // transforms the difference between two event coordinates
+  // into the difference as represent in the SVG coordinate system
+  normalizeDifference(e, d) {
+    const difference = {};
+    const normalizedPoint1 = this.eventCoordsToSVGCoords(e.pageX - d.x, e.pageY - d.y);
+    const normalizedPoint2 = this.eventCoordsToSVGCoords(e.pageX, e.pageY);
+    difference.x = normalizedPoint2.x - normalizedPoint1.x;
+    difference.y = normalizedPoint2.y - normalizedPoint1.y;
+    return difference;
+  }
+
+  // transforms the event coordinates
+  // to points in the SVG coordinate system
+  eventCoordsToSVGCoords(x, y) {
+    const svg = this.refs.svgSubjectArea;
+    const newPoint = svg.createSVGPoint();
+    newPoint.x = x;
+    newPoint.y = y;
+    const matrixForWindowCoordsToSVGUserSpaceCoords = this.getMatrixForWindowCoordsToSVGUserSpaceCoords();
+    const pointforSVGSystem = newPoint.matrixTransform(matrixForWindowCoordsToSVGUserSpaceCoords);
+    return pointforSVGSystem;
+  }
+
+  render() {
+    let taskDescription;
+    let TaskComponent;
+    const { type, src } = getSubjectLocation(this.props.subject, this.props.frame);
+    const createdViewBox = `${this.props.viewBoxDimensions.x} ${this.props.viewBoxDimensions.y} ${this.props.viewBoxDimensions.width} ${this.props.viewBoxDimensions.height}`;
+
+    if (this.props.annotation) {
+      taskDescription = this.props.workflow.tasks[this.props.annotation.task];
+      TaskComponent = tasks[taskDescription.type];
+    }
+
+    const svgStyle = {};
+    if (type === 'image' && !this.props.loading) {
+      // Images are rendered again within the SVG itself.
+      // When cropped right next to the edge of the image,
+      // the original tag can show through, so fill the SVG to cover it.
+      svgStyle.background = 'black';
+
+      // Allow touch scrolling on subject for mobile and tablets
+      if (taskDescription) {
+        if ((taskDescription.type !== 'drawing') && (taskDescription.type !== 'crop')) {
+          svgStyle.pointerEvents = 'none';
+        }
+      }
+      if (this.props.panEnabled === true) {
+        svgStyle.pointerEvents = 'all';
+      }
+    }
+
+    const svgProps = {};
+
+    const hookProps = {
+      taskTypes: tasks,
+      workflow: this.props.workflow,
+      task: taskDescription,
+      classification: this.props.classification,
+      annotation: this.props.annotation,
+      frame: this.props.frame,
+      scale: this.getScale(),
+      naturalWidth: this.props.naturalWidth,
+      naturalHeight: this.props.naturalHeight,
+      containerRect: this.getSizeRect(),
+      getEventOffset: this.getEventOffset,
+      onChange: this.props.onChange,
+      preferences: this.props.preferences,
+      normalizeDifference: this.normalizeDifference,
+      getScreenCurrentTransformationMatrix: this.getScreenCurrentTransformationMatrix
+    };
+
+    Object.keys(tasks).map((task) => {
+      const Component = tasks[task];
+      if (Component.getSVGProps) {
+        Object.assign(svgProps, Component.getSVGProps(hookProps));
+      }
+    });
+
+    const children = React.Children.map(this.props.children, (child) => {
+      return React.cloneElement(child, hookProps);
+    });
+
+    return (
+      <svg
+        ref="svgSubjectArea"
+        className="subject"
+        style={svgStyle}
+        viewBox={createdViewBox}
+        {...svgProps}
+      >
+        <g
+          ref="transformationContainer"
+          transform={this.props.transform}
+        >
+          <rect
+            ref={(rect) => { this.sizeRect = rect; }}
+            width={this.props.naturalWidth}
+            height={this.props.naturalHeight}
+            fill="rgba(0, 0, 0, 0.01)"
+            fillOpacity="0.01"
+            stroke="none"
+          />
+          {type === 'image' && (
+            <Draggable onDrag={this.props.panByDrag} disabled={this.props.disabled}>
+              <SVGImage
+                className={this.props.panEnabled ? 'pan-active' : ''}
+                src={src}
+                width={this.props.naturalWidth}
+                height={this.props.naturalHeight}
+                modification={this.props.modification}
+              />
+            </Draggable>
+          )}
+
+          {children}
+
+        </g>
+      </svg>
+    );
+  }
+}
+
+ImageAnnotator.propTypes = {
+  annotation: React.PropTypes.shape({
+    task: React.PropTypes.string
+  }),
+  children: React.PropTypes.node,
+  classification: React.PropTypes.shape({
+    annotations: React.PropTypes.array,
+    loading: React.PropTypes.bool
+  }),
+  disabled: React.PropTypes.bool,
+  frame: React.PropTypes.number,
+  loading: React.PropTypes.bool,
+  modification: React.PropTypes.object,
+  naturalHeight: React.PropTypes.number,
+  naturalWidth: React.PropTypes.number,
+  onChange: React.PropTypes.func,
+  panByDrag: React.PropTypes.func,
+  panEnabled: React.PropTypes.bool,
+  preferences: React.PropTypes.object,
+  subject: React.PropTypes.shape({
+    already_seen: React.PropTypes.bool,
+    retired: React.PropTypes.bool
+  }),
+  transform: React.PropTypes.string,
+  viewBoxDimensions: React.PropTypes.shape({
+    height: React.PropTypes.number,
+    width: React.PropTypes.number,
+    x: React.PropTypes.number,
+    y: React.PropTypes.number
+  }),
+  workflow: React.PropTypes.shape({
+    tasks: React.PropTypes.object
+  })
+};
+
+ImageAnnotator.defaultProps = {
+  user: null,
+  project: null,
+  subject: null,
+  workflow: null,
+  classification: null,
+  annotation: null,
+  onLoad: () => {},
+  frame: 0,
+  onChange: () => {}
+};

--- a/app/classifier/annotation-renderer/index.jsx
+++ b/app/classifier/annotation-renderer/index.jsx
@@ -19,6 +19,7 @@ const VIEWERS = {
 
 function AnnotationRenderer(props) {
   const Renderer = VIEWERS[props.type] || DefaultRenderer;
+
   return (
     <Renderer {...props} >
       {props.children}

--- a/app/classifier/annotation-renderer/index.jsx
+++ b/app/classifier/annotation-renderer/index.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import ImageAnnotator from './image';
+import SVGAnnotator from './svg';
 
 const VIEWERS = {
-  image: ImageAnnotator
+  image: SVGAnnotator
 };
 
 function AnnotationRenderer(props) {

--- a/app/classifier/annotation-renderer/index.jsx
+++ b/app/classifier/annotation-renderer/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import SVGAnnotator from './svg';
+import SVGRenderer from './svg';
 
 function DefaultRenderer(props) {
   return (
@@ -14,7 +14,7 @@ DefaultRenderer.propTypes = {
 };
 
 const VIEWERS = {
-  image: SVGAnnotator
+  image: SVGRenderer
 };
 
 function AnnotationRenderer(props) {

--- a/app/classifier/annotation-renderer/index.jsx
+++ b/app/classifier/annotation-renderer/index.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import ImageAnnotator from './image';
+
+const VIEWERS = {
+  image: ImageAnnotator
+};
+
+function AnnotationRenderer(props) {
+  const Renderer = VIEWERS[props.type];
+  return (
+    <Renderer {...props} >
+      {props.children}
+    </Renderer>
+  );
+}
+
+AnnotationRenderer.propTypes = {
+  children: React.PropTypes.node,
+  type: React.PropTypes.string
+};
+
+export default AnnotationRenderer;

--- a/app/classifier/annotation-renderer/index.jsx
+++ b/app/classifier/annotation-renderer/index.jsx
@@ -1,12 +1,24 @@
 import React from 'react';
 import SVGAnnotator from './svg';
 
+function DefaultRenderer(props) {
+  return (
+    <div className="frame-annotator">
+      {props.children}
+    </div>
+  );
+}
+
+DefaultRenderer.propTypes = {
+  children: React.PropTypes.node
+};
+
 const VIEWERS = {
   image: SVGAnnotator
 };
 
 function AnnotationRenderer(props) {
-  const Renderer = VIEWERS[props.type];
+  const Renderer = VIEWERS[props.type] || DefaultRenderer;
   return (
     <Renderer {...props} >
       {props.children}

--- a/app/classifier/annotation-renderer/svg.jsx
+++ b/app/classifier/annotation-renderer/svg.jsx
@@ -78,13 +78,11 @@ export default class SVGAnnotator extends React.Component {
 
   render() {
     let taskDescription;
-    let TaskComponent;
     const { type, src } = getSubjectLocation(this.props.subject, this.props.frame);
     const createdViewBox = `${this.props.viewBoxDimensions.x} ${this.props.viewBoxDimensions.y} ${this.props.viewBoxDimensions.width} ${this.props.viewBoxDimensions.height}`;
 
     if (this.props.annotation) {
       taskDescription = this.props.workflow.tasks[this.props.annotation.task];
-      TaskComponent = tasks[taskDescription.type];
     }
 
     const svgStyle = {};

--- a/app/classifier/annotation-renderer/svg.jsx
+++ b/app/classifier/annotation-renderer/svg.jsx
@@ -38,13 +38,13 @@ export default class SVGAnnotator extends React.Component {
 
   // get current transformation matrix
   getScreenCurrentTransformationMatrix() {
-    const svg = this.refs.svgSubjectArea;
+    const svg = this.svgSubjectArea;
     return svg.getScreenCTM();
   }
 
   // find the original matrix for the SVG coordinate system
   getMatrixForWindowCoordsToSVGUserSpaceCoords() {
-    const transformationContainer = this.refs.transformationContainer;
+    const { transformationContainer } = this;
     return transformationContainer.getScreenCTM().inverse();
   }
 
@@ -67,7 +67,7 @@ export default class SVGAnnotator extends React.Component {
   // transforms the event coordinates
   // to points in the SVG coordinate system
   eventCoordsToSVGCoords(x, y) {
-    const svg = this.refs.svgSubjectArea;
+    const svg = this.svgSubjectArea;
     const newPoint = svg.createSVGPoint();
     newPoint.x = x;
     newPoint.y = y;
@@ -138,14 +138,14 @@ export default class SVGAnnotator extends React.Component {
 
     return (
       <svg
-        ref="svgSubjectArea"
+        ref={(element) => { if (element) this.svgSubjectArea = element; }}
         className="subject"
         style={svgStyle}
         viewBox={createdViewBox}
         {...svgProps}
       >
         <g
-          ref="transformationContainer"
+          ref={(element) => { if (element) this.transformationContainer = element; }}
           transform={this.props.transform}
         >
           <rect

--- a/app/classifier/annotation-renderer/svg.jsx
+++ b/app/classifier/annotation-renderer/svg.jsx
@@ -4,7 +4,7 @@ import tasks from '../tasks';
 import getSubjectLocation from '../../lib/get-subject-location';
 import SVGImage from '../../components/svg-image';
 
-export default class ImageAnnotator extends React.Component {
+export default class SVGAnnotator extends React.Component {
   constructor(props) {
     super(props);
     this.getScreenCurrentTransformationMatrix = this.getScreenCurrentTransformationMatrix.bind(this);
@@ -176,7 +176,7 @@ export default class ImageAnnotator extends React.Component {
   }
 }
 
-ImageAnnotator.propTypes = {
+SVGAnnotator.propTypes = {
   annotation: React.PropTypes.shape({
     task: React.PropTypes.string
   }),
@@ -211,7 +211,7 @@ ImageAnnotator.propTypes = {
   })
 };
 
-ImageAnnotator.defaultProps = {
+SVGAnnotator.defaultProps = {
   user: null,
   project: null,
   subject: null,

--- a/app/classifier/annotation-renderer/svg.jsx
+++ b/app/classifier/annotation-renderer/svg.jsx
@@ -4,7 +4,7 @@ import tasks from '../tasks';
 import getSubjectLocation from '../../lib/get-subject-location';
 import SVGImage from '../../components/svg-image';
 
-export default class SVGAnnotator extends React.Component {
+export default class SVGRenderer extends React.Component {
   constructor(props) {
     super(props);
     this.getScreenCurrentTransformationMatrix = this.getScreenCurrentTransformationMatrix.bind(this);
@@ -96,7 +96,7 @@ export default class SVGAnnotator extends React.Component {
 
       // Allow touch scrolling on subject for mobile and tablets
       if (taskDescription) {
-        if ((taskDescription.type !== 'drawing') && (taskDescription.type !== 'crop')) {
+        if (tasks[taskDescription.type] && tasks[taskDescription.type].AnnotationRenderer !== SVGRenderer) {
           svgStyle.pointerEvents = 'none';
         }
       }
@@ -133,11 +133,13 @@ export default class SVGAnnotator extends React.Component {
     });
 
     let children = [];
-    const isDrawingTask = taskDescription && (taskDescription.type === 'drawing' || taskDescription.type === 'crop');
+    const isDrawingTask = taskDescription && (tasks[taskDescription.type].AnnotationRenderer === SVGRenderer);
     if (isDrawingTask && InsideSubject && !this.props.panEnabled) {
       children.push(<InsideSubject key="inside" {...hookProps} />);
     }
-    const persistentHooks = ['drawing', 'crop']
+    const persistentHooks = Object
+      .keys(tasks)
+      .filter((key) => { return tasks[key].AnnotationRenderer === SVGRenderer; })
       .map((taskName) => {
         const PersistInsideSubject = tasks[taskName].PersistInsideSubject;
         if (PersistInsideSubject) {
@@ -188,7 +190,7 @@ export default class SVGAnnotator extends React.Component {
   }
 }
 
-SVGAnnotator.propTypes = {
+SVGRenderer.propTypes = {
   annotation: React.PropTypes.shape({
     task: React.PropTypes.string
   }),
@@ -222,7 +224,7 @@ SVGAnnotator.propTypes = {
   })
 };
 
-SVGAnnotator.defaultProps = {
+SVGRenderer.defaultProps = {
   user: null,
   project: null,
   subject: null,

--- a/app/classifier/frame-annotator.jsx
+++ b/app/classifier/frame-annotator.jsx
@@ -28,12 +28,12 @@ export default class FrameAnnotator extends React.Component {
     }
   }
 
-  handleAnnotationChange(oldAnnotation, currentAnnotation) {
+  handleAnnotationChange(oldAnnotation) {
     if (oldAnnotation) {
       const lastTask = this.props.workflow.tasks[oldAnnotation.task];
       const LastTaskComponent = tasks[lastTask.type];
       if (LastTaskComponent.onLeaveAnnotation) {
-        return LastTaskComponent.onLeaveAnnotation(lastTask, oldAnnotation);
+        LastTaskComponent.onLeaveAnnotation(lastTask, oldAnnotation);
       }
     }
   }
@@ -41,16 +41,14 @@ export default class FrameAnnotator extends React.Component {
   render() {
     let warningBanner;
     let taskDescription;
-    let TaskComponent;
     let BeforeSubject;
     let InsideSubject;
     let AfterSubject;
-    const { type, src } = getSubjectLocation(this.props.subject, this.props.frame);
+    const { type } = getSubjectLocation(this.props.subject, this.props.frame);
 
     if (this.props.annotation) {
       taskDescription = this.props.workflow.tasks[this.props.annotation.task];
-      TaskComponent = tasks[taskDescription.type];
-      ({BeforeSubject, InsideSubject, AfterSubject} = TaskComponent);
+      ({ BeforeSubject, InsideSubject, AfterSubject } = tasks[taskDescription.type]);
     }
 
     if (this.state.alreadySeen) {
@@ -93,6 +91,7 @@ export default class FrameAnnotator extends React.Component {
         if (PersistInsideSubject) {
           return <PersistInsideSubject key={taskName} {...hookProps} />;
         }
+        return null;
       })
       .filter(Boolean);
     subjectChildren = subjectChildren.concat(persistentHooks);

--- a/app/classifier/frame-annotator.jsx
+++ b/app/classifier/frame-annotator.jsx
@@ -125,31 +125,22 @@ FrameAnnotator.propTypes = {
   annotation: React.PropTypes.shape({
     task: React.PropTypes.string
   }),
-  children: React.PropTypes.object,
+  children: React.PropTypes.node,
   classification: React.PropTypes.shape({
     annotations: React.PropTypes.array,
     loading: React.PropTypes.bool
   }),
-  disabled: React.PropTypes.bool,
   frame: React.PropTypes.number,
-  loading: React.PropTypes.bool,
-  modification: React.PropTypes.object,
   naturalHeight: React.PropTypes.number,
   naturalWidth: React.PropTypes.number,
   onChange: React.PropTypes.func,
-  panByDrag: React.PropTypes.func,
   panEnabled: React.PropTypes.bool,
-  preferences: React.PropTypes.object,
+  preferences: React.PropTypes.shape({
+    id: React.PropTypes.string
+  }),
   subject: React.PropTypes.shape({
     already_seen: React.PropTypes.bool,
     retired: React.PropTypes.bool
-  }),
-  transform: React.PropTypes.string,
-  viewBoxDimensions: React.PropTypes.shape({
-    height: React.PropTypes.number,
-    width: React.PropTypes.number,
-    x: React.PropTypes.number,
-    y: React.PropTypes.number
   }),
   workflow: React.PropTypes.shape({
     tasks: React.PropTypes.object

--- a/app/classifier/frame-annotator.jsx
+++ b/app/classifier/frame-annotator.jsx
@@ -117,6 +117,7 @@ FrameAnnotator.propTypes = {
   naturalHeight: React.PropTypes.number,
   naturalWidth: React.PropTypes.number,
   onChange: React.PropTypes.func,
+  panEnabled: React.PropTypes.bool,
   preferences: React.PropTypes.shape({
     id: React.PropTypes.string
   }),
@@ -138,5 +139,6 @@ FrameAnnotator.defaultProps = {
   annotation: {},
   onLoad: () => {},
   frame: 0,
-  onChange: () => {}
+  onChange: () => {},
+  panEnabled: false
 };

--- a/app/classifier/frame-annotator.jsx
+++ b/app/classifier/frame-annotator.jsx
@@ -31,9 +31,11 @@ export default class FrameAnnotator extends React.Component {
   handleAnnotationChange(oldAnnotation) {
     if (oldAnnotation) {
       const lastTask = this.props.workflow.tasks[oldAnnotation.task];
-      const LastTaskComponent = tasks[lastTask.type];
-      if (LastTaskComponent.onLeaveAnnotation) {
-        LastTaskComponent.onLeaveAnnotation(lastTask, oldAnnotation);
+      if (lastTask) {
+        const LastTaskComponent = tasks[lastTask.type];
+        if (LastTaskComponent.onLeaveAnnotation) {
+          LastTaskComponent.onLeaveAnnotation(lastTask, oldAnnotation);
+        }
       }
     }
   }
@@ -42,13 +44,12 @@ export default class FrameAnnotator extends React.Component {
     let warningBanner;
     let taskDescription;
     let BeforeSubject;
-    let InsideSubject;
     let AfterSubject;
     const { type } = getSubjectLocation(this.props.subject, this.props.frame);
 
-    if (this.props.annotation) {
+    if (this.props.annotation.task) {
       taskDescription = this.props.workflow.tasks[this.props.annotation.task];
-      ({ BeforeSubject, InsideSubject, AfterSubject } = tasks[taskDescription.type]);
+      ({ BeforeSubject, AfterSubject } = tasks[taskDescription.type]);
     }
 
     if (this.state.alreadySeen) {
@@ -80,22 +81,6 @@ export default class FrameAnnotator extends React.Component {
       preferences: this.props.preferences
     };
 
-    let subjectChildren = [];
-    if (!!InsideSubject && !this.props.panEnabled) {
-      subjectChildren.push(<InsideSubject key="inside" {...hookProps} />);
-    }
-    const persistentHooks = Object
-      .keys(tasks)
-      .map((taskName) => {
-        const PersistInsideSubject = tasks[taskName].PersistInsideSubject;
-        if (PersistInsideSubject) {
-          return <PersistInsideSubject key={taskName} {...hookProps} />;
-        }
-        return null;
-      })
-      .filter(Boolean);
-    subjectChildren = subjectChildren.concat(persistentHooks);
-
     return (
       <div className="frame-annotator">
         <div className="subject-area">
@@ -103,9 +88,7 @@ export default class FrameAnnotator extends React.Component {
           {!!BeforeSubject && (
             <BeforeSubject {...hookProps} />)}
 
-          <AnnotationRenderer type={type} {...this.props}>
-            {subjectChildren}
-          </AnnotationRenderer>
+          <AnnotationRenderer type={type} {...this.props} />
 
           {this.props.children}
 
@@ -134,7 +117,6 @@ FrameAnnotator.propTypes = {
   naturalHeight: React.PropTypes.number,
   naturalWidth: React.PropTypes.number,
   onChange: React.PropTypes.func,
-  panEnabled: React.PropTypes.bool,
   preferences: React.PropTypes.shape({
     id: React.PropTypes.string
   }),
@@ -153,7 +135,7 @@ FrameAnnotator.defaultProps = {
   subject: null,
   workflow: null,
   classification: null,
-  annotation: null,
+  annotation: {},
   onLoad: () => {},
   frame: 0,
   onChange: () => {}

--- a/app/classifier/frame-annotator.spec.js
+++ b/app/classifier/frame-annotator.spec.js
@@ -59,7 +59,7 @@ describe('<FrameAnnotator />', function() {
   describe('<SVGImage />', function() {
     let wrapper;
     before(function() {
-      wrapper = shallow(
+      wrapper = mount(
         <FrameAnnotator
           annotation={annotation}
           classification={classification}
@@ -77,8 +77,9 @@ describe('<FrameAnnotator />', function() {
     });
 
     it('does not render if type is not an image', function() {
-      subject.locations = [{ 'video/mp4': 'video.mp4' }];
-      wrapper.setProps({ subject });
+      const newSubject = Object.assign({}, subject);
+      newSubject.locations = [{ 'video/mp4': 'video.mp4' }];
+      wrapper.setProps({ subject: newSubject });
 
       assert.equal(wrapper.find(SVGImage).length, 0);
     });
@@ -158,18 +159,15 @@ describe('<FrameAnnotator />', function() {
       assert.equal(wrapper.find(TaskComponent.BeforeSubject).length, 1);
     });
 
-    it('renders InsideSubject hook', function() {
-      assert.equal(wrapper.find(TaskComponent.InsideSubject).length, 1);
-    });
-
     it('renders AfterSubject hook', function() {
       assert.equal(wrapper.find(TaskComponent.AfterSubject).length, 1);
     });
-
-    it('renders PersistInsideSubject hook', function() {
-      const drawingAnnotation = { task: 'draw' };
+    
+    it('renders InsideSubject hook', function() {
       TaskComponent = tasks['drawing'];
-      wrapper = shallow(
+      const drawingAnnotation = TaskComponent.getDefaultAnnotation();
+      drawingAnnotation.task = 'draw';
+      wrapper = mount(
         <FrameAnnotator
           annotation={drawingAnnotation}
           classification={classification}
@@ -180,6 +178,11 @@ describe('<FrameAnnotator />', function() {
           viewBoxDimensions={viewBoxDimensions}
           workflow={workflow}
         />);
+
+      assert.equal(wrapper.find(TaskComponent.InsideSubject).length, 1);
+    });
+
+    it('renders PersistInsideSubject hook', function() {
 
       assert.equal(wrapper.find(TaskComponent.PersistInsideSubject).length, 1)
     });

--- a/app/classifier/tasks/crop/index.cjsx
+++ b/app/classifier/tasks/crop/index.cjsx
@@ -3,6 +3,7 @@ CropInitializer = require './initializer'
 GenericTask = require('../generic.jsx').default
 GenericEditor = require '../generic-editor'
 Summary = require './summary'
+SVGRenderer = require('../../annotation-renderer/svg').default
 
 module.exports = React.createClass
   displayName: 'CropTask'
@@ -10,6 +11,7 @@ module.exports = React.createClass
   statics:
     Editor: GenericEditor
     Summary: Summary
+    AnnotationRenderer: SVGRenderer
 
     getSVGProps: ({workflow, classification, annotation}) ->
       tasks = require('../index').default

--- a/app/classifier/tasks/drawing/index.cjsx
+++ b/app/classifier/tasks/drawing/index.cjsx
@@ -9,6 +9,7 @@ GenericTask = require('../generic.jsx').default
 icons = require './icons'
 drawingTools = require '../../drawing-tools'
 GridButtons = require './grid-buttons'
+SVGRenderer = require('../../annotation-renderer/svg').default
 
 module.exports = React.createClass
   displayName: 'DrawingTask'
@@ -19,6 +20,7 @@ module.exports = React.createClass
     InsideSubject: MarkingInitializer
     PersistInsideSubject: MarkingsRenderer
     PersistAfterTask: HidePreviousMarksToggle
+    AnnotationRenderer: SVGRenderer
 
     getDefaultTask: ->
       type: 'drawing'

--- a/app/components/frame-viewer.jsx
+++ b/app/components/frame-viewer.jsx
@@ -43,47 +43,33 @@ export default class FrameViewer extends React.Component {
     const zoomEnabled = this.props.workflow && this.props.workflow.configuration.pan_and_zoom && type === 'image';
 
     if (FrameWrapper) {
-      if (type === 'image') {
-        return (
-          <PanZoom ref={(c) => { this.panZoom = c; }} enabled={zoomEnabled} frameDimensions={this.state.frameDimensions}>
-            <FrameWrapper
-              frame={this.props.frame}
-              naturalWidth={this.state.frameDimensions.width || 0}
-              naturalHeight={this.state.frameDimensions.height || 0}
-              workflow={this.props.workflow}
-              subject={this.props.subject}
-              classification={this.props.classification}
-              annotation={this.props.annotation}
-              loading={this.state.loading}
-              preferences={this.props.preferences}
-              modification={this.props.modification || {}}
-              onChange={this.props.onChange}
-            >
-              <FileViewer
-                src={src}
-                type={type}
-                format={format}
-                frame={this.props.frame}
-                onLoad={this.handleLoad}
-                onFocus={this.panZoom ? this.panZoom.togglePanOn : () => {}}
-                onBlur={this.panZoom ? this.panZoom.togglePanOff : () => {}}
-              />
-            </FrameWrapper>
-          </PanZoom>
-        );
-      } else {
-        return (
-          <div className="frame-annotator">
+      return (
+        <PanZoom ref={(c) => { this.panZoom = c; }} enabled={zoomEnabled} frameDimensions={this.state.frameDimensions}>
+          <FrameWrapper
+            frame={this.props.frame}
+            naturalWidth={this.state.frameDimensions.width || 0}
+            naturalHeight={this.state.frameDimensions.height || 0}
+            workflow={this.props.workflow}
+            subject={this.props.subject}
+            classification={this.props.classification}
+            annotation={this.props.annotation}
+            loading={this.state.loading}
+            preferences={this.props.preferences}
+            modification={this.props.modification || {}}
+            onChange={this.props.onChange}
+          >
             <FileViewer
               src={src}
               type={type}
               format={format}
               frame={this.props.frame}
               onLoad={this.handleLoad}
+              onFocus={this.panZoom ? this.panZoom.togglePanOn : () => {}}
+              onBlur={this.panZoom ? this.panZoom.togglePanOff : () => {}}
             />
-          </div>
-        );
-      }
+          </FrameWrapper>
+        </PanZoom>
+      );
     } else {
       return (
         <FileViewer


### PR DESCRIPTION
Describe your changes.
Separate SVG drawings out of the frame annotator so that we can add renderers for annotations for subjects other than images.

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://generic-subject-marking.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?