### PR TITLE
Don't pass children down with FrameAnnotator props

### DIFF
--- a/app/classifier/frame-annotator.jsx
+++ b/app/classifier/frame-annotator.jsx
@@ -81,6 +81,9 @@ export default class FrameAnnotator extends React.Component {
       preferences: this.props.preferences
     };
 
+    const rendererProps = Object.assign({}, this.props);
+    delete rendererProps.children;
+
     return (
       <div className="frame-annotator">
         <div className="subject-area">
@@ -88,7 +91,7 @@ export default class FrameAnnotator extends React.Component {
           {!!BeforeSubject && (
             <BeforeSubject {...hookProps} />)}
 
-          <AnnotationRenderer type={type} {...this.props} />
+          <AnnotationRenderer type={type} {...rendererProps} />
 
           {this.props.children}
 
@@ -117,7 +120,6 @@ FrameAnnotator.propTypes = {
   naturalHeight: React.PropTypes.number,
   naturalWidth: React.PropTypes.number,
   onChange: React.PropTypes.func,
-  panEnabled: React.PropTypes.bool,
   preferences: React.PropTypes.shape({
     id: React.PropTypes.string
   }),


### PR DESCRIPTION
Fixes #3750 where the subject viewer is rendered twice.

Describe your changes.
Children should not be implicitly passed down from `FrameAnnotator` since the child component is self-closing in the JSX code.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://fix-3750.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?