### PR TITLE
Fix mousewheel zoom on Chrome

### DIFF
--- a/app/components/pan-zoom.jsx
+++ b/app/components/pan-zoom.jsx
@@ -43,7 +43,7 @@ const PanZoom = React.createClass({
     // while the user is in pan and zoom mode.
     if (this.props.enabled) {
       addEventListener('keydown', this.frameKeyPan);
-      addEventListener('wheel', this.frameKeyPan);
+      addEventListener('wheel', this.wheelZoom);
     }
   },
 
@@ -61,7 +61,7 @@ const PanZoom = React.createClass({
 
   componentWillUnmount() {
     removeEventListener('keydown', this.frameKeyPan);
-    removeEventListener('wheel', this.frameKeyPan);
+    removeEventListener('wheel', this.wheelZoom);
   },
 
   render() {
@@ -285,14 +285,15 @@ const PanZoom = React.createClass({
         this.setState({ zooming: true });
         this.zoom(1.1);
         break;
-      // zooming by wheel
-      case 1:
-        e.preventDefault();
-        this.setState({ zooming: true });
-        (e.deltaY > 0) ? this.zoom(1.1) : this.zoom(0.9);
-        break;
       // no default
     }
+  },
+
+  wheelZoom(e) {
+    if (!this.state.panEnabled) return;
+    e.preventDefault();
+    this.setState({ zooming: true });
+    (e.deltaY > 0) ? this.zoom(1.1) : this.zoom(0.9);
   },
 
   panHorizontal(direction) {

--- a/app/components/pan-zoom.spec.js
+++ b/app/components/pan-zoom.spec.js
@@ -323,19 +323,37 @@ describe('PanZoom', function () {
         assert.equal(wrapper.state('zooming'), true);
       });
 
+    });
+
+    describe('#wheelZoom()', function () {
+      const originalFrameDimensions = { width: 100, height: 100, x: 0, y: 0 };
+      const zoomedViewBoxDimensions = { width: 50, height: 50, x: 25, y: 25 };
+      let panHorizontalSpy;
+      let panVerticalSpy;
+      let zoomSpy;
+      let wrapper;
+
+      beforeEach(function () {
+        wrapper = mount(<PanZoom enabled={true} frameDimensions={originalFrameDimensions} />);
+        panHorizontalSpy = sinon.spy(wrapper.instance(), 'panHorizontal');
+        panVerticalSpy = sinon.spy(wrapper.instance(), 'panVertical');
+        zoomSpy = sinon.spy(wrapper.instance(), 'zoom');
+        wrapper.setState({ viewBoxDimensions: zoomedViewBoxDimensions, panEnabled: true });
+      });
+
       it('should call #zoom(1.1) on mousewheel event with deltaY > 0', function () {
-        const mouseEvent = { which: 1, deltaY: 4, preventDefault() { return 'This is a mock'; } };
+        const mouseEvent = { deltaY: 4, preventDefault() { return 'This is a mock'; } };
         wrapper.setState({ zooming: false });
-        wrapper.instance().frameKeyPan(mouseEvent);
+        wrapper.instance().wheelZoom(mouseEvent);
 
         sinon.assert.calledWith(zoomSpy, 1.1);
         assert.equal(wrapper.state('zooming'), true);
       });
 
       it('should call #zoom(0.9) on mousewheel event with deltaY < 0', function () {
-        const mouseEvent = { which: 1, deltaY: -4, preventDefault() { return 'This is a mock'; } };
+        const mouseEvent = { deltaY: -4, preventDefault() { return 'This is a mock'; } };
         wrapper.setState({ zooming: false });
-        wrapper.instance().frameKeyPan(mouseEvent);
+        wrapper.instance().wheelZoom(mouseEvent);
 
         sinon.assert.calledWith(zoomSpy, 0.9);
         assert.equal(wrapper.state('zooming'), true);


### PR DESCRIPTION
Fixes mouse wheel zoom, which has [broken in Chrome](https://www.zooniverse.org/talk/17/302541).

Describe your changes.
Adds an explicit handler for wheel events.
Removes `e.which` to detect mouse wheel events, since that is unreliable.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://fix-mousewheel-zoom.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?