### PR TITLE
Call split classification log after the post, so we have an id

### DIFF
--- a/app/pages/project/classify.cjsx
+++ b/app/pages/project/classify.cjsx
@@ -240,7 +240,6 @@ module.exports = React.createClass
     classification = @state.classification
     console?.info 'Completed classification', classification
 
-    Split.classificationCreated(classification)
     {workflow, subjects} = classification.links
     seenThisSession.add workflow, subjects
     @queueClassification classification unless @state.demoMode
@@ -265,6 +264,7 @@ module.exports = React.createClass
         apiClient.type('classifications').create(classificationData).save()
           .then (actualClassification) =>
             console?.log 'Saved classification', actualClassification.id
+            Split.classificationCreated(actualClassification) # Metric log needs classification id
             actualClassification.destroy()
             indexInQueue = queue.indexOf classificationData
             queue.splice indexInQueue, 1


### PR DESCRIPTION
Fixes a regression introduced in #3681 

Log classificationCreated metric after the classification post, so that we have the id.

Staging project with active Seven-Ten split now correctly posts to `/metrics` with a value in the payload: 
https://metric-log-fix.pfe-preview.zooniverse.org/projects/srallen086/workflow-assignment-testing/classify

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?