### PR TITLE
FileViewer should always return a React component

### DIFF
--- a/app/components/file-viewer/index.jsx
+++ b/app/components/file-viewer/index.jsx
@@ -3,6 +3,18 @@ import VideoPlayer from './video-player';
 import TextViewer from './text-viewer';
 import ImageViewer from './image-viewer';
 
+function DefaultViewer(props) {
+  return (
+    <p>
+    Unknown file type: {props.type}
+    </p>
+  );
+}
+
+DefaultViewer.propTypes = {
+  type: React.PropTypes.string
+};
+
 const VIEWERS = {
   image: ImageViewer,
   text: TextViewer,
@@ -10,7 +22,8 @@ const VIEWERS = {
 };
 
 function FileViewer(props) {
-  const Viewer = VIEWERS[props.type];
+  const Viewer = VIEWERS[props.type] || DefaultViewer;
+
   return (
     <Viewer
       src={props.src}


### PR DESCRIPTION
Might help fix #3729 .

Describe your changes.
Adds a default FileViewer component for the case where file type is undefined/unknown on first render.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://default-file-viewer.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?