### PR TITLE
Stop playing on subject change

### DIFF
--- a/app/components/subject-viewer.cjsx
+++ b/app/components/subject-viewer.cjsx
@@ -69,10 +69,15 @@ module.exports = React.createClass
   componentWillReceiveProps: (nextProps) ->
     unless nextProps.subject is @props.subject
       clearTimeout @signInAttentionTimeout
-      @setState loading: true
+      @setState
+        playing: false
+        loading: true
+        frame: 0
 
   componentDidUpdate: (prevProps) ->
     if @props.subject isnt prevProps.subject
+      # turn off the slideshow player and reset any counters
+      @setPlaying false
       @setState frame: @getInitialFrame()
 
   logSubjClick: (logType) ->


### PR DESCRIPTION
Fixes #3729.

Describe your changes.
Stop the slideshow player on subject change, and reset the frame counter.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://fix-3729.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?