### PR TITLE
Pass annotations explicitly to the markings renderer

### DIFF
--- a/app/classifier/annotation-renderer/svg.jsx
+++ b/app/classifier/annotation-renderer/svg.jsx
@@ -111,6 +111,7 @@ export default class SVGRenderer extends React.Component {
     const hookProps = {
       taskTypes: tasks,
       workflow: this.props.workflow,
+      tasks: this.props.workflow.tasks,
       task: taskDescription,
       classification: this.props.classification,
       annotations,

--- a/app/classifier/annotation-renderer/svg.jsx
+++ b/app/classifier/annotation-renderer/svg.jsx
@@ -106,12 +106,14 @@ export default class SVGRenderer extends React.Component {
     }
 
     const svgProps = {};
+    const { annotations } = this.props.classification;
 
     const hookProps = {
       taskTypes: tasks,
       workflow: this.props.workflow,
       task: taskDescription,
       classification: this.props.classification,
+      annotations,
       annotation: this.props.annotation,
       frame: this.props.frame,
       scale: this.getScale(),

--- a/app/classifier/tasks/combo/index.cjsx
+++ b/app/classifier/tasks/combo/index.cjsx
@@ -92,11 +92,6 @@ ComboTask = React.createClass
           unless taskType is 'combo'
             TaskComponent = props.taskTypes[taskType]
             if TaskComponent.PersistInsideSubject?
-              # allComboAnnotations needs to be here so previous combo task annotations don't disappear
-              # This is a hack to make drawing tasks work in a combo task.
-              fauxClassification =
-                annotations: allComboAnnotations
-                update: () => props.classification.update()
               # when a combo annotation changes make sure the combo annotation updated correctly with only the
               # curreny combo task's annotatons.  This is a hack to make drawing tasks work in a combo task.
               fauxChange = (annotation) ->
@@ -115,8 +110,8 @@ ComboTask = React.createClass
                 key={taskType}
                 {...props}
                 onChange={fauxChange}
+                annotations={allComboAnnotations}
                 annotation={fauxAnnotation}
-                classification={fauxClassification}
               />}
       </g>
 

--- a/app/classifier/tasks/combo/index.cjsx
+++ b/app/classifier/tasks/combo/index.cjsx
@@ -1,5 +1,6 @@
 React = require 'react'
 SVGRenderer = require('../../annotation-renderer/svg').default
+MarkingsRenderer = require('./markings-renderer').default
 
 ComboTask = React.createClass
   statics:
@@ -69,51 +70,7 @@ ComboTask = React.createClass
             <TaskComponent.InsideSubject key={i} {...props} task={childTaskDescription} annotation={annotation} />}
       </g>
 
-    PersistInsideSubject: (props) ->
-      # a list that holds the annotations for the current combo task
-      currentComboAnnotations = []
-      allTaskTypes = props.classification.annotations.map (annotation) -> props.workflow.tasks[annotation.task].type
-      i = allTaskTypes.lastIndexOf('combo')
-      if i > -1
-        currentComboAnnotations = props.classification.annotations[i].value
-      # a list that holds the annotations for all combo tasks
-      allComboAnnotations = []
-      allComboTypes = []
-      props.classification.annotations.forEach (annotation) ->
-        taskDescription = props.workflow.tasks[annotation.task]
-        if taskDescription.type is 'combo'
-          allComboAnnotations.push annotation.value...
-          annotation.value.forEach (a) ->
-            allComboTypes.push(props.workflow.tasks[a.task].type)
-
-
-      <g className="combo-task-persist-inside-subject-container">
-        {Object.keys(props.taskTypes).map (taskType) ->
-          unless taskType is 'combo'
-            TaskComponent = props.taskTypes[taskType]
-            if TaskComponent.PersistInsideSubject?
-              # when a combo annotation changes make sure the combo annotation updated correctly with only the
-              # curreny combo task's annotatons.  This is a hack to make drawing tasks work in a combo task.
-              fauxChange = (annotation) ->
-                  props.onChange Object.assign({}, props.annotation, { value: currentComboAnnotations })
-              if props.annotation?.task? && props.workflow.tasks? && props.workflow.tasks[props.annotation.task]?.type is 'combo'
-                idx = allComboTypes.lastIndexOf(taskType)
-                if idx > -1
-                  # if the current annotation is for the combo task pass in the `inner` annotations
-                  # This is a hack to make drawing tasks work in a combo task.
-                  fauxAnnotation = allComboAnnotations[idx]
-                else
-                  fauxAnnotation = props.annotation
-              else
-                fauxAnnotation = props.annotation
-              <TaskComponent.PersistInsideSubject
-                key={taskType}
-                {...props}
-                onChange={fauxChange}
-                annotations={allComboAnnotations}
-                annotation={fauxAnnotation}
-              />}
-      </g>
+    PersistInsideSubject: MarkingsRenderer
 
   getDefaultProps: ->
     taskTypes: null

--- a/app/classifier/tasks/combo/markings-renderer.jsx
+++ b/app/classifier/tasks/combo/markings-renderer.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+
+export default function MarkingsRenderer(props) {
+  // a list that holds the annotations for the current combo task
+  let currentComboAnnotations = [];
+  const allTaskTypes = props.classification.annotations.map( annotation => props.workflow.tasks[annotation.task].type);
+  const i = allTaskTypes.lastIndexOf('combo');
+  if (i > -1) {
+    currentComboAnnotations = props.classification.annotations[i].value;
+  }
+  // a list that holds the annotations for all combo tasks
+  let allComboAnnotations = [];
+  const allComboTypes = [];
+  props.classification.annotations.map( (annotation) => {
+    const taskDescription = props.workflow.tasks[annotation.task];
+    if (taskDescription.type === 'combo') {
+      allComboAnnotations = allComboAnnotations.concat(annotation.value);
+      annotation.value.map((a) => {
+        allComboTypes.push(props.workflow.tasks[a.task].type);
+      });
+    }
+  });
+
+
+  return (
+    <g className="combo-task-persist-inside-subject-container">
+      {Object.keys(props.taskTypes)
+        .filter((taskType) => { return taskType !== 'combo'; })
+        .map((taskType) => {
+          const TaskComponent = props.taskTypes[taskType];
+          if (TaskComponent.PersistInsideSubject) {
+            // when a combo annotation changes make sure the combo annotation updated correctly with only the
+            // curreny combo task's annotatons.  This is a hack to make drawing tasks work in a combo task.
+            function fauxChange(annotation) {
+              props.onChange(Object.assign({}, props.annotation, { value: currentComboAnnotations }));
+            };
+            let fauxAnnotation = props.annotation;
+            if (props.annotation && props.annotation.task && props.workflow.tasks && props.workflow.tasks[props.annotation.task].type === 'combo') {
+              const idx = allComboTypes.lastIndexOf(taskType);
+              if (idx > -1) {
+                // if the current annotation is for the combo task pass in the `inner` annotations
+                //This is a hack to make drawing tasks work in a combo task.
+                fauxAnnotation = allComboAnnotations[idx];
+              }
+            }
+            return (
+              <TaskComponent.PersistInsideSubject
+                key={taskType}
+                {...props}
+                onChange={fauxChange}
+                annotations={allComboAnnotations}
+                annotation={fauxAnnotation}
+              />
+            );
+          }
+        })
+      }
+  </g>
+  );
+}

--- a/app/classifier/tasks/combo/markings-renderer.jsx
+++ b/app/classifier/tasks/combo/markings-renderer.jsx
@@ -21,6 +21,9 @@ export default function MarkingsRenderer(props) {
     }
   });
 
+  function onChange(annotation) {
+    props.onChange(Object.assign({}, props.annotation, { value: currentComboAnnotations }));
+  }
 
   return (
     <g className="combo-task-persist-inside-subject-container">
@@ -31,9 +34,7 @@ export default function MarkingsRenderer(props) {
           if (TaskComponent.PersistInsideSubject) {
             // when a combo annotation changes make sure the combo annotation updated correctly with only the
             // curreny combo task's annotatons.  This is a hack to make drawing tasks work in a combo task.
-            function fauxChange(annotation) {
-              props.onChange(Object.assign({}, props.annotation, { value: currentComboAnnotations }));
-            }
+            
             let { annotation } = props;
             if (annotation &&
               annotation.task &&
@@ -51,7 +52,7 @@ export default function MarkingsRenderer(props) {
               <TaskComponent.PersistInsideSubject
                 key={taskType}
                 {...props}
-                onChange={fauxChange}
+                onChange={onChange}
                 annotations={allComboAnnotations}
                 annotation={annotation}
                 tasks={props.workflow.tasks}

--- a/app/classifier/tasks/combo/markings-renderer.jsx
+++ b/app/classifier/tasks/combo/markings-renderer.jsx
@@ -54,6 +54,7 @@ export default function MarkingsRenderer(props) {
                 onChange={fauxChange}
                 annotations={allComboAnnotations}
                 annotation={annotation}
+                tasks={props.workflow.tasks}
               />
             );
           }

--- a/app/classifier/tasks/combo/markings-renderer.jsx
+++ b/app/classifier/tasks/combo/markings-renderer.jsx
@@ -33,8 +33,7 @@ export default function MarkingsRenderer(props) {
           const TaskComponent = props.taskTypes[taskType];
           if (TaskComponent.PersistInsideSubject) {
             // when a combo annotation changes make sure the combo annotation updated correctly with only the
-            // curreny combo task's annotatons.  This is a hack to make drawing tasks work in a combo task.
-            
+            // current combo task's annotatons.  This is a hack to make drawing tasks work in a combo task.
             let { annotation } = props;
             if (annotation &&
               annotation.task &&

--- a/app/classifier/tasks/combo/markings-renderer.jsx
+++ b/app/classifier/tasks/combo/markings-renderer.jsx
@@ -34,13 +34,17 @@ export default function MarkingsRenderer(props) {
             function fauxChange(annotation) {
               props.onChange(Object.assign({}, props.annotation, { value: currentComboAnnotations }));
             };
-            let fauxAnnotation = props.annotation;
-            if (props.annotation && props.annotation.task && props.workflow.tasks && props.workflow.tasks[props.annotation.task].type === 'combo') {
+            let {annotation} = props;
+            if (annotation &&
+              annotation.task &&
+              props.workflow.tasks &&
+              props.workflow.tasks[annotation.task].type === 'combo'
+            ) {
               const idx = allComboTypes.lastIndexOf(taskType);
               if (idx > -1) {
                 // if the current annotation is for the combo task pass in the `inner` annotations
                 //This is a hack to make drawing tasks work in a combo task.
-                fauxAnnotation = allComboAnnotations[idx];
+                annotation = allComboAnnotations[idx];
               }
             }
             return (
@@ -49,7 +53,7 @@ export default function MarkingsRenderer(props) {
                 {...props}
                 onChange={fauxChange}
                 annotations={allComboAnnotations}
-                annotation={fauxAnnotation}
+                annotation={annotation}
               />
             );
           }

--- a/app/classifier/tasks/combo/markings-renderer.jsx
+++ b/app/classifier/tasks/combo/markings-renderer.jsx
@@ -62,3 +62,13 @@ export default function MarkingsRenderer(props) {
   </g>
   );
 }
+
+MarkingsRenderer.propTypes = {
+  classification: React.PropTypes.shape({
+    annotations: React.PropTypes.array
+  }),
+  taskTypes: React.PropTypes.arrayOf(React.PropTypes.string),
+  workflow: React.PropTypes.shape({
+    tasks: React.PropTypes.array
+  })
+}

--- a/app/classifier/tasks/combo/markings-renderer.jsx
+++ b/app/classifier/tasks/combo/markings-renderer.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 export default function MarkingsRenderer(props) {
   // a list that holds the annotations for the current combo task
   let currentComboAnnotations = [];
-  const allTaskTypes = props.classification.annotations.map( annotation => props.workflow.tasks[annotation.task].type);
+  const allTaskTypes = props.classification.annotations.map(annotation => props.workflow.tasks[annotation.task].type);
   const i = allTaskTypes.lastIndexOf('combo');
   if (i > -1) {
     currentComboAnnotations = props.classification.annotations[i].value;
@@ -11,7 +11,7 @@ export default function MarkingsRenderer(props) {
   // a list that holds the annotations for all combo tasks
   let allComboAnnotations = [];
   const allComboTypes = [];
-  props.classification.annotations.map( (annotation) => {
+  props.classification.annotations.map((annotation) => {
     const taskDescription = props.workflow.tasks[annotation.task];
     if (taskDescription.type === 'combo') {
       allComboAnnotations = allComboAnnotations.concat(annotation.value);
@@ -33,8 +33,8 @@ export default function MarkingsRenderer(props) {
             // curreny combo task's annotatons.  This is a hack to make drawing tasks work in a combo task.
             function fauxChange(annotation) {
               props.onChange(Object.assign({}, props.annotation, { value: currentComboAnnotations }));
-            };
-            let {annotation} = props;
+            }
+            let { annotation } = props;
             if (annotation &&
               annotation.task &&
               props.workflow.tasks &&
@@ -43,7 +43,7 @@ export default function MarkingsRenderer(props) {
               const idx = allComboTypes.lastIndexOf(taskType);
               if (idx > -1) {
                 // if the current annotation is for the combo task pass in the `inner` annotations
-                //This is a hack to make drawing tasks work in a combo task.
+                // This is a hack to make drawing tasks work in a combo task.
                 annotation = allComboAnnotations[idx];
               }
             }
@@ -59,7 +59,7 @@ export default function MarkingsRenderer(props) {
           }
         })
       }
-  </g>
+    </g>
   );
 }
 
@@ -71,4 +71,4 @@ MarkingsRenderer.propTypes = {
   workflow: React.PropTypes.shape({
     tasks: React.PropTypes.array
   })
-}
+};

--- a/app/classifier/tasks/drawing/markings-renderer.cjsx
+++ b/app/classifier/tasks/drawing/markings-renderer.cjsx
@@ -8,6 +8,7 @@ module.exports = React.createClass
     classification: null
     annotations: []
     annotation: null
+    tasks: {}
     workflow: null
     scale: null
 
@@ -21,7 +22,7 @@ module.exports = React.createClass
     # Automatically select new marks.
     annotation = nextProps.annotation
     if annotation? && annotation.task?
-      taskDescription = @props.workflow?.tasks[annotation.task]
+      taskDescription = @props.tasks[annotation.task]
     if taskDescription?.type is 'drawing' and Array.isArray annotation.value
       for mark in annotation.value
         newSetOfMarks.push mark
@@ -39,7 +40,7 @@ module.exports = React.createClass
       {for annotation in @props.annotations
         annotation._key ?= Math.random()
         isPriorAnnotation = annotation isnt @props.annotation
-        taskDescription = @props.workflow.tasks[annotation.task]
+        taskDescription = @props.tasks[annotation.task]
         if taskDescription.type is 'drawing'
           <g key={annotation._key} className="marks-for-annotation" data-disabled={isPriorAnnotation || null}>
             {for mark, i in annotation.value when @props.workflow?.configuration.multi_image_clone_markers or parseInt(mark.frame) is parseInt(@props.frame)

--- a/app/classifier/tasks/drawing/markings-renderer.cjsx
+++ b/app/classifier/tasks/drawing/markings-renderer.cjsx
@@ -6,6 +6,7 @@ module.exports = React.createClass
 
   getDefaultProps: ->
     classification: null
+    annotations: []
     annotation: null
     workflow: null
     scale: null
@@ -35,7 +36,7 @@ module.exports = React.createClass
   render: ->
     skippedMarks = 0
     <g>
-      {for annotation in @props.classification?.annotations ? []
+      {for annotation in @props.annotations
         annotation._key ?= Math.random()
         isPriorAnnotation = annotation isnt @props.annotation
         taskDescription = @props.workflow.tasks[annotation.task]


### PR DESCRIPTION
Fixes the `fauxClassification` hack in the combo task.

Describe your changes.
Adds an annotations prop for passing annotations to `MarkingsRenderer`.
Allows the combo task to override the classification and pass its own set of marks to render.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://drawing-annotations.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?