### PR TITLE
Add full height and width line tools

### DIFF
--- a/app/classifier/drawing-tools/full-height-line.cjsx
+++ b/app/classifier/drawing-tools/full-height-line.cjsx
@@ -4,8 +4,7 @@ Draggable = require '../../lib/draggable'
 deleteIfOutOfBounds = require './delete-if-out-of-bounds'
 DeleteButton = require './delete-button'
 
-MINIMUM_LENGTH = 5
-GRAB_STROKE_WIDTH = 6
+GRAB_STROKE_WIDTH = 20
 BUFFER = 16
 DELETE_BUTTON_WIDTH = 8
 

--- a/app/classifier/drawing-tools/full-height-line.cjsx
+++ b/app/classifier/drawing-tools/full-height-line.cjsx
@@ -1,0 +1,54 @@
+React = require 'react'
+DrawingToolRoot = require './root'
+Draggable = require '../../lib/draggable'
+deleteIfOutOfBounds = require './delete-if-out-of-bounds'
+DeleteButton = require './delete-button'
+
+MINIMUM_LENGTH = 5
+GRAB_STROKE_WIDTH = 6
+BUFFER = 16
+DELETE_BUTTON_WIDTH = 8
+
+module.exports = React.createClass
+  displayName: 'FullHeightLineTool'
+
+  statics:
+    defaultValues: ({x}) ->
+      x: x
+
+    initMove: ({x}) ->
+      x: x
+
+    initValid: ({x}, {containerRect}) ->
+      x >= 0 and x <= containerRect.width
+
+  render: ->
+    {x} = @props.mark
+    points =
+      x1: x
+      y1: '0%'
+      x2: x
+      y2: '100%'
+    {x1, y1, x2, y2} = points
+
+    deletePosition =
+      x: x
+      y: @props.containerRect.height / 2
+
+    <DrawingToolRoot tool={this}>
+      <line {...points} />
+
+      <Draggable onDrag={@handleStrokeDrag} onEnd={deleteIfOutOfBounds.bind null, this} disabled={@props.disabled}>
+        <line {...points} strokeWidth={GRAB_STROKE_WIDTH / ((@props.scale.horizontal + @props.scale.vertical) / 2)} strokeOpacity="0" />
+      </Draggable>
+
+      {if @props.selected
+        <g>
+          <DeleteButton tool={this} x={deletePosition.x} y={deletePosition.y} getScreenCurrentTransformationMatrix={@props.getScreenCurrentTransformationMatrix} />
+        </g>}
+    </DrawingToolRoot>
+
+  handleStrokeDrag: (e, d) ->
+    difference = @props.normalizeDifference(e, d)
+    @props.mark.x += difference.x
+    @props.onChange @props.mark

--- a/app/classifier/drawing-tools/full-width-line.cjsx
+++ b/app/classifier/drawing-tools/full-width-line.cjsx
@@ -4,8 +4,7 @@ Draggable = require '../../lib/draggable'
 deleteIfOutOfBounds = require './delete-if-out-of-bounds'
 DeleteButton = require './delete-button'
 
-MINIMUM_LENGTH = 5
-GRAB_STROKE_WIDTH = 6
+GRAB_STROKE_WIDTH = 20
 BUFFER = 16
 DELETE_BUTTON_WIDTH = 8
 

--- a/app/classifier/drawing-tools/full-width-line.cjsx
+++ b/app/classifier/drawing-tools/full-width-line.cjsx
@@ -1,0 +1,54 @@
+React = require 'react'
+DrawingToolRoot = require './root'
+Draggable = require '../../lib/draggable'
+deleteIfOutOfBounds = require './delete-if-out-of-bounds'
+DeleteButton = require './delete-button'
+
+MINIMUM_LENGTH = 5
+GRAB_STROKE_WIDTH = 6
+BUFFER = 16
+DELETE_BUTTON_WIDTH = 8
+
+module.exports = React.createClass
+  displayName: 'FullWidthLineTool'
+
+  statics:
+    defaultValues: ({y}) ->
+      y: y
+
+    initMove: ({y}) ->
+      y: y
+
+    initValid: ({y}, {containerRect}) ->
+      y >= 0 and y <= containerRect.height
+
+  render: ->
+    {y} = @props.mark
+    points =
+      x1: '0%'
+      y1: y
+      x2: '100%'
+      y2: y
+    {x1, y1, x2, y2} = points
+
+    deletePosition =
+      x: @props.containerRect.width / 2
+      y: y
+
+    <DrawingToolRoot tool={this}>
+      <line {...points} />
+
+      <Draggable onDrag={@handleStrokeDrag} onEnd={deleteIfOutOfBounds.bind null, this} disabled={@props.disabled}>
+        <line {...points} strokeWidth={GRAB_STROKE_WIDTH / ((@props.scale.horizontal + @props.scale.vertical) / 2)} strokeOpacity="0" />
+      </Draggable>
+
+      {if @props.selected
+        <g>
+          <DeleteButton tool={this} x={deletePosition.x} y={deletePosition.y} getScreenCurrentTransformationMatrix={@props.getScreenCurrentTransformationMatrix} />
+        </g>}
+    </DrawingToolRoot>
+
+  handleStrokeDrag: (e, d) ->
+    difference = @props.normalizeDifference(e, d)
+    @props.mark.y += difference.y
+    @props.onChange @props.mark

--- a/app/classifier/drawing-tools/index.coffee
+++ b/app/classifier/drawing-tools/index.coffee
@@ -7,6 +7,8 @@ module.exports =
   freehandSegmentLine: require './freehand-segment-line'
   freehandSegmentShape: require './freehand-segment-shape'
   freehandShape: require './freehand-shape'
+  fullWidthLine: require './full-width-line'
+  fullHeightLine: require './full-height-line'
   grid: require './grid'
   line: require './line'
   point: require './point'

--- a/app/classifier/tasks/drawing/icons.cjsx
+++ b/app/classifier/tasks/drawing/icons.cjsx
@@ -62,3 +62,13 @@ module.exports =
   freehandSegmentShape: <svg viewBox="0 0 100 100">
     <path d="M20,60 C10,10,80,10,50,50 C20,90 90,90 80,40 z" />
   </svg>
+
+  fullWidthLine: <svg viewBox="0 0 100 100">
+    <rect className="shape" x="0" y="0" width="100%" height="100%" strokeDasharray={[10, 10]} />
+    <line className="shape" x1="0" y1="50" x2="100" y2="50" />
+  </svg>
+
+  fullHeightLine: <svg viewBox="0 0 100 100">
+    <rect className="shape" x="0" y="0" width="100%" height="100%" strokeDasharray={[10, 10]} />
+    <line className="shape" x1="50" y1="0" x2="50" y2="100" />
+  </svg>

--- a/app/pages/dev-classifier/mock-data.coffee
+++ b/app/pages/dev-classifier/mock-data.coffee
@@ -136,8 +136,8 @@ workflow = apiClient.type('workflows').create
         {type: 'freehandShape', label: 'Freehand Shape', color: 'darkseagreen'}
         {type: 'freehandSegmentLine', label: 'Freehand Segment Line', color: 'gold'}
         {type: 'freehandSegmentShape', label: 'Freehand Segment Shape', color: 'goldenrod'}
-
-
+        {type: 'fullWidthLine', label: 'Full Width Line', color: 'orchid'}
+        {type: 'fullHeightLine', label: 'Full Height Line', color: 'mediumvioletred'}
       ]
       next: 'survey'
 


### PR DESCRIPTION
Fixes #1029. I still had my head in drawing tools, and thought I'd knock something up quickly.

https://full-width-line-marking.pfe-preview.zooniverse.org/projects/rogerhutchings/one-click-lines

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://full-width-line-marking.pfe-preview.zooniverse.org/projects/rogerhutchings/one-click-lines
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?