### PR TITLE
Don't let deleted workflows be default

### DIFF
--- a/app/pages/lab/workflow.cjsx
+++ b/app/pages/lab/workflow.cjsx
@@ -661,6 +661,10 @@ EditWorkflowPage = React.createClass
     if confirmed
       @setState deletionInProgress: true
 
+      if @props.workflow.id is @props.project.configuration?.default_workflow
+        @props.project.update 'configuration.default_workflow': null
+        @props.project.save()
+
       @props.workflow.delete().then =>
         @props.project.uncacheLink 'workflows'
         @context.router.push "/lab/#{@props.project.id}"

--- a/app/pages/lab/workflow.cjsx
+++ b/app/pages/lab/workflow.cjsx
@@ -624,7 +624,7 @@ EditWorkflowPage = React.createClass
       @props.project.update 'configuration.default_workflow': @props.workflow.id
       @props.project.save()
     else
-      @props.project.update 'configuration.default_workflow': null
+      @props.project.update 'configuration.default_workflow': undefined
       @props.project.save()
 
   handleTutorialToggle: (tutorial, workflowTutorials, e) ->
@@ -662,7 +662,7 @@ EditWorkflowPage = React.createClass
       @setState deletionInProgress: true
 
       if @props.workflow.id is @props.project.configuration?.default_workflow
-        @props.project.update 'configuration.default_workflow': null
+        @props.project.update 'configuration.default_workflow': undefined
         @props.project.save()
 
       @props.workflow.delete().then =>


### PR DESCRIPTION
Fixes a scenario where a project sets a workflow as default and then deletes it. This removes the project workflow default if it is the default. 

https://remove-default-if-deleted.pfe-preview.zooniverse.org/

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?