### PR TITLE
Native video

### DIFF
--- a/app/components/file-viewer/video-player.jsx
+++ b/app/components/file-viewer/video-player.jsx
@@ -95,6 +95,7 @@ class VideoPlayer extends React.Component {
       <div className="subject-video-frame">
         <video
           className="subject"
+          controls={true}
           ref={(element) => { this.player = element; }}
           src={this.props.src}
           type={`${this.props.type}/${this.props.format}`}
@@ -109,34 +110,6 @@ class VideoPlayer extends React.Component {
 
         {this.props.showControls && (
           <span className="subject-video-controls">
-            <span className="subject-frame-play-controls">
-              {(this.state.playing) ?
-                <button
-                  type="button"
-                  className="secret-button"
-                  aria-label="Pause"
-                  onClick={this.playVideo.bind(this, false)}
-                >
-                  <i className="fa fa-pause fa-fw" />
-                </button> :
-                <button
-                  type="button"
-                  className="secret-button"
-                  aria-label="Play"
-                  onClick={this.playVideo.bind(this, true)}
-                >
-                  <i className="fa fa-play fa-fw" />
-                </button>
-                }
-            </span>
-            <input
-              type="range"
-              className="video-scrubber"
-              ref={(element) => { this.scrubber = element; }}
-              min="0"
-              step="any"
-              onChange={this.seekVideo}
-            />
             <span className="video-speed">
             Speed: {this.renderSpeedControls(rates)}
             </span>

--- a/app/components/file-viewer/video-player.jsx
+++ b/app/components/file-viewer/video-player.jsx
@@ -1,19 +1,13 @@
 import React from 'react';
 
-const IS_IE = 'ActiveXObject' in window;
-
 class VideoPlayer extends React.Component {
   constructor(props) {
     super(props);
 
     this.player = null;
-    this.scrubber = null;
 
-    this.endVideo = this.endVideo.bind(this);
     this.playVideo = this.playVideo.bind(this);
-    this.seekVideo = this.seekVideo.bind(this);
     this.setPlayRate = this.setPlayRate.bind(this);
-    this.updateScrubber = this.updateScrubber.bind(this);
 
     this.state = {
       playing: false,
@@ -21,21 +15,8 @@ class VideoPlayer extends React.Component {
     };
   }
 
-  componentDidMount() {
-    if (this.scrubber) {
-      this.scrubber.value = 0;
-      if (IS_IE) this.scrubber.addEventListener('change', this.seekVideo);
-    }
-  }
-
   componentDidUpdate() {
     if (this.player) this.player.playbackRate = this.state.playbackRate;
-  }
-
-  componentWillUnmount() {
-    if (this.scrubber && IS_IE) {
-      this.scrubber.removeEventListener('change', this.seekVideo);
-    }
   }
 
   setPlayRate(e) {
@@ -55,19 +36,8 @@ class VideoPlayer extends React.Component {
     }
   }
 
-  seekVideo() {
-    const { player, scrubber } = this;
-    player.currentTime = scrubber.value;
-  }
-
   endVideo() {
     this.setState({ playing: false });
-  }
-
-  updateScrubber() {
-    const { player, scrubber } = this;
-    if (!scrubber.getAttribute('max')) scrubber.setAttribute('max', player.duration);
-    scrubber.value = player.currentTime;
   }
 
   renderSpeedControls(rates) {
@@ -103,7 +73,6 @@ class VideoPlayer extends React.Component {
           onCanPlay={this.props.onLoad}
           onClick={this.playVideo.bind(this, !this.state.playing)}
           onEnded={this.endVideo}
-          onTimeUpdate={this.updateScrubber}
         >
           Your browser does not support the video format. Please upgrade your browser.
         </video>

--- a/css/subject-viewer.styl
+++ b/css/subject-viewer.styl
@@ -25,7 +25,9 @@
 
   .subject-video-controls
     display: inline-block
-    position: relative
+    position: absolute
+    bottom: -1.4em
+    left: 0
     width: 30vw
 
   .video-scrubber


### PR DESCRIPTION
Fixes #3765 

Removes the custom video play button and scrubber, in favour of the native browser controls.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://native-video.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?