### PR TITLE
Don't redirect /projects to /projects?status=live

### DIFF
--- a/app/pages/projects/index.jsx
+++ b/app/pages/projects/index.jsx
@@ -20,15 +20,10 @@ class ProjectsPage extends Component {
   constructor(props) {
     super(props);
     this.updateQuery = this.updateQuery.bind(this);
-    this.checkURLForStatusFilter = this.checkURLForStatusFilter.bind(this);
   }
 
   getChildContext() {
     return { updateQuery: this.updateQuery };
-  }
-
-  componentWillMount() {
-    this.checkURLForStatusFilter(this.props);
   }
 
   componentDidMount() {
@@ -38,20 +33,8 @@ class ProjectsPage extends Component {
     }
   }
 
-  componentWillReceiveProps(nextProps) {
-    this.checkURLForStatusFilter(nextProps);
-  }
-
   componentWillUnmount() {
     document.documentElement.classList.remove('on-secondary-page');
-  }
-
-//  Makes sure the active class is applied also when status param is null
-  checkURLForStatusFilter(props) {
-    const { location } = props;
-    if (!location.query.status) {
-      this.updateQuery({ status: 'live' });
-    }
   }
 
   updateQuery(newParams) {

--- a/app/pages/projects/status-link.jsx
+++ b/app/pages/projects/status-link.jsx
@@ -15,6 +15,7 @@ class StatusLink extends Component {
 
   render() {
     const { children, location, status } = this.props;
+    location.query.status = location.query.status || 'live';
     const isActive = location.query.status === status;
     return (
       <button onClick={this.handleClick} className={isActive ? 'active' : null}>


### PR DESCRIPTION
Fixes #3784 .

Describe your changes.
Set a default value for the status param instead. Remove the method that updates browser history automatically if the query param isn't present.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://fix-3784.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?