### PR TITLE
Mark up project status tabs as tabs

### DIFF
--- a/app/pages/projects/index.jsx
+++ b/app/pages/projects/index.jsx
@@ -58,7 +58,7 @@ class ProjectsPage extends Component {
         <section className="hero projects-hero">
           <div className="hero-container">
             <Translate content="projectsHome.title" component="h1" />
-            <nav className="hero-nav">
+            <nav className="hero-nav" role="tablist">
               <StatusLink location={location} status="live" updateQuery={this.updateQuery}>
                 <Translate content="projectsHome.nav.active" />
               </StatusLink>

--- a/app/pages/projects/status-link.jsx
+++ b/app/pages/projects/status-link.jsx
@@ -18,7 +18,7 @@ class StatusLink extends Component {
     location.query.status = location.query.status || 'live';
     const isActive = location.query.status === status;
     return (
-      <button onClick={this.handleClick} className={isActive ? 'active' : null}>
+      <button role="tab" onClick={this.handleClick} aria-selected={isActive ? 'true' : 'false'}>
         {children}
       </button>
     );

--- a/css/secondary-page.styl
+++ b/css/secondary-page.styl
@@ -62,6 +62,7 @@
               background: rgba(255,255,255, 0.2)
               color: rgba(255,255,255,1)
             &.active
+            &[aria-selected=true]
               color: white
               border-bottom: solid 2px white
               border-top: 0


### PR DESCRIPTION
Adds tab roles and states to the Active/Paused/Finished buttons on the Projects page. Styles them according to selected state.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://fix-3784.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?