### PR TITLE
Check for image src before setting a collection preview

### DIFF
--- a/app/pages/collections/collection-card.jsx
+++ b/app/pages/collections/collection-card.jsx
@@ -13,7 +13,7 @@ export default class CollectionCard extends React.Component {
   }
 
   setSubjectPreview(src) {
-    const splitSrc = src.split('.');
+    const splitSrc = src ? src.split('.') : [];
     if (src && splitSrc[splitSrc.length - 1] !== 'mp4') {
       this.collectionCard.style.backgroundImage = `url('${src}')`;
       this.collectionCard.style.backgroundPosition = 'initial';


### PR DESCRIPTION
Without this small change, empty collections break the collections list page and preview images don't appear.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://fix-collection-cards.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?