### PR TITLE
Fix typo

### DIFF
--- a/app/classifier/drawing-tools/circle.cjsx
+++ b/app/classifier/drawing-tools/circle.cjsx
@@ -12,7 +12,7 @@ DELETE_BUTTON_ANGLE = 45
 BUFFER = 16
 
 module.exports = React.createClass
-  displayName: 'EllipseTool'
+  displayName: 'CircleTool'
 
   statics:
     defaultValues: ({x, y}) ->


### PR DESCRIPTION
Describe your changes.
The circle component was wrongly named `EllipseTool`, probably a result of copying and pasting code. Different `diplayNames` are useful for debugging older components.