### PR TITLE
Fix prop type validation

### DIFF
--- a/app/classifier/tasks/combo/markings-renderer.jsx
+++ b/app/classifier/tasks/combo/markings-renderer.jsx
@@ -68,8 +68,8 @@ MarkingsRenderer.propTypes = {
   classification: React.PropTypes.shape({
     annotations: React.PropTypes.array
   }),
-  taskTypes: React.PropTypes.arrayOf(React.PropTypes.string),
+  taskTypes: React.PropTypes.object,
   workflow: React.PropTypes.shape({
-    tasks: React.PropTypes.array
+    tasks: React.PropTypes.object
   })
 };


### PR DESCRIPTION
Fixes a couple of warnings that come up when running tests.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?