### PR TITLE
Hide aggregation export button

### DIFF
--- a/app/pages/lab/data-dumps.cjsx
+++ b/app/pages/lab/data-dumps.cjsx
@@ -24,11 +24,22 @@ module.exports = React.createClass
   getInitialState: ->
     avatarError: null
     backgroundError: null
+    showAggregationExportButton: false
+
+  componentDidMount: ->
+    @showAggregationExport @props.project
 
   showWorkflowExport: ->
     Dialog.alert(
       <ExportWorkflowsDialog project={@props.project} />
     )
+
+  showAggregationExport: (project) ->
+    project.get('aggregations_export').then (export) =>
+      if export[0].metadata.state is 'ready'
+        @setState showAggregationExportButton: true
+    .catch (error) =>
+      console.error error
 
   render: ->
     <div className="data-exports">
@@ -67,16 +78,19 @@ module.exports = React.createClass
               buttonKey="projectDetails.workflowContentsExport"
               exportType="workflow_contents_export"  />
           </div>
-           <div className="row" style={"display":"none"}>
-            <DataExportButton
-              project={@props.project}
-              buttonKey="projectDetails.aggregationExport"
-              contentType="application/x-gzip"
-              exportType="aggregations_export"
-              newFeature=true
-            />
-            <small className="form-help">Text tasks and survey tasks cannot be aggregated at this time.</small>
-          </div>
+          {
+           if @state.showAggregationExportButton
+             <div className="row">
+              <DataExportButton
+                project={@props.project}
+                buttonKey="projectDetails.aggregationExport"
+                contentType="application/x-gzip"
+                exportType="aggregations_export"
+                newFeature=true
+              />
+              <small className="form-help">Text tasks and survey tasks cannot be aggregated at this time.</small>
+            </div>
+          }
           <hr />
 
           Talk Data<br />

--- a/app/pages/lab/data-dumps.cjsx
+++ b/app/pages/lab/data-dumps.cjsx
@@ -24,22 +24,11 @@ module.exports = React.createClass
   getInitialState: ->
     avatarError: null
     backgroundError: null
-    showAggregationExportButton: false
-
-  componentDidMount: ->
-    @showAggregationExport @props.project
 
   showWorkflowExport: ->
     Dialog.alert(
       <ExportWorkflowsDialog project={@props.project} />
     )
-
-  showAggregationExport: (project) ->
-    project.get('aggregations_export').then (export) =>
-      if export[0].metadata.state is 'ready'
-        @setState showAggregationExportButton: true
-    .catch (error) =>
-      console.error error
 
   render: ->
     <div className="data-exports">
@@ -78,19 +67,15 @@ module.exports = React.createClass
               buttonKey="projectDetails.workflowContentsExport"
               exportType="workflow_contents_export"  />
           </div>
-          {
-           if @state.showAggregationExportButton
-             <div className="row">
-              <DataExportButton
-                project={@props.project}
-                buttonKey="projectDetails.aggregationExport"
-                contentType="application/x-gzip"
-                exportType="aggregations_export"
-                newFeature=true
-              />
-              <small className="form-help">Text tasks and survey tasks cannot be aggregated at this time.</small>
-            </div>
-          }
+          <div className="row">
+            <DataExportButton
+              project={@props.project}
+              buttonKey="projectDetails.aggregationExport"
+              contentType="application/x-gzip"
+              exportType="aggregations_export"
+              newFeature=true
+            />
+          </div>
           <hr />
 
           Talk Data<br />

--- a/app/pages/lab/data-dumps.cjsx
+++ b/app/pages/lab/data-dumps.cjsx
@@ -67,7 +67,7 @@ module.exports = React.createClass
               buttonKey="projectDetails.workflowContentsExport"
               exportType="workflow_contents_export"  />
           </div>
-           <div className="row">
+           <div className="row" style={"display":"none"}>
             <DataExportButton
               project={@props.project}
               buttonKey="projectDetails.aggregationExport"

--- a/app/partials/data-export-button.cjsx
+++ b/app/partials/data-export-button.cjsx
@@ -25,8 +25,6 @@ module.exports = React.createClass
       .catch (error) =>
         if error.status isnt 404
           @setState exportError: error
-        else
-          console.error error
 
   requestDataExport: ->
     @setState exportError: null

--- a/app/partials/data-export-button.cjsx
+++ b/app/partials/data-export-button.cjsx
@@ -1,5 +1,4 @@
 React = require 'react'
-PromiseRenderer = require '../components/promise-renderer'
 apiClient = require 'panoptes-client/lib/api-client'
 moment = require 'moment'
 Translate = require 'react-translate-component'

--- a/app/partials/data-export-button.cjsx
+++ b/app/partials/data-export-button.cjsx
@@ -24,7 +24,7 @@ module.exports = React.createClass
       .then ([exported]) =>
         @setState mostRecent: exported
       .catch (error) =>
-        console.error error
+        @setState exportError: error
 
   requestDataExport: ->
     @setState exportError: null

--- a/app/partials/data-export-button.cjsx
+++ b/app/partials/data-export-button.cjsx
@@ -14,32 +14,17 @@ module.exports = React.createClass
   getInitialState: ->
     exportRequested: false
     exportError: null
-    showButton: true
     mostRecent: null
 
   componentDidMount: ->
     @exportGet()
-    @showDataExportBtn()
-
-  componentWillReceiveProps: ->
-    @exportGet()
-    @showDataExportBtn()
 
   exportGet: ->
     @props.project.get(@props.exportType)
       .then ([exported]) =>
         @setState mostRecent: exported
-        @showDataExportBtn()
       .catch (error) =>
         console.error error
-
-  showDataExportBtn: ->
-    if @props.exportType isnt 'aggregations_export'
-      @setState showButton: true
-    else if @state?.mostRecent?.metadata?.state?
-      @setState showButton: true
-    else
-      @setState showButton: false
 
   requestDataExport: ->
     @setState exportError: null
@@ -57,7 +42,7 @@ module.exports = React.createClass
 
   render: ->
     <div>
-      { if @state.showButton
+      { if (@props.exportType isnt 'aggregations_export' or @state?.mostRecent?.metadata?.state?)
         <div>
           { if @props.newFeature
             <i className="fa fa-cog fa-lg fa-fw"></i> }

--- a/app/partials/data-export-button.cjsx
+++ b/app/partials/data-export-button.cjsx
@@ -23,7 +23,10 @@ module.exports = React.createClass
       .then ([exported]) =>
         @setState mostRecent: exported
       .catch (error) =>
-        @setState exportError: error
+        if error.status isnt 404
+          @setState exportError: error
+        else
+          console.error error
 
   requestDataExport: ->
     @setState exportError: null


### PR DESCRIPTION
Fixes #3742.

I didn't want to remove code, and the issue did not say to create a experimental feature flag, so I just added `display:none` styling on the button.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?