### PR TITLE
better ETC for finished workflows

### DIFF
--- a/app/pages/project/stats/stats.jsx
+++ b/app/pages/project/stats/stats.jsx
@@ -177,9 +177,12 @@ GraphSelect.propTypes = {
   handleWorkflowChange: React.PropTypes.func,
 };
 
-export const Eta = (props) => {
-  let output = <div />;
-  if (props.data.length > 1) {
+function calcEta(props) {
+  let eta = undefined;
+  if (props.completeness) {
+    eta = 0;
+  }
+  else if (props.data.length > 1) {
     let value;
     let days;
     if (props.data.length > 15) {
@@ -191,7 +194,15 @@ export const Eta = (props) => {
       days = props.data.length - 1;
     }
     const rate = value.reduce((a, b) => (a + b));
-    const eta = Math.max(0, Math.ceil(days * (props.totalCount - props.currentCount) / rate));
+    eta = Math.max(0, Math.ceil(days * (props.totalCount - props.currentCount) / rate));
+  }
+  return eta
+ }
+
+export const Eta = (props) => {
+  let output = <div />;
+  const eta = calcEta(props);
+  if (eta !== undefined) {
     output = (
       <div>
         <span className="progress-stats-label">ETC*</span> {`${eta} days`}
@@ -205,6 +216,7 @@ Eta.propTypes = {
   currentCount: React.PropTypes.number,
   data: React.PropTypes.array,
   totalCount: React.PropTypes.number,
+  completeness: React.PropTypes.bool,
 };
 
 export class WorkflowProgress extends React.Component {
@@ -271,6 +283,7 @@ export class WorkflowProgress extends React.Component {
             data={this.state.statData}
             currentCount={this.props.workflow.classifications_count}
             totalCount={total}
+            completeness={this.props.workflow.completeness == 1}
           />
         );
       }

--- a/app/pages/project/stats/stats.jsx
+++ b/app/pages/project/stats/stats.jsx
@@ -177,12 +177,12 @@ GraphSelect.propTypes = {
   handleWorkflowChange: React.PropTypes.func,
 };
 
-export const Eta = (eta) => {
+export const Eta = (props) => {
   let output = <div />;
-  if (eta !== undefined) {
+  if (props.numDays !== undefined) {
     output = (
       <div>
-        <span className="progress-stats-label">ETC*</span> {`${eta.numDays} days`}
+        <span className="progress-stats-label">ETC*</span> {`${props.numDays} days`}
       </div>
     );
   }


### PR DESCRIPTION
Fixes https://www.zooniverse.org/talk/17/331857?comment=553695

don't calc and eta for complete workflows, just report 0. 

This looks like i should be extracting the ETA to a class as i've got a props data clump here. Thoughts on best practice for this instead of just 2 functions to create the html. 

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?