### PR TITLE
Workflow exports links

### DIFF
--- a/app/pages/admin/project-status/experimental-features.jsx
+++ b/app/pages/admin/project-status/experimental-features.jsx
@@ -17,7 +17,6 @@ const experimentalFeatures = [
   'persist annotations',
   'shortcut',
   'metadata based feedback',
-  'export classifications by workflow',
   'freehandLine',
   'freehandShape',
   'freehandSegmentLine',

--- a/app/pages/lab/data-dumps.cjsx
+++ b/app/pages/lab/data-dumps.cjsx
@@ -43,12 +43,9 @@ module.exports = React.createClass
               buttonKey="projectDetails.classificationExport"
               exportType="classifications_export"  />
           </div>
-          {
-            if "export classifications by workflow" in @props.project.experimental_tools
-              <div className="row">
-                <WorkflowClassificationExportButton project={@props.project} />
-              </div>
-          }
+          <div className="row">
+            <WorkflowClassificationExportButton project={@props.project} />
+          </div>
           <div className="row">
             <DataExportButton
               project={@props.project}

--- a/app/pages/lab/export-workflows-dialog.jsx
+++ b/app/pages/lab/export-workflows-dialog.jsx
@@ -53,8 +53,6 @@ class ExportWorkflowsDialog extends React.Component {
             })
             .catch((error) => {
               if (error.status !== 404) {
-                this.props.onFail(error);
-              } else {
                 const workflowErrorState = this.state.workflowError;
                 workflowErrorState[workflow.id] = error[0];
                 this.setState({ workflowError: workflowErrorState });

--- a/app/pages/lab/export-workflows-dialog.jsx
+++ b/app/pages/lab/export-workflows-dialog.jsx
@@ -142,6 +142,12 @@ const ExportWorkflowListItem = ({ workflow, media, onChange }) => {
   );
 };
 
+ExportWorkflowListItem.propTypes = {
+  workflow: React.PropTypes.shape({ id: React.PropTypes.string, display_name: React.PropTypes.string }).isRequired,
+  media: React.PropTypes.shape({}),
+  onChange: React.PropTypes.func.isRequired
+};
+
 const ExportWorkflowLink = ({ media }) => {
   /* eslint-disable multiline-ternary */
   return (
@@ -151,5 +157,10 @@ const ExportWorkflowLink = ({ media }) => {
   );
   /* eslint-enable */
 }
+
+ExportWorkflowLink.propTypes = {
+  media: React.PropTypes.shape({ src: React.PropTypes.string, updated_at: React.PropTypes.string })
+};
+
 
 export default ExportWorkflowsDialog;

--- a/app/pages/lab/export-workflows-dialog.jsx
+++ b/app/pages/lab/export-workflows-dialog.jsx
@@ -118,7 +118,7 @@ ExportWorkflowsDialog.propTypes = {
 };
 
 const ExportWorkflowListItem = ({ workflow, media, onChange }) => {
-  const myMedia = workflow ? media[workflow.id.toString()] : null;
+  const myMedia = workflow ? media[workflow.id] : null;
   const now = new Date();
   const lockoutTime = new Date();
   lockoutTime.setDate(now.getDate() - 1);

--- a/app/pages/lab/export-workflows-dialog.jsx
+++ b/app/pages/lab/export-workflows-dialog.jsx
@@ -10,11 +10,9 @@ class ExportWorkflowsDialog extends React.Component {
       loading: false,
       workflows: [],
       media: {},
-      selectedWorkflowId: null,
-      workflowSelected: false
+      selectedWorkflowId: null
     };
 
-    this.toggleExport = this.toggleExport.bind(this);
     this.requestDataExport = this.requestDataExport.bind(this);
     this.updateWorkflowsFromProject = this.updateWorkflowsFromProject.bind(this);
     this.renderWorkflowOptions = this.renderWorkflowOptions.bind(this);
@@ -58,12 +56,6 @@ class ExportWorkflowsDialog extends React.Component {
             });
         });
       });
-  }
-
-  toggleExport() {
-    if (this.workflowList.selectedIndex >= 0) {
-      this.setState({ workflowSelected: true });
-    }
   }
 
   requestDataExport() {
@@ -146,7 +138,7 @@ ExportWorkflowListItem.propTypes = {
 /* eslint-disable multiline-ternary, no-confusing-arrow */
 const ExportWorkflowLink = ({ media }) =>
   media ?
-    <a href={media.src}>{Moment(media.updated_at).fromNow()}</a> :
+    <a title={media.updated_at} href={media.src}>{Moment(media.updated_at).fromNow()}</a> :
     <span>No exports have been requested.</span>;
 /* eslint-enable */
 

--- a/app/pages/lab/export-workflows-dialog.jsx
+++ b/app/pages/lab/export-workflows-dialog.jsx
@@ -82,6 +82,7 @@ class ExportWorkflowsDialog extends React.Component {
               return <ExportWorkflowListItem key={result.id} workflow={result} media={this.state.media} onChange={boundHandler} />;
             })}
           </ul>
+          { this.props.exportError ? <div className="form-help error">We had a problem requesting your export data: {this.props.exportError.toString()}</div> : null }
         </div>
       );
     }

--- a/app/pages/lab/export-workflows-dialog.jsx
+++ b/app/pages/lab/export-workflows-dialog.jsx
@@ -129,8 +129,6 @@ const ExportWorkflowListItem = ({ workflow, media, onChange, workflowError }) =>
   const lockout = myMedia && (new Date(myMedia.updated_at) > lockoutTime);
   const titleString = lockout ? 'This item can only be exported every 24 hours' : '';
 
-  const myWorkflowError = workflowError ? workflowError[workflow.id] : null;
-
   return (
     <div>
       <li className="workflow-export-list__item">
@@ -145,10 +143,20 @@ const ExportWorkflowListItem = ({ workflow, media, onChange, workflowError }) =>
         />
         {workflow.display_name}
         <small>
-          <ExportWorkflowLink media={myMedia} />
+          {myMedia &&
+            <a
+              title={myMedia.updated_at}
+              href={myMedia.src}
+              className="workflow-export-list__link"
+            >
+              {Moment(media.updated_at).fromNow()}
+            </a>}
+          {!myMedia &&
+            <span className="workflow-export-list__span">No exports have been requested.</span>}
         </small>
+        {workflowError[workflow.id] &&
+          <div className="form-help error">We had a problem requesting your export data: {workflowError[workflow.id]}</div>}
       </li>
-      { myWorkflowError ? <div className="form-help error">We had a problem requesting your export data: {myWorkflowError.toString()}</div> : null }
     </div>
   );
 };
@@ -162,9 +170,7 @@ ExportWorkflowListItem.defaultProps = {
     id: ''
   },
   onChange: () => {},
-  workflowError: {
-    id: ''
-  }
+  workflowError: {}
 };
 
 ExportWorkflowListItem.propTypes = {
@@ -174,31 +180,7 @@ ExportWorkflowListItem.propTypes = {
   }).isRequired,
   media: React.PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
   onChange: React.PropTypes.func.isRequired,
-  workflowError: React.PropTypes.shape({ id: React.PropTypes.string })
-};
-
-/* eslint-disable multiline-ternary, no-confusing-arrow */
-const ExportWorkflowLink = ({ media }) =>
-  media ?
-    <a
-      title={media.updated_at}
-      href={media.src}
-      className="workflow-export-list__link"
-    >
-      {Moment(media.updated_at).fromNow()}
-    </a> :
-    <span className="workflow-export-list__span">No exports have been requested.</span>;
-/* eslint-enable */
-
-ExportWorkflowLink.propTypes = {
-  media: React.PropTypes.shape({
-    src: React.PropTypes.string,
-    updated_at: React.PropTypes.string
-  })
-};
-
-ExportWorkflowLink.defaultProps = {
-  media: null
+  workflowError: React.PropTypes.object // eslint-disable-line react/forbid-prop-types
 };
 
 export default ExportWorkflowsDialog;

--- a/app/pages/lab/export-workflows-dialog.jsx
+++ b/app/pages/lab/export-workflows-dialog.jsx
@@ -51,7 +51,7 @@ class ExportWorkflowsDialog extends React.Component {
               this.setState({ media: mediaState });
             })
             .catch((error) => {
-              if (error.status === 404) {
+              if (error.status !== 404) {
                 this.props.onFail(error);
               } else {
                 console.error(error); // eslint-disable-line no-console

--- a/app/pages/lab/export-workflows-dialog.jsx
+++ b/app/pages/lab/export-workflows-dialog.jsx
@@ -11,7 +11,7 @@ class ExportWorkflowsDialog extends React.Component {
       workflows: [],
       media: {},
       selectedWorkflowId: null,
-      workflowSelected: false,
+      workflowSelected: false
     };
 
     this.toggleExport = this.toggleExport.bind(this);
@@ -81,19 +81,12 @@ class ExportWorkflowsDialog extends React.Component {
     if (this.state.workflows && this.state.workflows.length > 0) {
       return (
         <div>
-          <ul>
+          <ul className="workflow-export-list">
             {this.state.workflows.map((result) => {
               const boundHandler = this.setSelectedWorkflowId.bind(this, result.id);
               return <ExportWorkflowListItem key={result.id} workflow={result} media={this.state.media} onChange={boundHandler} />;
             })}
           </ul>
-          <select size="5" ref={(c) => { this.workflowList = c; }} className="multiline-select standard-input" style={{ padding: '0.3vh 0.3vw' }} onChange={this.toggleExport} style={{'display': 'none'}}>
-            {this.state.workflows.map((result) => {
-              return (
-                <option key={result.id} value={result.id}>{result.display_name}</option>
-              );
-            })}
-          </select>
         </div>
       );
     }
@@ -120,11 +113,10 @@ class ExportWorkflowsDialog extends React.Component {
 ExportWorkflowsDialog.propTypes = {
   project: React.PropTypes.shape({ links: React.PropTypes.object }).isRequired,
   onSuccess: React.PropTypes.func.isRequired,
-  onFail: React.PropTypes.func.isRequired,
+  onFail: React.PropTypes.func.isRequired
 };
 
 const ExportWorkflowListItem = ({ workflow, media, onChange }) => {
-
   const myMedia = workflow ? media[workflow.id.toString()] : null;
   const now = new Date();
   const lockoutTime = new Date();
@@ -137,30 +129,34 @@ const ExportWorkflowListItem = ({ workflow, media, onChange }) => {
     <li>
       <input type="radio" title={titleString} name="which-workflow" id={`export-${workflow.id}`} disabled={lockout} onChange={onChange} />
       {workflow.display_name}
-      <ExportWorkflowLink media={myMedia} />
+      <small>
+        <ExportWorkflowLink media={myMedia} />
+      </small>
     </li>
   );
 };
 
 ExportWorkflowListItem.propTypes = {
   workflow: React.PropTypes.shape({ id: React.PropTypes.string, display_name: React.PropTypes.string }).isRequired,
-  media: React.PropTypes.shape({}),
+  media: React.PropTypes.shape({}).isRequired,
   onChange: React.PropTypes.func.isRequired
 };
 
-const ExportWorkflowLink = ({ media }) => {
-  /* eslint-disable multiline-ternary */
-  return (
-    media ?
-      <a href={media.src}>{Moment(media.updated_at).fromNow()}</a> :
-      <span>No exports have been requested.</span>
-  );
-  /* eslint-enable */
-}
+
+/* eslint-disable multiline-ternary, no-confusing-arrow */
+const ExportWorkflowLink = ({ media }) =>
+  media ?
+    <a href={media.src}>{Moment(media.updated_at).fromNow()}</a> :
+    <span>No exports have been requested.</span>;
+/* eslint-enable */
+
 
 ExportWorkflowLink.propTypes = {
   media: React.PropTypes.shape({ src: React.PropTypes.string, updated_at: React.PropTypes.string })
 };
 
+ExportWorkflowLink.defaultProps = {
+  media: null
+};
 
 export default ExportWorkflowsDialog;

--- a/app/pages/lab/workflow-classification-export-button.jsx
+++ b/app/pages/lab/workflow-classification-export-button.jsx
@@ -26,7 +26,7 @@ class WorkflowClassificationExportButton extends React.Component {
   showWorkflowExport() {
     this.setState({ exportRequested: false, exportError: null });
     Dialog.alert(
-      <ExportWorkflowsDialog project={this.props.project} onSuccess={this.handleExportSuccess} onFail={this.handleExportFail} />,
+      <ExportWorkflowsDialog project={this.props.project} onSuccess={this.handleExportSuccess} onFail={this.handleExportFail} exportError={this.state.exportError} />,
     );
   }
 
@@ -35,7 +35,6 @@ class WorkflowClassificationExportButton extends React.Component {
       <div>
         <button onClick={this.showWorkflowExport}>Request new workflow classification export</button>
         <small className="form-help"> CSV format.</small>
-        { this.state.exportError ? <div className="form-help error">We had a problem requesting your export data: {this.state.exportError.toString()}</div> : null }
         { this.state.exportRequested ? <div className="form-help success">We’ve received your request, check your email for a link to your data soon!</div> : null }
       </div>
     );

--- a/app/pages/lab/workflow-classification-export-button.jsx
+++ b/app/pages/lab/workflow-classification-export-button.jsx
@@ -26,7 +26,7 @@ class WorkflowClassificationExportButton extends React.Component {
   showWorkflowExport() {
     this.setState({ exportRequested: false, exportError: null });
     Dialog.alert(
-      <ExportWorkflowsDialog project={this.props.project} onSuccess={this.handleExportSuccess} onFail={this.handleExportFail} exportError={this.state.exportError} />,
+      <ExportWorkflowsDialog project={this.props.project} onSuccess={this.handleExportSuccess} onFail={this.handleExportFail} />,
     );
   }
 

--- a/app/pages/lab/workflow-classification-export-button.jsx
+++ b/app/pages/lab/workflow-classification-export-button.jsx
@@ -7,7 +7,7 @@ class WorkflowClassificationExportButton extends React.Component {
     super(props);
     this.state = {
       exportError: null,
-      exportRequested: false,
+      exportRequested: false
     };
 
     this.showWorkflowExport = this.showWorkflowExport.bind(this);
@@ -33,7 +33,6 @@ class WorkflowClassificationExportButton extends React.Component {
   render() {
     return (
       <div>
-        <i className="fa fa-cog fa-lg fa-fw"></i>
         <button onClick={this.showWorkflowExport}>Request new workflow classification export</button>
         <small className="form-help"> CSV format.</small>
         { this.state.exportError ? <div className="form-help error">We had a problem requesting your export data: {this.state.exportError.toString()}</div> : null }
@@ -44,7 +43,7 @@ class WorkflowClassificationExportButton extends React.Component {
 }
 
 WorkflowClassificationExportButton.propTypes = {
-  project: React.PropTypes.shape({ links: React.PropTypes.object }).isRequired,
+  project: React.PropTypes.shape({ links: React.PropTypes.object }).isRequired
 };
 
 export default WorkflowClassificationExportButton;

--- a/css/main.styl
+++ b/css/main.styl
@@ -87,6 +87,7 @@
 @require './project-modal-editor'
 @require './workflow-editor'
 @require './workflow-visualizer'
+@require './workflow-export-dialog'
 
 // User profile
 @require './user-profile'

--- a/css/workflow-export-dialog.styl
+++ b/css/workflow-export-dialog.styl
@@ -1,11 +1,14 @@
 .workflow-export-list
   padding-left: 0
 
-  li
-    list-style-type: none
+.workflow-export-list__item
+  list-style-type: none
 
-    input
-      margin-right: 1em
+.workflow-export-list__input
+  margin-right: 1em
 
-    a, span
-      margin-left: 1em
+.workflow-export-list__link
+  margin-left: 1em
+
+.workflow-export-list__span
+  margin-left: 1em

--- a/css/workflow-export-dialog.styl
+++ b/css/workflow-export-dialog.styl
@@ -1,0 +1,11 @@
+.workflow-export-list
+  padding-left: 0
+
+  li
+    list-style-type: none
+
+    input
+      margin-right: 1em
+
+    a, span
+      margin-left: 1em


### PR DESCRIPTION
Fixes #3693.

Describe your changes.
- Replace select box with radio button list.
- API request to fetch export media.
- Links to previous exports.
- Only export every 24 hours.

https://workflow-exports-links.pfe-preview.zooniverse.org/lab/1663/data-exports

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [x] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [x] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [x] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [x] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?