### PR TITLE
Set pointer events CSS for combo tasks

### DIFF
--- a/app/classifier/annotation-renderer/svg.jsx
+++ b/app/classifier/annotation-renderer/svg.jsx
@@ -120,7 +120,12 @@ export default class SVGRenderer extends React.Component {
     Object.keys(tasks).map((task) => {
       const Component = tasks[task];
       if (Component.getSVGProps) {
-        Object.assign(svgProps, Component.getSVGProps(hookProps));
+        const { style } = svgProps;
+        const newProps = Component.getSVGProps(hookProps);
+        const newStyle = newProps ? Object.assign(style, newProps.style) : style;
+        svgProps.style = newStyle;
+        delete newProps.style;
+        Object.assign(svgProps, newProps);
       }
     });
 

--- a/app/classifier/annotation-renderer/svg.jsx
+++ b/app/classifier/annotation-renderer/svg.jsx
@@ -89,25 +89,6 @@ export default class SVGRenderer extends React.Component {
       ({ InsideSubject } = tasks[taskDescription.type]);
     }
 
-    const svgStyle = {};
-    if (type === 'image' && !this.props.loading) {
-      // Images are rendered again within the SVG itself.
-      // When cropped right next to the edge of the image,
-      // the original tag can show through, so fill the SVG to cover it.
-      svgStyle.background = 'black';
-
-      // Allow touch scrolling on subject for mobile and tablets
-      if (taskDescription) {
-        if (tasks[taskDescription.type] && tasks[taskDescription.type].AnnotationRenderer !== SVGRenderer) {
-          svgStyle.pointerEvents = 'none';
-        }
-      }
-      if (this.props.panEnabled === true) {
-        svgStyle.pointerEvents = 'all';
-      }
-    }
-
-    const svgProps = {};
     const { annotations } = this.props.classification;
 
     const hookProps = {
@@ -130,12 +111,23 @@ export default class SVGRenderer extends React.Component {
       workflow: this.props.workflow
     };
 
+    const svgProps = {
+      style: {
+        background: 'black'
+      }
+    };
+
     Object.keys(tasks).map((task) => {
       const Component = tasks[task];
       if (Component.getSVGProps) {
         Object.assign(svgProps, Component.getSVGProps(hookProps));
       }
     });
+
+    // pan/zoom should override any custom pointer event styles
+    if (this.props.panEnabled === true) {
+      svgProps.style.pointerEvents = 'all';
+    }
 
     let children = [];
     const isDrawingTask = taskDescription && (tasks[taskDescription.type].AnnotationRenderer === SVGRenderer);
@@ -162,7 +154,6 @@ export default class SVGRenderer extends React.Component {
         <svg
           ref={(element) => { if (element) this.svgSubjectArea = element; }}
           className="subject"
-          style={svgStyle}
           viewBox={createdViewBox}
           {...svgProps}
         >
@@ -211,7 +202,6 @@ SVGRenderer.propTypes = {
   }),
   disabled: React.PropTypes.bool,
   frame: React.PropTypes.number,
-  loading: React.PropTypes.bool,
   modification: React.PropTypes.object,
   naturalHeight: React.PropTypes.number,
   naturalWidth: React.PropTypes.number,

--- a/app/classifier/annotation-renderer/svg.jsx
+++ b/app/classifier/annotation-renderer/svg.jsx
@@ -175,7 +175,7 @@ export default class SVGRenderer extends React.Component {
               stroke="none"
             />
             {type === 'image' && (
-              <Draggable onDrag={this.props.panByDrag} disabled={this.props.disabled}>
+              <Draggable onDrag={this.props.panEnabled ? this.props.panByDrag : () => {}}>
                 <SVGImage
                   className={this.props.panEnabled ? 'pan-active' : ''}
                   src={src}
@@ -205,7 +205,6 @@ SVGRenderer.propTypes = {
     annotations: React.PropTypes.array,
     loading: React.PropTypes.bool
   }),
-  disabled: React.PropTypes.bool,
   frame: React.PropTypes.number,
   modification: React.PropTypes.object,
   naturalHeight: React.PropTypes.number,

--- a/app/classifier/tasks/combo/index.cjsx
+++ b/app/classifier/tasks/combo/index.cjsx
@@ -72,6 +72,18 @@ ComboTask = React.createClass
 
     PersistInsideSubject: MarkingsRenderer
 
+    getSVGProps: ({task, taskTypes, workflow})->
+      drawingTasks = task?.tasks?.filter (taskKey) =>
+        {type} = workflow.tasks[taskKey]
+        taskTypes[type].annotationRenderer is SVGRenderer
+      if drawingTasks?.length is 0
+        svgProps =
+          style:
+            pointerEvents: 'none'
+      else
+        svgProps = null
+      svgProps
+
   getDefaultProps: ->
     taskTypes: null
     workflow: null

--- a/app/classifier/tasks/combo/index.cjsx
+++ b/app/classifier/tasks/combo/index.cjsx
@@ -81,7 +81,7 @@ ComboTask = React.createClass
           style:
             pointerEvents: 'none'
       else
-        svgProps = null
+        svgProps = {}
       svgProps
 
   getDefaultProps: ->

--- a/app/classifier/tasks/crop/index.cjsx
+++ b/app/classifier/tasks/crop/index.cjsx
@@ -14,6 +14,9 @@ module.exports = React.createClass
     AnnotationRenderer: SVGRenderer
 
     getSVGProps: ({workflow, classification, annotation}) ->
+      svgProps = 
+        style:
+          pointerEvents: 'none'
       tasks = require('../index').default
       [previousCropAnnotation] = classification.annotations.filter (anAnnotation) =>
         taskDescription = workflow.tasks[anAnnotation.task]
@@ -21,7 +24,8 @@ module.exports = React.createClass
         TaskComponent is this and anAnnotation.value? and anAnnotation isnt annotation
       if previousCropAnnotation?
         {x, y, width, height} = previousCropAnnotation.value
-        viewBox: "#{x} #{y} #{width} #{height}"
+        svgProps.viewBox = "#{x} #{y} #{width} #{height}"
+      svgProps
 
     InsideSubject: CropInitializer
 

--- a/app/classifier/tasks/drawing/index.cjsx
+++ b/app/classifier/tasks/drawing/index.cjsx
@@ -22,6 +22,10 @@ module.exports = React.createClass
     PersistAfterTask: HidePreviousMarksToggle
     AnnotationRenderer: SVGRenderer
 
+    getSvgProps: ->
+      style:
+        pointerEvents: none
+
     getDefaultTask: ->
       type: 'drawing'
       instruction: 'Explain what to draw.'

--- a/app/components/frame-viewer.jsx
+++ b/app/components/frame-viewer.jsx
@@ -65,8 +65,8 @@ export default class FrameViewer extends React.Component {
               format={format}
               frame={this.props.frame}
               onLoad={this.handleLoad}
-              onFocus={this.panZoom ? this.panZoom.togglePanOn : () => {}}
-              onBlur={this.panZoom ? this.panZoom.togglePanOff : () => {}}
+              onFocus={(this.panZoom && zoomEnabled) ? this.panZoom.togglePanOn : () => {}}
+              onBlur={(this.panZoom && zoomEnabled) ? this.panZoom.togglePanOff : () => {}}
             />
           </FrameWrapper>
         </PanZoom>


### PR DESCRIPTION
Fixes #3803 .

Describe your changes.
Add `pointerEvents: 'none'` to the SVG inline styles if the combo does not contain any drawing tasks.

We should really be using CSS classes instead of inline styles. This is just a quick patch to get Notes from Nature working again.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://combo-pointer-events.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?