### PR TITLE
Tab to survey choices as a grouped control

### DIFF
--- a/app/classifier/tasks/survey/chooser.cjsx
+++ b/app/classifier/tasks/survey/chooser.cjsx
@@ -146,11 +146,17 @@ module.exports = React.createClass
           for choiceID, i in sortedFilteredChoices
             choice = @props.task.choices[choiceID]
             chosenAlready = choiceID in selectedChoices
+            tabIndex = -1
+            if i == 0 and @props.focusedChoice.length == 0
+              tabIndex = 0
+            if choiceID is @props.focusedChoice
+              tabIndex = 0
             <button
               autoFocus={choiceID is @props.focusedChoice}
               key={choiceID}
               data-choiceID={choiceID}
               ref={(button) => @choiceButtons.push button}
+              tabIndex={tabIndex}
               type="button"
               className="survey-task-chooser-choice-button #{'survey-task-chooser-choice-button-chosen' if chosenAlready}"
               onClick={@props.onChoose.bind null, choiceID}


### PR DESCRIPTION
Reduces the amount of tabbing required to navigate the survey task

Describe your changes.
Treat the choice list in the same way as a dropdown menu for keyboard navigation.

Apply tabindex=0 to a single choice (either the currently focused choice or the first choice.) Tab/shift-Tab then navigates into and out of the menu rather than between choices. Use the up/down keys to select choices when the list has focus.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://survey-chooser-focus.pfe-preview.zooniverse.org
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?