### PR TITLE
ensure param is available everywhere it's used

### DIFF
--- a/app/pages/project/stats/stats.jsx
+++ b/app/pages/project/stats/stats.jsx
@@ -226,7 +226,7 @@ export class WorkflowProgress extends React.Component {
       });
   }
 
-  calcDaysToCompletion() {
+  calcDaysToCompletion(totalCount) {
     let numDays = undefined;
     const dataLength = this.state.statData.length;
     const compeletness = this.props.workflow.completeness == 1;
@@ -245,7 +245,6 @@ export class WorkflowProgress extends React.Component {
         days = dataLength - 1;
       }
       const rate = value.reduce((a, b) => (a + b));
-      const totalCount = this.props.workflow.subjects_count * this.props.workflow.retirement.options.count;
       numDays = Math.max(0, Math.ceil(days * (totalCount - this.props.workflow.classifications_count) / rate));
     }
     return numDays;
@@ -254,10 +253,10 @@ export class WorkflowProgress extends React.Component {
   render() {
     let retirement;
     let eta;
-    let total;
     let retiredDiv;
     let classificationDiv;
     let completeness = this.props.workflow.completeness;
+    const totalCount = this.props.workflow.subjects_count * this.props.workflow.retirement.options.count;
     if (this.props.workflow.retirement.criteria !== 'never_retire') {
       retiredDiv = (
         <div>
@@ -276,12 +275,12 @@ export class WorkflowProgress extends React.Component {
         </div>
       );
       if (this.state.statData) {
-        eta = <Eta numDays={this.calcDaysToCompletion()}/>;
+        eta = <Eta numDays={this.calcDaysToCompletion(totalCount)}/>;
       }
       if (this.props.workflow.configuration) {
         if (this.props.workflow.configuration.stats_completeness_type === 'classification') {
-          completeness = this.props.workflow.classifications_count / total;
-          classificationsString += ` / ${total.toLocaleString()}`;
+          completeness = this.props.workflow.classifications_count / totalCount;
+          classificationsString += ` / ${totalCount.toLocaleString()}`;
           classificationDiv = (
             <div>
               <span className="progress-stats-label">Classifications:</span>


### PR DESCRIPTION
previous refactor ignored other use or a the totalCount param, extracted to a const and passing around where it's needed.

Fixes #3815  linked to #3804

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?