### PR TITLE
Revert "Set pointer events CSS for combo tasks"

### DIFF
--- a/app/classifier/tasks/combo/index.cjsx
+++ b/app/classifier/tasks/combo/index.cjsx
@@ -72,18 +72,6 @@ ComboTask = React.createClass
 
     PersistInsideSubject: MarkingsRenderer
 
-    getSVGProps: ({task, taskTypes, workflow})->
-      drawingTasks = task?.tasks?.filter (taskKey) =>
-        {type} = workflow.tasks[taskKey]
-        taskTypes[type].annotationRenderer is SVGRenderer
-      if drawingTasks?.length is 0
-        svgProps =
-          style:
-            pointerEvents: 'none'
-      else
-        svgProps = {}
-      svgProps
-
   getDefaultProps: ->
     taskTypes: null
     workflow: null

--- a/app/classifier/tasks/crop/index.cjsx
+++ b/app/classifier/tasks/crop/index.cjsx
@@ -14,9 +14,6 @@ module.exports = React.createClass
     AnnotationRenderer: SVGRenderer
 
     getSVGProps: ({workflow, classification, annotation}) ->
-      svgProps = 
-        style:
-          pointerEvents: 'none'
       tasks = require('../index').default
       [previousCropAnnotation] = classification.annotations.filter (anAnnotation) =>
         taskDescription = workflow.tasks[anAnnotation.task]
@@ -24,8 +21,7 @@ module.exports = React.createClass
         TaskComponent is this and anAnnotation.value? and anAnnotation isnt annotation
       if previousCropAnnotation?
         {x, y, width, height} = previousCropAnnotation.value
-        svgProps.viewBox = "#{x} #{y} #{width} #{height}"
-      svgProps
+        viewBox: "#{x} #{y} #{width} #{height}"
 
     InsideSubject: CropInitializer
 

--- a/app/classifier/tasks/drawing/index.cjsx
+++ b/app/classifier/tasks/drawing/index.cjsx
@@ -22,10 +22,6 @@ module.exports = React.createClass
     PersistAfterTask: HidePreviousMarksToggle
     AnnotationRenderer: SVGRenderer
 
-    getSvgProps: ->
-      style:
-        pointerEvents: none
-
     getDefaultTask: ->
       type: 'drawing'
       instruction: 'Explain what to draw.'

--- a/app/components/frame-viewer.jsx
+++ b/app/components/frame-viewer.jsx
@@ -65,8 +65,8 @@ export default class FrameViewer extends React.Component {
               format={format}
               frame={this.props.frame}
               onLoad={this.handleLoad}
-              onFocus={(this.panZoom && zoomEnabled) ? this.panZoom.togglePanOn : () => {}}
-              onBlur={(this.panZoom && zoomEnabled) ? this.panZoom.togglePanOff : () => {}}
+              onFocus={this.panZoom ? this.panZoom.togglePanOn : () => {}}
+              onBlur={this.panZoom ? this.panZoom.togglePanOff : () => {}}
             />
           </FrameWrapper>
         </PanZoom>


### PR DESCRIPTION
Reverts zooniverse/Panoptes-Front-End#3808. This caused a bug by not allowing marking tasks to annotate a subject.