### PR TITLE
hide download button shown in Chrome

### DIFF
--- a/app/components/file-viewer/video-player.jsx
+++ b/app/components/file-viewer/video-player.jsx
@@ -15,6 +15,10 @@ class VideoPlayer extends React.Component {
     };
   }
 
+  componentDidMount() {
+    this.player.controlsList = "nodownload"; // Non-spec option for Chrome browsers to hide the display of a download button
+  }
+
   componentDidUpdate() {
     if (this.player) this.player.playbackRate = this.state.playbackRate;
   }

--- a/css/subject-viewer.styl
+++ b/css/subject-viewer.styl
@@ -21,7 +21,17 @@
         font-weight: 700
 
   video
+    background-color: black
     width: 100%
+    
+    &::-internal-media-controls-download-button 
+      display: none
+
+    &::-webkit-media-controls-enclosure 
+      overflow: hidden
+
+    &::-webkit-media-controls-panel 
+      width: calc(100% + 30px); /* Adjust as needed */
 
   .subject-video-controls
     display: inline-block


### PR DESCRIPTION
Fixes #3818.

This adds the CSS hack to hide the download button for Chrome 57 users and the `controlsList` property for Chrome 58 users. We aren't really going to stop users from being able to download, but this at least hides the button Chrome added recently so it doesn't look like we're promoting downloads. React doesn't support the `controlsList` property yet, so I'm adding it manually on `componentDidMount` using a ref to the element. I've also added a black background color to the video element for small screen sizes. The video can get smaller in the player and can show the project background.

https://fix-3818.pfe-preview.zooniverse.org/projects/zooniverse/arizona-batwatch/classify?env=production

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?