### PR TITLE
Allow feedback to handle dud subjects

### DIFF
--- a/app/pages/lab/feedback/types/point/point-edit-form.jsx
+++ b/app/pages/lab/feedback/types/point/point-edit-form.jsx
@@ -55,16 +55,16 @@ class PointEditForm extends React.Component {
   render() {
     const fields = this.getFields()
     return (
-      <div className='single-edit-feedback-modal'>
-        <Translate content='PointEditForm.title' className='form-label' />
+      <div className="single-edit-feedback-modal">
+        <Translate content="PointEditForm.title" className="form-label" />
         {fields.map(this.renderInput)}
 
-        <div className='single-edit-feedback-modal__buttons'>
-          <button onClick={this.handleCancel} className='minor-button'>
-            <Translate content='PointEditForm.cancel' />
+        <div className="single-edit-feedback-modal__buttons">
+          <button onClick={this.handleCancel} className="minor-button">
+            <Translate content="PointEditForm.cancel" />
           </button>
-          <button onClick={this.handleSave} disabled={!this.state.valid} className='major-button'>
-            <Translate content='PointEditForm.save' />
+          <button onClick={this.handleSave} disabled={!this.state.valid} className="major-button">
+            <Translate content="PointEditForm.save" />
           </button>
         </div>
       </div>
@@ -135,7 +135,7 @@ class PointEditForm extends React.Component {
           <div>
             <Translate content={`PointEditForm.fields.${field.id}.title`} />
           </div>
-          <small className='form-help'>
+          <small className="form-help">
             <Translate content={`PointEditForm.fields.${field.id}.help`} />
           </small>
           <input {...inputProps} />


### PR DESCRIPTION
Fixes #3760. You can test it at https://marking-feedback-dud.pfe-preview.zooniverse.org/projects/rogerhutchings/feedback-test/classify, and choosing the Point Feedback workflow.

cc @aprajita

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?