### PR TITLE
Fix Done & Talk button

### DIFF
--- a/app/classifier/task-nav.jsx
+++ b/app/classifier/task-nav.jsx
@@ -117,7 +117,8 @@ class TaskNav extends React.Component {
 
     const task = this.props.task ? this.props.task : this.props.workflow.tasks[this.props.workflow.first_task];
 
-    const disableTalk = this.props.classification.metadata.subject_flagged;
+    const disableTalk = this.props.classification.metadata.subject_flagged ||
+    (isFeedbackActive(this.props.project) && isThereFeedback(this.props.subject, this.props.workflow));
     const visibleTasks = Object.keys(this.props.workflow.tasks).filter((key) => { return this.props.workflow.tasks[key].type !== 'shortcut'; });
     const TaskComponent = tasks[task.type];
 
@@ -166,7 +167,7 @@ class TaskNav extends React.Component {
             >
               Back
             </button>}
-          {(!nextTaskKey && this.props.workflow.configuration.hide_classification_summaries && this.props.project && !disableTalk && (!isFeedbackActive(this.props.project) && isThereFeedback(this.props.subject, this.props.workflow))) &&
+          {(!nextTaskKey && this.props.workflow.configuration.hide_classification_summaries && this.props.project && !disableTalk) &&
             <Link
               onClick={this.completeClassification}
               to={`/projects/${this.props.project.slug}/talk/subjects/${this.props.subject.id}`}


### PR DESCRIPTION
Fixes: Done & Talk isn't showing up on any project that uses it eg. Steller Watch and Gravity Spy

Describe your changes.
Inverts one of the true/false checks for feedback so that talk is disabled if feedback is active and the current subject has feedback.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://fix-done-talk.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?