### PR TITLE
Account menu keyboard focus

### DIFF
--- a/app/layout/account-bar.jsx
+++ b/app/layout/account-bar.jsx
@@ -6,8 +6,8 @@ import auth from 'panoptes-client/lib/auth';
 import talkClient from 'panoptes-client/lib/talk-client';
 import counterpart from 'counterpart';
 import Translate from 'react-translate-component';
-import Avatar from '../partials/avatar';
 import TriggeredModalForm from 'modal-form/triggered';
+import Avatar from '../partials/avatar';
 import PassContext from '../components/pass-context';
 import NotificationsLink from '../talk/lib/notifications-link';
 
@@ -23,20 +23,20 @@ counterpart.registerTranslations('en', {
     settings: 'Settings',
     signOut: 'Sign Out',
     collections: 'Collections',
-    favorites: 'Favorites',
-  },
+    favorites: 'Favorites'
+  }
 });
 
 const AccountBar = React.createClass({
   contextTypes: {
     user: React.PropTypes.object,
     router: routerShape,
-    geordi: React.PropTypes.object,
+    geordi: React.PropTypes.object
   },
 
   getInitialState() {
     return {
-      unread: false,
+      unread: false
     };
   },
 
@@ -60,10 +60,10 @@ const AccountBar = React.createClass({
     talkClient.type('conversations').get({
       user_id: this.context.user.id,
       unread: true,
-      page_size: 1,
+      page_size: 1
     }).then((conversations) => {
       this.setState({
-        unread: conversations.length > 0,
+        unread: conversations.length > 0
       });
     });
   },
@@ -79,7 +79,7 @@ const AccountBar = React.createClass({
 
     const newIndex = {
       [UP]: Math.max(0, focusIndex - 1),
-      [DOWN]: Math.min(focusables.length - 1, focusIndex + 1),
+      [DOWN]: Math.min(focusables.length - 1, focusIndex + 1)
     }[event.which];
 
     if (focusables[newIndex] !== undefined) {
@@ -91,7 +91,7 @@ const AccountBar = React.createClass({
   handleSignOutClick() {
     !!this.logClick && this.logClick('accountMenu.signOut');
     !!this.context.geordi && this.context.geordi.logEvent({
-      type: 'logout',
+      type: 'logout'
     });
 
     auth.signOut();
@@ -120,9 +120,9 @@ const AccountBar = React.createClass({
                 role="menuitem"
                 to={`/users/${this.context.user.login}`}
                 className="site-nav__link"
-                onClick={!!this.logClick ? this.logClick.bind(this, 'accountMenu.profile') : null}
+                onClick={this.logClick ? this.logClick.bind(this, 'accountMenu.profile') : null}
               >
-                <i className="fa fa-user fa-fw"></i>{' '}
+                <i className="fa fa-user fa-fw" />{' '}
                 <Translate content="accountMenu.profile" />
               </Link>
               <br />
@@ -130,9 +130,9 @@ const AccountBar = React.createClass({
                 role="menuitem"
                 to="/"
                 className="site-nav__link"
-                onClick={!!this.logClick ? this.logClick.bind(this, 'accountMenu.home') : null}
+                onClick={this.logClick ? this.logClick.bind(this, 'accountMenu.home') : null}
               >
-                <i className="fa fa-home fa-fw"></i>{' '}
+                <i className="fa fa-home fa-fw" />{' '}
                 <Translate content="accountMenu.home" />
               </Link>
               <br />
@@ -140,9 +140,9 @@ const AccountBar = React.createClass({
                 role="menuitem"
                 to="/settings"
                 className="site-nav__link"
-                onClick={!!this.logClick ? this.logClick.bind(this, 'accountMenu.settings') : null}
+                onClick={this.logClick ? this.logClick.bind(this, 'accountMenu.settings') : null}
               >
-                <i className="fa fa-cogs fa-fw"></i>{' '}
+                <i className="fa fa-cogs fa-fw" />{' '}
                 <Translate content="accountMenu.settings" />
               </Link>
               <br />
@@ -150,9 +150,9 @@ const AccountBar = React.createClass({
                 role="menuitem"
                 to={`/collections/${this.context.user.login}`}
                 className="site-nav__link"
-                onClick={!!this.logClick ? this.logClick.bind(this, 'accountMenu.collections') : null}
+                onClick={this.logClick ? this.logClick.bind(this, 'accountMenu.collections') : null}
               >
-                <i className="fa fa-image fa-fw"></i>{' '}
+                <i className="fa fa-image fa-fw" />{' '}
                 <Translate content="accountMenu.collections" />
               </Link>
               <br />
@@ -160,9 +160,9 @@ const AccountBar = React.createClass({
                 role="menuitem"
                 to={`/favorites/${this.context.user.login}`}
                 className="site-nav__link"
-                onClick={!!this.logClick ? this.logClick.bind(this, 'accountMenu.favorites') : null}
+                onClick={this.logClick ? this.logClick.bind(this, 'accountMenu.favorites') : null}
               >
-                <i className="fa fa-star fa-fw"></i>{' '}
+                <i className="fa fa-star fa-fw" />{' '}
                 <Translate content="accountMenu.favorites" />
               </Link>
               <hr />
@@ -173,7 +173,7 @@ const AccountBar = React.createClass({
                 onClick={this.handleSignOutClick}
               >
                 <span className="site-nav__link">
-                  <i className="fa fa-sign-out fa-fw"></i>{' '}
+                  <i className="fa fa-sign-out fa-fw" />{' '}
                   <Translate content="accountMenu.signOut" />
                 </span>
               </button>
@@ -181,7 +181,7 @@ const AccountBar = React.createClass({
           </PassContext>
         </TriggeredModalForm>
 
-        <span className="site-nav__link-buncher"></span>
+        <span className="site-nav__link-buncher" />
 
         <Link
           to="/inbox"
@@ -190,7 +190,7 @@ const AccountBar = React.createClass({
           aria-label={`
             Inbox ${this.state.unread ? 'with unread messages' : ''}
           `.trim()}
-          onClick={!!this.logClick ? this.logClick.bind(this, 'accountMenu.inbox', 'top-menu') : null}
+          onClick={this.logClick ? this.logClick.bind(this, 'accountMenu.inbox', 'top-menu') : null}
         >
           <span
             className={`
@@ -208,11 +208,11 @@ const AccountBar = React.createClass({
         <NotificationsLink params={this.props.params} user={this.context.user} linkProps={{
           className: 'site-nav__link site-nav__icon site-nav__icon--notifications',
           activeClassName: 'site-nav__link--active',
-          onClick: !!this.logClick ? this.logClick.bind(this, 'accountMenu.notifications') : null
+          onClick: this.logClick ? this.logClick.bind(this, 'accountMenu.notifications') : null
         }} />
       </span>
     );
-  },
+  }
 });
 
 export default AccountBar;

--- a/app/layout/account-bar.jsx
+++ b/app/layout/account-bar.jsx
@@ -69,9 +69,10 @@ class AccountBar extends React.Component {
   navigateMenu(event) {
     const focusables = [ReactDOM.findDOMNode(this.accountMenuButton)];
     if (this.accountMenu) {
-      for (const item of this.accountMenu.querySelectorAll(FOCUSABLES)) {
+      const menuItems = this.accountMenu.querySelectorAll(FOCUSABLES);
+      Array.prototype.forEach.call(menuItems, (item) => {
         focusables.push(item);
-      }
+      });
     }
     const focusIndex = focusables.indexOf(document.activeElement);
 

--- a/app/layout/account-bar.jsx
+++ b/app/layout/account-bar.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import ReactDOM from 'react-dom';
 import { routerShape } from 'react-router/lib/PropTypes';
 import { Link } from 'react-router';
 import auth from 'panoptes-client/lib/auth';
@@ -67,21 +68,14 @@ const AccountBar = React.createClass({
     });
   },
 
-  handleAccountMenuOpen() {
-    setTimeout(() => { // Wait for the modal's internal state change to happen.
-      if (this.refs.accountMenuButton.state.open) {
-        // React's `autoFocus` apparently doesn't work on <a> tags.
-        const firstFocusable = this.refs.accountMenu.querySelector(FOCUSABLES);
-        if (!!firstFocusable) {
-          firstFocusable.focus();
-        }
-      }
-    });
-  },
-
   navigateMenu(event) {
-    const focusables = this.refs.accountMenu.querySelectorAll(FOCUSABLES);
-    const focusIndex = Array.prototype.indexOf.call(focusables, document.activeElement);
+    const focusables = [ReactDOM.findDOMNode(this.accountMenuButton)];
+    if (this.accountMenu) {
+      for (const item of this.accountMenu.querySelectorAll(FOCUSABLES)) {
+        focusables.push(item);
+      }
+    }
+    const focusIndex = focusables.indexOf(document.activeElement);
 
     const newIndex = {
       [UP]: Math.max(0, focusIndex - 1),
@@ -107,7 +101,7 @@ const AccountBar = React.createClass({
     return (
       <span className="account-bar">
         <TriggeredModalForm
-          ref="accountMenuButton"
+          ref={(button) => { this.accountMenuButton = button; }}
           className="site-nav__modal"
           trigger={
             <span className="site-nav__link">
@@ -117,11 +111,11 @@ const AccountBar = React.createClass({
           }
           triggerProps={{
             className: 'secret-button',
-            onClick: this.handleAccountMenuOpen,
+            onKeyDown: this.navigateMenu
           }}
         >
           <PassContext context={this.context}>
-            <div ref="accountMenu" role="menu" onKeyDown={this.navigateMenu}>
+            <div ref={(menu) => { this.accountMenu = menu; }} role="menu" onKeyDown={this.navigateMenu}>
               <Link
                 role="menuitem"
                 to={`/users/${this.context.user.login}`}

--- a/app/layout/account-bar.jsx
+++ b/app/layout/account-bar.jsx
@@ -27,34 +27,32 @@ counterpart.registerTranslations('en', {
   }
 });
 
-const AccountBar = React.createClass({
-  contextTypes: {
-    user: React.PropTypes.object,
-    router: routerShape,
-    geordi: React.PropTypes.object
-  },
-
-  getInitialState() {
-    return {
+class AccountBar extends React.Component {
+  constructor(props) {
+    super(props);
+    this.navigateMenu = this.navigateMenu.bind(this);
+    this.handleSignOutClick = this.handleSignOutClick.bind(this);
+    this.lookUpUnread = this.lookUpUnread.bind(this);
+    this.state = {
       unread: false
     };
-  },
+  }
 
   componentDidMount() {
     addEventListener('locationchange', this.lookUpUnread);
     this.lookUpUnread();
-  },
+  }
 
   componentWillReceiveProps(nextProps, nextContext) {
     this.logClick = !!nextContext &&
       !!nextContext.geordi &&
       !!nextContext.geordi.makeHandler &&
       nextContext.geordi.makeHandler('about-menu');
-  },
+  }
 
   componentWillUnmount() {
     removeEventListener('locationchange', this.lookUpUnread);
-  },
+  }
 
   lookUpUnread() {
     talkClient.type('conversations').get({
@@ -66,7 +64,7 @@ const AccountBar = React.createClass({
         unread: conversations.length > 0
       });
     });
-  },
+  }
 
   navigateMenu(event) {
     const focusables = [ReactDOM.findDOMNode(this.accountMenuButton)];
@@ -86,7 +84,7 @@ const AccountBar = React.createClass({
       focusables[newIndex].focus();
       event.preventDefault();
     }
-  },
+  }
 
   handleSignOutClick() {
     !!this.logClick && this.logClick('accountMenu.signOut');
@@ -95,7 +93,7 @@ const AccountBar = React.createClass({
     });
 
     auth.signOut();
-  },
+  }
 
   render() {
     return (
@@ -213,6 +211,16 @@ const AccountBar = React.createClass({
       </span>
     );
   }
-});
+}
+
+AccountBar.contextTypes = {
+  user: React.PropTypes.object,
+  router: routerShape,
+  geordi: React.PropTypes.object
+};
+
+AccountBar.propTypes = {
+  params: React.PropTypes.array
+};
 
 export default AccountBar;


### PR DESCRIPTION
Describe your changes.
Doesn't focus the first menu item when the account menu opens. Instead, enter the menu, from the account button, with the down arrow key.

Also cleans up the account bar javascript and removes `React.CreateClass`.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://account-menu-focus.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?