### PR TITLE
Limit accuracy for freehand drawing to 1 decimal place

### DIFF
--- a/app/classifier/drawing-tools/freehand-helpers.coffee
+++ b/app/classifier/drawing-tools/freehand-helpers.coffee
@@ -1,3 +1,5 @@
+round = require 'lodash/round'
+
 createPathFromCoords = (coordsArray) ->
   [firstCoord, otherCoords...] = coordsArray
   path = "M #{firstCoord.x},#{firstCoord.y} "
@@ -11,6 +13,11 @@ filterDupeCoords = (coordsArray) ->
     filtered
   , []
 
+roundCoords = ({x, y}) ->
+  x: round x, 2
+  y: round y, 2
+
 module.exports =
   createPathFromCoords: createPathFromCoords
   filterDupeCoords: filterDupeCoords
+  roundCoords: roundCoords

--- a/app/classifier/drawing-tools/freehand-helpers.coffee
+++ b/app/classifier/drawing-tools/freehand-helpers.coffee
@@ -13,9 +13,9 @@ filterDupeCoords = (coordsArray) ->
     filtered
   , []
 
-roundCoords = ({x, y}) ->
-  x: round x, 2
-  y: round y, 2
+roundCoords = ({x, y}, precision = 1) ->
+  x: round x, precision
+  y: round y, precision
 
 module.exports =
   createPathFromCoords: createPathFromCoords

--- a/app/classifier/drawing-tools/freehand-line.cjsx
+++ b/app/classifier/drawing-tools/freehand-line.cjsx
@@ -3,7 +3,7 @@ DrawingToolRoot = require './root'
 deleteIfOutOfBounds = require './delete-if-out-of-bounds'
 DeleteButton = require './delete-button'
 {svgPathProperties} = require 'svg-path-properties'
-{createPathFromCoords, filterDupeCoords} = require './freehand-helpers'
+{createPathFromCoords, filterDupeCoords, roundCoords} = require './freehand-helpers'
 
 BUFFER = 16
 DELETE_BUTTON_WIDTH = 8
@@ -20,12 +20,12 @@ module.exports = React.createClass
       points: []
       _inProgress: false
 
-    initStart: ({x, y}, mark) ->
-      mark.points.push {x, y}
+    initStart: (coords, mark) ->
+      mark.points.push roundCoords coords
       _inProgress: true
 
-    initMove: ({x, y}, mark) ->
-      mark.points.push {x, y}
+    initMove: (coords, mark) ->
+      mark.points.push roundCoords coords
 
     initRelease: (coords, mark) ->
       points: filterDupeCoords mark.points

--- a/app/classifier/drawing-tools/freehand-segment-line.cjsx
+++ b/app/classifier/drawing-tools/freehand-segment-line.cjsx
@@ -2,7 +2,7 @@ React = require 'react'
 DrawingToolRoot = require './root'
 deleteIfOutOfBounds = require './delete-if-out-of-bounds'
 DeleteButton = require './delete-button'
-{createPathFromCoords, filterDupeCoords} = require './freehand-helpers'
+{createPathFromCoords, filterDupeCoords, roundCoords} = require './freehand-helpers'
 
 BUFFER = 16
 DELETE_BUTTON_WIDTH = 8
@@ -22,13 +22,13 @@ module.exports = React.createClass
       _inProgress: false
       _currentlyDrawing: false
 
-    initStart: ({x, y}, mark) ->
-      mark.points.push {x, y}
+    initStart: (coords, mark) ->
+      mark.points.push roundCoords coords
       _inProgress: true
       _currentlyDrawing: true
 
-    initMove: ({x, y}, mark) ->
-      mark.points.push {x, y}
+    initMove: (coords, mark) ->
+      mark.points.push roundCoords coords
 
     initRelease: (coords, mark) ->
       _currentlyDrawing: false

--- a/app/classifier/drawing-tools/freehand-segment-shape.cjsx
+++ b/app/classifier/drawing-tools/freehand-segment-shape.cjsx
@@ -2,7 +2,7 @@ React = require 'react'
 DrawingToolRoot = require './root'
 deleteIfOutOfBounds = require './delete-if-out-of-bounds'
 DeleteButton = require './delete-button'
-{createPathFromCoords, filterDupeCoords} = require './freehand-helpers'
+{createPathFromCoords, filterDupeCoords, roundCoords} = require './freehand-helpers'
 
 BUFFER = 16
 DELETE_BUTTON_WIDTH = 8
@@ -21,13 +21,13 @@ module.exports = React.createClass
       _inProgress: false
       _currentlyDrawing: false
 
-    initStart: ({x, y}, mark) ->
-      mark.points.push {x, y}
+    initStart: (coords, mark) ->
+      mark.points.push roundCoords coords
       _inProgress: true
       _currentlyDrawing: true
 
-    initMove: ({x, y}, mark) ->
-      mark.points.push {x, y}
+    initMove: (coords, mark) ->
+      mark.points.push roundCoords coords
 
     initRelease: (coords, mark) ->
       _currentlyDrawing: false

--- a/app/classifier/drawing-tools/freehand-shape.cjsx
+++ b/app/classifier/drawing-tools/freehand-shape.cjsx
@@ -3,7 +3,7 @@ DrawingToolRoot = require './root'
 deleteIfOutOfBounds = require './delete-if-out-of-bounds'
 DeleteButton = require './delete-button'
 {svgPathProperties} = require 'svg-path-properties'
-{createPathFromCoords, filterDupeCoords} = require './freehand-helpers'
+{createPathFromCoords, filterDupeCoords, roundCoords} = require './freehand-helpers'
 
 BUFFER = 16
 DELETE_BUTTON_WIDTH = 8
@@ -17,12 +17,12 @@ module.exports = React.createClass
       points: []
       _inProgress: false
 
-    initStart: ({x, y}, mark) ->
-      mark.points.push {x, y}
+    initStart: (coords, mark) ->
+      mark.points.push roundCoords coords
       _inProgress: true
 
-    initMove: ({x, y}, mark) ->
-      mark.points.push {x, y}
+    initMove: (coords, mark) ->
+      mark.points.push roundCoords coords
 
     initRelease: (coords, mark) ->
       mark.points.push mark.points[0]

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "lodash.merge": "~2.4.1",
     "lodash.pick": "~3.1.0",
     "lodash.uniq": "~3.2.2",
+    "lodash.round": "~4.0.4",
     "markdownz": "~7.2",
     "modal-form": "~2.4",
     "moment": "~2.9.0",


### PR DESCRIPTION
Contributes to #3551. Uses the `lodash.round` function to round coord data to 1 decimal place. This is then filtered for duplicates as normal.

https://freehand-limit-accuracy.pfe-preview.zooniverse.org/projects/rogerhutchings/etch-a-cell/classify

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?