### PR TITLE
News menu focus

### DIFF
--- a/app/layout/account-bar.jsx
+++ b/app/layout/account-bar.jsx
@@ -1,20 +1,14 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
 import { routerShape } from 'react-router/lib/PropTypes';
 import { Link } from 'react-router';
 import auth from 'panoptes-client/lib/auth';
 import talkClient from 'panoptes-client/lib/talk-client';
 import counterpart from 'counterpart';
 import Translate from 'react-translate-component';
-import TriggeredModalForm from 'modal-form/triggered';
 import Avatar from '../partials/avatar';
 import PassContext from '../components/pass-context';
 import NotificationsLink from '../talk/lib/notifications-link';
-
-const FOCUSABLES = 'a[href], button';
-
-const UP = 38;
-const DOWN = 40;
+import ExpandableMenu from './expandable-menu';
 
 counterpart.registerTranslations('en', {
   accountMenu: {
@@ -30,7 +24,6 @@ counterpart.registerTranslations('en', {
 class AccountBar extends React.Component {
   constructor(props) {
     super(props);
-    this.navigateMenu = this.navigateMenu.bind(this);
     this.handleSignOutClick = this.handleSignOutClick.bind(this);
     this.lookUpUnread = this.lookUpUnread.bind(this);
     this.state = {
@@ -66,27 +59,6 @@ class AccountBar extends React.Component {
     });
   }
 
-  navigateMenu(event) {
-    const focusables = [ReactDOM.findDOMNode(this.accountMenuButton)];
-    if (this.accountMenu) {
-      const menuItems = this.accountMenu.querySelectorAll(FOCUSABLES);
-      Array.prototype.forEach.call(menuItems, (item) => {
-        focusables.push(item);
-      });
-    }
-    const focusIndex = focusables.indexOf(document.activeElement);
-
-    const newIndex = {
-      [UP]: Math.max(0, focusIndex - 1),
-      [DOWN]: Math.min(focusables.length - 1, focusIndex + 1)
-    }[event.which];
-
-    if (focusables[newIndex] !== undefined) {
-      focusables[newIndex].focus();
-      event.preventDefault();
-    }
-  }
-
   handleSignOutClick() {
     !!this.logClick && this.logClick('accountMenu.signOut');
     !!this.context.geordi && this.context.geordi.logEvent({
@@ -99,8 +71,7 @@ class AccountBar extends React.Component {
   render() {
     return (
       <span className="account-bar">
-        <TriggeredModalForm
-          ref={(button) => { this.accountMenuButton = button; }}
+        <ExpandableMenu
           className="site-nav__modal"
           trigger={
             <span className="site-nav__link">
@@ -109,8 +80,7 @@ class AccountBar extends React.Component {
             </span>
           }
           triggerProps={{
-            className: 'secret-button',
-            onKeyDown: this.navigateMenu
+            className: 'secret-button'
           }}
         >
           <PassContext context={this.context}>
@@ -178,7 +148,7 @@ class AccountBar extends React.Component {
               </button>
             </div>
           </PassContext>
-        </TriggeredModalForm>
+        </ExpandableMenu>
 
         <span className="site-nav__link-buncher" />
 

--- a/app/layout/expandable-menu.jsx
+++ b/app/layout/expandable-menu.jsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import TriggeredModalForm from 'modal-form/triggered';
+
+const FOCUSABLES = 'a[href], button';
+
+const UP = 38;
+const DOWN = 40;
+
+class ExpandableMenu extends React.Component {
+  constructor(props) {
+    super(props);
+    this.navigateMenu = this.navigateMenu.bind(this);
+  }
+
+  navigateMenu(event) {
+    const focusables = [ReactDOM.findDOMNode(this.menuButton)];
+    if (this.menu) {
+      const menuItems = this.menu.querySelectorAll(FOCUSABLES);
+      Array.prototype.forEach.call(menuItems, (item) => {
+        focusables.push(item);
+      });
+    }
+    const focusIndex = focusables.indexOf(document.activeElement);
+
+    const newIndex = {
+      [UP]: Math.max(0, focusIndex - 1),
+      [DOWN]: Math.min(focusables.length - 1, focusIndex + 1)
+    }[event.which];
+
+    if (focusables[newIndex] !== undefined) {
+      focusables[newIndex].focus();
+      event.preventDefault();
+    }
+  }
+
+  render() {
+    return (
+      <TriggeredModalForm
+        ref={(button) => { this.menuButton = button; }}
+        className={this.props.className}
+        trigger={this.props.trigger}
+        triggerProps={Object.assign(this.props.triggerProps, { onKeyDown: this.navigateMenu })}
+      >
+        <div
+          ref={(menu) => { this.menu = menu; }}
+          onKeyDown={this.navigateMenu}
+        >
+          {this.props.children}
+        </div>
+      </TriggeredModalForm>
+    );
+  }
+}
+
+ExpandableMenu.propTypes = {
+  children: React.PropTypes.node,
+  className: React.PropTypes.string,
+  trigger: React.PropTypes.node,
+  triggerProps: React.PropTypes.object
+};
+
+ExpandableMenu.defaultProps = {
+  triggerProps: {}
+};
+
+export default ExpandableMenu;

--- a/app/layout/site-subnav.jsx
+++ b/app/layout/site-subnav.jsx
@@ -3,19 +3,6 @@ import ExpandableMenu from './expandable-menu';
 
 class SiteSubnav extends React.Component {
 
-  trigger() {
-    return (
-      <span
-        className="site-nav__link"
-        activeClassName="site-nav__link--active"
-        title="News"
-        aria-label="News"
-      >
-        News
-      </span>
-    );
-  }
-
   render() {
     if (this.props.isMobile) {
       return this.props.children;
@@ -23,7 +10,14 @@ class SiteSubnav extends React.Component {
       return (
         <ExpandableMenu
           className="site-nav__modal"
-          trigger={this.trigger()}
+          trigger={
+            <span
+              className="site-nav__link"
+              activeClassName="site-nav__link--active"
+            >
+              News
+            </span>
+          }
         >
           {this.props.children}
         </ExpandableMenu>

--- a/app/layout/site-subnav.jsx
+++ b/app/layout/site-subnav.jsx
@@ -1,17 +1,7 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
-import TriggeredModalForm from 'modal-form/triggered';
-
-const FOCUSABLES = 'a[href], button';
-
-const UP = 38;
-const DOWN = 40;
+import ExpandableMenu from './expandable-menu';
 
 class SiteSubnav extends React.Component {
-  constructor(props) {
-    super(props);
-    this.navigateMenu = this.navigateMenu.bind(this);
-  }
 
   trigger() {
     return (
@@ -26,47 +16,17 @@ class SiteSubnav extends React.Component {
     );
   }
 
-  navigateMenu(event) {
-    const focusables = [ReactDOM.findDOMNode(this.menuButton)];
-    if (this.menu) {
-      const menuItems = this.menu.querySelectorAll(FOCUSABLES);
-      Array.prototype.forEach.call(menuItems, (item) => {
-        focusables.push(item);
-      });
-    }
-    const focusIndex = focusables.indexOf(document.activeElement);
-
-    const newIndex = {
-      [UP]: Math.max(0, focusIndex - 1),
-      [DOWN]: Math.min(focusables.length - 1, focusIndex + 1)
-    }[event.which];
-
-    if (focusables[newIndex] !== undefined) {
-      focusables[newIndex].focus();
-      event.preventDefault();
-    }
-  }
-
   render() {
     if (this.props.isMobile) {
       return this.props.children;
     } else {
       return (
-        <TriggeredModalForm
-          ref={(button) => { this.menuButton = button; }}
+        <ExpandableMenu
           className="site-nav__modal"
           trigger={this.trigger()}
-          triggerProps={{
-            onKeyDown: this.navigateMenu
-          }}
         >
-          <div
-            ref={(menu) => { this.menu = menu; }}
-            onKeyDown={this.navigateMenu}
-          >
-            {this.props.children}
-          </div>
-        </TriggeredModalForm>
+          {this.props.children}
+        </ExpandableMenu>
       );
     }
   }

--- a/app/layout/site-subnav.jsx
+++ b/app/layout/site-subnav.jsx
@@ -1,5 +1,11 @@
 import React from 'react';
+import ReactDOM from 'react-dom';
 import TriggeredModalForm from 'modal-form/triggered';
+
+const FOCUSABLES = 'a[href], button';
+
+const UP = 38;
+const DOWN = 40;
 
 const SiteSubnav = React.createClass({
   propTypes: {
@@ -16,13 +22,46 @@ const SiteSubnav = React.createClass({
     );
   },
 
+  navigateMenu(event) {
+    const focusables = [ReactDOM.findDOMNode(this.menuButton)];
+    if (this.menu) {
+      const menuItems = this.menu.querySelectorAll(FOCUSABLES);
+      Array.prototype.forEach.call(menuItems, (item) => {
+        focusables.push(item);
+      });
+    }
+    const focusIndex = focusables.indexOf(document.activeElement);
+
+    const newIndex = {
+      [UP]: Math.max(0, focusIndex - 1),
+      [DOWN]: Math.min(focusables.length - 1, focusIndex + 1)
+    }[event.which];
+
+    if (focusables[newIndex] !== undefined) {
+      focusables[newIndex].focus();
+      event.preventDefault();
+    }
+  },
+
   render() {
     if(this.props.isMobile) {
       return this.props.children;
     } else {
       return(
-        <TriggeredModalForm className="site-nav__modal" trigger={this.trigger()}>
-          {this.props.children}
+        <TriggeredModalForm
+          ref={(button) => { this.menuButton = button; }}
+          className="site-nav__modal"
+          trigger={this.trigger()}
+          triggerProps={{
+            onKeyDown: this.navigateMenu
+          }}
+        >
+          <div
+            ref={(menu) => { this.menu = menu; }}
+            onKeyDown={this.navigateMenu}
+          >
+            {this.props.children}
+          </div>
         </TriggeredModalForm>
       );
     }

--- a/app/layout/site-subnav.jsx
+++ b/app/layout/site-subnav.jsx
@@ -7,20 +7,24 @@ const FOCUSABLES = 'a[href], button';
 const UP = 38;
 const DOWN = 40;
 
-const SiteSubnav = React.createClass({
-  propTypes: {
-    isMobile: React.PropTypes.bool,
-    children: React.PropTypes.node
-  },
+class SiteSubnav extends React.Component {
+  constructor(props) {
+    super(props);
+    this.navigateMenu = this.navigateMenu.bind(this);
+  }
 
   trigger() {
-    return(
-      <span className="site-nav__link"
+    return (
+      <span
+        className="site-nav__link"
         activeClassName="site-nav__link--active"
         title="News"
-        aria-label="News">News</span>
+        aria-label="News"
+      >
+        News
+      </span>
     );
-  },
+  }
 
   navigateMenu(event) {
     const focusables = [ReactDOM.findDOMNode(this.menuButton)];
@@ -41,13 +45,13 @@ const SiteSubnav = React.createClass({
       focusables[newIndex].focus();
       event.preventDefault();
     }
-  },
+  }
 
   render() {
-    if(this.props.isMobile) {
+    if (this.props.isMobile) {
       return this.props.children;
     } else {
-      return(
+      return (
         <TriggeredModalForm
           ref={(button) => { this.menuButton = button; }}
           className="site-nav__modal"
@@ -66,6 +70,11 @@ const SiteSubnav = React.createClass({
       );
     }
   }
-});
+}
+
+SiteSubnav.propTypes = {
+  isMobile: React.PropTypes.bool,
+  children: React.PropTypes.node
+};
 
 export default SiteSubnav;


### PR DESCRIPTION
Describe your changes.
Adds keyboard support to the News menu, as per #3826.

Adds an `ExpandableMenu` component which can be used for any button that triggers a popup menu.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://news-menu-focus.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?