### PR TITLE
Add support for another custom Gravity Spy feedback message

### DIFF
--- a/app/classifier/gs-gold-standard-summary.jsx
+++ b/app/classifier/gs-gold-standard-summary.jsx
@@ -26,6 +26,14 @@ const GSGoldStandardSummary = ({ classification, subject, workflow }) => {
     </div>);
   }
 
+  if (subject.metadata['#Label'] === 'special') {
+    return (
+      <div>
+        <p>{subject.metadata['#feedback_1_message']}</p>
+      </div>
+    );
+  }
+
   return (
     <div>
       <p>You responded {choiceLabels.join(', ')}.</p>


### PR DESCRIPTION
In anticipation of the announcement next Thursday, this adds support for subjects that have the specified metadata fields to show a custom message. We should get this merged by Tuesday next week at the latest.

CC @rogerhutchings we'll need to consider adding into the generalized feedback feature a way for projects to show a custom feedback message regardless of the annotation. I would have liked Gravity Spy to use the new generalized feedback feature, but I don't think it is designed to handle this use case even if we had survey task support added. 

This test project has a couple of subjects labelled as 'special' that comes up and has a feedback message that says 'congrats': https://gs-special-event-feedback-message.pfe-preview.zooniverse.org/projects/markb-panoptes/gravity-spy-gold-standard-notice-test-project/classify

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?