### PR TITLE
Add markdown support for GS custom summary message

### DIFF
--- a/app/classifier/gs-gold-standard-summary.jsx
+++ b/app/classifier/gs-gold-standard-summary.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Markdown } from 'markdownz';
 
 /* eslint-disable multiline-ternary, react/forbid-prop-types */
 
@@ -29,7 +30,7 @@ const GSGoldStandardSummary = ({ classification, subject, workflow }) => {
   if (subject.metadata['#Label'] === 'special') {
     return (
       <div>
-        <p>{subject.metadata['#feedback_1_message']}</p>
+        <Markdown>{subject.metadata['#post_classification_feedback']}</Markdown>
       </div>
     );
   }


### PR DESCRIPTION
Adds markdown support for Gravity Spy's custom message. Also renamed the metadata field being used to be close to what will be used more generally (See #3833 )

Can be seen with this test project with the 'special' labelled subjects: https://use-markdown-gs-feedback.pfe-preview.zooniverse.org/projects/markb-panoptes/gravity-spy-gold-standard-notice-test-project/classify

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?