### PR TITLE
Add check for classification completion for rendering Done & Talk

### DIFF
--- a/app/classifier/task-nav.jsx
+++ b/app/classifier/task-nav.jsx
@@ -167,7 +167,7 @@ class TaskNav extends React.Component {
             >
               Back
             </button>}
-          {(!nextTaskKey && this.props.workflow.configuration.hide_classification_summaries && this.props.project && !disableTalk) &&
+          {(!nextTaskKey && this.props.workflow.configuration.hide_classification_summaries && this.props.project && !disableTalk && !completed) &&
             <Link
               onClick={this.completeClassification}
               to={`/projects/${this.props.project.slug}/talk/subjects/${this.props.subject.id}`}


### PR DESCRIPTION
Fixes #3836.

Adding `!completed` to the conditional for the Done & Talk button rendering in the Task Nav fixes it for Gravity Spy where they normally hide the summary unless it's a subject that has metadata feedback. 

https://fix-3836.pfe-preview.zooniverse.org/projects/markb-panoptes/gravity-spy-gold-standard-notice-test-project/classify

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?