### PR TITLE
Combo task editor

### DIFF
--- a/app/classifier/tasks/combo/editor.cjsx
+++ b/app/classifier/tasks/combo/editor.cjsx
@@ -8,6 +8,11 @@ ComboTaskEditor = React.createClass
     task: null
     onChange: ->
 
+  componentWillMount: () ->
+    @props.task.tasks.map (taskKey, i) =>
+      unless @props.workflow.tasks[taskKey]
+        @removeTask(i)
+
   removeTask: (index) ->
     @props.task.tasks.splice index, 1
     @props.onChange @props.task

--- a/app/classifier/tasks/combo/editor.spec.js
+++ b/app/classifier/tasks/combo/editor.spec.js
@@ -1,0 +1,28 @@
+import { shallow, mount } from 'enzyme';
+import React from 'react';
+import assert from 'assert';
+import ComboEditor from './editor';
+import { workflow } from '../../../pages/dev-classifier/mock-data';
+
+const task = {
+  type: 'combo',
+  loosen_requirements: true,
+  tasks: ['write', 'ask', 'features', 'draw', 'survey', 'slider']
+};
+
+describe('ComboEditor', function () {
+  it('should render for a workflow and task', () => {
+    const wrapper = shallow(<ComboEditor workflow={workflow} task={task} />);
+    assert.equal(wrapper.instance() instanceof ComboEditor, true);
+  });
+});
+
+describe('deleting a workflow task', () => {
+  const { tasks } = workflow;
+  delete tasks.ask;
+  it('should render and update the combo task', () => {
+    const wrapper = mount(<ComboEditor workflow={workflow} task={task} />);
+    const { props } = wrapper.instance();
+    assert.equal(props.task.tasks.indexOf('ask'), -1);
+  });
+});


### PR DESCRIPTION
Fixes #3840 .

Describe your changes.
Checks `workflow.tasks` for task keys that have been deleted, when the ComboEditor mounts.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://combo-task-editor.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?