### PR TITLE
Mutate copies of mock workflow and task data

### DIFF
--- a/app/classifier/frame-annotator.spec.js
+++ b/app/classifier/frame-annotator.spec.js
@@ -226,7 +226,7 @@ describe('<FrameAnnotator />', function() {
     });
 
     it('does not allow pointer events for other combo tasks', function() {
-      const comboTask = workflow.tasks.combo;
+      const comboTask = Object.assign({}, workflow.tasks.combo);
       comboTask.tasks = ['write', 'ask', 'features'];
       workflow.tasks.textCombo = comboTask;
       const comboAnnotation = tasks.combo.getDefaultAnnotation(workflow.tasks.textCombo, workflow, tasks);

--- a/app/classifier/tasks/combo/editor.spec.js
+++ b/app/classifier/tasks/combo/editor.spec.js
@@ -18,10 +18,12 @@ describe('ComboEditor', function () {
 });
 
 describe('deleting a workflow task', () => {
-  const { tasks } = workflow;
+  const workflowCopy = Object.assign({}, workflow);
+  const tasks = Object.assign({}, workflow.tasks);
   delete tasks.ask;
+  workflowCopy.tasks = tasks;
   it('should render and update the combo task', () => {
-    const wrapper = mount(<ComboEditor workflow={workflow} task={task} />);
+    const wrapper = mount(<ComboEditor workflow={workflowCopy} task={task} />);
     const { props } = wrapper.instance();
     assert.equal(props.task.tasks.indexOf('ask'), -1);
   });


### PR DESCRIPTION
Otherwise, this will break other tests that import the mock workflow data.

Fixes tests that were broken in #3847