### PR TITLE
Add combo editor tests

### DIFF
--- a/app/classifier/tasks/combo/editor.spec.js
+++ b/app/classifier/tasks/combo/editor.spec.js
@@ -1,4 +1,4 @@
-import { shallow, mount } from 'enzyme';
+import { mount } from 'enzyme';
 import React from 'react';
 import assert from 'assert';
 import ComboEditor from './editor';
@@ -10,10 +10,23 @@ const task = {
   tasks: ['write', 'ask', 'features', 'draw', 'survey', 'slider']
 };
 
-describe('ComboEditor', function () {
+describe('ComboEditor', () => {
+  const wrapper = mount(<ComboEditor workflow={workflow} task={task} />);
+
   it('should render for a workflow and task', () => {
-    const wrapper = shallow(<ComboEditor workflow={workflow} task={task} />);
     assert.equal(wrapper.instance() instanceof ComboEditor, true);
+  });
+
+  it('should add new tasks to the combo when selected', () => {
+    wrapper.find('select[value="stuck"]').simulate('change', { target: { value: 'dropdown' }});
+    const { props } = wrapper.instance();
+    assert.notEqual(props.task.tasks.indexOf('dropdown'), -1);
+  });
+
+  it('should allow tasks to be deleted from the combo', () => {
+    wrapper.find('ul.drag-reorderable button').first().simulate('click');
+    const { props } = wrapper.instance();
+    assert.equal(props.task.tasks.indexOf('write'), -1);
   });
 });
 


### PR DESCRIPTION
Add tests for adding and deleting a task from the combo task.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?