### PR TITLE
Add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
I was having weird issues with my editor defaulting to 4 spaces on a new machine, and then I realised I hadn't set up my editorconfig properly. And then I realised we didn't have one for PFE.

More info: http://editorconfig.org/