### PR TITLE
Use naturalHeight and naturalWidth to determine validity of full height / width lines

### DIFF
--- a/app/classifier/drawing-tools/full-height-line.cjsx
+++ b/app/classifier/drawing-tools/full-height-line.cjsx
@@ -18,8 +18,8 @@ module.exports = React.createClass
     initMove: ({x}) ->
       x: x
 
-    initValid: ({x}, {containerRect}) ->
-      x >= 0 and x <= containerRect.width
+    initValid: ({x}, {naturalWidth}) ->
+      x >= 0 and x <= naturalWidth
 
   render: ->
     {x} = @props.mark

--- a/app/classifier/drawing-tools/full-width-line.cjsx
+++ b/app/classifier/drawing-tools/full-width-line.cjsx
@@ -18,8 +18,8 @@ module.exports = React.createClass
     initMove: ({y}) ->
       y: y
 
-    initValid: ({y}, {containerRect}) ->
-      y >= 0 and y <= containerRect.height
+    initValid: ({y}, {naturalHeight}) ->
+      y >= 0 and y <= naturalHeight
 
   render: ->
     {y} = @props.mark


### PR DESCRIPTION
The full width and height line tools were using the `containerRect` property to determine valid annotations, causing annotations at the edges to be invalid. This fix changes that to use the `naturalHeight` / `naturalWidth` props instead.

Fixes #3865 .

Staging branch: https://full-height-line-fix.pfe-preview.zooniverse.org
Test project on staging: https://full-height-line-fix.pfe-preview.zooniverse.org/projects/rogerhutchings/one-click-lines/classify

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?