### PR TITLE
IE11 fix for highligther tool

### DIFF
--- a/app/classifier/tasks/highlighter/index.jsx
+++ b/app/classifier/tasks/highlighter/index.jsx
@@ -46,7 +46,7 @@ export default class Highlighter extends React.Component {
   selectableArea(selection, range, offset, start, end){
     const spansNodes = range.startContainer !== range.endContainer
     const noAreaSelected = start === end;
-    const subjectSelection = selection.anchorNode.parentElement.parentElement.className === 'label-renderer';
+    const subjectSelection = selection.anchorNode.parentNode.parentNode.className === 'label-renderer';
     const isSelectable = !spansNodes && !noAreaSelected && subjectSelection;
     return isSelectable;
   }

--- a/app/classifier/tasks/highlighter/index.jsx
+++ b/app/classifier/tasks/highlighter/index.jsx
@@ -55,8 +55,9 @@ export default class Highlighter extends React.Component {
     const { anchorNode } = selection;
     const { parentNode } = anchorNode;
     let start = 0;
-    for (const node of parentNode.childNodes) {
-      // ignore comments (nodeType 8) when calculating offset distance
+    let nodeArray = parentNode.childNodes;
+    for (var i = 0; i < nodeArray.length; i++) {
+      let node = nodeArray[i];
       if (node.nodeType !== 8 && node !== anchorNode) {
         const text = node.getAttribute ? node.getAttribute('data-selection') : node.textContent;
         start += text.length;

--- a/app/pages/admin/project-status/experimental-features.jsx
+++ b/app/pages/admin/project-status/experimental-features.jsx
@@ -25,6 +25,7 @@ const experimentalFeatures = [
   'sim notification',
   'general feedback',
   'slider',
+  'highlighter'
 ];
 
 class ExperimentalFeatures extends Component {

--- a/app/pages/lab/workflow.cjsx
+++ b/app/pages/lab/workflow.cjsx
@@ -177,13 +177,14 @@ EditWorkflowPage = React.createClass
                       <small><strong>Survey</strong></small>
                     </button>
                   </AutoSave>{' '}
-                  <AutoSave resource={@props.workflow}>
-                    <button type="submit" className="minor-button" onClick={@addNewTask.bind this, 'highlighter'} title="Highlighter: The volunteer can highlight piece of text.">
-                      <i className="fa fa-i-cursor fa-2x"></i>
-                      <br />
-                      <small><strong>Highlighter</strong></small>
-                    </button>
-                  </AutoSave>{' '}
+                  {if @canUseTask(@props.project, "highlighter")
+                    <AutoSave resource={@props.workflow}>
+                      <button type="submit" className="minor-button" onClick={@addNewTask.bind this, 'highlighter'} title="Highlighter: The volunteer can highlight piece of text.">
+                        <i className="fa fa-i-cursor fa-2x"></i>
+                        <br />
+                        <small><strong>Highlighter</strong></small>
+                      </button>
+                    </AutoSave>}{' '}
                   {if @canUseTask(@props.project, "crop")
                     <AutoSave resource={@props.workflow}>
                       <button type="submit" className="minor-button" onClick={@addNewTask.bind this, 'crop'} title="Crop tasks: the volunteer draws a rectangle around an area of interest, and the view of the subject is approximately cropped to that area.">


### PR DESCRIPTION
Fixes two issues with the highlighter tool in IE11. 

Describe your changes.
In `#getOffset`, the `for...of` loop is replaced with a `for` loop.
In `#selectableArea`, `parentElement` is replaced with `parentNode`.

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://ie-fix-highligther-v2.pfe-preview.zooniverse.org
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?