### PR TITLE
Allow drawing inside freehand lines

### DIFF
--- a/app/classifier/drawing-tools/freehand-line.cjsx
+++ b/app/classifier/drawing-tools/freehand-line.cjsx
@@ -66,7 +66,7 @@ module.exports = React.createClass
 
       {if @props.selected
         deletePosition = @getDeletePosition points
-        <g>
+        <g pointerEvents="fill">
           <DeleteButton tool={this}
             x={deletePosition.x}
             y={deletePosition.y}

--- a/app/classifier/drawing-tools/freehand-line.cjsx
+++ b/app/classifier/drawing-tools/freehand-line.cjsx
@@ -52,7 +52,9 @@ module.exports = React.createClass
 
     lineClass = if _inProgress then 'drawing' else 'clickable'
 
-    <DrawingToolRoot tool={this}>
+    # Setting the pointerEvents prop stops the shape from acting like a closed
+    # path for click events
+    <DrawingToolRoot tool={this} pointerEvents="visibleStroke">
       <path d={path}
         strokeWidth={GRAB_STROKE_WIDTH / ((@props.scale.horizontal + @props.scale.vertical) / 2)}
         strokeOpacity="0"

--- a/app/classifier/drawing-tools/freehand-line.cjsx
+++ b/app/classifier/drawing-tools/freehand-line.cjsx
@@ -43,12 +43,6 @@ module.exports = React.createClass
     x: if not @outOfBounds(x, scale) then x else startCoords.x + mod
     y: startCoords.y
 
-  handleHover: (e) ->
-    if e.type == 'mouseenter'
-      @setState hover: true
-    else if e.type == 'mouseleave'
-      @setState hover: false
-
   outOfBounds: (deleteBtnX, scale) ->
     deleteBtnX - (DELETE_BUTTON_WIDTH / scale) < 0
 


### PR DESCRIPTION
Sets the `pointerEvents` prop to stop clicks inside a shape triggering click the select event, allowing users to draw inside.

Test project: https://freehand-fix.pfe-preview.zooniverse.org/projects/rogerhutchings/etch-a-cell/classify

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://freehand-fix.pfe-preview.zooniverse.org
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?