### PR TITLE
Adjust Navbar Weight

### DIFF
--- a/app/layout/site-nav.jsx
+++ b/app/layout/site-nav.jsx
@@ -13,7 +13,7 @@ import SiteSubnav from './site-subnav';
 import ExpandableMenu from './expandable-menu';
 
 
-const MAX_MOBILE_WIDTH = 1035;
+const MAX_MOBILE_WIDTH = 1080;
 const ZOO_LOGO = <ZooniverseLogo width="1.8em" height="1.8em" style={{ verticalAlign: '-0.5em' }} />;
 const HAMBURGER_MENU = <span style={{ display: 'inline-block', transform: 'scale(2.5, 2)' }}>≡</span>;
 

--- a/css/site-nav.styl
+++ b/css/site-nav.styl
@@ -18,6 +18,7 @@
     color: LIGHT_GREY
     display: inline-block
     font-size: 1em
+    font-weight: 700
     letter-spacing: 0.15em
     margin: 0.5em 1em 0 1em
     padding-bottom: 0.3em


### PR DESCRIPTION
Fixes #3880 .

Describe your changes.
Bolden font-weight on navbar links, as the text was light on Safari/Edge. Also adjusted the mobile navbar breakpoint since the weight affected the width of each link.

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)

https://nav-bar-adjust.pfe-preview.zooniverse.org/

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?