### PR TITLE
Force image resources to update in project builder

### DIFF
--- a/app/pages/lab/project-details.cjsx
+++ b/app/pages/lab/project-details.cjsx
@@ -41,15 +41,16 @@ module.exports = React.createClass
       apiClient.type('users').get(scientists).then (researchers) =>
         @setState({ researchers })
 
-    avatar = @props.project.get('avatar')
+    @updateImage 'avatar'
+    @updateImage 'background'
+
+  updateImage: (type) ->
+    @props.project.get(type)
+      .then (image) =>
+        @setState 
+          "#{type}": image
       .catch (error) =>
         console.log error
-    background = @props.project.get('background')
-      .catch (error) =>
-        console.log error
-    Promise.all([avatar, background])
-      .then ([avatar, background]) =>
-        @setState {avatar, background}
 
   splitTags: (kind) ->
     disciplineTagList = []
@@ -240,6 +241,7 @@ module.exports = React.createClass
         @props.project.refresh() # Update the resource's links.
       .then =>
         @props.project.emit 'change' # Re-render
+        @updateImage type
       .catch (error) =>
         newState = {}
         newState[errorProp] = error


### PR DESCRIPTION
Fixes #3862 
Fixes #2317

Updates the state of the `ProjectDetails` component when a new image resource is uploaded so changes are immediately reflected.

https://project-avatar.pfe-preview.zooniverse.org/

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?