### PR TITLE
Change survey focus style to a blue border

### DIFF
--- a/css/survey-task.styl
+++ b/css/survey-task.styl
@@ -298,6 +298,7 @@ $survey-task-pill-button
 
 .survey-task-choice-answer
   background: rgba(232, 232, 232, 1)
+  border: 1px transparent solid
   border-radius: 4px
   cursor: pointer
   font-size: 10px
@@ -313,7 +314,7 @@ $survey-task-pill-button
     color: white
 
   &[data-focused]
-    background: SECOND_HIGHLIGHT
+    border: 1px MAIN_HIGHLIGHT solid
     color: white
 
   span


### PR DESCRIPTION
Changes the focus style for survey choice checkboxes and radio buttons to a blue border. The green background currently in use is confusing, since it makes the focussed answer appear to have been selected, even when it hasn't.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://survey-focus-style.pfe-preview.zooniverse.org/?env=production
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?