### PR TITLE
Remove the non-existent role 'workaround'

### DIFF
--- a/app/pages/lab/index.cjsx
+++ b/app/pages/lab/index.cjsx
@@ -238,7 +238,7 @@ module.exports = React.createClass
         <ProjectList
           title="Your projects"
           page={@props.location.query['owned-page']}
-          roles={['owner', 'workaround']}
+          roles={['owner']}
           withAvatars
           onChangePage={@handlePageChange.bind this, 'owned-page'}
         />


### PR DESCRIPTION
The unknown role "workaround" has been spotted by @marten. This seems to be its only instance and it can be removed with no harm to the surrounding ecosystem.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://remove-dummy-role.pfe-preview.zooniverse.org/lab/?env=production
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)