### PR TITLE
WorldWide Telescope Adjustments

### DIFF
--- a/app/classifier/world-wide-telescope.jsx
+++ b/app/classifier/world-wide-telescope.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import shortid from 'shortid';
+import getSubjectLocation from '../lib/get-subject-location';
 
 class SimplePoint {
   constructor(x, y) {
@@ -109,7 +110,36 @@ class StarChart {
   }
 
   addAxisLabel(axisLabel) {
-    this.axisLabels.push(axisLabel);
+    const otherUnitValue = 6;
+    if (axisLabel.value === otherUnitValue) {
+      this.removeIrrelevantPoints(axisLabel);
+    } else {
+      this.axisLabels.push(axisLabel);
+    }
+  }
+
+  removeIrrelevantPoints(axisLabel) {
+    let midpointDistance = Infinity;
+    let pointsToRemove;
+    this.axisPoints.forEach((p1) => {
+      this.axisPoints.forEach((p2) => {
+        if (p1 !== p2) {
+          const tempMidpoint = {
+            x: (p1.x + p2.x) / 2,
+            y: (p1.y + p2.y) / 2
+          };
+          const distanceFromLabel = this.calculateDistance(tempMidpoint, axisLabel);
+          if (distanceFromLabel < midpointDistance) {
+            midpointDistance = distanceFromLabel;
+            pointsToRemove = [p1, p2];
+          }
+        }
+      });
+    });
+    pointsToRemove.map((point) => {
+      const index = this.axisPoints.indexOf(point);
+      this.axisPoints.splice(index, 1);
+    });
   }
 
   findAxis(points) {
@@ -412,7 +442,7 @@ export default class WorldWideTelescope extends React.Component {
   }
 
   render() {
-    const subjImage = this.props.subject.locations[0]['image/jpeg'];
+    const subjImage = getSubjectLocation(this.props.subject).src;
     const plates = [];
 
     try {

--- a/app/classifier/world-wide-telescope.jsx
+++ b/app/classifier/world-wide-telescope.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import shortid from 'shortid';
 import getSubjectLocation from '../lib/get-subject-location';
 
 class SimplePoint {
@@ -305,7 +304,7 @@ class Plate {
     this.url = url;
     this.imageBounds = this.starChart.bounds();
     const [xRange, yRange] = [this.starChart.xAxis.range, this.starChart.yAxis.range];
-
+    console.log(starChart);
     this.xyCorners = [
       new SimplePoint(xRange[0].x, yRange[0].y), new SimplePoint(xRange[1].x, yRange[0].y),
       new SimplePoint(xRange[1].x, yRange[1].y), new SimplePoint(xRange[0].x, yRange[1].y)
@@ -388,19 +387,11 @@ class Plate {
     return (this.starChart.xAxis.unit === Axis.RA || this.starChart.xAxis.unit === Axis.RA1950 || this.starChart.xAxis.unit === Axis.GLON) ? 180 : 90;
   }
 
-  computeName() {
-    if (this.subject.metadata.Journal) {
-      return this.subject.metadata.Journal;
-    }
-    return (shortid.generate());
-  }
-
   getWwtUrl() {
     const base = 'http://www.worldwidetelescope.org/wwtweb/ShowImage.aspx';
     const rotation = this.computeRotation();
-    const name = this.computeName();
     const center = this.centerCoords();
-    return `${base}?name=${name}&ra=${center.ra}&dec=${center.dec}&x=${center.x}&y=${center.y}&scale=${this.scale()}&rotation=${rotation}&imageurl=${this.getCropUrl()}`;
+    return `${base}?name=${'Zooniverse'}&ra=${center.ra}&dec=${center.dec}&x=${center.x}&y=${center.y}&scale=${this.scale()}&rotation=${rotation}&imageurl=${this.getCropUrl()}`;
   }
 }
 
@@ -462,12 +453,14 @@ export default class WorldWideTelescope extends React.Component {
 
     return (
       <div>
+        {plates.length && (<p>View Your Classification!</p>)}
         {plates.map((plate, idx) => {
           return (
-            <div key={idx}>
-              <p>View Your Classification in the WorldWide Telescope!</p>
-              <img role="presentation" className="chart-image" src={`${plate.getCropUrl()}`} />
-              <a target="_blank" rel="noopener noreferrer" href={plate.getWwtUrl()} className="telescope-button standard-button">World Wide Telescope</a>
+            <div className="worldwide-telescope" key={idx}>
+              <div>
+                <img role="presentation" className="worldwide-telescope__chart-image" src={`${plate.getCropUrl()}`} />
+              </div>
+              <a target="_blank" rel="noopener noreferrer" href={plate.getWwtUrl()} className="standard-button">World Wide Telescope</a>
             </div>
           );
         })}

--- a/app/classifier/world-wide-telescope.jsx
+++ b/app/classifier/world-wide-telescope.jsx
@@ -304,7 +304,6 @@ class Plate {
     this.url = url;
     this.imageBounds = this.starChart.bounds();
     const [xRange, yRange] = [this.starChart.xAxis.range, this.starChart.yAxis.range];
-    console.log(starChart);
     this.xyCorners = [
       new SimplePoint(xRange[0].x, yRange[0].y), new SimplePoint(xRange[1].x, yRange[0].y),
       new SimplePoint(xRange[1].x, yRange[1].y), new SimplePoint(xRange[0].x, yRange[1].y)

--- a/app/classifier/world-wide-telescope.spec.js
+++ b/app/classifier/world-wide-telescope.spec.js
@@ -1,10 +1,11 @@
 import React from 'react';
 import assert from 'assert';
 import WorldWideTelescope from './world-wide-telescope';
-import { shallow, mount } from 'enzyme';
+import { shallow } from 'enzyme';
 
 const testSubject = {
-  locations: [{ 'image/jpeg': 'http://www.image.com' }]
+  locations: [{ 'image/jpeg': 'http://www.image.com' }],
+  metadata: {}
 };
 
 const incompleteAnnotations = [
@@ -123,12 +124,12 @@ const testWorkflow = {
 
 describe('WorldWideTelescope render without incomplete annotations', function () {
   it('will render an empty div with no annotations', function() {
-    const page = mount(<WorldWideTelescope subject={testSubject} />);
+    const page = shallow(<WorldWideTelescope subject={testSubject} />);
     assert.equal(page.find('div').children().length, 0)
   });
 
   it('will render an empty div with incomplete annotations', function() {
-    const page = mount(<WorldWideTelescope subject={testSubject} workflow={testWorkflow} annotations={incompleteAnnotations} />);
+    const page = shallow(<WorldWideTelescope subject={testSubject} workflow={testWorkflow} annotations={incompleteAnnotations} />);
     assert.equal(page.find('div').children().length, 0)
   });
 });
@@ -136,8 +137,8 @@ describe('WorldWideTelescope render without incomplete annotations', function ()
 describe('WorldWideTelescope with classification', function() {
   let wrapper;
 
-  beforeEach(function () {
-    wrapper = mount(<WorldWideTelescope subject={testSubject} annotations={testAnnotations} workflow={testWorkflow} />);
+  before(function () {
+    wrapper = shallow(<WorldWideTelescope subject={testSubject} annotations={testAnnotations} workflow={testWorkflow} />);
   });
 
   it('will render a WWT link for each full classification', function() {

--- a/css/world-wide-telescope.styl
+++ b/css/world-wide-telescope.styl
@@ -1,6 +1,14 @@
-.chart-image
-  border-radius: .25em
-  max-height: 3em
+.worldwide-telescope
+  align-items: center
+  display: flex
 
-.telescope-button
-  float: right
+  > div
+    text-align: center
+    width: 5em
+
+  &__chart-image
+    border-radius: .25em
+    distance: block
+    max-height: 4em
+    max-width: 4em
+    vertical-align: middle


### PR DESCRIPTION
Describe your changes.
Astronomy Rewind is launching a workflow soon that uses the WWT. With that, there are a couple changes that were made to the component.

- A hashed string is confusing for the URL title. 'Zooniverse' will suffice
- The WWT button displayed awkwardly and had redundant text
- If possible, use a subject's metadata to find a publication date and determine an epoch
- Any axis point belonging to a unit besides RA/DEC/GLAT/GLON should be tossed out

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)

https://wwt-adjustments.pfe-preview.zooniverse.org/

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?