### PR TITLE
increase workflow request default page_size from 100 to 150

### DIFF
--- a/app/lib/get-workflows-in-order.coffee
+++ b/app/lib/get-workflows-in-order.coffee
@@ -3,7 +3,7 @@ getWorkflowsInOrder = (project, query = {}) ->
 
   # TODO remove default page_size once pagination solution implemented
   unless query?.page_size?
-    query['page_size'] = 100
+    query['page_size'] = 150
 
   project.get('workflows', query).then (workflows) ->
     workflowsByID = {}


### PR DESCRIPTION
Fixes Notes from Nature hitting the maximum workflows requested.

Increase workflow request default page_size from 100 to 150.

History:
1. https://github.com/zooniverse/Panoptes-Front-End/pull/2820
2. https://github.com/zooniverse/Panoptes-Front-End/pull/3144

Organizations will eventually address this issue with NfN, or could do something clever with allowing param for `page_size`, or could expand functionality of paginator to include Show 10 or 50 or 100 or All, but neither of last two options solves issue in all instances, see comments in History #1 above.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? - https://inc-workflow-page-size.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?