### PR TITLE
Fixes 3895 by fixing tools styling on Talk

### DIFF
--- a/css/talk.styl
+++ b/css/talk.styl
@@ -135,7 +135,7 @@ COPY_GREY_LIGHT = #afaeae
       display: block
     .subject-tools
       display: flex
-      justify-content: space-around
+      justify-content: space-between
 
   .tagged-results
     display: flex

--- a/css/talk.styl
+++ b/css/talk.styl
@@ -133,6 +133,9 @@ COPY_GREY_LIGHT = #afaeae
       width: 100%
     @media screen and (max-width: TALK_BREAKPOINT)
       display: block
+    .subject-tools
+      display: flex
+      justify-content: space-around
 
   .tagged-results
     display: flex


### PR DESCRIPTION
Fixes #3895. Adds styles for the subject tools on Talk similar to the styling it has on the classify page.

https://fix-3895.pfe-preview.zooniverse.org/projects/zooniverse/arizona-batwatch/talk/230/368256?env=production

I also checked Gravity Spy and it looks ok there, too. Still needs cross-browser check.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?