### PR TITLE
Reveal Project Social Icons in Lab

### DIFF
--- a/app/lib/social-icons.js
+++ b/app/lib/social-icons.js
@@ -7,7 +7,6 @@ const SOCIAL_ICONS = {
   'reddit.com/': 'reddit',
   'tumblr.com/': 'tumblr',
   'twitter.com/': 'twitter',
-  'vine.com/': 'vine',
   'weibo.com/': 'weibo',
   'wordpress.com/': 'wordpress',
   'youtube.com/': 'youtube'

--- a/app/lib/social-icons.js
+++ b/app/lib/social-icons.js
@@ -1,0 +1,16 @@
+const SOCIAL_ICONS = {
+  'bitbucket.com/': 'bitbucket',
+  'facebook.com/': 'facebook-square',
+  'github.com/': 'github',
+  'pinterest.com/': 'pinterest',
+  'plus.google.com/': 'google-plus',
+  'reddit.com/': 'reddit',
+  'tumblr.com/': 'tumblr',
+  'twitter.com/': 'twitter',
+  'vine.com/': 'vine',
+  'weibo.com/': 'weibo',
+  'wordpress.com/': 'wordpress',
+  'youtube.com/': 'youtube'
+};
+
+export default SOCIAL_ICONS;

--- a/app/pages/lab/external-links-editor.jsx
+++ b/app/pages/lab/external-links-editor.jsx
@@ -95,6 +95,9 @@ export default class ExternalLinksEditor extends React.Component {
         link._key = Math.random();
       }
     }
+    const filterSocial = tableUrls.filter((url) => {
+      return !url.path;
+    });
 
     return (
       <table className="external-links-table">
@@ -106,11 +109,11 @@ export default class ExternalLinksEditor extends React.Component {
         </thead>
         <DragReorderable
           tag="tbody"
-          items={tableUrls}
+          items={filterSocial}
           render={this.renderRow}
           onChange={this.handleLinkReorder}
         />
-      </table>      
+      </table>
     );
   }
 

--- a/app/pages/lab/external-links-editor.jsx
+++ b/app/pages/lab/external-links-editor.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
+import DragReorderable from 'drag-reorderable';
 import AutoSave from '../../components/auto-save.coffee';
 import handleInputChange from '../../lib/handle-input-change.coffee';
-import DragReorderable from 'drag-reorderable';
 
 export default class ExternalLinksEditor extends React.Component {
   constructor(props) {
@@ -17,8 +17,8 @@ export default class ExternalLinksEditor extends React.Component {
     const changes = {
       [`urls.${this.props.project.urls.length}`]: {
         label: 'Example',
-        url: 'https://example.com/',
-      },
+        url: 'https://example.com/'
+      }
     };
     this.props.project.update(changes);
   }
@@ -37,7 +37,7 @@ export default class ExternalLinksEditor extends React.Component {
     if (indexToRemove > -1) {
       urlList.splice(indexToRemove, 1);
       const changes = {
-        urls: urlList,
+        urls: urlList
       };
       this.props.project.update(changes);
       // Remove link is handeld outside of the AutoSave so save directly
@@ -81,7 +81,7 @@ export default class ExternalLinksEditor extends React.Component {
         </AutoSave>
         <td>
           <button type="button" onClick={this.handleRemoveLink.bind(this, link)}>
-            <i className="fa fa-remove"></i>
+            <i className="fa fa-remove" />
           </button>
         </td>
       </tr>
@@ -89,15 +89,12 @@ export default class ExternalLinksEditor extends React.Component {
   }
 
   renderTable(urls) {
-    const tableUrls = [].concat(urls);
+    const tableUrls = urls.filter(url => !url.path);
     for (const link of tableUrls) {
       if (!link._key) {
         link._key = Math.random();
       }
     }
-    const filterSocial = tableUrls.filter((url) => {
-      return !url.path;
-    });
 
     return (
       <table className="external-links-table">
@@ -109,7 +106,7 @@ export default class ExternalLinksEditor extends React.Component {
         </thead>
         <DragReorderable
           tag="tbody"
-          items={filterSocial}
+          items={tableUrls}
           render={this.renderRow}
           onChange={this.handleLinkReorder}
         />
@@ -133,9 +130,13 @@ export default class ExternalLinksEditor extends React.Component {
 }
 
 ExternalLinksEditor.defaultProps = {
-  project: {},
+  project: {}
 };
 
 ExternalLinksEditor.propTypes = {
-  project: React.PropTypes.object.isRequired,
+  project: React.PropTypes.shape({
+    save: React.PropTypes.func,
+    update: React.PropTypes.func,
+    urls: React.PropTypes.array
+  })
 };

--- a/app/pages/lab/external-links-editor.jsx
+++ b/app/pages/lab/external-links-editor.jsx
@@ -24,9 +24,9 @@ export default class ExternalLinksEditor extends React.Component {
   }
 
   handleLinkReorder(newLinkOrder) {
-    const changes = {
-      urls: newLinkOrder,
-    };
+    const socialUrls = this.props.project.urls.filter(url => url.path);
+    const urls = newLinkOrder.concat(socialUrls);
+    const changes = { urls };
     this.props.project.update(changes);
     this.props.project.save();
   }

--- a/app/pages/lab/project-details.cjsx
+++ b/app/pages/lab/project-details.cjsx
@@ -12,6 +12,7 @@ alert = require('../../lib/alert')
 Select = require 'react-select'
 `import CharLimit from '../../components/char-limit';`
 `import ExternalLinksEditor from './external-links-editor';`
+`import SocialLinksEditor from './social-links-editor';`
 `import DisplayNameSlugEditor from '../../partials/display-name-slug-editor';`
 
 MAX_AVATAR_SIZE = 64000
@@ -47,7 +48,7 @@ module.exports = React.createClass
   updateImage: (type) ->
     @props.project.get(type)
       .then (image) =>
-        @setState 
+        @setState
           "#{type}": image
       .catch (error) =>
         console.log error
@@ -192,6 +193,7 @@ module.exports = React.createClass
             External links<br />
             <small className="form-help">Adding an external link will make it appear as a new tab alongside the about, classify, talk, and collect tabs. You can rearrange the displayed order by clicking and dragging on the left gray tab next to each link below.</small>
             <ExternalLinksEditor project={@props.project} />
+            <SocialLinksEditor project={@props.project} />
           </div>
         </div>
       </div>

--- a/app/pages/lab/project-details.cjsx
+++ b/app/pages/lab/project-details.cjsx
@@ -201,8 +201,10 @@ module.exports = React.createClass
             <div className="edit-social-links">
               <h5>Social Links Section</h5>
               <small className="form-help">
-                Adding a social link will apend a media icon at
-                the end of your project menu bar.
+                Adding a social link will append a media icon at
+                the end of your project menu bar. You can rearrange the
+                displayed order by clicking and dragging on the left gray
+                tab next to each link below.
               </small>
               <SocialLinksEditor project={@props.project} />
             </div>

--- a/app/pages/lab/project-details.cjsx
+++ b/app/pages/lab/project-details.cjsx
@@ -191,9 +191,21 @@ module.exports = React.createClass
 
           <div>
             External links<br />
-            <small className="form-help">Adding an external link will make it appear as a new tab alongside the about, classify, talk, and collect tabs. You can rearrange the displayed order by clicking and dragging on the left gray tab next to each link below.</small>
+            <small className="form-help">
+              Adding an external link will make it appear as a new tab alongside
+              the about, classify, talk, and collect tabs. You can rearrange the
+              displayed order by clicking and dragging on the left gray tab next
+              to each link below.
+            </small>
             <ExternalLinksEditor project={@props.project} />
-            <SocialLinksEditor project={@props.project} />
+            <div className="edit-social-links">
+              <h5>Social Links Section</h5>
+              <small className="form-help">
+                Adding a social link will apend a media icon at
+                the end of your project menu bar.
+              </small>
+              <SocialLinksEditor project={@props.project} />
+            </div>
           </div>
         </div>
       </div>

--- a/app/pages/lab/social-links-editor.jsx
+++ b/app/pages/lab/social-links-editor.jsx
@@ -82,6 +82,14 @@ export default class SocialLinksEditor extends React.Component {
     }
   }
 
+  handleDisableDrag(event) {
+    event.target.parentElement.parentElement.setAttribute('draggable', false);
+  }
+
+  handleEnableDrag(event) {
+    event.target.parentElement.parentElement.setAttribute('draggable', true);
+  }
+
   indexFinder(toSearch, toFind) { //eslint-disable-line
     return toSearch.findIndex(i => (i.site === toFind));
   }
@@ -99,6 +107,8 @@ export default class SocialLinksEditor extends React.Component {
             name={`urls.${site}.url`}
             value={value}
             onChange={this.handleNewLink.bind(this, site)}
+            onMouseDown={this.handleDisableDrag}
+            onMouseUp={this.handleEnableDrag}
           />
         </AutoSave>
         <td>

--- a/app/pages/lab/social-links-editor.jsx
+++ b/app/pages/lab/social-links-editor.jsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import AutoSave from '../../components/auto-save.coffee';
+import DragReorderable from 'drag-reorderable';
+import SOCIAL_ICONS from '../../lib/social-icons';
+
+export default class SocialLinksEditor extends React.Component {
+  constructor(props) {
+    super(props);
+    this.handleNewLink = this.handleNewLink.bind(this);
+    this.handleLinkReorder = this.handleLinkReorder.bind(this);
+    this.handleRemoveLink = this.handleRemoveLink.bind(this);
+  }
+
+  handleNewLink(site, e) {
+    let index = this.props.project.urls.findIndex(i => (i.site === site));
+    if (index < 0) { index = this.props.project.urls.length; }
+
+    if (e.target.value) {
+      const changes = {
+        [`urls.${index}`]: {
+          label: '',
+          path: e.target.value,
+          site,
+          url: `https://${site}${e.target.value}`
+        }
+      };
+      this.props.project.update(changes);
+    } else {
+      this.handleRemoveLink(site);
+    }
+  }
+
+  handleLinkReorder(newLinkOrder) {
+    const changes = {
+      urls: newLinkOrder
+    };
+    this.props.project.update(changes);
+    this.props.project.save();
+  }
+
+  handleRemoveLink(linkToRemove) {
+    const urls = this.props.project.urls.slice();
+    const indexToRemove = urls.findIndex(i => (i.site === linkToRemove));
+    if (indexToRemove > -1) {
+      urls.splice(indexToRemove, 1);
+      this.props.project.update({ urls }).save();
+    }
+  }
+
+  handleDisableDrag(event) {
+    event.target.parentElement.parentElement.setAttribute('draggable', false);
+  }
+
+  handleEnableDrag(event) {
+    event.target.parentElement.parentElement.setAttribute('draggable', true);
+  }
+
+  render() {
+    return (
+      <div>
+        <h5>Social Links Section</h5>
+        <small className="form-help">
+          Adding a social link will apend a media icon at
+          the end of your project menu bar.
+        </small>
+        {Object.keys(SOCIAL_ICONS).map((site, index) => {
+          let value = '';
+          this.props.project.urls.forEach((item) => {
+            if (item.site === site) {
+              value = item.path;
+            }
+          });
+          return (
+            <tr key={index}>
+              <td>
+                {site}
+              </td>
+              <AutoSave tag="td" resource={this.props.project}>
+                <input
+                  type="text"
+                  name={`urls.${site}.url`}
+                  value={value}
+                  onChange={this.handleNewLink.bind(this, site)}
+                  onMouseDown={this.handleDisableDrag}
+                  onMouseUp={this.handleEnableDrag}
+                />
+              </AutoSave>
+              <td>
+                <button type="button" onClick={this.handleRemoveLink.bind(this, site)}>
+                  <i className="fa fa-remove" />
+                </button>
+              </td>
+            </tr>
+          );
+        })}
+      </div>
+    );
+  }
+}
+
+SocialLinksEditor.defaultProps = {
+  project: {}
+};
+
+SocialLinksEditor.propTypes = {
+  project: React.PropTypes.shape({
+    save: React.PropTypes.func,
+    update: React.PropTypes.func,
+    urls: React.PropTypes.array
+  })
+};

--- a/app/pages/lab/social-links-editor.jsx
+++ b/app/pages/lab/social-links-editor.jsx
@@ -1,18 +1,40 @@
 import React from 'react';
-import AutoSave from '../../components/auto-save.coffee';
 import DragReorderable from 'drag-reorderable';
+import AutoSave from '../../components/auto-save.coffee';
 import SOCIAL_ICONS from '../../lib/social-icons';
 
 export default class SocialLinksEditor extends React.Component {
   constructor(props) {
     super(props);
+    const socialOrder = Object.keys(SOCIAL_ICONS).map(key => key);
+    this.state = {
+      socialOrder
+    };
+    this.reorderDefault = this.reorderDefault.bind(this);
     this.handleNewLink = this.handleNewLink.bind(this);
     this.handleLinkReorder = this.handleLinkReorder.bind(this);
     this.handleRemoveLink = this.handleRemoveLink.bind(this);
+    this.renderRow = this.renderRow.bind(this);
+  }
+
+  componentDidMount() {
+    this.reorderDefault();
+  }
+
+  reorderDefault() {
+    const socialUrls = this.props.project.urls.filter(url => url.path);
+    const newOrder = [];
+    socialUrls.map(link => newOrder.push(link.site));
+    this.state.socialOrder.map((item) => {
+      if (newOrder.indexOf(item) < 0) {
+        newOrder.push(item);
+      }
+    });
+    this.setState({ socialOrder: newOrder });
   }
 
   handleNewLink(site, e) {
-    let index = this.props.project.urls.findIndex(i => (i.site === site));
+    let index = this.indexFinder(this.props.project.urls, site);
     if (index < 0) { index = this.props.project.urls.length; }
 
     if (e.target.value) {
@@ -31,69 +53,73 @@ export default class SocialLinksEditor extends React.Component {
   }
 
   handleLinkReorder(newLinkOrder) {
-    const changes = {
-      urls: newLinkOrder
-    };
-    this.props.project.update(changes);
-    this.props.project.save();
+    const socialUrls = [];
+    const urls = this.props.project.urls.slice();
+    let index = urls.length - 1;
+    while (index >= 0) {
+      if (urls[index].path) {
+        socialUrls.push(urls.splice(index, 1)[0]);
+      }
+      index -= 1;
+    }
+    newLinkOrder.map((item) => {
+      const urlIndex = this.indexFinder(socialUrls, item);
+      if (urlIndex >= 0) {
+        urls.push(socialUrls[urlIndex]);
+      }
+    });
+    const changes = { urls };
+    this.props.project.update(changes).save();
+    this.setState({ socialOrder: newLinkOrder });
   }
 
   handleRemoveLink(linkToRemove) {
     const urls = this.props.project.urls.slice();
-    const indexToRemove = urls.findIndex(i => (i.site === linkToRemove));
+    const indexToRemove = this.indexFinder(urls, linkToRemove);
     if (indexToRemove > -1) {
       urls.splice(indexToRemove, 1);
       this.props.project.update({ urls }).save();
     }
   }
 
-  handleDisableDrag(event) {
-    event.target.parentElement.parentElement.setAttribute('draggable', false);
+  indexFinder(toSearch, toFind) { //eslint-disable-line
+    return toSearch.findIndex(i => (i.site === toFind));
   }
 
-  handleEnableDrag(event) {
-    event.target.parentElement.parentElement.setAttribute('draggable', true);
+  renderRow(site, i) {
+    const index = this.indexFinder(this.props.project.urls, site);
+    const value = index >= 0 ? this.props.project.urls[index].path : '';
+
+    return (
+      <tr key={i}>
+        <td>{site}</td>
+        <AutoSave tag="td" resource={this.props.project}>
+          <input
+            type="text"
+            name={`urls.${site}.url`}
+            value={value}
+            onChange={this.handleNewLink.bind(this, site)}
+          />
+        </AutoSave>
+        <td>
+          <button type="button" onClick={this.handleRemoveLink.bind(this, site)}>
+            <i className="fa fa-remove" />
+          </button>
+        </td>
+      </tr>
+    );
   }
 
   render() {
     return (
-      <div>
-        <h5>Social Links Section</h5>
-        <small className="form-help">
-          Adding a social link will apend a media icon at
-          the end of your project menu bar.
-        </small>
-        {Object.keys(SOCIAL_ICONS).map((site, index) => {
-          let value = '';
-          this.props.project.urls.forEach((item) => {
-            if (item.site === site) {
-              value = item.path;
-            }
-          });
-          return (
-            <tr key={index}>
-              <td>
-                {site}
-              </td>
-              <AutoSave tag="td" resource={this.props.project}>
-                <input
-                  type="text"
-                  name={`urls.${site}.url`}
-                  value={value}
-                  onChange={this.handleNewLink.bind(this, site)}
-                  onMouseDown={this.handleDisableDrag}
-                  onMouseUp={this.handleEnableDrag}
-                />
-              </AutoSave>
-              <td>
-                <button type="button" onClick={this.handleRemoveLink.bind(this, site)}>
-                  <i className="fa fa-remove" />
-                </button>
-              </td>
-            </tr>
-          );
-        })}
-      </div>
+      <table className="edit-social-links">
+        <DragReorderable
+          tag="tbody"
+          items={this.state.socialOrder}
+          render={this.renderRow}
+          onChange={this.handleLinkReorder}
+        />
+      </table>
     );
   }
 }

--- a/app/pages/lab/social-links-editor.jsx
+++ b/app/pages/lab/social-links-editor.jsx
@@ -53,22 +53,10 @@ export default class SocialLinksEditor extends React.Component {
   }
 
   handleLinkReorder(newLinkOrder) {
-    const socialUrls = [];
-    const urls = this.props.project.urls.slice();
-    let index = urls.length - 1;
-    while (index >= 0) {
-      if (urls[index].path) {
-        socialUrls.push(urls.splice(index, 1)[0]);
-      }
-      index -= 1;
-    }
-    newLinkOrder.map((item) => {
-      const urlIndex = this.indexFinder(socialUrls, item);
-      if (urlIndex >= 0) {
-        urls.push(socialUrls[urlIndex]);
-      }
-    });
-    const changes = { urls };
+    const externalUrls = this.props.project.urls.filter(url => !url.path);
+    const socialUrls = this.props.project.urls.filter(url => url.path);
+    const newSocialUrls = socialUrls.sort((a, b) => newLinkOrder.indexOf(a.site) - newLinkOrder.indexOf(b.site));
+    const changes = { urls: externalUrls.concat(newSocialUrls) };
     this.props.project.update(changes).save();
     this.setState({ socialOrder: newLinkOrder });
   }
@@ -90,7 +78,7 @@ export default class SocialLinksEditor extends React.Component {
     event.target.parentElement.parentElement.setAttribute('draggable', true);
   }
 
-  indexFinder(toSearch, toFind) { //eslint-disable-line
+  indexFinder(toSearch, toFind) {
     return toSearch.findIndex(i => (i.site === toFind));
   }
 

--- a/app/pages/lab/social-links-editor.spec.js
+++ b/app/pages/lab/social-links-editor.spec.js
@@ -1,0 +1,57 @@
+import React from 'react';
+import assert from 'assert';
+import { shallow, mount } from 'enzyme';
+import sinon from 'sinon';
+import SocialLinksEditor from './social-links-editor';
+
+const testProject = {
+  urls: [
+    {
+      label: 'Example1',
+      url: 'https://example.com/1'
+    },
+    {
+      label: '',
+      url: 'https://facebook.com/2',
+      site: 'facebook.com/',
+      path: 'test'
+    }
+  ],
+  save: () => {},
+  update: () => {}
+};
+
+describe('SocialLinksEditor', () => {
+  let wrapper;
+
+  it('should render without crashing', () => {
+    shallow(<SocialLinksEditor project={testProject} />);
+  });
+
+  before(function () {
+    wrapper = mount(<SocialLinksEditor project={testProject} />);
+  });
+
+  it('should contain the correct number of rows', () => {
+    const rows = wrapper.find('tr');
+    assert.equal(rows.length, 11);
+  });
+
+  it('should rearrange the default social links on load', () => {
+    const rearrangedLinks = wrapper.state().socialOrder;
+    assert.equal(rearrangedLinks[0], 'facebook.com/');
+  });
+
+  it('should correctly display paths', () => {
+    const input = wrapper.find('input').first();
+    assert.equal(input.props().value, 'test');
+  });
+
+  it('should call handleRemoveLink() when link is removed', () => {
+    const removeStub = sinon.stub(wrapper.instance(), 'handleRemoveLink');
+    const button = wrapper.find('button').first();
+    wrapper.update();
+    button.simulate('click');
+    sinon.assert.calledOnce(removeStub);
+  });
+});

--- a/app/pages/project/project-page.cjsx
+++ b/app/pages/project/project-page.cjsx
@@ -7,6 +7,7 @@ Translate = require 'react-translate-component'
 Thumbnail = require('../../components/thumbnail').default
 classnames = require 'classnames'
 PotentialFieldGuide = require './potential-field-guide'
+`import SOCIAL_ICONS from '../../lib/social-icons'`
 
 counterpart.registerTranslations 'en',
   project:
@@ -17,21 +18,6 @@ counterpart.registerTranslations 'en',
       classify: 'Classify'
       talk: 'Talk'
       collections: 'Collect'
-
-SOCIAL_ICONS =
-  'bitbucket.com/': 'bitbucket'
-  'facebook.com/': 'facebook-square'
-  'github.com/': 'github'
-  'pinterest.com/': 'pinterest'
-  'plus.google.com/': 'google-plus'
-  'reddit.com/': 'reddit'
-  'tumblr.com/': 'tumblr'
-  'twitter.com/': 'twitter'
-  'vine.com/': 'vine'
-  'weibo.com/': 'weibo'
-  'wordpress.com/': 'wordpress'
-  'youtu.be/': 'youtube'
-  'youtube.com/': 'youtube'
 
 AVATAR_SIZE = 100
 
@@ -109,6 +95,7 @@ ProjectPage = React.createClass
       @props.project.display_name
 
   render: ->
+    rearrangedLinks = @props.project.urls.sort (a, b) => a.path isnt b.path? 0 : a.path? -1 : 1
     betaApproved = @props.project.beta_approved
     projectPath = "/projects/#{@props.project.slug}"
     onHomePage = @props.routes[2].path is undefined
@@ -182,7 +169,7 @@ ProjectPage = React.createClass
           <Translate content="project.nav.collections" />
         </Link>
 
-        {@props.project.urls.map ({label, url}, i) =>
+        {rearrangedLinks.map ({label, url}, i) =>
           unless !!label
             for pattern, icon of SOCIAL_ICONS
               if url.indexOf(pattern) isnt -1

--- a/app/pages/project/project-page.cjsx
+++ b/app/pages/project/project-page.cjsx
@@ -95,7 +95,7 @@ ProjectPage = React.createClass
       @props.project.display_name
 
   render: ->
-    rearrangedLinks = @props.project.urls.sort (a, b) => a.path isnt b.path? 0 : a.path? -1 : 1
+    rearrangedLinks = @props.project.urls.sort (a, b) => a.path? & !b.path? ? 1 : 0
     betaApproved = @props.project.beta_approved
     projectPath = "/projects/#{@props.project.slug}"
     onHomePage = @props.routes[2].path is undefined

--- a/app/pages/project/project-page.cjsx
+++ b/app/pages/project/project-page.cjsx
@@ -176,7 +176,7 @@ ProjectPage = React.createClass
                 iconForLabel = icon
             iconForLabel ?= 'globe'
             label = <i className="fa fa-#{iconForLabel} fa-fw fa-2x"></i>
-          <a key={i} href={url} className="tabbed-content-tab" target="#{@props.project.id}#{url}">{label}</a>}
+          <a key={i} href={url} className="tabbed-content-tab #{if iconForLabel then 'social-icon' else ''}" target="#{@props.project.id}#{url}">{label}</a>}
       </nav>
 
       {if !!@props.project.configuration?.announcement

--- a/css/lab.styl
+++ b/css/lab.styl
@@ -80,11 +80,14 @@
       padding: 0 10px
       color: ALERT_COLOR
 
-.external-links-table
+.external-links-table, .edit-social-links
   >.drag-reorderable
     > [draggable]
       >td:first-of-type
         border-left: 1ch solid rgba(gray, 0.2)
+
+.edit-social-links
+  margin: 1em 0
 
 .disabled-section
   pointer-events: none

--- a/css/tabbed-content.styl
+++ b/css/tabbed-content.styl
@@ -64,3 +64,6 @@
   &.active
     border-bottom-color: TEAL_MID
     font-weight: bold
+
+  &.social-icon
+    padding: 0.5em

--- a/test/setup.js
+++ b/test/setup.js
@@ -13,3 +13,4 @@ Object.keys(document.defaultView).forEach((property) => {
 global.navigator = {
   userAgent: 'node.js'
 };
+global.document.documentElement.dataset = {};


### PR DESCRIPTION
Fixes #489 

Describe your changes.
This adds a social links editor to the project lab page. More info. can be found in the issue.

This proved to be a bit trickier than I first suspected, since a projects external links and social links are both contained in the same `project.urls` array, and I had to find a way to identify, edit, and separate a project's social links from regular external links. 

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)

https://reveal-social-icons.pfe-preview.zooniverse.org/

## Optional

- [x] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?