### PR TITLE
Reworked workflows lab page to toggle between reorder and list views

### DIFF
--- a/app/pages/lab/subject-sets.jsx
+++ b/app/pages/lab/subject-sets.jsx
@@ -8,7 +8,7 @@ const SubjectSetsPage = (props) => {
 
   return (
     <div>
-      <header className="form-label">Subject sets</header>
+      <h1 className="form-label">Subject sets</h1>
       <p>
         Subject sets are a group of data presented to volunteers in a project.
       </p>

--- a/app/pages/lab/workflows-container.jsx
+++ b/app/pages/lab/workflows-container.jsx
@@ -21,7 +21,8 @@ export default class WorkflowsContainer extends React.Component {
   }
 
   componentDidMount() {
-    this.getWorkflowList();
+    const page = (this.props.location && this.props.location.query) ? this.props.location.query.page : 1;
+    this.getWorkflowList(page);
   }
 
   onPageChange(page) {
@@ -33,8 +34,9 @@ export default class WorkflowsContainer extends React.Component {
     this.getWorkflowList(page);
   }
 
-  getWorkflowList(page = 1) {
+  getWorkflowList(page) {
     if (this.state.reorder) {
+      this.context.router.push({ pathname: this.props.location.pathname, query: null });
       getWorkflowsInOrder(this.props.project, { fields: 'display_name', page_size: this.props.project.links.workflows.length })
       .then((workflows) => {
         this.setState({ workflows, loading: false });
@@ -80,7 +82,7 @@ export default class WorkflowsContainer extends React.Component {
   }
 
   toggleReorder() {
-    this.setState((prevState) => { return { reorder: !prevState.reorder }; });
+    this.setState((prevState) => { return { reorder: !prevState.reorder }; }, this.getWorkflowList);
   }
 
   render() {
@@ -90,6 +92,7 @@ export default class WorkflowsContainer extends React.Component {
       handleWorkflowReorder: this.handleWorkflowReorder,
       showCreateWorkflow: this.showCreateWorkflow,
       labPath: this.labPath,
+      onPageChange: this.onPageChange,
       toggleReorder: this.toggleReorder
     };
 

--- a/app/pages/lab/workflows.jsx
+++ b/app/pages/lab/workflows.jsx
@@ -42,6 +42,7 @@ const WorkflowsPage = (props) => {
           <ul className="nav-list">
             {props.workflows.map(workflow => renderWorkflow(workflow))}
           </ul>
+          <hr />
           <Paginator
             className="talk"
             page={meta.page}

--- a/app/pages/lab/workflows.jsx
+++ b/app/pages/lab/workflows.jsx
@@ -4,6 +4,7 @@ import DragReorderable from 'drag-reorderable';
 import ModalFormDialog from 'modal-form/dialog';
 import WorkflowCreateForm from './workflow-create-form';
 import LoadingIndicator from '../../components/loading-indicator';
+import Paginator from '../../talk/lib/paginator';
 
 const WorkflowsPage = (props) => {
   const renderWorkflow = ((workflow) => {
@@ -19,23 +20,46 @@ const WorkflowsPage = (props) => {
     );
   });
 
+  const reorderButton = props.reorder ?
+    <button type="button" data-button="reorderWorkflow" onClick={props.toggleReorder}>List view</button> :
+    <button type="button" data-button="reorderWorkflow" onClick={props.toggleReorder}>Reorder view</button>;
+  const meta = props.workflows.length ? props.workflows[0].getMeta() : {};
+
   return (
     <div>
-      <header className="form-label">Workflows</header>
+      <h1 className="form-label">Workflows</h1>
 
       <p>A workflow is the sequence of tasks that you’re asking volunteers to perform.</p>
-      <p> An asterisk (*) denotes a default workflow. </p>
-      <p> If you have multiple workflows you can rearrange the order in which they are listed on your project's front page by clicking and dragging on the left gray tab next to each workflow title listed below. </p>
+      <p>An asterisk (*) denotes a default workflow.</p>
+      <p>If you have multiple workflows you can rearrange the order in which they are listed on your project's front page by clicking the reorder view button and then clicking and dragging on the left gray tab next to each workflow title listed below.</p>
+      <p>{reorderButton}</p>
+      
+      {props.reorder &&
+        <DragReorderable tag="ul" className="nav-list" items={props.workflows} render={renderWorkflow} onChange={props.handleWorkflowReorder} />}
 
-      <DragReorderable tag="ul" className="nav-list" items={props.workflows} render={renderWorkflow} onChange={props.handleWorkflowReorder} />
+      {(!props.reorder && props.workflows.length > 0) &&
+        <div>
+          <ul className="nav-list">
+            {props.workflows.map(workflow => renderWorkflow(workflow))}
+          </ul>
+          <Paginator
+            className="talk"
+            page={meta.page}
+            onPageChange={props.onPageChange}
+            pageCount={meta.page_count}
+          />
+        </div>}
 
       {(props.workflows.length === 0 && props.loading === false) && (
         <p>No workflows are currently associated with this project.</p>
       )}
 
-      <div className="nav-list-item">
+      <hr />
+
+      <div>
         <button
           type="button"
+          data-button="createWorkflow"
           onClick={props.showCreateWorkflow}
           disabled={props.workflowCreationInProgress}
         >
@@ -74,12 +98,15 @@ WorkflowsPage.propTypes = {
   handleWorkflowReorder: React.PropTypes.func,
   labPath: React.PropTypes.func,
   loading: React.PropTypes.bool,
+  onPageChange: React.PropTypes.func,
   project: React.PropTypes.shape({
     configuration: React.PropTypes.object,
     id: React.PropTypes.string,
     live: React.PropTypes.bool
   }),
+  reorder: React.PropTypes.bool,
   showCreateWorkflow: React.PropTypes.func,
+  toggleReorder: React.PropTypes.func,
   workflows: React.PropTypes.arrayOf(React.PropTypes.object),
   workflowActions: React.PropTypes.shape({
     createWorkflowForProject: React.PropTypes.func

--- a/app/pages/lab/workflows.jsx
+++ b/app/pages/lab/workflows.jsx
@@ -44,7 +44,6 @@ const WorkflowsPage = (props) => {
           </ul>
           <hr />
           <Paginator
-            className="talk"
             page={meta.page}
             onPageChange={props.onPageChange}
             pageCount={meta.page_count}

--- a/app/pages/lab/workflows.spec.js
+++ b/app/pages/lab/workflows.spec.js
@@ -19,7 +19,9 @@ const project = {
 
 describe('WorkflowsPage', function () {
   let wrapper;
-  const newWorkflow = sinon.spy();
+  let reorderWorkflowButton;
+  const showCreateWorkflowSpy = sinon.spy();
+  const toggleReorderSpy = sinon.spy();
 
   before(function () {
     wrapper = shallow(
@@ -27,10 +29,12 @@ describe('WorkflowsPage', function () {
         labPath={(url) => { return url; }}
         handleWorkflowReorder={() => {}}
         project={project}
-        showCreateWorkflow={newWorkflow}
+        showCreateWorkflow={showCreateWorkflowSpy}
+        toggleReorder={toggleReorderSpy}
       />
     );
     wrapper.setProps({ loading: false });
+    reorderWorkflowButton = wrapper.find('[data-button="reorderWorkflow"]');
   });
 
   it('will display a message when no workflows are present', function () {
@@ -40,11 +44,35 @@ describe('WorkflowsPage', function () {
 
   it('will display the correct amount of workflows', function () {
     wrapper.setProps({ workflows });
-    assert.equal(wrapper.find('DragReorderable').render().find('li').length, 2);
+    assert.equal(wrapper.find('.nav-list li').length, 2);
   });
 
   it('should call the workflow create handler', function () {
-    wrapper.find('button').simulate('click');
-    sinon.assert.called(newWorkflow);
+    wrapper.find('[data-button="createWorkflow"]').simulate('click');
+    sinon.assert.calledOnce(showCreateWorkflowSpy);
+  });
+
+  it('should default render the list view', function() {
+    assert.equal(wrapper.find('Paginator').length, 1);
+    assert.equal(reorderWorkflowButton.text(), 'Reorder view');
+  });
+
+  it('should call the toggleReorder handler', function() {
+    reorderWorkflowButton.simulate('click');
+    sinon.assert.calledOnce(toggleReorderSpy);
+  });
+
+  it('should render the reorderable view after toggled', function() {
+    wrapper.setProps({ reorder: true });
+    assert.equal(wrapper.find('DragReorderable').length, 1);
+    assert.equal(wrapper.find('[data-button="reorderWorkflow"]').text(), 'List view');
+  });
+
+  it('should re-render the list view when list view button is clicked', function() {
+    reorderWorkflowButton.simulate('click');
+    sinon.assert.calledTwice(toggleReorderSpy);
+    wrapper.setProps({ reorder: false });
+    assert.equal(wrapper.find('Paginator').length, 1);
+    assert.equal(reorderWorkflowButton.text(), 'Reorder view');
   });
 });

--- a/css/common.styl
+++ b/css/common.styl
@@ -36,6 +36,18 @@ MINI_COURSE_BLUE = #468ee5
 
 PROJECT_SUBMENU_BLUE = #153D84
 
+NOTIFICATION_BACKGROUND = #fafafa
+TALK_BACKGROUND = #f7f7f7
+TALK_BORDER = #F2F1F1
+TALK_BORDER_RADIUS = 6px
+TALK_PADDING = 5px
+TALK_MARGIN = 10px auto
+TALK_BREAKPOINT = 670px
+
+COPY_GREY_DARK = #404040
+COPY_GREY_MID = #898989
+COPY_GREY_LIGHT = #afaeae
+
 background-stripes(color1, color2, size)
   background-image: linear-gradient(
     45deg,

--- a/css/paginator.styl
+++ b/css/paginator.styl
@@ -1,28 +1,39 @@
 .paginator
+  opacity: 0.97
   text-align: center
 
   > button
-    margin: 5px
+    @extends $reset-button
+    border: solid thin TALK_BORDER
+    border-radius: 6px
+    font-size: 0.8em
+    padding: 0.2em 0.4em
+    margin: 2.5px
 
   .paginator-page-selector
     display: inline-block
     margin: 0 0.25em
 
     > select, > select > option
+      border: 2px solid LIGHT_GREY
+      background: #fff
+      border-radius: TALK_BORDER_RADIUS
       color: black
+      font-size: 0.8em
+      padding: 0.2em
 
-  .paginator-prev
+  .paginator-prev, .paginator-first
     background: none
     color: FOREGROUND
-    &:hover
-      background: ALERT_COLOR
+    &:hover, &:focus
+      background: MAIN_HIGHLIGHT
       color: #fff
-      border-color: darken(ALERT_COLOR, 10%)
+      border-color: darken(TALK_BORDER, 10%)
 
-  .paginator-next
+  .paginator-next, .paginator-last
     background: none
     color: FOREGROUND
-    &:hover
-      background: SUCCESS
+    &:hover, &:focus
+      background: MAIN_HIGHLIGHT
       color: #fff
-      border-color: darken(SUCCESS, 10%)
+      border-color: darken(TALK_BORDER, 10%)

--- a/css/talk.styl
+++ b/css/talk.styl
@@ -1,16 +1,3 @@
-// talk default css rules
-NOTIFICATION_BACKGROUND = #fafafa
-TALK_BACKGROUND = #f7f7f7
-TALK_BORDER = #F2F1F1
-TALK_BORDER_RADIUS = 6px
-TALK_PADDING = 5px
-TALK_MARGIN = 10px auto
-TALK_BREAKPOINT = 670px
-
-COPY_GREY_DARK = #404040
-COPY_GREY_MID = #898989
-COPY_GREY_LIGHT = #afaeae
-
 .talk-module // shared styles among talk box shaped things
   background: TALK_BACKGROUND
   border-radius: TALK_BORDER_RADIUS


### PR DESCRIPTION
For #3904.

I've add a button to toggle between a default list view with pagination and a view that uses `DragReorderable`. I've updated the tests to reflect the UI changes. This needs to be checked to see if it works for Notes from Nature.

https://reworked-workflows-ui.pfe-preview.zooniverse.org/

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?