### PR TITLE
use /help instead of /lab-how-to in markdown

### DIFF
--- a/app/pages/lab/landing-page.cjsx
+++ b/app/pages/lab/landing-page.cjsx
@@ -10,7 +10,7 @@ LoginDialog = require '../../partials/login-dialog'
 counterpart.registerTranslations 'en',
   labLanding:
     title: "Zooniverse Project Builder"
-    content: "Anyone can build a Zooniverse project. Just upload your data and choose the tasks you want the volunteers to do. To find out more, read our [How to Build a Project documentation](/lab-how-to), or click the button below to get started."
+    content: "Anyone can build a Zooniverse project. Just upload your data and choose the tasks you want the volunteers to do. To find out more, read our [How to Build a Project documentation](/help), or click the button below to get started."
     buttons:
       getStarted: "Get started!"
       signIn: "Sign in"


### PR DESCRIPTION
Fixes #3900. 

**Describe your changes.**
In labLanding.content, I changed `/lab-how-to` to `/help`. I think the way markdown renders the link bypasses the routes setup in `router.cjsx`. Linking to `/help` in `labLanding.content` provides users with an active tab of content instead of no content.

# Review Checklist

- [X] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [X] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch? https://fix-3900.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?