### PR TITLE
Lab visibility paginator

### DIFF
--- a/app/main.cjsx
+++ b/app/main.cjsx
@@ -22,8 +22,9 @@ shouldUpdateScroll = (prevRouterProps, routerProps) ->
   pathname = routerProps.location.pathname.split('/')
   isStats = ('stats' in pathname) and ('projects' in pathname)
   isSubjectTalk = ('talk' in pathname) and ('talk' in pathname)
+  isLabVisibility = ('lab' in pathname) and ('visibility' in pathname)
   hashChange = routerProps.location.hash.length
-  if isStats or hashChange or isSubjectTalk
+  if isStats or hashChange or isSubjectTalk or isLabVisibility
     false
   else
     true

--- a/app/pages/lab/visibility.cjsx
+++ b/app/pages/lab/visibility.cjsx
@@ -83,6 +83,7 @@ module.exports = React.createClass
       opacity: 0.7
       pointerEvents: 'none'
 
+
     <div>
       <p className="form-label">Project state and visibility</p>
 
@@ -240,17 +241,16 @@ module.exports = React.createClass
           </table>
         </div>}
 
-      <br/>
+      {if @state.workflows.length > 0
+        meta = @state.workflows[0].getMeta()
 
-      {@state.workflows.length > 0 && (
         <Paginator
-          className="talk"
-          page={@state.workflows[0]._meta.workflows.page}
-          pageCount={@state.workflows[0]._meta.workflows.page_count}
-        />
-      )}
+          className="lab-visibility-paginator"
+          page={meta.page}
+          pageCount={meta.page_count}
+        />}
 
-      <hr/>
+      <hr />
 
       <p className="form-label">Status</p>
       <p className="form-help">In a live project active workflows are available to volunteers and cannot be edited. Inactive workflows can be edited if a project is live or in development.</p>

--- a/app/pages/lab/visibility.cjsx
+++ b/app/pages/lab/visibility.cjsx
@@ -40,6 +40,8 @@ module.exports = React.createClass
       pathname: @props.location.pathname
       query: nextQuery
     @getWorkflowList page
+    .then () =>
+      @workflowList?.scrollIntoView()
 
   getWorkflowList: (page) ->
     @setState { loadingWorkflows: true }
@@ -49,9 +51,6 @@ module.exports = React.createClass
         @setState
           workflows: workflows
           loadingWorkflows: false
-      .then () =>
-        if @props.location?.query?.page?
-          @workflowList?.scrollIntoView()
 
   setRadio: (property, value) ->
     @set property, value

--- a/app/pages/lab/visibility.cjsx
+++ b/app/pages/lab/visibility.cjsx
@@ -1,5 +1,4 @@
 React = require 'react'
-ReactDOM = require 'react-dom'
 apiClient = require 'panoptes-client/lib/api-client'
 WorkflowToggle = require '../../components/workflow-toggle'
 SetToggle = require '../../lib/set-toggle'

--- a/app/pages/lab/visibility.cjsx
+++ b/app/pages/lab/visibility.cjsx
@@ -11,9 +11,12 @@ Paginator = require '../../talk/lib/paginator'
 module.exports = React.createClass
   displayName: 'EditProjectVisibility'
 
+  contextTypes:
+    router: React.PropTypes.object.isRequired
+
   getDefaultProps: ->
     project: null
-    location: query: page: 1
+    # location: query: page: 1
 
   getInitialState: ->
     error: null
@@ -29,11 +32,15 @@ module.exports = React.createClass
   setterProperty: 'project'
 
   componentDidMount: ->
-    @getWorkflowList @props.location.query.page
+    page = if @props.location?.query?.page? then @props.location.query.page else 1
+    @getWorkflowList page
 
-  componentWillReceiveProps: (nextProps) ->
-    if nextProps.location.query.page isnt @props.location.query.page
-      @getWorkflowList nextProps.location.query.page
+  onPageChange: (page) ->
+    nextQuery = Object.assign {}, @props.location.query, { page }
+    @context.router.push
+      pathname: @props.location.pathname
+      query: nextQuery
+    @getWorkflowList page
 
   getWorkflowList: (page = 1) ->
     @setState { loadingWorkflows: true }
@@ -149,7 +156,7 @@ module.exports = React.createClass
 
       <hr/>
 
-      <p className="form-label">Workflow Settings</p>
+      <p className="form-label" id="workflow-list">Workflow Settings</p>
       {if @state.loadingWorkflows is true
         <div className="workflow-status-list">Loading workflows...</div>
       else if @state.workflows.length is 0
@@ -247,6 +254,7 @@ module.exports = React.createClass
         <Paginator
           page={meta.page}
           pageCount={meta.page_count}
+          onPageChange={@onPageChange}
         />}
 
       <hr />

--- a/app/pages/lab/visibility.cjsx
+++ b/app/pages/lab/visibility.cjsx
@@ -16,7 +16,6 @@ module.exports = React.createClass
 
   getDefaultProps: ->
     project: null
-    # location: query: page: 1
 
   getInitialState: ->
     error: null

--- a/app/pages/lab/visibility.cjsx
+++ b/app/pages/lab/visibility.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+ReactDOM = require 'react-dom'
 apiClient = require 'panoptes-client/lib/api-client'
 WorkflowToggle = require '../../components/workflow-toggle'
 SetToggle = require '../../lib/set-toggle'
@@ -40,8 +41,6 @@ module.exports = React.createClass
       pathname: @props.location.pathname
       query: nextQuery
     @getWorkflowList page
-    workflowList = document.getElementById("workflow-list")
-    workflowList?.scrollIntoView()
 
   getWorkflowList: (page) ->
     @setState { loadingWorkflows: true }
@@ -51,6 +50,8 @@ module.exports = React.createClass
         @setState
           workflows: workflows
           loadingWorkflows: false
+      .then () =>
+        @workflowList?.scrollIntoView()
 
   setRadio: (property, value) ->
     @set property, value
@@ -90,7 +91,6 @@ module.exports = React.createClass
     looksDisabled =
       opacity: 0.7
       pointerEvents: 'none'
-
 
     <div>
       <p className="form-label">Project state and visibility</p>
@@ -157,7 +157,7 @@ module.exports = React.createClass
 
       <hr/>
 
-      <p className="form-label" id="workflow-list">Workflow Settings</p>
+      <p className="form-label" ref={ (node) => @workflowList = node }>Workflow Settings</p>
       {if @state.loadingWorkflows is true
         <div className="workflow-status-list">Loading workflows...</div>
       else if @state.workflows.length is 0

--- a/app/pages/lab/visibility.cjsx
+++ b/app/pages/lab/visibility.cjsx
@@ -239,6 +239,9 @@ module.exports = React.createClass
             </tbody>
           </table>
         </div>}
+
+      <br/>
+
       {@state.workflows.length > 0 && (
         <Paginator
           className="talk"
@@ -246,6 +249,9 @@ module.exports = React.createClass
           pageCount={@state.workflows[0]._meta.workflows.page_count}
         />
       )}
+
+      <hr/>
+
       <p className="form-label">Status</p>
       <p className="form-help">In a live project active workflows are available to volunteers and cannot be edited. Inactive workflows can be edited if a project is live or in development.</p>
       <p className="form-help">If an active workflow is the default workflow for the project and is made inactive, then it will be removed as the default workflow.</p>

--- a/app/pages/lab/visibility.cjsx
+++ b/app/pages/lab/visibility.cjsx
@@ -41,8 +41,10 @@ module.exports = React.createClass
       pathname: @props.location.pathname
       query: nextQuery
     @getWorkflowList page
+    workflowList = document.getElementById("workflow-list")
+    workflowList?.scrollIntoView()
 
-  getWorkflowList: (page = 1) ->
+  getWorkflowList: (page) ->
     @setState { loadingWorkflows: true }
     # TODO remove page_size once getWorkflowsInOrder does not override default page_size
     getWorkflowsInOrder(@props.project, { page: page, page_size: 20, fields: 'active,configuration,display_name' })

--- a/app/pages/lab/visibility.cjsx
+++ b/app/pages/lab/visibility.cjsx
@@ -50,7 +50,8 @@ module.exports = React.createClass
           workflows: workflows
           loadingWorkflows: false
       .then () =>
-        @workflowList?.scrollIntoView()
+        if @props.location?.query?.page?
+          @workflowList?.scrollIntoView()
 
   setRadio: (property, value) ->
     @set property, value

--- a/app/pages/lab/visibility.cjsx
+++ b/app/pages/lab/visibility.cjsx
@@ -245,7 +245,7 @@ module.exports = React.createClass
         meta = @state.workflows[0].getMeta()
 
         <Paginator
-          className="lab-visibility-paginator"
+          className="paginator"
           page={meta.page}
           pageCount={meta.page_count}
         />}

--- a/app/pages/lab/visibility.cjsx
+++ b/app/pages/lab/visibility.cjsx
@@ -245,7 +245,6 @@ module.exports = React.createClass
         meta = @state.workflows[0].getMeta()
 
         <Paginator
-          className="paginator"
           page={meta.page}
           pageCount={meta.page_count}
         />}

--- a/css/lab.styl
+++ b/css/lab.styl
@@ -61,44 +61,6 @@
     border: none
     padding: 0
 
-// base styles for lab-visibility-paginator
-.lab-visibility-paginator
-  margin-top: 1em
-  color: #404040
-
-  *
-    box-sizing: border-box
-
-  .button
-  button:not(.link-style)
-    @extend .standard-button
-    background: #f7f7f7
-    border-radius: 6px
-    border: 2px solid #F2F1F1
-    color: COPY
-    padding: 0.2em 0.4em
-    font-size: 0.8em
-    margin: 0
-
-    &:hover
-      color: white
-      border-color: MAIN_HIGHLIGHT
-
-  select
-    border: 2px solid LIGHT_GREY
-    background: #fff
-    border-radius: 6px
-    font-size: 0.8em
-    padding: 0.2em
-
-  button.link-style
-    @extend $reset-button
-    text-decoration: underline
-    color: TEAL_MID
-    &::-moz-focus-inner
-      border: 0
-      padding: 0
-
 .edit-project-talk
   .suggested-tags
     input[type="text"]

--- a/css/lab.styl
+++ b/css/lab.styl
@@ -61,6 +61,44 @@
     border: none
     padding: 0
 
+// base styles for lab-visibility-paginator
+.lab-visibility-paginator
+  margin-top: 1em
+  color: #404040
+
+  *
+    box-sizing: border-box
+
+  .button
+  button:not(.link-style)
+    @extend .standard-button
+    background: #f7f7f7
+    border-radius: 6px
+    border: 2px solid #F2F1F1
+    color: COPY
+    padding: 0.2em 0.4em
+    font-size: 0.8em
+    margin: 0
+
+    &:hover
+      color: white
+      border-color: MAIN_HIGHLIGHT
+
+  select
+    border: 2px solid LIGHT_GREY
+    background: #fff
+    border-radius: 6px
+    font-size: 0.8em
+    padding: 0.2em
+
+  button.link-style
+    @extend $reset-button
+    text-decoration: underline
+    color: TEAL_MID
+    &::-moz-focus-inner
+      border: 0
+      padding: 0
+
 .edit-project-talk
   .suggested-tags
     input[type="text"]


### PR DESCRIPTION
Fixes part of #3904.

Describe your changes.
- Add paginator component for workflows in project builder visibility page.
- Uses page_size of 20. This can be removed when getWorkflowsInOrder does not override the default page_size.

Staged at https://lab-visibility-paginator.pfe-preview.zooniverse.org/lab/1613/visibility

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?