### PR TITLE
Add JSON loader to production webpack config

### DIFF
--- a/webpack.build.js
+++ b/webpack.build.js
@@ -46,7 +46,7 @@ module.exports = {
     ]),
   ],
   resolve: {
-    extensions: ['.js', '.jsx', '.cjsx', '.coffee', '.styl', '.css'],
+    extensions: ['.js', '.jsx', '.json', '.cjsx', '.coffee', '.styl', '.css'],
     modules: ['.', 'node_modules'],
   },
   module: {


### PR DESCRIPTION
Fixes #3917.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?