### PR TITLE
fix project discipline tags

### DIFF
--- a/app/pages/lab/project-details.cjsx
+++ b/app/pages/lab/project-details.cjsx
@@ -55,12 +55,11 @@ module.exports = React.createClass
   splitTags: (kind) ->
     disciplineTagList = []
     otherTagList = []
-    for t in @props.project.tags
-      name = t[1]
-      if name in DISCIPLINE_NAMES
-        disciplineTagList.push name
+    for tag in @props.project.tags
+      if tag in DISCIPLINE_NAMES
+        disciplineTagList.push tag
       else
-        otherTagList.push name
+        otherTagList.push tag
     {disciplineTagList, otherTagList}
 
   researcherOptions: ->


### PR DESCRIPTION
Fixes #3735 #3897 - API now always returns a list of tags, so use the tag, not a part of it.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [X] Did you deploy a staging branch? https://fix-tags-single-letter.pfe-preview.zooniverse.org
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?