### PR TITLE
Use 1 for completeness

### DIFF
--- a/app/pages/project/index.cjsx
+++ b/app/pages/project/index.cjsx
@@ -110,7 +110,7 @@ ProjectPageController = React.createClass
 
           awaitProjectAvatar = apiClient.type('avatars').get(project.links.avatar.id).catch((error) => [])
 
-          awaitProjectCompleteness = Promise.resolve(project.completeness > 0.99)
+          awaitProjectCompleteness = Promise.resolve(project.completeness is 1.0)
 
           awaitProjectRoles = project.get('project_roles', { page_size: 50 }).catch((error) => console.error(error))
 


### PR DESCRIPTION
Fixing for projects that are close to complete but aren't yet actually. Requested fix from slack chat. Uses `project.completeness is 1.0` instead of `project.completeness > 0.99`

https://use-one-for-project-completeness.pfe-preview.zooniverse.org/projects/panthera-research/camera-catalogue?env=production

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?