### PR TITLE
Collections subject adding bug fixes

### DIFF
--- a/app/collections/collection-search.cjsx
+++ b/app/collections/collection-search.cjsx
@@ -6,7 +6,7 @@ module.exports = React.createClass
   displayName: 'CollectionSearch'
 
   propTypes:
-    multi: React.PropTypes.bool
+    multi: React.PropTypes.bool.isRequired
     onChange: React.PropTypes.func
 
   getDefaultProps: ->

--- a/app/collections/collection-search.cjsx
+++ b/app/collections/collection-search.cjsx
@@ -7,17 +7,19 @@ module.exports = React.createClass
 
   propTypes:
     multi: React.PropTypes.bool
-    project: React.PropTypes.object
+    onChange: React.PropTypes.func
 
   getDefaultProps: ->
     multi: false
-    project: null
 
   getInitialState: ->
     collections: []
 
   onChange: (collections) ->
-    @setState {collections}
+    @setState({ collections }, ->
+      if @props.onChange
+        @props.onChange()
+    )
 
   searchCollections: (value) ->
     query =
@@ -28,15 +30,12 @@ module.exports = React.createClass
 
     apiClient.type('collections').get query
       .then (collections) ->
-
-        opts = collections.map (collection) ->
-          {
+        options = collections.map (collection) -> {
             value: collection.id,
             label: collection.display_name,
             collection: collection
           }
-
-        {options: opts}
+        { options }
 
   getSelected: ->
     @state.collections
@@ -52,4 +51,5 @@ module.exports = React.createClass
       searchPromptText="Type to search Collections"
       className="collection-search"
       closeAfterClick={true}
-      loadOptions={@searchCollections} />
+      loadOptions={@searchCollections}
+    />

--- a/app/collections/collections-manager.jsx
+++ b/app/collections/collections-manager.jsx
@@ -1,46 +1,80 @@
 import React from 'react';
 import CollectionsCreateForm from './create-form';
 import CollectionSearch from './collection-search';
+import LoadingIndicator from '../components/loading-indicator';
 
 class CollectionsManager extends React.Component {
   constructor(props) {
     super(props);
 
     this.state = {
+      adding: false,
       collections: [],
-      error: null,
-      hasCollectionSelected: false
+      errors: [],
+      hasCollectionSelected: true
     };
 
     this.addToCollections = this.addToCollections.bind(this);
+    this.onChange = this.onChange.bind(this);
+  }
+
+  onChange() {
+    const collections = this.search.getSelected();
+
+    if (collections.length > 0) {
+      this.setState({ hasCollectionSelected: false });
+    }
   }
 
   addToCollections() {
+    this.setState({ adding: true, errors: [] });
     const collections = this.search.getSelected();
-    if (!(collections.length > 0)) return;
+    if (collections.length === 0) return;
 
-    const promises = collections.map(collection =>
-      collection.collection.addLink('subjects', this.props.subjectIDs)
-    );
+    const promises = collections.map((searchResult) => {
+      const collection = searchResult.collection;
+      const subjectsToAdd = this.props.subjectIDs.filter((id) => {
+        if (!collection.links.subjects.includes(id)) return id;
+      });
+
+      if (subjectsToAdd.length === 0) {
+        const noSubjectsError = [
+          `There are no subjects to add or subjects are already added to ${collection.display_name}.`
+        ];
+        const errors = noSubjectsError.concat(this.state.errors);
+        this.setState({ errors });
+      }
+
+      return collection.addLink('subjects', subjectsToAdd)
+        .catch((error) => {
+          const newError = [`${collection.display_name}: ${error}`];
+          const errors = newError.concat(this.state.errors);
+          this.setState({ errors });
+        });
+    });
 
     Promise.all(promises)
       .then(() => {
-        this.props.onSuccess();
-      }).catch(error => this.setState({ error }));
+        if (this.state.errors.length === 0) this.props.onSuccess();
+        this.setState({ adding: false });
+      }).catch(error => this.setState({ adding: false, errors: [error.toString()] }));
   }
 
   render() {
     return (
       <div className="collections-manager">
-        <h1>Add Subject to Collection</h1>
+        <h1>Add Subject to Collection{' '}{this.state.adding && <LoadingIndicator />}</h1>
 
         <div>
-          {this.state.error &&
-            <div className="form-help error">{this.state.error.toString()}</div>}
+          {this.state.errors.length > 0 &&
+            <ul>
+              {this.state.errors.map((error, i) =>
+                <li key={i} className="form-help error">{error}</li>)}
+            </ul>}
           <CollectionSearch
             ref={(node) => { this.search = node; }}
+            onChange={this.onChange}
             multi={true}
-            project={this.props.project}
           />
           <button
             type="button"

--- a/app/collections/collections-manager.jsx
+++ b/app/collections/collections-manager.jsx
@@ -11,7 +11,7 @@ class CollectionsManager extends React.Component {
       adding: false,
       collections: [],
       errors: [],
-      hasCollectionSelected: true
+      hasCollectionSelected: false
     };
 
     this.addToCollections = this.addToCollections.bind(this);
@@ -22,7 +22,7 @@ class CollectionsManager extends React.Component {
     const collections = this.search.getSelected();
 
     if (collections.length > 0) {
-      this.setState({ hasCollectionSelected: false });
+      this.setState({ hasCollectionSelected: true });
     }
   }
 
@@ -34,7 +34,7 @@ class CollectionsManager extends React.Component {
     const promises = collections.map((searchResult) => {
       const collection = searchResult.collection;
       const subjectsToAdd = this.props.subjectIDs.filter((id) => {
-        if (!collection.links.subjects.includes(id)) return id;
+        return !collection.links.subjects.includes(id);
       });
 
       if (subjectsToAdd.length === 0) {
@@ -63,7 +63,9 @@ class CollectionsManager extends React.Component {
   render() {
     return (
       <div className="collections-manager">
-        <h1>Add Subject to Collection{' '}{this.state.adding && <LoadingIndicator />}</h1>
+        <h2 className="collections-manager__header">
+          Add Subject to Collection{' '}<LoadingIndicator off={!this.state.adding} />
+        </h2>
 
         <div>
           {this.state.errors.length > 0 &&
@@ -79,7 +81,7 @@ class CollectionsManager extends React.Component {
           <button
             type="button"
             className="standard-button search-button"
-            disabled={this.state.hasCollectionSelected}
+            disabled={!this.state.hasCollectionSelected}
             onClick={this.addToCollections}
           >
             Add

--- a/app/collections/collections-manager.spec.js
+++ b/app/collections/collections-manager.spec.js
@@ -28,12 +28,17 @@ describe('<CollectionsManager />', function() {
     assert.equal(wrapper.find('CollectionsCreateForm').length, 1);
   });
 
+  it('should render the loading indicator if it is adding subjects', function() {
+    wrapper.setState({ adding: true });
+    assert.equal(wrapper.find('LoadingIndicator').length, 1);
+  });
+
   it('should not render error messages if there is not one', function() {
     assert.equal(wrapper.find('.error').length, 0);
   });
 
   it('should render error message if there is one', function() {
-    wrapper.setState({ error: 'it broke!' });
+    wrapper.setState({ errors: ['it broke!'] });
     assert.equal(wrapper.find('.error').length, 1);
   });
 

--- a/app/collections/show-list.cjsx
+++ b/app/collections/show-list.cjsx
@@ -10,7 +10,6 @@ alert = require '../lib/alert'
 Paginator = require '../talk/lib/paginator'
 SubjectViewer = require '../components/subject-viewer'
 Loading = require '../components/loading-indicator'
-# CollectionsManager = require './collections-manager'
 `import CollectionsManager from './collections-manager';`
 getSubjectLocation = require('../lib/get-subject-location')
 

--- a/css/collections-page.styl
+++ b/css/collections-page.styl
@@ -256,8 +256,9 @@ $collection-viewer-button
   margin: 1em
   padding: 1em
 
-  h1
+  &__header
     margin-bottom: 20px
+    min-width: 375px
 
   .collection-search
     display: inline-block


### PR DESCRIPTION
Fixes #3821 by preemptively filtering out the ids of the subjects to add array by comparing it to the serialized subjects linked of the collection. This also fixes when the add button is disabled as well as improve the error messaging UI. If all of the selected subjects are already added to the target collection, a clearer message is displayed and the modal doesn't auto-close so the user has a chance to read it.

https://fix-3821.pfe-preview.zooniverse.org/

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?