### PR TITLE
Prevent Publications page crashing on staging

### DIFF
--- a/app/pages/about/publications-page.cjsx
+++ b/app/pages/about/publications-page.cjsx
@@ -66,7 +66,7 @@ module.exports = React.createClass
               <ul key={category} className="publications-list">
                 {for projectListing in projects
                   project = @state.projects[projectListing.slug]
-                  <div key={projectListing.name or project.slug}>
+                  <div key={projectListing.name or projectListing.slug}>
                     <div>
                       <h3 className="project-name">
                         {if project then project.display_name else projectListing.name}


### PR DESCRIPTION
## PR Overview
* Fixes #3931
* On localhost (i.e. when viewing _staging_ data) the Publications page crashes.
* This crash does not occur when viewing zooniverse.org (i.e. when viewing _production_ data)
* This boils down to the fact that the Publications page expects a list of projects from the Panoptes API that's different between staging and production.
* This PR fixes the issue for localhost.

Tagging @mariamsaeedi for the opportunity to review how a PR is constructed.

### Details

In this section of code...
```
67.  {for projectListing in projects
68.    project = @state.projects[projectListing.slug]
69.    <div key={projectListing.name or project.slug}>
```
...there is no guarantee that the `project` variable on line 68 will be defined. `projectListing.slug` will iterate through all the project slugs listed in `app/lib/publications.js`, but there's no guarantee that the keyed array `@state.projects` will have a matching project.

In any case, using `project.slug` without checking if `project` _isn't undefined_ is bad practice, so the solution would be to simply use `projectListing.slug` in its stead, since `projectListing` is almost guaranteed to be an object unless something has gone terribly wrong with `app/lib/publications.js`.

### Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)
