### PR TITLE
Fix a couple of long lines in AudioPlayer for eslint

### DIFF
--- a/app/components/file-viewer/audio-player.jsx
+++ b/app/components/file-viewer/audio-player.jsx
@@ -81,7 +81,14 @@ class AudioPlayer extends React.Component {
   }
 
   renderProgressMarker() {
-    return (<ProgressIndicator progressPosition={this.state.progressPosition} progressRange={[0, this.state.trackDuration]} naturalWidth={100} naturalHeight={100} />);
+    return (
+      <ProgressIndicator
+        progressPosition={this.state.progressPosition}
+        progressRange={[0, this.state.trackDuration]}
+        naturalWidth={100}
+        naturalHeight={100}
+      />
+    );
   }
 
   render() {
@@ -92,7 +99,15 @@ class AudioPlayer extends React.Component {
         <div>
           {this.renderProgressMarker()}
           <div className="audio-image-component">
-            <ImageViewer src={imageSrc} type={this.imageTypeString()} format={this.imageFormatString()} frame={this.props.frame} onLoad={this.props.onLoad} onFocus={this.props.onFocus} onBlur={this.props.onBlur} />
+            <ImageViewer
+              src={imageSrc}
+              type={this.imageTypeString()}
+              format={this.imageFormatString()}
+              frame={this.props.frame}
+              onLoad={this.props.onLoad}
+              onFocus={this.props.onFocus}
+              onBlur={this.props.onBlur}
+            />
           </div>
         </div>
       );
@@ -104,9 +119,15 @@ class AudioPlayer extends React.Component {
         </div>
         <div className="audio-player-component">
           <audio
-            className="subject" controls={true} ref={(element) => {
-              this.player = element;
-            }} src={this.audioSrc()} type={this.audioTypeString()} preload="auto" onCanPlay={this.onAudioLoad.bind(this)} onEnded={this.endAudio} onTimeUpdate={this.updateProgress.bind(this)}
+            className="subject"
+            controls={true}
+            ref={(element) => { this.player = element; }}
+            src={this.audioSrc()}
+            type={this.audioTypeString()}
+            preload="auto"
+            onCanPlay={this.onAudioLoad.bind(this)}
+            onEnded={this.endAudio}
+            onTimeUpdate={this.updateProgress.bind(this)}
           >
             Your browser does not support the audio format. Please upgrade your browser.
           </audio>

--- a/app/components/file-viewer/audio-player.jsx
+++ b/app/components/file-viewer/audio-player.jsx
@@ -8,7 +8,10 @@ class AudioPlayer extends React.Component {
 
     this.player = null;
 
+    this.endAudio = this.endAudio.bind(this);
     this.playAudio = this.playAudio.bind(this);
+    this.onAudioLoad = this.onAudioLoad.bind(this);
+    this.updateProgress = this.updateProgress.bind(this);
 
     this.state = {
       playing: false,
@@ -125,9 +128,9 @@ class AudioPlayer extends React.Component {
             src={this.audioSrc()}
             type={this.audioTypeString()}
             preload="auto"
-            onCanPlay={this.onAudioLoad.bind(this)}
+            onCanPlay={this.onAudioLoad}
             onEnded={this.endAudio}
-            onTimeUpdate={this.updateProgress.bind(this)}
+            onTimeUpdate={this.updateProgress}
           >
             Your browser does not support the audio format. Please upgrade your browser.
           </audio>


### PR DESCRIPTION
Fixes a couple of eslint warnings about long lines

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://audio-player-long-lines.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?