### PR TITLE
Prevent muliple classifications of same choice

### DIFF
--- a/app/classifier/tasks/survey/choice.cjsx
+++ b/app/classifier/tasks/survey/choice.cjsx
@@ -52,7 +52,7 @@ module.exports = React.createClass
     onCancel: Function.prototype
 
   getInitialState: ->
-    answers: {}
+    answers: @props.annotation?.answers || {}
     focusedAnswer: ''
 
   checkFilledIn: ->

--- a/app/classifier/tasks/survey/index.cjsx
+++ b/app/classifier/tasks/survey/index.cjsx
@@ -48,7 +48,8 @@ module.exports = React.createClass
       {if @state.selectedChoiceID is ''
         <Chooser task={@props.task} filters={@state.filters} onFilter={@handleFilter} onChoose={@handleChoice} onRemove={@handleRemove} annotation={@props.annotation} focusedChoice={@state.focusedChoice} />
       else
-        <Choice task={@props.task} choiceID={@state.selectedChoiceID} onSwitch={@handleChoice} onCancel={@clearSelection} onConfirm={@handleAnnotation} />}
+        existingAnnotation = _.find(@props.annotation.value, 'choice', @state.selectedChoiceID) || {}
+        <Choice annotation={existingAnnotation} task={@props.task} choiceID={@state.selectedChoiceID} onSwitch={@handleChoice} onCancel={@clearSelection} onConfirm={@handleAnnotation} />}
     </div>
 
   handleFilter: (characteristicID, valueID) ->
@@ -75,7 +76,7 @@ module.exports = React.createClass
     @setState filters: {}
 
   clearSelection: ->
-    @setState 
+    @setState
       selectedChoiceID: ''
       focusedChoice: @state.selectedChoiceID
     newAnnotation = Object.assign {}, @props.annotation, _choiceInProgress: false


### PR DESCRIPTION
Fixes #3727 .

Describe your changes.
If the selected choice matches an existing one, the latter is passed as a prop to the choice component. 

**Expected behaviour**: see the same choice displayed, same answers, etc. Also classification submitted for same choice should be one.

**Current behviour**: Tested with Western Montana Wildlife: if choice already exists, the existing one is correctly displayed. _However two annotations with the same choice are still submitted in the classification._

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://fix-3727.pfe-preview.zooniverse.org/?env=production
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?