### PR TITLE
Survey task: Prevent multiple classifications of same choice

### DIFF
--- a/app/classifier/tasks/survey/choice.cjsx
+++ b/app/classifier/tasks/survey/choice.cjsx
@@ -45,7 +45,12 @@ module.exports = React.createClass
   displayName: 'Choice'
 
   propTypes:
-    annotation: React.PropTypes.object.isRequired
+    annotation: React.PropTypes.shape({
+      answers: React.PropTypes.object,
+      choice: React.PropTypes.string,
+      filters: React.PropTypes.object
+    })
+
 
   getDefaultProps: ->
     annotation: { answers: {} }
@@ -56,7 +61,7 @@ module.exports = React.createClass
     onCancel: Function.prototype
 
   getInitialState: ->
-    answers: @props.annotation?.answers || {}
+    answers: @props.annotation.answers
     focusedAnswer: ''
 
   checkFilledIn: ->

--- a/app/classifier/tasks/survey/choice.cjsx
+++ b/app/classifier/tasks/survey/choice.cjsx
@@ -44,7 +44,11 @@ ImageFlipper = React.createClass
 module.exports = React.createClass
   displayName: 'Choice'
 
+  propTypes:
+    annotation: React.PropTypes.object.isRequired
+
   getDefaultProps: ->
+    annotation: { answers: {} }
     task: null
     choiceID: ''
     onSwitch: Function.prototype

--- a/app/classifier/tasks/survey/choice.cjsx
+++ b/app/classifier/tasks/survey/choice.cjsx
@@ -45,15 +45,14 @@ module.exports = React.createClass
   displayName: 'Choice'
 
   propTypes:
-    annotation: React.PropTypes.shape({
+    annotationValue: React.PropTypes.shape({
       answers: React.PropTypes.object,
       choice: React.PropTypes.string,
       filters: React.PropTypes.object
     })
 
-
   getDefaultProps: ->
-    annotation: { answers: {} }
+    annotationValue: { answers: {} }
     task: null
     choiceID: ''
     onSwitch: Function.prototype
@@ -61,7 +60,7 @@ module.exports = React.createClass
     onCancel: Function.prototype
 
   getInitialState: ->
-    answers: @props.annotation.answers
+    answers: @props.annotationValue.answers
     focusedAnswer: ''
 
   checkFilledIn: ->

--- a/app/classifier/tasks/survey/choice.cjsx
+++ b/app/classifier/tasks/survey/choice.cjsx
@@ -52,7 +52,7 @@ module.exports = React.createClass
     onCancel: Function.prototype
 
   getInitialState: ->
-    answers: {}
+    answers: @props.annotation?.answers || {}
     focusedAnswer: ''
 
   checkFilledIn: ->

--- a/app/classifier/tasks/survey/index.cjsx
+++ b/app/classifier/tasks/survey/index.cjsx
@@ -50,8 +50,8 @@ module.exports = React.createClass
       else
         # @ is undefined within the scope of find
         currentSelection = @state.selectedChoiceID
-        existingAnnotation = @props.annotation.value.find (value) -> value.choice is currentSelection
-        <Choice annotation={existingAnnotation} task={@props.task} choiceID={@state.selectedChoiceID} onSwitch={@handleChoice} onCancel={@clearSelection} onConfirm={@handleAnnotation} />}
+        existingAnnotationValue = @props.annotation.value.find (value) -> value.choice is currentSelection
+        <Choice annotationValue={existingAnnotationValue} task={@props.task} choiceID={@state.selectedChoiceID} onSwitch={@handleChoice} onCancel={@clearSelection} onConfirm={@handleAnnotation} />}
     </div>
 
   handleFilter: (characteristicID, valueID) ->

--- a/app/classifier/tasks/survey/index.cjsx
+++ b/app/classifier/tasks/survey/index.cjsx
@@ -86,8 +86,7 @@ module.exports = React.createClass
 
   handleAnnotation: (choice, answers, e) ->
     filters = JSON.parse JSON.stringify @state.filters
-    currentSelection = @state.selectedChoiceID
-    value = @props.annotation.value?.filter (value) -> value.choice isnt currentSelection
+    value = @props.annotation.value?.filter (value) -> value.choice isnt choice
     value.push {choice, answers, filters}
     @clearFilters()
     @clearSelection()

--- a/app/classifier/tasks/survey/index.cjsx
+++ b/app/classifier/tasks/survey/index.cjsx
@@ -86,14 +86,9 @@ module.exports = React.createClass
 
   handleAnnotation: (choice, answers, e) ->
     filters = JSON.parse JSON.stringify @state.filters
-    value = @props.annotation.value?.slice?(0) ? []
-    # @ is undefined within the scope of findIndex
     currentSelection = @state.selectedChoiceID
-    annotationIndex = value.findIndex (value) -> value.choice is currentSelection
-    if value[annotationIndex]
-      value[annotationIndex] = @props.annotation.value[annotationIndex]
-    else
-      value.push {choice, answers, filters}
+    value = @props.annotation.value?.filter (value) -> value.choice isnt currentSelection
+    value.push {choice, answers, filters}
     @clearFilters()
     @clearSelection()
     setTimeout => # Wait for filters and selection to clear.

--- a/app/classifier/tasks/survey/index.cjsx
+++ b/app/classifier/tasks/survey/index.cjsx
@@ -50,7 +50,7 @@ module.exports = React.createClass
       else
         # @ is undefined within the scope of find
         currentSelection = @state.selectedChoiceID
-        existingAnnotation = @props.annotation.value.find (value) -> value.choice is currentSelection || {}
+        existingAnnotation = @props.annotation.value.find (value) -> value.choice is currentSelection
         <Choice annotation={existingAnnotation} task={@props.task} choiceID={@state.selectedChoiceID} onSwitch={@handleChoice} onCancel={@clearSelection} onConfirm={@handleAnnotation} />}
     </div>
 

--- a/app/classifier/tasks/survey/index.cjsx
+++ b/app/classifier/tasks/survey/index.cjsx
@@ -48,7 +48,10 @@ module.exports = React.createClass
       {if @state.selectedChoiceID is ''
         <Chooser task={@props.task} filters={@state.filters} onFilter={@handleFilter} onChoose={@handleChoice} onRemove={@handleRemove} annotation={@props.annotation} focusedChoice={@state.focusedChoice} />
       else
-        <Choice task={@props.task} choiceID={@state.selectedChoiceID} onSwitch={@handleChoice} onCancel={@clearSelection} onConfirm={@handleAnnotation} />}
+        # @ is undefined within the scope of find
+        currentSelection = @state.selectedChoiceID
+        existingAnnotation = @props.annotation.value.find (value) -> value.choice is currentSelection || {}
+        <Choice annotation={existingAnnotation} task={@props.task} choiceID={@state.selectedChoiceID} onSwitch={@handleChoice} onCancel={@clearSelection} onConfirm={@handleAnnotation} />}
     </div>
 
   handleFilter: (characteristicID, valueID) ->
@@ -75,7 +78,7 @@ module.exports = React.createClass
     @setState filters: {}
 
   clearSelection: ->
-    @setState 
+    @setState
       selectedChoiceID: ''
       focusedChoice: @state.selectedChoiceID
     newAnnotation = Object.assign {}, @props.annotation, _choiceInProgress: false
@@ -84,7 +87,13 @@ module.exports = React.createClass
   handleAnnotation: (choice, answers, e) ->
     filters = JSON.parse JSON.stringify @state.filters
     value = @props.annotation.value?.slice?(0) ? []
-    value.push {choice, answers, filters}
+    # @ is undefined within the scope of findIndex
+    currentSelection = @state.selectedChoiceID
+    annotationIndex = value.findIndex (value) -> value.choice is currentSelection
+    if value[annotationIndex]
+      value[annotationIndex] = @props.annotation.value[annotationIndex]
+    else
+      value.push {choice, answers, filters}
     @clearFilters()
     @clearSelection()
     setTimeout => # Wait for filters and selection to clear.


### PR DESCRIPTION
Fixes #3727 .

Replaces https://github.com/zooniverse/Panoptes-Front-End/pull/3946

Describe your changes.
If the current choice of a survey task already exists, this allows to edit it and submit it as _one_ classification.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://remove-multiple-choice.pfe-preview.zooniverse.org/?env=production Tested with Western Montana Widlife
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)