### PR TITLE
Add webpack dashboard custom port to cli script.

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
   "license": "Apache-2.0",
   "repository": "zooniverse/Panoptes-Front-End",
   "scripts": {
-    "start": "export NODE_ENV=development; check-engines && check-dependencies && webpack-dashboard -- babel-node ./dev-server.js",
+    "start": "export NODE_ENV=development; check-engines && check-dependencies && webpack-dashboard -p 3736 -- babel-node ./dev-server.js",
     "_build": "export HEAD_COMMIT=$(git rev-parse --short HEAD); check-engines && check-dependencies && rimraf dist; webpack --config ./webpack.build.js --progress --profile --colors",
     "serve-static": "export NODE_ENV=staging; check-engines && check-dependencies && npm run _build && node ./static-server.js",
     "serve-hot": "export BABEL_ENV=hot-reload; npm start",


### PR DESCRIPTION
Describe your changes.
- custom port for dashboard plugin matches the one set in [`webpack config`](https://github.com/zooniverse/Panoptes-Front-End/blob/master/webpack.dev.js#L33)

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)

- staged [here](https://webpack-dashboard-custom-port.pfe-preview.zooniverse.org/)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?