### PR TITLE
Survey task: Prevent multiple classifications of same choice

### DIFF
--- a/app/classifier/tasks/survey/choice.cjsx
+++ b/app/classifier/tasks/survey/choice.cjsx
@@ -60,7 +60,7 @@ module.exports = React.createClass
     onCancel: Function.prototype
 
   getInitialState: ->
-    answers: @props.annotationValue.answers
+    answers: Object.assign {}, @props.annotationValue.answers
     focusedAnswer: ''
 
   checkFilledIn: ->

--- a/app/classifier/tasks/survey/choice.cjsx
+++ b/app/classifier/tasks/survey/choice.cjsx
@@ -44,7 +44,15 @@ ImageFlipper = React.createClass
 module.exports = React.createClass
   displayName: 'Choice'
 
+  propTypes:
+    annotationValue: React.PropTypes.shape({
+      answers: React.PropTypes.object,
+      choice: React.PropTypes.string,
+      filters: React.PropTypes.object
+    })
+
   getDefaultProps: ->
+    annotationValue: { answers: {} }
     task: null
     choiceID: ''
     onSwitch: Function.prototype
@@ -52,7 +60,7 @@ module.exports = React.createClass
     onCancel: Function.prototype
 
   getInitialState: ->
-    answers: {}
+    answers: @props.annotationValue.answers
     focusedAnswer: ''
 
   checkFilledIn: ->

--- a/app/classifier/tasks/survey/index.cjsx
+++ b/app/classifier/tasks/survey/index.cjsx
@@ -48,7 +48,10 @@ module.exports = React.createClass
       {if @state.selectedChoiceID is ''
         <Chooser task={@props.task} filters={@state.filters} onFilter={@handleFilter} onChoose={@handleChoice} onRemove={@handleRemove} annotation={@props.annotation} focusedChoice={@state.focusedChoice} />
       else
-        <Choice task={@props.task} choiceID={@state.selectedChoiceID} onSwitch={@handleChoice} onCancel={@clearSelection} onConfirm={@handleAnnotation} />}
+        # @ is undefined within the scope of find
+        currentSelection = @state.selectedChoiceID
+        existingAnnotationValue = @props.annotation.value.find (value) -> value.choice is currentSelection
+        <Choice annotationValue={existingAnnotationValue} task={@props.task} choiceID={@state.selectedChoiceID} onSwitch={@handleChoice} onCancel={@clearSelection} onConfirm={@handleAnnotation} />}
     </div>
 
   handleFilter: (characteristicID, valueID) ->
@@ -75,7 +78,7 @@ module.exports = React.createClass
     @setState filters: {}
 
   clearSelection: ->
-    @setState 
+    @setState
       selectedChoiceID: ''
       focusedChoice: @state.selectedChoiceID
     newAnnotation = Object.assign {}, @props.annotation, _choiceInProgress: false
@@ -83,7 +86,7 @@ module.exports = React.createClass
 
   handleAnnotation: (choice, answers, e) ->
     filters = JSON.parse JSON.stringify @state.filters
-    value = @props.annotation.value?.slice?(0) ? []
+    value = @props.annotation.value?.filter (value) -> value.choice isnt choice
     value.push {choice, answers, filters}
     @clearFilters()
     @clearSelection()

--- a/app/classifier/tasks/survey/index.spec.js
+++ b/app/classifier/tasks/survey/index.spec.js
@@ -1,0 +1,38 @@
+import { mount } from 'enzyme';
+import React from 'react';
+import assert from 'assert';
+import SurveyTask from './';
+import { workflow } from '../../../pages/dev-classifier/mock-data';
+
+describe('Survey Task', function(){
+  let annotation = { value: [] };
+  const task = workflow.tasks.survey
+  let wrapper;
+
+  beforeEach(function(){
+    wrapper = mount(<SurveyTask task={task} annotation={annotation} />);
+  });
+
+  it(`should render a survey task`, function(){
+    assert.equal(wrapper.prop('task'), task);
+  });
+
+  it(`should render a valid annotation as a selected choice`, function(){
+    let annotation = { 
+      value: [{
+        "choice": "ar",
+        "answers": {
+          "ho": "two",
+          "be": [
+            "ea"
+          ]
+        },
+        "filters": {}
+      }]
+    };
+    wrapper.setProps({ annotation });
+    wrapper.update();
+    const selectedChoice = wrapper.find('[data-choiceID="ar"]');
+    assert.equal(selectedChoice.prop('className'), 'survey-task-chooser-choice-button survey-task-chooser-choice-button-chosen');
+  });
+})

--- a/app/classifier/tasks/survey/index.spec.js
+++ b/app/classifier/tasks/survey/index.spec.js
@@ -2,6 +2,7 @@ import { mount } from 'enzyme';
 import React from 'react';
 import assert from 'assert';
 import SurveyTask from './';
+import Choice from './choice';
 import { workflow } from '../../../pages/dev-classifier/mock-data';
 
 describe('Survey Task', function(){
@@ -17,22 +18,30 @@ describe('Survey Task', function(){
     assert.equal(wrapper.prop('task'), task);
   });
 
+  annotation = { 
+    value: [{
+      "choice": "ar",
+      "answers": {
+        "ho": "two",
+        "be": [
+          "ea"
+        ]
+      },
+      "filters": {}
+    }]
+  };
+
   it(`should render a valid annotation as a selected choice`, function(){
-    let annotation = { 
-      value: [{
-        "choice": "ar",
-        "answers": {
-          "ho": "two",
-          "be": [
-            "ea"
-          ]
-        },
-        "filters": {}
-      }]
-    };
     wrapper.setProps({ annotation });
     wrapper.update();
     const selectedChoice = wrapper.find('[data-choiceID="ar"]');
     assert.equal(selectedChoice.prop('className'), 'survey-task-chooser-choice-button survey-task-chooser-choice-button-chosen');
+  });
+
+  it('should render the Choice component when a choice is selected', function(){
+    wrapper.setState({ selectedChoiceID: 'ar' });
+    const choice = wrapper.find(Choice);
+    assert.equal(choice.props().choiceID, 'ar');
+    assert.equal(choice.props().annotationValue, annotation.value[0]);
   });
 })

--- a/app/classifier/tasks/survey/index.spec.js
+++ b/app/classifier/tasks/survey/index.spec.js
@@ -45,19 +45,25 @@ describe('Survey Task', function(){
   });
 
   it('should pass existing answers to the Choice component', function(){
+    wrapper.setProps({ annotation });
+    wrapper.update();
     wrapper.setState({ selectedChoiceID: 'ar' });
     const choice = wrapper.find(Choice);
     assert.equal(choice.props().annotationValue, annotation.value[0]);
   });
   
   it('should reset saved choices when the annotation resets', function(){
-    wrapper.setState({ selectedChoiceID: '' });
     wrapper.setProps({ annotation });
     wrapper.update();
     wrapper.setState({ selectedChoiceID: 'ar' });
+    let choice = wrapper.find(Choice);
+    assert.equal(choice.props().annotationValue.answers.ho, "two");
+    assert.equal(choice.node.state.answers.ho, "two")
+    wrapper.setState({ selectedChoiceID: '' });
     wrapper.setProps({ annotation: { value: [] } });
     wrapper.update();
-    const choice = wrapper.find(Choice);
+    wrapper.setState({ selectedChoiceID: 'ar' });
+    choice = wrapper.find(Choice);
     assert.equal(choice.props().annotationValue.answers.ho, undefined);
     assert.equal(choice.node.state.answers.ho, undefined)
   });

--- a/app/classifier/tasks/survey/index.spec.js
+++ b/app/classifier/tasks/survey/index.spec.js
@@ -51,11 +51,14 @@ describe('Survey Task', function(){
   });
   
   it('should reset saved choices when the annotation resets', function(){
-    annotation = { value: [] };
-    wrapper.setState({ selectedChoiceID: 'ar' });
+    wrapper.setState({ selectedChoiceID: '' });
     wrapper.setProps({ annotation });
+    wrapper.update();
+    wrapper.setState({ selectedChoiceID: 'ar' });
+    wrapper.setProps({ annotation: { value: [] } });
     wrapper.update();
     const choice = wrapper.find(Choice);
     assert.equal(choice.props().annotationValue.answers.ho, undefined);
+    assert.equal(choice.node.state.answers.ho, undefined)
   });
 })

--- a/app/classifier/tasks/survey/index.spec.js
+++ b/app/classifier/tasks/survey/index.spec.js
@@ -6,7 +6,7 @@ import Choice from './choice';
 import { workflow } from '../../../pages/dev-classifier/mock-data';
 
 describe('Survey Task', function(){
-  let annotation = { value: [] };
+  const annotation = { value: [] };
   const task = workflow.tasks.survey
   let wrapper;
 
@@ -18,53 +18,55 @@ describe('Survey Task', function(){
     assert.equal(wrapper.prop('task'), task);
   });
 
-  annotation = { 
-    value: [{
-      "choice": "ar",
-      "answers": {
-        "ho": "two",
-        "be": [
-          "ea"
-        ]
-      },
-      "filters": {}
-    }]
-  };
-
-  it(`should render a valid annotation as a selected choice`, function(){
-    wrapper.setProps({ annotation });
-    wrapper.update();
-    const selectedChoice = wrapper.find('[data-choiceID="ar"]');
-    assert.equal(selectedChoice.prop('className'), 'survey-task-chooser-choice-button survey-task-chooser-choice-button-chosen');
-  });
-
   it('should render the Choice component when a choice is selected', function(){
     wrapper.setState({ selectedChoiceID: 'ar' });
     const choice = wrapper.find(Choice);
     assert.equal(choice.props().choiceID, 'ar');
   });
-
-  it('should pass existing answers to the Choice component', function(){
-    wrapper.setProps({ annotation });
-    wrapper.update();
-    wrapper.setState({ selectedChoiceID: 'ar' });
-    const choice = wrapper.find(Choice);
-    assert.equal(choice.props().annotationValue, annotation.value[0]);
-  });
   
-  it('should reset saved choices when the annotation resets', function(){
-    wrapper.setProps({ annotation });
-    wrapper.update();
-    wrapper.setState({ selectedChoiceID: 'ar' });
-    let choice = wrapper.find(Choice);
-    assert.equal(choice.props().annotationValue.answers.ho, "two");
-    assert.equal(choice.node.state.answers.ho, "two")
-    wrapper.setState({ selectedChoiceID: '' });
-    wrapper.setProps({ annotation: { value: [] } });
-    wrapper.update();
-    wrapper.setState({ selectedChoiceID: 'ar' });
-    choice = wrapper.find(Choice);
-    assert.equal(choice.props().annotationValue.answers.ho, undefined);
-    assert.equal(choice.node.state.answers.ho, undefined)
+  describe('with an existing annotation', function(){
+    const annotation = { 
+      value: [{
+        "choice": "ar",
+        "answers": {
+          "ho": "two",
+          "be": [
+            "ea"
+          ]
+        },
+        "filters": {}
+      }]
+    };
+    const task = workflow.tasks.survey
+    let wrapper;
+
+    beforeEach(function(){
+      wrapper = mount(<SurveyTask task={task} annotation={annotation} />);
+    });
+
+    it(`should render a valid annotation as a selected choice`, function(){
+      const selectedChoice = wrapper.find('[data-choiceID="ar"]');
+      assert.equal(selectedChoice.prop('className'), 'survey-task-chooser-choice-button survey-task-chooser-choice-button-chosen');
+    });
+
+    it('should pass existing answers to the Choice component', function(){
+      wrapper.setState({ selectedChoiceID: 'ar' });
+      const choice = wrapper.find(Choice);
+      assert.equal(choice.props().annotationValue, annotation.value[0]);
+    });
+  
+    it('should reset saved choices when the annotation resets', function(){
+      wrapper.setState({ selectedChoiceID: 'ar' });
+      let choice = wrapper.find(Choice);
+      assert.equal(choice.props().annotationValue.answers.ho, "two");
+      assert.equal(choice.node.state.answers.ho, "two")
+      wrapper.setState({ selectedChoiceID: '' });
+      wrapper.setProps({ annotation: { value: [] } });
+      wrapper.update();
+      wrapper.setState({ selectedChoiceID: 'ar' });
+      choice = wrapper.find(Choice);
+      assert.equal(choice.props().annotationValue.answers.ho, undefined);
+      assert.equal(choice.node.state.answers.ho, undefined)
+    });
   });
 })

--- a/app/classifier/tasks/survey/index.spec.js
+++ b/app/classifier/tasks/survey/index.spec.js
@@ -42,6 +42,20 @@ describe('Survey Task', function(){
     wrapper.setState({ selectedChoiceID: 'ar' });
     const choice = wrapper.find(Choice);
     assert.equal(choice.props().choiceID, 'ar');
+  });
+
+  it('should pass existing answers to the Choice component', function(){
+    wrapper.setState({ selectedChoiceID: 'ar' });
+    const choice = wrapper.find(Choice);
     assert.equal(choice.props().annotationValue, annotation.value[0]);
+  });
+  
+  it('should reset saved choices when the annotation resets', function(){
+    annotation = { value: [] };
+    wrapper.setState({ selectedChoiceID: 'ar' });
+    wrapper.setProps({ annotation });
+    wrapper.update();
+    const choice = wrapper.find(Choice);
+    assert.equal(choice.props().annotationValue.answers.ho, undefined);
   });
 })


### PR DESCRIPTION
Re-opens #3947 in order to investigate #3950 

Describe your changes.
Updates the survey task to remember answers and remove duplicate choices from the classifications.

Fixes #3950 by storing a copy of the annotation answers in Choice component state.

Adds some basic tests for the survey task.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://remove-multiple-choice.pfe-preview.zooniverse.org/
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?