### PR TITLE
Highlighter Tool fix for IE11 and Edge

### DIFF
--- a/app/classifier/tasks/highlighter/index.jsx
+++ b/app/classifier/tasks/highlighter/index.jsx
@@ -39,7 +39,7 @@ export default class Highlighter extends React.Component {
   static extraNewLineCharacter(range) {
     const content = range.startContainer.textContent;
     const selectedText = range.toString();
-    let endOffset = range.endOffset;
+    let { endOffset } = range;
     if (content[range.endOffset - 1] !== selectedText[-1] && content[range.endOffset - 1] === '\n') {
       endOffset = range.endOffset - 1;
     }

--- a/app/classifier/tasks/highlighter/index.jsx
+++ b/app/classifier/tasks/highlighter/index.jsx
@@ -34,6 +34,17 @@ export default class Highlighter extends React.Component {
     const isSelectable = !spansNodes && !noAreaSelected && subjectSelection;
     return isSelectable;
   }
+  // in Edge and IE, when highlighting a word at the end of a line
+  // sometimes an extra character is added to the range.endOffset value
+  static extraNewLineCharacter(range) {
+    const content = range.startContainer.textContent;
+    const selectedText = range.toString();
+    let endOffset = range.endOffset;
+    if (content[range.endOffset - 1] !== selectedText[-1] && content[range.endOffset - 1] === '\n') {
+      endOffset = range.endOffset - 1;
+    }
+    return endOffset;
+  }
   constructor(props) {
     super(props);
     this.handleChange = this.handleChange.bind(this);
@@ -45,7 +56,8 @@ export default class Highlighter extends React.Component {
     const range = selection.getRangeAt(0);
     const offset = this.constructor.getOffset(selection);
     const start = offset + range.startOffset;
-    const end = offset + range.endOffset;
+    const endOffset = this.constructor.extraNewLineCharacter(range);
+    const end = offset + endOffset;
     const task = this.props.workflow.tasks[this.props.annotation.task];
     const labelInformation = task.highlighterLabels[toolIndex];
     const selectable = this.constructor.selectableArea(selection, range, offset, start, end);


### PR DESCRIPTION
Fixes an issue of inconsistent `range.endOffset` values in IE11 and Edge when highlighting the end of a line. See #3873 and #3738.  

**Describe your changes.**
Adds method `#extraNewLineCharacter()` to Highlighter. The method checks the `range.endOffset` value for an extra newline character. If there is an extra newline character included in the `range.endOffset` value, the method returns a value one less than the `range.endOffset`.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://highlighter-ie-edge-issue.pfe-preview.zooniverse.org
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?