### PR TITLE
edit stats workflow request to page_size of project.links.workflows.length

### DIFF
--- a/app/pages/project/stats/index.jsx
+++ b/app/pages/project/stats/index.jsx
@@ -38,7 +38,8 @@ class ProjectStatsPageController extends React.Component {
       'retirement,subjects_count'
     ];
     const query = {
-      fields: fields.join(',')
+      fields: fields.join(','),
+      page_size: project.links.workflows.length
     };
     getWorkflowsInOrder(project, query)
       .then((workflows) => {


### PR DESCRIPTION
Towards #3904.

Currently NfN's most recent workflow, 4667 Butterfly_Hummingbird Moths, does not appear on [the project stats page](https://www.zooniverse.org/projects/zooniverse/notes-from-nature/stats) because the `getWorkflowsInOrder` request's `page_size` is 100, and this workflow is over that `page_size`.

This PR changes the stats page `getWorkflowsInOrder` request's `page_size` to the `project.links.workflows.length`, resulting in the inclusion of the recent workflow - https://edit-stats-workflows-request.pfe-preview.zooniverse.org/projects/zooniverse/notes-from-nature/stats?env=production.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?