### PR TITLE
exception for _toolIndex in no-underscore-dangle eslint rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -24,6 +24,7 @@
     "multiline-ternary": ["warn", "never"],
     "no-else-return": "off",
     "no-trailing-spaces": 1,
+    "no-underscore-dangle": ["error", { "allow": ["_toolIndex"] }],
     "no-unused-vars": 1,
     "no-useless-constructor": 1,
     "no-useless-return": 1,

--- a/app/classifier/tasks/highlighter/index.jsx
+++ b/app/classifier/tasks/highlighter/index.jsx
@@ -1,5 +1,3 @@
-/* eslint no-underscore-dangle: ["error", { "allow": ["_toolIndex"] }] */
-
 import React from 'react';
 import { Markdown } from 'markdownz';
 import GenericTaskEditor from '../generic-editor';


### PR DESCRIPTION
**Describe your changes.**
In the eslint file, I added an exception for the no-underscore-dangle rule, so that we don't get lint errors when using `_toolIndex`.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?