### PR TITLE
Add comment in webpack config file regarding custom port.

### DIFF
--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -30,7 +30,7 @@ var config = {
       inject: 'body',
       filename: 'index.html'
     }),
-    new DashboardPlugin({ port: 3736 })
+    new DashboardPlugin({ port: 3736 }) // Change this here and in the package.json start script if needed.
   ],
   resolve: {
     extensions: ['*', '.js', '.jsx', '.json', '.cjsx', '.coffee', '.styl', '.css'],


### PR DESCRIPTION
Addition to [PR 3951](https://github.com/zooniverse/Panoptes-Front-End/pull/3951).

Describe your changes.
- Add comment in `webpack.dev` referencing the webpack dashboard custom port config in `package.json`.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)

- Staged [here](https://webpack-dashboard-custom-port.pfe-preview.zooniverse.org/).

## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?