### PR TITLE
remove activeClassName from a and span elements

### DIFF
--- a/app/layout/site-nav.jsx
+++ b/app/layout/site-nav.jsx
@@ -152,7 +152,6 @@ const SiteNav = React.createClass({
             <a
               href="http://daily.zooniverse.org/"
               className="site-nav__link"
-              activeClassName="site-nav__link--active"
               rel="noopener noreferrer"
               target="_blank"
               onClick={!!this.logClick ? this.logClick.bind(this, 'mainNav.daily', 'globe-menu') : null}
@@ -163,7 +162,6 @@ const SiteNav = React.createClass({
             <a
               href="http://blog.zooniverse.org/"
               className="site-nav__link"
-              activeClassName="site-nav__link--active"
               rel="noopener noreferrer"
               target="_blank"
               onClick={!!this.logClick ? this.logClick.bind(this, 'mainNav.blog', 'globe-menu') : null}

--- a/app/layout/site-subnav.jsx
+++ b/app/layout/site-subnav.jsx
@@ -11,10 +11,7 @@ class SiteSubnav extends React.Component {
         <ExpandableMenu
           className="site-nav__modal"
           trigger={
-            <span
-              className="site-nav__link"
-              activeClassName="site-nav__link--active"
-            >
+            <span className="site-nav__link">
               News
             </span>
           }


### PR DESCRIPTION
Clearing a warning thrown in the dev environment. I believe `activeClassName` is only applicable to Link components.

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?