### PR TITLE
Add Instagram and Medium Social Icons

### DIFF
--- a/app/lib/social-icons.js
+++ b/app/lib/social-icons.js
@@ -9,7 +9,9 @@ const SOCIAL_ICONS = {
   'twitter.com/': 'twitter',
   'weibo.com/': 'weibo',
   'wordpress.com/': 'wordpress',
-  'youtube.com/': 'youtube'
+  'youtube.com/': 'youtube',
+  'instagram.com/': 'instagram',
+  'medium.com/': 'medium'
 };
 
 export default SOCIAL_ICONS;

--- a/app/pages/lab/social-links-editor.spec.js
+++ b/app/pages/lab/social-links-editor.spec.js
@@ -34,7 +34,7 @@ describe('SocialLinksEditor', () => {
 
   it('should contain the correct number of rows', () => {
     const rows = wrapper.find('tr');
-    assert.equal(rows.length, 11);
+    assert.equal(rows.length, 13);
   });
 
   it('should rearrange the default social links on load', () => {


### PR DESCRIPTION
Fixes # .

Describe your changes.
This PR adds Instagram and Medium as social media icon options on the project builder.

https://add-instagram.pfe-preview.zooniverse.org/

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?