### PR TITLE
Remove type-check checkbox

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,6 @@ Describe your changes.
 - [ ] Does it work on mobile?
 - [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
 - [ ] Did you deploy a staging branch?
-- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)
 
 
 ## Optional

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,11 +8,12 @@ Describe your changes.
 - [ ] Does it work on mobile?
 - [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
 - [ ] Did you deploy a staging branch?
+- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
+- [ ] Are the tests passing locally and on Travis?
 
 
 ## Optional
 
-- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
 - [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
 - [ ] If changes are made to the classifier, does the dev classifier still work?
 - [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?


### PR DESCRIPTION
This resumes the conversation about the PR template I interrupted by hastily closing https://github.com/zooniverse/Panoptes-Front-End/pull/3963

Describe your changes.
As suggested by @srallen, I removed the type-check checkbox, because the linter catches that.