### PR TITLE
Use node 8 for CI and Docker builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-node_js: "8.0.0"
+node_js: "8"
 
 script:
   - npm run test-travis

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /src
 RUN apt-get update && \
     apt-get install -y curl libfreetype6 libfontconfig1 git ruby unzip flex \
                        bison && \
-    curl https://deb.nodesource.com/setup_6.x | bash - && \
+    curl https://deb.nodesource.com/setup_8.x | bash - && \
     apt-get install -y nodejs && apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Updates Travis and Docker configs to use latest node 8.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?