### PR TITLE
Add group query param and group id to classification metadata

### DIFF
--- a/app/pages/project/classify.cjsx
+++ b/app/pages/project/classify.cjsx
@@ -145,6 +145,9 @@ module.exports = React.createClass
           workflow: workflow.id
           subjects: [subject.id]
 
+      if @props.location.query?.group?
+        classification.update({ 'metadata.user_group': @props.location.query.group })
+
       # If the user hasn't interacted with a classification resource before,
       # we won't know how to resolve its links, so attach these manually.
       classification._workflow = workflow
@@ -210,6 +213,8 @@ module.exports = React.createClass
       {if @props.projectIsComplete
         <FinishedBanner project={@props.project} />}
 
+      {if @props.location.query?.group?
+        <p className="anouncement-banner--group">You are classifying as a student of your classroom.</p>}
       {if @state.classification?
         <Classifier
           {...@props}

--- a/css/classify.styl
+++ b/css/classify.styl
@@ -44,6 +44,12 @@
       p
         display: inline-block
 
+  .anouncement-banner--group
+    @extends $announcement-banner
+    background-color: SUCCESS
+    margin: 1em auto
+    max-width: 400px
+
 .classifier
   display: flex
   justify-content: center


### PR DESCRIPTION
For #3122 and to support the Intro2Astro use case with the EducationAPI front end being built.

This adds a check for the presence of the url query param `?group=id` and if present, adds the `user_group` id to the classification metadata on create as well as adds a UI notification banner that you are a student classifying with your classroom.

Can be seen working on staging: https://classify-by-group.pfe-preview.zooniverse.org/projects/brooke/i-fancy-cats/classify?group=2534

Note: I'm not validating the id in the query param that it is actually a group that exists nor am I validating that the user is authenticated or that the user is in that group. We may want to consider these validations, but I can add those in subsequent PRs. 

I know we talked in the last retrospective being more strict about coffeescript to javascript conversions, so I am working on that, but in a separate branch.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?