### PR TITLE
respect projects page_size query param

### DIFF
--- a/app/pages/projects/filtered-projects-list.jsx
+++ b/app/pages/projects/filtered-projects-list.jsx
@@ -13,8 +13,8 @@ counterpart.registerTranslations('en', {
 
 class FilteredProjectsList extends Component {
   render() {
-    const { discipline, page, sort, status } = this.props.location.query;
-    const filteringProps = { discipline, page, sort, status };
+    const { discipline, page, sort, status, page_size } = this.props.location.query;
+    const filteringProps = { discipline, page, sort, status, page_size };
     return (
       <ProjectFilteringInterface
         onChangeQuery={this.context.updateQuery}

--- a/app/pages/projects/project-filtering-interface.jsx
+++ b/app/pages/projects/project-filtering-interface.jsx
@@ -24,25 +24,27 @@ class ProjectFilteringInterface extends Component {
       pages: 0,
       projectCount: 0,
       query: {},
+      pageSize: null,
     };
   }
 
   componentDidMount() {
-    const { discipline, page, sort, status } = this.props;
-    this.loadProjects(discipline, page, sort, status);
+    const { discipline, page, sort, status, page_size } = this.props;
+    this.loadProjects(discipline, page, sort, status, page_size);
   }
 
   componentWillReceiveProps(nextProps) {
-    const { discipline, page, sort, status } = nextProps;
+    const { discipline, page, sort, status, page_size } = nextProps;
     if (discipline !== this.props.discipline ||
         page !== this.props.page ||
         sort !== this.props.sort ||
-        status !== this.props.status) {
-      this.loadProjects(discipline, page, sort, status);
+        status !== this.props.status ||
+        page_size !== this.props.page_size) {
+      this.loadProjects(discipline, page, sort, status, page_size);
     }
   }
 
-  loadProjects(discipline, page, sort, status) {
+  loadProjects(discipline, page, sort, status, pageSize) {
     this.setState({
       error: null,
       loading: true,
@@ -55,6 +57,7 @@ class ProjectFilteringInterface extends Component {
       cards: true,
       include: ['avatar'],
       state: status,
+      page_size: pageSize,
     };
     if (!query.tags) {
       delete query.tags;
@@ -68,8 +71,9 @@ class ProjectFilteringInterface extends Component {
             const meta = projects[0].getMeta();
             pages = meta.page_count;
             projectCount = meta.count;
+            pageSize = meta.page_size;
           }
-          this.setState({ projects, pages, projectCount });
+          this.setState({ projects, pages, projectCount, pageSize });
         } else {
           this.setState({ projects: [], pages: 0, projectCount: 0 });
         }
@@ -101,8 +105,8 @@ class ProjectFilteringInterface extends Component {
     let pageStart = null;
     let pageEnd = null;
     if (this.state.projectCount > 0) {
-      pageStart = ((this.props.page - 1) * 20) + 1;
-      pageEnd = Math.min(this.props.page * 20, this.state.projectCount);
+      pageStart = ((this.props.page - 1) * this.state.pageSize) + 1;
+      pageEnd = Math.min(this.props.page * this.state.pageSize, this.state.projectCount);
       showingMessage = 'projects.countMessage';
     } else {
       showingMessage = 'projects.notFoundMessage';

--- a/app/pages/projects/project-filtering-interface.jsx
+++ b/app/pages/projects/project-filtering-interface.jsx
@@ -104,9 +104,10 @@ class ProjectFilteringInterface extends Component {
     let showingMessage = '';
     let pageStart = null;
     let pageEnd = null;
-    if (this.state.projectCount > 0) {
-      pageStart = ((this.props.page - 1) * this.state.pageSize) + 1;
-      pageEnd = Math.min(this.props.page * this.state.pageSize, this.state.projectCount);
+    const { pageSize, projectCount } = this.state;
+    if (projectCount > 0) {
+      pageStart = ((this.props.page - 1) * pageSize) + 1;
+      pageEnd = Math.min(this.props.page * pageSize, projectCount);
       showingMessage = 'projects.countMessage';
     } else {
       showingMessage = 'projects.notFoundMessage';
@@ -116,7 +117,7 @@ class ProjectFilteringInterface extends Component {
         <Translate
           pageStart={pageStart}
           pageEnd={pageEnd}
-          projectCount={this.state.projectCount}
+          projectCount={projectCount}
           content={showingMessage}
         />
       </p>


### PR DESCRIPTION
Allow the page_size query param to filter to the API call for easy page size modifications from the URL. Useful for testing things like project card listing sizes.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [X] Did you deploy a staging branch? https://respect_page_size.pfe-preview.zooniverse.org/projects?env=production&page=1&page_size=50
- [ ] Did you get any type checking errors from [Babel Typecheck](https://github.com/codemix/babel-plugin-typecheck)


## Optional

- [ ] If it's a new component, is it in ES6? Is it clear of warnings from ESLint?
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?