### PR TITLE
Fix general feedback series of small bugs

### DIFF
--- a/app/classifier/annotation-renderer/svg.jsx
+++ b/app/classifier/annotation-renderer/svg.jsx
@@ -194,10 +194,10 @@ export default class SVGRenderer extends React.Component {
               </Draggable>
             )}
             {children}
-            {(showFeedback) && (<SVGFeedbackViewer />)}
+            {(showFeedback) && (<SVGFeedbackViewer annotations={annotations} />)}
           </g>
         </svg>
-        {(showFeedback) && (<SVGToolTipLayer getScreenCTM={this.getScreenCurrentTransformationMatrix} />)}
+        {(showFeedback) && (<SVGToolTipLayer annotations={annotations} getScreenCTM={this.getScreenCurrentTransformationMatrix} />)}
         {this.props.children}
       </div>
     );

--- a/app/classifier/feedback/helpers.js
+++ b/app/classifier/feedback/helpers.js
@@ -16,4 +16,8 @@ const isThereFeedback = (subject, workflow) =>
     return newResult;
   }, false);
 
-export { isFeedbackActive, isThereFeedback };
+const renderUniqueFeedback = (annotations, feedback) => {
+  const annotationFrame = annotations.map(item => item.value.map(value => value.frame));
+  return feedback.filter(item => item.frame === annotationFrame);
+};
+export { isFeedbackActive, isThereFeedback, renderUniqueFeedback };

--- a/app/classifier/feedback/process-feedback-drawing.js
+++ b/app/classifier/feedback/process-feedback-drawing.js
@@ -11,6 +11,7 @@ const isWithinTolerance = (annotationX, annotationY, feedbackX, feedbackY, toler
 
 const createFeedbackItem = (success, annotation, rule) => {
   const feedbackItem = {
+    frame: annotation.value.map(item => parseInt(item.frame)),
     task: annotation.task,
     type: 'drawing',
     success,

--- a/app/classifier/feedback/process-feedback-drawing.js
+++ b/app/classifier/feedback/process-feedback-drawing.js
@@ -16,16 +16,10 @@ const createFeedbackItem = (success, annotation, rule) => {
     success,
     message: (success) ? rule.successMessage : rule.failureMessage
   };
-
-  if (rule.dud) {
-    feedbackItem.target = 'summary';
-  } else {
-    feedbackItem.x = rule.x;
-    feedbackItem.y = rule.y;
-    feedbackItem.tol = rule.tol;
-    feedbackItem.target = 'classifier';
-  }
-
+  feedbackItem.x = rule.x;
+  feedbackItem.y = rule.y;
+  feedbackItem.tol = rule.tol;
+  feedbackItem.target = 'classifier';
   return feedbackItem;
 };
 

--- a/app/classifier/feedback/process-feedback-drawing.spec.js
+++ b/app/classifier/feedback/process-feedback-drawing.spec.js
@@ -114,7 +114,7 @@ describe('processDrawingFeedback', function () {
     assert.strictEqual(result[0].task, DUD_ANNOTATION.task);
     assert.strictEqual(result[0].success, true);
     assert.strictEqual(result[0].message, SUCCESS_MESSAGE);
-    assert.strictEqual(result[0].target, 'summary');
+    assert.strictEqual(result[0].target, 'classifier');
   });
 
   it('should return nothing if the subject is a dud and there are no annotations, but showing a success message is disabled', function () {
@@ -131,7 +131,7 @@ describe('processDrawingFeedback', function () {
     assert.strictEqual(result[0].task, NORMAL_ANNOTATION.task);
     assert.strictEqual(result[0].success, false);
     assert.strictEqual(result[0].message, FAILURE_MESSAGE);
-    assert.strictEqual(result[0].target, 'summary');
+    assert.strictEqual(result[0].target, 'classifier');
   });
 
   it('should return nothing if the subject is a dud and there are annotations, but showing a failure message is disabled', function () {

--- a/app/classifier/feedback/process-feedback-single.js
+++ b/app/classifier/feedback/process-feedback-single.js
@@ -13,7 +13,7 @@ const processSingleFeedback = (annotation, subject, task) => {
         question: task.question,
         success: result,
         message: (result) ? rule.successMessage : rule.failureMessage,
-        target: 'summary'
+        target: 'classifier'
       });
     }
 

--- a/app/classifier/feedback/process-feedback-single.spec.js
+++ b/app/classifier/feedback/process-feedback-single.spec.js
@@ -49,7 +49,7 @@ describe('processSingleFeedback', function () {
     assert.strictEqual(result[0].success, true);
     assert.strictEqual(result[0].message, SUCCESS_MESSAGE);
     assert.strictEqual(result[0].question, QUESTION);
-    assert.strictEqual(result[0].target, 'summary');
+    assert.strictEqual(result[0].target, 'classifier');
   });
 
   it('should return nothing if a rule and annotation match, but showing a success message is disabled', function () {
@@ -65,7 +65,7 @@ describe('processSingleFeedback', function () {
     assert.strictEqual(result[0].success, false);
     assert.strictEqual(result[0].message, FAILURE_MESSAGE);
     assert.strictEqual(result[0].question, QUESTION);
-    assert.strictEqual(result[0].target, 'summary');
+    assert.strictEqual(result[0].target, 'classifier');
   });
 
   it('should return nothing if a rule and annotation don\'t match, but showing a failure message is disabled', function () {

--- a/app/classifier/feedback/svg-feedback-viewer.jsx
+++ b/app/classifier/feedback/svg-feedback-viewer.jsx
@@ -1,6 +1,7 @@
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import FeedbackPoint from './feedback-point';
+import { renderUniqueFeedback } from '../feedback/helpers';
 
 function renderFeedbackPoints(feedback) {
   return (
@@ -19,7 +20,8 @@ class FeedbackViewer extends React.Component {
   }
 
   render() {
-    const { feedback } = this.props;
+    const { annotations, feedback } = this.props;
+    const uniqueFeedback = renderUniqueFeedback(annotations, feedback);
     return (feedback.length) ? renderFeedbackPoints(feedback) : null;
   }
 }

--- a/app/classifier/feedback/svg-tooltip-layer.jsx
+++ b/app/classifier/feedback/svg-tooltip-layer.jsx
@@ -1,6 +1,7 @@
 import React, { PropTypes } from 'react';
 import { connect } from 'react-redux';
 import Tooltip from './tooltip';
+import { renderUniqueFeedback } from '../feedback/helpers';
 
 class SVGToolTipLayer extends React.Component {
   constructor(props) {
@@ -8,8 +9,7 @@ class SVGToolTipLayer extends React.Component {
     this.renderTooltips = this.renderTooltips.bind(this);
   }
 
-  renderTooltips() {
-    const { feedback } = this.props;
+  renderTooltips(feedback) {
     return (
       <div className="classifier-tooltips">
         {feedback.map(item =>
@@ -23,7 +23,9 @@ class SVGToolTipLayer extends React.Component {
   }
 
   render() {
-    return (this.props.feedback.length) ? this.renderTooltips() : null;
+    const { annotations, feedback } = this.props;
+    const uniqueFeedback = renderUniqueFeedback(annotations, feedback);
+    return (this.props.feedback.length) ? this.renderTooltips(uniqueFeedback) : null;
   }
 }
 

--- a/app/classifier/feedback/tooltip.jsx
+++ b/app/classifier/feedback/tooltip.jsx
@@ -3,28 +3,28 @@ import React, { PropTypes } from 'react';
 const Tooltip = ({ item }) => {
   const position = {
     left: `${item.x}px`,
-    bottom: `${parseInt(item.y, 10) + parseInt(item.tol, 10) + 15}px`
-  };
-
-  return (
-    <div
-      className={`feedback-tooltip feedback-tooltip--${item.success ? 'success' : 'failure'}`}
-      key={`feedback-tooltip-${item.x}-${item.y}`}
-      style={position}
-    >
-      <div className="feedback-tooltip__content">
-        {item.message}
+    bottom: `${parseInt(item.y, 10) + parseInt(item.tol, 10) + 15}px`,
+  }
+  if (item.x && item.y) {
+    return (
+      <div
+        className={`feedback-tooltip feedback-tooltip--${item.success ? 'success' : 'failure'}`}
+        key={`feedback-tooltip-${item.x}-${item.y}`}
+        style={position}>
+        <div className="feedback-tooltip__content">
+          {item.message}
+        </div>
+        <svg
+          className="feedback-tooltip__triangle"
+          version="1.1"
+          viewBox="0 10 20 15"
+          xmlns="http://www.w3.org/2000/svg">
+          <polygon points="0,0 20,0 10,15"/>
+        </svg>
       </div>
-      <svg
-        className="feedback-tooltip__triangle"
-        version="1.1"
-        viewBox="0 10 20 15"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <polygon points="0,0 20,0 10,15" />
-      </svg>
-    </div>
-  );
+    );
+  }
+  return <div />;
 };
 
 Tooltip.propTypes = {


### PR DESCRIPTION
Fixes #3858 

Describe your changes.
This PR addresses three main points:

- [ ] fix tooltips locations
- [x] metadata messages override defaults
- [ ] with clone marker on, all images show feedback, only one should be enough for this setup

And, possibly, a nice to have:
- [x] dud messaging only in classification summary text, request pop-up messages for duds

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://fix-sw-feedback.pfe-preview.zooniverse.org/
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

## Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
