### PR TITLE
Optimise subject viewer CSS and fix Firefox image rendering bug

### DIFF
--- a/app/classifier/annotation-renderer/svg.jsx
+++ b/app/classifier/annotation-renderer/svg.jsx
@@ -180,7 +180,7 @@ export default class SVGRenderer extends React.Component {
                 fillOpacity="0.01"
                 stroke="none"
               />
-              {type === 'image' && (
+              {type === 'image' && this.props.naturalWidth && (
                 <Draggable onDrag={this.props.panEnabled ? this.props.panByDrag : () => {}}>
                   <SVGImage
                     className={this.props.panEnabled ? 'pan-active' : ''}

--- a/app/classifier/annotation-renderer/svg.jsx
+++ b/app/classifier/annotation-renderer/svg.jsx
@@ -115,10 +115,7 @@ export default class SVGRenderer extends React.Component {
     // disable subject pointer events by default.
     // Tasks then need to enable pointer events, when required, in SVGProps.
     const svgProps = {
-      style: {
-        background: 'black',
-        pointerEvents: 'none'
-      }
+      style: {}
     };
 
     Object.keys(tasks).map((task) => {
@@ -164,41 +161,42 @@ export default class SVGRenderer extends React.Component {
 
     return (
       <div>
-        <svg
-          ref={(element) => { if (element) this.svgSubjectArea = element; }}
-          className="subject"
-          viewBox={createdViewBox}
-          {...svgProps}
-        >
-          <g
-            ref={(element) => { if (element) this.transformationContainer = element; }}
-            transform={this.props.transform}
-          >
-            <rect
-              ref={(rect) => { this.sizeRect = rect; }}
-              width={this.props.naturalWidth}
-              height={this.props.naturalHeight}
-              fill="rgba(0, 0, 0, 0.01)"
-              fillOpacity="0.01"
-              stroke="none"
-            />
-            {type === 'image' && (
-              <Draggable onDrag={this.props.panEnabled ? this.props.panByDrag : () => {}}>
-                <SVGImage
-                  className={this.props.panEnabled ? 'pan-active' : ''}
-                  src={src}
-                  width={this.props.naturalWidth}
-                  height={this.props.naturalHeight}
-                  modification={this.props.modification}
-                />
-              </Draggable>
-            )}
-            {children}
-            {(showFeedback) && (<SVGFeedbackViewer />)}
-          </g>
-        </svg>
-        {(showFeedback) && (<SVGToolTipLayer getScreenCTM={this.getScreenCurrentTransformationMatrix} />)}
         {this.props.children}
+        <div className="subject svg-subject">
+          <svg
+            ref={(element) => { if (element) this.svgSubjectArea = element; }}
+            viewBox={createdViewBox}
+            {...svgProps}
+          >
+            <g
+              ref={(element) => { if (element) this.transformationContainer = element; }}
+              transform={this.props.transform}
+            >
+              <rect
+                ref={(rect) => { this.sizeRect = rect; }}
+                width={this.props.naturalWidth}
+                height={this.props.naturalHeight}
+                fill="rgba(0, 0, 0, 0.01)"
+                fillOpacity="0.01"
+                stroke="none"
+              />
+              {type === 'image' && (
+                <Draggable onDrag={this.props.panEnabled ? this.props.panByDrag : () => {}}>
+                  <SVGImage
+                    className={this.props.panEnabled ? 'pan-active' : ''}
+                    src={src}
+                    width={this.props.naturalWidth}
+                    height={this.props.naturalHeight}
+                    modification={this.props.modification}
+                  />
+                </Draggable>
+              )}
+              {children}
+              {(showFeedback) && (<SVGFeedbackViewer />)}
+            </g>
+          </svg>
+        </div>
+        {(showFeedback) && (<SVGToolTipLayer getScreenCTM={this.getScreenCurrentTransformationMatrix} />)}
       </div>
     );
   }

--- a/app/classifier/frame-annotator.spec.js
+++ b/app/classifier/frame-annotator.spec.js
@@ -207,32 +207,32 @@ describe('<FrameAnnotator />', function() {
         />);
     });
 
-    it('allows pointer events for drawing tasks', function() {
-      assert(wrapper.find('svg.subject').prop('style').pointerEvents === 'all');
+    it('overrides pointer event styles for drawing tasks', function() {
+      assert(wrapper.find('svg').prop('style').pointerEvents === 'all');
     });
 
-    it('does not allow pointer events for question tasks', function() {
+    it('does not override pointer event styles for question tasks', function() {
       const questionAnnotation = tasks.single.getDefaultAnnotation();
       questionAnnotation.task = 'init';
       wrapper.setProps({annotation: questionAnnotation});
-      assert(wrapper.find('svg.subject').prop('style').pointerEvents === 'none');
+      assert(wrapper.find('svg').prop('style').pointerEvents === undefined);
     });
 
-    it('allows pointer events for combo drawing tasks', function() {
+    it('overrides pointer event styles for combo drawing tasks', function() {
       const comboAnnotation = tasks.combo.getDefaultAnnotation(workflow.tasks.combo, workflow, tasks);
       comboAnnotation.task = 'combo';
       wrapper.setProps({annotation: comboAnnotation});
-      assert(wrapper.find('svg.subject').prop('style').pointerEvents === 'all');
+      assert(wrapper.find('svg').prop('style').pointerEvents === 'all');
     });
 
-    it('does not allow pointer events for other combo tasks', function() {
+    it('does not override pointer event styles for other combo tasks', function() {
       const comboTask = Object.assign({}, workflow.tasks.combo);
       comboTask.tasks = ['write', 'ask', 'features'];
       workflow.tasks.textCombo = comboTask;
       const comboAnnotation = tasks.combo.getDefaultAnnotation(workflow.tasks.textCombo, workflow, tasks);
       comboAnnotation.task = 'textCombo';
       wrapper.setProps({annotation: comboAnnotation});
-      assert(wrapper.find('svg.subject').prop('style').pointerEvents === 'none');
+      assert(wrapper.find('svg').prop('style').pointerEvents === undefined);
     });
   });
 });

--- a/app/classifier/frame-annotator.spec.js
+++ b/app/classifier/frame-annotator.spec.js
@@ -23,8 +23,8 @@ const viewBoxDimensions = {
   y: 0
 };
 
-const naturalHeight = 0;
-const naturalWidth = 0;
+const naturalHeight = 100;
+const naturalWidth = 100;
 
 describe('<FrameAnnotator />', function() {
   it('should render without crashing', function() {

--- a/app/classifier/tasks/combo/markings-renderer.jsx
+++ b/app/classifier/tasks/combo/markings-renderer.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import SVGRenderer from '../../annotation-renderer/svg';
 
 export default function MarkingsRenderer(props) {
   // a list that holds the annotations for the current combo task
@@ -31,7 +32,7 @@ export default function MarkingsRenderer(props) {
         .filter((taskType) => { return taskType !== 'combo'; })
         .map((taskType) => {
           const TaskComponent = props.taskTypes[taskType];
-          if (TaskComponent.PersistInsideSubject) {
+          if (TaskComponent.AnnotationRenderer === SVGRenderer && TaskComponent.PersistInsideSubject) {
             // when a combo annotation changes make sure the combo annotation updated correctly with only the
             // current combo task's annotatons.  This is a hack to make drawing tasks work in a combo task.
             let { annotation } = props;

--- a/css/classify.styl
+++ b/css/classify.styl
@@ -73,7 +73,6 @@
     box-shadow: 0 0 0 1px gray
     max-height: 90vh
     max-width: 100%
-    user-select: none
 
   .marking-initializer
     cursor: crosshair

--- a/css/frame-annotator.styl
+++ b/css/frame-annotator.styl
@@ -3,13 +3,19 @@
   position: relative; // Contain absolutely-positioned children
   max-width: 100%;
 
-  svg
+  .svg-subject
+    background: #000
     position: absolute
     left: 0
     top: 0
     width: 100%
     height: 100%
     overflow: hidden
+    
+    svg
+      pointer-events: none
+      width: 100%
+      height: 100%
     
   button.disabled
     color: #ADABAB;

--- a/css/frame-annotator.styl
+++ b/css/frame-annotator.styl
@@ -5,6 +5,7 @@
 
   .svg-subject
     background: #000
+    pointer-events: none
     position: absolute
     left: 0
     top: 0
@@ -13,7 +14,6 @@
     overflow: hidden
     
     svg
-      pointer-events: none
       width: 100%
       height: 100%
     


### PR DESCRIPTION
Fixes #3989 
Describe your changes.
Some small changes to the subject viewer. Inline styles are moved to the style sheet. Background colour and positioning are applied to a `div`, instead of to the `svg` element.

The combo task now checks whether a task renders SVG before rendering SVG marks.

These changes were made while trying to discover why Firefox 55 isn't displaying SVG images properly in the classifier. Unfortunately, it doesn't fix that bug.

UPDATE: checking the image size before rendering seems to fix the SVG image in FF 55+.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://fix-3989.pfe-preview.zooniverse.org/
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?


## Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
