### PR TITLE
Resize home page images

### DIFF
--- a/app/pages/home-common/featured-project.jsx
+++ b/app/pages/home-common/featured-project.jsx
@@ -10,20 +10,23 @@ Featured Project Component
 
 import React from 'react';
 import { Link } from 'react-router';
+import Thumbnail from '../../components/thumbnail';
 
-const FeaturedProject = (() =>
+const FeaturedProject = (() => (
   <section className="home-featured">
     <h1 className="secondary-kicker">Featured Project</h1>
     <div className="home-featured-images">
-      <img
+      <Thumbnail
         alt="Planetary Response Network & Rescue Global: Caribbean Storms 2017"
-        src="/assets/featured-projects/featured-project-20170913-irma.jpg"
+        src="//zooniverse.org/assets/featured-projects/featured-project-20170913-irma.jpg"
+        width={800}
       />
     </div>
     <h2 className="secondary-headline">Caribbean Storms 2017</h2>
     <p className="display-body">Check back daily to join the relief effort to help the victims of Hurricane Irma.</p>
     <Link to="projects/vrooje/planetary-response-network-and-rescue-global-caribbean-storms-2017">View Project!</Link>
   </section>
+  )
 );
 
 export default FeaturedProject;

--- a/app/pages/home-common/featured-project.jsx
+++ b/app/pages/home-common/featured-project.jsx
@@ -18,7 +18,7 @@ const FeaturedProject = (() => (
     <div className="home-featured-images">
       <Thumbnail
         alt="Planetary Response Network & Rescue Global: Caribbean Storms 2017"
-        src="//zooniverse.org/assets/featured-projects/featured-project-20170913-irma.jpg"
+        src="//www.zooniverse.org/assets/featured-projects/featured-project-20170913-irma.jpg"
         width={800}
       />
     </div>

--- a/app/pages/home-common/featured-project.spec.js
+++ b/app/pages/home-common/featured-project.spec.js
@@ -2,6 +2,7 @@ import { shallow } from 'enzyme';
 import React from 'react';
 import assert from 'assert';
 import FeaturedProject from './featured-project';
+import Thumbnail from '../../components/thumbnail';
 
 describe('FeaturedProject', () => {
   it('should render without crashing', () => {
@@ -21,8 +22,8 @@ describe('FeaturedProject', () => {
 
   it('should have an img tag with src and alt properties', () => {
     const wrapper = shallow(<FeaturedProject />);
-    const { alt, src } = wrapper.find('img').props();
-    assert.equal(wrapper.find('img').length, 1);
+    const { alt, src } = wrapper.find(Thumbnail).props();
+    assert.equal(wrapper.find(Thumbnail).length, 1);
     assert.ok(alt.length > 0, 'alt attribute is empty');
     assert.ok(src.length > 0, 'src attribute is empty');
   });

--- a/app/pages/home-not-logged-in/discover.jsx
+++ b/app/pages/home-not-logged-in/discover.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Translate from 'react-translate-component';
 import counterpart from 'counterpart';
+import Thumbnail from '../../components/thumbnail';
 
 counterpart.registerTranslations('en', {
   discoverHomePage: {
@@ -53,7 +54,7 @@ const HomePageDiscover = (({ showDialog }) =>
     </div>
 
     <div className="home-discover__image">
-      <img role="presentation" src="/assets/home-computer.png" />
+      <Thumbnail role="presentation" src="//www.zooniverse.org/assets/home-computer.png" width={450} />
     </div>
 
   </section>

--- a/app/pages/home-not-logged-in/research.jsx
+++ b/app/pages/home-not-logged-in/research.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Translate from 'react-translate-component';
 import counterpart from 'counterpart';
 import { Link } from 'react-router';
+import Thumbnail from '../../components/thumbnail';
 
 counterpart.registerTranslations('en', {
   researchHomePage: {
@@ -63,14 +64,14 @@ const HomePageResearch = (({ count, screenWidth, showDialog, volunteerCount }) =
     </div>
 
     <div className="home-research__researchers">
-      <div><img role="presentation" src="/assets/home-researchers1.jpg" /></div>
+      <div><Thumbnail role="presentation" src="//www.zooniverse.org/assets/home-researchers1.jpg" width={450} /></div>
 
       {screenWidth > 550 && (
-        <div><img role="presentation" src="/assets/home-researchers2.jpg" /></div>
+        <div><Thumbnail img role="presentation" src="//www.zooniverse.org/assets/home-researchers2.jpg" width={450} /></div>
       )}
 
       {screenWidth > 900 && (
-        <div><img role="presentation" src="/assets/home-researchers3.jpg" /></div>
+        <div><Thumbnail role="presentation" src="//www.zooniverse.org/assets/home-researchers3.jpg" width={450} /></div>
       )}
     </div>
 


### PR DESCRIPTION
Fixes #3994 .

Describe your changes.
Renders home page images using the Thumbnail component, with a reasonable maximum width set.

Ideally, we should not be committing large images into this repo in the first place, so the originals might need some optimisation.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://resize-images.pfe-preview.zooniverse.org/
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?


## Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
