### PR TITLE
Move Sprinks et al. 2017 from climate to meta

### DIFF
--- a/app/lib/publications.js
+++ b/app/lib/publications.js
@@ -586,16 +586,6 @@ const Publications = {
       ]
     },
     {
-      slug: "zooniverse/planet-four",
-      publications: [
-        {
-          citation: "Task Workflow Design and its impact on performance and volunteers' subjective preference in Virtual Citizen Science, Sprinks+ 2017.",
-          href: "http://www.sciencedirect.com/science/article/pii/S1071581917300332",
-          date: "2017"
-        }
-      ]
-    },
-    {
       slug: "jukoch/pattern-perception",
       publications: [
         {
@@ -759,6 +749,11 @@ const Publications = {
     {
     name: "Meta Studies",
     publications: [
+      {
+        citation: "Task Workflow Design and its impact on performance and volunteers' subjective preference in Virtual Citizen Science, Sprinks+ 2017.",
+        href: "http://www.sciencedirect.com/science/article/pii/S1071581917300332",
+        date: "2017"
+      },
       {
         citation: "Blending Machine and Human Learning Processes, Crowston, Kevin, Østerlund, Carsten, Lee, Tae Kyoung, 2017",
         href: "http://scholarspace.manoa.hawaii.edu/handle/10125/41159",


### PR DESCRIPTION
Fixes #3988 .

Describe your changes.
Moves the Sprinks et al. 2017 paper from climate to meta in the publications list.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://fix-3988.pfe-preview.zooniverse.org/
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?


## Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
