### PR TITLE
edit slider input number styling

### DIFF
--- a/css/slider-task.styl
+++ b/css/slider-task.styl
@@ -24,7 +24,7 @@
 .slider-task-number
   flex: 1
   input
-    min-width: 50px
+    padding: 1em
     width: 5em
 
 .slider-task-container


### PR DESCRIPTION
Fixes #3996.

On wide screens the slider number input satisfied the minimum pixel width (50px) at the specified width (5em), but the padding overcrowded the number. This sets a padding (1em) and width (5em) that I believes scales appropriately.

# Review Checklist

- [ ] Does it work in all major browsers: ~~Firefox~~, ~~Chrome~~, Edge, ~~Safari~~?
- [ ] Does it work on mobile? **the slider task doesn't appear to work on mobile before these changes?** if confirmed, create new issue for
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? - https://fix-3996.pfe-preview.zooniverse.org
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?


## Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
