### PR TITLE
refactor slider task to stateless component

### DIFF
--- a/app/classifier/tasks/slider/index.jsx
+++ b/app/classifier/tasks/slider/index.jsx
@@ -22,7 +22,7 @@ const SliderSummary = (props) => {
       </div>
     </div>
   );
-}
+};
 
 SliderSummary.propTypes = {
   task: React.PropTypes.shape(
@@ -37,94 +37,68 @@ SliderSummary.propTypes = {
   ).isRequired
 };
 
-class SliderTask extends React.Component {
-  constructor(props) {
-    super(props);
-    let value = this.props.task.defaultValue;
-    if (this.props.annotation.value !== null) {
-      value = this.props.annotation.value;
-    }
-    this.state = { value };
-    this.handleChange = this.handleChange.bind(this);
-  }
-
-  componentDidMount() {
-    const newAnnotation = Object.assign({}, this.props.annotation, { value: this.props.task.defaultValue });
-    this.props.onChange(newAnnotation);
-  }
-
-  componentWillReceiveProps(nextProps) {
-    if (this.props.annotation.value === null) {
-      const newAnnotation = Object.assign({}, this.props.annotation, { value: this.props.task.defaultValue });
-      this.props.onChange(newAnnotation);
-    } else if (this.props.annotation.value !== this.state.value) {
-      this.setState({ value: this.props.annotation.value });
-    }
-  }
-
-  handleChange(e) {
+const SliderTask = ({ task, annotation, onChange, autoFocus }) => {
+  const handleChange = (e) => {
     let value = e.target.value;
-    if (parseFloat(value, 10) > parseFloat(this.props.task.max, 10)) {
-      value = this.props.task.max;
-    } else if (parseFloat(value, 10) < parseFloat(this.props.task.min, 10)) {
-      value = this.props.task.min;
+    if (parseFloat(value, 10) > parseFloat(task.max, 10)) {
+      value = task.max;
+    } else if (parseFloat(value, 10) < parseFloat(task.min, 10)) {
+      value = task.min;
     }
-    this.setState({ value });
-    const newAnnotation = Object.assign({}, this.props.annotation, { value });
-    this.props.onChange(newAnnotation);
-  }
+    const newAnnotation = Object.assign({}, annotation, { value });
+    onChange(newAnnotation);
+  };
 
-  render() {
-    return (
-      <div>
-        <GenericTask
-          question={this.props.task.instruction}
-          help={this.props.task.help}
-          required={this.props.task.required}
-        >
-          <div className="slider-task-container full ">
-            <div className="slider-task-range">
-              <label className="answer">
-                <div>
-                  <input
-                    className="standard-input"
-                    type="range"
-                    autoFocus={this.props.autoFocus}
-                    onChange={this.handleChange}
-                    max={this.props.task.max}
-                    min={this.props.task.min}
-                    step={this.props.task.step}
-                    value={this.state.value}
-                  />
+  return (
+    <div>
+      <GenericTask
+        question={task.instruction}
+        help={task.help}
+        required={task.required}
+      >
+        <div className="slider-task-container full ">
+          <div className="slider-task-range">
+            <label htmlFor="slider-range" className="answer">
+              <div>
+                <input
+                  className="standard-input"
+                  type="range"
+                  autoFocus={autoFocus}
+                  onChange={handleChange.bind(this)}
+                  max={task.max}
+                  min={task.min}
+                  step={task.step}
+                  value={annotation.value || task.defaultValue}
+                />
+              </div>
+              <div className="slider-task-range__label-container">
+                <div className="slider-task-range__label-container__left">
+                  {task.min}
                 </div>
-                <div className="slider-task-range__label-container">
-                  <div className="slider-task-range__label-container__left">
-                    {this.props.task.min}
-                  </div>
-                  <div className="slider-task-range__label-container__right">
-                    {this.props.task.max}
-                  </div>
+                <div className="slider-task-range__label-container__right">
+                  {task.max}
                 </div>
-              </label>
-            </div>
-            <label className="answer slider-task-number">
-              <input
-                className="standard-input"
-                type="number"
-                autoFocus={this.props.autoFocus}
-                onChange={this.handleChange}
-                max={this.props.task.max}
-                min={this.props.task.min}
-                step="any"
-                value={this.state.value}
-              />
+              </div>
             </label>
           </div>
-        </GenericTask>
-      </div>
-    );
-  }
-}
+          <label htmlFor="slider-number" className="answer slider-task-number">
+            <input
+              className="standard-input"
+              type="number"
+              autoFocus={autoFocus}
+              onChange={handleChange.bind(this)}
+              max={task.max}
+              min={task.min}
+              step={task.step}
+              value={annotation.value || task.defaultValue}
+            />
+          </label>
+        </div>
+      </GenericTask>
+    </div>
+  );
+};
+
 SliderTask.displayName = 'SliderTask';
 SliderTask.Editor = SliderTaskEditor;
 SliderTask.Summary = SliderSummary;

--- a/app/classifier/tasks/slider/slider.spec.js
+++ b/app/classifier/tasks/slider/slider.spec.js
@@ -86,7 +86,7 @@ describe('SliderTask', function () {
     });
 
     it('should have the correct step value', function () {
-      assert.equal(number.node.step, 'any');
+      assert.equal(number.node.step, task.step);
     });
   });
 


### PR DESCRIPTION
Fixes #4003.

Refactor slider task to stateless component.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? - https://refactor-slider-no-state.pfe-preview.zooniverse.org/
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?


## Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
