### PR TITLE
Sync slider task value and annotation value

### DIFF
--- a/app/classifier/tasks/slider/index.jsx
+++ b/app/classifier/tasks/slider/index.jsx
@@ -58,7 +58,7 @@ class SliderTask extends React.Component {
       const newAnnotation = Object.assign({}, this.props.annotation, { value: this.props.task.defaultValue });
       this.props.onChange(newAnnotation);
     } else if (this.props.annotation.value !== this.state.value) {
-      this.setState({ value: this.props.annotation.value });
+      this.setState({ value: nextProps.annotation.value });
     }
   }
 
@@ -115,7 +115,7 @@ class SliderTask extends React.Component {
                 onChange={this.handleChange}
                 max={this.props.task.max}
                 min={this.props.task.min}
-                step="any"
+                step={this.props.task.step}
                 value={this.state.value}
               />
             </label>

--- a/app/classifier/tasks/slider/slider.spec.js
+++ b/app/classifier/tasks/slider/slider.spec.js
@@ -86,7 +86,7 @@ describe('SliderTask', function () {
     });
 
     it('should have the correct step value', function () {
-      assert.equal(number.node.step, 'any');
+      assert.equal(number.node.step, task.step);
     });
   });
 


### PR DESCRIPTION
Fixes #4003 .

Describe your changes.
Set value properly on annotation prop change.
Set step properly on the number input (though browsers may ignore this.)

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch? https://fix-4003.pfe-preview.zooniverse.org/
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?


## Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
