### PR TITLE
Delete users

### DIFF
--- a/app/pages/admin/user-settings-list.jsx
+++ b/app/pages/admin/user-settings-list.jsx
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import { Redirect, Link } from 'react-router';
 import apiClient from 'panoptes-client/lib/api-client';
 
 import LoadingIndicator from '../../components/loading-indicator';
@@ -45,12 +46,7 @@ class UserSettingsList extends Component {
       return <p>Can&apos;t edit your own account</p>;
     }
 
-    return (
-      <div>
-        <UserSettings editUser={this.state.editUser} />
-        <UserProjects user={this.state.editUser} />
-      </div>
-    );
+    this.context.router.push(`/admin/users/${this.state.editUser.id}`);
   }
 
   render() {
@@ -61,7 +57,7 @@ class UserSettingsList extends Component {
             <UserSearch ref={(component) => { this.userSearch = component; }} multi={false} />
           </div>
           <button type="button" onClick={this.listUsers}>
-            Find user
+            Edit user
           </button>
         </div>
         {this.userResults()}
@@ -69,5 +65,9 @@ class UserSettingsList extends Component {
     );
   }
 }
+
+UserSettingsList.contextTypes = {
+  router: React.PropTypes.object.isRequired
+};
 
 export default UserSettingsList;

--- a/app/pages/admin/user-settings-list.jsx
+++ b/app/pages/admin/user-settings-list.jsx
@@ -28,8 +28,7 @@ class UserSettingsList extends Component {
     const userId = this.userSearch.value().value;
 
     if (userId) {
-      this.getEditUser(userId);
-      this.setState({ userId });
+      this.context.router.push(`/admin/users/${userId}`);
     }
   }
 
@@ -42,11 +41,7 @@ class UserSettingsList extends Component {
       return <LoadingIndicator />;
     }
 
-    if (this.state.editUser === this.props.user) {
-      return <p>Can&apos;t edit your own account</p>;
-    }
 
-    this.context.router.push(`/admin/users/${this.state.editUser.id}`);
   }
 
   render() {

--- a/app/pages/admin/user-settings.jsx
+++ b/app/pages/admin/user-settings.jsx
@@ -44,7 +44,7 @@ class UserSettings extends Component {
     }
 
     if (this.state.editUser === this.props.user) {
-      return <p>Can&apos;t edit your own account</p>;
+      return <div>You cannot edit your own account</div>;
     }
 
     const handleChange = handleInputChange.bind(this.state.editUser);

--- a/app/pages/admin/user-settings.jsx
+++ b/app/pages/admin/user-settings.jsx
@@ -1,8 +1,11 @@
 import React, { Component } from 'react';
 
 import AutoSave from '../../components/auto-save';
+import LoadingIndicator from '../../components/loading-indicator';
 import handleInputChange from '../../lib/handle-input-change';
 import UserLimitToggle from './user-settings/limit-toggle';
+import DeleteUser from './user-settings/delete-user';
+
 
 class UserSettings extends Component {
   constructor(props) {
@@ -70,6 +73,10 @@ class UserSettings extends Component {
           <li>Uploaded subjects: {this.props.editUser.uploaded_subjects_count}</li>
           <li><UserLimitToggle editUser={this.props.editUser} /></li>
         </ul>
+
+        <div>
+            <DeleteUser user={this.props.editUser} />
+        </div>
       </div>
     );
   }

--- a/app/pages/admin/user-settings.jsx
+++ b/app/pages/admin/user-settings.jsx
@@ -17,7 +17,7 @@ class UserSettings extends Component {
     this.getUser = this.getUser.bind(this);
 
     this.state = {
-      user: null
+      editUser: null
     };
   }
 
@@ -26,47 +26,52 @@ class UserSettings extends Component {
   }
 
   getUser() {
-    apiClient.type('users').get(this.props.params.id).then((user) => {
-      user.listen('change', this.boundForceUpdate);
-      this.setState({ user });
+    apiClient.type('users').get(this.props.params.id).then((editUser) => {
+      editUser.listen('change', this.boundForceUpdate);
+      this.setState({ editUser });
     });
   }
 
   componentWillUnmount() {
-    this.state.user.stopListening('change', this.boundForceUpdate);
+    this.state.editUser.stopListening('change', this.boundForceUpdate);
   }
 
   render() {
-    if (!this.state.user) {
+    if (!this.state.editUser) {
       return (
         <div>No user found</div>
       );
     }
 
-    const handleChange = handleInputChange.bind(this.state.user);
+    if (this.state.editUser === this.props.user) {
+      return <p>Can&apos;t edit your own account</p>;
+    }
+
+    const handleChange = handleInputChange.bind(this.state.editUser);
 
     return (
       <div>
         <div className="project-status">
-          <h4>Settings for {this.state.user.login}</h4>
+          <h4>Settings for {this.state.editUser.login}</h4>
 
-          <UserProperties user={this.state.user} />
+          <UserProperties user={this.state.editUser} />
 
           <ul>
-            <li>Uploaded subjects: {this.state.user.uploaded_subjects_count}</li>
-            <li><UserLimitToggle editUser={this.state.user} /></li>
+            <li>Uploaded subjects: {this.state.editUser.uploaded_subjects_count}</li>
+            <li><UserLimitToggle editUser={this.state.editUser} /></li>
           </ul>
 
-          <DeleteUser user={this.state.user} />
+          <DeleteUser user={this.state.editUser} />
         </div>
 
-        <UserProjects user={this.state.user} />
+        <UserProjects user={this.state.editUser} />
       </div>
     );
   }
 }
 
 UserSettings.propTypes = {
+  user: React.PropTypes.object,
   editUser: React.PropTypes.object
 };
 

--- a/app/pages/admin/user-settings.jsx
+++ b/app/pages/admin/user-settings.jsx
@@ -1,8 +1,11 @@
 import React, { Component } from 'react';
+import apiClient from 'panoptes-client/lib/api-client';
 
 import AutoSave from '../../components/auto-save';
 import LoadingIndicator from '../../components/loading-indicator';
 import handleInputChange from '../../lib/handle-input-change';
+import UserProperties from './user-settings/properties';
+import UserProjects from './user-settings/projects';
 import UserLimitToggle from './user-settings/limit-toggle';
 import DeleteUser from './user-settings/delete-user';
 
@@ -11,72 +14,53 @@ class UserSettings extends Component {
   constructor(props) {
     super(props);
     this.boundForceUpdate = this.forceUpdate.bind(this);
+    this.getUser = this.getUser.bind(this);
+
+    this.state = {
+      user: null
+    };
   }
 
   componentDidMount() {
-    if (this.props.editUser != null) {
-      this.props.editUser.listen('change', this.boundForceUpdate);
-    }
+    this.getUser();
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (this.props.editUser != null) {
-      this.props.editUser.stopListening('change', this.boundForceUpdate);
-    }
-    nextProps.editUser.listen('change', this.boundForceUpdate);
+  getUser() {
+    apiClient.type('users').get(this.props.params.id).then((user) => {
+      user.listen('change', this.boundForceUpdate);
+      this.setState({ user });
+    });
   }
 
   componentWillUnmount() {
-    this.props.editUser.stopListening('change', this.boundForceUpdate);
+    this.state.user.stopListening('change', this.boundForceUpdate);
   }
 
   render() {
-    if (!this.props.editUser) {
+    if (!this.state.user) {
       return (
         <div>No user found</div>
       );
     }
 
-    const handleChange = handleInputChange.bind(this.props.editUser);
+    const handleChange = handleInputChange.bind(this.state.user);
 
     return (
-      <div className="project-status">
-        <h4>Settings for {this.props.editUser.login}</h4>
-        <ul>
-          <li>
-            <input type="checkbox" name="admin" checked={this.props.editUser.admin} disabled />{' '}
-            Admin
-          </li>
-          <li>
-            <input type="checkbox" name="login_prompt" checked={this.props.editUser.login_prompt} disabled />{' '}
-            Login prompt
-          </li>
-          <li>
-            <input type="checkbox" name="private_profile" checked={this.props.editUser.private_profile} disabled />{' '}
-            Private profile
-          </li>
-          <li>
-            <AutoSave resource={this.props.editUser}>
-              <input type="checkbox" name="upload_whitelist" checked={this.props.editUser.upload_whitelist} onChange={handleChange} />{' '}
-              Whitelist subject uploads
-            </AutoSave>
-          </li>
-          <li>
-            <AutoSave resource={this.props.editUser}>
-              <input type="checkbox" name="banned" checked={this.props.editUser.banned} onChange={handleChange} />{' '}
-              Ban user
-            </AutoSave>
-          </li>
-        </ul>
+      <div>
+        <div className="project-status">
+          <h4>Settings for {this.state.user.login}</h4>
 
-        <ul>
-          <li>Uploaded subjects: {this.props.editUser.uploaded_subjects_count}</li>
-          <li><UserLimitToggle editUser={this.props.editUser} /></li>
-        </ul>
+          <UserProperties user={this.state.user} />
 
-        <div>
-            <DeleteUser user={this.props.editUser} />
+          <ul>
+            <li>Uploaded subjects: {this.state.user.uploaded_subjects_count}</li>
+            <li><UserLimitToggle editUser={this.state.user} /></li>
+          </ul>
+
+          <DeleteUser user={this.state.user} />
         </div>
+
+        <UserProjects user={this.state.user} />
       </div>
     );
   }

--- a/app/pages/admin/user-settings.spec.js
+++ b/app/pages/admin/user-settings.spec.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import assert from 'assert';
+import { shallow } from 'enzyme';
+import UserSettings from './user-settings';
+
+describe('UserSettings', () => {
+  let wrapper;
+  let user = {id: 1, login: "tester"};
+  let editUser = {id: 2, login: 'volunteer'};
+
+  it('errors when no user found', () => {
+    wrapper = shallow(<UserSettings user={user} />);
+    wrapper.setState({ editUser: null });
+    assert(wrapper.contains('No user found'));
+  });
+
+  it('errors when editing yourself', () => {
+    wrapper = shallow(<UserSettings user={user} />);
+    wrapper.setState({ editUser: user });
+    assert(wrapper.contains("You cannot edit your own account"));
+  });
+
+  it('renders without errors if there is a user', () => {
+    wrapper = shallow(<UserSettings user={user} />);
+    wrapper.setState({ editUser: editUser });
+    assert.equal(wrapper.find('UserProperties').length, 1);
+    assert.equal(wrapper.find('LimitToggle').length, 1);
+    assert.equal(wrapper.find('DeleteUser').length, 1);
+    assert.equal(wrapper.find('Projects').length, 1);
+  });
+});

--- a/app/pages/admin/user-settings/delete-user.jsx
+++ b/app/pages/admin/user-settings/delete-user.jsx
@@ -1,0 +1,63 @@
+import React, { Component } from 'react';
+
+import LoadingIndicator from '../../../components/loading-indicator';
+
+class DeleteUser extends Component {
+    constructor(props) {
+        super(props);
+        this.state = {deletionInProgress: false};
+        this.handleClick = this.handleClick.bind(this)
+        this.performDelete = this.performDelete.bind(this)
+    }
+
+    render() {
+        return (
+            <div>
+                <button type="button" className="minor-button" disabled={this.state.deletionInProgress} onClick={this.handleClick} style={{background: "red", color: "white"}}>
+                    Delete this user
+                    <LoadingIndicator off={!this.state.deletionInProgress} />
+                </button>
+                {this.state.deletionError && (
+                     <div className="form-help error">{this.state.deletionError.message}</div>
+                )}
+            </div>
+        );
+    }
+
+    handleClick() {
+        this.setState({deletionError: null});
+
+        var phrase = prompt("You are about to delete this user and all their projects! This cannot be reversed.\nEnter this user's login to confirm.");
+
+        if (phrase === this.props.user.login) {
+            this.performDelete();
+        } else {
+            this.setState({deletionError: {message: "Entered login did not match user. Aborted deletion."}});
+        }
+    }
+
+    performDelete() {
+        this.setState({deletionInProgress: true});
+
+        this.props.user.delete()
+            .then(() => {
+                this.context.router.push('/admin');
+            })
+            .catch((error) => {
+                this.setState({deletionError: error, deletionInProgress: false});
+            })
+            .then(() => {
+                this.setState({deletionInProgress: false});
+            })
+    }
+};
+
+DeleteUser.propTypes = {
+    user: React.PropTypes.object
+}
+
+DeleteUser.contextTypes = {
+  router: React.PropTypes.object.isRequired
+};
+
+export default DeleteUser;

--- a/app/pages/admin/user-settings/delete-user.jsx
+++ b/app/pages/admin/user-settings/delete-user.jsx
@@ -3,57 +3,57 @@ import React, { Component } from 'react';
 import LoadingIndicator from '../../../components/loading-indicator';
 
 class DeleteUser extends Component {
-    constructor(props) {
-        super(props);
-        this.state = {deletionInProgress: false};
-        this.handleClick = this.handleClick.bind(this)
-        this.performDelete = this.performDelete.bind(this)
+  constructor(props) {
+    super(props);
+    this.state = {deletionInProgress: false};
+    this.handleClick = this.handleClick.bind(this)
+    this.performDelete = this.performDelete.bind(this)
+  }
+
+  render() {
+    return (
+      <div>
+        <button type="button" className="minor-button" disabled={this.state.deletionInProgress} onClick={this.handleClick} style={{background: "red", color: "white"}}>
+          Delete this user
+          <LoadingIndicator off={!this.state.deletionInProgress} />
+        </button>
+        {this.state.deletionError && (
+           <div className="form-help error">{this.state.deletionError.message}</div>
+        )}
+      </div>
+    );
+  }
+
+  handleClick() {
+    this.setState({deletionError: null});
+
+    var phrase = prompt("You are about to delete this user and all their projects! This cannot be reversed.\nEnter this user's login to confirm.");
+
+    if (phrase === this.props.user.login) {
+      this.performDelete();
+    } else {
+      this.setState({deletionError: {message: "Entered login did not match user. Aborted deletion."}});
     }
+  }
 
-    render() {
-        return (
-            <div>
-                <button type="button" className="minor-button" disabled={this.state.deletionInProgress} onClick={this.handleClick} style={{background: "red", color: "white"}}>
-                    Delete this user
-                    <LoadingIndicator off={!this.state.deletionInProgress} />
-                </button>
-                {this.state.deletionError && (
-                     <div className="form-help error">{this.state.deletionError.message}</div>
-                )}
-            </div>
-        );
-    }
+  performDelete() {
+    this.setState({deletionInProgress: true});
 
-    handleClick() {
-        this.setState({deletionError: null});
-
-        var phrase = prompt("You are about to delete this user and all their projects! This cannot be reversed.\nEnter this user's login to confirm.");
-
-        if (phrase === this.props.user.login) {
-            this.performDelete();
-        } else {
-            this.setState({deletionError: {message: "Entered login did not match user. Aborted deletion."}});
-        }
-    }
-
-    performDelete() {
-        this.setState({deletionInProgress: true});
-
-        this.props.user.delete()
-            .then(() => {
-                this.context.router.push('/admin');
-            })
-            .catch((error) => {
-                this.setState({deletionError: error, deletionInProgress: false});
-            })
-            .then(() => {
-                this.setState({deletionInProgress: false});
-            })
-    }
+    this.props.user.delete()
+        .then(() => {
+          this.context.router.push('/admin');
+        })
+        .catch((error) => {
+          this.setState({deletionError: error, deletionInProgress: false});
+        })
+        .then(() => {
+          this.setState({deletionInProgress: false});
+        })
+  }
 };
 
 DeleteUser.propTypes = {
-    user: React.PropTypes.object
+  user: React.PropTypes.object
 }
 
 DeleteUser.contextTypes = {

--- a/app/pages/admin/user-settings/delete-user.jsx
+++ b/app/pages/admin/user-settings/delete-user.jsx
@@ -27,7 +27,7 @@ class DeleteUser extends Component {
   handleClick() {
     this.setState({deletionError: null});
 
-    var phrase = prompt("You are about to delete this user and all their projects! This cannot be reversed.\nEnter this user's login to confirm.");
+    var phrase = prompt("You are about to delete this user! This cannot be reversed.\nEnter this user's login to confirm.");
 
     if (phrase === this.props.user.login) {
       this.performDelete();

--- a/app/pages/admin/user-settings/properties.jsx
+++ b/app/pages/admin/user-settings/properties.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+
+import AutoSave from '../../../components/auto-save';
+import handleInputChange from '../../../lib/handle-input-change';
+
+const UserProperties = (props) => {
+  const handleChange = handleInputChange.bind(props.user);
+
+  return (
+    <div>
+      <ul>
+        <li>
+          <input type="checkbox" name="admin" checked={props.user.admin} disabled />{' '}
+          Admin
+        </li>
+        <li>
+          <input type="checkbox" name="login_prompt" checked={props.user.login_prompt} disabled />{' '}
+          Login prompt
+        </li>
+        <li>
+          <input type="checkbox" name="private_profile" checked={props.user.private_profile} disabled />{' '}
+          Private profile
+        </li>
+        <li>
+          <AutoSave resource={props.user}>
+            <input type="checkbox" name="upload_whitelist" checked={props.user.upload_whitelist} onChange={handleChange} />{' '}
+            Whitelist subject uploads
+          </AutoSave>
+        </li>
+        <li>
+          <AutoSave resource={this.props.user}>
+            <input type="checkbox" name="banned" checked={this.props.user.banned} onChange={handleChange} />{' '}
+            Ban user
+          </AutoSave>
+        </li>
+      </ul>
+
+    </div>
+  );
+}
+
+UserProperties.propTypes = {
+  user: React.PropTypes.object
+}
+
+export default UserProperties;

--- a/app/pages/admin/user-settings/properties.jsx
+++ b/app/pages/admin/user-settings/properties.jsx
@@ -28,8 +28,8 @@ const UserProperties = (props) => {
           </AutoSave>
         </li>
         <li>
-          <AutoSave resource={this.props.user}>
-            <input type="checkbox" name="banned" checked={this.props.user.banned} onChange={handleChange} />{' '}
+          <AutoSave resource={props.user}>
+            <input type="checkbox" name="banned" checked={props.user.banned} onChange={handleChange} />{' '}
             Ban user
           </AutoSave>
         </li>

--- a/app/router.cjsx
+++ b/app/router.cjsx
@@ -11,6 +11,7 @@ React = require 'react'
 `import { AboutProjectResearch, AboutProjectEducation, AboutProjectFAQ, AboutProjectResults } from './pages/project/about/simple-pages';`
 `import AboutProjectTeam from './pages/project/about/team';`
 `import UserSettingsList from './pages/admin/user-settings-list';`
+`import UserSettings from './pages/admin/user-settings';`
 `import ProjectStatusList from './pages/admin/project-status-list';`
 `import ProjectStatus from './pages/admin/project-status';`
 `import Grantbot from './pages/admin/grantbot';`
@@ -244,6 +245,8 @@ module.exports =
 
     <Route path="admin" component={AdminPage}>
       <IndexRoute component={UserSettingsList} />
+      <Route path="users" component={UserSettingsList} />
+      <Route path="users/:id" component={UserSettings} />
       <Route path="project_status" component={ProjectStatusList} />
       <Route path="project_status/:owner/:name" component={ProjectStatus} />
       <Route path="grantbot" component={Grantbot} />

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,6 @@
 {
   "name": "panoptes-front-end",
+  "requires": true,
   "lockfileVersion": 1,
   "dependencies": {
     "abab": {
@@ -5524,9 +5525,9 @@
       "dev": true
     },
     "json-api-client": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/json-api-client/-/json-api-client-3.2.1.tgz",
-      "integrity": "sha1-VZ1BDu37+RUboxHYLeDtbHkqkDs=",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/json-api-client/-/json-api-client-3.2.2.tgz",
+      "integrity": "sha1-5DNNAvFJJC+fnv48/01DpI4pA6o=",
       "requires": {
         "normalizeurl": "0.1.3",
         "superagent": "1.8.5"
@@ -6704,7 +6705,7 @@
       "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-2.7.2.tgz",
       "integrity": "sha1-xYWVYtNgVCaKoxHihVqhZ3EU+oI=",
       "requires": {
-        "json-api-client": "3.2.1",
+        "json-api-client": "3.2.2",
         "local-storage": "1.4.2",
         "sugar-client": "1.0.1"
       }
@@ -9070,26 +9071,14 @@
         "component-emitter": "1.2.1",
         "cookiejar": "2.0.6",
         "debug": "2.3.3",
-        "extend": "3.0.0",
+        "extend": "3.0.1",
         "form-data": "1.0.0-rc3",
         "formidable": "1.0.17",
         "methods": "1.1.2",
         "mime": "1.3.4",
-        "qs": "2.3.3",
+        "qs": "6.0.4",
         "readable-stream": "1.0.27-1",
         "reduce-component": "1.0.1"
-      },
-      "dependencies": {
-        "extend": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
-          "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ="
-        },
-        "qs": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
-          "integrity": "sha1-6eha2+ddoLvkyOBHaghikPhjtAQ="
-        }
       }
     },
     "supports-color": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "events": "~1.1.1",
     "hash.js": "~1.0.3",
     "he": "~1.1.0",
+    "json-api-client": "~3.2.2",
     "lodash": "~4.17.4",
     "markdownz": "~7.3.1",
     "modal-form": "~2.4",


### PR DESCRIPTION
Fixes https://github.com/zooniverse/Panoptes-Front-End/issues/1913

Added a button for deleting a user in the admin section.

Refactored to move the editting page under a different route. Without this, there was no way to tell the router to go back to the admin index and stop showing the deleted resource. This also means you can now send URLs for specific users around in Slack etc, and can refresh the page when you're devving on it without needing to re-type the user login every time.

TODO:

- [ ] Figure out how to add tests (loads user dynamically from API, which is making it difficult)
- [x] Update to the correct `json-api-client`

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?


## Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
