### PR TITLE
Fix broken latest talk comment link

### DIFF
--- a/app/talk/latest-comment-link.cjsx
+++ b/app/talk/latest-comment-link.cjsx
@@ -71,7 +71,7 @@ module.exports = React.createClass
       scrollToLastComment: true, page: @lastPage()
 
     baseLink = "/"
-    if @props.project?
+    if @props.project? and @props.project.slug?
       baseLink += "projects/#{@props.project.slug}/"
 
     <div className="talk-latest-comment-link">


### PR DESCRIPTION
Adds a check for project slug when constructing a project URL for the latest comment in Talk. Fixes #4016.

https://talk-link-fix.pfe-preview.zooniverse.org/

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?


## Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
