### PR TITLE
Fix Epoch Calculations With WWT

### DIFF
--- a/app/classifier/world-wide-telescope.jsx
+++ b/app/classifier/world-wide-telescope.jsx
@@ -258,24 +258,21 @@ StarCoord._epochConvert = (ra, dec) => {
 };
 
 StarCoord._transform = (ra, dec) => {
-  const r0 = new Array (
-   Math.cos(ra) * Math.cos(dec),
-   Math.sin(ra) * Math.cos(dec),
-   Math.sin(dec) );
+  const r0 = [ Math.cos(ra) * Math.cos(dec), Math.sin(ra) * Math.cos(dec), Math.sin(dec) ];
 
-  const matrix = new Array (
+  const matrix = [
    0.9999256782, -0.0111820611, -0.0048579477,
    0.0111820610,  0.9999374784, -0.0000271765,
-   0.0048579479, -0.0000271474,  0.9999881997 );
+   0.0048579479, -0.0000271474,  0.9999881997 ];
 
-  const s0 = new Array (
+  const s0 = [
    r0[0]*matrix[0] + r0[1]*matrix[1] + r0[2]*matrix[2],
    r0[0]*matrix[3] + r0[1]*matrix[4] + r0[2]*matrix[5],
-   r0[0]*matrix[6] + r0[1]*matrix[7] + r0[2]*matrix[8] );
+   r0[0]*matrix[6] + r0[1]*matrix[7] + r0[2]*matrix[8] ];
 
   const r = Math.sqrt( s0[0]*s0[0] + s0[1]*s0[1] + s0[2]*s0[2] );
 
-  const result = new Array ( 0.0, 0.0 );
+  const result = [ 0.0, 0.0 ];
   result[1] = Math.asin( s0[2]/r );
   const cosaa = ( (s0[0]/r) / Math.cos(result[1] ) );
   const sinaa = ( (s0[1]/r) / Math.cos(result[1] ) );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,5 @@
 {
   "name": "panoptes-front-end",
-  "requires": true,
   "lockfileVersion": 1,
   "dependencies": {
     "abab": {
@@ -13,11 +12,7 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
       "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
-      "dev": true,
-      "requires": {
-        "mime-types": "2.1.15",
-        "negotiator": "0.6.1"
-      }
+      "dev": true
     },
     "acorn": {
       "version": "2.7.0",
@@ -30,9 +25,6 @@
       "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz",
       "integrity": "sha1-x1K9IQvvZ5UBtsbLf8hPj0cVjMQ=",
       "dev": true,
-      "requires": {
-        "acorn": "4.0.13"
-      },
       "dependencies": {
         "acorn": {
           "version": "4.0.13",
@@ -47,19 +39,13 @@
       "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.9.tgz",
       "integrity": "sha1-VbtemGkVB7dFedBRNBMhfDgMVM8=",
       "dev": true,
-      "optional": true,
-      "requires": {
-        "acorn": "2.7.0"
-      }
+      "optional": true
     },
     "acorn-jsx": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
-      "requires": {
-        "acorn": "3.3.0"
-      },
       "dependencies": {
         "acorn": {
           "version": "3.3.0",
@@ -72,10 +58,7 @@
     "add-dom-event-listener": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/add-dom-event-listener/-/add-dom-event-listener-1.0.2.tgz",
-      "integrity": "sha1-j67SxBAIchzxEdodMNmVuFvkK+0=",
-      "requires": {
-        "object-assign": "4.1.1"
-      }
+      "integrity": "sha1-j67SxBAIchzxEdodMNmVuFvkK+0="
     },
     "after": {
       "version": "0.8.2",
@@ -86,11 +69,7 @@
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
       "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-      "dev": true,
-      "requires": {
-        "co": "4.6.0",
-        "json-stable-stringify": "1.0.1"
-      }
+      "dev": true
     },
     "ajv-keywords": {
       "version": "1.5.1",
@@ -102,12 +81,7 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "dev": true,
-      "requires": {
-        "kind-of": "3.2.2",
-        "longest": "1.0.1",
-        "repeat-string": "1.6.1"
-      }
+      "dev": true
     },
     "alphanum-sort": {
       "version": "1.0.2",
@@ -154,19 +128,12 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
       "integrity": "sha1-o+Uvo5FoyCX/V7AkgSbOWo/5VQc=",
-      "dev": true,
-      "requires": {
-        "arrify": "1.0.1",
-        "micromatch": "2.3.11"
-      }
+      "dev": true
     },
     "argparse": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
-      "requires": {
-        "sprintf-js": "1.0.3"
-      },
       "dependencies": {
         "sprintf-js": {
           "version": "1.0.3",
@@ -179,10 +146,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-      "dev": true,
-      "requires": {
-        "arr-flatten": "1.0.3"
-      }
+      "dev": true
     },
     "arr-flatten": {
       "version": "1.0.3",
@@ -206,10 +170,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-      "dev": true,
-      "requires": {
-        "array-uniq": "1.0.3"
-      }
+      "dev": true
     },
     "array-uniq": {
       "version": "1.0.3",
@@ -249,21 +210,13 @@
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz",
       "integrity": "sha1-SLokC0WpKA6UdImQull9IWYX/UA=",
-      "dev": true,
-      "requires": {
-        "bn.js": "4.11.6",
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.0"
-      }
+      "dev": true
     },
     "assert": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
       "integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
-      "dev": true,
-      "requires": {
-        "util": "0.10.3"
-      }
+      "dev": true
     },
     "assert-plus": {
       "version": "0.2.0",
@@ -292,26 +245,13 @@
       "version": "6.7.7",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
       "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
-      "dev": true,
-      "requires": {
-        "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000692",
-        "normalize-range": "0.1.2",
-        "num2fraction": "1.2.2",
-        "postcss": "5.2.17",
-        "postcss-value-parser": "3.3.0"
-      }
+      "dev": true
     },
     "aws-sdk": {
       "version": "2.1.50",
       "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1.50.tgz",
       "integrity": "sha1-Zd3CuEDmkCEIftNfKC1jKgUpShs=",
       "dev": true,
-      "requires": {
-        "sax": "0.5.3",
-        "xml2js": "0.2.8",
-        "xmlbuilder": "0.4.2"
-      },
       "dependencies": {
         "sax": {
           "version": "0.5.3",
@@ -336,221 +276,103 @@
     "axios": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.11.1.tgz",
-      "integrity": "sha1-Oc22WBPixUnRwunDiffjOqZcyiI=",
-      "requires": {
-        "follow-redirects": "0.0.7"
-      }
+      "integrity": "sha1-Oc22WBPixUnRwunDiffjOqZcyiI="
     },
     "babel-cli": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-cli/-/babel-cli-6.24.1.tgz",
       "integrity": "sha1-IHzXBbumFImy6kG1MSNBz2rKIoM=",
-      "dev": true,
-      "requires": {
-        "babel-core": "6.24.1",
-        "babel-polyfill": "6.23.0",
-        "babel-register": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "chokidar": "1.7.0",
-        "commander": "2.9.0",
-        "convert-source-map": "1.5.0",
-        "fs-readdir-recursive": "1.0.0",
-        "glob": "7.1.2",
-        "lodash": "4.17.4",
-        "output-file-sync": "1.1.2",
-        "path-is-absolute": "1.0.1",
-        "slash": "1.0.0",
-        "source-map": "0.5.6",
-        "v8flags": "2.1.1"
-      }
+      "dev": true
     },
     "babel-code-frame": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
       "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
-      "dev": true,
-      "requires": {
-        "chalk": "1.1.3",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.1"
-      }
+      "dev": true
     },
     "babel-core": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.24.1.tgz",
       "integrity": "sha1-jEKFZNzh4fQfszfsNPTDsCK1rYM=",
-      "dev": true,
-      "requires": {
-        "babel-code-frame": "6.22.0",
-        "babel-generator": "6.25.0",
-        "babel-helpers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-register": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.25.0",
-        "babel-traverse": "6.25.0",
-        "babel-types": "6.25.0",
-        "babylon": "6.17.4",
-        "convert-source-map": "1.5.0",
-        "debug": "2.3.3",
-        "json5": "0.5.1",
-        "lodash": "4.17.4",
-        "minimatch": "3.0.4",
-        "path-is-absolute": "1.0.1",
-        "private": "0.1.7",
-        "slash": "1.0.0",
-        "source-map": "0.5.6"
-      }
+      "dev": true
     },
     "babel-generator": {
       "version": "6.25.0",
       "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.25.0.tgz",
       "integrity": "sha1-M6GvcNXyiQrrRlpKd5PB32qeqfw=",
-      "dev": true,
-      "requires": {
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.25.0",
-        "detect-indent": "4.0.0",
-        "jsesc": "1.3.0",
-        "lodash": "4.17.4",
-        "source-map": "0.5.6",
-        "trim-right": "1.0.1"
-      }
+      "dev": true
     },
     "babel-helper-builder-react-jsx": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.24.1.tgz",
       "integrity": "sha1-CteRfjPI11HmRtrKTnfMGTd9LLw=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.25.0",
-        "esutils": "2.0.2"
-      }
+      "dev": true
     },
     "babel-helper-call-delegate": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
       "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
-      "dev": true,
-      "requires": {
-        "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "babel-traverse": "6.25.0",
-        "babel-types": "6.25.0"
-      }
+      "dev": true
     },
     "babel-helper-define-map": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.24.1.tgz",
       "integrity": "sha1-epdH8ljYlH0y1RX2qhx70CIEoIA=",
-      "dev": true,
-      "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.25.0",
-        "lodash": "4.17.4"
-      }
+      "dev": true
     },
     "babel-helper-function-name": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
       "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
-      "dev": true,
-      "requires": {
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.25.0",
-        "babel-traverse": "6.25.0",
-        "babel-types": "6.25.0"
-      }
+      "dev": true
     },
     "babel-helper-get-function-arity": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
       "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.25.0"
-      }
+      "dev": true
     },
     "babel-helper-hoist-variables": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
       "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.25.0"
-      }
+      "dev": true
     },
     "babel-helper-optimise-call-expression": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
       "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.25.0"
-      }
+      "dev": true
     },
     "babel-helper-regex": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz",
       "integrity": "sha1-024i+rEAjXnYhkjjIRaGgShFbOg=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.25.0",
-        "lodash": "4.17.4"
-      }
+      "dev": true
     },
     "babel-helper-replace-supers": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
       "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
-      "dev": true,
-      "requires": {
-        "babel-helper-optimise-call-expression": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.25.0",
-        "babel-traverse": "6.25.0",
-        "babel-types": "6.25.0"
-      }
+      "dev": true
     },
     "babel-helpers": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
       "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.25.0"
-      }
+      "dev": true
     },
     "babel-loader": {
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-6.4.1.tgz",
       "integrity": "sha1-CzQRLVsHSKjc2/Uaz2+b1C1QuMo=",
-      "dev": true,
-      "requires": {
-        "find-cache-dir": "0.1.1",
-        "loader-utils": "0.2.17",
-        "mkdirp": "0.5.1",
-        "object-assign": "4.1.1"
-      }
+      "dev": true
     },
     "babel-messages": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.23.0"
-      }
+      "dev": true
     },
     "babel-plugin-add-module-exports": {
       "version": "0.2.1",
@@ -562,19 +384,13 @@
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
       "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.23.0"
-      }
+      "dev": true
     },
     "babel-plugin-react-transform": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/babel-plugin-react-transform/-/babel-plugin-react-transform-2.0.2.tgz",
       "integrity": "sha1-UVu/qZaJOYEULZCx+bFjXeKZUQk=",
-      "dev": true,
-      "requires": {
-        "lodash": "4.17.4"
-      }
+      "dev": true
     },
     "babel-plugin-rewire": {
       "version": "1.0.0",
@@ -598,250 +414,145 @@
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
       "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.23.0"
-      }
+      "dev": true
     },
     "babel-plugin-transform-es2015-block-scoped-functions": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
       "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.23.0"
-      }
+      "dev": true
     },
     "babel-plugin-transform-es2015-block-scoping": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz",
       "integrity": "sha1-dsKV3DpHQbFmWt/TFnIV3P8ypXY=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.25.0",
-        "babel-traverse": "6.25.0",
-        "babel-types": "6.25.0",
-        "lodash": "4.17.4"
-      }
+      "dev": true
     },
     "babel-plugin-transform-es2015-classes": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
       "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
-      "dev": true,
-      "requires": {
-        "babel-helper-define-map": "6.24.1",
-        "babel-helper-function-name": "6.24.1",
-        "babel-helper-optimise-call-expression": "6.24.1",
-        "babel-helper-replace-supers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.25.0",
-        "babel-traverse": "6.25.0",
-        "babel-types": "6.25.0"
-      }
+      "dev": true
     },
     "babel-plugin-transform-es2015-computed-properties": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
       "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.25.0"
-      }
+      "dev": true
     },
     "babel-plugin-transform-es2015-destructuring": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
       "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.23.0"
-      }
+      "dev": true
     },
     "babel-plugin-transform-es2015-duplicate-keys": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
       "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.25.0"
-      }
+      "dev": true
     },
     "babel-plugin-transform-es2015-for-of": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
       "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.23.0"
-      }
+      "dev": true
     },
     "babel-plugin-transform-es2015-function-name": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
       "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
-      "dev": true,
-      "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.25.0"
-      }
+      "dev": true
     },
     "babel-plugin-transform-es2015-literals": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
       "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.23.0"
-      }
+      "dev": true
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz",
       "integrity": "sha1-0+MQtA72ZKNmIiAAl8bUQCmPK/4=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-transform-strict-mode": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.25.0",
-        "babel-types": "6.25.0"
-      }
+      "dev": true
     },
     "babel-plugin-transform-es2015-object-super": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
       "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
-      "dev": true,
-      "requires": {
-        "babel-helper-replace-supers": "6.24.1",
-        "babel-runtime": "6.23.0"
-      }
+      "dev": true
     },
     "babel-plugin-transform-es2015-parameters": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
       "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
-      "dev": true,
-      "requires": {
-        "babel-helper-call-delegate": "6.24.1",
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "babel-template": "6.25.0",
-        "babel-traverse": "6.25.0",
-        "babel-types": "6.25.0"
-      }
+      "dev": true
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
       "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.25.0"
-      }
+      "dev": true
     },
     "babel-plugin-transform-es2015-spread": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
       "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.23.0"
-      }
+      "dev": true
     },
     "babel-plugin-transform-es2015-sticky-regex": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
       "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
-      "dev": true,
-      "requires": {
-        "babel-helper-regex": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.25.0"
-      }
+      "dev": true
     },
     "babel-plugin-transform-es2015-template-literals": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
       "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.23.0"
-      }
+      "dev": true
     },
     "babel-plugin-transform-es2015-typeof-symbol": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
       "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.23.0"
-      }
+      "dev": true
     },
     "babel-plugin-transform-es2015-unicode-regex": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
       "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
-      "dev": true,
-      "requires": {
-        "babel-helper-regex": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "regexpu-core": "2.0.0"
-      }
+      "dev": true
     },
     "babel-plugin-transform-flow-strip-types": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz",
       "integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-syntax-flow": "6.18.0",
-        "babel-runtime": "6.23.0"
-      }
+      "dev": true
     },
     "babel-plugin-transform-object-assign": {
       "version": "6.8.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-assign/-/babel-plugin-transform-object-assign-6.8.0.tgz",
       "integrity": "sha1-duF/LcDzbxT1SLmv16rvWNKeu3U=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.23.0"
-      }
+      "dev": true
     },
     "babel-plugin-transform-react-display-name": {
       "version": "6.25.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.25.0.tgz",
       "integrity": "sha1-Z+K/Hx6ck6sI25Z5LgU5K/LMKNE=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.23.0"
-      }
+      "dev": true
     },
     "babel-plugin-transform-react-jsx": {
       "version": "6.7.5",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.7.5.tgz",
       "integrity": "sha1-VmfGGlZCevdI6ux97Ca0Ru6VEco=",
       "dev": true,
-      "requires": {
-        "babel-helper-builder-react-jsx": "6.24.1",
-        "babel-plugin-syntax-jsx": "6.18.0",
-        "babel-runtime": "5.8.38"
-      },
       "dependencies": {
         "babel-runtime": {
           "version": "5.8.38",
           "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
           "integrity": "sha1-HAsC62MxL18If/IEUIJ7QlydTBk=",
-          "dev": true,
-          "requires": {
-            "core-js": "1.2.7"
-          }
+          "dev": true
         }
       }
     },
@@ -849,60 +560,37 @@
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.22.0.tgz",
       "integrity": "sha1-322AqdomEqEh5t3XVYvL7PBuY24=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-syntax-jsx": "6.18.0",
-        "babel-runtime": "6.23.0"
-      }
+      "dev": true
     },
     "babel-plugin-transform-react-jsx-source": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.22.0.tgz",
       "integrity": "sha1-ZqwSFT9c0tF7PBkmj0vwGX9E7NY=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-syntax-jsx": "6.18.0",
-        "babel-runtime": "6.23.0"
-      }
+      "dev": true
     },
     "babel-plugin-transform-regenerator": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz",
       "integrity": "sha1-uNowWtQ8PJm0hI5P5AN7dw0jxBg=",
-      "dev": true,
-      "requires": {
-        "regenerator-transform": "0.9.11"
-      }
+      "dev": true
     },
     "babel-plugin-transform-strict-mode": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
       "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.25.0"
-      }
+      "dev": true
     },
     "babel-plugin-typecheck": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-typecheck/-/babel-plugin-typecheck-3.9.0.tgz",
       "integrity": "sha1-DtrHVzriTuWMb5Exn1dLxRJLDw8=",
-      "dev": true,
-      "requires": {
-        "babel-generator": "6.25.0"
-      }
+      "dev": true
     },
     "babel-polyfill": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.23.0.tgz",
       "integrity": "sha1-g2TKYt+Or7gwSZ9pkXdGbDsDSZ0=",
       "dev": true,
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "core-js": "2.4.1",
-        "regenerator-runtime": "0.10.5"
-      },
       "dependencies": {
         "core-js": {
           "version": "2.4.1",
@@ -916,60 +604,19 @@
       "version": "6.6.0",
       "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.6.0.tgz",
       "integrity": "sha1-iLM+WP7JTG695Y3GXs5dFODsJWg=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-check-es2015-constants": "6.22.0",
-        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "6.24.1",
-        "babel-plugin-transform-es2015-classes": "6.24.1",
-        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
-        "babel-plugin-transform-es2015-destructuring": "6.23.0",
-        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-        "babel-plugin-transform-es2015-for-of": "6.23.0",
-        "babel-plugin-transform-es2015-function-name": "6.24.1",
-        "babel-plugin-transform-es2015-literals": "6.22.0",
-        "babel-plugin-transform-es2015-modules-commonjs": "6.24.1",
-        "babel-plugin-transform-es2015-object-super": "6.24.1",
-        "babel-plugin-transform-es2015-parameters": "6.24.1",
-        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-        "babel-plugin-transform-es2015-spread": "6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-        "babel-plugin-transform-es2015-template-literals": "6.22.0",
-        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-        "babel-plugin-transform-regenerator": "6.24.1"
-      }
+      "dev": true
     },
     "babel-preset-react": {
       "version": "6.16.0",
       "resolved": "https://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.16.0.tgz",
       "integrity": "sha1-qhF9YN4JKGB+NDxIKJBuRmGCQxY=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-syntax-flow": "6.18.0",
-        "babel-plugin-syntax-jsx": "6.18.0",
-        "babel-plugin-transform-flow-strip-types": "6.22.0",
-        "babel-plugin-transform-react-display-name": "6.25.0",
-        "babel-plugin-transform-react-jsx": "6.7.5",
-        "babel-plugin-transform-react-jsx-self": "6.22.0",
-        "babel-plugin-transform-react-jsx-source": "6.22.0"
-      }
+      "dev": true
     },
     "babel-register": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.24.1.tgz",
       "integrity": "sha1-fhDhOi9xBlvfrVoXh7pFvKbe118=",
       "dev": true,
-      "requires": {
-        "babel-core": "6.24.1",
-        "babel-runtime": "6.23.0",
-        "core-js": "2.4.1",
-        "home-or-tmp": "2.0.0",
-        "lodash": "4.17.4",
-        "mkdirp": "0.5.1",
-        "source-map-support": "0.4.15"
-      },
       "dependencies": {
         "core-js": {
           "version": "2.4.1",
@@ -983,10 +630,6 @@
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
       "integrity": "sha1-CpSJ8UTecO+zzkMArM2zKeL8VDs=",
-      "requires": {
-        "core-js": "2.4.1",
-        "regenerator-runtime": "0.10.5"
-      },
       "dependencies": {
         "core-js": {
           "version": "2.4.1",
@@ -999,43 +642,19 @@
       "version": "6.25.0",
       "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
       "integrity": "sha1-ZlJBFmt8KqTGGdceGSlpVSsQwHE=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-traverse": "6.25.0",
-        "babel-types": "6.25.0",
-        "babylon": "6.17.4",
-        "lodash": "4.17.4"
-      }
+      "dev": true
     },
     "babel-traverse": {
       "version": "6.25.0",
       "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
       "integrity": "sha1-IldJfi/NGbie3BPEyROB+VEklvE=",
-      "dev": true,
-      "requires": {
-        "babel-code-frame": "6.22.0",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.25.0",
-        "babylon": "6.17.4",
-        "debug": "2.3.3",
-        "globals": "9.18.0",
-        "invariant": "2.2.2",
-        "lodash": "4.17.4"
-      }
+      "dev": true
     },
     "babel-types": {
       "version": "6.25.0",
       "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
       "integrity": "sha1-cK+ySNVmDl0Y+BHZHIMDtUE0oY4=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "esutils": "2.0.2",
-        "lodash": "4.17.4",
-        "to-fast-properties": "1.0.3"
-      }
+      "dev": true
     },
     "babylon": {
       "version": "6.17.4",
@@ -1077,18 +696,12 @@
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
       "dev": true,
-      "optional": true,
-      "requires": {
-        "tweetnacl": "0.14.5"
-      }
+      "optional": true
     },
     "better-assert": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
-      "integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=",
-      "requires": {
-        "callsite": "1.0.0"
-      }
+      "integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI="
     },
     "big.js": {
       "version": "3.1.3",
@@ -1135,44 +748,25 @@
       "version": "2.10.1",
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-      "dev": true,
-      "requires": {
-        "hoek": "2.16.3"
-      }
+      "dev": true
     },
     "bower-config": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/bower-config/-/bower-config-1.4.0.tgz",
       "integrity": "sha1-FsOMETX4BxwZ8lk41hsNjL8Y0/E=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "mout": "1.0.0",
-        "optimist": "0.6.1",
-        "osenv": "0.1.4",
-        "untildify": "2.1.0"
-      }
+      "dev": true
     },
     "brace-expansion": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-      "dev": true,
-      "requires": {
-        "balanced-match": "1.0.0",
-        "concat-map": "0.0.1"
-      }
+      "dev": true
     },
     "braces": {
       "version": "1.8.5",
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-      "dev": true,
-      "requires": {
-        "expand-range": "1.8.2",
-        "preserve": "0.2.0",
-        "repeat-element": "1.1.2"
-      }
+      "dev": true
     },
     "brorand": {
       "version": "1.1.0",
@@ -1190,91 +784,49 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz",
       "integrity": "sha1-Xncl297x/Vkw1OurSFZ85FHEigo=",
-      "dev": true,
-      "requires": {
-        "buffer-xor": "1.0.3",
-        "cipher-base": "1.0.3",
-        "create-hash": "1.1.3",
-        "evp_bytestokey": "1.0.0",
-        "inherits": "2.0.3"
-      }
+      "dev": true
     },
     "browserify-cipher": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
       "integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
-      "dev": true,
-      "requires": {
-        "browserify-aes": "1.0.6",
-        "browserify-des": "1.0.0",
-        "evp_bytestokey": "1.0.0"
-      }
+      "dev": true
     },
     "browserify-des": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
       "integrity": "sha1-2qJ3cXRwki7S/hhZQRihdUOXId0=",
-      "dev": true,
-      "requires": {
-        "cipher-base": "1.0.3",
-        "des.js": "1.0.0",
-        "inherits": "2.0.3"
-      }
+      "dev": true
     },
     "browserify-rsa": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
-      "dev": true,
-      "requires": {
-        "bn.js": "4.11.6",
-        "randombytes": "2.0.5"
-      }
+      "dev": true
     },
     "browserify-sign": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
       "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
-      "dev": true,
-      "requires": {
-        "bn.js": "4.11.6",
-        "browserify-rsa": "4.0.1",
-        "create-hash": "1.1.3",
-        "create-hmac": "1.1.6",
-        "elliptic": "6.4.0",
-        "inherits": "2.0.3",
-        "parse-asn1": "5.1.0"
-      }
+      "dev": true
     },
     "browserify-zlib": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
       "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
-      "dev": true,
-      "requires": {
-        "pako": "0.2.9"
-      }
+      "dev": true
     },
     "browserslist": {
       "version": "1.7.7",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
       "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
-      "dev": true,
-      "requires": {
-        "caniuse-db": "1.0.30000692",
-        "electron-to-chromium": "1.3.14"
-      }
+      "dev": true
     },
     "buffer": {
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "dev": true,
-      "requires": {
-        "base64-js": "1.2.0",
-        "ieee754": "1.1.8",
-        "isarray": "1.0.0"
-      },
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
@@ -1306,10 +858,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
-      "dev": true,
-      "requires": {
-        "callsites": "0.2.0"
-      }
+      "dev": true
     },
     "callsite": {
       "version": "1.0.0",
@@ -1326,11 +875,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
       "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
-      "dev": true,
-      "requires": {
-        "no-case": "2.3.1",
-        "upper-case": "1.1.3"
-      }
+      "dev": true
     },
     "camelcase": {
       "version": "1.2.1",
@@ -1343,12 +888,6 @@
       "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-1.6.1.tgz",
       "integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
       "dev": true,
-      "requires": {
-        "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000692",
-        "lodash.memoize": "4.1.2",
-        "lodash.uniq": "4.5.0"
-      },
       "dependencies": {
         "lodash.uniq": {
           "version": "4.5.0",
@@ -1374,24 +913,13 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-      "dev": true,
-      "requires": {
-        "align-text": "0.1.4",
-        "lazy-cache": "1.0.4"
-      }
+      "dev": true
     },
     "chalk": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-      "dev": true,
-      "requires": {
-        "ansi-styles": "2.2.1",
-        "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
-      }
+      "dev": true
     },
     "chartist": {
       "version": "0.9.8",
@@ -1403,15 +931,6 @@
       "resolved": "https://registry.npmjs.org/check-dependencies/-/check-dependencies-0.12.3.tgz",
       "integrity": "sha1-a6ST1CIdvD9pURM1OuRjj3csXHU=",
       "dev": true,
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "bower-config": "1.4.0",
-        "chalk": "1.1.3",
-        "findup-sync": "0.4.3",
-        "lodash": "4.17.4",
-        "minimist": "1.2.0",
-        "semver": "5.3.0"
-      },
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
@@ -1425,48 +944,20 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/check-engines/-/check-engines-1.2.0.tgz",
       "integrity": "sha1-kewECik5KkX6zIvznBPFbQHN/5c=",
-      "dev": true,
-      "requires": {
-        "semver": "5.3.0"
-      }
+      "dev": true
     },
     "cheerio": {
       "version": "0.20.0",
       "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.20.0.tgz",
       "integrity": "sha1-XHEPK6uVZTJyhCugHG6mGzVF7DU=",
       "dev": true,
-      "requires": {
-        "css-select": "1.2.0",
-        "dom-serializer": "0.1.0",
-        "entities": "1.1.1",
-        "htmlparser2": "3.8.3",
-        "jsdom": "7.2.2",
-        "lodash": "4.17.4"
-      },
       "dependencies": {
         "jsdom": {
           "version": "7.2.2",
           "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-7.2.2.tgz",
           "integrity": "sha1-QLQCdwwr2iNGkJa+6Rq2deOx/G4=",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "abab": "1.0.3",
-            "acorn": "2.7.0",
-            "acorn-globals": "1.0.9",
-            "cssom": "0.3.2",
-            "cssstyle": "0.2.37",
-            "escodegen": "1.8.1",
-            "nwmatcher": "1.4.1",
-            "parse5": "1.5.1",
-            "request": "2.81.0",
-            "sax": "1.2.2",
-            "symbol-tree": "3.2.2",
-            "tough-cookie": "2.3.2",
-            "webidl-conversions": "2.0.1",
-            "whatwg-url-compat": "0.6.5",
-            "xml-name-validator": "2.0.1"
-          }
+          "optional": true
         }
       }
     },
@@ -1474,27 +965,13 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
       "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
-      "dev": true,
-      "requires": {
-        "anymatch": "1.3.0",
-        "async-each": "1.0.1",
-        "fsevents": "1.1.2",
-        "glob-parent": "2.0.0",
-        "inherits": "2.0.3",
-        "is-binary-path": "1.0.1",
-        "is-glob": "2.0.1",
-        "path-is-absolute": "1.0.1",
-        "readdirp": "2.1.0"
-      }
+      "dev": true
     },
     "cipher-base": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.3.tgz",
       "integrity": "sha1-7qvxlEGc6QDaMBjCB9IS8qbfCgc=",
-      "dev": true,
-      "requires": {
-        "inherits": "2.0.3"
-      }
+      "dev": true
     },
     "circular-json": {
       "version": "0.3.1",
@@ -1506,20 +983,13 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cjsx-loader/-/cjsx-loader-3.0.0.tgz",
       "integrity": "sha1-BtylKvKvZJqMBTnBeZD2M63G3Y8=",
-      "dev": true,
-      "requires": {
-        "coffee-react-transform": "4.0.0",
-        "loader-utils": "0.2.17"
-      }
+      "dev": true
     },
     "clap": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/clap/-/clap-1.2.0.tgz",
       "integrity": "sha1-WckP4+E3EEdG/xlGmiemNP9oyFc=",
-      "dev": true,
-      "requires": {
-        "chalk": "1.1.3"
-      }
+      "dev": true
     },
     "classnames": {
       "version": "2.2.5",
@@ -1530,19 +1000,13 @@
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.1.4.tgz",
       "integrity": "sha1-7siBHbJ0V+AHjYypIfqBty+oK/Q=",
-      "dev": true,
-      "requires": {
-        "source-map": "0.5.6"
-      }
+      "dev": true
     },
     "cli-cursor": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
       "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-      "dev": true,
-      "requires": {
-        "restore-cursor": "1.0.1"
-      }
+      "dev": true
     },
     "cli-width": {
       "version": "2.1.0",
@@ -1555,11 +1019,6 @@
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
       "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
       "dev": true,
-      "requires": {
-        "center-align": "0.1.3",
-        "right-align": "0.1.3",
-        "wordwrap": "0.0.2"
-      },
       "dependencies": {
         "wordwrap": {
           "version": "0.0.2",
@@ -1585,10 +1044,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/coa/-/coa-1.0.3.tgz",
       "integrity": "sha1-G1Sl4dz3fJkEVdTe6pjFZEFtyJM=",
-      "dev": true,
-      "requires": {
-        "q": "1.5.0"
-      }
+      "dev": true
     },
     "code-point-at": {
       "version": "1.1.0",
@@ -1601,20 +1057,12 @@
       "resolved": "https://registry.npmjs.org/coffee-loader/-/coffee-loader-0.7.3.tgz",
       "integrity": "sha1-+tvG79b8fsyIxbMEaiwpIGa8tUo=",
       "dev": true,
-      "requires": {
-        "loader-utils": "1.1.0"
-      },
       "dependencies": {
         "loader-utils": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
           "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
-          "dev": true,
-          "requires": {
-            "big.js": "3.1.3",
-            "emojis-list": "2.1.0",
-            "json5": "0.5.1"
-          }
+          "dev": true
         }
       }
     },
@@ -1622,13 +1070,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/coffee-react/-/coffee-react-5.0.1.tgz",
       "integrity": "sha1-PQNWboZGiUyWIZPELC6JX5H0nss=",
-      "dev": true,
-      "requires": {
-        "coffee-react-jstransform": "1.0.0",
-        "coffee-react-transform": "4.0.0",
-        "coffee-script": "1.10.0",
-        "mkdirp": "0.5.1"
-      }
+      "dev": true
     },
     "coffee-react-jstransform": {
       "version": "1.0.0",
@@ -1652,21 +1094,13 @@
       "version": "0.11.4",
       "resolved": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
       "integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
-      "dev": true,
-      "requires": {
-        "clone": "1.0.2",
-        "color-convert": "1.9.0",
-        "color-string": "0.3.0"
-      }
+      "dev": true
     },
     "color-convert": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
       "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
-      "dev": true,
-      "requires": {
-        "color-name": "1.1.2"
-      }
+      "dev": true
     },
     "color-name": {
       "version": "1.1.2",
@@ -1678,21 +1112,13 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
       "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
-      "dev": true,
-      "requires": {
-        "color-name": "1.1.2"
-      }
+      "dev": true
     },
     "colormin": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/colormin/-/colormin-1.1.2.tgz",
       "integrity": "sha1-6i90IKcrlogaOKrlnsEkpvcpgTM=",
-      "dev": true,
-      "requires": {
-        "color": "0.11.4",
-        "css-color-names": "0.0.4",
-        "has": "1.0.1"
-      }
+      "dev": true
     },
     "colors": {
       "version": "1.1.2",
@@ -1703,19 +1129,13 @@
     "combined-stream": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-      "requires": {
-        "delayed-stream": "1.0.0"
-      }
+      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk="
     },
     "commander": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
       "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-      "dev": true,
-      "requires": {
-        "graceful-readlink": "1.0.1"
-      }
+      "dev": true
     },
     "commondir": {
       "version": "1.0.1",
@@ -1732,10 +1152,7 @@
     "component-classes": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/component-classes/-/component-classes-1.2.6.tgz",
-      "integrity": "sha1-xkI5TDYYpNiwuJGe/Mu9kw5c1pE=",
-      "requires": {
-        "component-indexof": "0.0.3"
-      }
+      "integrity": "sha1-xkI5TDYYpNiwuJGe/Mu9kw5c1pE="
     },
     "component-emitter": {
       "version": "1.2.1",
@@ -1763,11 +1180,6 @@
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
       "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
       "dev": true,
-      "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.0",
-        "typedarray": "0.0.6"
-      },
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
@@ -1779,25 +1191,13 @@
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.0.tgz",
           "integrity": "sha512-c7KMXGd4b48nN3OJ1U9qOsn6pXNzf6kLd3kdZCkg2sxAcoiufInqF0XckwEnlrcwuaYwonlNK8GQUIOC/WC7sg==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.0",
-            "string_decoder": "1.0.2",
-            "util-deprecate": "1.0.2"
-          }
+          "dev": true
         },
         "string_decoder": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
           "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
           "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          },
           "dependencies": {
             "safe-buffer": {
               "version": "5.0.1",
@@ -1813,10 +1213,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
       "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
-      "dev": true,
-      "requires": {
-        "date-now": "0.1.4"
-      }
+      "dev": true
     },
     "constants-browserify": {
       "version": "1.0.0",
@@ -1876,29 +1273,12 @@
       "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-4.0.1.tgz",
       "integrity": "sha1-lyjjg7lDFgUNDHRjlY8rhcCqggA=",
       "dev": true,
-      "requires": {
-        "bluebird": "2.11.0",
-        "fs-extra": "0.26.7",
-        "glob": "6.0.4",
-        "is-glob": "3.1.0",
-        "loader-utils": "0.2.17",
-        "lodash": "4.17.4",
-        "minimatch": "3.0.4",
-        "node-dir": "0.1.17"
-      },
       "dependencies": {
         "glob": {
           "version": "6.0.4",
           "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
           "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
-          "dev": true,
-          "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
+          "dev": true
         },
         "is-extglob": {
           "version": "2.1.1",
@@ -1910,10 +1290,7 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "2.1.1"
-          }
+          "dev": true
         }
       }
     },
@@ -1930,105 +1307,53 @@
     "counterpart": {
       "version": "0.17.9",
       "resolved": "https://registry.npmjs.org/counterpart/-/counterpart-0.17.9.tgz",
-      "integrity": "sha1-A3nk0JC579spxjamB8UuNXNPXxM=",
-      "requires": {
-        "date-names": "0.1.9",
-        "except": "0.1.3",
-        "extend": "3.0.1",
-        "pluralizers": "0.1.6",
-        "sprintf-js": "1.1.1"
-      }
+      "integrity": "sha1-A3nk0JC579spxjamB8UuNXNPXxM="
     },
     "create-ecdh": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
       "integrity": "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=",
-      "dev": true,
-      "requires": {
-        "bn.js": "4.11.6",
-        "elliptic": "6.4.0"
-      }
+      "dev": true
     },
     "create-hash": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
       "integrity": "sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0=",
-      "dev": true,
-      "requires": {
-        "cipher-base": "1.0.3",
-        "inherits": "2.0.3",
-        "ripemd160": "2.0.1",
-        "sha.js": "2.4.8"
-      }
+      "dev": true
     },
     "create-hmac": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz",
       "integrity": "sha1-rLniIaThe9sHbpBlfEK5PjcmzwY=",
-      "dev": true,
-      "requires": {
-        "cipher-base": "1.0.3",
-        "create-hash": "1.1.3",
-        "inherits": "2.0.3",
-        "ripemd160": "2.0.1",
-        "safe-buffer": "5.1.0",
-        "sha.js": "2.4.8"
-      }
+      "dev": true
     },
     "create-react-class": {
       "version": "15.6.0",
       "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.0.tgz",
-      "integrity": "sha1-q0SEl8JlZuHilBPogyB9V8/nvtQ=",
-      "requires": {
-        "fbjs": "0.8.12",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1"
-      }
+      "integrity": "sha1-q0SEl8JlZuHilBPogyB9V8/nvtQ="
     },
     "cross-spawn": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
       "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
-      "dev": true,
-      "requires": {
-        "lru-cache": "4.1.1",
-        "which": "1.2.14"
-      }
+      "dev": true
     },
     "cryptiles": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
       "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-      "dev": true,
-      "requires": {
-        "boom": "2.10.1"
-      }
+      "dev": true
     },
     "crypto-browserify": {
       "version": "3.11.0",
       "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.0.tgz",
       "integrity": "sha1-NlKgkGq5sqfgw85mpAjpV6JIVSI=",
-      "dev": true,
-      "requires": {
-        "browserify-cipher": "1.0.0",
-        "browserify-sign": "4.0.4",
-        "create-ecdh": "4.0.0",
-        "create-hash": "1.1.3",
-        "create-hmac": "1.1.6",
-        "diffie-hellman": "5.0.2",
-        "inherits": "2.0.3",
-        "pbkdf2": "3.0.12",
-        "public-encrypt": "4.0.0",
-        "randombytes": "2.0.5"
-      }
+      "dev": true
     },
     "css-animation": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/css-animation/-/css-animation-1.3.2.tgz",
-      "integrity": "sha1-31FYIO9ZA3M60tsJmUA7MDe4uIA=",
-      "requires": {
-        "component-classes": "1.2.6"
-      }
+      "integrity": "sha1-31FYIO9ZA3M60tsJmUA7MDe4uIA="
     },
     "css-color-names": {
       "version": "0.0.4",
@@ -2041,33 +1366,12 @@
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-0.28.4.tgz",
       "integrity": "sha1-bPNXkZLONV6LONX0Ldeh8uyJjQ8=",
       "dev": true,
-      "requires": {
-        "babel-code-frame": "6.22.0",
-        "css-selector-tokenizer": "0.7.0",
-        "cssnano": "3.10.0",
-        "icss-utils": "2.1.0",
-        "loader-utils": "1.1.0",
-        "lodash.camelcase": "4.3.0",
-        "object-assign": "4.1.1",
-        "postcss": "5.2.17",
-        "postcss-modules-extract-imports": "1.1.0",
-        "postcss-modules-local-by-default": "1.2.0",
-        "postcss-modules-scope": "1.1.0",
-        "postcss-modules-values": "1.3.0",
-        "postcss-value-parser": "3.3.0",
-        "source-list-map": "0.1.8"
-      },
       "dependencies": {
         "loader-utils": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
           "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
-          "dev": true,
-          "requires": {
-            "big.js": "3.1.3",
-            "emojis-list": "2.1.0",
-            "json5": "0.5.1"
-          }
+          "dev": true
         }
       }
     },
@@ -2081,35 +1385,19 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
       "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
-      "dev": true,
-      "requires": {
-        "boolbase": "1.0.0",
-        "css-what": "2.1.0",
-        "domutils": "1.5.1",
-        "nth-check": "1.0.1"
-      }
+      "dev": true
     },
     "css-selector-tokenizer": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.0.tgz",
       "integrity": "sha1-5piEdK6MlTR3v15+/s/OzNnPTIY=",
       "dev": true,
-      "requires": {
-        "cssesc": "0.1.0",
-        "fastparse": "1.1.1",
-        "regexpu-core": "1.0.0"
-      },
       "dependencies": {
         "regexpu-core": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
           "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
-          "dev": true,
-          "requires": {
-            "regenerate": "1.3.2",
-            "regjsgen": "0.2.0",
-            "regjsparser": "0.1.5"
-          }
+          "dev": true
         }
       }
     },
@@ -2129,51 +1417,13 @@
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-3.10.0.tgz",
       "integrity": "sha1-Tzj2zqK5sX+gFJDyPx3GjqZcHDg=",
-      "dev": true,
-      "requires": {
-        "autoprefixer": "6.7.7",
-        "decamelize": "1.2.0",
-        "defined": "1.0.0",
-        "has": "1.0.1",
-        "object-assign": "4.1.1",
-        "postcss": "5.2.17",
-        "postcss-calc": "5.3.1",
-        "postcss-colormin": "2.2.2",
-        "postcss-convert-values": "2.6.1",
-        "postcss-discard-comments": "2.0.4",
-        "postcss-discard-duplicates": "2.1.0",
-        "postcss-discard-empty": "2.1.0",
-        "postcss-discard-overridden": "0.1.1",
-        "postcss-discard-unused": "2.2.3",
-        "postcss-filter-plugins": "2.0.2",
-        "postcss-merge-idents": "2.1.7",
-        "postcss-merge-longhand": "2.0.2",
-        "postcss-merge-rules": "2.1.2",
-        "postcss-minify-font-values": "1.0.5",
-        "postcss-minify-gradients": "1.0.5",
-        "postcss-minify-params": "1.2.2",
-        "postcss-minify-selectors": "2.1.1",
-        "postcss-normalize-charset": "1.1.1",
-        "postcss-normalize-url": "3.0.8",
-        "postcss-ordered-values": "2.2.3",
-        "postcss-reduce-idents": "2.4.0",
-        "postcss-reduce-initial": "1.0.1",
-        "postcss-reduce-transforms": "1.0.4",
-        "postcss-svgo": "2.1.6",
-        "postcss-unique-selectors": "2.0.2",
-        "postcss-value-parser": "3.3.0",
-        "postcss-zindex": "2.2.0"
-      }
+      "dev": true
     },
     "csso": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/csso/-/csso-2.3.2.tgz",
       "integrity": "sha1-3dUsWHAz9J6Utx/FVWnyUuj/X4U=",
-      "dev": true,
-      "requires": {
-        "clap": "1.2.0",
-        "source-map": "0.5.6"
-      }
+      "dev": true
     },
     "cssom": {
       "version": "0.3.2",
@@ -2185,19 +1435,13 @@
       "version": "0.2.37",
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
       "integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
-      "dev": true,
-      "requires": {
-        "cssom": "0.3.2"
-      }
+      "dev": true
     },
     "d": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
-      "dev": true,
-      "requires": {
-        "es5-ext": "0.10.23"
-      }
+      "dev": true
     },
     "damerau-levenshtein": {
       "version": "1.0.4",
@@ -2210,9 +1454,6 @@
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
-      "requires": {
-        "assert-plus": "1.0.0"
-      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -2246,10 +1487,7 @@
     "debug": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-      "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
-      "requires": {
-        "ms": "0.7.2"
-      }
+      "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w="
     },
     "decamelize": {
       "version": "1.2.0",
@@ -2272,11 +1510,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
-      "dev": true,
-      "requires": {
-        "foreach": "2.0.5",
-        "object-keys": "1.0.11"
-      }
+      "dev": true
     },
     "defined": {
       "version": "1.0.0",
@@ -2288,16 +1522,7 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
-      "dev": true,
-      "requires": {
-        "globby": "5.0.0",
-        "is-path-cwd": "1.0.0",
-        "is-path-in-cwd": "1.0.0",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "rimraf": "2.5.4"
-      }
+      "dev": true
     },
     "delayed-stream": {
       "version": "1.0.0",
@@ -2314,11 +1539,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
       "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
-      "dev": true,
-      "requires": {
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.0"
-      }
+      "dev": true
     },
     "destroy": {
       "version": "1.0.4",
@@ -2330,32 +1551,18 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-0.1.0.tgz",
       "integrity": "sha1-STXe39lIhkjgBrASlWbpOGcR6mM=",
-      "dev": true,
-      "requires": {
-        "fs-exists-sync": "0.1.0"
-      }
+      "dev": true
     },
     "detect-indent": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
-      "dev": true,
-      "requires": {
-        "repeating": "2.0.1"
-      }
+      "dev": true
     },
     "devour-client": {
       "version": "1.3.9",
       "resolved": "https://registry.npmjs.org/devour-client/-/devour-client-1.3.9.tgz",
       "integrity": "sha1-ikVplngjs3zahCbSqQGqEc74wY0=",
-      "requires": {
-        "axios": "0.11.1",
-        "es6-promise": "3.3.1",
-        "lodash": "4.17.4",
-        "minilog": "3.1.0",
-        "pluralize": "1.2.1",
-        "qs": "6.4.0"
-      },
       "dependencies": {
         "qs": {
           "version": "6.4.0",
@@ -2374,35 +1581,19 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
       "integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
-      "dev": true,
-      "requires": {
-        "bn.js": "4.11.6",
-        "miller-rabin": "4.0.0",
-        "randombytes": "2.0.5"
-      }
+      "dev": true
     },
     "docco": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/docco/-/docco-0.6.3.tgz",
       "integrity": "sha1-xHtYI9eVY9b8Or1J895ImG5VIu4=",
-      "dev": true,
-      "requires": {
-        "commander": "2.9.0",
-        "fs-extra": "0.26.7",
-        "highlight.js": "9.12.0",
-        "marked": "0.3.6",
-        "underscore": "1.8.3"
-      }
+      "dev": true
     },
     "doctrine": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
       "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
       "dev": true,
-      "requires": {
-        "esutils": "2.0.2",
-        "isarray": "1.0.0"
-      },
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
@@ -2422,9 +1613,6 @@
       "resolved": "https://registry.npmjs.org/dom-converter/-/dom-converter-0.1.4.tgz",
       "integrity": "sha1-pF71cnuJDJv/5tfIduexnLDhfzs=",
       "dev": true,
-      "requires": {
-        "utila": "0.3.3"
-      },
       "dependencies": {
         "utila": {
           "version": "0.3.3",
@@ -2444,10 +1632,6 @@
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
       "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
       "dev": true,
-      "requires": {
-        "domelementtype": "1.1.3",
-        "entities": "1.1.1"
-      },
       "dependencies": {
         "domelementtype": {
           "version": "1.1.3",
@@ -2479,20 +1663,13 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
       "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
-      "dev": true,
-      "requires": {
-        "domelementtype": "1.3.0"
-      }
+      "dev": true
     },
     "domutils": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
       "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
-      "dev": true,
-      "requires": {
-        "dom-serializer": "0.1.0",
-        "domelementtype": "1.3.0"
-      }
+      "dev": true
     },
     "drag-reorderable": {
       "version": "0.1.0",
@@ -2504,10 +1681,7 @@
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "dev": true,
-      "optional": true,
-      "requires": {
-        "jsbn": "0.1.1"
-      }
+      "optional": true
     },
     "ee-first": {
       "version": "1.1.1",
@@ -2531,16 +1705,7 @@
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
       "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
-      "dev": true,
-      "requires": {
-        "bn.js": "4.11.6",
-        "brorand": "1.1.0",
-        "hash.js": "1.0.3",
-        "hmac-drbg": "1.0.1",
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.0",
-        "minimalistic-crypto-utils": "1.0.1"
-      }
+      "dev": true
     },
     "emojis-list": {
       "version": "2.1.0",
@@ -2557,80 +1722,37 @@
     "encoding": {
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-      "requires": {
-        "iconv-lite": "0.4.18"
-      }
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s="
     },
     "engine.io": {
       "version": "1.8.4",
       "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-1.8.4.tgz",
       "integrity": "sha1-d7zhK4Dl1gQpM3/sOw2vaR68kAM=",
       "dev": true,
-      "requires": {
-        "accepts": "1.3.3",
-        "base64id": "1.0.0",
-        "cookie": "0.3.1",
-        "debug": "2.3.3",
-        "engine.io-parser": "1.3.2",
-        "ws": "1.1.4"
-      },
       "dependencies": {
         "ws": {
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.4.tgz",
           "integrity": "sha1-V/QNA2gy5fUFVmKjl8Tedu1mv2E=",
-          "dev": true,
-          "requires": {
-            "options": "0.0.6",
-            "ultron": "1.0.2"
-          }
+          "dev": true
         }
       }
     },
     "engine.io-client": {
       "version": "1.8.4",
       "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.8.4.tgz",
-      "integrity": "sha1-n+hd7iWFPKa6viW9KtaHEIY+kcI=",
-      "requires": {
-        "component-emitter": "1.2.1",
-        "component-inherit": "0.0.3",
-        "debug": "2.3.3",
-        "engine.io-parser": "1.3.2",
-        "has-cors": "1.1.0",
-        "indexof": "0.0.1",
-        "parsejson": "0.0.3",
-        "parseqs": "0.0.5",
-        "parseuri": "0.0.5",
-        "ws": "1.1.2",
-        "xmlhttprequest-ssl": "1.5.3",
-        "yeast": "0.1.2"
-      }
+      "integrity": "sha1-n+hd7iWFPKa6viW9KtaHEIY+kcI="
     },
     "engine.io-parser": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.3.2.tgz",
-      "integrity": "sha1-k3sHnwAH0Ik+xW1GyyILjLQ1Igo=",
-      "requires": {
-        "after": "0.8.2",
-        "arraybuffer.slice": "0.0.6",
-        "base64-arraybuffer": "0.1.5",
-        "blob": "0.0.4",
-        "has-binary": "0.1.7",
-        "wtf-8": "1.0.0"
-      }
+      "integrity": "sha1-k3sHnwAH0Ik+xW1GyyILjLQ1Igo="
     },
     "enhanced-resolve": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.1.0.tgz",
       "integrity": "sha1-n0tib1dyRe3PSyrYPYbhf09CHew=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "memory-fs": "0.4.1",
-        "object-assign": "4.1.1",
-        "tapable": "0.2.6"
-      }
+      "dev": true
     },
     "entities": {
       "version": "1.1.1",
@@ -2641,95 +1763,49 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/enzyme/-/enzyme-2.4.2.tgz",
       "integrity": "sha1-Cbrs7Ypq1I1Qf5B1rJzhJ0+c/2I=",
-      "dev": true,
-      "requires": {
-        "cheerio": "0.20.0",
-        "function.prototype.name": "1.0.0",
-        "in-publish": "2.0.0",
-        "is-subset": "0.1.1",
-        "lodash": "4.17.4",
-        "object-is": "1.0.1",
-        "object.assign": "4.0.4",
-        "object.entries": "1.0.4",
-        "object.values": "1.0.4",
-        "uuid": "2.0.3"
-      }
+      "dev": true
     },
     "errno": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
       "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
-      "dev": true,
-      "requires": {
-        "prr": "0.0.0"
-      }
+      "dev": true
     },
     "error-ex": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
-      "dev": true,
-      "requires": {
-        "is-arrayish": "0.2.1"
-      }
+      "dev": true
     },
     "es-abstract": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.7.0.tgz",
       "integrity": "sha1-363ndOAb/Nl/lhgCmMRJyGI/uUw=",
-      "dev": true,
-      "requires": {
-        "es-to-primitive": "1.1.1",
-        "function-bind": "1.1.0",
-        "is-callable": "1.1.3",
-        "is-regex": "1.0.4"
-      }
+      "dev": true
     },
     "es-to-primitive": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
       "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
-      "dev": true,
-      "requires": {
-        "is-callable": "1.1.3",
-        "is-date-object": "1.0.1",
-        "is-symbol": "1.0.1"
-      }
+      "dev": true
     },
     "es5-ext": {
       "version": "0.10.23",
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.23.tgz",
       "integrity": "sha1-dXi1G+l0IHpUh4IbVlOMIk5Oezg=",
-      "dev": true,
-      "requires": {
-        "es6-iterator": "2.0.1",
-        "es6-symbol": "3.1.1"
-      }
+      "dev": true
     },
     "es6-iterator": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
       "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
-      "dev": true,
-      "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.23",
-        "es6-symbol": "3.1.1"
-      }
+      "dev": true
     },
     "es6-map": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
       "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
-      "dev": true,
-      "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.23",
-        "es6-iterator": "2.0.1",
-        "es6-set": "0.1.5",
-        "es6-symbol": "3.1.1",
-        "event-emitter": "0.3.5"
-      }
+      "dev": true
     },
     "es6-promise": {
       "version": "3.3.1",
@@ -2740,36 +1816,19 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
-      "dev": true,
-      "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.23",
-        "es6-iterator": "2.0.1",
-        "es6-symbol": "3.1.1",
-        "event-emitter": "0.3.5"
-      }
+      "dev": true
     },
     "es6-symbol": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
-      "dev": true,
-      "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.23"
-      }
+      "dev": true
     },
     "es6-weak-map": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
       "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
-      "dev": true,
-      "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.23",
-        "es6-iterator": "2.0.1",
-        "es6-symbol": "3.1.1"
-      }
+      "dev": true
     },
     "escape-html": {
       "version": "1.0.3",
@@ -2788,23 +1847,13 @@
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
       "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
       "dev": true,
-      "requires": {
-        "esprima": "2.7.3",
-        "estraverse": "1.9.3",
-        "esutils": "2.0.2",
-        "optionator": "0.8.2",
-        "source-map": "0.2.0"
-      },
       "dependencies": {
         "source-map": {
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
           "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "amdefine": "1.0.1"
-          }
+          "optional": true
         }
       }
     },
@@ -2813,12 +1862,6 @@
       "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
       "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
       "dev": true,
-      "requires": {
-        "es6-map": "0.1.5",
-        "es6-weak-map": "2.0.2",
-        "esrecurse": "4.1.0",
-        "estraverse": "4.2.0"
-      },
       "dependencies": {
         "estraverse": {
           "version": "4.2.0",
@@ -2833,42 +1876,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-3.9.1.tgz",
       "integrity": "sha1-WoWXcG/GBIvGBhrHVNSiEdKPT1s=",
       "dev": true,
-      "requires": {
-        "babel-code-frame": "6.22.0",
-        "chalk": "1.1.3",
-        "concat-stream": "1.6.0",
-        "debug": "2.3.3",
-        "doctrine": "1.5.0",
-        "escope": "3.6.0",
-        "espree": "3.4.3",
-        "estraverse": "4.2.0",
-        "esutils": "2.0.2",
-        "file-entry-cache": "2.0.0",
-        "glob": "7.1.2",
-        "globals": "9.18.0",
-        "ignore": "3.3.3",
-        "imurmurhash": "0.1.4",
-        "inquirer": "0.12.0",
-        "is-my-json-valid": "2.16.0",
-        "is-resolvable": "1.0.0",
-        "js-yaml": "3.7.0",
-        "json-stable-stringify": "1.0.1",
-        "levn": "0.3.0",
-        "lodash": "4.17.4",
-        "mkdirp": "0.5.1",
-        "natural-compare": "1.4.0",
-        "optionator": "0.8.2",
-        "path-is-inside": "1.0.2",
-        "pluralize": "1.2.1",
-        "progress": "1.1.8",
-        "require-uncached": "1.0.3",
-        "shelljs": "0.7.8",
-        "strip-bom": "3.0.0",
-        "strip-json-comments": "1.0.4",
-        "table": "3.8.3",
-        "text-table": "0.2.0",
-        "user-home": "2.0.0"
-      },
       "dependencies": {
         "estraverse": {
           "version": "4.2.0",
@@ -2880,10 +1887,7 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
           "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
-          "dev": true,
-          "requires": {
-            "os-homedir": "1.0.2"
-          }
+          "dev": true
         }
       }
     },
@@ -2891,10 +1895,7 @@
       "version": "13.0.0",
       "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-13.0.0.tgz",
       "integrity": "sha1-aI0V08J2wMdTrlOMkqRDl9dq5G4=",
-      "dev": true,
-      "requires": {
-        "eslint-config-airbnb-base": "10.0.1"
-      }
+      "dev": true
     },
     "eslint-config-airbnb-base": {
       "version": "10.0.1",
@@ -2912,31 +1913,19 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.2.3.tgz",
       "integrity": "sha1-Wt2BBujJKNssuiMrzZ76hG49oWw=",
-      "dev": true,
-      "requires": {
-        "debug": "2.3.3",
-        "object-assign": "4.1.1",
-        "resolve": "1.3.3"
-      }
+      "dev": true
     },
     "eslint-module-utils": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.0.0.tgz",
       "integrity": "sha1-pvjCHZATWHWc3DXbrBmCrh7li84=",
       "dev": true,
-      "requires": {
-        "debug": "2.2.0",
-        "pkg-dir": "1.0.0"
-      },
       "dependencies": {
         "debug": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.1"
-          }
+          "dev": true
         },
         "ms": {
           "version": "0.7.1",
@@ -2950,30 +1939,13 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.2.0.tgz",
       "integrity": "sha1-crowb60wXWfEgWNIpGmaQimsi04=",
-      "dev": true,
-      "requires": {
-        "builtin-modules": "1.1.1",
-        "contains-path": "0.1.0",
-        "debug": "2.3.3",
-        "doctrine": "1.5.0",
-        "eslint-import-resolver-node": "0.2.3",
-        "eslint-module-utils": "2.0.0",
-        "has": "1.0.1",
-        "lodash.cond": "4.5.2",
-        "minimatch": "3.0.4",
-        "pkg-up": "1.0.0"
-      }
+      "dev": true
     },
     "eslint-plugin-jsx-a11y": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-2.2.3.tgz",
       "integrity": "sha1-TjXLcbin23AqxBXIBuuOjZ6mxl0=",
-      "dev": true,
-      "requires": {
-        "damerau-levenshtein": "1.0.4",
-        "jsx-ast-utils": "1.4.1",
-        "object-assign": "4.1.1"
-      }
+      "dev": true
     },
     "eslint-plugin-promise": {
       "version": "1.3.2",
@@ -2985,11 +1957,7 @@
       "version": "6.6.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-6.6.0.tgz",
       "integrity": "sha1-kc7s76iiLY9dI++ag5UWp9n6Y6E=",
-      "dev": true,
-      "requires": {
-        "doctrine": "1.5.0",
-        "jsx-ast-utils": "1.4.1"
-      }
+      "dev": true
     },
     "eslint-plugin-standard": {
       "version": "1.3.3",
@@ -3002,18 +1970,25 @@
       "resolved": "https://registry.npmjs.org/eslint-watch/-/eslint-watch-3.1.2.tgz",
       "integrity": "sha1-uTs+ygiRXxE9yQCZT4gNsTZN5LM=",
       "dev": true,
-      "requires": {
-        "babel-polyfill": "6.23.0",
-        "bluebird": "2.11.0",
-        "chalk": "1.1.3",
-        "chokidar": "1.7.0",
-        "debug": "2.3.3",
-        "keypress": "0.2.1",
-        "lodash": "4.17.4",
-        "optionator": "0.8.2",
-        "source-map-support": "0.4.15",
-        "text-table": "0.2.0",
-        "unicons": "0.0.3"
+      "dependencies": {
+        "bluebird": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
+          "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw=",
+          "dev": true
+        },
+        "debug": {
+          "version": "2.6.8",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
       }
     },
     "espree": {
@@ -3021,10 +1996,6 @@
       "resolved": "https://registry.npmjs.org/espree/-/espree-3.4.3.tgz",
       "integrity": "sha1-KRC1zNSc6JPC//+qtP2LOjG4I3Q=",
       "dev": true,
-      "requires": {
-        "acorn": "5.0.3",
-        "acorn-jsx": "3.0.1"
-      },
       "dependencies": {
         "acorn": {
           "version": "5.0.3",
@@ -3045,10 +2016,6 @@
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
       "integrity": "sha1-RxO2U2rffyrE8yfVWed1a/9kgiA=",
       "dev": true,
-      "requires": {
-        "estraverse": "4.1.1",
-        "object-assign": "4.1.1"
-      },
       "dependencies": {
         "estraverse": {
           "version": "4.1.1",
@@ -3080,11 +2047,7 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
-      "dev": true,
-      "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.23"
-      }
+      "dev": true
     },
     "events": {
       "version": "1.1.1",
@@ -3095,18 +2058,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz",
       "integrity": "sha1-SXtmrZ/vZc18CKYYCCS6FHa2blM=",
-      "dev": true,
-      "requires": {
-        "create-hash": "1.1.3"
-      }
+      "dev": true
     },
     "except": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/except/-/except-0.1.3.tgz",
-      "integrity": "sha1-mCYckZWFUVNrREgiOOl4P7c9KSo=",
-      "requires": {
-        "indexof": "0.0.1"
-      }
+      "integrity": "sha1-mCYckZWFUVNrREgiOOl4P7c9KSo="
     },
     "exenv": {
       "version": "1.2.2",
@@ -3123,73 +2080,31 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-      "dev": true,
-      "requires": {
-        "is-posix-bracket": "0.1.1"
-      }
+      "dev": true
     },
     "expand-range": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-      "dev": true,
-      "requires": {
-        "fill-range": "2.2.3"
-      }
+      "dev": true
     },
     "expand-tilde": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
       "integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
-      "dev": true,
-      "requires": {
-        "os-homedir": "1.0.2"
-      }
+      "dev": true
     },
     "express": {
       "version": "4.15.3",
       "resolved": "https://registry.npmjs.org/express/-/express-4.15.3.tgz",
       "integrity": "sha1-urZdDwOqgMNYQIly/HAPkWlEtmI=",
       "dev": true,
-      "requires": {
-        "accepts": "1.3.3",
-        "array-flatten": "1.1.1",
-        "content-disposition": "0.5.2",
-        "content-type": "1.0.2",
-        "cookie": "0.3.1",
-        "cookie-signature": "1.0.6",
-        "debug": "2.6.7",
-        "depd": "1.1.0",
-        "encodeurl": "1.0.1",
-        "escape-html": "1.0.3",
-        "etag": "1.8.0",
-        "finalhandler": "1.0.3",
-        "fresh": "0.5.0",
-        "merge-descriptors": "1.0.1",
-        "methods": "1.1.2",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.1",
-        "path-to-regexp": "0.1.7",
-        "proxy-addr": "1.1.4",
-        "qs": "6.4.0",
-        "range-parser": "1.2.0",
-        "send": "0.15.3",
-        "serve-static": "1.12.3",
-        "setprototypeof": "1.0.3",
-        "statuses": "1.3.1",
-        "type-is": "1.6.15",
-        "utils-merge": "1.0.0",
-        "vary": "1.1.1"
-      },
       "dependencies": {
         "debug": {
           "version": "2.6.7",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
           "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4=",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
+          "dev": true
         },
         "ms": {
           "version": "2.0.0",
@@ -3214,42 +2129,25 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-      "dev": true,
-      "requires": {
-        "is-extglob": "1.0.0"
-      }
+      "dev": true
     },
     "extract-text-webpack-plugin": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/extract-text-webpack-plugin/-/extract-text-webpack-plugin-2.1.2.tgz",
       "integrity": "sha1-dW7076gVXDaBgz+8NNpTuUF0bWw=",
       "dev": true,
-      "requires": {
-        "async": "2.4.1",
-        "loader-utils": "1.1.0",
-        "schema-utils": "0.3.0",
-        "webpack-sources": "1.0.1"
-      },
       "dependencies": {
         "async": {
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/async/-/async-2.4.1.tgz",
           "integrity": "sha1-YqVrJ5yYoR0JhwlqAcw+6463u9c=",
-          "dev": true,
-          "requires": {
-            "lodash": "4.17.4"
-          }
+          "dev": true
         },
         "loader-utils": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
           "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
-          "dev": true,
-          "requires": {
-            "big.js": "3.1.3",
-            "emojis-list": "2.1.0",
-            "json5": "0.5.1"
-          }
+          "dev": true
         }
       }
     },
@@ -3280,64 +2178,36 @@
     "faye-websocket": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.9.4.tgz",
-      "integrity": "sha1-iFk0x57/sECVSeDAo4Ae0XpAza0=",
-      "requires": {
-        "websocket-driver": "0.6.5"
-      }
+      "integrity": "sha1-iFk0x57/sECVSeDAo4Ae0XpAza0="
     },
     "fbjs": {
       "version": "0.8.12",
       "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.12.tgz",
-      "integrity": "sha1-ELXZL3bUVXX9Y6IX1OoCvqL47QQ=",
-      "requires": {
-        "core-js": "1.2.7",
-        "isomorphic-fetch": "2.2.1",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1",
-        "promise": "7.3.0",
-        "setimmediate": "1.0.5",
-        "ua-parser-js": "0.7.12"
-      }
+      "integrity": "sha1-ELXZL3bUVXX9Y6IX1OoCvqL47QQ="
     },
     "figures": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
       "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-      "dev": true,
-      "requires": {
-        "escape-string-regexp": "1.0.5",
-        "object-assign": "4.1.1"
-      }
+      "dev": true
     },
     "file-entry-cache": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
-      "dev": true,
-      "requires": {
-        "flat-cache": "1.2.2",
-        "object-assign": "4.1.1"
-      }
+      "dev": true
     },
     "file-loader": {
       "version": "0.11.2",
       "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-0.11.2.tgz",
       "integrity": "sha512-N+uhF3mswIFeziHQjGScJ/yHXYt3DiLBeC+9vWW+WjUBiClMSOlV1YrXQi+7KM2aA3Rn4Bybgv+uXFQbfkzpvg==",
       "dev": true,
-      "requires": {
-        "loader-utils": "1.1.0"
-      },
       "dependencies": {
         "loader-utils": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
           "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
-          "dev": true,
-          "requires": {
-            "big.js": "3.1.3",
-            "emojis-list": "2.1.0",
-            "json5": "0.5.1"
-          }
+          "dev": true
         }
       }
     },
@@ -3357,38 +2227,19 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
       "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
-      "dev": true,
-      "requires": {
-        "is-number": "2.1.0",
-        "isobject": "2.1.0",
-        "randomatic": "1.1.7",
-        "repeat-element": "1.1.2",
-        "repeat-string": "1.6.1"
-      }
+      "dev": true
     },
     "finalhandler": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.3.tgz",
       "integrity": "sha1-70fneVDpmXgOhgIqVg4yF+DQzIk=",
       "dev": true,
-      "requires": {
-        "debug": "2.6.7",
-        "encodeurl": "1.0.1",
-        "escape-html": "1.0.3",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.1",
-        "statuses": "1.3.1",
-        "unpipe": "1.0.0"
-      },
       "dependencies": {
         "debug": {
           "version": "2.6.7",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
           "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4=",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
+          "dev": true
         },
         "ms": {
           "version": "2.0.0",
@@ -3402,46 +2253,25 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
       "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
-      "dev": true,
-      "requires": {
-        "commondir": "1.0.1",
-        "mkdirp": "0.5.1",
-        "pkg-dir": "1.0.0"
-      }
+      "dev": true
     },
     "find-up": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-      "dev": true,
-      "requires": {
-        "path-exists": "2.1.0",
-        "pinkie-promise": "2.0.1"
-      }
+      "dev": true
     },
     "findup-sync": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.4.3.tgz",
       "integrity": "sha1-QAQ5Kee8YK3wt/SCfExudaDeyhI=",
-      "dev": true,
-      "requires": {
-        "detect-file": "0.1.0",
-        "is-glob": "2.0.1",
-        "micromatch": "2.3.11",
-        "resolve-dir": "0.1.1"
-      }
+      "dev": true
     },
     "flat-cache": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
       "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
-      "dev": true,
-      "requires": {
-        "circular-json": "0.3.1",
-        "del": "2.2.2",
-        "graceful-fs": "4.1.11",
-        "write": "0.2.1"
-      }
+      "dev": true
     },
     "flatten": {
       "version": "1.0.2",
@@ -3452,11 +2282,7 @@
     "follow-redirects": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-0.0.7.tgz",
-      "integrity": "sha1-NLkLqyqRGqNHVx2pDyK9NuzYqRk=",
-      "requires": {
-        "debug": "2.3.3",
-        "stream-consume": "0.1.0"
-      }
+      "integrity": "sha1-NLkLqyqRGqNHVx2pDyK9NuzYqRk="
     },
     "for-in": {
       "version": "1.0.2",
@@ -3468,10 +2294,7 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-      "dev": true,
-      "requires": {
-        "for-in": "1.0.2"
-      }
+      "dev": true
     },
     "foreach": {
       "version": "2.0.5",
@@ -3488,21 +2311,13 @@
     "form-data": {
       "version": "1.0.0-rc3",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
-      "integrity": "sha1-01vGLn+8KTeuePlIqqDTjZBgdXc=",
-      "requires": {
-        "async": "1.5.2",
-        "combined-stream": "1.0.5",
-        "mime-types": "2.1.15"
-      }
+      "integrity": "sha1-01vGLn+8KTeuePlIqqDTjZBgdXc="
     },
     "formatio": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
       "integrity": "sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=",
-      "dev": true,
-      "requires": {
-        "samsam": "1.1.2"
-      }
+      "dev": true
     },
     "formidable": {
       "version": "1.0.17",
@@ -3531,14 +2346,7 @@
       "version": "0.26.7",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz",
       "integrity": "sha1-muH92UiXeY7at20JGM9C0MMYT6k=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "jsonfile": "2.4.0",
-        "klaw": "1.3.1",
-        "path-is-absolute": "1.0.1",
-        "rimraf": "2.5.4"
-      }
+      "dev": true
     },
     "fs-readdir-recursive": {
       "version": "1.0.0",
@@ -3558,10 +2366,6 @@
       "integrity": "sha512-Sn44E5wQW4bTHXvQmvSHwqbuiXtduD6Rrjm2ZtUEGbyrig+nUH3t/QD4M4/ZXViY556TBpRgZkHLDx3JxPwxiw==",
       "dev": true,
       "optional": true,
-      "requires": {
-        "nan": "2.6.2",
-        "node-pre-gyp": "0.6.36"
-      },
       "dependencies": {
         "abbrev": {
           "version": "1.1.0",
@@ -3575,11 +2379,7 @@
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
           "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
-          }
+          "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
@@ -3599,11 +2399,7 @@
           "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
           "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.2.9"
-          }
+          "optional": true
         },
         "asn1": {
           "version": "0.2.3",
@@ -3651,38 +2447,25 @@
           "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
           "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "tweetnacl": "0.14.5"
-          }
+          "optional": true
         },
         "block-stream": {
           "version": "0.0.9",
           "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
           "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-          "dev": true,
-          "requires": {
-            "inherits": "2.0.3"
-          }
+          "dev": true
         },
         "boom": {
           "version": "2.10.1",
           "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
           "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-          "dev": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.7",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
           "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
-          "dev": true,
-          "requires": {
-            "balanced-match": "0.4.2",
-            "concat-map": "0.0.1"
-          }
+          "dev": true
         },
         "buffer-shims": {
           "version": "1.0.0",
@@ -3714,10 +2497,7 @@
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
           "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-          "dev": true,
-          "requires": {
-            "delayed-stream": "1.0.0"
-          }
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
@@ -3742,10 +2522,7 @@
           "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
           "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "boom": "2.10.1"
-          }
+          "optional": true
         },
         "dashdash": {
           "version": "1.14.1",
@@ -3753,9 +2530,6 @@
           "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
           "dev": true,
           "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          },
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
@@ -3771,10 +2545,7 @@
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
           "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
+          "optional": true
         },
         "deep-extend": {
           "version": "0.4.2",
@@ -3801,10 +2572,7 @@
           "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
           "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
+          "optional": true
         },
         "extend": {
           "version": "3.0.1",
@@ -3831,12 +2599,7 @@
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
           "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.15"
-          }
+          "optional": true
         },
         "fs.realpath": {
           "version": "1.0.0",
@@ -3848,42 +2611,21 @@
           "version": "1.0.11",
           "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
           "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "inherits": "2.0.3",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.1"
-          }
+          "dev": true
         },
         "fstream-ignore": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
           "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "fstream": "1.0.11",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4"
-          }
+          "optional": true
         },
         "gauge": {
           "version": "2.7.4",
           "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
           "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "aproba": "1.1.1",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
-          }
+          "optional": true
         },
         "getpass": {
           "version": "0.1.7",
@@ -3891,9 +2633,6 @@
           "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
           "dev": true,
           "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          },
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
@@ -3908,15 +2647,7 @@
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
+          "dev": true
         },
         "graceful-fs": {
           "version": "4.1.11",
@@ -3936,11 +2667,7 @@
           "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
           "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "ajv": "4.11.8",
-            "har-schema": "1.0.5"
-          }
+          "optional": true
         },
         "has-unicode": {
           "version": "2.0.1",
@@ -3954,13 +2681,7 @@
           "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
           "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
-          }
+          "optional": true
         },
         "hoek": {
           "version": "2.16.3",
@@ -3973,22 +2694,13 @@
           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
           "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.4.0",
-            "sshpk": "1.13.0"
-          }
+          "optional": true
         },
         "inflight": {
           "version": "1.0.6",
           "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-          "dev": true,
-          "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
-          }
+          "dev": true
         },
         "inherits": {
           "version": "2.0.3",
@@ -4007,10 +2719,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
+          "dev": true
         },
         "is-typedarray": {
           "version": "1.0.0",
@@ -4037,10 +2746,7 @@
           "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
           "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
+          "optional": true
         },
         "jsbn": {
           "version": "0.1.1",
@@ -4061,10 +2767,7 @@
           "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
           "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "jsonify": "0.0.0"
-          }
+          "optional": true
         },
         "json-stringify-safe": {
           "version": "5.0.1",
@@ -4086,12 +2789,6 @@
           "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
           "dev": true,
           "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "extsprintf": "1.0.2",
-            "json-schema": "0.2.3",
-            "verror": "1.3.6"
-          },
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
@@ -4112,19 +2809,13 @@
           "version": "2.1.15",
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
           "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
-          "dev": true,
-          "requires": {
-            "mime-db": "1.27.0"
-          }
+          "dev": true
         },
         "minimatch": {
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "1.1.7"
-          }
+          "dev": true
         },
         "minimist": {
           "version": "0.0.8",
@@ -4136,10 +2827,7 @@
           "version": "0.5.1",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
+          "dev": true
         },
         "ms": {
           "version": "2.0.0",
@@ -4153,42 +2841,21 @@
           "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.36.tgz",
           "integrity": "sha1-22BBEst04NR3VU6bUFsXq936t4Y=",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "mkdirp": "0.5.1",
-            "nopt": "4.0.1",
-            "npmlog": "4.1.0",
-            "rc": "1.2.1",
-            "request": "2.81.0",
-            "rimraf": "2.6.1",
-            "semver": "5.3.0",
-            "tar": "2.2.1",
-            "tar-pack": "3.4.0"
-          }
+          "optional": true
         },
         "nopt": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
           "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "abbrev": "1.1.0",
-            "osenv": "0.1.4"
-          }
+          "optional": true
         },
         "npmlog": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz",
           "integrity": "sha512-ocolIkZYZt8UveuiDS0yAkkIjid1o7lPG8cYm05yNYzBn8ykQtaiPMEGp8fY9tKdDgm8okpdKzkvu1y9hUYugA==",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
-          }
+          "optional": true
         },
         "number-is-nan": {
           "version": "1.0.1",
@@ -4214,10 +2881,7 @@
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-          "dev": true,
-          "requires": {
-            "wrappy": "1.0.2"
-          }
+          "dev": true
         },
         "os-homedir": {
           "version": "1.0.2",
@@ -4238,11 +2902,7 @@
           "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
           "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
-          }
+          "optional": true
         },
         "path-is-absolute": {
           "version": "1.0.1",
@@ -4283,12 +2943,6 @@
           "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
           "dev": true,
           "optional": true,
-          "requires": {
-            "deep-extend": "0.4.2",
-            "ini": "1.3.4",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
-          },
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
@@ -4303,56 +2957,20 @@
           "version": "2.2.9",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
           "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
-          "dev": true,
-          "requires": {
-            "buffer-shims": "1.0.0",
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "string_decoder": "1.0.1",
-            "util-deprecate": "1.0.2"
-          }
+          "dev": true
         },
         "request": {
           "version": "2.81.0",
           "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
           "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.1.4",
-            "har-validator": "4.2.1",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.15",
-            "oauth-sign": "0.8.2",
-            "performance-now": "0.2.0",
-            "qs": "6.4.0",
-            "safe-buffer": "5.0.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.2",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.0.1"
-          }
+          "optional": true
         },
         "rimraf": {
           "version": "2.6.1",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
           "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
-          "dev": true,
-          "requires": {
-            "glob": "7.1.2"
-          }
+          "dev": true
         },
         "safe-buffer": {
           "version": "5.0.1",
@@ -4386,10 +3004,7 @@
           "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
           "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
+          "optional": true
         },
         "sshpk": {
           "version": "1.13.0",
@@ -4397,17 +3012,6 @@
           "integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
           "dev": true,
           "optional": true,
-          "requires": {
-            "asn1": "0.2.3",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.1",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.1",
-            "getpass": "0.1.7",
-            "jodid25519": "1.0.2",
-            "jsbn": "0.1.1",
-            "tweetnacl": "0.14.5"
-          },
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
@@ -4422,21 +3026,13 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
           "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
+          "dev": true
         },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true,
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
+          "dev": true
         },
         "stringstream": {
           "version": "0.0.5",
@@ -4449,10 +3045,7 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
+          "dev": true
         },
         "strip-json-comments": {
           "version": "2.0.1",
@@ -4465,49 +3058,28 @@
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
           "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-          "dev": true,
-          "requires": {
-            "block-stream": "0.0.9",
-            "fstream": "1.0.11",
-            "inherits": "2.0.3"
-          }
+          "dev": true
         },
         "tar-pack": {
           "version": "3.4.0",
           "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz",
           "integrity": "sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ=",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "debug": "2.6.8",
-            "fstream": "1.0.11",
-            "fstream-ignore": "1.0.5",
-            "once": "1.4.0",
-            "readable-stream": "2.2.9",
-            "rimraf": "2.6.1",
-            "tar": "2.2.1",
-            "uid-number": "0.0.6"
-          }
+          "optional": true
         },
         "tough-cookie": {
           "version": "2.3.2",
           "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
           "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "punycode": "1.4.1"
-          }
+          "optional": true
         },
         "tunnel-agent": {
           "version": "0.6.0",
           "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
           "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
+          "optional": true
         },
         "tweetnacl": {
           "version": "0.14.5",
@@ -4541,20 +3113,14 @@
           "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
           "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "extsprintf": "1.0.2"
-          }
+          "optional": true
         },
         "wide-align": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
           "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
           "dev": true,
-          "optional": true,
-          "requires": {
-            "string-width": "1.0.2"
-          }
+          "optional": true
         },
         "wrappy": {
           "version": "1.0.2",
@@ -4574,12 +3140,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.0.0.tgz",
       "integrity": "sha1-X1I8pk5JGl+Vq6gMweORCAoUSC4=",
-      "dev": true,
-      "requires": {
-        "define-properties": "1.1.2",
-        "function-bind": "1.1.0",
-        "is-callable": "1.1.3"
-      }
+      "dev": true
     },
     "generate-function": {
       "version": "2.0.0",
@@ -4591,10 +3152,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-      "dev": true,
-      "requires": {
-        "is-property": "1.0.2"
-      }
+      "dev": true
     },
     "get-caller-file": {
       "version": "1.0.2",
@@ -4607,9 +3165,6 @@
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
-      "requires": {
-        "assert-plus": "1.0.0"
-      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -4623,66 +3178,37 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-      "dev": true,
-      "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
-      }
+      "dev": true
     },
     "glob-base": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-      "dev": true,
-      "requires": {
-        "glob-parent": "2.0.0",
-        "is-glob": "2.0.1"
-      }
+      "dev": true
     },
     "glob-parent": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-      "dev": true,
-      "requires": {
-        "is-glob": "2.0.1"
-      }
+      "dev": true
     },
     "global": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
       "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
-      "dev": true,
-      "requires": {
-        "min-document": "2.19.0",
-        "process": "0.5.2"
-      }
+      "dev": true
     },
     "global-modules": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
       "integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
-      "dev": true,
-      "requires": {
-        "global-prefix": "0.1.5",
-        "is-windows": "0.2.0"
-      }
+      "dev": true
     },
     "global-prefix": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
       "integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
-      "dev": true,
-      "requires": {
-        "homedir-polyfill": "1.0.1",
-        "ini": "1.3.4",
-        "is-windows": "0.2.0",
-        "which": "1.2.14"
-      }
+      "dev": true
     },
     "globals": {
       "version": "9.18.0",
@@ -4694,15 +3220,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-      "dev": true,
-      "requires": {
-        "array-union": "1.0.2",
-        "arrify": "1.0.1",
-        "glob": "7.1.2",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
-      }
+      "dev": true
     },
     "graceful-fs": {
       "version": "4.1.11",
@@ -4732,37 +3250,24 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
       "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
-      "dev": true,
-      "requires": {
-        "ajv": "4.11.8",
-        "har-schema": "1.0.5"
-      }
+      "dev": true
     },
     "has": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
-      "dev": true,
-      "requires": {
-        "function-bind": "1.1.0"
-      }
+      "dev": true
     },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "2.1.1"
-      }
+      "dev": true
     },
     "has-binary": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz",
-      "integrity": "sha1-aOYesWIQyVRaClzOBqhzkS/h5ow=",
-      "requires": {
-        "isarray": "0.0.1"
-      }
+      "integrity": "sha1-aOYesWIQyVRaClzOBqhzkS/h5ow="
     },
     "has-cors": {
       "version": "1.1.0",
@@ -4779,30 +3284,18 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
       "integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
-      "dev": true,
-      "requires": {
-        "inherits": "2.0.3"
-      }
+      "dev": true
     },
     "hash.js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz",
-      "integrity": "sha1-EzL/ABVsCg/92CNgE9B7d6BFFXM=",
-      "requires": {
-        "inherits": "2.0.3"
-      }
+      "integrity": "sha1-EzL/ABVsCg/92CNgE9B7d6BFFXM="
     },
     "hawk": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
       "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-      "dev": true,
-      "requires": {
-        "boom": "2.10.1",
-        "cryptiles": "2.0.5",
-        "hoek": "2.16.3",
-        "sntp": "1.0.9"
-      }
+      "dev": true
     },
     "he": {
       "version": "1.1.1",
@@ -4818,24 +3311,13 @@
     "history": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/history/-/history-2.1.2.tgz",
-      "integrity": "sha1-SqLeiXoOSGfkU5hDvm7Nsphr/ew=",
-      "requires": {
-        "deep-equal": "1.0.1",
-        "invariant": "2.2.2",
-        "query-string": "3.0.3",
-        "warning": "2.1.0"
-      }
+      "integrity": "sha1-SqLeiXoOSGfkU5hDvm7Nsphr/ew="
     },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
-      "dev": true,
-      "requires": {
-        "hash.js": "1.0.3",
-        "minimalistic-assert": "1.0.0",
-        "minimalistic-crypto-utils": "1.0.1"
-      }
+      "dev": true
     },
     "hoek": {
       "version": "2.16.3",
@@ -4852,20 +3334,13 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
       "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
-      "dev": true,
-      "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
-      }
+      "dev": true
     },
     "homedir-polyfill": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
       "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
-      "dev": true,
-      "requires": {
-        "parse-passwd": "1.0.0"
-      }
+      "dev": true
     },
     "hosted-git-info": {
       "version": "2.4.2",
@@ -4883,10 +3358,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.1.tgz",
       "integrity": "sha1-eb96eF6klf5mFl5zQVPzY/9UN9o=",
-      "dev": true,
-      "requires": {
-        "whatwg-encoding": "1.0.1"
-      }
+      "dev": true
     },
     "html-entities": {
       "version": "1.2.1",
@@ -4898,31 +3370,13 @@
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.2.tgz",
       "integrity": "sha1-1zvD/0SJQkCIGM5gm/P7DqfvTrc=",
-      "dev": true,
-      "requires": {
-        "camel-case": "3.0.0",
-        "clean-css": "4.1.4",
-        "commander": "2.9.0",
-        "he": "1.1.1",
-        "ncname": "1.0.0",
-        "param-case": "2.1.1",
-        "relateurl": "0.2.7",
-        "uglify-js": "3.0.18"
-      }
+      "dev": true
     },
     "html-webpack-plugin": {
       "version": "2.28.0",
       "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-2.28.0.tgz",
       "integrity": "sha1-LnhjtX5f1I/iYzA+L/yTTDBk0Ak=",
       "dev": true,
-      "requires": {
-        "bluebird": "3.5.0",
-        "html-minifier": "3.5.2",
-        "loader-utils": "0.2.17",
-        "lodash": "4.17.4",
-        "pretty-error": "2.1.1",
-        "toposort": "1.0.3"
-      },
       "dependencies": {
         "bluebird": {
           "version": "3.5.0",
@@ -4937,13 +3391,6 @@
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
       "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
       "dev": true,
-      "requires": {
-        "domelementtype": "1.3.0",
-        "domhandler": "2.3.0",
-        "domutils": "1.5.1",
-        "entities": "1.0.0",
-        "readable-stream": "1.1.14"
-      },
       "dependencies": {
         "entities": {
           "version": "1.0.0",
@@ -4955,13 +3402,7 @@
           "version": "1.1.14",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
+          "dev": true
         }
       }
     },
@@ -4969,24 +3410,13 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.1.tgz",
       "integrity": "sha1-X4uO2YrKVFZWv1cplzh/kEpyIlc=",
-      "dev": true,
-      "requires": {
-        "depd": "1.1.0",
-        "inherits": "2.0.3",
-        "setprototypeof": "1.0.3",
-        "statuses": "1.3.1"
-      }
+      "dev": true
     },
     "http-signature": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
       "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-      "dev": true,
-      "requires": {
-        "assert-plus": "0.2.0",
-        "jsprim": "1.4.0",
-        "sshpk": "1.13.1"
-      }
+      "dev": true
     },
     "https-browserify": {
       "version": "0.0.1",
@@ -4999,11 +3429,6 @@
       "resolved": "https://registry.npmjs.org/iced-coffee-script/-/iced-coffee-script-1.8.0-e.tgz",
       "integrity": "sha1-6dPhe4cPyoF5/Q9iVOJ2GvzloTY=",
       "dev": true,
-      "requires": {
-        "docco": "0.6.3",
-        "iced-runtime": "1.0.3",
-        "mkdirp": "0.3.5"
-      },
       "dependencies": {
         "mkdirp": {
           "version": "0.3.5",
@@ -5035,29 +3460,18 @@
       "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-2.1.0.tgz",
       "integrity": "sha1-g/Cg7DeL8yRheLbCrZE28TWxyWI=",
       "dev": true,
-      "requires": {
-        "postcss": "6.0.2"
-      },
       "dependencies": {
         "postcss": {
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.2.tgz",
           "integrity": "sha1-XE/qWJ8Kw7AMqnWxy8OihBlbfl0=",
-          "dev": true,
-          "requires": {
-            "chalk": "1.1.3",
-            "source-map": "0.5.6",
-            "supports-color": "3.2.3"
-          }
+          "dev": true
         },
         "supports-color": {
           "version": "3.2.3",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-          "dev": true,
-          "requires": {
-            "has-flag": "1.0.0"
-          }
+          "dev": true
         }
       }
     },
@@ -5100,11 +3514,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
-      "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
-      }
+      "dev": true
     },
     "inherits": {
       "version": "2.0.3",
@@ -5121,22 +3531,7 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
       "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
-      "dev": true,
-      "requires": {
-        "ansi-escapes": "1.4.0",
-        "ansi-regex": "2.1.1",
-        "chalk": "1.1.3",
-        "cli-cursor": "1.0.2",
-        "cli-width": "2.1.0",
-        "figures": "1.7.0",
-        "lodash": "4.17.4",
-        "readline2": "1.0.1",
-        "run-async": "0.1.0",
-        "rx-lite": "3.1.2",
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "through": "2.3.8"
-      }
+      "dev": true
     },
     "interpret": {
       "version": "1.0.3",
@@ -5147,10 +3542,7 @@
     "invariant": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-      "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
-      "requires": {
-        "loose-envify": "1.3.1"
-      }
+      "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A="
     },
     "invert-kv": {
       "version": "1.0.0",
@@ -5180,10 +3572,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
-      "dev": true,
-      "requires": {
-        "binary-extensions": "1.8.0"
-      }
+      "dev": true
     },
     "is-buffer": {
       "version": "1.1.5",
@@ -5195,10 +3584,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-      "dev": true,
-      "requires": {
-        "builtin-modules": "1.1.1"
-      }
+      "dev": true
     },
     "is-callable": {
       "version": "1.1.3",
@@ -5222,10 +3608,7 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-      "dev": true,
-      "requires": {
-        "is-primitive": "2.0.0"
-      }
+      "dev": true
     },
     "is-extendable": {
       "version": "0.1.1",
@@ -5243,49 +3626,31 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-      "dev": true,
-      "requires": {
-        "number-is-nan": "1.0.1"
-      }
+      "dev": true
     },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-      "dev": true,
-      "requires": {
-        "number-is-nan": "1.0.1"
-      }
+      "dev": true
     },
     "is-glob": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-      "dev": true,
-      "requires": {
-        "is-extglob": "1.0.0"
-      }
+      "dev": true
     },
     "is-my-json-valid": {
       "version": "2.16.0",
       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
       "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
-      "dev": true,
-      "requires": {
-        "generate-function": "2.0.0",
-        "generate-object-property": "1.2.0",
-        "jsonpointer": "4.0.1",
-        "xtend": "4.0.1"
-      }
+      "dev": true
     },
     "is-number": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-      "dev": true,
-      "requires": {
-        "kind-of": "3.2.2"
-      }
+      "dev": true
     },
     "is-path-cwd": {
       "version": "1.0.0",
@@ -5297,19 +3662,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
       "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
-      "dev": true,
-      "requires": {
-        "is-path-inside": "1.0.0"
-      }
+      "dev": true
     },
     "is-path-inside": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
       "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
-      "dev": true,
-      "requires": {
-        "path-is-inside": "1.0.2"
-      }
+      "dev": true
     },
     "is-plain-obj": {
       "version": "1.1.0",
@@ -5339,19 +3698,13 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-      "dev": true,
-      "requires": {
-        "has": "1.0.1"
-      }
+      "dev": true
     },
     "is-resolvable": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
       "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
-      "dev": true,
-      "requires": {
-        "tryit": "1.0.3"
-      }
+      "dev": true
     },
     "is-stream": {
       "version": "1.1.0",
@@ -5368,10 +3721,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-2.1.0.tgz",
       "integrity": "sha1-z2EJDaDZ77yrhyLeum8DIgjbsOk=",
-      "dev": true,
-      "requires": {
-        "html-comment-regex": "1.1.1"
-      }
+      "dev": true
     },
     "is-symbol": {
       "version": "1.0.1",
@@ -5413,9 +3763,6 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
       "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
       "dev": true,
-      "requires": {
-        "isarray": "1.0.0"
-      },
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
@@ -5428,11 +3775,7 @@
     "isomorphic-fetch": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-      "requires": {
-        "node-fetch": "1.7.1",
-        "whatwg-fetch": "2.0.3"
-      }
+      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk="
     },
     "isstream": {
       "version": "0.1.2",
@@ -5455,11 +3798,7 @@
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
       "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
-      "dev": true,
-      "requires": {
-        "argparse": "1.0.9",
-        "esprima": "2.7.3"
-      }
+      "dev": true
     },
     "jsbn": {
       "version": "0.1.1",
@@ -5473,27 +3812,6 @@
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-9.12.0.tgz",
       "integrity": "sha1-6MVG//ywbADUgzyoRBD+1/igl9Q=",
       "dev": true,
-      "requires": {
-        "abab": "1.0.3",
-        "acorn": "4.0.13",
-        "acorn-globals": "3.1.0",
-        "array-equal": "1.0.0",
-        "content-type-parser": "1.0.1",
-        "cssom": "0.3.2",
-        "cssstyle": "0.2.37",
-        "escodegen": "1.8.1",
-        "html-encoding-sniffer": "1.0.1",
-        "nwmatcher": "1.4.1",
-        "parse5": "1.5.1",
-        "request": "2.81.0",
-        "sax": "1.2.2",
-        "symbol-tree": "3.2.2",
-        "tough-cookie": "2.3.2",
-        "webidl-conversions": "4.0.1",
-        "whatwg-encoding": "1.0.1",
-        "whatwg-url": "4.8.0",
-        "xml-name-validator": "2.0.1"
-      },
       "dependencies": {
         "acorn": {
           "version": "4.0.13",
@@ -5505,10 +3823,7 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-3.1.0.tgz",
           "integrity": "sha1-/YJw9x+7SZawBPqIDuXUZXOnMb8=",
-          "dev": true,
-          "requires": {
-            "acorn": "4.0.13"
-          }
+          "dev": true
         },
         "webidl-conversions": {
           "version": "4.0.1",
@@ -5527,11 +3842,7 @@
     "json-api-client": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/json-api-client/-/json-api-client-3.2.1.tgz",
-      "integrity": "sha1-VZ1BDu37+RUboxHYLeDtbHkqkDs=",
-      "requires": {
-        "normalizeurl": "0.1.3",
-        "superagent": "1.8.5"
-      }
+      "integrity": "sha1-VZ1BDu37+RUboxHYLeDtbHkqkDs="
     },
     "json-loader": {
       "version": "0.5.4",
@@ -5555,10 +3866,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "dev": true,
-      "requires": {
-        "jsonify": "0.0.0"
-      }
+      "dev": true
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -5582,10 +3890,7 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11"
-      }
+      "dev": true
     },
     "jsonify": {
       "version": "0.0.0",
@@ -5604,12 +3909,6 @@
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
       "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
       "dev": true,
-      "requires": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.0.2",
-        "json-schema": "0.2.3",
-        "verror": "1.3.6"
-      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -5635,19 +3934,13 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "dev": true,
-      "requires": {
-        "is-buffer": "1.1.5"
-      }
+      "dev": true
     },
     "klaw": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11"
-      }
+      "dev": true
     },
     "lazy-cache": {
       "version": "1.0.4",
@@ -5659,50 +3952,30 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-      "dev": true,
-      "requires": {
-        "invert-kv": "1.0.0"
-      }
+      "dev": true
     },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "dev": true,
-      "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
-      }
+      "dev": true
     },
     "linkify-it": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.0.3.tgz",
-      "integrity": "sha1-2UpGSPmxwXnWT6lykSaL22zpQ08=",
-      "requires": {
-        "uc.micro": "1.0.3"
-      }
+      "integrity": "sha1-2UpGSPmxwXnWT6lykSaL22zpQ08="
     },
     "load-json-file": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "parse-json": "2.2.0",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "strip-bom": "2.0.0"
-      },
       "dependencies": {
         "strip-bom": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "dev": true,
-          "requires": {
-            "is-utf8": "0.2.1"
-          }
+          "dev": true
         }
       }
     },
@@ -5716,13 +3989,7 @@
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
       "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
-      "dev": true,
-      "requires": {
-        "big.js": "3.1.3",
-        "emojis-list": "2.1.0",
-        "json5": "0.5.1",
-        "object-assign": "4.1.1"
-      }
+      "dev": true
     },
     "local-storage": {
       "version": "1.4.2",
@@ -5743,10 +4010,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
       "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
-      "requires": {
-        "lodash._basecopy": "3.0.1",
-        "lodash.keys": "3.1.2"
-      },
       "dependencies": {
         "lodash.isarray": {
           "version": "3.0.4",
@@ -5756,12 +4019,7 @@
         "lodash.keys": {
           "version": "3.1.2",
           "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-          "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-          "requires": {
-            "lodash._getnative": "3.9.1",
-            "lodash.isarguments": "3.1.0",
-            "lodash.isarray": "3.0.4"
-          }
+          "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo="
         }
       }
     },
@@ -5778,12 +4036,7 @@
     "lodash._createassigner": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
-      "integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE=",
-      "requires": {
-        "lodash._bindcallback": "3.0.1",
-        "lodash._isiterateecall": "3.0.9",
-        "lodash.restparam": "3.6.1"
-      }
+      "integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE="
     },
     "lodash._getnative": {
       "version": "3.9.1",
@@ -5798,29 +4051,7 @@
     "lodash.assign": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
-      "integrity": "sha1-POnwI0tLIiPilrj6CsH+6OvKZPo=",
-      "requires": {
-        "lodash._baseassign": "3.2.0",
-        "lodash._createassigner": "3.1.1",
-        "lodash.keys": "3.1.2"
-      },
-      "dependencies": {
-        "lodash.isarray": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-          "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
-        },
-        "lodash.keys": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-          "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-          "requires": {
-            "lodash._getnative": "3.9.1",
-            "lodash.isarguments": "3.1.0",
-            "lodash.isarray": "3.0.4"
-          }
-        }
-      }
+      "integrity": "sha1-POnwI0tLIiPilrj6CsH+6OvKZPo="
     },
     "lodash.camelcase": {
       "version": "4.3.0",
@@ -5845,11 +4076,6 @@
       "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
       "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
       "dev": true,
-      "requires": {
-        "lodash._baseassign": "3.2.0",
-        "lodash._basecreate": "3.0.3",
-        "lodash._isiterateecall": "3.0.9"
-      },
       "dependencies": {
         "lodash._basecreate": {
           "version": "3.0.3",
@@ -5863,6 +4089,16 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
       "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
+    },
+    "lodash.isarray": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
+    },
+    "lodash.keys": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo="
     },
     "lodash.memoize": {
       "version": "4.1.2",
@@ -5890,10 +4126,7 @@
     "loose-envify": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
-      "requires": {
-        "js-tokens": "3.0.1"
-      }
+      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg="
     },
     "lower-case": {
       "version": "1.1.4",
@@ -5905,11 +4138,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
       "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
-      "dev": true,
-      "requires": {
-        "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
-      }
+      "dev": true
     },
     "macaddress": {
       "version": "0.2.8",
@@ -5920,22 +4149,12 @@
     "markdown-it": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-7.0.1.tgz",
-      "integrity": "sha1-8S2LiKk+ZCVDSN/Rg71wv2BWekI=",
-      "requires": {
-        "argparse": "1.0.9",
-        "entities": "1.1.1",
-        "linkify-it": "2.0.3",
-        "mdurl": "1.0.1",
-        "uc.micro": "1.0.3"
-      }
+      "integrity": "sha1-8S2LiKk+ZCVDSN/Rg71wv2BWekI="
     },
     "markdown-it-anchor": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-2.5.1.tgz",
-      "integrity": "sha1-h+O7K1rZWv8m46Bdy4T/TPJV0PM=",
-      "requires": {
-        "string": "3.3.3"
-      }
+      "integrity": "sha1-h+O7K1rZWv8m46Bdy4T/TPJV0PM="
     },
     "markdown-it-container": {
       "version": "2.0.0",
@@ -5971,10 +4190,6 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/markdown-it-table-of-contents/-/markdown-it-table-of-contents-0.2.3.tgz",
       "integrity": "sha1-j2FnED80mDSu2yjWmj7XG665gjc=",
-      "requires": {
-        "lodash.assign": "3.2.0",
-        "string": "3.1.3"
-      },
       "dependencies": {
         "string": {
           "version": "3.1.3",
@@ -5991,22 +4206,7 @@
     "markdownz": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/markdownz/-/markdownz-7.3.1.tgz",
-      "integrity": "sha512-Z2QKQe7tavl1jIl50LvnCFcEjv9b9s5oal+cpyAjRzi24yrmGvq3pumF3Q//ca76jRad6SsiVHIYhJwNzdoCqQ==",
-      "requires": {
-        "markdown-it": "7.0.1",
-        "markdown-it-anchor": "2.5.1",
-        "markdown-it-container": "2.0.0",
-        "markdown-it-emoji": "1.2.0",
-        "markdown-it-footnote": "3.0.1",
-        "markdown-it-imsize": "2.0.1",
-        "markdown-it-sub": "1.0.0",
-        "markdown-it-sup": "1.0.0",
-        "markdown-it-table-of-contents": "0.2.3",
-        "markdown-it-video": "0.4.0",
-        "react": "15.4.2",
-        "react-dom": "15.4.2",
-        "twemoji": "1.4.1"
-      }
+      "integrity": "sha512-Z2QKQe7tavl1jIl50LvnCFcEjv9b9s5oal+cpyAjRzi24yrmGvq3pumF3Q//ca76jRad6SsiVHIYhJwNzdoCqQ=="
     },
     "marked": {
       "version": "0.3.6",
@@ -6036,10 +4236,6 @@
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
       "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
       "dev": true,
-      "requires": {
-        "errno": "0.1.4",
-        "readable-stream": "2.3.0"
-      },
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
@@ -6051,25 +4247,13 @@
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.0.tgz",
           "integrity": "sha512-c7KMXGd4b48nN3OJ1U9qOsn6pXNzf6kLd3kdZCkg2sxAcoiufInqF0XckwEnlrcwuaYwonlNK8GQUIOC/WC7sg==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.0",
-            "string_decoder": "1.0.2",
-            "util-deprecate": "1.0.2"
-          }
+          "dev": true
         },
         "string_decoder": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
           "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
           "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          },
           "dependencies": {
             "safe-buffer": {
               "version": "5.0.1",
@@ -6101,32 +4285,13 @@
       "version": "2.3.11",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-      "dev": true,
-      "requires": {
-        "arr-diff": "2.0.0",
-        "array-unique": "0.2.1",
-        "braces": "1.8.5",
-        "expand-brackets": "0.1.5",
-        "extglob": "0.3.2",
-        "filename-regex": "2.0.1",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1",
-        "kind-of": "3.2.2",
-        "normalize-path": "2.1.1",
-        "object.omit": "2.0.1",
-        "parse-glob": "3.0.4",
-        "regex-cache": "0.4.3"
-      }
+      "dev": true
     },
     "miller-rabin": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.0.tgz",
       "integrity": "sha1-SmL7HUKTPAVYOYL0xxb2+55sbT0=",
-      "dev": true,
-      "requires": {
-        "bn.js": "4.11.6",
-        "brorand": "1.1.0"
-      }
+      "dev": true
     },
     "mime": {
       "version": "1.3.4",
@@ -6141,27 +4306,18 @@
     "mime-types": {
       "version": "2.1.15",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
-      "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
-      "requires": {
-        "mime-db": "1.27.0"
-      }
+      "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0="
     },
     "min-document": {
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
       "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
-      "dev": true,
-      "requires": {
-        "dom-walk": "0.1.1"
-      }
+      "dev": true
     },
     "minilog": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/minilog/-/minilog-3.1.0.tgz",
-      "integrity": "sha1-0tDxiHyjY9Gs8OqG1cTfKTs/tnU=",
-      "requires": {
-        "microee": "0.0.6"
-      }
+      "integrity": "sha1-0tDxiHyjY9Gs8OqG1cTfKTs/tnU="
     },
     "minimalistic-assert": {
       "version": "1.0.0",
@@ -6179,10 +4335,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
-      "requires": {
-        "brace-expansion": "1.1.8"
-      }
+      "dev": true
     },
     "minimist": {
       "version": "0.0.8",
@@ -6194,52 +4347,25 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
-      "requires": {
-        "minimist": "0.0.8"
-      }
+      "dev": true
     },
     "mocha": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.1.2.tgz",
       "integrity": "sha1-Ufk7Qyv34bF1/8Iog8zQvjLbprU=",
       "dev": true,
-      "requires": {
-        "browser-stdout": "1.3.0",
-        "commander": "2.9.0",
-        "debug": "2.2.0",
-        "diff": "1.4.0",
-        "escape-string-regexp": "1.0.5",
-        "glob": "7.0.5",
-        "growl": "1.9.2",
-        "json3": "3.3.2",
-        "lodash.create": "3.1.1",
-        "mkdirp": "0.5.1",
-        "supports-color": "3.1.2"
-      },
       "dependencies": {
         "debug": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.1"
-          }
+          "dev": true
         },
         "glob": {
           "version": "7.0.5",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz",
           "integrity": "sha1-tCAqaQmbu00pKnwblbZoK2fr3JU=",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
+          "dev": true
         },
         "ms": {
           "version": "0.7.1",
@@ -6251,10 +4377,7 @@
           "version": "3.1.2",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
           "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
-          "dev": true,
-          "requires": {
-            "has-flag": "1.0.0"
-          }
+          "dev": true
         }
       }
     },
@@ -6302,10 +4425,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/ncname/-/ncname-1.0.0.tgz",
       "integrity": "sha1-W1etGLHKCShk72Kwse2BlPODtxw=",
-      "dev": true,
-      "requires": {
-        "xml-char-classes": "1.0.0"
-      }
+      "dev": true
     },
     "negotiator": {
       "version": "0.6.1",
@@ -6317,68 +4437,30 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/nib/-/nib-1.1.2.tgz",
       "integrity": "sha1-amnt5AgblcDe+L4CSkyK4MLLtsc=",
-      "dev": true,
-      "requires": {
-        "stylus": "0.54.5"
-      }
+      "dev": true
     },
     "no-case": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.1.tgz",
       "integrity": "sha1-euuhxzpSGEJlVUt9wDuvcg34AIE=",
-      "dev": true,
-      "requires": {
-        "lower-case": "1.1.4"
-      }
+      "dev": true
     },
     "node-dir": {
       "version": "0.1.17",
       "resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.17.tgz",
       "integrity": "sha1-X1Zl2TNRM1yqvvjxxVRRbPXx5OU=",
-      "dev": true,
-      "requires": {
-        "minimatch": "3.0.4"
-      }
+      "dev": true
     },
     "node-fetch": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.1.tgz",
-      "integrity": "sha512-j8XsFGCLw79vWXkZtMSmmLaOk9z5SQ9bV/tkbZVCqvgwzrjAGq66igobLofHtF63NvMTp2WjytpsNTGKa+XRIQ==",
-      "requires": {
-        "encoding": "0.1.12",
-        "is-stream": "1.1.0"
-      }
+      "integrity": "sha512-j8XsFGCLw79vWXkZtMSmmLaOk9z5SQ9bV/tkbZVCqvgwzrjAGq66igobLofHtF63NvMTp2WjytpsNTGKa+XRIQ=="
     },
     "node-libs-browser": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.0.0.tgz",
       "integrity": "sha1-o6WeyXAkmFtG6Vg3lkb5bEthZkY=",
       "dev": true,
-      "requires": {
-        "assert": "1.4.1",
-        "browserify-zlib": "0.1.4",
-        "buffer": "4.9.1",
-        "console-browserify": "1.1.0",
-        "constants-browserify": "1.0.0",
-        "crypto-browserify": "3.11.0",
-        "domain-browser": "1.1.7",
-        "events": "1.1.1",
-        "https-browserify": "0.0.1",
-        "os-browserify": "0.2.1",
-        "path-browserify": "0.0.0",
-        "process": "0.11.10",
-        "punycode": "1.4.1",
-        "querystring-es3": "0.2.1",
-        "readable-stream": "2.3.0",
-        "stream-browserify": "2.0.1",
-        "stream-http": "2.7.2",
-        "string_decoder": "0.10.31",
-        "timers-browserify": "2.0.2",
-        "tty-browserify": "0.0.0",
-        "url": "0.11.0",
-        "util": "0.10.3",
-        "vm-browserify": "0.0.4"
-      },
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
@@ -6397,24 +4479,12 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.0.tgz",
           "integrity": "sha512-c7KMXGd4b48nN3OJ1U9qOsn6pXNzf6kLd3kdZCkg2sxAcoiufInqF0XckwEnlrcwuaYwonlNK8GQUIOC/WC7sg==",
           "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.0",
-            "string_decoder": "1.0.2",
-            "util-deprecate": "1.0.2"
-          },
           "dependencies": {
             "string_decoder": {
               "version": "1.0.2",
               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
               "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
               "dev": true,
-              "requires": {
-                "safe-buffer": "5.0.1"
-              },
               "dependencies": {
                 "safe-buffer": {
                   "version": "5.0.1",
@@ -6432,22 +4502,13 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz",
       "integrity": "sha1-2Bntoqne29H/pWPqQHHZNngilbs=",
-      "dev": true,
-      "requires": {
-        "hosted-git-info": "2.4.2",
-        "is-builtin-module": "1.0.0",
-        "semver": "5.3.0",
-        "validate-npm-package-license": "3.0.1"
-      }
+      "dev": true
     },
     "normalize-path": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-      "dev": true,
-      "requires": {
-        "remove-trailing-separator": "1.0.2"
-      }
+      "dev": true
     },
     "normalize-range": {
       "version": "0.1.2",
@@ -6460,22 +4521,12 @@
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
       "integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
       "dev": true,
-      "requires": {
-        "object-assign": "4.1.1",
-        "prepend-http": "1.0.4",
-        "query-string": "4.3.4",
-        "sort-keys": "1.1.2"
-      },
       "dependencies": {
         "query-string": {
           "version": "4.3.4",
           "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
           "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
-          "dev": true,
-          "requires": {
-            "object-assign": "4.1.1",
-            "strict-uri-encode": "1.1.0"
-          }
+          "dev": true
         }
       }
     },
@@ -6488,10 +4539,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
       "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
-      "dev": true,
-      "requires": {
-        "boolbase": "1.0.0"
-      }
+      "dev": true
     },
     "num2fraction": {
       "version": "1.2.2",
@@ -6544,64 +4592,37 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.0.4.tgz",
       "integrity": "sha1-scnMBE7xuf5jYG/BQau7MuFHMMw=",
-      "dev": true,
-      "requires": {
-        "define-properties": "1.1.2",
-        "function-bind": "1.1.0",
-        "object-keys": "1.0.11"
-      }
+      "dev": true
     },
     "object.entries": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.0.4.tgz",
       "integrity": "sha1-G/mk3SKI9bM/Opk9JXZh8F0WGl8=",
-      "dev": true,
-      "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.7.0",
-        "function-bind": "1.1.0",
-        "has": "1.0.1"
-      }
+      "dev": true
     },
     "object.omit": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-      "dev": true,
-      "requires": {
-        "for-own": "0.1.5",
-        "is-extendable": "0.1.1"
-      }
+      "dev": true
     },
     "object.values": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.0.4.tgz",
       "integrity": "sha1-5STaCbT2b/Bd9FdUbscqyZ8TBpo=",
-      "dev": true,
-      "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.7.0",
-        "function-bind": "1.1.0",
-        "has": "1.0.1"
-      }
+      "dev": true
     },
     "on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
       "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
-      "dev": true,
-      "requires": {
-        "ee-first": "1.1.1"
-      }
+      "dev": true
     },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
-      "requires": {
-        "wrappy": "1.0.2"
-      }
+      "dev": true
     },
     "onetime": {
       "version": "1.1.0",
@@ -6613,25 +4634,13 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "dev": true,
-      "requires": {
-        "minimist": "0.0.8",
-        "wordwrap": "0.0.3"
-      }
+      "dev": true
     },
     "optionator": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
-      "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
-      },
       "dependencies": {
         "wordwrap": {
           "version": "1.0.0",
@@ -6662,10 +4671,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-      "dev": true,
-      "requires": {
-        "lcid": "1.0.0"
-      }
+      "dev": true
     },
     "os-tmpdir": {
       "version": "1.0.2",
@@ -6677,22 +4683,13 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
       "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
-      "dev": true,
-      "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
-      }
+      "dev": true
     },
     "output-file-sync": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
       "integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "mkdirp": "0.5.1",
-        "object-assign": "4.1.1"
-      }
+      "dev": true
     },
     "pako": {
       "version": "0.2.9",
@@ -6703,12 +4700,7 @@
     "panoptes-client": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-2.7.2.tgz",
-      "integrity": "sha1-xYWVYtNgVCaKoxHihVqhZ3EU+oI=",
-      "requires": {
-        "json-api-client": "3.2.1",
-        "local-storage": "1.4.2",
-        "sugar-client": "1.0.1"
-      }
+      "integrity": "sha1-xYWVYtNgVCaKoxHihVqhZ3EU+oI="
     },
     "papaparse": {
       "version": "github:mholt/PapaParse#cada171c8a07bd4d7d2b0175f1e26e8bdc2a3870"
@@ -6717,44 +4709,25 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
       "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
-      "dev": true,
-      "requires": {
-        "no-case": "2.3.1"
-      }
+      "dev": true
     },
     "parse-asn1": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
       "integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
-      "dev": true,
-      "requires": {
-        "asn1.js": "4.9.1",
-        "browserify-aes": "1.0.6",
-        "create-hash": "1.1.3",
-        "evp_bytestokey": "1.0.0",
-        "pbkdf2": "3.0.12"
-      }
+      "dev": true
     },
     "parse-glob": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-      "dev": true,
-      "requires": {
-        "glob-base": "0.3.0",
-        "is-dotfile": "1.0.3",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1"
-      }
+      "dev": true
     },
     "parse-json": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-      "dev": true,
-      "requires": {
-        "error-ex": "1.3.1"
-      }
+      "dev": true
     },
     "parse-passwd": {
       "version": "1.0.0",
@@ -6771,26 +4744,17 @@
     "parsejson": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.3.tgz",
-      "integrity": "sha1-q343WfIJ7OmUN5c/fQ8fZK4OZKs=",
-      "requires": {
-        "better-assert": "1.0.2"
-      }
+      "integrity": "sha1-q343WfIJ7OmUN5c/fQ8fZK4OZKs="
     },
     "parseqs": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
-      "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
-      "requires": {
-        "better-assert": "1.0.2"
-      }
+      "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0="
     },
     "parseuri": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
-      "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
-      "requires": {
-        "better-assert": "1.0.2"
-      }
+      "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo="
     },
     "parseurl": {
       "version": "1.3.1",
@@ -6808,10 +4772,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-      "dev": true,
-      "requires": {
-        "pinkie-promise": "2.0.1"
-      }
+      "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -6841,25 +4802,13 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
-      }
+      "dev": true
     },
     "pbkdf2": {
       "version": "3.0.12",
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.12.tgz",
       "integrity": "sha1-vjZ4XFBn6kjYBv+SMojF91C2uKI=",
-      "dev": true,
-      "requires": {
-        "create-hash": "1.1.3",
-        "create-hmac": "1.1.6",
-        "ripemd160": "2.0.1",
-        "safe-buffer": "5.1.0",
-        "sha.js": "2.4.8"
-      }
+      "dev": true
     },
     "performance-now": {
       "version": "0.2.0",
@@ -6883,28 +4832,19 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "dev": true,
-      "requires": {
-        "pinkie": "2.0.4"
-      }
+      "dev": true
     },
     "pkg-dir": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
       "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
-      "dev": true,
-      "requires": {
-        "find-up": "1.1.2"
-      }
+      "dev": true
     },
     "pkg-up": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-1.0.0.tgz",
       "integrity": "sha1-Pgj7RhUlxEIWJKM7n35tCvWwWiY=",
-      "dev": true,
-      "requires": {
-        "find-up": "1.1.2"
-      }
+      "dev": true
     },
     "pluralize": {
       "version": "1.2.1",
@@ -6921,21 +4861,12 @@
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
       "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
       "dev": true,
-      "requires": {
-        "chalk": "1.1.3",
-        "js-base64": "2.1.9",
-        "source-map": "0.5.6",
-        "supports-color": "3.2.3"
-      },
       "dependencies": {
         "supports-color": {
           "version": "3.2.3",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-          "dev": true,
-          "requires": {
-            "has-flag": "1.0.0"
-          }
+          "dev": true
         }
       }
     },
@@ -6943,122 +4874,73 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.3.1.tgz",
       "integrity": "sha1-d7rnypKK2FcW4v2kLyYb98HWW14=",
-      "dev": true,
-      "requires": {
-        "postcss": "5.2.17",
-        "postcss-message-helpers": "2.0.0",
-        "reduce-css-calc": "1.3.0"
-      }
+      "dev": true
     },
     "postcss-colormin": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.2.2.tgz",
       "integrity": "sha1-ZjFBfV8OkJo9fsJrJMio0eT5bks=",
-      "dev": true,
-      "requires": {
-        "colormin": "1.1.2",
-        "postcss": "5.2.17",
-        "postcss-value-parser": "3.3.0"
-      }
+      "dev": true
     },
     "postcss-convert-values": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.6.1.tgz",
       "integrity": "sha1-u9hZPFwf0uPRwyK7kl3K6Nrk1i0=",
-      "dev": true,
-      "requires": {
-        "postcss": "5.2.17",
-        "postcss-value-parser": "3.3.0"
-      }
+      "dev": true
     },
     "postcss-discard-comments": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz",
       "integrity": "sha1-vv6J+v1bPazlzM5Rt2uBUUvgDj0=",
-      "dev": true,
-      "requires": {
-        "postcss": "5.2.17"
-      }
+      "dev": true
     },
     "postcss-discard-duplicates": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.1.0.tgz",
       "integrity": "sha1-uavye4isGIFYpesSq8riAmO5GTI=",
-      "dev": true,
-      "requires": {
-        "postcss": "5.2.17"
-      }
+      "dev": true
     },
     "postcss-discard-empty": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz",
       "integrity": "sha1-0rS9nVztXr2Nyt52QMfXzX9PkrU=",
-      "dev": true,
-      "requires": {
-        "postcss": "5.2.17"
-      }
+      "dev": true
     },
     "postcss-discard-overridden": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz",
       "integrity": "sha1-ix6vVU9ob7KIzYdMVWZ7CqNmjVg=",
-      "dev": true,
-      "requires": {
-        "postcss": "5.2.17"
-      }
+      "dev": true
     },
     "postcss-discard-unused": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz",
       "integrity": "sha1-vOMLLMWR/8Y0Mitfs0ZLbZNPRDM=",
-      "dev": true,
-      "requires": {
-        "postcss": "5.2.17",
-        "uniqs": "2.0.0"
-      }
+      "dev": true
     },
     "postcss-filter-plugins": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.2.tgz",
       "integrity": "sha1-bYWGJTTXNaxCDkqFgG4fXUKG2Ew=",
-      "dev": true,
-      "requires": {
-        "postcss": "5.2.17",
-        "uniqid": "4.1.1"
-      }
+      "dev": true
     },
     "postcss-merge-idents": {
       "version": "2.1.7",
       "resolved": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz",
       "integrity": "sha1-TFUwMTwI4dWzu/PSu8dH4njuonA=",
-      "dev": true,
-      "requires": {
-        "has": "1.0.1",
-        "postcss": "5.2.17",
-        "postcss-value-parser": "3.3.0"
-      }
+      "dev": true
     },
     "postcss-merge-longhand": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.2.tgz",
       "integrity": "sha1-I9kM0Sewp3mUkVMyc5A0oaTz1lg=",
-      "dev": true,
-      "requires": {
-        "postcss": "5.2.17"
-      }
+      "dev": true
     },
     "postcss-merge-rules": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.1.2.tgz",
       "integrity": "sha1-0d9d+qexrMO+VT8OnhDofGG19yE=",
-      "dev": true,
-      "requires": {
-        "browserslist": "1.7.7",
-        "caniuse-api": "1.6.1",
-        "postcss": "5.2.17",
-        "postcss-selector-parser": "2.2.3",
-        "vendors": "1.0.1"
-      }
+      "dev": true
     },
     "postcss-message-helpers": {
       "version": "2.0.0",
@@ -7070,75 +4952,43 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz",
       "integrity": "sha1-S1jttWZB66fIR0qzUmyv17vey2k=",
-      "dev": true,
-      "requires": {
-        "object-assign": "4.1.1",
-        "postcss": "5.2.17",
-        "postcss-value-parser": "3.3.0"
-      }
+      "dev": true
     },
     "postcss-minify-gradients": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz",
       "integrity": "sha1-Xb2hE3NwP4PPtKPqOIHY11/15uE=",
-      "dev": true,
-      "requires": {
-        "postcss": "5.2.17",
-        "postcss-value-parser": "3.3.0"
-      }
+      "dev": true
     },
     "postcss-minify-params": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.2.2.tgz",
       "integrity": "sha1-rSzgcTc7lDs9kwo/pZo1jCjW8fM=",
-      "dev": true,
-      "requires": {
-        "alphanum-sort": "1.0.2",
-        "postcss": "5.2.17",
-        "postcss-value-parser": "3.3.0",
-        "uniqs": "2.0.0"
-      }
+      "dev": true
     },
     "postcss-minify-selectors": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.1.1.tgz",
       "integrity": "sha1-ssapjAByz5G5MtGkllCBFDEXNb8=",
-      "dev": true,
-      "requires": {
-        "alphanum-sort": "1.0.2",
-        "has": "1.0.1",
-        "postcss": "5.2.17",
-        "postcss-selector-parser": "2.2.3"
-      }
+      "dev": true
     },
     "postcss-modules-extract-imports": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.1.0.tgz",
       "integrity": "sha1-thTJcgvmgW6u41+zpfqh26agXds=",
       "dev": true,
-      "requires": {
-        "postcss": "6.0.2"
-      },
       "dependencies": {
         "postcss": {
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.2.tgz",
           "integrity": "sha1-XE/qWJ8Kw7AMqnWxy8OihBlbfl0=",
-          "dev": true,
-          "requires": {
-            "chalk": "1.1.3",
-            "source-map": "0.5.6",
-            "supports-color": "3.2.3"
-          }
+          "dev": true
         },
         "supports-color": {
           "version": "3.2.3",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-          "dev": true,
-          "requires": {
-            "has-flag": "1.0.0"
-          }
+          "dev": true
         }
       }
     },
@@ -7147,30 +4997,18 @@
       "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz",
       "integrity": "sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=",
       "dev": true,
-      "requires": {
-        "css-selector-tokenizer": "0.7.0",
-        "postcss": "6.0.2"
-      },
       "dependencies": {
         "postcss": {
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.2.tgz",
           "integrity": "sha1-XE/qWJ8Kw7AMqnWxy8OihBlbfl0=",
-          "dev": true,
-          "requires": {
-            "chalk": "1.1.3",
-            "source-map": "0.5.6",
-            "supports-color": "3.2.3"
-          }
+          "dev": true
         },
         "supports-color": {
           "version": "3.2.3",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-          "dev": true,
-          "requires": {
-            "has-flag": "1.0.0"
-          }
+          "dev": true
         }
       }
     },
@@ -7179,30 +5017,18 @@
       "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.1.0.tgz",
       "integrity": "sha1-1upkmUx5+XtipytCb75gVqGUu5A=",
       "dev": true,
-      "requires": {
-        "css-selector-tokenizer": "0.7.0",
-        "postcss": "6.0.2"
-      },
       "dependencies": {
         "postcss": {
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.2.tgz",
           "integrity": "sha1-XE/qWJ8Kw7AMqnWxy8OihBlbfl0=",
-          "dev": true,
-          "requires": {
-            "chalk": "1.1.3",
-            "source-map": "0.5.6",
-            "supports-color": "3.2.3"
-          }
+          "dev": true
         },
         "supports-color": {
           "version": "3.2.3",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-          "dev": true,
-          "requires": {
-            "has-flag": "1.0.0"
-          }
+          "dev": true
         }
       }
     },
@@ -7211,30 +5037,18 @@
       "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.3.0.tgz",
       "integrity": "sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=",
       "dev": true,
-      "requires": {
-        "icss-replace-symbols": "1.1.0",
-        "postcss": "6.0.2"
-      },
       "dependencies": {
         "postcss": {
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.2.tgz",
           "integrity": "sha1-XE/qWJ8Kw7AMqnWxy8OihBlbfl0=",
-          "dev": true,
-          "requires": {
-            "chalk": "1.1.3",
-            "source-map": "0.5.6",
-            "supports-color": "3.2.3"
-          }
+          "dev": true
         },
         "supports-color": {
           "version": "3.2.3",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-          "dev": true,
-          "requires": {
-            "has-flag": "1.0.0"
-          }
+          "dev": true
         }
       }
     },
@@ -7242,96 +5056,55 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz",
       "integrity": "sha1-757nEhLX/nWceO0WL2HtYrXLk/E=",
-      "dev": true,
-      "requires": {
-        "postcss": "5.2.17"
-      }
+      "dev": true
     },
     "postcss-normalize-url": {
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz",
       "integrity": "sha1-EI90s/L82viRov+j6kWSJ5/HgiI=",
-      "dev": true,
-      "requires": {
-        "is-absolute-url": "2.1.0",
-        "normalize-url": "1.9.1",
-        "postcss": "5.2.17",
-        "postcss-value-parser": "3.3.0"
-      }
+      "dev": true
     },
     "postcss-ordered-values": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.2.3.tgz",
       "integrity": "sha1-7sbCpntsQSqNsgQud/6NpD+VwR0=",
-      "dev": true,
-      "requires": {
-        "postcss": "5.2.17",
-        "postcss-value-parser": "3.3.0"
-      }
+      "dev": true
     },
     "postcss-reduce-idents": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz",
       "integrity": "sha1-wsbSDMlYKE9qv75j92Cb9AkFmtM=",
-      "dev": true,
-      "requires": {
-        "postcss": "5.2.17",
-        "postcss-value-parser": "3.3.0"
-      }
+      "dev": true
     },
     "postcss-reduce-initial": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz",
       "integrity": "sha1-aPgGlfBF0IJjqHmtJA343WT2ROo=",
-      "dev": true,
-      "requires": {
-        "postcss": "5.2.17"
-      }
+      "dev": true
     },
     "postcss-reduce-transforms": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.4.tgz",
       "integrity": "sha1-/3b02CEkN7McKYpC0uFEQCV3GuE=",
-      "dev": true,
-      "requires": {
-        "has": "1.0.1",
-        "postcss": "5.2.17",
-        "postcss-value-parser": "3.3.0"
-      }
+      "dev": true
     },
     "postcss-selector-parser": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
       "integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
-      "dev": true,
-      "requires": {
-        "flatten": "1.0.2",
-        "indexes-of": "1.0.1",
-        "uniq": "1.0.1"
-      }
+      "dev": true
     },
     "postcss-svgo": {
       "version": "2.1.6",
       "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.6.tgz",
       "integrity": "sha1-tt8YqmE7Zm4TPwittSGcJoSsEI0=",
-      "dev": true,
-      "requires": {
-        "is-svg": "2.1.0",
-        "postcss": "5.2.17",
-        "postcss-value-parser": "3.3.0",
-        "svgo": "0.7.2"
-      }
+      "dev": true
     },
     "postcss-unique-selectors": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz",
       "integrity": "sha1-mB1X0p3csz57Hf4f1DuGSfkzyh0=",
-      "dev": true,
-      "requires": {
-        "alphanum-sort": "1.0.2",
-        "postcss": "5.2.17",
-        "uniqs": "2.0.0"
-      }
+      "dev": true
     },
     "postcss-value-parser": {
       "version": "3.3.0",
@@ -7343,12 +5116,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.2.0.tgz",
       "integrity": "sha1-0hCd3AVbka9n/EyzsCWUZjnSryI=",
-      "dev": true,
-      "requires": {
-        "has": "1.0.1",
-        "postcss": "5.2.17",
-        "uniqs": "2.0.0"
-      }
+      "dev": true
     },
     "prelude-ls": {
       "version": "1.1.2",
@@ -7372,11 +5140,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-2.1.1.tgz",
       "integrity": "sha1-X0+HyPkeWuPzuoerTPXgOxoX8aM=",
-      "dev": true,
-      "requires": {
-        "renderkid": "2.0.1",
-        "utila": "0.4.0"
-      }
+      "dev": true
     },
     "private": {
       "version": "0.1.7",
@@ -7405,29 +5169,18 @@
     "promise": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.0.tgz",
-      "integrity": "sha512-bzAZ0u9Kxa0FYyfISjr9/PK7sCclAzc5rP4UgynMWA2Qv/gpZLKynJmTEXYq2i/giYdjBfRONDhfbsMlGIgvjA==",
-      "requires": {
-        "asap": "2.0.5"
-      }
+      "integrity": "sha512-bzAZ0u9Kxa0FYyfISjr9/PK7sCclAzc5rP4UgynMWA2Qv/gpZLKynJmTEXYq2i/giYdjBfRONDhfbsMlGIgvjA=="
     },
     "prop-types": {
       "version": "15.5.10",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.5.10.tgz",
-      "integrity": "sha1-J5ffwxJhguOpXj37suiT3ddFYVQ=",
-      "requires": {
-        "fbjs": "0.8.12",
-        "loose-envify": "1.3.1"
-      }
+      "integrity": "sha1-J5ffwxJhguOpXj37suiT3ddFYVQ="
     },
     "proxy-addr": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.4.tgz",
       "integrity": "sha1-J+VF9pYKRKYn2bREZ+NcG2tM4vM=",
-      "dev": true,
-      "requires": {
-        "forwarded": "0.1.0",
-        "ipaddr.js": "1.3.0"
-      }
+      "dev": true
     },
     "prr": {
       "version": "0.0.0",
@@ -7445,28 +5198,13 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
       "integrity": "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=",
-      "dev": true,
-      "requires": {
-        "bn.js": "4.11.6",
-        "browserify-rsa": "4.0.1",
-        "create-hash": "1.1.3",
-        "parse-asn1": "5.1.0",
-        "randombytes": "2.0.5"
-      }
+      "dev": true
     },
     "publisssh": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/publisssh/-/publisssh-1.1.0.tgz",
       "integrity": "sha1-GFQZZA8MuF2ZPJhD+xP/fmbsBIo=",
       "dev": true,
-      "requires": {
-        "aws-sdk": "2.1.50",
-        "chalk": "0.5.1",
-        "iced-coffee-script": "1.8.0-e",
-        "mime": "1.3.4",
-        "optimist": "0.6.1",
-        "wrench": "1.5.9"
-      },
       "dependencies": {
         "ansi-regex": {
           "version": "0.2.1",
@@ -7484,32 +5222,19 @@
           "version": "0.5.1",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "1.1.0",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "0.1.0",
-            "strip-ansi": "0.3.0",
-            "supports-color": "0.2.0"
-          }
+          "dev": true
         },
         "has-ansi": {
           "version": "0.1.0",
           "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
           "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "0.2.1"
-          }
+          "dev": true
         },
         "strip-ansi": {
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
           "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "0.2.1"
-          }
+          "dev": true
         },
         "supports-color": {
           "version": "0.2.0",
@@ -7528,11 +5253,7 @@
     "pusher-js": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/pusher-js/-/pusher-js-3.2.4.tgz",
-      "integrity": "sha1-Kd/FxY/6V23HGvugeBWj+JWnHcU=",
-      "requires": {
-        "faye-websocket": "0.9.4",
-        "xmlhttprequest": "1.8.0"
-      }
+      "integrity": "sha1-Kd/FxY/6V23HGvugeBWj+JWnHcU="
     },
     "q": {
       "version": "1.5.0",
@@ -7548,10 +5269,7 @@
     "query-string": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/query-string/-/query-string-3.0.3.tgz",
-      "integrity": "sha1-ri4UtNBQcdTpuetIc8NbDc1C5jg=",
-      "requires": {
-        "strict-uri-encode": "1.1.0"
-      }
+      "integrity": "sha1-ri4UtNBQcdTpuetIc8NbDc1C5jg="
     },
     "querystring": {
       "version": "0.2.0",
@@ -7570,28 +5288,18 @@
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
       "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
       "dev": true,
-      "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
-      },
       "dependencies": {
         "is-number": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          },
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "1.1.5"
-              }
+              "dev": true
             }
           }
         },
@@ -7599,10 +5307,7 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-          "dev": true,
-          "requires": {
-            "is-buffer": "1.1.5"
-          }
+          "dev": true
         }
       }
     },
@@ -7610,10 +5315,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz",
       "integrity": "sha512-8T7Zn1AhMsQ/HI1SjcCfT/t4ii3eAqco3yOcSzS4mozsOz69lHLsoMXmF9nZgnFanYscnSlUSgs8uZyKzpE6kg==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.0"
-      }
+      "dev": true
     },
     "range-parser": {
       "version": "1.2.0",
@@ -7625,117 +5327,61 @@
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/rc-align/-/rc-align-2.3.4.tgz",
       "integrity": "sha1-2Dvat1YPAULnKj3h1JXatroiUkk=",
-      "requires": {
-        "dom-align": "1.6.2",
-        "prop-types": "15.5.10",
-        "rc-util": "4.0.4"
-      },
       "dependencies": {
         "rc-util": {
           "version": "4.0.4",
           "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-4.0.4.tgz",
-          "integrity": "sha1-mYE92Qrufim2STmnCsF26tP0/zk=",
-          "requires": {
-            "add-dom-event-listener": "1.0.2",
-            "babel-runtime": "6.23.0",
-            "shallowequal": "0.2.2"
-          }
+          "integrity": "sha1-mYE92Qrufim2STmnCsF26tP0/zk="
         }
       }
     },
     "rc-animate": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/rc-animate/-/rc-animate-2.4.0.tgz",
-      "integrity": "sha1-pRtH2t+K2a8Izd+1sCF7+oGu6AM=",
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "css-animation": "1.3.2",
-        "prop-types": "15.5.10"
-      }
+      "integrity": "sha1-pRtH2t+K2a8Izd+1sCF7+oGu6AM="
     },
     "rc-slider": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/rc-slider/-/rc-slider-3.3.2.tgz",
-      "integrity": "sha1-1dqzZPEUiegMe/ia7euv3JJdZ6U=",
-      "requires": {
-        "classnames": "2.2.5",
-        "object-assign": "4.1.1",
-        "rc-tooltip": "3.4.6",
-        "rc-util": "3.4.1"
-      }
+      "integrity": "sha1-1dqzZPEUiegMe/ia7euv3JJdZ6U="
     },
     "rc-tooltip": {
       "version": "3.4.6",
       "resolved": "https://registry.npmjs.org/rc-tooltip/-/rc-tooltip-3.4.6.tgz",
-      "integrity": "sha1-7ZjeKntBLlJ8a9iiqX3d8Lq9LyE=",
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "prop-types": "15.5.10",
-        "rc-trigger": "1.11.2"
-      }
+      "integrity": "sha1-7ZjeKntBLlJ8a9iiqX3d8Lq9LyE="
     },
     "rc-trigger": {
       "version": "1.11.2",
       "resolved": "https://registry.npmjs.org/rc-trigger/-/rc-trigger-1.11.2.tgz",
       "integrity": "sha512-ns6eVMvzFc7ZRhRDhAV5RyIxsDUBwjxrEb7njzisvfkwMhRoNkYeN3iwtmIb7DBNE4rsBunsfZIPdKGedKVUJQ==",
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "create-react-class": "15.6.0",
-        "prop-types": "15.5.10",
-        "rc-align": "2.3.4",
-        "rc-animate": "2.4.0",
-        "rc-util": "4.0.4"
-      },
       "dependencies": {
         "rc-util": {
           "version": "4.0.4",
           "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-4.0.4.tgz",
-          "integrity": "sha1-mYE92Qrufim2STmnCsF26tP0/zk=",
-          "requires": {
-            "add-dom-event-listener": "1.0.2",
-            "babel-runtime": "6.23.0",
-            "shallowequal": "0.2.2"
-          }
+          "integrity": "sha1-mYE92Qrufim2STmnCsF26tP0/zk="
         }
       }
     },
     "rc-util": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-3.4.1.tgz",
-      "integrity": "sha1-S34LDHWTvbz/jtBF2I+7x3OnsGE=",
-      "requires": {
-        "add-dom-event-listener": "1.0.2",
-        "classnames": "2.2.5",
-        "shallowequal": "0.2.2"
-      }
+      "integrity": "sha1-S34LDHWTvbz/jtBF2I+7x3OnsGE="
     },
     "react": {
       "version": "15.4.2",
       "resolved": "https://registry.npmjs.org/react/-/react-15.4.2.tgz",
-      "integrity": "sha1-QfeZGyYYU5K6m66WyIiefgGDl+8=",
-      "requires": {
-        "fbjs": "0.8.12",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1"
-      }
+      "integrity": "sha1-QfeZGyYYU5K6m66WyIiefgGDl+8="
     },
     "react-addons-test-utils": {
       "version": "15.4.2",
       "resolved": "https://registry.npmjs.org/react-addons-test-utils/-/react-addons-test-utils-15.4.2.tgz",
       "integrity": "sha1-k7yqcY/K5zYNQuj7HAl1bMNjAqI=",
-      "dev": true,
-      "requires": {
-        "fbjs": "0.8.12",
-        "object-assign": "4.1.1"
-      }
+      "dev": true
     },
     "react-chartist": {
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/react-chartist/-/react-chartist-0.10.2.tgz",
-      "integrity": "sha1-1fY5Mf+looSORqtGZGogPpOXRKs=",
-      "requires": {
-        "chartist": "0.9.8"
-      }
+      "integrity": "sha1-1fY5Mf+looSORqtGZGogPpOXRKs="
     },
     "react-component-resizable": {
       "version": "1.1.0-rc1",
@@ -7751,54 +5397,27 @@
     "react-dom": {
       "version": "15.4.2",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.4.2.tgz",
-      "integrity": "sha1-AVNj8FsKH9Uq6e/dOgBg2QaVII8=",
-      "requires": {
-        "fbjs": "0.8.12",
-        "loose-envify": "1.3.1",
-        "object-assign": "4.1.1"
-      }
+      "integrity": "sha1-AVNj8FsKH9Uq6e/dOgBg2QaVII8="
     },
     "react-helmet": {
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-5.1.3.tgz",
-      "integrity": "sha1-zUBiZZOinuz2hLbTjXEfRMSBiK8=",
-      "requires": {
-        "deep-equal": "1.0.1",
-        "object-assign": "4.1.1",
-        "prop-types": "15.5.10",
-        "react-side-effect": "1.1.3"
-      }
+      "integrity": "sha1-zUBiZZOinuz2hLbTjXEfRMSBiK8="
     },
     "react-input-autosize": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/react-input-autosize/-/react-input-autosize-1.1.4.tgz",
-      "integrity": "sha1-y8RQctQITdxXgG2447NOZEuDZqw=",
-      "requires": {
-        "create-react-class": "15.6.0",
-        "prop-types": "15.5.10"
-      }
+      "integrity": "sha1-y8RQctQITdxXgG2447NOZEuDZqw="
     },
     "react-interpolate-component": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/react-interpolate-component/-/react-interpolate-component-0.10.0.tgz",
       "integrity": "sha1-0NINFt8QaXzctDvfVW2+1ZETvyE=",
-      "requires": {
-        "except": "0.1.3",
-        "fbjs": "0.4.0",
-        "object-assign": "4.1.1"
-      },
       "dependencies": {
         "fbjs": {
           "version": "0.4.0",
           "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.4.0.tgz",
-          "integrity": "sha1-xXaGEApA1FDsJE7QxEowk/cq9xw=",
-          "requires": {
-            "core-js": "1.2.7",
-            "loose-envify": "1.3.1",
-            "promise": "7.3.0",
-            "ua-parser-js": "0.7.12",
-            "whatwg-fetch": "0.9.0"
-          }
+          "integrity": "sha1-xXaGEApA1FDsJE7QxEowk/cq9xw="
         },
         "whatwg-fetch": {
           "version": "0.9.0",
@@ -7811,11 +5430,7 @@
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/react-proxy/-/react-proxy-1.1.8.tgz",
       "integrity": "sha1-nb/Z2SdSjDqp9ETkVYw3gwq4wmo=",
-      "dev": true,
-      "requires": {
-        "lodash": "4.17.4",
-        "react-deep-force-update": "1.0.1"
-      }
+      "dev": true
     },
     "react-pullout": {
       "version": "1.0.3",
@@ -7825,68 +5440,34 @@
     "react-redux": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.0.5.tgz",
-      "integrity": "sha1-+OjHsjlCJXblLWt9sGQ5RpvphGo=",
-      "requires": {
-        "create-react-class": "15.6.0",
-        "hoist-non-react-statics": "1.2.0",
-        "invariant": "2.2.2",
-        "lodash": "4.17.4",
-        "lodash-es": "4.17.4",
-        "loose-envify": "1.3.1",
-        "prop-types": "15.5.10"
-      }
+      "integrity": "sha1-+OjHsjlCJXblLWt9sGQ5RpvphGo="
     },
     "react-router": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-2.5.2.tgz",
-      "integrity": "sha1-HB/JU2Y5PJbB+0kywFBhKBlrEgM=",
-      "requires": {
-        "history": "2.1.2",
-        "hoist-non-react-statics": "1.2.0",
-        "invariant": "2.2.2",
-        "loose-envify": "1.3.1",
-        "warning": "2.1.0"
-      }
+      "integrity": "sha1-HB/JU2Y5PJbB+0kywFBhKBlrEgM="
     },
     "react-router-scroll": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/react-router-scroll/-/react-router-scroll-0.3.3.tgz",
       "integrity": "sha1-5XIA/YY+co/OjpC+kz9TFZkPwOY=",
-      "requires": {
-        "history": "2.1.2",
-        "scroll-behavior": "0.8.2",
-        "warning": "3.0.0"
-      },
       "dependencies": {
         "warning": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
-          "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
-          "requires": {
-            "loose-envify": "1.3.1"
-          }
+          "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w="
         }
       }
     },
     "react-select": {
       "version": "1.0.0-rc.5",
       "resolved": "https://registry.npmjs.org/react-select/-/react-select-1.0.0-rc.5.tgz",
-      "integrity": "sha1-nTFvJSsa3Dct21zfHxGca3z9tdY=",
-      "requires": {
-        "classnames": "2.2.5",
-        "create-react-class": "15.6.0",
-        "prop-types": "15.5.10",
-        "react-input-autosize": "1.1.4"
-      }
+      "integrity": "sha1-nTFvJSsa3Dct21zfHxGca3z9tdY="
     },
     "react-side-effect": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-1.1.3.tgz",
       "integrity": "sha1-USwlq+DewXKDTEAB7FxR4E1BvFw=",
-      "requires": {
-        "exenv": "1.2.2",
-        "shallowequal": "1.0.2"
-      },
       "dependencies": {
         "shallowequal": {
           "version": "1.0.2",
@@ -7898,74 +5479,41 @@
     "react-swipe": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/react-swipe/-/react-swipe-5.0.8.tgz",
-      "integrity": "sha1-lcrjHy104bSIbwH/y3KDezdbZus=",
-      "requires": {
-        "object-assign": "4.1.1",
-        "prop-types": "15.5.10",
-        "swipe-js-iso": "2.0.3"
-      }
+      "integrity": "sha1-lcrjHy104bSIbwH/y3KDezdbZus="
     },
     "react-transform-hmr": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/react-transform-hmr/-/react-transform-hmr-1.0.4.tgz",
       "integrity": "sha1-4aQL0Krvxy6N/Xp82gmvhQZjl7s=",
-      "dev": true,
-      "requires": {
-        "global": "4.3.2",
-        "react-proxy": "1.1.8"
-      }
+      "dev": true
     },
     "react-translate-component": {
       "version": "0.13.2",
       "resolved": "https://registry.npmjs.org/react-translate-component/-/react-translate-component-0.13.2.tgz",
-      "integrity": "sha1-WtQcf3irt6FVah3mKCj9Yjg3pXk=",
-      "requires": {
-        "object-assign": "4.1.1"
-      }
+      "integrity": "sha1-WtQcf3irt6FVah3mKCj9Yjg3pXk="
     },
     "read-pkg": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-      "dev": true,
-      "requires": {
-        "load-json-file": "1.1.0",
-        "normalize-package-data": "2.3.8",
-        "path-type": "1.1.0"
-      }
+      "dev": true
     },
     "read-pkg-up": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-      "dev": true,
-      "requires": {
-        "find-up": "1.1.2",
-        "read-pkg": "1.1.0"
-      }
+      "dev": true
     },
     "readable-stream": {
       "version": "1.0.27-1",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.27-1.tgz",
-      "integrity": "sha1-a2eYPCA1fO/QfwFlABoW1xDZEHg=",
-      "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "0.0.1",
-        "string_decoder": "0.10.31"
-      }
+      "integrity": "sha1-a2eYPCA1fO/QfwFlABoW1xDZEHg="
     },
     "readdirp": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
       "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "minimatch": "3.0.4",
-        "readable-stream": "2.3.0",
-        "set-immediate-shim": "1.0.1"
-      },
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
@@ -7977,25 +5525,13 @@
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.0.tgz",
           "integrity": "sha512-c7KMXGd4b48nN3OJ1U9qOsn6pXNzf6kLd3kdZCkg2sxAcoiufInqF0XckwEnlrcwuaYwonlNK8GQUIOC/WC7sg==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.0",
-            "string_decoder": "1.0.2",
-            "util-deprecate": "1.0.2"
-          }
+          "dev": true
         },
         "string_decoder": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
           "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
           "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          },
           "dependencies": {
             "safe-buffer": {
               "version": "5.0.1",
@@ -8011,21 +5547,13 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
       "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
-      "dev": true,
-      "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
-        "mute-stream": "0.0.5"
-      }
+      "dev": true
     },
     "rechoir": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-      "dev": true,
-      "requires": {
-        "resolve": "1.3.3"
-      }
+      "dev": true
     },
     "reduce-component": {
       "version": "1.0.1",
@@ -8037,11 +5565,6 @@
       "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
       "integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
       "dev": true,
-      "requires": {
-        "balanced-match": "0.4.2",
-        "math-expression-evaluator": "1.2.17",
-        "reduce-function-call": "1.0.2"
-      },
       "dependencies": {
         "balanced-match": {
           "version": "0.4.2",
@@ -8056,9 +5579,6 @@
       "resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.2.tgz",
       "integrity": "sha1-WiAL+S4ON3UXUv5FsKszD9S2vpk=",
       "dev": true,
-      "requires": {
-        "balanced-match": "0.4.2"
-      },
       "dependencies": {
         "balanced-match": {
           "version": "0.4.2",
@@ -8071,13 +5591,7 @@
     "redux": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/redux/-/redux-3.6.0.tgz",
-      "integrity": "sha1-iHwrPQub2G7KK+cFccJ2VMGeGI0=",
-      "requires": {
-        "lodash": "4.17.4",
-        "lodash-es": "4.17.4",
-        "loose-envify": "1.3.1",
-        "symbol-observable": "1.0.4"
-      }
+      "integrity": "sha1-iHwrPQub2G7KK+cFccJ2VMGeGI0="
     },
     "redux-devtools-extension": {
       "version": "2.13.2",
@@ -8104,33 +5618,19 @@
       "version": "0.9.11",
       "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.11.tgz",
       "integrity": "sha1-On0GdSDLe3F2dp61/4aGkb7+EoM=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.23.0",
-        "babel-types": "6.25.0",
-        "private": "0.1.7"
-      }
+      "dev": true
     },
     "regex-cache": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
       "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
-      "dev": true,
-      "requires": {
-        "is-equal-shallow": "0.1.3",
-        "is-primitive": "2.0.0"
-      }
+      "dev": true
     },
     "regexpu-core": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
       "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
-      "dev": true,
-      "requires": {
-        "regenerate": "1.3.2",
-        "regjsgen": "0.2.0",
-        "regjsparser": "0.1.5"
-      }
+      "dev": true
     },
     "regjsgen": {
       "version": "0.2.0",
@@ -8143,9 +5643,6 @@
       "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
       "dev": true,
-      "requires": {
-        "jsesc": "0.5.0"
-      },
       "dependencies": {
         "jsesc": {
           "version": "0.5.0",
@@ -8172,55 +5669,30 @@
       "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.1.tgz",
       "integrity": "sha1-iYyr/Ivt5Le5ETWj/9Mj5YwNsxk=",
       "dev": true,
-      "requires": {
-        "css-select": "1.2.0",
-        "dom-converter": "0.1.4",
-        "htmlparser2": "3.3.0",
-        "strip-ansi": "3.0.1",
-        "utila": "0.3.3"
-      },
       "dependencies": {
         "domhandler": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.1.0.tgz",
           "integrity": "sha1-0mRvXlf2w7qxHPbLBdPArPdBJZQ=",
-          "dev": true,
-          "requires": {
-            "domelementtype": "1.3.0"
-          }
+          "dev": true
         },
         "domutils": {
           "version": "1.1.6",
           "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.1.6.tgz",
           "integrity": "sha1-vdw94Jm5ou+sxRxiPyj0FuzFdIU=",
-          "dev": true,
-          "requires": {
-            "domelementtype": "1.3.0"
-          }
+          "dev": true
         },
         "htmlparser2": {
           "version": "3.3.0",
           "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.3.0.tgz",
           "integrity": "sha1-zHDQWln2VC5D8OaFyYLhTJJKnv4=",
-          "dev": true,
-          "requires": {
-            "domelementtype": "1.3.0",
-            "domhandler": "2.1.0",
-            "domutils": "1.1.6",
-            "readable-stream": "1.0.34"
-          }
+          "dev": true
         },
         "readable-stream": {
           "version": "1.0.34",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
+          "dev": true
         },
         "utila": {
           "version": "0.3.3",
@@ -8246,51 +5718,19 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-      "dev": true,
-      "requires": {
-        "is-finite": "1.0.2"
-      }
+      "dev": true
     },
     "request": {
       "version": "2.81.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
       "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
       "dev": true,
-      "requires": {
-        "aws-sign2": "0.6.0",
-        "aws4": "1.6.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.5",
-        "extend": "3.0.1",
-        "forever-agent": "0.6.1",
-        "form-data": "2.1.4",
-        "har-validator": "4.2.1",
-        "hawk": "3.1.3",
-        "http-signature": "1.1.1",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.15",
-        "oauth-sign": "0.8.2",
-        "performance-now": "0.2.0",
-        "qs": "6.4.0",
-        "safe-buffer": "5.1.0",
-        "stringstream": "0.0.5",
-        "tough-cookie": "2.3.2",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.1.0"
-      },
       "dependencies": {
         "form-data": {
           "version": "2.1.4",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
           "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-          "dev": true,
-          "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.15"
-          }
+          "dev": true
         },
         "qs": {
           "version": "6.4.0",
@@ -8322,30 +5762,19 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
-      "dev": true,
-      "requires": {
-        "caller-path": "0.1.0",
-        "resolve-from": "1.0.1"
-      }
+      "dev": true
     },
     "resolve": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
       "integrity": "sha1-ZVkHw0aahoDcLeOidaj91paR8OU=",
-      "dev": true,
-      "requires": {
-        "path-parse": "1.0.5"
-      }
+      "dev": true
     },
     "resolve-dir": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
       "integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
-      "dev": true,
-      "requires": {
-        "expand-tilde": "1.2.2",
-        "global-modules": "0.2.3"
-      }
+      "dev": true
     },
     "resolve-from": {
       "version": "1.0.1",
@@ -8357,48 +5786,31 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
       "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-      "dev": true,
-      "requires": {
-        "exit-hook": "1.1.1",
-        "onetime": "1.1.0"
-      }
+      "dev": true
     },
     "right-align": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-      "dev": true,
-      "requires": {
-        "align-text": "0.1.4"
-      }
+      "dev": true
     },
     "rimraf": {
       "version": "2.5.4",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
       "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
-      "dev": true,
-      "requires": {
-        "glob": "7.1.2"
-      }
+      "dev": true
     },
     "ripemd160": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
       "integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
-      "dev": true,
-      "requires": {
-        "hash-base": "2.0.2",
-        "inherits": "2.0.3"
-      }
+      "dev": true
     },
     "run-async": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
       "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
-      "dev": true,
-      "requires": {
-        "once": "1.4.0"
-      }
+      "dev": true
     },
     "rx-lite": {
       "version": "3.1.2",
@@ -8429,32 +5841,19 @@
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.3.0.tgz",
       "integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
       "dev": true,
-      "requires": {
-        "ajv": "5.2.0"
-      },
       "dependencies": {
         "ajv": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.0.tgz",
           "integrity": "sha1-wXNQJMXaLvdcwZBxMHPUTwmL9IY=",
-          "dev": true,
-          "requires": {
-            "co": "4.6.0",
-            "fast-deep-equal": "0.1.0",
-            "json-schema-traverse": "0.3.0",
-            "json-stable-stringify": "1.0.1"
-          }
+          "dev": true
         }
       }
     },
     "scroll-behavior": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/scroll-behavior/-/scroll-behavior-0.8.2.tgz",
-      "integrity": "sha1-rOE+QLAB2NTQB67A5/tmjPkENUY=",
-      "requires": {
-        "dom-helpers": "2.4.0",
-        "invariant": "2.2.2"
-      }
+      "integrity": "sha1-rOE+QLAB2NTQB67A5/tmjPkENUY="
     },
     "semver": {
       "version": "5.3.0",
@@ -8467,30 +5866,12 @@
       "resolved": "https://registry.npmjs.org/send/-/send-0.15.3.tgz",
       "integrity": "sha1-UBP5+ZAj31DRvZiSwZ4979HVMwk=",
       "dev": true,
-      "requires": {
-        "debug": "2.6.7",
-        "depd": "1.1.0",
-        "destroy": "1.0.4",
-        "encodeurl": "1.0.1",
-        "escape-html": "1.0.3",
-        "etag": "1.8.0",
-        "fresh": "0.5.0",
-        "http-errors": "1.6.1",
-        "mime": "1.3.4",
-        "ms": "2.0.0",
-        "on-finished": "2.3.0",
-        "range-parser": "1.2.0",
-        "statuses": "1.3.1"
-      },
       "dependencies": {
         "debug": {
           "version": "2.6.7",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
           "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4=",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
+          "dev": true
         },
         "ms": {
           "version": "2.0.0",
@@ -8504,13 +5885,7 @@
       "version": "1.12.3",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.3.tgz",
       "integrity": "sha1-n0uhni8wMMVH+K+ZEHg47DjVseI=",
-      "dev": true,
-      "requires": {
-        "encodeurl": "1.0.1",
-        "escape-html": "1.0.3",
-        "parseurl": "1.3.1",
-        "send": "0.15.3"
-      }
+      "dev": true
     },
     "set-blocking": {
       "version": "2.0.0",
@@ -8538,29 +5913,18 @@
     "seven-ten": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/seven-ten/-/seven-ten-3.1.0.tgz",
-      "integrity": "sha1-8A84UbHgdw1R8sSy3Z2nWpbo5jY=",
-      "requires": {
-        "devour-client": "1.3.9",
-        "react": "15.4.2",
-        "react-dom": "15.4.2"
-      }
+      "integrity": "sha1-8A84UbHgdw1R8sSy3Z2nWpbo5jY="
     },
     "sha.js": {
       "version": "2.4.8",
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz",
       "integrity": "sha1-NwaMLEdra69ALRSknGf1l5IfY08=",
-      "dev": true,
-      "requires": {
-        "inherits": "2.0.3"
-      }
+      "dev": true
     },
     "shallowequal": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-0.2.2.tgz",
       "integrity": "sha1-HjL9W8q2rWiKSBLLDMBO/HXHAU4=",
-      "requires": {
-        "lodash.keys": "3.1.2"
-      },
       "dependencies": {
         "lodash.isarray": {
           "version": "3.0.4",
@@ -8570,12 +5934,7 @@
         "lodash.keys": {
           "version": "3.1.2",
           "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-          "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-          "requires": {
-            "lodash._getnative": "3.9.1",
-            "lodash.isarguments": "3.1.0",
-            "lodash.isarray": "3.0.4"
-          }
+          "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo="
         }
       }
     },
@@ -8583,12 +5942,7 @@
       "version": "0.7.8",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
       "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
-      "dev": true,
-      "requires": {
-        "glob": "7.1.2",
-        "interpret": "1.0.3",
-        "rechoir": "0.6.2"
-      }
+      "dev": true
     },
     "shortid": {
       "version": "2.2.8",
@@ -8599,13 +5953,7 @@
       "version": "1.17.7",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.17.7.tgz",
       "integrity": "sha1-RUKk9JugxFwF6y6d2dID4rjv4L8=",
-      "dev": true,
-      "requires": {
-        "formatio": "1.1.1",
-        "lolex": "1.3.2",
-        "samsam": "1.1.2",
-        "util": "0.10.3"
-      }
+      "dev": true
     },
     "slash": {
       "version": "1.0.0",
@@ -8623,25 +5971,13 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
       "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-      "dev": true,
-      "requires": {
-        "hoek": "2.16.3"
-      }
+      "dev": true
     },
     "socket.io": {
       "version": "1.7.4",
       "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.7.4.tgz",
       "integrity": "sha1-L37O3DORvy1cc+KR/iM+bjTU3QA=",
       "dev": true,
-      "requires": {
-        "debug": "2.3.3",
-        "engine.io": "1.8.4",
-        "has-binary": "0.1.7",
-        "object-assign": "4.1.0",
-        "socket.io-adapter": "0.5.0",
-        "socket.io-client": "1.7.4",
-        "socket.io-parser": "2.3.1"
-      },
       "dependencies": {
         "object-assign": {
           "version": "4.1.0",
@@ -8655,42 +5991,19 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.5.0.tgz",
       "integrity": "sha1-y21LuL7IHhB4uZZ3+c7QBGBmu4s=",
-      "dev": true,
-      "requires": {
-        "debug": "2.3.3",
-        "socket.io-parser": "2.3.1"
-      }
+      "dev": true
     },
     "socket.io-client": {
       "version": "1.7.4",
       "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.7.4.tgz",
       "integrity": "sha1-7J+CA1btme9tNX8HVtZIcXvdQoE=",
-      "dev": true,
-      "requires": {
-        "backo2": "1.0.2",
-        "component-bind": "1.0.0",
-        "component-emitter": "1.2.1",
-        "debug": "2.3.3",
-        "engine.io-client": "1.8.4",
-        "has-binary": "0.1.7",
-        "indexof": "0.0.1",
-        "object-component": "0.0.3",
-        "parseuri": "0.0.5",
-        "socket.io-parser": "2.3.1",
-        "to-array": "0.1.4"
-      }
+      "dev": true
     },
     "socket.io-parser": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.3.1.tgz",
       "integrity": "sha1-3VMgJRA85Clpcya+/WQAX8/ltKA=",
       "dev": true,
-      "requires": {
-        "component-emitter": "1.1.2",
-        "debug": "2.2.0",
-        "isarray": "0.0.1",
-        "json3": "3.3.2"
-      },
       "dependencies": {
         "component-emitter": {
           "version": "1.1.2",
@@ -8702,10 +6015,7 @@
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.1"
-          }
+          "dev": true
         },
         "ms": {
           "version": "0.7.1",
@@ -8724,10 +6034,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
       "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
-      "dev": true,
-      "requires": {
-        "is-plain-obj": "1.1.0"
-      }
+      "dev": true
     },
     "source-list-map": {
       "version": "0.1.8",
@@ -8745,19 +6052,13 @@
       "version": "0.4.15",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.15.tgz",
       "integrity": "sha1-AyAt9lwG0r2MfsI2KhkwVv7407E=",
-      "dev": true,
-      "requires": {
-        "source-map": "0.5.6"
-      }
+      "dev": true
     },
     "spdx-correct": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
       "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
-      "dev": true,
-      "requires": {
-        "spdx-license-ids": "1.2.2"
-      }
+      "dev": true
     },
     "spdx-expression-parse": {
       "version": "1.0.4",
@@ -8781,16 +6082,6 @@
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
       "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
       "dev": true,
-      "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "tweetnacl": "0.14.5"
-      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -8811,10 +6102,6 @@
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
       "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
       "dev": true,
-      "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.0"
-      },
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
@@ -8826,25 +6113,13 @@
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.0.tgz",
           "integrity": "sha512-c7KMXGd4b48nN3OJ1U9qOsn6pXNzf6kLd3kdZCkg2sxAcoiufInqF0XckwEnlrcwuaYwonlNK8GQUIOC/WC7sg==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.0",
-            "string_decoder": "1.0.2",
-            "util-deprecate": "1.0.2"
-          }
+          "dev": true
         },
         "string_decoder": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
           "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
           "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          },
           "dependencies": {
             "safe-buffer": {
               "version": "5.0.1",
@@ -8866,13 +6141,6 @@
       "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.2.tgz",
       "integrity": "sha512-c0yTD2rbQzXtSsFSVhtpvY/vS6u066PcXOX9kBB3mSO76RiUQzL340uJkGBWnlBg4/HZzqiUXtaVA7wcRcJgEw==",
       "dev": true,
-      "requires": {
-        "builtin-status-codes": "3.0.0",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.0",
-        "to-arraybuffer": "1.0.1",
-        "xtend": "4.0.1"
-      },
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
@@ -8884,25 +6152,13 @@
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.0.tgz",
           "integrity": "sha512-c7KMXGd4b48nN3OJ1U9qOsn6pXNzf6kLd3kdZCkg2sxAcoiufInqF0XckwEnlrcwuaYwonlNK8GQUIOC/WC7sg==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.0",
-            "string_decoder": "1.0.2",
-            "util-deprecate": "1.0.2"
-          }
+          "dev": true
         },
         "string_decoder": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
           "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
           "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          },
           "dependencies": {
             "safe-buffer": {
               "version": "5.0.1",
@@ -8933,12 +6189,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-      "dev": true,
-      "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
-        "strip-ansi": "3.0.1"
-      }
+      "dev": true
     },
     "stringstream": {
       "version": "0.0.5",
@@ -8950,10 +6201,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "2.1.1"
-      }
+      "dev": true
     },
     "strip-bom": {
       "version": "3.0.0",
@@ -8972,20 +6220,12 @@
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.16.1.tgz",
       "integrity": "sha1-UOMlJY1OeEId2WgGNrQehmFZXRA=",
       "dev": true,
-      "requires": {
-        "loader-utils": "1.1.0"
-      },
       "dependencies": {
         "loader-utils": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
           "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
-          "dev": true,
-          "requires": {
-            "big.js": "3.1.3",
-            "emojis-list": "2.1.0",
-            "json5": "0.5.1"
-          }
+          "dev": true
         }
       }
     },
@@ -8994,28 +6234,12 @@
       "resolved": "https://registry.npmjs.org/stylus/-/stylus-0.54.5.tgz",
       "integrity": "sha1-QrlWCTHKcJDOhRWnmLqeaqPW3Hk=",
       "dev": true,
-      "requires": {
-        "css-parse": "1.7.0",
-        "debug": "2.3.3",
-        "glob": "7.0.6",
-        "mkdirp": "0.5.1",
-        "sax": "0.5.8",
-        "source-map": "0.1.43"
-      },
       "dependencies": {
         "glob": {
           "version": "7.0.6",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
           "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
+          "dev": true
         },
         "sax": {
           "version": "0.5.8",
@@ -9027,10 +6251,7 @@
           "version": "0.1.43",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
           "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
-          "dev": true,
-          "requires": {
-            "amdefine": "1.0.1"
-          }
+          "dev": true
         }
       }
     },
@@ -9039,22 +6260,12 @@
       "resolved": "https://registry.npmjs.org/stylus-loader/-/stylus-loader-3.0.1.tgz",
       "integrity": "sha1-d/SzT9Aw0lsmF7z1UT21sHMMQIk=",
       "dev": true,
-      "requires": {
-        "loader-utils": "1.1.0",
-        "lodash.clonedeep": "4.5.0",
-        "when": "3.6.4"
-      },
       "dependencies": {
         "loader-utils": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
           "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
-          "dev": true,
-          "requires": {
-            "big.js": "3.1.3",
-            "emojis-list": "2.1.0",
-            "json5": "0.5.1"
-          }
+          "dev": true
         }
       }
     },
@@ -9067,19 +6278,6 @@
       "version": "1.8.5",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-1.8.5.tgz",
       "integrity": "sha1-HA3cOvMOgOuE68BcshItqP6UC1U=",
-      "requires": {
-        "component-emitter": "1.2.1",
-        "cookiejar": "2.0.6",
-        "debug": "2.3.3",
-        "extend": "3.0.0",
-        "form-data": "1.0.0-rc3",
-        "formidable": "1.0.17",
-        "methods": "1.1.2",
-        "mime": "1.3.4",
-        "qs": "2.3.3",
-        "readable-stream": "1.0.27-1",
-        "reduce-component": "1.0.1"
-      },
       "dependencies": {
         "extend": {
           "version": "3.0.0",
@@ -9108,16 +6306,7 @@
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/svgo/-/svgo-0.7.2.tgz",
       "integrity": "sha1-n1dyQTlSE1xv779Ar+ak+qiLS7U=",
-      "dev": true,
-      "requires": {
-        "coa": "1.0.3",
-        "colors": "1.1.2",
-        "csso": "2.3.2",
-        "js-yaml": "3.7.0",
-        "mkdirp": "0.5.1",
-        "sax": "1.2.2",
-        "whet.extend": "0.9.9"
-      }
+      "dev": true
     },
     "swipe-js-iso": {
       "version": "2.0.3",
@@ -9140,14 +6329,6 @@
       "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
       "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
       "dev": true,
-      "requires": {
-        "ajv": "4.11.8",
-        "ajv-keywords": "1.5.1",
-        "chalk": "1.1.3",
-        "lodash": "4.17.4",
-        "slice-ansi": "0.0.4",
-        "string-width": "2.0.0"
-      },
       "dependencies": {
         "is-fullwidth-code-point": {
           "version": "2.0.0",
@@ -9159,11 +6340,7 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
           "integrity": "sha1-Y1xUNsxypuDDh87KJ41OLuxSaH4=",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "3.0.1"
-          }
+          "dev": true
         }
       }
     },
@@ -9189,10 +6366,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.2.tgz",
       "integrity": "sha1-q0iDz1l9zVCvIRNJoA+8pWrIa4Y=",
-      "dev": true,
-      "requires": {
-        "setimmediate": "1.0.5"
-      }
+      "dev": true
     },
     "to-array": {
       "version": "0.1.4",
@@ -9222,10 +6396,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
       "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
-      "dev": true,
-      "requires": {
-        "punycode": "1.4.1"
-      }
+      "dev": true
     },
     "tr46": {
       "version": "0.0.3",
@@ -9255,10 +6426,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.0"
-      }
+      "dev": true
     },
     "tweetnacl": {
       "version": "0.14.5",
@@ -9276,20 +6444,13 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "dev": true,
-      "requires": {
-        "prelude-ls": "1.1.2"
-      }
+      "dev": true
     },
     "type-is": {
       "version": "1.6.15",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
       "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
-      "dev": true,
-      "requires": {
-        "media-typer": "0.3.0",
-        "mime-types": "2.1.15"
-      }
+      "dev": true
     },
     "typedarray": {
       "version": "0.0.6",
@@ -9311,11 +6472,7 @@
       "version": "3.0.18",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.0.18.tgz",
       "integrity": "sha512-0M/KeXO8bPYtlqnwIYpO4R6om1mrScMzPuWn2UPfUYOaowIhQmmFpL9Q5tlD18ulKLRKD12GQ0IiYDKJS/si1w==",
-      "dev": true,
-      "requires": {
-        "commander": "2.9.0",
-        "source-map": "0.5.6"
-      }
+      "dev": true
     },
     "uglify-to-browserify": {
       "version": "1.0.2",
@@ -9351,10 +6508,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/uniqid/-/uniqid-4.1.1.tgz",
       "integrity": "sha1-iSIN32t1GuUrX3JISGNShZa7hME=",
-      "dev": true,
-      "requires": {
-        "macaddress": "0.2.8"
-      }
+      "dev": true
     },
     "uniqs": {
       "version": "2.0.0",
@@ -9372,10 +6526,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/untildify/-/untildify-2.1.0.tgz",
       "integrity": "sha1-F+soB5h/dpUunASF/DEdBqgmouA=",
-      "dev": true,
-      "requires": {
-        "os-homedir": "1.0.2"
-      }
+      "dev": true
     },
     "upper-case": {
       "version": "1.1.3",
@@ -9388,10 +6539,6 @@
       "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
       "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
       "dev": true,
-      "requires": {
-        "punycode": "1.3.2",
-        "querystring": "0.2.0"
-      },
       "dependencies": {
         "punycode": {
           "version": "1.3.2",
@@ -9412,9 +6559,6 @@
       "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
       "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
       "dev": true,
-      "requires": {
-        "inherits": "2.0.1"
-      },
       "dependencies": {
         "inherits": {
           "version": "2.0.1",
@@ -9452,20 +6596,13 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
       "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
-      "dev": true,
-      "requires": {
-        "user-home": "1.1.1"
-      }
+      "dev": true
     },
     "validate-npm-package-license": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
       "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
-      "dev": true,
-      "requires": {
-        "spdx-correct": "1.0.2",
-        "spdx-expression-parse": "1.0.4"
-      }
+      "dev": true
     },
     "vary": {
       "version": "1.1.1",
@@ -9483,10 +6620,7 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
       "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
-      "dev": true,
-      "requires": {
-        "extsprintf": "1.0.2"
-      }
+      "dev": true
     },
     "visible-element": {
       "version": "1.0.1",
@@ -9497,38 +6631,24 @@
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
       "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
-      "dev": true,
-      "requires": {
-        "indexof": "0.0.1"
-      }
+      "dev": true
     },
     "warning": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/warning/-/warning-2.1.0.tgz",
-      "integrity": "sha1-ISINnGOvx3qMkhEeARr3Bc4MaQE=",
-      "requires": {
-        "loose-envify": "1.3.1"
-      }
+      "integrity": "sha1-ISINnGOvx3qMkhEeARr3Bc4MaQE="
     },
     "watchpack": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.3.1.tgz",
       "integrity": "sha1-fYaTkHsozmAT5/NhCqKhrPB9rYc=",
       "dev": true,
-      "requires": {
-        "async": "2.4.1",
-        "chokidar": "1.7.0",
-        "graceful-fs": "4.1.11"
-      },
       "dependencies": {
         "async": {
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/async/-/async-2.4.1.tgz",
           "integrity": "sha1-YqVrJ5yYoR0JhwlqAcw+6463u9c=",
-          "dev": true,
-          "requires": {
-            "lodash": "4.17.4"
-          }
+          "dev": true
         }
       }
     },
@@ -9544,28 +6664,6 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-2.3.3.tgz",
       "integrity": "sha1-7swIPBj7e/lY6k9AtXpmQMWgzHg=",
       "dev": true,
-      "requires": {
-        "acorn": "4.0.13",
-        "acorn-dynamic-import": "2.0.2",
-        "ajv": "4.11.8",
-        "ajv-keywords": "1.5.1",
-        "async": "2.4.1",
-        "enhanced-resolve": "3.1.0",
-        "interpret": "1.0.3",
-        "json-loader": "0.5.4",
-        "loader-runner": "2.3.0",
-        "loader-utils": "0.2.17",
-        "memory-fs": "0.4.1",
-        "mkdirp": "0.5.1",
-        "node-libs-browser": "2.0.0",
-        "source-map": "0.5.6",
-        "supports-color": "3.2.3",
-        "tapable": "0.2.6",
-        "uglify-js": "2.8.29",
-        "watchpack": "1.3.1",
-        "webpack-sources": "0.2.3",
-        "yargs": "6.6.0"
-      },
       "dependencies": {
         "acorn": {
           "version": "4.0.13",
@@ -9577,10 +6675,7 @@
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/async/-/async-2.4.1.tgz",
           "integrity": "sha1-YqVrJ5yYoR0JhwlqAcw+6463u9c=",
-          "dev": true,
-          "requires": {
-            "lodash": "4.17.4"
-          }
+          "dev": true
         },
         "source-list-map": {
           "version": "1.1.2",
@@ -9592,33 +6687,19 @@
           "version": "3.2.3",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-          "dev": true,
-          "requires": {
-            "has-flag": "1.0.0"
-          }
+          "dev": true
         },
         "uglify-js": {
           "version": "2.8.29",
           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
           "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
           "dev": true,
-          "requires": {
-            "source-map": "0.5.6",
-            "uglify-to-browserify": "1.0.2",
-            "yargs": "3.10.0"
-          },
           "dependencies": {
             "yargs": {
               "version": "3.10.0",
               "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
               "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-              "dev": true,
-              "requires": {
-                "camelcase": "1.2.1",
-                "cliui": "2.1.0",
-                "decamelize": "1.2.0",
-                "window-size": "0.1.0"
-              }
+              "dev": true
             }
           }
         },
@@ -9626,11 +6707,7 @@
           "version": "0.2.3",
           "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-0.2.3.tgz",
           "integrity": "sha1-F8Yr+vE8cH+dAsR54Nzd6DgGl/s=",
-          "dev": true,
-          "requires": {
-            "source-list-map": "1.1.2",
-            "source-map": "0.5.6"
-          }
+          "dev": true
         }
       }
     },
@@ -9638,49 +6715,25 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/webpack-dashboard/-/webpack-dashboard-0.3.0.tgz",
       "integrity": "sha1-0P4YKgl2qP8OoBsFB/KaA0zWChw=",
-      "dev": true,
-      "requires": {
-        "blessed": "0.1.81",
-        "commander": "2.9.0",
-        "cross-spawn": "4.0.2",
-        "filesize": "3.5.10",
-        "socket.io": "1.7.4",
-        "socket.io-client": "1.7.4"
-      }
+      "dev": true
     },
     "webpack-dev-middleware": {
       "version": "1.10.2",
       "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.10.2.tgz",
       "integrity": "sha1-LiUs4d+wINvaHMs33ybzCrAU29E=",
-      "dev": true,
-      "requires": {
-        "memory-fs": "0.4.1",
-        "mime": "1.3.4",
-        "path-is-absolute": "1.0.1",
-        "range-parser": "1.2.0"
-      }
+      "dev": true
     },
     "webpack-hot-middleware": {
       "version": "2.18.0",
       "resolved": "https://registry.npmjs.org/webpack-hot-middleware/-/webpack-hot-middleware-2.18.0.tgz",
       "integrity": "sha1-oWu1Nbg6aslKeKxevOTzBZ6CdNM=",
-      "dev": true,
-      "requires": {
-        "ansi-html": "0.0.7",
-        "html-entities": "1.2.1",
-        "querystring": "0.2.0",
-        "strip-ansi": "3.0.1"
-      }
+      "dev": true
     },
     "webpack-sources": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.0.1.tgz",
       "integrity": "sha512-05tMxipUCwHqYaVS8xc7sYPTly8PzXayRCB4dTxLhWTqlKUiwH6ezmEe0OSreL1c30LAuA3Zqmc+uEBUGFJDjw==",
       "dev": true,
-      "requires": {
-        "source-list-map": "2.0.0",
-        "source-map": "0.5.6"
-      },
       "dependencies": {
         "source-list-map": {
           "version": "2.0.0",
@@ -9699,10 +6752,7 @@
     "websocket-driver": {
       "version": "0.6.5",
       "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.5.tgz",
-      "integrity": "sha1-XLJVbOuF9Dc8bYI4qmkchFThOjY=",
-      "requires": {
-        "websocket-extensions": "0.1.1"
-      }
+      "integrity": "sha1-XLJVbOuF9Dc8bYI4qmkchFThOjY="
     },
     "websocket-extensions": {
       "version": "0.1.1",
@@ -9714,9 +6764,6 @@
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.1.tgz",
       "integrity": "sha1-PGxFGhmO567FWx7GHQkgxngBpfQ=",
       "dev": true,
-      "requires": {
-        "iconv-lite": "0.4.13"
-      },
       "dependencies": {
         "iconv-lite": {
           "version": "0.4.13",
@@ -9736,10 +6783,6 @@
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-4.8.0.tgz",
       "integrity": "sha1-0pgaqRSMHgCkHFphMRZqtGg7vMA=",
       "dev": true,
-      "requires": {
-        "tr46": "0.0.3",
-        "webidl-conversions": "3.0.1"
-      },
       "dependencies": {
         "webidl-conversions": {
           "version": "3.0.1",
@@ -9754,10 +6797,7 @@
       "resolved": "https://registry.npmjs.org/whatwg-url-compat/-/whatwg-url-compat-0.6.5.tgz",
       "integrity": "sha1-AImBEa9om7CXVBzVpFymyHmERb8=",
       "dev": true,
-      "optional": true,
-      "requires": {
-        "tr46": "0.0.3"
-      }
+      "optional": true
     },
     "when": {
       "version": "3.6.4",
@@ -9775,10 +6815,7 @@
       "version": "1.2.14",
       "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
       "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
-      "dev": true,
-      "requires": {
-        "isexe": "2.0.0"
-      }
+      "dev": true
     },
     "which-module": {
       "version": "1.0.0",
@@ -9802,11 +6839,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-      "dev": true,
-      "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1"
-      }
+      "dev": true
     },
     "wrappy": {
       "version": "1.0.2",
@@ -9824,19 +6857,12 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
-      "dev": true,
-      "requires": {
-        "mkdirp": "0.5.1"
-      }
+      "dev": true
     },
     "ws": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.2.tgz",
-      "integrity": "sha1-iiRPoFJAHgjJiGz0SoUYnh/UBn8=",
-      "requires": {
-        "options": "0.0.6",
-        "ultron": "1.0.2"
-      }
+      "integrity": "sha1-iiRPoFJAHgjJiGz0SoUYnh/UBn8="
     },
     "wtf-8": {
       "version": "1.0.0",
@@ -9860,9 +6886,6 @@
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.8.tgz",
       "integrity": "sha1-m4FpCTFjH/CdGVdUn69U9PmAs8I=",
       "dev": true,
-      "requires": {
-        "sax": "0.5.8"
-      },
       "dependencies": {
         "sax": {
           "version": "0.5.8",
@@ -9911,21 +6934,6 @@
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
       "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
       "dev": true,
-      "requires": {
-        "camelcase": "3.0.0",
-        "cliui": "3.2.0",
-        "decamelize": "1.2.0",
-        "get-caller-file": "1.0.2",
-        "os-locale": "1.4.0",
-        "read-pkg-up": "1.0.1",
-        "require-directory": "2.1.1",
-        "require-main-filename": "1.0.1",
-        "set-blocking": "2.0.0",
-        "string-width": "1.0.2",
-        "which-module": "1.0.0",
-        "y18n": "3.2.1",
-        "yargs-parser": "4.2.1"
-      },
       "dependencies": {
         "camelcase": {
           "version": "3.0.0",
@@ -9937,12 +6945,7 @@
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-          "dev": true,
-          "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wrap-ansi": "2.1.0"
-          }
+          "dev": true
         }
       }
     },
@@ -9951,9 +6954,6 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
       "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
       "dev": true,
-      "requires": {
-        "camelcase": "3.0.0"
-      },
       "dependencies": {
         "camelcase": {
           "version": "3.0.0",
@@ -9971,19 +6971,12 @@
     "zooniverse-geordi-client": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/zooniverse-geordi-client/-/zooniverse-geordi-client-1.4.0.tgz",
-      "integrity": "sha1-0VAANjnzeL7bGUdLH2Rh8wrw5T8=",
-      "requires": {
-        "es6-promise": "3.3.1",
-        "zooniverse-user-string-getter": "1.1.23"
-      }
+      "integrity": "sha1-0VAANjnzeL7bGUdLH2Rh8wrw5T8="
     },
     "zooniverse-user-string-getter": {
       "version": "1.1.23",
       "resolved": "https://registry.npmjs.org/zooniverse-user-string-getter/-/zooniverse-user-string-getter-1.1.23.tgz",
-      "integrity": "sha1-sjKhrg9wPyb30pxnIguKGC7pKEk=",
-      "requires": {
-        "es6-promise": "3.3.1"
-      }
+      "integrity": "sha1-sjKhrg9wPyb30pxnIguKGC7pKEk="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,6 @@
 {
   "name": "panoptes-front-end",
+  "requires": true,
   "lockfileVersion": 1,
   "dependencies": {
     "abab": {
@@ -12,7 +13,11 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
       "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "mime-types": "2.1.15",
+        "negotiator": "0.6.1"
+      }
     },
     "acorn": {
       "version": "2.7.0",
@@ -25,6 +30,9 @@
       "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz",
       "integrity": "sha1-x1K9IQvvZ5UBtsbLf8hPj0cVjMQ=",
       "dev": true,
+      "requires": {
+        "acorn": "4.0.13"
+      },
       "dependencies": {
         "acorn": {
           "version": "4.0.13",
@@ -39,13 +47,19 @@
       "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.9.tgz",
       "integrity": "sha1-VbtemGkVB7dFedBRNBMhfDgMVM8=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "acorn": "2.7.0"
+      }
     },
     "acorn-jsx": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
+      "requires": {
+        "acorn": "3.3.0"
+      },
       "dependencies": {
         "acorn": {
           "version": "3.3.0",
@@ -58,7 +72,10 @@
     "add-dom-event-listener": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/add-dom-event-listener/-/add-dom-event-listener-1.0.2.tgz",
-      "integrity": "sha1-j67SxBAIchzxEdodMNmVuFvkK+0="
+      "integrity": "sha1-j67SxBAIchzxEdodMNmVuFvkK+0=",
+      "requires": {
+        "object-assign": "4.1.1"
+      }
     },
     "after": {
       "version": "0.8.2",
@@ -69,7 +86,11 @@
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
       "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "co": "4.6.0",
+        "json-stable-stringify": "1.0.1"
+      }
     },
     "ajv-keywords": {
       "version": "1.5.1",
@@ -81,7 +102,12 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2",
+        "longest": "1.0.1",
+        "repeat-string": "1.6.1"
+      }
     },
     "alphanum-sort": {
       "version": "1.0.2",
@@ -128,12 +154,19 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
       "integrity": "sha1-o+Uvo5FoyCX/V7AkgSbOWo/5VQc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "arrify": "1.0.1",
+        "micromatch": "2.3.11"
+      }
     },
     "argparse": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+      "requires": {
+        "sprintf-js": "1.0.3"
+      },
       "dependencies": {
         "sprintf-js": {
           "version": "1.0.3",
@@ -146,7 +179,10 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "arr-flatten": "1.0.3"
+      }
     },
     "arr-flatten": {
       "version": "1.0.3",
@@ -170,7 +206,10 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "array-uniq": "1.0.3"
+      }
     },
     "array-uniq": {
       "version": "1.0.3",
@@ -210,13 +249,21 @@
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz",
       "integrity": "sha1-SLokC0WpKA6UdImQull9IWYX/UA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "bn.js": "4.11.6",
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.0"
+      }
     },
     "assert": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
       "integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "util": "0.10.3"
+      }
     },
     "assert-plus": {
       "version": "0.2.0",
@@ -245,13 +292,26 @@
       "version": "6.7.7",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
       "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "browserslist": "1.7.7",
+        "caniuse-db": "1.0.30000692",
+        "normalize-range": "0.1.2",
+        "num2fraction": "1.2.2",
+        "postcss": "5.2.17",
+        "postcss-value-parser": "3.3.0"
+      }
     },
     "aws-sdk": {
       "version": "2.1.50",
       "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1.50.tgz",
       "integrity": "sha1-Zd3CuEDmkCEIftNfKC1jKgUpShs=",
       "dev": true,
+      "requires": {
+        "sax": "0.5.3",
+        "xml2js": "0.2.8",
+        "xmlbuilder": "0.4.2"
+      },
       "dependencies": {
         "sax": {
           "version": "0.5.3",
@@ -276,103 +336,221 @@
     "axios": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.11.1.tgz",
-      "integrity": "sha1-Oc22WBPixUnRwunDiffjOqZcyiI="
+      "integrity": "sha1-Oc22WBPixUnRwunDiffjOqZcyiI=",
+      "requires": {
+        "follow-redirects": "0.0.7"
+      }
     },
     "babel-cli": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-cli/-/babel-cli-6.24.1.tgz",
       "integrity": "sha1-IHzXBbumFImy6kG1MSNBz2rKIoM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-core": "6.24.1",
+        "babel-polyfill": "6.23.0",
+        "babel-register": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "chokidar": "1.7.0",
+        "commander": "2.9.0",
+        "convert-source-map": "1.5.0",
+        "fs-readdir-recursive": "1.0.0",
+        "glob": "7.1.2",
+        "lodash": "4.17.4",
+        "output-file-sync": "1.1.2",
+        "path-is-absolute": "1.0.1",
+        "slash": "1.0.0",
+        "source-map": "0.5.6",
+        "v8flags": "2.1.1"
+      }
     },
     "babel-code-frame": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
       "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.1"
+      }
     },
     "babel-core": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.24.1.tgz",
       "integrity": "sha1-jEKFZNzh4fQfszfsNPTDsCK1rYM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "6.22.0",
+        "babel-generator": "6.25.0",
+        "babel-helpers": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-register": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "babel-template": "6.25.0",
+        "babel-traverse": "6.25.0",
+        "babel-types": "6.25.0",
+        "babylon": "6.17.4",
+        "convert-source-map": "1.5.0",
+        "debug": "2.3.3",
+        "json5": "0.5.1",
+        "lodash": "4.17.4",
+        "minimatch": "3.0.4",
+        "path-is-absolute": "1.0.1",
+        "private": "0.1.7",
+        "slash": "1.0.0",
+        "source-map": "0.5.6"
+      }
     },
     "babel-generator": {
       "version": "6.25.0",
       "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.25.0.tgz",
       "integrity": "sha1-M6GvcNXyiQrrRlpKd5PB32qeqfw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.25.0",
+        "detect-indent": "4.0.0",
+        "jsesc": "1.3.0",
+        "lodash": "4.17.4",
+        "source-map": "0.5.6",
+        "trim-right": "1.0.1"
+      }
     },
     "babel-helper-builder-react-jsx": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.24.1.tgz",
       "integrity": "sha1-CteRfjPI11HmRtrKTnfMGTd9LLw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.25.0",
+        "esutils": "2.0.2"
+      }
     },
     "babel-helper-call-delegate": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
       "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-hoist-variables": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "babel-traverse": "6.25.0",
+        "babel-types": "6.25.0"
+      }
     },
     "babel-helper-define-map": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.24.1.tgz",
       "integrity": "sha1-epdH8ljYlH0y1RX2qhx70CIEoIA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-function-name": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.25.0",
+        "lodash": "4.17.4"
+      }
     },
     "babel-helper-function-name": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
       "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-get-function-arity": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "babel-template": "6.25.0",
+        "babel-traverse": "6.25.0",
+        "babel-types": "6.25.0"
+      }
     },
     "babel-helper-get-function-arity": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
       "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.25.0"
+      }
     },
     "babel-helper-hoist-variables": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
       "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.25.0"
+      }
     },
     "babel-helper-optimise-call-expression": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
       "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.25.0"
+      }
     },
     "babel-helper-regex": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz",
       "integrity": "sha1-024i+rEAjXnYhkjjIRaGgShFbOg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.25.0",
+        "lodash": "4.17.4"
+      }
     },
     "babel-helper-replace-supers": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
       "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-optimise-call-expression": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.23.0",
+        "babel-template": "6.25.0",
+        "babel-traverse": "6.25.0",
+        "babel-types": "6.25.0"
+      }
     },
     "babel-helpers": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
       "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "babel-template": "6.25.0"
+      }
     },
     "babel-loader": {
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-6.4.1.tgz",
       "integrity": "sha1-CzQRLVsHSKjc2/Uaz2+b1C1QuMo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "find-cache-dir": "0.1.1",
+        "loader-utils": "0.2.17",
+        "mkdirp": "0.5.1",
+        "object-assign": "4.1.1"
+      }
     },
     "babel-messages": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0"
+      }
     },
     "babel-plugin-add-module-exports": {
       "version": "0.2.1",
@@ -384,13 +562,19 @@
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
       "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0"
+      }
     },
     "babel-plugin-react-transform": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/babel-plugin-react-transform/-/babel-plugin-react-transform-2.0.2.tgz",
       "integrity": "sha1-UVu/qZaJOYEULZCx+bFjXeKZUQk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash": "4.17.4"
+      }
     },
     "babel-plugin-rewire": {
       "version": "1.0.0",
@@ -414,145 +598,250 @@
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
       "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0"
+      }
     },
     "babel-plugin-transform-es2015-block-scoped-functions": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
       "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0"
+      }
     },
     "babel-plugin-transform-es2015-block-scoping": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz",
       "integrity": "sha1-dsKV3DpHQbFmWt/TFnIV3P8ypXY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "babel-template": "6.25.0",
+        "babel-traverse": "6.25.0",
+        "babel-types": "6.25.0",
+        "lodash": "4.17.4"
+      }
     },
     "babel-plugin-transform-es2015-classes": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
       "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-define-map": "6.24.1",
+        "babel-helper-function-name": "6.24.1",
+        "babel-helper-optimise-call-expression": "6.24.1",
+        "babel-helper-replace-supers": "6.24.1",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.23.0",
+        "babel-template": "6.25.0",
+        "babel-traverse": "6.25.0",
+        "babel-types": "6.25.0"
+      }
     },
     "babel-plugin-transform-es2015-computed-properties": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
       "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "babel-template": "6.25.0"
+      }
     },
     "babel-plugin-transform-es2015-destructuring": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
       "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0"
+      }
     },
     "babel-plugin-transform-es2015-duplicate-keys": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
       "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.25.0"
+      }
     },
     "babel-plugin-transform-es2015-for-of": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
       "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0"
+      }
     },
     "babel-plugin-transform-es2015-function-name": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
       "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-function-name": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.25.0"
+      }
     },
     "babel-plugin-transform-es2015-literals": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
       "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0"
+      }
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz",
       "integrity": "sha1-0+MQtA72ZKNmIiAAl8bUQCmPK/4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-plugin-transform-strict-mode": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "babel-template": "6.25.0",
+        "babel-types": "6.25.0"
+      }
     },
     "babel-plugin-transform-es2015-object-super": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
       "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-replace-supers": "6.24.1",
+        "babel-runtime": "6.23.0"
+      }
     },
     "babel-plugin-transform-es2015-parameters": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
       "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-call-delegate": "6.24.1",
+        "babel-helper-get-function-arity": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "babel-template": "6.25.0",
+        "babel-traverse": "6.25.0",
+        "babel-types": "6.25.0"
+      }
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
       "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.25.0"
+      }
     },
     "babel-plugin-transform-es2015-spread": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
       "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0"
+      }
     },
     "babel-plugin-transform-es2015-sticky-regex": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
       "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-regex": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.25.0"
+      }
     },
     "babel-plugin-transform-es2015-template-literals": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
       "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0"
+      }
     },
     "babel-plugin-transform-es2015-typeof-symbol": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
       "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0"
+      }
     },
     "babel-plugin-transform-es2015-unicode-regex": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
       "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-helper-regex": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "regexpu-core": "2.0.0"
+      }
     },
     "babel-plugin-transform-flow-strip-types": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz",
       "integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-flow": "6.18.0",
+        "babel-runtime": "6.23.0"
+      }
     },
     "babel-plugin-transform-object-assign": {
       "version": "6.8.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-object-assign/-/babel-plugin-transform-object-assign-6.8.0.tgz",
       "integrity": "sha1-duF/LcDzbxT1SLmv16rvWNKeu3U=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0"
+      }
     },
     "babel-plugin-transform-react-display-name": {
       "version": "6.25.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.25.0.tgz",
       "integrity": "sha1-Z+K/Hx6ck6sI25Z5LgU5K/LMKNE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0"
+      }
     },
     "babel-plugin-transform-react-jsx": {
       "version": "6.7.5",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.7.5.tgz",
       "integrity": "sha1-VmfGGlZCevdI6ux97Ca0Ru6VEco=",
       "dev": true,
+      "requires": {
+        "babel-helper-builder-react-jsx": "6.24.1",
+        "babel-plugin-syntax-jsx": "6.18.0",
+        "babel-runtime": "5.8.38"
+      },
       "dependencies": {
         "babel-runtime": {
           "version": "5.8.38",
           "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
           "integrity": "sha1-HAsC62MxL18If/IEUIJ7QlydTBk=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-js": "1.2.7"
+          }
         }
       }
     },
@@ -560,37 +849,60 @@
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.22.0.tgz",
       "integrity": "sha1-322AqdomEqEh5t3XVYvL7PBuY24=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-jsx": "6.18.0",
+        "babel-runtime": "6.23.0"
+      }
     },
     "babel-plugin-transform-react-jsx-source": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.22.0.tgz",
       "integrity": "sha1-ZqwSFT9c0tF7PBkmj0vwGX9E7NY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-jsx": "6.18.0",
+        "babel-runtime": "6.23.0"
+      }
     },
     "babel-plugin-transform-regenerator": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz",
       "integrity": "sha1-uNowWtQ8PJm0hI5P5AN7dw0jxBg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "regenerator-transform": "0.9.11"
+      }
     },
     "babel-plugin-transform-strict-mode": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
       "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.25.0"
+      }
     },
     "babel-plugin-typecheck": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-typecheck/-/babel-plugin-typecheck-3.9.0.tgz",
       "integrity": "sha1-DtrHVzriTuWMb5Exn1dLxRJLDw8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-generator": "6.25.0"
+      }
     },
     "babel-polyfill": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.23.0.tgz",
       "integrity": "sha1-g2TKYt+Or7gwSZ9pkXdGbDsDSZ0=",
       "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "core-js": "2.4.1",
+        "regenerator-runtime": "0.10.5"
+      },
       "dependencies": {
         "core-js": {
           "version": "2.4.1",
@@ -604,19 +916,60 @@
       "version": "6.6.0",
       "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.6.0.tgz",
       "integrity": "sha1-iLM+WP7JTG695Y3GXs5dFODsJWg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-plugin-check-es2015-constants": "6.22.0",
+        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
+        "babel-plugin-transform-es2015-block-scoping": "6.24.1",
+        "babel-plugin-transform-es2015-classes": "6.24.1",
+        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
+        "babel-plugin-transform-es2015-destructuring": "6.23.0",
+        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
+        "babel-plugin-transform-es2015-for-of": "6.23.0",
+        "babel-plugin-transform-es2015-function-name": "6.24.1",
+        "babel-plugin-transform-es2015-literals": "6.22.0",
+        "babel-plugin-transform-es2015-modules-commonjs": "6.24.1",
+        "babel-plugin-transform-es2015-object-super": "6.24.1",
+        "babel-plugin-transform-es2015-parameters": "6.24.1",
+        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+        "babel-plugin-transform-es2015-spread": "6.22.0",
+        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+        "babel-plugin-transform-es2015-template-literals": "6.22.0",
+        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
+        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
+        "babel-plugin-transform-regenerator": "6.24.1"
+      }
     },
     "babel-preset-react": {
       "version": "6.16.0",
       "resolved": "https://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.16.0.tgz",
       "integrity": "sha1-qhF9YN4JKGB+NDxIKJBuRmGCQxY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-plugin-syntax-flow": "6.18.0",
+        "babel-plugin-syntax-jsx": "6.18.0",
+        "babel-plugin-transform-flow-strip-types": "6.22.0",
+        "babel-plugin-transform-react-display-name": "6.25.0",
+        "babel-plugin-transform-react-jsx": "6.7.5",
+        "babel-plugin-transform-react-jsx-self": "6.22.0",
+        "babel-plugin-transform-react-jsx-source": "6.22.0"
+      }
     },
     "babel-register": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.24.1.tgz",
       "integrity": "sha1-fhDhOi9xBlvfrVoXh7pFvKbe118=",
       "dev": true,
+      "requires": {
+        "babel-core": "6.24.1",
+        "babel-runtime": "6.23.0",
+        "core-js": "2.4.1",
+        "home-or-tmp": "2.0.0",
+        "lodash": "4.17.4",
+        "mkdirp": "0.5.1",
+        "source-map-support": "0.4.15"
+      },
       "dependencies": {
         "core-js": {
           "version": "2.4.1",
@@ -630,6 +983,10 @@
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
       "integrity": "sha1-CpSJ8UTecO+zzkMArM2zKeL8VDs=",
+      "requires": {
+        "core-js": "2.4.1",
+        "regenerator-runtime": "0.10.5"
+      },
       "dependencies": {
         "core-js": {
           "version": "2.4.1",
@@ -642,19 +999,43 @@
       "version": "6.25.0",
       "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
       "integrity": "sha1-ZlJBFmt8KqTGGdceGSlpVSsQwHE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "babel-traverse": "6.25.0",
+        "babel-types": "6.25.0",
+        "babylon": "6.17.4",
+        "lodash": "4.17.4"
+      }
     },
     "babel-traverse": {
       "version": "6.25.0",
       "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
       "integrity": "sha1-IldJfi/NGbie3BPEyROB+VEklvE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "6.22.0",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.25.0",
+        "babylon": "6.17.4",
+        "debug": "2.3.3",
+        "globals": "9.18.0",
+        "invariant": "2.2.2",
+        "lodash": "4.17.4"
+      }
     },
     "babel-types": {
       "version": "6.25.0",
       "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
       "integrity": "sha1-cK+ySNVmDl0Y+BHZHIMDtUE0oY4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "esutils": "2.0.2",
+        "lodash": "4.17.4",
+        "to-fast-properties": "1.0.3"
+      }
     },
     "babylon": {
       "version": "6.17.4",
@@ -696,12 +1077,18 @@
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "tweetnacl": "0.14.5"
+      }
     },
     "better-assert": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
-      "integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI="
+      "integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=",
+      "requires": {
+        "callsite": "1.0.0"
+      }
     },
     "big.js": {
       "version": "3.1.3",
@@ -748,25 +1135,44 @@
       "version": "2.10.1",
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "hoek": "2.16.3"
+      }
     },
     "bower-config": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/bower-config/-/bower-config-1.4.0.tgz",
       "integrity": "sha1-FsOMETX4BxwZ8lk41hsNjL8Y0/E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "mout": "1.0.0",
+        "optimist": "0.6.1",
+        "osenv": "0.1.4",
+        "untildify": "2.1.0"
+      }
     },
     "brace-expansion": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
     },
     "braces": {
       "version": "1.8.5",
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "expand-range": "1.8.2",
+        "preserve": "0.2.0",
+        "repeat-element": "1.1.2"
+      }
     },
     "brorand": {
       "version": "1.1.0",
@@ -784,49 +1190,91 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz",
       "integrity": "sha1-Xncl297x/Vkw1OurSFZ85FHEigo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "buffer-xor": "1.0.3",
+        "cipher-base": "1.0.3",
+        "create-hash": "1.1.3",
+        "evp_bytestokey": "1.0.0",
+        "inherits": "2.0.3"
+      }
     },
     "browserify-cipher": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
       "integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "browserify-aes": "1.0.6",
+        "browserify-des": "1.0.0",
+        "evp_bytestokey": "1.0.0"
+      }
     },
     "browserify-des": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
       "integrity": "sha1-2qJ3cXRwki7S/hhZQRihdUOXId0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "cipher-base": "1.0.3",
+        "des.js": "1.0.0",
+        "inherits": "2.0.3"
+      }
     },
     "browserify-rsa": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "bn.js": "4.11.6",
+        "randombytes": "2.0.5"
+      }
     },
     "browserify-sign": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
       "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "bn.js": "4.11.6",
+        "browserify-rsa": "4.0.1",
+        "create-hash": "1.1.3",
+        "create-hmac": "1.1.6",
+        "elliptic": "6.4.0",
+        "inherits": "2.0.3",
+        "parse-asn1": "5.1.0"
+      }
     },
     "browserify-zlib": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
       "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "pako": "0.2.9"
+      }
     },
     "browserslist": {
       "version": "1.7.7",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
       "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "caniuse-db": "1.0.30000692",
+        "electron-to-chromium": "1.3.14"
+      }
     },
     "buffer": {
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "dev": true,
+      "requires": {
+        "base64-js": "1.2.0",
+        "ieee754": "1.1.8",
+        "isarray": "1.0.0"
+      },
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
@@ -858,7 +1306,10 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "callsites": "0.2.0"
+      }
     },
     "callsite": {
       "version": "1.0.0",
@@ -875,7 +1326,11 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
       "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "no-case": "2.3.1",
+        "upper-case": "1.1.3"
+      }
     },
     "camelcase": {
       "version": "1.2.1",
@@ -888,6 +1343,12 @@
       "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-1.6.1.tgz",
       "integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
       "dev": true,
+      "requires": {
+        "browserslist": "1.7.7",
+        "caniuse-db": "1.0.30000692",
+        "lodash.memoize": "4.1.2",
+        "lodash.uniq": "4.5.0"
+      },
       "dependencies": {
         "lodash.uniq": {
           "version": "4.5.0",
@@ -913,13 +1374,24 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "align-text": "0.1.4",
+        "lazy-cache": "1.0.4"
+      }
     },
     "chalk": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
+      }
     },
     "chartist": {
       "version": "0.9.8",
@@ -931,6 +1403,15 @@
       "resolved": "https://registry.npmjs.org/check-dependencies/-/check-dependencies-0.12.3.tgz",
       "integrity": "sha1-a6ST1CIdvD9pURM1OuRjj3csXHU=",
       "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "bower-config": "1.4.0",
+        "chalk": "1.1.3",
+        "findup-sync": "0.4.3",
+        "lodash": "4.17.4",
+        "minimist": "1.2.0",
+        "semver": "5.3.0"
+      },
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
@@ -944,20 +1425,48 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/check-engines/-/check-engines-1.2.0.tgz",
       "integrity": "sha1-kewECik5KkX6zIvznBPFbQHN/5c=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "semver": "5.3.0"
+      }
     },
     "cheerio": {
       "version": "0.20.0",
       "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.20.0.tgz",
       "integrity": "sha1-XHEPK6uVZTJyhCugHG6mGzVF7DU=",
       "dev": true,
+      "requires": {
+        "css-select": "1.2.0",
+        "dom-serializer": "0.1.0",
+        "entities": "1.1.1",
+        "htmlparser2": "3.8.3",
+        "jsdom": "7.2.2",
+        "lodash": "4.17.4"
+      },
       "dependencies": {
         "jsdom": {
           "version": "7.2.2",
           "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-7.2.2.tgz",
           "integrity": "sha1-QLQCdwwr2iNGkJa+6Rq2deOx/G4=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "abab": "1.0.3",
+            "acorn": "2.7.0",
+            "acorn-globals": "1.0.9",
+            "cssom": "0.3.2",
+            "cssstyle": "0.2.37",
+            "escodegen": "1.8.1",
+            "nwmatcher": "1.4.1",
+            "parse5": "1.5.1",
+            "request": "2.81.0",
+            "sax": "1.2.2",
+            "symbol-tree": "3.2.2",
+            "tough-cookie": "2.3.2",
+            "webidl-conversions": "2.0.1",
+            "whatwg-url-compat": "0.6.5",
+            "xml-name-validator": "2.0.1"
+          }
         }
       }
     },
@@ -965,13 +1474,27 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
       "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "anymatch": "1.3.0",
+        "async-each": "1.0.1",
+        "fsevents": "1.1.2",
+        "glob-parent": "2.0.0",
+        "inherits": "2.0.3",
+        "is-binary-path": "1.0.1",
+        "is-glob": "2.0.1",
+        "path-is-absolute": "1.0.1",
+        "readdirp": "2.1.0"
+      }
     },
     "cipher-base": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.3.tgz",
       "integrity": "sha1-7qvxlEGc6QDaMBjCB9IS8qbfCgc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3"
+      }
     },
     "circular-json": {
       "version": "0.3.1",
@@ -983,13 +1506,20 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cjsx-loader/-/cjsx-loader-3.0.0.tgz",
       "integrity": "sha1-BtylKvKvZJqMBTnBeZD2M63G3Y8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "coffee-react-transform": "4.0.0",
+        "loader-utils": "0.2.17"
+      }
     },
     "clap": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/clap/-/clap-1.2.0.tgz",
       "integrity": "sha1-WckP4+E3EEdG/xlGmiemNP9oyFc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3"
+      }
     },
     "classnames": {
       "version": "2.2.5",
@@ -1000,13 +1530,19 @@
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.1.4.tgz",
       "integrity": "sha1-7siBHbJ0V+AHjYypIfqBty+oK/Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "source-map": "0.5.6"
+      }
     },
     "cli-cursor": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
       "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "restore-cursor": "1.0.1"
+      }
     },
     "cli-width": {
       "version": "2.1.0",
@@ -1019,6 +1555,11 @@
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
       "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
       "dev": true,
+      "requires": {
+        "center-align": "0.1.3",
+        "right-align": "0.1.3",
+        "wordwrap": "0.0.2"
+      },
       "dependencies": {
         "wordwrap": {
           "version": "0.0.2",
@@ -1044,7 +1585,10 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/coa/-/coa-1.0.3.tgz",
       "integrity": "sha1-G1Sl4dz3fJkEVdTe6pjFZEFtyJM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "q": "1.5.0"
+      }
     },
     "code-point-at": {
       "version": "1.1.0",
@@ -1057,12 +1601,20 @@
       "resolved": "https://registry.npmjs.org/coffee-loader/-/coffee-loader-0.7.3.tgz",
       "integrity": "sha1-+tvG79b8fsyIxbMEaiwpIGa8tUo=",
       "dev": true,
+      "requires": {
+        "loader-utils": "1.1.0"
+      },
       "dependencies": {
         "loader-utils": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
           "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "big.js": "3.1.3",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1"
+          }
         }
       }
     },
@@ -1070,7 +1622,13 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/coffee-react/-/coffee-react-5.0.1.tgz",
       "integrity": "sha1-PQNWboZGiUyWIZPELC6JX5H0nss=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "coffee-react-jstransform": "1.0.0",
+        "coffee-react-transform": "4.0.0",
+        "coffee-script": "1.10.0",
+        "mkdirp": "0.5.1"
+      }
     },
     "coffee-react-jstransform": {
       "version": "1.0.0",
@@ -1094,13 +1652,21 @@
       "version": "0.11.4",
       "resolved": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
       "integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "clone": "1.0.2",
+        "color-convert": "1.9.0",
+        "color-string": "0.3.0"
+      }
     },
     "color-convert": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
       "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.2"
+      }
     },
     "color-name": {
       "version": "1.1.2",
@@ -1112,13 +1678,21 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
       "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.2"
+      }
     },
     "colormin": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/colormin/-/colormin-1.1.2.tgz",
       "integrity": "sha1-6i90IKcrlogaOKrlnsEkpvcpgTM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "color": "0.11.4",
+        "css-color-names": "0.0.4",
+        "has": "1.0.1"
+      }
     },
     "colors": {
       "version": "1.1.2",
@@ -1129,13 +1703,19 @@
     "combined-stream": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk="
+      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+      "requires": {
+        "delayed-stream": "1.0.0"
+      }
     },
     "commander": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
       "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-readlink": "1.0.1"
+      }
     },
     "commondir": {
       "version": "1.0.1",
@@ -1152,7 +1732,10 @@
     "component-classes": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/component-classes/-/component-classes-1.2.6.tgz",
-      "integrity": "sha1-xkI5TDYYpNiwuJGe/Mu9kw5c1pE="
+      "integrity": "sha1-xkI5TDYYpNiwuJGe/Mu9kw5c1pE=",
+      "requires": {
+        "component-indexof": "0.0.3"
+      }
     },
     "component-emitter": {
       "version": "1.2.1",
@@ -1180,6 +1763,11 @@
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
       "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
       "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.0",
+        "typedarray": "0.0.6"
+      },
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
@@ -1191,13 +1779,25 @@
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.0.tgz",
           "integrity": "sha512-c7KMXGd4b48nN3OJ1U9qOsn6pXNzf6kLd3kdZCkg2sxAcoiufInqF0XckwEnlrcwuaYwonlNK8GQUIOC/WC7sg==",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.0",
+            "string_decoder": "1.0.2",
+            "util-deprecate": "1.0.2"
+          }
         },
         "string_decoder": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
           "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
           "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          },
           "dependencies": {
             "safe-buffer": {
               "version": "5.0.1",
@@ -1213,7 +1813,10 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
       "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "date-now": "0.1.4"
+      }
     },
     "constants-browserify": {
       "version": "1.0.0",
@@ -1273,12 +1876,29 @@
       "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-4.0.1.tgz",
       "integrity": "sha1-lyjjg7lDFgUNDHRjlY8rhcCqggA=",
       "dev": true,
+      "requires": {
+        "bluebird": "2.11.0",
+        "fs-extra": "0.26.7",
+        "glob": "6.0.4",
+        "is-glob": "3.1.0",
+        "loader-utils": "0.2.17",
+        "lodash": "4.17.4",
+        "minimatch": "3.0.4",
+        "node-dir": "0.1.17"
+      },
       "dependencies": {
         "glob": {
           "version": "6.0.4",
           "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
           "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
         },
         "is-extglob": {
           "version": "2.1.1",
@@ -1290,7 +1910,10 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-extglob": "2.1.1"
+          }
         }
       }
     },
@@ -1307,53 +1930,105 @@
     "counterpart": {
       "version": "0.17.9",
       "resolved": "https://registry.npmjs.org/counterpart/-/counterpart-0.17.9.tgz",
-      "integrity": "sha1-A3nk0JC579spxjamB8UuNXNPXxM="
+      "integrity": "sha1-A3nk0JC579spxjamB8UuNXNPXxM=",
+      "requires": {
+        "date-names": "0.1.9",
+        "except": "0.1.3",
+        "extend": "3.0.1",
+        "pluralizers": "0.1.6",
+        "sprintf-js": "1.1.1"
+      }
     },
     "create-ecdh": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
       "integrity": "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "bn.js": "4.11.6",
+        "elliptic": "6.4.0"
+      }
     },
     "create-hash": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
       "integrity": "sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "cipher-base": "1.0.3",
+        "inherits": "2.0.3",
+        "ripemd160": "2.0.1",
+        "sha.js": "2.4.8"
+      }
     },
     "create-hmac": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz",
       "integrity": "sha1-rLniIaThe9sHbpBlfEK5PjcmzwY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "cipher-base": "1.0.3",
+        "create-hash": "1.1.3",
+        "inherits": "2.0.3",
+        "ripemd160": "2.0.1",
+        "safe-buffer": "5.1.0",
+        "sha.js": "2.4.8"
+      }
     },
     "create-react-class": {
       "version": "15.6.0",
       "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.0.tgz",
-      "integrity": "sha1-q0SEl8JlZuHilBPogyB9V8/nvtQ="
+      "integrity": "sha1-q0SEl8JlZuHilBPogyB9V8/nvtQ=",
+      "requires": {
+        "fbjs": "0.8.12",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1"
+      }
     },
     "cross-spawn": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
       "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lru-cache": "4.1.1",
+        "which": "1.2.14"
+      }
     },
     "cryptiles": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
       "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "boom": "2.10.1"
+      }
     },
     "crypto-browserify": {
       "version": "3.11.0",
       "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.0.tgz",
       "integrity": "sha1-NlKgkGq5sqfgw85mpAjpV6JIVSI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "browserify-cipher": "1.0.0",
+        "browserify-sign": "4.0.4",
+        "create-ecdh": "4.0.0",
+        "create-hash": "1.1.3",
+        "create-hmac": "1.1.6",
+        "diffie-hellman": "5.0.2",
+        "inherits": "2.0.3",
+        "pbkdf2": "3.0.12",
+        "public-encrypt": "4.0.0",
+        "randombytes": "2.0.5"
+      }
     },
     "css-animation": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/css-animation/-/css-animation-1.3.2.tgz",
-      "integrity": "sha1-31FYIO9ZA3M60tsJmUA7MDe4uIA="
+      "integrity": "sha1-31FYIO9ZA3M60tsJmUA7MDe4uIA=",
+      "requires": {
+        "component-classes": "1.2.6"
+      }
     },
     "css-color-names": {
       "version": "0.0.4",
@@ -1366,12 +2041,33 @@
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-0.28.4.tgz",
       "integrity": "sha1-bPNXkZLONV6LONX0Ldeh8uyJjQ8=",
       "dev": true,
+      "requires": {
+        "babel-code-frame": "6.22.0",
+        "css-selector-tokenizer": "0.7.0",
+        "cssnano": "3.10.0",
+        "icss-utils": "2.1.0",
+        "loader-utils": "1.1.0",
+        "lodash.camelcase": "4.3.0",
+        "object-assign": "4.1.1",
+        "postcss": "5.2.17",
+        "postcss-modules-extract-imports": "1.1.0",
+        "postcss-modules-local-by-default": "1.2.0",
+        "postcss-modules-scope": "1.1.0",
+        "postcss-modules-values": "1.3.0",
+        "postcss-value-parser": "3.3.0",
+        "source-list-map": "0.1.8"
+      },
       "dependencies": {
         "loader-utils": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
           "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "big.js": "3.1.3",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1"
+          }
         }
       }
     },
@@ -1385,19 +2081,35 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
       "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "boolbase": "1.0.0",
+        "css-what": "2.1.0",
+        "domutils": "1.5.1",
+        "nth-check": "1.0.1"
+      }
     },
     "css-selector-tokenizer": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.0.tgz",
       "integrity": "sha1-5piEdK6MlTR3v15+/s/OzNnPTIY=",
       "dev": true,
+      "requires": {
+        "cssesc": "0.1.0",
+        "fastparse": "1.1.1",
+        "regexpu-core": "1.0.0"
+      },
       "dependencies": {
         "regexpu-core": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
           "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "regenerate": "1.3.2",
+            "regjsgen": "0.2.0",
+            "regjsparser": "0.1.5"
+          }
         }
       }
     },
@@ -1417,13 +2129,51 @@
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-3.10.0.tgz",
       "integrity": "sha1-Tzj2zqK5sX+gFJDyPx3GjqZcHDg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "autoprefixer": "6.7.7",
+        "decamelize": "1.2.0",
+        "defined": "1.0.0",
+        "has": "1.0.1",
+        "object-assign": "4.1.1",
+        "postcss": "5.2.17",
+        "postcss-calc": "5.3.1",
+        "postcss-colormin": "2.2.2",
+        "postcss-convert-values": "2.6.1",
+        "postcss-discard-comments": "2.0.4",
+        "postcss-discard-duplicates": "2.1.0",
+        "postcss-discard-empty": "2.1.0",
+        "postcss-discard-overridden": "0.1.1",
+        "postcss-discard-unused": "2.2.3",
+        "postcss-filter-plugins": "2.0.2",
+        "postcss-merge-idents": "2.1.7",
+        "postcss-merge-longhand": "2.0.2",
+        "postcss-merge-rules": "2.1.2",
+        "postcss-minify-font-values": "1.0.5",
+        "postcss-minify-gradients": "1.0.5",
+        "postcss-minify-params": "1.2.2",
+        "postcss-minify-selectors": "2.1.1",
+        "postcss-normalize-charset": "1.1.1",
+        "postcss-normalize-url": "3.0.8",
+        "postcss-ordered-values": "2.2.3",
+        "postcss-reduce-idents": "2.4.0",
+        "postcss-reduce-initial": "1.0.1",
+        "postcss-reduce-transforms": "1.0.4",
+        "postcss-svgo": "2.1.6",
+        "postcss-unique-selectors": "2.0.2",
+        "postcss-value-parser": "3.3.0",
+        "postcss-zindex": "2.2.0"
+      }
     },
     "csso": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/csso/-/csso-2.3.2.tgz",
       "integrity": "sha1-3dUsWHAz9J6Utx/FVWnyUuj/X4U=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "clap": "1.2.0",
+        "source-map": "0.5.6"
+      }
     },
     "cssom": {
       "version": "0.3.2",
@@ -1435,13 +2185,19 @@
       "version": "0.2.37",
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
       "integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "cssom": "0.3.2"
+      }
     },
     "d": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "es5-ext": "0.10.23"
+      }
     },
     "damerau-levenshtein": {
       "version": "1.0.4",
@@ -1454,6 +2210,9 @@
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -1487,7 +2246,10 @@
     "debug": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-      "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w="
+      "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
+      "requires": {
+        "ms": "0.7.2"
+      }
     },
     "decamelize": {
       "version": "1.2.0",
@@ -1510,7 +2272,11 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "foreach": "2.0.5",
+        "object-keys": "1.0.11"
+      }
     },
     "defined": {
       "version": "1.0.0",
@@ -1522,7 +2288,16 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "globby": "5.0.0",
+        "is-path-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.0",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "rimraf": "2.5.4"
+      }
     },
     "delayed-stream": {
       "version": "1.0.0",
@@ -1539,7 +2314,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
       "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.0"
+      }
     },
     "destroy": {
       "version": "1.0.4",
@@ -1551,18 +2330,32 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-0.1.0.tgz",
       "integrity": "sha1-STXe39lIhkjgBrASlWbpOGcR6mM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "fs-exists-sync": "0.1.0"
+      }
     },
     "detect-indent": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "repeating": "2.0.1"
+      }
     },
     "devour-client": {
       "version": "1.3.9",
       "resolved": "https://registry.npmjs.org/devour-client/-/devour-client-1.3.9.tgz",
       "integrity": "sha1-ikVplngjs3zahCbSqQGqEc74wY0=",
+      "requires": {
+        "axios": "0.11.1",
+        "es6-promise": "3.3.1",
+        "lodash": "4.17.4",
+        "minilog": "3.1.0",
+        "pluralize": "1.2.1",
+        "qs": "6.4.0"
+      },
       "dependencies": {
         "qs": {
           "version": "6.4.0",
@@ -1581,19 +2374,35 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
       "integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "bn.js": "4.11.6",
+        "miller-rabin": "4.0.0",
+        "randombytes": "2.0.5"
+      }
     },
     "docco": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/docco/-/docco-0.6.3.tgz",
       "integrity": "sha1-xHtYI9eVY9b8Or1J895ImG5VIu4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "commander": "2.9.0",
+        "fs-extra": "0.26.7",
+        "highlight.js": "9.12.0",
+        "marked": "0.3.6",
+        "underscore": "1.8.3"
+      }
     },
     "doctrine": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
       "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
       "dev": true,
+      "requires": {
+        "esutils": "2.0.2",
+        "isarray": "1.0.0"
+      },
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
@@ -1613,6 +2422,9 @@
       "resolved": "https://registry.npmjs.org/dom-converter/-/dom-converter-0.1.4.tgz",
       "integrity": "sha1-pF71cnuJDJv/5tfIduexnLDhfzs=",
       "dev": true,
+      "requires": {
+        "utila": "0.3.3"
+      },
       "dependencies": {
         "utila": {
           "version": "0.3.3",
@@ -1632,6 +2444,10 @@
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
       "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
       "dev": true,
+      "requires": {
+        "domelementtype": "1.1.3",
+        "entities": "1.1.1"
+      },
       "dependencies": {
         "domelementtype": {
           "version": "1.1.3",
@@ -1663,13 +2479,20 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
       "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "domelementtype": "1.3.0"
+      }
     },
     "domutils": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
       "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "dom-serializer": "0.1.0",
+        "domelementtype": "1.3.0"
+      }
     },
     "drag-reorderable": {
       "version": "0.1.0",
@@ -1681,7 +2504,10 @@
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "jsbn": "0.1.1"
+      }
     },
     "ee-first": {
       "version": "1.1.1",
@@ -1705,7 +2531,16 @@
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
       "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "bn.js": "4.11.6",
+        "brorand": "1.1.0",
+        "hash.js": "1.0.3",
+        "hmac-drbg": "1.0.1",
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.0",
+        "minimalistic-crypto-utils": "1.0.1"
+      }
     },
     "emojis-list": {
       "version": "2.1.0",
@@ -1722,37 +2557,80 @@
     "encoding": {
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s="
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "requires": {
+        "iconv-lite": "0.4.18"
+      }
     },
     "engine.io": {
       "version": "1.8.4",
       "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-1.8.4.tgz",
       "integrity": "sha1-d7zhK4Dl1gQpM3/sOw2vaR68kAM=",
       "dev": true,
+      "requires": {
+        "accepts": "1.3.3",
+        "base64id": "1.0.0",
+        "cookie": "0.3.1",
+        "debug": "2.3.3",
+        "engine.io-parser": "1.3.2",
+        "ws": "1.1.4"
+      },
       "dependencies": {
         "ws": {
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.4.tgz",
           "integrity": "sha1-V/QNA2gy5fUFVmKjl8Tedu1mv2E=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "options": "0.0.6",
+            "ultron": "1.0.2"
+          }
         }
       }
     },
     "engine.io-client": {
       "version": "1.8.4",
       "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.8.4.tgz",
-      "integrity": "sha1-n+hd7iWFPKa6viW9KtaHEIY+kcI="
+      "integrity": "sha1-n+hd7iWFPKa6viW9KtaHEIY+kcI=",
+      "requires": {
+        "component-emitter": "1.2.1",
+        "component-inherit": "0.0.3",
+        "debug": "2.3.3",
+        "engine.io-parser": "1.3.2",
+        "has-cors": "1.1.0",
+        "indexof": "0.0.1",
+        "parsejson": "0.0.3",
+        "parseqs": "0.0.5",
+        "parseuri": "0.0.5",
+        "ws": "1.1.2",
+        "xmlhttprequest-ssl": "1.5.3",
+        "yeast": "0.1.2"
+      }
     },
     "engine.io-parser": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.3.2.tgz",
-      "integrity": "sha1-k3sHnwAH0Ik+xW1GyyILjLQ1Igo="
+      "integrity": "sha1-k3sHnwAH0Ik+xW1GyyILjLQ1Igo=",
+      "requires": {
+        "after": "0.8.2",
+        "arraybuffer.slice": "0.0.6",
+        "base64-arraybuffer": "0.1.5",
+        "blob": "0.0.4",
+        "has-binary": "0.1.7",
+        "wtf-8": "1.0.0"
+      }
     },
     "enhanced-resolve": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.1.0.tgz",
       "integrity": "sha1-n0tib1dyRe3PSyrYPYbhf09CHew=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "memory-fs": "0.4.1",
+        "object-assign": "4.1.1",
+        "tapable": "0.2.6"
+      }
     },
     "entities": {
       "version": "1.1.1",
@@ -1763,49 +2641,95 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/enzyme/-/enzyme-2.4.2.tgz",
       "integrity": "sha1-Cbrs7Ypq1I1Qf5B1rJzhJ0+c/2I=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "cheerio": "0.20.0",
+        "function.prototype.name": "1.0.0",
+        "in-publish": "2.0.0",
+        "is-subset": "0.1.1",
+        "lodash": "4.17.4",
+        "object-is": "1.0.1",
+        "object.assign": "4.0.4",
+        "object.entries": "1.0.4",
+        "object.values": "1.0.4",
+        "uuid": "2.0.3"
+      }
     },
     "errno": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
       "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "prr": "0.0.0"
+      }
     },
     "error-ex": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-arrayish": "0.2.1"
+      }
     },
     "es-abstract": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.7.0.tgz",
       "integrity": "sha1-363ndOAb/Nl/lhgCmMRJyGI/uUw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "1.1.1",
+        "function-bind": "1.1.0",
+        "is-callable": "1.1.3",
+        "is-regex": "1.0.4"
+      }
     },
     "es-to-primitive": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
       "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-callable": "1.1.3",
+        "is-date-object": "1.0.1",
+        "is-symbol": "1.0.1"
+      }
     },
     "es5-ext": {
       "version": "0.10.23",
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.23.tgz",
       "integrity": "sha1-dXi1G+l0IHpUh4IbVlOMIk5Oezg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "es6-iterator": "2.0.1",
+        "es6-symbol": "3.1.1"
+      }
     },
     "es6-iterator": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
       "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.23",
+        "es6-symbol": "3.1.1"
+      }
     },
     "es6-map": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
       "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.23",
+        "es6-iterator": "2.0.1",
+        "es6-set": "0.1.5",
+        "es6-symbol": "3.1.1",
+        "event-emitter": "0.3.5"
+      }
     },
     "es6-promise": {
       "version": "3.3.1",
@@ -1816,19 +2740,36 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.23",
+        "es6-iterator": "2.0.1",
+        "es6-symbol": "3.1.1",
+        "event-emitter": "0.3.5"
+      }
     },
     "es6-symbol": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.23"
+      }
     },
     "es6-weak-map": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
       "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.23",
+        "es6-iterator": "2.0.1",
+        "es6-symbol": "3.1.1"
+      }
     },
     "escape-html": {
       "version": "1.0.3",
@@ -1847,13 +2788,23 @@
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
       "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
       "dev": true,
+      "requires": {
+        "esprima": "2.7.3",
+        "estraverse": "1.9.3",
+        "esutils": "2.0.2",
+        "optionator": "0.8.2",
+        "source-map": "0.2.0"
+      },
       "dependencies": {
         "source-map": {
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
           "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "amdefine": "1.0.1"
+          }
         }
       }
     },
@@ -1862,6 +2813,12 @@
       "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
       "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
       "dev": true,
+      "requires": {
+        "es6-map": "0.1.5",
+        "es6-weak-map": "2.0.2",
+        "esrecurse": "4.1.0",
+        "estraverse": "4.2.0"
+      },
       "dependencies": {
         "estraverse": {
           "version": "4.2.0",
@@ -1876,6 +2833,42 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-3.9.1.tgz",
       "integrity": "sha1-WoWXcG/GBIvGBhrHVNSiEdKPT1s=",
       "dev": true,
+      "requires": {
+        "babel-code-frame": "6.22.0",
+        "chalk": "1.1.3",
+        "concat-stream": "1.6.0",
+        "debug": "2.3.3",
+        "doctrine": "1.5.0",
+        "escope": "3.6.0",
+        "espree": "3.4.3",
+        "estraverse": "4.2.0",
+        "esutils": "2.0.2",
+        "file-entry-cache": "2.0.0",
+        "glob": "7.1.2",
+        "globals": "9.18.0",
+        "ignore": "3.3.3",
+        "imurmurhash": "0.1.4",
+        "inquirer": "0.12.0",
+        "is-my-json-valid": "2.16.0",
+        "is-resolvable": "1.0.0",
+        "js-yaml": "3.7.0",
+        "json-stable-stringify": "1.0.1",
+        "levn": "0.3.0",
+        "lodash": "4.17.4",
+        "mkdirp": "0.5.1",
+        "natural-compare": "1.4.0",
+        "optionator": "0.8.2",
+        "path-is-inside": "1.0.2",
+        "pluralize": "1.2.1",
+        "progress": "1.1.8",
+        "require-uncached": "1.0.3",
+        "shelljs": "0.7.8",
+        "strip-bom": "3.0.0",
+        "strip-json-comments": "1.0.4",
+        "table": "3.8.3",
+        "text-table": "0.2.0",
+        "user-home": "2.0.0"
+      },
       "dependencies": {
         "estraverse": {
           "version": "4.2.0",
@@ -1887,7 +2880,10 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
           "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "os-homedir": "1.0.2"
+          }
         }
       }
     },
@@ -1895,7 +2891,10 @@
       "version": "13.0.0",
       "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-13.0.0.tgz",
       "integrity": "sha1-aI0V08J2wMdTrlOMkqRDl9dq5G4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "eslint-config-airbnb-base": "10.0.1"
+      }
     },
     "eslint-config-airbnb-base": {
       "version": "10.0.1",
@@ -1913,19 +2912,31 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.2.3.tgz",
       "integrity": "sha1-Wt2BBujJKNssuiMrzZ76hG49oWw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "debug": "2.3.3",
+        "object-assign": "4.1.1",
+        "resolve": "1.3.3"
+      }
     },
     "eslint-module-utils": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.0.0.tgz",
       "integrity": "sha1-pvjCHZATWHWc3DXbrBmCrh7li84=",
       "dev": true,
+      "requires": {
+        "debug": "2.2.0",
+        "pkg-dir": "1.0.0"
+      },
       "dependencies": {
         "debug": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "0.7.1"
+          }
         },
         "ms": {
           "version": "0.7.1",
@@ -1939,13 +2950,30 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.2.0.tgz",
       "integrity": "sha1-crowb60wXWfEgWNIpGmaQimsi04=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "builtin-modules": "1.1.1",
+        "contains-path": "0.1.0",
+        "debug": "2.3.3",
+        "doctrine": "1.5.0",
+        "eslint-import-resolver-node": "0.2.3",
+        "eslint-module-utils": "2.0.0",
+        "has": "1.0.1",
+        "lodash.cond": "4.5.2",
+        "minimatch": "3.0.4",
+        "pkg-up": "1.0.0"
+      }
     },
     "eslint-plugin-jsx-a11y": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-2.2.3.tgz",
       "integrity": "sha1-TjXLcbin23AqxBXIBuuOjZ6mxl0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "damerau-levenshtein": "1.0.4",
+        "jsx-ast-utils": "1.4.1",
+        "object-assign": "4.1.1"
+      }
     },
     "eslint-plugin-promise": {
       "version": "1.3.2",
@@ -1957,7 +2985,11 @@
       "version": "6.6.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-6.6.0.tgz",
       "integrity": "sha1-kc7s76iiLY9dI++ag5UWp9n6Y6E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "doctrine": "1.5.0",
+        "jsx-ast-utils": "1.4.1"
+      }
     },
     "eslint-plugin-standard": {
       "version": "1.3.3",
@@ -1970,25 +3002,18 @@
       "resolved": "https://registry.npmjs.org/eslint-watch/-/eslint-watch-3.1.2.tgz",
       "integrity": "sha1-uTs+ygiRXxE9yQCZT4gNsTZN5LM=",
       "dev": true,
-      "dependencies": {
-        "bluebird": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
-          "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw=",
-          "dev": true
-        },
-        "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-          "dev": true
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        }
+      "requires": {
+        "babel-polyfill": "6.23.0",
+        "bluebird": "2.11.0",
+        "chalk": "1.1.3",
+        "chokidar": "1.7.0",
+        "debug": "2.3.3",
+        "keypress": "0.2.1",
+        "lodash": "4.17.4",
+        "optionator": "0.8.2",
+        "source-map-support": "0.4.15",
+        "text-table": "0.2.0",
+        "unicons": "0.0.3"
       }
     },
     "espree": {
@@ -1996,6 +3021,10 @@
       "resolved": "https://registry.npmjs.org/espree/-/espree-3.4.3.tgz",
       "integrity": "sha1-KRC1zNSc6JPC//+qtP2LOjG4I3Q=",
       "dev": true,
+      "requires": {
+        "acorn": "5.0.3",
+        "acorn-jsx": "3.0.1"
+      },
       "dependencies": {
         "acorn": {
           "version": "5.0.3",
@@ -2016,6 +3045,10 @@
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
       "integrity": "sha1-RxO2U2rffyrE8yfVWed1a/9kgiA=",
       "dev": true,
+      "requires": {
+        "estraverse": "4.1.1",
+        "object-assign": "4.1.1"
+      },
       "dependencies": {
         "estraverse": {
           "version": "4.1.1",
@@ -2047,7 +3080,11 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.23"
+      }
     },
     "events": {
       "version": "1.1.1",
@@ -2058,12 +3095,18 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz",
       "integrity": "sha1-SXtmrZ/vZc18CKYYCCS6FHa2blM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "create-hash": "1.1.3"
+      }
     },
     "except": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/except/-/except-0.1.3.tgz",
-      "integrity": "sha1-mCYckZWFUVNrREgiOOl4P7c9KSo="
+      "integrity": "sha1-mCYckZWFUVNrREgiOOl4P7c9KSo=",
+      "requires": {
+        "indexof": "0.0.1"
+      }
     },
     "exenv": {
       "version": "1.2.2",
@@ -2080,31 +3123,73 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-posix-bracket": "0.1.1"
+      }
     },
     "expand-range": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "fill-range": "2.2.3"
+      }
     },
     "expand-tilde": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
       "integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "os-homedir": "1.0.2"
+      }
     },
     "express": {
       "version": "4.15.3",
       "resolved": "https://registry.npmjs.org/express/-/express-4.15.3.tgz",
       "integrity": "sha1-urZdDwOqgMNYQIly/HAPkWlEtmI=",
       "dev": true,
+      "requires": {
+        "accepts": "1.3.3",
+        "array-flatten": "1.1.1",
+        "content-disposition": "0.5.2",
+        "content-type": "1.0.2",
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.7",
+        "depd": "1.1.0",
+        "encodeurl": "1.0.1",
+        "escape-html": "1.0.3",
+        "etag": "1.8.0",
+        "finalhandler": "1.0.3",
+        "fresh": "0.5.0",
+        "merge-descriptors": "1.0.1",
+        "methods": "1.1.2",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.1",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "1.1.4",
+        "qs": "6.4.0",
+        "range-parser": "1.2.0",
+        "send": "0.15.3",
+        "serve-static": "1.12.3",
+        "setprototypeof": "1.0.3",
+        "statuses": "1.3.1",
+        "type-is": "1.6.15",
+        "utils-merge": "1.0.0",
+        "vary": "1.1.1"
+      },
       "dependencies": {
         "debug": {
           "version": "2.6.7",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
           "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
         },
         "ms": {
           "version": "2.0.0",
@@ -2129,25 +3214,42 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-extglob": "1.0.0"
+      }
     },
     "extract-text-webpack-plugin": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/extract-text-webpack-plugin/-/extract-text-webpack-plugin-2.1.2.tgz",
       "integrity": "sha1-dW7076gVXDaBgz+8NNpTuUF0bWw=",
       "dev": true,
+      "requires": {
+        "async": "2.4.1",
+        "loader-utils": "1.1.0",
+        "schema-utils": "0.3.0",
+        "webpack-sources": "1.0.1"
+      },
       "dependencies": {
         "async": {
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/async/-/async-2.4.1.tgz",
           "integrity": "sha1-YqVrJ5yYoR0JhwlqAcw+6463u9c=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash": "4.17.4"
+          }
         },
         "loader-utils": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
           "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "big.js": "3.1.3",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1"
+          }
         }
       }
     },
@@ -2178,36 +3280,64 @@
     "faye-websocket": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.9.4.tgz",
-      "integrity": "sha1-iFk0x57/sECVSeDAo4Ae0XpAza0="
+      "integrity": "sha1-iFk0x57/sECVSeDAo4Ae0XpAza0=",
+      "requires": {
+        "websocket-driver": "0.6.5"
+      }
     },
     "fbjs": {
       "version": "0.8.12",
       "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.12.tgz",
-      "integrity": "sha1-ELXZL3bUVXX9Y6IX1OoCvqL47QQ="
+      "integrity": "sha1-ELXZL3bUVXX9Y6IX1OoCvqL47QQ=",
+      "requires": {
+        "core-js": "1.2.7",
+        "isomorphic-fetch": "2.2.1",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1",
+        "promise": "7.3.0",
+        "setimmediate": "1.0.5",
+        "ua-parser-js": "0.7.12"
+      }
     },
     "figures": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
       "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "1.0.5",
+        "object-assign": "4.1.1"
+      }
     },
     "file-entry-cache": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "flat-cache": "1.2.2",
+        "object-assign": "4.1.1"
+      }
     },
     "file-loader": {
       "version": "0.11.2",
       "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-0.11.2.tgz",
       "integrity": "sha512-N+uhF3mswIFeziHQjGScJ/yHXYt3DiLBeC+9vWW+WjUBiClMSOlV1YrXQi+7KM2aA3Rn4Bybgv+uXFQbfkzpvg==",
       "dev": true,
+      "requires": {
+        "loader-utils": "1.1.0"
+      },
       "dependencies": {
         "loader-utils": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
           "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "big.js": "3.1.3",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1"
+          }
         }
       }
     },
@@ -2227,19 +3357,38 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
       "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-number": "2.1.0",
+        "isobject": "2.1.0",
+        "randomatic": "1.1.7",
+        "repeat-element": "1.1.2",
+        "repeat-string": "1.6.1"
+      }
     },
     "finalhandler": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.3.tgz",
       "integrity": "sha1-70fneVDpmXgOhgIqVg4yF+DQzIk=",
       "dev": true,
+      "requires": {
+        "debug": "2.6.7",
+        "encodeurl": "1.0.1",
+        "escape-html": "1.0.3",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.1",
+        "statuses": "1.3.1",
+        "unpipe": "1.0.0"
+      },
       "dependencies": {
         "debug": {
           "version": "2.6.7",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
           "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
         },
         "ms": {
           "version": "2.0.0",
@@ -2253,25 +3402,46 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
       "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "commondir": "1.0.1",
+        "mkdirp": "0.5.1",
+        "pkg-dir": "1.0.0"
+      }
     },
     "find-up": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "path-exists": "2.1.0",
+        "pinkie-promise": "2.0.1"
+      }
     },
     "findup-sync": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.4.3.tgz",
       "integrity": "sha1-QAQ5Kee8YK3wt/SCfExudaDeyhI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "detect-file": "0.1.0",
+        "is-glob": "2.0.1",
+        "micromatch": "2.3.11",
+        "resolve-dir": "0.1.1"
+      }
     },
     "flat-cache": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
       "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "circular-json": "0.3.1",
+        "del": "2.2.2",
+        "graceful-fs": "4.1.11",
+        "write": "0.2.1"
+      }
     },
     "flatten": {
       "version": "1.0.2",
@@ -2282,7 +3452,11 @@
     "follow-redirects": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-0.0.7.tgz",
-      "integrity": "sha1-NLkLqyqRGqNHVx2pDyK9NuzYqRk="
+      "integrity": "sha1-NLkLqyqRGqNHVx2pDyK9NuzYqRk=",
+      "requires": {
+        "debug": "2.3.3",
+        "stream-consume": "0.1.0"
+      }
     },
     "for-in": {
       "version": "1.0.2",
@@ -2294,7 +3468,10 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "for-in": "1.0.2"
+      }
     },
     "foreach": {
       "version": "2.0.5",
@@ -2311,13 +3488,21 @@
     "form-data": {
       "version": "1.0.0-rc3",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc3.tgz",
-      "integrity": "sha1-01vGLn+8KTeuePlIqqDTjZBgdXc="
+      "integrity": "sha1-01vGLn+8KTeuePlIqqDTjZBgdXc=",
+      "requires": {
+        "async": "1.5.2",
+        "combined-stream": "1.0.5",
+        "mime-types": "2.1.15"
+      }
     },
     "formatio": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
       "integrity": "sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "samsam": "1.1.2"
+      }
     },
     "formidable": {
       "version": "1.0.17",
@@ -2346,7 +3531,14 @@
       "version": "0.26.7",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz",
       "integrity": "sha1-muH92UiXeY7at20JGM9C0MMYT6k=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "jsonfile": "2.4.0",
+        "klaw": "1.3.1",
+        "path-is-absolute": "1.0.1",
+        "rimraf": "2.5.4"
+      }
     },
     "fs-readdir-recursive": {
       "version": "1.0.0",
@@ -2366,6 +3558,10 @@
       "integrity": "sha512-Sn44E5wQW4bTHXvQmvSHwqbuiXtduD6Rrjm2ZtUEGbyrig+nUH3t/QD4M4/ZXViY556TBpRgZkHLDx3JxPwxiw==",
       "dev": true,
       "optional": true,
+      "requires": {
+        "nan": "2.6.2",
+        "node-pre-gyp": "0.6.36"
+      },
       "dependencies": {
         "abbrev": {
           "version": "1.1.0",
@@ -2379,7 +3575,11 @@
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
           "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "co": "4.6.0",
+            "json-stable-stringify": "1.0.1"
+          }
         },
         "ansi-regex": {
           "version": "2.1.1",
@@ -2399,7 +3599,11 @@
           "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
           "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "delegates": "1.0.0",
+            "readable-stream": "2.2.9"
+          }
         },
         "asn1": {
           "version": "0.2.3",
@@ -2447,25 +3651,38 @@
           "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
           "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "tweetnacl": "0.14.5"
+          }
         },
         "block-stream": {
           "version": "0.0.9",
           "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
           "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "inherits": "2.0.3"
+          }
         },
         "boom": {
           "version": "2.10.1",
           "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
           "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
         },
         "brace-expansion": {
           "version": "1.1.7",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
           "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "balanced-match": "0.4.2",
+            "concat-map": "0.0.1"
+          }
         },
         "buffer-shims": {
           "version": "1.0.0",
@@ -2497,7 +3714,10 @@
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
           "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "delayed-stream": "1.0.0"
+          }
         },
         "concat-map": {
           "version": "0.0.1",
@@ -2522,7 +3742,10 @@
           "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
           "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "boom": "2.10.1"
+          }
         },
         "dashdash": {
           "version": "1.14.1",
@@ -2530,6 +3753,9 @@
           "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
           "dev": true,
           "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
@@ -2545,7 +3771,10 @@
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
           "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
         },
         "deep-extend": {
           "version": "0.4.2",
@@ -2572,7 +3801,10 @@
           "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
           "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
         },
         "extend": {
           "version": "3.0.1",
@@ -2599,7 +3831,12 @@
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
           "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.15"
+          }
         },
         "fs.realpath": {
           "version": "1.0.0",
@@ -2611,21 +3848,42 @@
           "version": "1.0.11",
           "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
           "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "inherits": "2.0.3",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.1"
+          }
         },
         "fstream-ignore": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
           "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "fstream": "1.0.11",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4"
+          }
         },
         "gauge": {
           "version": "2.7.4",
           "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
           "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "aproba": "1.1.1",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
+          }
         },
         "getpass": {
           "version": "0.1.7",
@@ -2633,6 +3891,9 @@
           "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
           "dev": true,
           "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
@@ -2647,7 +3908,15 @@
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
         },
         "graceful-fs": {
           "version": "4.1.11",
@@ -2667,7 +3936,11 @@
           "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
           "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "ajv": "4.11.8",
+            "har-schema": "1.0.5"
+          }
         },
         "has-unicode": {
           "version": "2.0.1",
@@ -2681,7 +3954,13 @@
           "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
           "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
+          }
         },
         "hoek": {
           "version": "2.16.3",
@@ -2694,13 +3973,22 @@
           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
           "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.0",
+            "sshpk": "1.13.0"
+          }
         },
         "inflight": {
           "version": "1.0.6",
           "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
         },
         "inherits": {
           "version": "2.0.3",
@@ -2719,7 +4007,10 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
         },
         "is-typedarray": {
           "version": "1.0.0",
@@ -2746,7 +4037,10 @@
           "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
           "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
         },
         "jsbn": {
           "version": "0.1.1",
@@ -2767,7 +4061,10 @@
           "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
           "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "jsonify": "0.0.0"
+          }
         },
         "json-stringify-safe": {
           "version": "5.0.1",
@@ -2789,6 +4086,12 @@
           "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
           "dev": true,
           "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.0.2",
+            "json-schema": "0.2.3",
+            "verror": "1.3.6"
+          },
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
@@ -2809,13 +4112,19 @@
           "version": "2.1.15",
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
           "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "mime-db": "1.27.0"
+          }
         },
         "minimatch": {
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.7"
+          }
         },
         "minimist": {
           "version": "0.0.8",
@@ -2827,7 +4136,10 @@
           "version": "0.5.1",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
         },
         "ms": {
           "version": "2.0.0",
@@ -2841,21 +4153,42 @@
           "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.36.tgz",
           "integrity": "sha1-22BBEst04NR3VU6bUFsXq936t4Y=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "mkdirp": "0.5.1",
+            "nopt": "4.0.1",
+            "npmlog": "4.1.0",
+            "rc": "1.2.1",
+            "request": "2.81.0",
+            "rimraf": "2.6.1",
+            "semver": "5.3.0",
+            "tar": "2.2.1",
+            "tar-pack": "3.4.0"
+          }
         },
         "nopt": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
           "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "abbrev": "1.1.0",
+            "osenv": "0.1.4"
+          }
         },
         "npmlog": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz",
           "integrity": "sha512-ocolIkZYZt8UveuiDS0yAkkIjid1o7lPG8cYm05yNYzBn8ykQtaiPMEGp8fY9tKdDgm8okpdKzkvu1y9hUYugA==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
+          }
         },
         "number-is-nan": {
           "version": "1.0.1",
@@ -2881,7 +4214,10 @@
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
         },
         "os-homedir": {
           "version": "1.0.2",
@@ -2902,7 +4238,11 @@
           "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
           "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
         },
         "path-is-absolute": {
           "version": "1.0.1",
@@ -2943,6 +4283,12 @@
           "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
           "dev": true,
           "optional": true,
+          "requires": {
+            "deep-extend": "0.4.2",
+            "ini": "1.3.4",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
+          },
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
@@ -2957,20 +4303,56 @@
           "version": "2.2.9",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
           "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "buffer-shims": "1.0.0",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "1.0.1",
+            "util-deprecate": "1.0.2"
+          }
         },
         "request": {
           "version": "2.81.0",
           "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
           "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "4.2.1",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.15",
+            "oauth-sign": "0.8.2",
+            "performance-now": "0.2.0",
+            "qs": "6.4.0",
+            "safe-buffer": "5.0.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.2",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.0.1"
+          }
         },
         "rimraf": {
           "version": "2.6.1",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
           "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
         },
         "safe-buffer": {
           "version": "5.0.1",
@@ -3004,7 +4386,10 @@
           "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
           "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
         },
         "sshpk": {
           "version": "1.13.0",
@@ -3012,6 +4397,17 @@
           "integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
           "dev": true,
           "optional": true,
+          "requires": {
+            "asn1": "0.2.3",
+            "assert-plus": "1.0.0",
+            "bcrypt-pbkdf": "1.0.1",
+            "dashdash": "1.14.1",
+            "ecc-jsbn": "0.1.1",
+            "getpass": "0.1.7",
+            "jodid25519": "1.0.2",
+            "jsbn": "0.1.1",
+            "tweetnacl": "0.14.5"
+          },
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
@@ -3026,13 +4422,21 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
           "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
         },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
         },
         "stringstream": {
           "version": "0.0.5",
@@ -3045,7 +4449,10 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
         },
         "strip-json-comments": {
           "version": "2.0.1",
@@ -3058,28 +4465,49 @@
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
           "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "block-stream": "0.0.9",
+            "fstream": "1.0.11",
+            "inherits": "2.0.3"
+          }
         },
         "tar-pack": {
           "version": "3.4.0",
           "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz",
           "integrity": "sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "debug": "2.6.8",
+            "fstream": "1.0.11",
+            "fstream-ignore": "1.0.5",
+            "once": "1.4.0",
+            "readable-stream": "2.2.9",
+            "rimraf": "2.6.1",
+            "tar": "2.2.1",
+            "uid-number": "0.0.6"
+          }
         },
         "tough-cookie": {
           "version": "2.3.2",
           "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
           "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "punycode": "1.4.1"
+          }
         },
         "tunnel-agent": {
           "version": "0.6.0",
           "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
           "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
         },
         "tweetnacl": {
           "version": "0.14.5",
@@ -3113,14 +4541,20 @@
           "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
           "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "extsprintf": "1.0.2"
+          }
         },
         "wide-align": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
           "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "string-width": "1.0.2"
+          }
         },
         "wrappy": {
           "version": "1.0.2",
@@ -3140,7 +4574,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.0.0.tgz",
       "integrity": "sha1-X1I8pk5JGl+Vq6gMweORCAoUSC4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2",
+        "function-bind": "1.1.0",
+        "is-callable": "1.1.3"
+      }
     },
     "generate-function": {
       "version": "2.0.0",
@@ -3152,7 +4591,10 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-property": "1.0.2"
+      }
     },
     "get-caller-file": {
       "version": "1.0.2",
@@ -3165,6 +4607,9 @@
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -3178,37 +4623,66 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
     },
     "glob-base": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "glob-parent": "2.0.0",
+        "is-glob": "2.0.1"
+      }
     },
     "glob-parent": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-glob": "2.0.1"
+      }
     },
     "global": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
       "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "min-document": "2.19.0",
+        "process": "0.5.2"
+      }
     },
     "global-modules": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
       "integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "global-prefix": "0.1.5",
+        "is-windows": "0.2.0"
+      }
     },
     "global-prefix": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
       "integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "homedir-polyfill": "1.0.1",
+        "ini": "1.3.4",
+        "is-windows": "0.2.0",
+        "which": "1.2.14"
+      }
     },
     "globals": {
       "version": "9.18.0",
@@ -3220,7 +4694,15 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "array-union": "1.0.2",
+        "arrify": "1.0.1",
+        "glob": "7.1.2",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
+      }
     },
     "graceful-fs": {
       "version": "4.1.11",
@@ -3250,24 +4732,37 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
       "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ajv": "4.11.8",
+        "har-schema": "1.0.5"
+      }
     },
     "has": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "function-bind": "1.1.0"
+      }
     },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
     },
     "has-binary": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz",
-      "integrity": "sha1-aOYesWIQyVRaClzOBqhzkS/h5ow="
+      "integrity": "sha1-aOYesWIQyVRaClzOBqhzkS/h5ow=",
+      "requires": {
+        "isarray": "0.0.1"
+      }
     },
     "has-cors": {
       "version": "1.1.0",
@@ -3284,18 +4779,30 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
       "integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3"
+      }
     },
     "hash.js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz",
-      "integrity": "sha1-EzL/ABVsCg/92CNgE9B7d6BFFXM="
+      "integrity": "sha1-EzL/ABVsCg/92CNgE9B7d6BFFXM=",
+      "requires": {
+        "inherits": "2.0.3"
+      }
     },
     "hawk": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
       "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "boom": "2.10.1",
+        "cryptiles": "2.0.5",
+        "hoek": "2.16.3",
+        "sntp": "1.0.9"
+      }
     },
     "he": {
       "version": "1.1.1",
@@ -3311,13 +4818,24 @@
     "history": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/history/-/history-2.1.2.tgz",
-      "integrity": "sha1-SqLeiXoOSGfkU5hDvm7Nsphr/ew="
+      "integrity": "sha1-SqLeiXoOSGfkU5hDvm7Nsphr/ew=",
+      "requires": {
+        "deep-equal": "1.0.1",
+        "invariant": "2.2.2",
+        "query-string": "3.0.3",
+        "warning": "2.1.0"
+      }
     },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "hash.js": "1.0.3",
+        "minimalistic-assert": "1.0.0",
+        "minimalistic-crypto-utils": "1.0.1"
+      }
     },
     "hoek": {
       "version": "2.16.3",
@@ -3334,13 +4852,20 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
       "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
+      }
     },
     "homedir-polyfill": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
       "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "parse-passwd": "1.0.0"
+      }
     },
     "hosted-git-info": {
       "version": "2.4.2",
@@ -3358,7 +4883,10 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.1.tgz",
       "integrity": "sha1-eb96eF6klf5mFl5zQVPzY/9UN9o=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "whatwg-encoding": "1.0.1"
+      }
     },
     "html-entities": {
       "version": "1.2.1",
@@ -3370,13 +4898,31 @@
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.2.tgz",
       "integrity": "sha1-1zvD/0SJQkCIGM5gm/P7DqfvTrc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "camel-case": "3.0.0",
+        "clean-css": "4.1.4",
+        "commander": "2.9.0",
+        "he": "1.1.1",
+        "ncname": "1.0.0",
+        "param-case": "2.1.1",
+        "relateurl": "0.2.7",
+        "uglify-js": "3.0.18"
+      }
     },
     "html-webpack-plugin": {
       "version": "2.28.0",
       "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-2.28.0.tgz",
       "integrity": "sha1-LnhjtX5f1I/iYzA+L/yTTDBk0Ak=",
       "dev": true,
+      "requires": {
+        "bluebird": "3.5.0",
+        "html-minifier": "3.5.2",
+        "loader-utils": "0.2.17",
+        "lodash": "4.17.4",
+        "pretty-error": "2.1.1",
+        "toposort": "1.0.3"
+      },
       "dependencies": {
         "bluebird": {
           "version": "3.5.0",
@@ -3391,6 +4937,13 @@
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
       "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
       "dev": true,
+      "requires": {
+        "domelementtype": "1.3.0",
+        "domhandler": "2.3.0",
+        "domutils": "1.5.1",
+        "entities": "1.0.0",
+        "readable-stream": "1.1.14"
+      },
       "dependencies": {
         "entities": {
           "version": "1.0.0",
@@ -3402,7 +4955,13 @@
           "version": "1.1.14",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
         }
       }
     },
@@ -3410,13 +4969,24 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.1.tgz",
       "integrity": "sha1-X4uO2YrKVFZWv1cplzh/kEpyIlc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "depd": "1.1.0",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.0.3",
+        "statuses": "1.3.1"
+      }
     },
     "http-signature": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
       "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "assert-plus": "0.2.0",
+        "jsprim": "1.4.0",
+        "sshpk": "1.13.1"
+      }
     },
     "https-browserify": {
       "version": "0.0.1",
@@ -3429,6 +4999,11 @@
       "resolved": "https://registry.npmjs.org/iced-coffee-script/-/iced-coffee-script-1.8.0-e.tgz",
       "integrity": "sha1-6dPhe4cPyoF5/Q9iVOJ2GvzloTY=",
       "dev": true,
+      "requires": {
+        "docco": "0.6.3",
+        "iced-runtime": "1.0.3",
+        "mkdirp": "0.3.5"
+      },
       "dependencies": {
         "mkdirp": {
           "version": "0.3.5",
@@ -3460,18 +5035,29 @@
       "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-2.1.0.tgz",
       "integrity": "sha1-g/Cg7DeL8yRheLbCrZE28TWxyWI=",
       "dev": true,
+      "requires": {
+        "postcss": "6.0.2"
+      },
       "dependencies": {
         "postcss": {
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.2.tgz",
           "integrity": "sha1-XE/qWJ8Kw7AMqnWxy8OihBlbfl0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3",
+            "source-map": "0.5.6",
+            "supports-color": "3.2.3"
+          }
         },
         "supports-color": {
           "version": "3.2.3",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "has-flag": "1.0.0"
+          }
         }
       }
     },
@@ -3514,7 +5100,11 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
     },
     "inherits": {
       "version": "2.0.3",
@@ -3531,7 +5121,22 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
       "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "1.4.0",
+        "ansi-regex": "2.1.1",
+        "chalk": "1.1.3",
+        "cli-cursor": "1.0.2",
+        "cli-width": "2.1.0",
+        "figures": "1.7.0",
+        "lodash": "4.17.4",
+        "readline2": "1.0.1",
+        "run-async": "0.1.0",
+        "rx-lite": "3.1.2",
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "through": "2.3.8"
+      }
     },
     "interpret": {
       "version": "1.0.3",
@@ -3542,7 +5147,10 @@
     "invariant": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-      "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A="
+      "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
+      "requires": {
+        "loose-envify": "1.3.1"
+      }
     },
     "invert-kv": {
       "version": "1.0.0",
@@ -3572,7 +5180,10 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "binary-extensions": "1.8.0"
+      }
     },
     "is-buffer": {
       "version": "1.1.5",
@@ -3584,7 +5195,10 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "builtin-modules": "1.1.1"
+      }
     },
     "is-callable": {
       "version": "1.1.3",
@@ -3608,7 +5222,10 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-primitive": "2.0.0"
+      }
     },
     "is-extendable": {
       "version": "0.1.1",
@@ -3626,31 +5243,49 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
     },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
     },
     "is-glob": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-extglob": "1.0.0"
+      }
     },
     "is-my-json-valid": {
       "version": "2.16.0",
       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
       "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "generate-function": "2.0.0",
+        "generate-object-property": "1.2.0",
+        "jsonpointer": "4.0.1",
+        "xtend": "4.0.1"
+      }
     },
     "is-number": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2"
+      }
     },
     "is-path-cwd": {
       "version": "1.0.0",
@@ -3662,13 +5297,19 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
       "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-path-inside": "1.0.0"
+      }
     },
     "is-path-inside": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
       "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "path-is-inside": "1.0.2"
+      }
     },
     "is-plain-obj": {
       "version": "1.1.0",
@@ -3698,13 +5339,19 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "has": "1.0.1"
+      }
     },
     "is-resolvable": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
       "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "tryit": "1.0.3"
+      }
     },
     "is-stream": {
       "version": "1.1.0",
@@ -3721,7 +5368,10 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-2.1.0.tgz",
       "integrity": "sha1-z2EJDaDZ77yrhyLeum8DIgjbsOk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "html-comment-regex": "1.1.1"
+      }
     },
     "is-symbol": {
       "version": "1.0.1",
@@ -3763,6 +5413,9 @@
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
       "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
       "dev": true,
+      "requires": {
+        "isarray": "1.0.0"
+      },
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
@@ -3775,7 +5428,11 @@
     "isomorphic-fetch": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk="
+      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "requires": {
+        "node-fetch": "1.7.1",
+        "whatwg-fetch": "2.0.3"
+      }
     },
     "isstream": {
       "version": "0.1.2",
@@ -3798,7 +5455,11 @@
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
       "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "argparse": "1.0.9",
+        "esprima": "2.7.3"
+      }
     },
     "jsbn": {
       "version": "0.1.1",
@@ -3812,6 +5473,27 @@
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-9.12.0.tgz",
       "integrity": "sha1-6MVG//ywbADUgzyoRBD+1/igl9Q=",
       "dev": true,
+      "requires": {
+        "abab": "1.0.3",
+        "acorn": "4.0.13",
+        "acorn-globals": "3.1.0",
+        "array-equal": "1.0.0",
+        "content-type-parser": "1.0.1",
+        "cssom": "0.3.2",
+        "cssstyle": "0.2.37",
+        "escodegen": "1.8.1",
+        "html-encoding-sniffer": "1.0.1",
+        "nwmatcher": "1.4.1",
+        "parse5": "1.5.1",
+        "request": "2.81.0",
+        "sax": "1.2.2",
+        "symbol-tree": "3.2.2",
+        "tough-cookie": "2.3.2",
+        "webidl-conversions": "4.0.1",
+        "whatwg-encoding": "1.0.1",
+        "whatwg-url": "4.8.0",
+        "xml-name-validator": "2.0.1"
+      },
       "dependencies": {
         "acorn": {
           "version": "4.0.13",
@@ -3823,7 +5505,10 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-3.1.0.tgz",
           "integrity": "sha1-/YJw9x+7SZawBPqIDuXUZXOnMb8=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "acorn": "4.0.13"
+          }
         },
         "webidl-conversions": {
           "version": "4.0.1",
@@ -3842,7 +5527,11 @@
     "json-api-client": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/json-api-client/-/json-api-client-3.2.1.tgz",
-      "integrity": "sha1-VZ1BDu37+RUboxHYLeDtbHkqkDs="
+      "integrity": "sha1-VZ1BDu37+RUboxHYLeDtbHkqkDs=",
+      "requires": {
+        "normalizeurl": "0.1.3",
+        "superagent": "1.8.5"
+      }
     },
     "json-loader": {
       "version": "0.5.4",
@@ -3866,7 +5555,10 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "jsonify": "0.0.0"
+      }
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -3890,7 +5582,10 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11"
+      }
     },
     "jsonify": {
       "version": "0.0.0",
@@ -3909,6 +5604,12 @@
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
       "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
       "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.0.2",
+        "json-schema": "0.2.3",
+        "verror": "1.3.6"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -3934,13 +5635,19 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-buffer": "1.1.5"
+      }
     },
     "klaw": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11"
+      }
     },
     "lazy-cache": {
       "version": "1.0.4",
@@ -3952,30 +5659,50 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "invert-kv": "1.0.0"
+      }
     },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
+      }
     },
     "linkify-it": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.0.3.tgz",
-      "integrity": "sha1-2UpGSPmxwXnWT6lykSaL22zpQ08="
+      "integrity": "sha1-2UpGSPmxwXnWT6lykSaL22zpQ08=",
+      "requires": {
+        "uc.micro": "1.0.3"
+      }
     },
     "load-json-file": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "parse-json": "2.2.0",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "strip-bom": "2.0.0"
+      },
       "dependencies": {
         "strip-bom": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-utf8": "0.2.1"
+          }
         }
       }
     },
@@ -3989,7 +5716,13 @@
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
       "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "big.js": "3.1.3",
+        "emojis-list": "2.1.0",
+        "json5": "0.5.1",
+        "object-assign": "4.1.1"
+      }
     },
     "local-storage": {
       "version": "1.4.2",
@@ -4010,6 +5743,10 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
       "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+      "requires": {
+        "lodash._basecopy": "3.0.1",
+        "lodash.keys": "3.1.2"
+      },
       "dependencies": {
         "lodash.isarray": {
           "version": "3.0.4",
@@ -4019,7 +5756,12 @@
         "lodash.keys": {
           "version": "3.1.2",
           "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-          "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo="
+          "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+          "requires": {
+            "lodash._getnative": "3.9.1",
+            "lodash.isarguments": "3.1.0",
+            "lodash.isarray": "3.0.4"
+          }
         }
       }
     },
@@ -4036,7 +5778,12 @@
     "lodash._createassigner": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
-      "integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE="
+      "integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE=",
+      "requires": {
+        "lodash._bindcallback": "3.0.1",
+        "lodash._isiterateecall": "3.0.9",
+        "lodash.restparam": "3.6.1"
+      }
     },
     "lodash._getnative": {
       "version": "3.9.1",
@@ -4051,7 +5798,29 @@
     "lodash.assign": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
-      "integrity": "sha1-POnwI0tLIiPilrj6CsH+6OvKZPo="
+      "integrity": "sha1-POnwI0tLIiPilrj6CsH+6OvKZPo=",
+      "requires": {
+        "lodash._baseassign": "3.2.0",
+        "lodash._createassigner": "3.1.1",
+        "lodash.keys": "3.1.2"
+      },
+      "dependencies": {
+        "lodash.isarray": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+          "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
+        },
+        "lodash.keys": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+          "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+          "requires": {
+            "lodash._getnative": "3.9.1",
+            "lodash.isarguments": "3.1.0",
+            "lodash.isarray": "3.0.4"
+          }
+        }
+      }
     },
     "lodash.camelcase": {
       "version": "4.3.0",
@@ -4076,6 +5845,11 @@
       "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
       "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
       "dev": true,
+      "requires": {
+        "lodash._baseassign": "3.2.0",
+        "lodash._basecreate": "3.0.3",
+        "lodash._isiterateecall": "3.0.9"
+      },
       "dependencies": {
         "lodash._basecreate": {
           "version": "3.0.3",
@@ -4089,16 +5863,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
       "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
-    },
-    "lodash.isarray": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
-    },
-    "lodash.keys": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo="
     },
     "lodash.memoize": {
       "version": "4.1.2",
@@ -4126,7 +5890,10 @@
     "loose-envify": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg="
+      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+      "requires": {
+        "js-tokens": "3.0.1"
+      }
     },
     "lower-case": {
       "version": "1.1.4",
@@ -4138,7 +5905,11 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
       "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
+      }
     },
     "macaddress": {
       "version": "0.2.8",
@@ -4149,12 +5920,22 @@
     "markdown-it": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-7.0.1.tgz",
-      "integrity": "sha1-8S2LiKk+ZCVDSN/Rg71wv2BWekI="
+      "integrity": "sha1-8S2LiKk+ZCVDSN/Rg71wv2BWekI=",
+      "requires": {
+        "argparse": "1.0.9",
+        "entities": "1.1.1",
+        "linkify-it": "2.0.3",
+        "mdurl": "1.0.1",
+        "uc.micro": "1.0.3"
+      }
     },
     "markdown-it-anchor": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-2.5.1.tgz",
-      "integrity": "sha1-h+O7K1rZWv8m46Bdy4T/TPJV0PM="
+      "integrity": "sha1-h+O7K1rZWv8m46Bdy4T/TPJV0PM=",
+      "requires": {
+        "string": "3.3.3"
+      }
     },
     "markdown-it-container": {
       "version": "2.0.0",
@@ -4190,6 +5971,10 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/markdown-it-table-of-contents/-/markdown-it-table-of-contents-0.2.3.tgz",
       "integrity": "sha1-j2FnED80mDSu2yjWmj7XG665gjc=",
+      "requires": {
+        "lodash.assign": "3.2.0",
+        "string": "3.1.3"
+      },
       "dependencies": {
         "string": {
           "version": "3.1.3",
@@ -4206,7 +5991,22 @@
     "markdownz": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/markdownz/-/markdownz-7.3.1.tgz",
-      "integrity": "sha512-Z2QKQe7tavl1jIl50LvnCFcEjv9b9s5oal+cpyAjRzi24yrmGvq3pumF3Q//ca76jRad6SsiVHIYhJwNzdoCqQ=="
+      "integrity": "sha512-Z2QKQe7tavl1jIl50LvnCFcEjv9b9s5oal+cpyAjRzi24yrmGvq3pumF3Q//ca76jRad6SsiVHIYhJwNzdoCqQ==",
+      "requires": {
+        "markdown-it": "7.0.1",
+        "markdown-it-anchor": "2.5.1",
+        "markdown-it-container": "2.0.0",
+        "markdown-it-emoji": "1.2.0",
+        "markdown-it-footnote": "3.0.1",
+        "markdown-it-imsize": "2.0.1",
+        "markdown-it-sub": "1.0.0",
+        "markdown-it-sup": "1.0.0",
+        "markdown-it-table-of-contents": "0.2.3",
+        "markdown-it-video": "0.4.0",
+        "react": "15.4.2",
+        "react-dom": "15.4.2",
+        "twemoji": "1.4.1"
+      }
     },
     "marked": {
       "version": "0.3.6",
@@ -4236,6 +6036,10 @@
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
       "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
       "dev": true,
+      "requires": {
+        "errno": "0.1.4",
+        "readable-stream": "2.3.0"
+      },
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
@@ -4247,13 +6051,25 @@
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.0.tgz",
           "integrity": "sha512-c7KMXGd4b48nN3OJ1U9qOsn6pXNzf6kLd3kdZCkg2sxAcoiufInqF0XckwEnlrcwuaYwonlNK8GQUIOC/WC7sg==",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.0",
+            "string_decoder": "1.0.2",
+            "util-deprecate": "1.0.2"
+          }
         },
         "string_decoder": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
           "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
           "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          },
           "dependencies": {
             "safe-buffer": {
               "version": "5.0.1",
@@ -4285,13 +6101,32 @@
       "version": "2.3.11",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "arr-diff": "2.0.0",
+        "array-unique": "0.2.1",
+        "braces": "1.8.5",
+        "expand-brackets": "0.1.5",
+        "extglob": "0.3.2",
+        "filename-regex": "2.0.1",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1",
+        "kind-of": "3.2.2",
+        "normalize-path": "2.1.1",
+        "object.omit": "2.0.1",
+        "parse-glob": "3.0.4",
+        "regex-cache": "0.4.3"
+      }
     },
     "miller-rabin": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.0.tgz",
       "integrity": "sha1-SmL7HUKTPAVYOYL0xxb2+55sbT0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "bn.js": "4.11.6",
+        "brorand": "1.1.0"
+      }
     },
     "mime": {
       "version": "1.3.4",
@@ -4306,18 +6141,27 @@
     "mime-types": {
       "version": "2.1.15",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
-      "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0="
+      "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
+      "requires": {
+        "mime-db": "1.27.0"
+      }
     },
     "min-document": {
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
       "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "dom-walk": "0.1.1"
+      }
     },
     "minilog": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/minilog/-/minilog-3.1.0.tgz",
-      "integrity": "sha1-0tDxiHyjY9Gs8OqG1cTfKTs/tnU="
+      "integrity": "sha1-0tDxiHyjY9Gs8OqG1cTfKTs/tnU=",
+      "requires": {
+        "microee": "0.0.6"
+      }
     },
     "minimalistic-assert": {
       "version": "1.0.0",
@@ -4335,7 +6179,10 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.8"
+      }
     },
     "minimist": {
       "version": "0.0.8",
@@ -4347,25 +6194,52 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
     },
     "mocha": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.1.2.tgz",
       "integrity": "sha1-Ufk7Qyv34bF1/8Iog8zQvjLbprU=",
       "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.0",
+        "commander": "2.9.0",
+        "debug": "2.2.0",
+        "diff": "1.4.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.0.5",
+        "growl": "1.9.2",
+        "json3": "3.3.2",
+        "lodash.create": "3.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "3.1.2"
+      },
       "dependencies": {
         "debug": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "0.7.1"
+          }
         },
         "glob": {
           "version": "7.0.5",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz",
           "integrity": "sha1-tCAqaQmbu00pKnwblbZoK2fr3JU=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
         },
         "ms": {
           "version": "0.7.1",
@@ -4377,7 +6251,10 @@
           "version": "3.1.2",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
           "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "has-flag": "1.0.0"
+          }
         }
       }
     },
@@ -4425,7 +6302,10 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/ncname/-/ncname-1.0.0.tgz",
       "integrity": "sha1-W1etGLHKCShk72Kwse2BlPODtxw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "xml-char-classes": "1.0.0"
+      }
     },
     "negotiator": {
       "version": "0.6.1",
@@ -4437,30 +6317,68 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/nib/-/nib-1.1.2.tgz",
       "integrity": "sha1-amnt5AgblcDe+L4CSkyK4MLLtsc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "stylus": "0.54.5"
+      }
     },
     "no-case": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.1.tgz",
       "integrity": "sha1-euuhxzpSGEJlVUt9wDuvcg34AIE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lower-case": "1.1.4"
+      }
     },
     "node-dir": {
       "version": "0.1.17",
       "resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.17.tgz",
       "integrity": "sha1-X1Zl2TNRM1yqvvjxxVRRbPXx5OU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "minimatch": "3.0.4"
+      }
     },
     "node-fetch": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.1.tgz",
-      "integrity": "sha512-j8XsFGCLw79vWXkZtMSmmLaOk9z5SQ9bV/tkbZVCqvgwzrjAGq66igobLofHtF63NvMTp2WjytpsNTGKa+XRIQ=="
+      "integrity": "sha512-j8XsFGCLw79vWXkZtMSmmLaOk9z5SQ9bV/tkbZVCqvgwzrjAGq66igobLofHtF63NvMTp2WjytpsNTGKa+XRIQ==",
+      "requires": {
+        "encoding": "0.1.12",
+        "is-stream": "1.1.0"
+      }
     },
     "node-libs-browser": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.0.0.tgz",
       "integrity": "sha1-o6WeyXAkmFtG6Vg3lkb5bEthZkY=",
       "dev": true,
+      "requires": {
+        "assert": "1.4.1",
+        "browserify-zlib": "0.1.4",
+        "buffer": "4.9.1",
+        "console-browserify": "1.1.0",
+        "constants-browserify": "1.0.0",
+        "crypto-browserify": "3.11.0",
+        "domain-browser": "1.1.7",
+        "events": "1.1.1",
+        "https-browserify": "0.0.1",
+        "os-browserify": "0.2.1",
+        "path-browserify": "0.0.0",
+        "process": "0.11.10",
+        "punycode": "1.4.1",
+        "querystring-es3": "0.2.1",
+        "readable-stream": "2.3.0",
+        "stream-browserify": "2.0.1",
+        "stream-http": "2.7.2",
+        "string_decoder": "0.10.31",
+        "timers-browserify": "2.0.2",
+        "tty-browserify": "0.0.0",
+        "url": "0.11.0",
+        "util": "0.10.3",
+        "vm-browserify": "0.0.4"
+      },
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
@@ -4479,12 +6397,24 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.0.tgz",
           "integrity": "sha512-c7KMXGd4b48nN3OJ1U9qOsn6pXNzf6kLd3kdZCkg2sxAcoiufInqF0XckwEnlrcwuaYwonlNK8GQUIOC/WC7sg==",
           "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.0",
+            "string_decoder": "1.0.2",
+            "util-deprecate": "1.0.2"
+          },
           "dependencies": {
             "string_decoder": {
               "version": "1.0.2",
               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
               "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
               "dev": true,
+              "requires": {
+                "safe-buffer": "5.0.1"
+              },
               "dependencies": {
                 "safe-buffer": {
                   "version": "5.0.1",
@@ -4502,13 +6432,22 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz",
       "integrity": "sha1-2Bntoqne29H/pWPqQHHZNngilbs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "2.4.2",
+        "is-builtin-module": "1.0.0",
+        "semver": "5.3.0",
+        "validate-npm-package-license": "3.0.1"
+      }
     },
     "normalize-path": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "remove-trailing-separator": "1.0.2"
+      }
     },
     "normalize-range": {
       "version": "0.1.2",
@@ -4521,12 +6460,22 @@
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
       "integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
       "dev": true,
+      "requires": {
+        "object-assign": "4.1.1",
+        "prepend-http": "1.0.4",
+        "query-string": "4.3.4",
+        "sort-keys": "1.1.2"
+      },
       "dependencies": {
         "query-string": {
           "version": "4.3.4",
           "resolved": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
           "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "object-assign": "4.1.1",
+            "strict-uri-encode": "1.1.0"
+          }
         }
       }
     },
@@ -4539,7 +6488,10 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
       "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "boolbase": "1.0.0"
+      }
     },
     "num2fraction": {
       "version": "1.2.2",
@@ -4592,37 +6544,64 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.0.4.tgz",
       "integrity": "sha1-scnMBE7xuf5jYG/BQau7MuFHMMw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2",
+        "function-bind": "1.1.0",
+        "object-keys": "1.0.11"
+      }
     },
     "object.entries": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.0.4.tgz",
       "integrity": "sha1-G/mk3SKI9bM/Opk9JXZh8F0WGl8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2",
+        "es-abstract": "1.7.0",
+        "function-bind": "1.1.0",
+        "has": "1.0.1"
+      }
     },
     "object.omit": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "for-own": "0.1.5",
+        "is-extendable": "0.1.1"
+      }
     },
     "object.values": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.0.4.tgz",
       "integrity": "sha1-5STaCbT2b/Bd9FdUbscqyZ8TBpo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2",
+        "es-abstract": "1.7.0",
+        "function-bind": "1.1.0",
+        "has": "1.0.1"
+      }
     },
     "on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
       "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ee-first": "1.1.1"
+      }
     },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
     },
     "onetime": {
       "version": "1.1.0",
@@ -4634,13 +6613,25 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8",
+        "wordwrap": "0.0.3"
+      }
     },
     "optionator": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
+      "requires": {
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
+      },
       "dependencies": {
         "wordwrap": {
           "version": "1.0.0",
@@ -4671,7 +6662,10 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lcid": "1.0.0"
+      }
     },
     "os-tmpdir": {
       "version": "1.0.2",
@@ -4683,13 +6677,22 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
       "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
+      }
     },
     "output-file-sync": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
       "integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "mkdirp": "0.5.1",
+        "object-assign": "4.1.1"
+      }
     },
     "pako": {
       "version": "0.2.9",
@@ -4700,7 +6703,12 @@
     "panoptes-client": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-2.7.2.tgz",
-      "integrity": "sha1-xYWVYtNgVCaKoxHihVqhZ3EU+oI="
+      "integrity": "sha1-xYWVYtNgVCaKoxHihVqhZ3EU+oI=",
+      "requires": {
+        "json-api-client": "3.2.1",
+        "local-storage": "1.4.2",
+        "sugar-client": "1.0.1"
+      }
     },
     "papaparse": {
       "version": "github:mholt/PapaParse#cada171c8a07bd4d7d2b0175f1e26e8bdc2a3870"
@@ -4709,25 +6717,44 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
       "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "no-case": "2.3.1"
+      }
     },
     "parse-asn1": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
       "integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "asn1.js": "4.9.1",
+        "browserify-aes": "1.0.6",
+        "create-hash": "1.1.3",
+        "evp_bytestokey": "1.0.0",
+        "pbkdf2": "3.0.12"
+      }
     },
     "parse-glob": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "glob-base": "0.3.0",
+        "is-dotfile": "1.0.3",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1"
+      }
     },
     "parse-json": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "error-ex": "1.3.1"
+      }
     },
     "parse-passwd": {
       "version": "1.0.0",
@@ -4744,17 +6771,26 @@
     "parsejson": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.3.tgz",
-      "integrity": "sha1-q343WfIJ7OmUN5c/fQ8fZK4OZKs="
+      "integrity": "sha1-q343WfIJ7OmUN5c/fQ8fZK4OZKs=",
+      "requires": {
+        "better-assert": "1.0.2"
+      }
     },
     "parseqs": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
-      "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0="
+      "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
+      "requires": {
+        "better-assert": "1.0.2"
+      }
     },
     "parseuri": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
-      "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo="
+      "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
+      "requires": {
+        "better-assert": "1.0.2"
+      }
     },
     "parseurl": {
       "version": "1.3.1",
@@ -4772,7 +6808,10 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "pinkie-promise": "2.0.1"
+      }
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -4802,13 +6841,25 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
+      }
     },
     "pbkdf2": {
       "version": "3.0.12",
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.12.tgz",
       "integrity": "sha1-vjZ4XFBn6kjYBv+SMojF91C2uKI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "create-hash": "1.1.3",
+        "create-hmac": "1.1.6",
+        "ripemd160": "2.0.1",
+        "safe-buffer": "5.1.0",
+        "sha.js": "2.4.8"
+      }
     },
     "performance-now": {
       "version": "0.2.0",
@@ -4832,19 +6883,28 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "pinkie": "2.0.4"
+      }
     },
     "pkg-dir": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
       "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "find-up": "1.1.2"
+      }
     },
     "pkg-up": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-1.0.0.tgz",
       "integrity": "sha1-Pgj7RhUlxEIWJKM7n35tCvWwWiY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "find-up": "1.1.2"
+      }
     },
     "pluralize": {
       "version": "1.2.1",
@@ -4861,12 +6921,21 @@
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
       "integrity": "sha1-z09Ze4ZNZcikkrLqvp1wbIecOIs=",
       "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "js-base64": "2.1.9",
+        "source-map": "0.5.6",
+        "supports-color": "3.2.3"
+      },
       "dependencies": {
         "supports-color": {
           "version": "3.2.3",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "has-flag": "1.0.0"
+          }
         }
       }
     },
@@ -4874,73 +6943,122 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.3.1.tgz",
       "integrity": "sha1-d7rnypKK2FcW4v2kLyYb98HWW14=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.17",
+        "postcss-message-helpers": "2.0.0",
+        "reduce-css-calc": "1.3.0"
+      }
     },
     "postcss-colormin": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.2.2.tgz",
       "integrity": "sha1-ZjFBfV8OkJo9fsJrJMio0eT5bks=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "colormin": "1.1.2",
+        "postcss": "5.2.17",
+        "postcss-value-parser": "3.3.0"
+      }
     },
     "postcss-convert-values": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.6.1.tgz",
       "integrity": "sha1-u9hZPFwf0uPRwyK7kl3K6Nrk1i0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.17",
+        "postcss-value-parser": "3.3.0"
+      }
     },
     "postcss-discard-comments": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz",
       "integrity": "sha1-vv6J+v1bPazlzM5Rt2uBUUvgDj0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.17"
+      }
     },
     "postcss-discard-duplicates": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.1.0.tgz",
       "integrity": "sha1-uavye4isGIFYpesSq8riAmO5GTI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.17"
+      }
     },
     "postcss-discard-empty": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz",
       "integrity": "sha1-0rS9nVztXr2Nyt52QMfXzX9PkrU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.17"
+      }
     },
     "postcss-discard-overridden": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz",
       "integrity": "sha1-ix6vVU9ob7KIzYdMVWZ7CqNmjVg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.17"
+      }
     },
     "postcss-discard-unused": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz",
       "integrity": "sha1-vOMLLMWR/8Y0Mitfs0ZLbZNPRDM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.17",
+        "uniqs": "2.0.0"
+      }
     },
     "postcss-filter-plugins": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.2.tgz",
       "integrity": "sha1-bYWGJTTXNaxCDkqFgG4fXUKG2Ew=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.17",
+        "uniqid": "4.1.1"
+      }
     },
     "postcss-merge-idents": {
       "version": "2.1.7",
       "resolved": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz",
       "integrity": "sha1-TFUwMTwI4dWzu/PSu8dH4njuonA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "has": "1.0.1",
+        "postcss": "5.2.17",
+        "postcss-value-parser": "3.3.0"
+      }
     },
     "postcss-merge-longhand": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.2.tgz",
       "integrity": "sha1-I9kM0Sewp3mUkVMyc5A0oaTz1lg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.17"
+      }
     },
     "postcss-merge-rules": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.1.2.tgz",
       "integrity": "sha1-0d9d+qexrMO+VT8OnhDofGG19yE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "browserslist": "1.7.7",
+        "caniuse-api": "1.6.1",
+        "postcss": "5.2.17",
+        "postcss-selector-parser": "2.2.3",
+        "vendors": "1.0.1"
+      }
     },
     "postcss-message-helpers": {
       "version": "2.0.0",
@@ -4952,43 +7070,75 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz",
       "integrity": "sha1-S1jttWZB66fIR0qzUmyv17vey2k=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "object-assign": "4.1.1",
+        "postcss": "5.2.17",
+        "postcss-value-parser": "3.3.0"
+      }
     },
     "postcss-minify-gradients": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz",
       "integrity": "sha1-Xb2hE3NwP4PPtKPqOIHY11/15uE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.17",
+        "postcss-value-parser": "3.3.0"
+      }
     },
     "postcss-minify-params": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.2.2.tgz",
       "integrity": "sha1-rSzgcTc7lDs9kwo/pZo1jCjW8fM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "alphanum-sort": "1.0.2",
+        "postcss": "5.2.17",
+        "postcss-value-parser": "3.3.0",
+        "uniqs": "2.0.0"
+      }
     },
     "postcss-minify-selectors": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.1.1.tgz",
       "integrity": "sha1-ssapjAByz5G5MtGkllCBFDEXNb8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "alphanum-sort": "1.0.2",
+        "has": "1.0.1",
+        "postcss": "5.2.17",
+        "postcss-selector-parser": "2.2.3"
+      }
     },
     "postcss-modules-extract-imports": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.1.0.tgz",
       "integrity": "sha1-thTJcgvmgW6u41+zpfqh26agXds=",
       "dev": true,
+      "requires": {
+        "postcss": "6.0.2"
+      },
       "dependencies": {
         "postcss": {
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.2.tgz",
           "integrity": "sha1-XE/qWJ8Kw7AMqnWxy8OihBlbfl0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3",
+            "source-map": "0.5.6",
+            "supports-color": "3.2.3"
+          }
         },
         "supports-color": {
           "version": "3.2.3",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "has-flag": "1.0.0"
+          }
         }
       }
     },
@@ -4997,18 +7147,30 @@
       "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz",
       "integrity": "sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=",
       "dev": true,
+      "requires": {
+        "css-selector-tokenizer": "0.7.0",
+        "postcss": "6.0.2"
+      },
       "dependencies": {
         "postcss": {
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.2.tgz",
           "integrity": "sha1-XE/qWJ8Kw7AMqnWxy8OihBlbfl0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3",
+            "source-map": "0.5.6",
+            "supports-color": "3.2.3"
+          }
         },
         "supports-color": {
           "version": "3.2.3",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "has-flag": "1.0.0"
+          }
         }
       }
     },
@@ -5017,18 +7179,30 @@
       "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.1.0.tgz",
       "integrity": "sha1-1upkmUx5+XtipytCb75gVqGUu5A=",
       "dev": true,
+      "requires": {
+        "css-selector-tokenizer": "0.7.0",
+        "postcss": "6.0.2"
+      },
       "dependencies": {
         "postcss": {
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.2.tgz",
           "integrity": "sha1-XE/qWJ8Kw7AMqnWxy8OihBlbfl0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3",
+            "source-map": "0.5.6",
+            "supports-color": "3.2.3"
+          }
         },
         "supports-color": {
           "version": "3.2.3",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "has-flag": "1.0.0"
+          }
         }
       }
     },
@@ -5037,18 +7211,30 @@
       "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.3.0.tgz",
       "integrity": "sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=",
       "dev": true,
+      "requires": {
+        "icss-replace-symbols": "1.1.0",
+        "postcss": "6.0.2"
+      },
       "dependencies": {
         "postcss": {
           "version": "6.0.2",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.2.tgz",
           "integrity": "sha1-XE/qWJ8Kw7AMqnWxy8OihBlbfl0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3",
+            "source-map": "0.5.6",
+            "supports-color": "3.2.3"
+          }
         },
         "supports-color": {
           "version": "3.2.3",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "has-flag": "1.0.0"
+          }
         }
       }
     },
@@ -5056,55 +7242,96 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz",
       "integrity": "sha1-757nEhLX/nWceO0WL2HtYrXLk/E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.17"
+      }
     },
     "postcss-normalize-url": {
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz",
       "integrity": "sha1-EI90s/L82viRov+j6kWSJ5/HgiI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-absolute-url": "2.1.0",
+        "normalize-url": "1.9.1",
+        "postcss": "5.2.17",
+        "postcss-value-parser": "3.3.0"
+      }
     },
     "postcss-ordered-values": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.2.3.tgz",
       "integrity": "sha1-7sbCpntsQSqNsgQud/6NpD+VwR0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.17",
+        "postcss-value-parser": "3.3.0"
+      }
     },
     "postcss-reduce-idents": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz",
       "integrity": "sha1-wsbSDMlYKE9qv75j92Cb9AkFmtM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.17",
+        "postcss-value-parser": "3.3.0"
+      }
     },
     "postcss-reduce-initial": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz",
       "integrity": "sha1-aPgGlfBF0IJjqHmtJA343WT2ROo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "postcss": "5.2.17"
+      }
     },
     "postcss-reduce-transforms": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.4.tgz",
       "integrity": "sha1-/3b02CEkN7McKYpC0uFEQCV3GuE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "has": "1.0.1",
+        "postcss": "5.2.17",
+        "postcss-value-parser": "3.3.0"
+      }
     },
     "postcss-selector-parser": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
       "integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "flatten": "1.0.2",
+        "indexes-of": "1.0.1",
+        "uniq": "1.0.1"
+      }
     },
     "postcss-svgo": {
       "version": "2.1.6",
       "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.6.tgz",
       "integrity": "sha1-tt8YqmE7Zm4TPwittSGcJoSsEI0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-svg": "2.1.0",
+        "postcss": "5.2.17",
+        "postcss-value-parser": "3.3.0",
+        "svgo": "0.7.2"
+      }
     },
     "postcss-unique-selectors": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz",
       "integrity": "sha1-mB1X0p3csz57Hf4f1DuGSfkzyh0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "alphanum-sort": "1.0.2",
+        "postcss": "5.2.17",
+        "uniqs": "2.0.0"
+      }
     },
     "postcss-value-parser": {
       "version": "3.3.0",
@@ -5116,7 +7343,12 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.2.0.tgz",
       "integrity": "sha1-0hCd3AVbka9n/EyzsCWUZjnSryI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "has": "1.0.1",
+        "postcss": "5.2.17",
+        "uniqs": "2.0.0"
+      }
     },
     "prelude-ls": {
       "version": "1.1.2",
@@ -5140,7 +7372,11 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-2.1.1.tgz",
       "integrity": "sha1-X0+HyPkeWuPzuoerTPXgOxoX8aM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "renderkid": "2.0.1",
+        "utila": "0.4.0"
+      }
     },
     "private": {
       "version": "0.1.7",
@@ -5169,18 +7405,29 @@
     "promise": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.0.tgz",
-      "integrity": "sha512-bzAZ0u9Kxa0FYyfISjr9/PK7sCclAzc5rP4UgynMWA2Qv/gpZLKynJmTEXYq2i/giYdjBfRONDhfbsMlGIgvjA=="
+      "integrity": "sha512-bzAZ0u9Kxa0FYyfISjr9/PK7sCclAzc5rP4UgynMWA2Qv/gpZLKynJmTEXYq2i/giYdjBfRONDhfbsMlGIgvjA==",
+      "requires": {
+        "asap": "2.0.5"
+      }
     },
     "prop-types": {
       "version": "15.5.10",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.5.10.tgz",
-      "integrity": "sha1-J5ffwxJhguOpXj37suiT3ddFYVQ="
+      "integrity": "sha1-J5ffwxJhguOpXj37suiT3ddFYVQ=",
+      "requires": {
+        "fbjs": "0.8.12",
+        "loose-envify": "1.3.1"
+      }
     },
     "proxy-addr": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.4.tgz",
       "integrity": "sha1-J+VF9pYKRKYn2bREZ+NcG2tM4vM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "forwarded": "0.1.0",
+        "ipaddr.js": "1.3.0"
+      }
     },
     "prr": {
       "version": "0.0.0",
@@ -5198,13 +7445,28 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
       "integrity": "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "bn.js": "4.11.6",
+        "browserify-rsa": "4.0.1",
+        "create-hash": "1.1.3",
+        "parse-asn1": "5.1.0",
+        "randombytes": "2.0.5"
+      }
     },
     "publisssh": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/publisssh/-/publisssh-1.1.0.tgz",
       "integrity": "sha1-GFQZZA8MuF2ZPJhD+xP/fmbsBIo=",
       "dev": true,
+      "requires": {
+        "aws-sdk": "2.1.50",
+        "chalk": "0.5.1",
+        "iced-coffee-script": "1.8.0-e",
+        "mime": "1.3.4",
+        "optimist": "0.6.1",
+        "wrench": "1.5.9"
+      },
       "dependencies": {
         "ansi-regex": {
           "version": "0.2.1",
@@ -5222,19 +7484,32 @@
           "version": "0.5.1",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
           "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-styles": "1.1.0",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "0.1.0",
+            "strip-ansi": "0.3.0",
+            "supports-color": "0.2.0"
+          }
         },
         "has-ansi": {
           "version": "0.1.0",
           "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
           "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-regex": "0.2.1"
+          }
         },
         "strip-ansi": {
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
           "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-regex": "0.2.1"
+          }
         },
         "supports-color": {
           "version": "0.2.0",
@@ -5253,7 +7528,11 @@
     "pusher-js": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/pusher-js/-/pusher-js-3.2.4.tgz",
-      "integrity": "sha1-Kd/FxY/6V23HGvugeBWj+JWnHcU="
+      "integrity": "sha1-Kd/FxY/6V23HGvugeBWj+JWnHcU=",
+      "requires": {
+        "faye-websocket": "0.9.4",
+        "xmlhttprequest": "1.8.0"
+      }
     },
     "q": {
       "version": "1.5.0",
@@ -5269,7 +7548,10 @@
     "query-string": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/query-string/-/query-string-3.0.3.tgz",
-      "integrity": "sha1-ri4UtNBQcdTpuetIc8NbDc1C5jg="
+      "integrity": "sha1-ri4UtNBQcdTpuetIc8NbDc1C5jg=",
+      "requires": {
+        "strict-uri-encode": "1.1.0"
+      }
     },
     "querystring": {
       "version": "0.2.0",
@@ -5288,18 +7570,28 @@
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
       "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
       "dev": true,
+      "requires": {
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
+      },
       "dependencies": {
         "is-number": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          },
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.5"
+              }
             }
           }
         },
@@ -5307,7 +7599,10 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-buffer": "1.1.5"
+          }
         }
       }
     },
@@ -5315,7 +7610,10 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz",
       "integrity": "sha512-8T7Zn1AhMsQ/HI1SjcCfT/t4ii3eAqco3yOcSzS4mozsOz69lHLsoMXmF9nZgnFanYscnSlUSgs8uZyKzpE6kg==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.0"
+      }
     },
     "range-parser": {
       "version": "1.2.0",
@@ -5327,61 +7625,117 @@
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/rc-align/-/rc-align-2.3.4.tgz",
       "integrity": "sha1-2Dvat1YPAULnKj3h1JXatroiUkk=",
+      "requires": {
+        "dom-align": "1.6.2",
+        "prop-types": "15.5.10",
+        "rc-util": "4.0.4"
+      },
       "dependencies": {
         "rc-util": {
           "version": "4.0.4",
           "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-4.0.4.tgz",
-          "integrity": "sha1-mYE92Qrufim2STmnCsF26tP0/zk="
+          "integrity": "sha1-mYE92Qrufim2STmnCsF26tP0/zk=",
+          "requires": {
+            "add-dom-event-listener": "1.0.2",
+            "babel-runtime": "6.23.0",
+            "shallowequal": "0.2.2"
+          }
         }
       }
     },
     "rc-animate": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/rc-animate/-/rc-animate-2.4.0.tgz",
-      "integrity": "sha1-pRtH2t+K2a8Izd+1sCF7+oGu6AM="
+      "integrity": "sha1-pRtH2t+K2a8Izd+1sCF7+oGu6AM=",
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "css-animation": "1.3.2",
+        "prop-types": "15.5.10"
+      }
     },
     "rc-slider": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/rc-slider/-/rc-slider-3.3.2.tgz",
-      "integrity": "sha1-1dqzZPEUiegMe/ia7euv3JJdZ6U="
+      "integrity": "sha1-1dqzZPEUiegMe/ia7euv3JJdZ6U=",
+      "requires": {
+        "classnames": "2.2.5",
+        "object-assign": "4.1.1",
+        "rc-tooltip": "3.4.6",
+        "rc-util": "3.4.1"
+      }
     },
     "rc-tooltip": {
       "version": "3.4.6",
       "resolved": "https://registry.npmjs.org/rc-tooltip/-/rc-tooltip-3.4.6.tgz",
-      "integrity": "sha1-7ZjeKntBLlJ8a9iiqX3d8Lq9LyE="
+      "integrity": "sha1-7ZjeKntBLlJ8a9iiqX3d8Lq9LyE=",
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "prop-types": "15.5.10",
+        "rc-trigger": "1.11.2"
+      }
     },
     "rc-trigger": {
       "version": "1.11.2",
       "resolved": "https://registry.npmjs.org/rc-trigger/-/rc-trigger-1.11.2.tgz",
       "integrity": "sha512-ns6eVMvzFc7ZRhRDhAV5RyIxsDUBwjxrEb7njzisvfkwMhRoNkYeN3iwtmIb7DBNE4rsBunsfZIPdKGedKVUJQ==",
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "create-react-class": "15.6.0",
+        "prop-types": "15.5.10",
+        "rc-align": "2.3.4",
+        "rc-animate": "2.4.0",
+        "rc-util": "4.0.4"
+      },
       "dependencies": {
         "rc-util": {
           "version": "4.0.4",
           "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-4.0.4.tgz",
-          "integrity": "sha1-mYE92Qrufim2STmnCsF26tP0/zk="
+          "integrity": "sha1-mYE92Qrufim2STmnCsF26tP0/zk=",
+          "requires": {
+            "add-dom-event-listener": "1.0.2",
+            "babel-runtime": "6.23.0",
+            "shallowequal": "0.2.2"
+          }
         }
       }
     },
     "rc-util": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-3.4.1.tgz",
-      "integrity": "sha1-S34LDHWTvbz/jtBF2I+7x3OnsGE="
+      "integrity": "sha1-S34LDHWTvbz/jtBF2I+7x3OnsGE=",
+      "requires": {
+        "add-dom-event-listener": "1.0.2",
+        "classnames": "2.2.5",
+        "shallowequal": "0.2.2"
+      }
     },
     "react": {
       "version": "15.4.2",
       "resolved": "https://registry.npmjs.org/react/-/react-15.4.2.tgz",
-      "integrity": "sha1-QfeZGyYYU5K6m66WyIiefgGDl+8="
+      "integrity": "sha1-QfeZGyYYU5K6m66WyIiefgGDl+8=",
+      "requires": {
+        "fbjs": "0.8.12",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1"
+      }
     },
     "react-addons-test-utils": {
       "version": "15.4.2",
       "resolved": "https://registry.npmjs.org/react-addons-test-utils/-/react-addons-test-utils-15.4.2.tgz",
       "integrity": "sha1-k7yqcY/K5zYNQuj7HAl1bMNjAqI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "fbjs": "0.8.12",
+        "object-assign": "4.1.1"
+      }
     },
     "react-chartist": {
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/react-chartist/-/react-chartist-0.10.2.tgz",
-      "integrity": "sha1-1fY5Mf+looSORqtGZGogPpOXRKs="
+      "integrity": "sha1-1fY5Mf+looSORqtGZGogPpOXRKs=",
+      "requires": {
+        "chartist": "0.9.8"
+      }
     },
     "react-component-resizable": {
       "version": "1.1.0-rc1",
@@ -5397,27 +7751,54 @@
     "react-dom": {
       "version": "15.4.2",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.4.2.tgz",
-      "integrity": "sha1-AVNj8FsKH9Uq6e/dOgBg2QaVII8="
+      "integrity": "sha1-AVNj8FsKH9Uq6e/dOgBg2QaVII8=",
+      "requires": {
+        "fbjs": "0.8.12",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1"
+      }
     },
     "react-helmet": {
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-5.1.3.tgz",
-      "integrity": "sha1-zUBiZZOinuz2hLbTjXEfRMSBiK8="
+      "integrity": "sha1-zUBiZZOinuz2hLbTjXEfRMSBiK8=",
+      "requires": {
+        "deep-equal": "1.0.1",
+        "object-assign": "4.1.1",
+        "prop-types": "15.5.10",
+        "react-side-effect": "1.1.3"
+      }
     },
     "react-input-autosize": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/react-input-autosize/-/react-input-autosize-1.1.4.tgz",
-      "integrity": "sha1-y8RQctQITdxXgG2447NOZEuDZqw="
+      "integrity": "sha1-y8RQctQITdxXgG2447NOZEuDZqw=",
+      "requires": {
+        "create-react-class": "15.6.0",
+        "prop-types": "15.5.10"
+      }
     },
     "react-interpolate-component": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/react-interpolate-component/-/react-interpolate-component-0.10.0.tgz",
       "integrity": "sha1-0NINFt8QaXzctDvfVW2+1ZETvyE=",
+      "requires": {
+        "except": "0.1.3",
+        "fbjs": "0.4.0",
+        "object-assign": "4.1.1"
+      },
       "dependencies": {
         "fbjs": {
           "version": "0.4.0",
           "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.4.0.tgz",
-          "integrity": "sha1-xXaGEApA1FDsJE7QxEowk/cq9xw="
+          "integrity": "sha1-xXaGEApA1FDsJE7QxEowk/cq9xw=",
+          "requires": {
+            "core-js": "1.2.7",
+            "loose-envify": "1.3.1",
+            "promise": "7.3.0",
+            "ua-parser-js": "0.7.12",
+            "whatwg-fetch": "0.9.0"
+          }
         },
         "whatwg-fetch": {
           "version": "0.9.0",
@@ -5430,7 +7811,11 @@
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/react-proxy/-/react-proxy-1.1.8.tgz",
       "integrity": "sha1-nb/Z2SdSjDqp9ETkVYw3gwq4wmo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash": "4.17.4",
+        "react-deep-force-update": "1.0.1"
+      }
     },
     "react-pullout": {
       "version": "1.0.3",
@@ -5440,34 +7825,68 @@
     "react-redux": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.0.5.tgz",
-      "integrity": "sha1-+OjHsjlCJXblLWt9sGQ5RpvphGo="
+      "integrity": "sha1-+OjHsjlCJXblLWt9sGQ5RpvphGo=",
+      "requires": {
+        "create-react-class": "15.6.0",
+        "hoist-non-react-statics": "1.2.0",
+        "invariant": "2.2.2",
+        "lodash": "4.17.4",
+        "lodash-es": "4.17.4",
+        "loose-envify": "1.3.1",
+        "prop-types": "15.5.10"
+      }
     },
     "react-router": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-2.5.2.tgz",
-      "integrity": "sha1-HB/JU2Y5PJbB+0kywFBhKBlrEgM="
+      "integrity": "sha1-HB/JU2Y5PJbB+0kywFBhKBlrEgM=",
+      "requires": {
+        "history": "2.1.2",
+        "hoist-non-react-statics": "1.2.0",
+        "invariant": "2.2.2",
+        "loose-envify": "1.3.1",
+        "warning": "2.1.0"
+      }
     },
     "react-router-scroll": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/react-router-scroll/-/react-router-scroll-0.3.3.tgz",
       "integrity": "sha1-5XIA/YY+co/OjpC+kz9TFZkPwOY=",
+      "requires": {
+        "history": "2.1.2",
+        "scroll-behavior": "0.8.2",
+        "warning": "3.0.0"
+      },
       "dependencies": {
         "warning": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
-          "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w="
+          "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
+          "requires": {
+            "loose-envify": "1.3.1"
+          }
         }
       }
     },
     "react-select": {
       "version": "1.0.0-rc.5",
       "resolved": "https://registry.npmjs.org/react-select/-/react-select-1.0.0-rc.5.tgz",
-      "integrity": "sha1-nTFvJSsa3Dct21zfHxGca3z9tdY="
+      "integrity": "sha1-nTFvJSsa3Dct21zfHxGca3z9tdY=",
+      "requires": {
+        "classnames": "2.2.5",
+        "create-react-class": "15.6.0",
+        "prop-types": "15.5.10",
+        "react-input-autosize": "1.1.4"
+      }
     },
     "react-side-effect": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-1.1.3.tgz",
       "integrity": "sha1-USwlq+DewXKDTEAB7FxR4E1BvFw=",
+      "requires": {
+        "exenv": "1.2.2",
+        "shallowequal": "1.0.2"
+      },
       "dependencies": {
         "shallowequal": {
           "version": "1.0.2",
@@ -5479,41 +7898,74 @@
     "react-swipe": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/react-swipe/-/react-swipe-5.0.8.tgz",
-      "integrity": "sha1-lcrjHy104bSIbwH/y3KDezdbZus="
+      "integrity": "sha1-lcrjHy104bSIbwH/y3KDezdbZus=",
+      "requires": {
+        "object-assign": "4.1.1",
+        "prop-types": "15.5.10",
+        "swipe-js-iso": "2.0.3"
+      }
     },
     "react-transform-hmr": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/react-transform-hmr/-/react-transform-hmr-1.0.4.tgz",
       "integrity": "sha1-4aQL0Krvxy6N/Xp82gmvhQZjl7s=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "global": "4.3.2",
+        "react-proxy": "1.1.8"
+      }
     },
     "react-translate-component": {
       "version": "0.13.2",
       "resolved": "https://registry.npmjs.org/react-translate-component/-/react-translate-component-0.13.2.tgz",
-      "integrity": "sha1-WtQcf3irt6FVah3mKCj9Yjg3pXk="
+      "integrity": "sha1-WtQcf3irt6FVah3mKCj9Yjg3pXk=",
+      "requires": {
+        "object-assign": "4.1.1"
+      }
     },
     "read-pkg": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "load-json-file": "1.1.0",
+        "normalize-package-data": "2.3.8",
+        "path-type": "1.1.0"
+      }
     },
     "read-pkg-up": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "find-up": "1.1.2",
+        "read-pkg": "1.1.0"
+      }
     },
     "readable-stream": {
       "version": "1.0.27-1",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.27-1.tgz",
-      "integrity": "sha1-a2eYPCA1fO/QfwFlABoW1xDZEHg="
+      "integrity": "sha1-a2eYPCA1fO/QfwFlABoW1xDZEHg=",
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "0.0.1",
+        "string_decoder": "0.10.31"
+      }
     },
     "readdirp": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
       "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "minimatch": "3.0.4",
+        "readable-stream": "2.3.0",
+        "set-immediate-shim": "1.0.1"
+      },
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
@@ -5525,13 +7977,25 @@
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.0.tgz",
           "integrity": "sha512-c7KMXGd4b48nN3OJ1U9qOsn6pXNzf6kLd3kdZCkg2sxAcoiufInqF0XckwEnlrcwuaYwonlNK8GQUIOC/WC7sg==",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.0",
+            "string_decoder": "1.0.2",
+            "util-deprecate": "1.0.2"
+          }
         },
         "string_decoder": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
           "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
           "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          },
           "dependencies": {
             "safe-buffer": {
               "version": "5.0.1",
@@ -5547,13 +8011,21 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
       "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "mute-stream": "0.0.5"
+      }
     },
     "rechoir": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "resolve": "1.3.3"
+      }
     },
     "reduce-component": {
       "version": "1.0.1",
@@ -5565,6 +8037,11 @@
       "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
       "integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
       "dev": true,
+      "requires": {
+        "balanced-match": "0.4.2",
+        "math-expression-evaluator": "1.2.17",
+        "reduce-function-call": "1.0.2"
+      },
       "dependencies": {
         "balanced-match": {
           "version": "0.4.2",
@@ -5579,6 +8056,9 @@
       "resolved": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.2.tgz",
       "integrity": "sha1-WiAL+S4ON3UXUv5FsKszD9S2vpk=",
       "dev": true,
+      "requires": {
+        "balanced-match": "0.4.2"
+      },
       "dependencies": {
         "balanced-match": {
           "version": "0.4.2",
@@ -5591,7 +8071,13 @@
     "redux": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/redux/-/redux-3.6.0.tgz",
-      "integrity": "sha1-iHwrPQub2G7KK+cFccJ2VMGeGI0="
+      "integrity": "sha1-iHwrPQub2G7KK+cFccJ2VMGeGI0=",
+      "requires": {
+        "lodash": "4.17.4",
+        "lodash-es": "4.17.4",
+        "loose-envify": "1.3.1",
+        "symbol-observable": "1.0.4"
+      }
     },
     "redux-devtools-extension": {
       "version": "2.13.2",
@@ -5618,19 +8104,33 @@
       "version": "0.9.11",
       "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.11.tgz",
       "integrity": "sha1-On0GdSDLe3F2dp61/4aGkb7+EoM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.25.0",
+        "private": "0.1.7"
+      }
     },
     "regex-cache": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
       "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-equal-shallow": "0.1.3",
+        "is-primitive": "2.0.0"
+      }
     },
     "regexpu-core": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
       "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "regenerate": "1.3.2",
+        "regjsgen": "0.2.0",
+        "regjsparser": "0.1.5"
+      }
     },
     "regjsgen": {
       "version": "0.2.0",
@@ -5643,6 +8143,9 @@
       "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
       "dev": true,
+      "requires": {
+        "jsesc": "0.5.0"
+      },
       "dependencies": {
         "jsesc": {
           "version": "0.5.0",
@@ -5669,30 +8172,55 @@
       "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.1.tgz",
       "integrity": "sha1-iYyr/Ivt5Le5ETWj/9Mj5YwNsxk=",
       "dev": true,
+      "requires": {
+        "css-select": "1.2.0",
+        "dom-converter": "0.1.4",
+        "htmlparser2": "3.3.0",
+        "strip-ansi": "3.0.1",
+        "utila": "0.3.3"
+      },
       "dependencies": {
         "domhandler": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.1.0.tgz",
           "integrity": "sha1-0mRvXlf2w7qxHPbLBdPArPdBJZQ=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "domelementtype": "1.3.0"
+          }
         },
         "domutils": {
           "version": "1.1.6",
           "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.1.6.tgz",
           "integrity": "sha1-vdw94Jm5ou+sxRxiPyj0FuzFdIU=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "domelementtype": "1.3.0"
+          }
         },
         "htmlparser2": {
           "version": "3.3.0",
           "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.3.0.tgz",
           "integrity": "sha1-zHDQWln2VC5D8OaFyYLhTJJKnv4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "domelementtype": "1.3.0",
+            "domhandler": "2.1.0",
+            "domutils": "1.1.6",
+            "readable-stream": "1.0.34"
+          }
         },
         "readable-stream": {
           "version": "1.0.34",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
         },
         "utila": {
           "version": "0.3.3",
@@ -5718,19 +8246,51 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-finite": "1.0.2"
+      }
     },
     "request": {
       "version": "2.81.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
       "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
       "dev": true,
+      "requires": {
+        "aws-sign2": "0.6.0",
+        "aws4": "1.6.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.5",
+        "extend": "3.0.1",
+        "forever-agent": "0.6.1",
+        "form-data": "2.1.4",
+        "har-validator": "4.2.1",
+        "hawk": "3.1.3",
+        "http-signature": "1.1.1",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.15",
+        "oauth-sign": "0.8.2",
+        "performance-now": "0.2.0",
+        "qs": "6.4.0",
+        "safe-buffer": "5.1.0",
+        "stringstream": "0.0.5",
+        "tough-cookie": "2.3.2",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.1.0"
+      },
       "dependencies": {
         "form-data": {
           "version": "2.1.4",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
           "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.15"
+          }
         },
         "qs": {
           "version": "6.4.0",
@@ -5762,19 +8322,30 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "caller-path": "0.1.0",
+        "resolve-from": "1.0.1"
+      }
     },
     "resolve": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
       "integrity": "sha1-ZVkHw0aahoDcLeOidaj91paR8OU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "path-parse": "1.0.5"
+      }
     },
     "resolve-dir": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
       "integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "expand-tilde": "1.2.2",
+        "global-modules": "0.2.3"
+      }
     },
     "resolve-from": {
       "version": "1.0.1",
@@ -5786,31 +8357,48 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
       "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "exit-hook": "1.1.1",
+        "onetime": "1.1.0"
+      }
     },
     "right-align": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "align-text": "0.1.4"
+      }
     },
     "rimraf": {
       "version": "2.5.4",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
       "integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2"
+      }
     },
     "ripemd160": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
       "integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "hash-base": "2.0.2",
+        "inherits": "2.0.3"
+      }
     },
     "run-async": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
       "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "once": "1.4.0"
+      }
     },
     "rx-lite": {
       "version": "3.1.2",
@@ -5841,19 +8429,32 @@
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.3.0.tgz",
       "integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
       "dev": true,
+      "requires": {
+        "ajv": "5.2.0"
+      },
       "dependencies": {
         "ajv": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.0.tgz",
           "integrity": "sha1-wXNQJMXaLvdcwZBxMHPUTwmL9IY=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "co": "4.6.0",
+            "fast-deep-equal": "0.1.0",
+            "json-schema-traverse": "0.3.0",
+            "json-stable-stringify": "1.0.1"
+          }
         }
       }
     },
     "scroll-behavior": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/scroll-behavior/-/scroll-behavior-0.8.2.tgz",
-      "integrity": "sha1-rOE+QLAB2NTQB67A5/tmjPkENUY="
+      "integrity": "sha1-rOE+QLAB2NTQB67A5/tmjPkENUY=",
+      "requires": {
+        "dom-helpers": "2.4.0",
+        "invariant": "2.2.2"
+      }
     },
     "semver": {
       "version": "5.3.0",
@@ -5866,12 +8467,30 @@
       "resolved": "https://registry.npmjs.org/send/-/send-0.15.3.tgz",
       "integrity": "sha1-UBP5+ZAj31DRvZiSwZ4979HVMwk=",
       "dev": true,
+      "requires": {
+        "debug": "2.6.7",
+        "depd": "1.1.0",
+        "destroy": "1.0.4",
+        "encodeurl": "1.0.1",
+        "escape-html": "1.0.3",
+        "etag": "1.8.0",
+        "fresh": "0.5.0",
+        "http-errors": "1.6.1",
+        "mime": "1.3.4",
+        "ms": "2.0.0",
+        "on-finished": "2.3.0",
+        "range-parser": "1.2.0",
+        "statuses": "1.3.1"
+      },
       "dependencies": {
         "debug": {
           "version": "2.6.7",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
           "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
         },
         "ms": {
           "version": "2.0.0",
@@ -5885,7 +8504,13 @@
       "version": "1.12.3",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.3.tgz",
       "integrity": "sha1-n0uhni8wMMVH+K+ZEHg47DjVseI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "encodeurl": "1.0.1",
+        "escape-html": "1.0.3",
+        "parseurl": "1.3.1",
+        "send": "0.15.3"
+      }
     },
     "set-blocking": {
       "version": "2.0.0",
@@ -5913,18 +8538,29 @@
     "seven-ten": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/seven-ten/-/seven-ten-3.1.0.tgz",
-      "integrity": "sha1-8A84UbHgdw1R8sSy3Z2nWpbo5jY="
+      "integrity": "sha1-8A84UbHgdw1R8sSy3Z2nWpbo5jY=",
+      "requires": {
+        "devour-client": "1.3.9",
+        "react": "15.4.2",
+        "react-dom": "15.4.2"
+      }
     },
     "sha.js": {
       "version": "2.4.8",
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz",
       "integrity": "sha1-NwaMLEdra69ALRSknGf1l5IfY08=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3"
+      }
     },
     "shallowequal": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-0.2.2.tgz",
       "integrity": "sha1-HjL9W8q2rWiKSBLLDMBO/HXHAU4=",
+      "requires": {
+        "lodash.keys": "3.1.2"
+      },
       "dependencies": {
         "lodash.isarray": {
           "version": "3.0.4",
@@ -5934,7 +8570,12 @@
         "lodash.keys": {
           "version": "3.1.2",
           "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-          "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo="
+          "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+          "requires": {
+            "lodash._getnative": "3.9.1",
+            "lodash.isarguments": "3.1.0",
+            "lodash.isarray": "3.0.4"
+          }
         }
       }
     },
@@ -5942,7 +8583,12 @@
       "version": "0.7.8",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
       "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2",
+        "interpret": "1.0.3",
+        "rechoir": "0.6.2"
+      }
     },
     "shortid": {
       "version": "2.2.8",
@@ -5953,7 +8599,13 @@
       "version": "1.17.7",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.17.7.tgz",
       "integrity": "sha1-RUKk9JugxFwF6y6d2dID4rjv4L8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "formatio": "1.1.1",
+        "lolex": "1.3.2",
+        "samsam": "1.1.2",
+        "util": "0.10.3"
+      }
     },
     "slash": {
       "version": "1.0.0",
@@ -5971,13 +8623,25 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
       "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "hoek": "2.16.3"
+      }
     },
     "socket.io": {
       "version": "1.7.4",
       "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.7.4.tgz",
       "integrity": "sha1-L37O3DORvy1cc+KR/iM+bjTU3QA=",
       "dev": true,
+      "requires": {
+        "debug": "2.3.3",
+        "engine.io": "1.8.4",
+        "has-binary": "0.1.7",
+        "object-assign": "4.1.0",
+        "socket.io-adapter": "0.5.0",
+        "socket.io-client": "1.7.4",
+        "socket.io-parser": "2.3.1"
+      },
       "dependencies": {
         "object-assign": {
           "version": "4.1.0",
@@ -5991,19 +8655,42 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.5.0.tgz",
       "integrity": "sha1-y21LuL7IHhB4uZZ3+c7QBGBmu4s=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "debug": "2.3.3",
+        "socket.io-parser": "2.3.1"
+      }
     },
     "socket.io-client": {
       "version": "1.7.4",
       "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.7.4.tgz",
       "integrity": "sha1-7J+CA1btme9tNX8HVtZIcXvdQoE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "backo2": "1.0.2",
+        "component-bind": "1.0.0",
+        "component-emitter": "1.2.1",
+        "debug": "2.3.3",
+        "engine.io-client": "1.8.4",
+        "has-binary": "0.1.7",
+        "indexof": "0.0.1",
+        "object-component": "0.0.3",
+        "parseuri": "0.0.5",
+        "socket.io-parser": "2.3.1",
+        "to-array": "0.1.4"
+      }
     },
     "socket.io-parser": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.3.1.tgz",
       "integrity": "sha1-3VMgJRA85Clpcya+/WQAX8/ltKA=",
       "dev": true,
+      "requires": {
+        "component-emitter": "1.1.2",
+        "debug": "2.2.0",
+        "isarray": "0.0.1",
+        "json3": "3.3.2"
+      },
       "dependencies": {
         "component-emitter": {
           "version": "1.1.2",
@@ -6015,7 +8702,10 @@
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "0.7.1"
+          }
         },
         "ms": {
           "version": "0.7.1",
@@ -6034,7 +8724,10 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
       "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-plain-obj": "1.1.0"
+      }
     },
     "source-list-map": {
       "version": "0.1.8",
@@ -6052,13 +8745,19 @@
       "version": "0.4.15",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.15.tgz",
       "integrity": "sha1-AyAt9lwG0r2MfsI2KhkwVv7407E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "source-map": "0.5.6"
+      }
     },
     "spdx-correct": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
       "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "spdx-license-ids": "1.2.2"
+      }
     },
     "spdx-expression-parse": {
       "version": "1.0.4",
@@ -6082,6 +8781,16 @@
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
       "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
       "dev": true,
+      "requires": {
+        "asn1": "0.2.3",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.1",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.1",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "tweetnacl": "0.14.5"
+      },
       "dependencies": {
         "assert-plus": {
           "version": "1.0.0",
@@ -6102,6 +8811,10 @@
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
       "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
       "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.0"
+      },
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
@@ -6113,13 +8826,25 @@
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.0.tgz",
           "integrity": "sha512-c7KMXGd4b48nN3OJ1U9qOsn6pXNzf6kLd3kdZCkg2sxAcoiufInqF0XckwEnlrcwuaYwonlNK8GQUIOC/WC7sg==",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.0",
+            "string_decoder": "1.0.2",
+            "util-deprecate": "1.0.2"
+          }
         },
         "string_decoder": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
           "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
           "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          },
           "dependencies": {
             "safe-buffer": {
               "version": "5.0.1",
@@ -6141,6 +8866,13 @@
       "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.2.tgz",
       "integrity": "sha512-c0yTD2rbQzXtSsFSVhtpvY/vS6u066PcXOX9kBB3mSO76RiUQzL340uJkGBWnlBg4/HZzqiUXtaVA7wcRcJgEw==",
       "dev": true,
+      "requires": {
+        "builtin-status-codes": "3.0.0",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.0",
+        "to-arraybuffer": "1.0.1",
+        "xtend": "4.0.1"
+      },
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
@@ -6152,13 +8884,25 @@
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.0.tgz",
           "integrity": "sha512-c7KMXGd4b48nN3OJ1U9qOsn6pXNzf6kLd3kdZCkg2sxAcoiufInqF0XckwEnlrcwuaYwonlNK8GQUIOC/WC7sg==",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "safe-buffer": "5.1.0",
+            "string_decoder": "1.0.2",
+            "util-deprecate": "1.0.2"
+          }
         },
         "string_decoder": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
           "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
           "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          },
           "dependencies": {
             "safe-buffer": {
               "version": "5.0.1",
@@ -6189,7 +8933,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "strip-ansi": "3.0.1"
+      }
     },
     "stringstream": {
       "version": "0.0.5",
@@ -6201,7 +8950,10 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
     },
     "strip-bom": {
       "version": "3.0.0",
@@ -6220,12 +8972,20 @@
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.16.1.tgz",
       "integrity": "sha1-UOMlJY1OeEId2WgGNrQehmFZXRA=",
       "dev": true,
+      "requires": {
+        "loader-utils": "1.1.0"
+      },
       "dependencies": {
         "loader-utils": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
           "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "big.js": "3.1.3",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1"
+          }
         }
       }
     },
@@ -6234,12 +8994,28 @@
       "resolved": "https://registry.npmjs.org/stylus/-/stylus-0.54.5.tgz",
       "integrity": "sha1-QrlWCTHKcJDOhRWnmLqeaqPW3Hk=",
       "dev": true,
+      "requires": {
+        "css-parse": "1.7.0",
+        "debug": "2.3.3",
+        "glob": "7.0.6",
+        "mkdirp": "0.5.1",
+        "sax": "0.5.8",
+        "source-map": "0.1.43"
+      },
       "dependencies": {
         "glob": {
           "version": "7.0.6",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
           "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
         },
         "sax": {
           "version": "0.5.8",
@@ -6251,7 +9027,10 @@
           "version": "0.1.43",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
           "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "amdefine": "1.0.1"
+          }
         }
       }
     },
@@ -6260,12 +9039,22 @@
       "resolved": "https://registry.npmjs.org/stylus-loader/-/stylus-loader-3.0.1.tgz",
       "integrity": "sha1-d/SzT9Aw0lsmF7z1UT21sHMMQIk=",
       "dev": true,
+      "requires": {
+        "loader-utils": "1.1.0",
+        "lodash.clonedeep": "4.5.0",
+        "when": "3.6.4"
+      },
       "dependencies": {
         "loader-utils": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
           "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "big.js": "3.1.3",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1"
+          }
         }
       }
     },
@@ -6278,6 +9067,19 @@
       "version": "1.8.5",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-1.8.5.tgz",
       "integrity": "sha1-HA3cOvMOgOuE68BcshItqP6UC1U=",
+      "requires": {
+        "component-emitter": "1.2.1",
+        "cookiejar": "2.0.6",
+        "debug": "2.3.3",
+        "extend": "3.0.0",
+        "form-data": "1.0.0-rc3",
+        "formidable": "1.0.17",
+        "methods": "1.1.2",
+        "mime": "1.3.4",
+        "qs": "2.3.3",
+        "readable-stream": "1.0.27-1",
+        "reduce-component": "1.0.1"
+      },
       "dependencies": {
         "extend": {
           "version": "3.0.0",
@@ -6306,7 +9108,16 @@
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/svgo/-/svgo-0.7.2.tgz",
       "integrity": "sha1-n1dyQTlSE1xv779Ar+ak+qiLS7U=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "coa": "1.0.3",
+        "colors": "1.1.2",
+        "csso": "2.3.2",
+        "js-yaml": "3.7.0",
+        "mkdirp": "0.5.1",
+        "sax": "1.2.2",
+        "whet.extend": "0.9.9"
+      }
     },
     "swipe-js-iso": {
       "version": "2.0.3",
@@ -6329,6 +9140,14 @@
       "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
       "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
       "dev": true,
+      "requires": {
+        "ajv": "4.11.8",
+        "ajv-keywords": "1.5.1",
+        "chalk": "1.1.3",
+        "lodash": "4.17.4",
+        "slice-ansi": "0.0.4",
+        "string-width": "2.0.0"
+      },
       "dependencies": {
         "is-fullwidth-code-point": {
           "version": "2.0.0",
@@ -6340,7 +9159,11 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
           "integrity": "sha1-Y1xUNsxypuDDh87KJ41OLuxSaH4=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "3.0.1"
+          }
         }
       }
     },
@@ -6366,7 +9189,10 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.2.tgz",
       "integrity": "sha1-q0iDz1l9zVCvIRNJoA+8pWrIa4Y=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "setimmediate": "1.0.5"
+      }
     },
     "to-array": {
       "version": "0.1.4",
@@ -6396,7 +9222,10 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
       "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "punycode": "1.4.1"
+      }
     },
     "tr46": {
       "version": "0.0.3",
@@ -6426,7 +9255,10 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.0"
+      }
     },
     "tweetnacl": {
       "version": "0.14.5",
@@ -6444,13 +9276,20 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2"
+      }
     },
     "type-is": {
       "version": "1.6.15",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
       "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "2.1.15"
+      }
     },
     "typedarray": {
       "version": "0.0.6",
@@ -6472,7 +9311,11 @@
       "version": "3.0.18",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.0.18.tgz",
       "integrity": "sha512-0M/KeXO8bPYtlqnwIYpO4R6om1mrScMzPuWn2UPfUYOaowIhQmmFpL9Q5tlD18ulKLRKD12GQ0IiYDKJS/si1w==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "commander": "2.9.0",
+        "source-map": "0.5.6"
+      }
     },
     "uglify-to-browserify": {
       "version": "1.0.2",
@@ -6508,7 +9351,10 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/uniqid/-/uniqid-4.1.1.tgz",
       "integrity": "sha1-iSIN32t1GuUrX3JISGNShZa7hME=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "macaddress": "0.2.8"
+      }
     },
     "uniqs": {
       "version": "2.0.0",
@@ -6526,7 +9372,10 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/untildify/-/untildify-2.1.0.tgz",
       "integrity": "sha1-F+soB5h/dpUunASF/DEdBqgmouA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "os-homedir": "1.0.2"
+      }
     },
     "upper-case": {
       "version": "1.1.3",
@@ -6539,6 +9388,10 @@
       "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
       "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
       "dev": true,
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      },
       "dependencies": {
         "punycode": {
           "version": "1.3.2",
@@ -6559,6 +9412,9 @@
       "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
       "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
       "dev": true,
+      "requires": {
+        "inherits": "2.0.1"
+      },
       "dependencies": {
         "inherits": {
           "version": "2.0.1",
@@ -6596,13 +9452,20 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
       "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "user-home": "1.1.1"
+      }
     },
     "validate-npm-package-license": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
       "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "spdx-correct": "1.0.2",
+        "spdx-expression-parse": "1.0.4"
+      }
     },
     "vary": {
       "version": "1.1.1",
@@ -6620,7 +9483,10 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
       "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "extsprintf": "1.0.2"
+      }
     },
     "visible-element": {
       "version": "1.0.1",
@@ -6631,24 +9497,38 @@
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
       "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "indexof": "0.0.1"
+      }
     },
     "warning": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/warning/-/warning-2.1.0.tgz",
-      "integrity": "sha1-ISINnGOvx3qMkhEeARr3Bc4MaQE="
+      "integrity": "sha1-ISINnGOvx3qMkhEeARr3Bc4MaQE=",
+      "requires": {
+        "loose-envify": "1.3.1"
+      }
     },
     "watchpack": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.3.1.tgz",
       "integrity": "sha1-fYaTkHsozmAT5/NhCqKhrPB9rYc=",
       "dev": true,
+      "requires": {
+        "async": "2.4.1",
+        "chokidar": "1.7.0",
+        "graceful-fs": "4.1.11"
+      },
       "dependencies": {
         "async": {
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/async/-/async-2.4.1.tgz",
           "integrity": "sha1-YqVrJ5yYoR0JhwlqAcw+6463u9c=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash": "4.17.4"
+          }
         }
       }
     },
@@ -6664,6 +9544,28 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-2.3.3.tgz",
       "integrity": "sha1-7swIPBj7e/lY6k9AtXpmQMWgzHg=",
       "dev": true,
+      "requires": {
+        "acorn": "4.0.13",
+        "acorn-dynamic-import": "2.0.2",
+        "ajv": "4.11.8",
+        "ajv-keywords": "1.5.1",
+        "async": "2.4.1",
+        "enhanced-resolve": "3.1.0",
+        "interpret": "1.0.3",
+        "json-loader": "0.5.4",
+        "loader-runner": "2.3.0",
+        "loader-utils": "0.2.17",
+        "memory-fs": "0.4.1",
+        "mkdirp": "0.5.1",
+        "node-libs-browser": "2.0.0",
+        "source-map": "0.5.6",
+        "supports-color": "3.2.3",
+        "tapable": "0.2.6",
+        "uglify-js": "2.8.29",
+        "watchpack": "1.3.1",
+        "webpack-sources": "0.2.3",
+        "yargs": "6.6.0"
+      },
       "dependencies": {
         "acorn": {
           "version": "4.0.13",
@@ -6675,7 +9577,10 @@
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/async/-/async-2.4.1.tgz",
           "integrity": "sha1-YqVrJ5yYoR0JhwlqAcw+6463u9c=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lodash": "4.17.4"
+          }
         },
         "source-list-map": {
           "version": "1.1.2",
@@ -6687,19 +9592,33 @@
           "version": "3.2.3",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "has-flag": "1.0.0"
+          }
         },
         "uglify-js": {
           "version": "2.8.29",
           "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
           "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
           "dev": true,
+          "requires": {
+            "source-map": "0.5.6",
+            "uglify-to-browserify": "1.0.2",
+            "yargs": "3.10.0"
+          },
           "dependencies": {
             "yargs": {
               "version": "3.10.0",
               "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
               "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-              "dev": true
+              "dev": true,
+              "requires": {
+                "camelcase": "1.2.1",
+                "cliui": "2.1.0",
+                "decamelize": "1.2.0",
+                "window-size": "0.1.0"
+              }
             }
           }
         },
@@ -6707,7 +9626,11 @@
           "version": "0.2.3",
           "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-0.2.3.tgz",
           "integrity": "sha1-F8Yr+vE8cH+dAsR54Nzd6DgGl/s=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "source-list-map": "1.1.2",
+            "source-map": "0.5.6"
+          }
         }
       }
     },
@@ -6715,25 +9638,49 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/webpack-dashboard/-/webpack-dashboard-0.3.0.tgz",
       "integrity": "sha1-0P4YKgl2qP8OoBsFB/KaA0zWChw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "blessed": "0.1.81",
+        "commander": "2.9.0",
+        "cross-spawn": "4.0.2",
+        "filesize": "3.5.10",
+        "socket.io": "1.7.4",
+        "socket.io-client": "1.7.4"
+      }
     },
     "webpack-dev-middleware": {
       "version": "1.10.2",
       "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.10.2.tgz",
       "integrity": "sha1-LiUs4d+wINvaHMs33ybzCrAU29E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "memory-fs": "0.4.1",
+        "mime": "1.3.4",
+        "path-is-absolute": "1.0.1",
+        "range-parser": "1.2.0"
+      }
     },
     "webpack-hot-middleware": {
       "version": "2.18.0",
       "resolved": "https://registry.npmjs.org/webpack-hot-middleware/-/webpack-hot-middleware-2.18.0.tgz",
       "integrity": "sha1-oWu1Nbg6aslKeKxevOTzBZ6CdNM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-html": "0.0.7",
+        "html-entities": "1.2.1",
+        "querystring": "0.2.0",
+        "strip-ansi": "3.0.1"
+      }
     },
     "webpack-sources": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.0.1.tgz",
       "integrity": "sha512-05tMxipUCwHqYaVS8xc7sYPTly8PzXayRCB4dTxLhWTqlKUiwH6ezmEe0OSreL1c30LAuA3Zqmc+uEBUGFJDjw==",
       "dev": true,
+      "requires": {
+        "source-list-map": "2.0.0",
+        "source-map": "0.5.6"
+      },
       "dependencies": {
         "source-list-map": {
           "version": "2.0.0",
@@ -6752,7 +9699,10 @@
     "websocket-driver": {
       "version": "0.6.5",
       "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.5.tgz",
-      "integrity": "sha1-XLJVbOuF9Dc8bYI4qmkchFThOjY="
+      "integrity": "sha1-XLJVbOuF9Dc8bYI4qmkchFThOjY=",
+      "requires": {
+        "websocket-extensions": "0.1.1"
+      }
     },
     "websocket-extensions": {
       "version": "0.1.1",
@@ -6764,6 +9714,9 @@
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.1.tgz",
       "integrity": "sha1-PGxFGhmO567FWx7GHQkgxngBpfQ=",
       "dev": true,
+      "requires": {
+        "iconv-lite": "0.4.13"
+      },
       "dependencies": {
         "iconv-lite": {
           "version": "0.4.13",
@@ -6783,6 +9736,10 @@
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-4.8.0.tgz",
       "integrity": "sha1-0pgaqRSMHgCkHFphMRZqtGg7vMA=",
       "dev": true,
+      "requires": {
+        "tr46": "0.0.3",
+        "webidl-conversions": "3.0.1"
+      },
       "dependencies": {
         "webidl-conversions": {
           "version": "3.0.1",
@@ -6797,7 +9754,10 @@
       "resolved": "https://registry.npmjs.org/whatwg-url-compat/-/whatwg-url-compat-0.6.5.tgz",
       "integrity": "sha1-AImBEa9om7CXVBzVpFymyHmERb8=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "tr46": "0.0.3"
+      }
     },
     "when": {
       "version": "3.6.4",
@@ -6815,7 +9775,10 @@
       "version": "1.2.14",
       "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
       "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "isexe": "2.0.0"
+      }
     },
     "which-module": {
       "version": "1.0.0",
@@ -6839,7 +9802,11 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1"
+      }
     },
     "wrappy": {
       "version": "1.0.2",
@@ -6857,12 +9824,19 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "mkdirp": "0.5.1"
+      }
     },
     "ws": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.2.tgz",
-      "integrity": "sha1-iiRPoFJAHgjJiGz0SoUYnh/UBn8="
+      "integrity": "sha1-iiRPoFJAHgjJiGz0SoUYnh/UBn8=",
+      "requires": {
+        "options": "0.0.6",
+        "ultron": "1.0.2"
+      }
     },
     "wtf-8": {
       "version": "1.0.0",
@@ -6886,6 +9860,9 @@
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.8.tgz",
       "integrity": "sha1-m4FpCTFjH/CdGVdUn69U9PmAs8I=",
       "dev": true,
+      "requires": {
+        "sax": "0.5.8"
+      },
       "dependencies": {
         "sax": {
           "version": "0.5.8",
@@ -6934,6 +9911,21 @@
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
       "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
       "dev": true,
+      "requires": {
+        "camelcase": "3.0.0",
+        "cliui": "3.2.0",
+        "decamelize": "1.2.0",
+        "get-caller-file": "1.0.2",
+        "os-locale": "1.4.0",
+        "read-pkg-up": "1.0.1",
+        "require-directory": "2.1.1",
+        "require-main-filename": "1.0.1",
+        "set-blocking": "2.0.0",
+        "string-width": "1.0.2",
+        "which-module": "1.0.0",
+        "y18n": "3.2.1",
+        "yargs-parser": "4.2.1"
+      },
       "dependencies": {
         "camelcase": {
           "version": "3.0.0",
@@ -6945,7 +9937,12 @@
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wrap-ansi": "2.1.0"
+          }
         }
       }
     },
@@ -6954,6 +9951,9 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
       "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
       "dev": true,
+      "requires": {
+        "camelcase": "3.0.0"
+      },
       "dependencies": {
         "camelcase": {
           "version": "3.0.0",
@@ -6971,12 +9971,19 @@
     "zooniverse-geordi-client": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/zooniverse-geordi-client/-/zooniverse-geordi-client-1.4.0.tgz",
-      "integrity": "sha1-0VAANjnzeL7bGUdLH2Rh8wrw5T8="
+      "integrity": "sha1-0VAANjnzeL7bGUdLH2Rh8wrw5T8=",
+      "requires": {
+        "es6-promise": "3.3.1",
+        "zooniverse-user-string-getter": "1.1.23"
+      }
     },
     "zooniverse-user-string-getter": {
       "version": "1.1.23",
       "resolved": "https://registry.npmjs.org/zooniverse-user-string-getter/-/zooniverse-user-string-getter-1.1.23.tgz",
-      "integrity": "sha1-sjKhrg9wPyb30pxnIguKGC7pKEk="
+      "integrity": "sha1-sjKhrg9wPyb30pxnIguKGC7pKEk=",
+      "requires": {
+        "es6-promise": "3.3.1"
+      }
     }
   }
 }


### PR DESCRIPTION
Describe your changes.
There was an error in the WorldWide Telescope calculations in converting a B1950 epoch into J2000. The correct answer was a bit more involved. In turn, this also fixes plate scale when creating the show image url for WWT.

RA/DEC calculations were tested against [this calculator](http://www.robertmartinayers.org/tools/coordinates.html).

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

[Staging Branch](https://wwt-coords.pfe-preview.zooniverse.org/)
[Staging Branch w/ Production Env](https://wwt-coords.pfe-preview.zooniverse.org/?env=production)

## Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
