### PR TITLE
Localise project pages

### DIFF
--- a/app/classifier/classifier.jsx
+++ b/app/classifier/classifier.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import apiClient from 'panoptes-client/lib/api-client';
 import { VisibilitySplit } from 'seven-ten';
-import counterpart from 'counterpart';
 import Translate from 'react-translate-component';
 import SubjectViewer from '../components/subject-viewer';
 import ClassificationSummary from './classification-summary';
@@ -23,13 +22,6 @@ import { isFeedbackActive, isThereFeedback } from './feedback/helpers';
 
 // For easy debugging
 window.cachedClassification = CacheClassification;
-
-counterpart.registerTranslations('en', {
-  classifier: {
-    tutorialButton: 'Show the project tutorial',
-    miniCourseButton: 'Restart the project mini-course'
-  }
-});
 
 class Classifier extends React.Component {
   constructor(props) {

--- a/app/classifier/classifier.jsx
+++ b/app/classifier/classifier.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import apiClient from 'panoptes-client/lib/api-client';
 import { VisibilitySplit } from 'seven-ten';
+import counterpart from 'counterpart';
+import Translate from 'react-translate-component';
 import SubjectViewer from '../components/subject-viewer';
 import ClassificationSummary from './classification-summary';
 import preloadSubject from '../lib/preload-subject';
@@ -21,6 +23,13 @@ import { isFeedbackActive, isThereFeedback } from './feedback/helpers';
 
 // For easy debugging
 window.cachedClassification = CacheClassification;
+
+counterpart.registerTranslations('en', {
+  classifier: {
+    tutorialButton: 'Show the project tutorial',
+    miniCourseButton: 'Restart the project mini-course'
+  }
+});
 
 class Classifier extends React.Component {
   constructor(props) {
@@ -296,7 +305,7 @@ class Classifier extends React.Component {
                   user={this.props.user}
                   workflow={this.props.workflow}
                 >
-                  Show the project tutorial
+                  <Translate content="classifier.tutorialButton" />
                 </RestartButton>
               </strong>
             </small>
@@ -315,7 +324,7 @@ class Classifier extends React.Component {
                     user={this.props.user}
                     workflow={this.props.workflow}
                   >
-                    Restart the project mini-course
+                    <Translate content="classifier.miniCourseButton" />
                   </RestartButton>
                 </VisibilitySplit>
               </strong>

--- a/app/classifier/task-nav.jsx
+++ b/app/classifier/task-nav.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router';
+import counterpart from 'counterpart';
+import Translate from 'react-translate-component';
 import { getSessionID } from '../lib/session';
 import tasks from './tasks';
 import CacheClassification from '../components/cache-classification';
@@ -8,8 +10,23 @@ import { isFeedbackActive, isThereFeedback } from './feedback/helpers';
 
 /* eslint-disable multiline-ternary, no-nested-ternary, react/jsx-no-bind */
 
+counterpart.registerTranslations('en', {
+  classifier: {
+    back: 'Back',
+    backButtonWarning: 'Going back will clear your work for the current task.',
+    done: 'Done',
+    doneAndTalk: 'Done & Talk',
+    next: 'Next',
+    talk: 'Talk'
+  }
+});
+
 const BackButtonWarning = () => {
-  return <p className="back-button-warning" >Going back will clear your work for the current task.</p>;
+  return (
+    <p className="back-button-warning" >
+      <Translate content="classifier.backButtonWarning" />
+    </p>
+  );
 };
 
 class TaskNav extends React.Component {
@@ -165,7 +182,7 @@ class TaskNav extends React.Component {
               onMouseLeave={this.warningToggleOff}
               onBlur={this.warningToggleOff}
             >
-              Back
+              <Translate content="classifier.back" />
             </button>}
           {(!nextTaskKey && this.props.workflow.configuration.hide_classification_summaries && this.props.project && !disableTalk && !completed) &&
             <Link
@@ -174,7 +191,7 @@ class TaskNav extends React.Component {
               className="talk standard-button"
               style={waitingForAnswer ? disabledStyle : {}}
             >
-              Done &amp; Talk
+              <Translate content="classifier.doneAndTalk" />
             </Link>}
           {(nextTaskKey && this.props.annotation && !this.props.annotation.shortcut) ?
             <button
@@ -183,7 +200,7 @@ class TaskNav extends React.Component {
               disabled={waitingForAnswer}
               onClick={this.addAnnotationForTask.bind(this, nextTaskKey)}
             >
-              Next
+              <Translate content="classifier.next" />
             </button> : !completed ?
               <button
                 type="button"
@@ -193,7 +210,7 @@ class TaskNav extends React.Component {
               >
                 {this.props.demoMode && <i className="fa fa-trash fa-fw" />}
                 {this.props.classification.gold_standard && <i className="fa fa-star fa-fw" />}
-                {' '}Done
+                {' '}<Translate content="classifier.done" />
               </button> :
               null
           }
@@ -203,7 +220,7 @@ class TaskNav extends React.Component {
               to={`/projects/${this.props.project.slug}/talk/subjects/${this.props.subject.id}`}
               className="talk standard-button"
             >
-              Talk
+              <Translate content="classifier.talk" />
             </Link>}
           {completed &&
             <button
@@ -211,7 +228,7 @@ class TaskNav extends React.Component {
               className="continue major-button"
               onClick={this.props.nextSubject}
             >
-              Next
+              <Translate content="classifier.next" />
             </button>}
           {this.props.children}
         </nav>

--- a/app/classifier/task-nav.jsx
+++ b/app/classifier/task-nav.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Link } from 'react-router';
-import counterpart from 'counterpart';
 import Translate from 'react-translate-component';
 import { getSessionID } from '../lib/session';
 import tasks from './tasks';
@@ -9,17 +8,6 @@ import GridTool from './drawing-tools/grid';
 import { isFeedbackActive, isThereFeedback } from './feedback/helpers';
 
 /* eslint-disable multiline-ternary, no-nested-ternary, react/jsx-no-bind */
-
-counterpart.registerTranslations('en', {
-  classifier: {
-    back: 'Back',
-    backButtonWarning: 'Going back will clear your work for the current task.',
-    done: 'Done',
-    doneAndTalk: 'Done & Talk',
-    next: 'Next',
-    talk: 'Talk'
-  }
-});
 
 const BackButtonWarning = () => {
   return (

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -1,0 +1,40 @@
+export default {
+  loading: '(Loading)',
+  classifier: {
+    back: 'Back',
+    backButtonWarning: 'Going back will clear your work for the current task.',
+    done: 'Done',
+    doneAndTalk: 'Done & Talk',
+    next: 'Next',
+    talk: 'Talk',
+    tutorialButton: 'Show the project tutorial',
+    miniCourseButton: 'Restart the project mini-course'
+  },
+  project: {
+    loading: 'Loading project',
+    disclaimer: 'This project has been built using the Zooniverse Project Builder but is not yet an official Zooniverse project. Queries and issues relating to this project directed at the Zooniverse Team may not receive any response.',
+    nav: {
+      about: 'About',
+      classify: 'Classify',
+      talk: 'Talk',
+      collections: 'Collect'
+    },
+    home: {
+      researcher: 'Words from the researcher',
+      about: 'About %(title)s',
+      metadata: {
+        statistics: '%(title)s Statistics',
+        classifications: 'Classifications',
+        volunteers: 'Volunteers',
+        completedSubjects: 'Completed Subjects',
+        subjects: 'Subjects'
+      },
+      talk: {
+        zero: 'Noone is talking about <strong>%(title)s</strong> right now.',
+        one: '<strong>1</strong> person is talking about <strong>%(title)s</strong> right now.',
+        other: '<strong>%(count)s</strong> people are talking about <strong>%(title)s</strong> right now.'
+      },
+      joinIn: 'Join in'
+    }
+  }
+};

--- a/app/locales/it.js
+++ b/app/locales/it.js
@@ -1,0 +1,40 @@
+export default {
+  loading: '(Loading)',
+  classifier: {
+    back: 'Back',
+    backButtonWarning: 'Going back will clear your work for the current task.',
+    done: 'Done',
+    doneAndTalk: 'Done & Talk',
+    next: 'Next',
+    talk: 'Talk',
+    tutorialButton: 'Show the project tutorial',
+    miniCourseButton: 'Restart the project mini-course'
+  },
+  project: {
+    disclaimer: "Questo progetto e' stato creato con il Project Builder di Zooniverse, ma non e' ancora un progetto ufficiale. Per questo motivo e' possibile che domande su questo progetto dirette al Team Zooniverse non ricevano una risposta.",
+    loading: 'Caricamento progetto',
+    nav: {
+      about: 'A proposito',
+      classify: 'Classifica',
+      talk: 'Forum',
+      collections: 'Colleziona'
+    },
+    home: {
+      researcher: 'Words from the researcher',
+      about: 'About %(title)s',
+      metadata: {
+        statistics: '%(title)s Statistics',
+        classifications: 'Classifications',
+        volunteers: 'Volunteers',
+        completedSubjects: 'Completed Subjects',
+        subjects: 'Subjects'
+      },
+      talk: {
+        zero: 'Nessuno sta parlando di <strong>%(title)s</strong> in questo momento.',
+        one: '<strong>1</strong> persona sta parlando di <strong>%(title)s</strong> in questo momento.',
+        other: '<strong>%(count)s</strong> persone stanno parlando di <strong>%(title)s</strong> in questo momento.'
+      },
+      joinIn: 'Partecipa'
+    }
+  }
+};

--- a/app/pages/project/home/metadata.jsx
+++ b/app/pages/project/home/metadata.jsx
@@ -1,22 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router';
-import counterpart from 'counterpart';
 import Translate from 'react-translate-component';
 import TalkStatus from './talk-status';
-
-counterpart.registerTranslations('en', {
-  project: {
-    home: {
-      metadata: {
-        statistics: '%(title)s Statistics',
-        classifications: 'Classifications',
-        volunteers: 'Volunteers',
-        completedSubjects: 'Completed Subjects',
-        subjects: 'Subjects'
-      }
-    }
-  }
-});
 
 class ProjectMetadataStat extends React.Component {
   render() {

--- a/app/pages/project/home/metadata.jsx
+++ b/app/pages/project/home/metadata.jsx
@@ -1,20 +1,36 @@
 import React from 'react';
 import { Link } from 'react-router';
+import counterpart from 'counterpart';
+import Translate from 'react-translate-component';
 import TalkStatus from './talk-status';
+
+counterpart.registerTranslations('en', {
+  project: {
+    home: {
+      metadata: {
+        statistics: '%(title)s Statistics',
+        classifications: 'Classifications',
+        volunteers: 'Volunteers',
+        completedSubjects: 'Completed Subjects',
+        subjects: 'Subjects'
+      }
+    }
+  }
+});
 
 class ProjectMetadataStat extends React.Component {
   render() {
     return (
       <div className="project-metadata-stat">
         <div className="project-metadata-stat__value">{this.props.value}</div>
-        <div className="project-metadata-stat__label">{this.props.label}</div>
+        <div className="project-metadata-stat__label">{this.props.children}</div>
       </div>
     );
   }
 }
 
 ProjectMetadataStat.propTypes = {
-  label: React.PropTypes.string.isRequired,
+  children: React.PropTypes.node.isRequired,
   value: React.PropTypes.string.isRequired,
 };
 
@@ -73,16 +89,27 @@ export default class ProjectMetadata extends React.Component {
       <div className="project-home-page__container">
         <div className="project-metadata">
           <Link to={statsLink}>
-            <span>{project.display_name}{' '}Statistics</span>
+            <Translate
+              content="project.home.metadata.statistics"
+              with={{ title: project.display_name }}
+            />
           </Link>
 
           {this.renderStatus()}
 
           <div className="project-metadata-stats">
-            <ProjectMetadataStat label="Volunteers" value={project.classifiers_count.toLocaleString()} />
-            <ProjectMetadataStat label="Classifications" value={this.state.classificationsCount.toLocaleString()} />
-            <ProjectMetadataStat label="Subjects" value={project.subjects_count.toLocaleString()} />
-            <ProjectMetadataStat label="Completed Subjects" value={project.retired_subjects_count.toLocaleString()} />
+            <ProjectMetadataStat value={project.classifiers_count.toLocaleString()}>
+              <Translate content="project.home.metadata.volunteers" />
+            </ProjectMetadataStat>
+            <ProjectMetadataStat value={this.state.classificationsCount.toLocaleString()}>
+              <Translate content="project.home.metadata.classifications" />
+            </ProjectMetadataStat>
+            <ProjectMetadataStat value={project.subjects_count.toLocaleString()}>
+              <Translate content="project.home.metadata.subjects" />
+            </ProjectMetadataStat>
+            <ProjectMetadataStat value={project.retired_subjects_count.toLocaleString()}>
+              <Translate content="project.home.metadata.completedSubjects" />
+            </ProjectMetadataStat>
           </div>
 
         </div>

--- a/app/pages/project/home/project-home.jsx
+++ b/app/pages/project/home/project-home.jsx
@@ -2,22 +2,12 @@ import React from 'react';
 import { Link } from 'react-router';
 import { Markdown } from 'markdownz';
 import Translate from 'react-translate-component';
-import counterpart from 'counterpart';
 import getSubjectLocation from '../../../lib/get-subject-location.coffee';
 import Thumbnail from '../../../components/thumbnail';
 import FinishedBanner from '../finished-banner';
 import ProjectMetadata from './metadata';
 import ProjectHomeWorkflowButtons from './home-workflow-buttons';
 import TalkStatus from './talk-status';
-
-counterpart.registerTranslations('en', {
-  project: {
-    home: {
-      researcher: 'Words from the researcher',
-      about: 'About %(title)s'
-    }
-  }
-});
 
 const ProjectHomePage = (props) => {
   const avatarSrc = props.researcherAvatar || '/assets/simple-avatar.png';

--- a/app/pages/project/home/project-home.jsx
+++ b/app/pages/project/home/project-home.jsx
@@ -1,12 +1,23 @@
 import React from 'react';
 import { Link } from 'react-router';
 import { Markdown } from 'markdownz';
+import Translate from 'react-translate-component';
+import counterpart from 'counterpart';
 import getSubjectLocation from '../../../lib/get-subject-location.coffee';
 import Thumbnail from '../../../components/thumbnail';
 import FinishedBanner from '../finished-banner';
 import ProjectMetadata from './metadata';
 import ProjectHomeWorkflowButtons from './home-workflow-buttons';
 import TalkStatus from './talk-status';
+
+counterpart.registerTranslations('en', {
+  project: {
+    home: {
+      researcher: 'Words from the researcher',
+      about: 'About %(title)s'
+    }
+  }
+});
 
 const ProjectHomePage = (props) => {
   const avatarSrc = props.researcherAvatar || '/assets/simple-avatar.png';
@@ -55,12 +66,16 @@ const ProjectHomePage = (props) => {
         </div>
       )}
 
-      <ProjectMetadata project={props.project} activeWorkflows={props.activeWorkflows} showTalkStatus={!renderTalkSubjectsPreview} />
+      <ProjectMetadata
+        project={props.project}
+        activeWorkflows={props.activeWorkflows}
+        showTalkStatus={!renderTalkSubjectsPreview}
+      />
 
       <div className="project-home-page__container">
         {props.project.researcher_quote && (
           <div className="project-home-page__researcher-words">
-            <h4>Words from the researcher</h4>
+            <h4><Translate content="project.home.researcher" /></h4>
 
             <div>
               <img role="presentation" src={avatarSrc} />
@@ -69,9 +84,18 @@ const ProjectHomePage = (props) => {
           </div>)}
 
         <div className="project-home-page__about-text">
-          <h4>About {props.project.display_name}</h4>
+          <h4>
+            <Translate
+              content="project.home.about"
+              with={{
+                title: props.project.display_name
+              }}
+            />
+          </h4>
           {props.project.introduction &&
-            <Markdown project={props.project}>{props.project.introduction}</Markdown>}
+            <Markdown project={props.project}>
+              {props.project.introduction}
+            </Markdown>}
         </div>
       </div>
     </div>

--- a/app/pages/project/home/talk-status.jsx
+++ b/app/pages/project/home/talk-status.jsx
@@ -64,9 +64,11 @@ export default class TalkStatus extends React.Component {
           }}
           unsafe={true}
         />
-        <Link to={`/projects/${this.props.project.slug}/talk`} className="join-in standard-button">
-          <Translate content="project.home.joinIn" />
-        </Link>
+        <div>
+          <Link to={`/projects/${this.props.project.slug}/talk`} className="join-in standard-button">
+            <Translate content="project.home.joinIn" />
+          </Link>
+        </div>
       </div>
     );
   }

--- a/app/pages/project/home/talk-status.jsx
+++ b/app/pages/project/home/talk-status.jsx
@@ -1,34 +1,7 @@
 import React from 'react';
 import { sugarApiClient } from 'panoptes-client/lib/sugar';
 import { Link } from 'react-router';
-import counterpart from 'counterpart';
 import Translate from 'react-translate-component';
-
-counterpart.registerTranslations('en', {
-  project: {
-    home: {
-      talk: {
-        zero: 'Noone is talking about <strong>%(title)s</strong> right now.',
-        one: '<strong>1</strong> person is talking about <strong>%(title)s</strong> right now.',
-        other: '<strong>%(count)s</strong> people are talking about <strong>%(title)s</strong> right now.'
-      },
-      joinIn: 'Join in'
-    }
-  }
-});
-
-counterpart.registerTranslations('it', {
-  project: {
-    home: {
-      talk: {
-        zero: 'Nessuno sta parlando di <strong>%(title)s</strong> in questo momento.',
-        one: '<strong>1</strong> persona sta parlando di <strong>%(title)s</strong> in questo momento.',
-        other: '<strong>%(count)s</strong> persone stanno parlando di <strong>%(title)s</strong> in questo momento.'
-      },
-      joinIn: 'Partecipa'
-    }
-  }
-});
 
 export default class TalkStatus extends React.Component {
 

--- a/app/pages/project/home/talk-status.jsx
+++ b/app/pages/project/home/talk-status.jsx
@@ -1,6 +1,21 @@
 import React from 'react';
 import { sugarApiClient } from 'panoptes-client/lib/sugar';
 import { Link } from 'react-router';
+import counterpart from 'counterpart';
+import Translate from 'react-translate-component';
+
+counterpart.registerTranslations('en', {
+  project: {
+    home: {
+      talk: {
+        zero: 'Noone is talking about <strong>%(title)s</strong> right now.',
+        one: '<strong>1</strong> person is talking about <strong>%(title)s</strong> right now.',
+        other: '<strong>%(count)s</strong> people are talking about <strong>%(title)s</strong> right now.'
+      },
+      joinIn: 'Join in'
+    }
+  }
+});
 
 export default class TalkStatus extends React.Component {
 
@@ -26,15 +41,19 @@ export default class TalkStatus extends React.Component {
   }
 
   render() {
-    const peopleAmount = this.state.activeUsers === 1 ? 'person is' : 'people are';
-
     return (
       <div className="project-home-page__talk-stat">
-        <span>
-          <strong>{this.state.activeUsers}</strong> {peopleAmount} talking about <strong>{this.props.project.display_name}
-          </strong> right now.
-        </span>
-        <Link to={`/projects/${this.props.project.slug}/talk`} className="join-in standard-button">Join in</Link>
+        <Translate
+          content="project.home.talk"
+          with={{
+            count: this.state.activeUsers,
+            title: this.props.project.display_name
+          }}
+          unsafe={true}
+        />
+        <Link to={`/projects/${this.props.project.slug}/talk`} className="join-in standard-button">
+          <Translate content="project.home.joinIn" />
+        </Link>
       </div>
     );
   }

--- a/app/pages/project/home/talk-status.jsx
+++ b/app/pages/project/home/talk-status.jsx
@@ -17,6 +17,19 @@ counterpart.registerTranslations('en', {
   }
 });
 
+counterpart.registerTranslations('it', {
+  project: {
+    home: {
+      talk: {
+        zero: 'Nessuno sta parlando di <strong>%(title)s</strong> in questo momento.',
+        one: '<strong>1</strong> persona sta parlando di <strong>%(title)s</strong> in questo momento.',
+        other: '<strong>%(count)s</strong> persone stanno parlando di <strong>%(title)s</strong> in questo momento.'
+      },
+      joinIn: 'Partecipa'
+    }
+  }
+});
+
 export default class TalkStatus extends React.Component {
 
   constructor() {

--- a/app/pages/project/index.cjsx
+++ b/app/pages/project/index.cjsx
@@ -6,8 +6,10 @@ counterpart = require 'counterpart'
 isAdmin = require '../../lib/is-admin'
 ProjectPage = require './project-page'
 
-counterpart.registerTranslations 'en',
-  loading: '(Loading)'
+counterpart.registerTranslations 'en', require('../../locales/en').default
+counterpart.registerTranslations 'it', require('../../locales/it').default
+counterpart.setFallbackLocale 'en'
+
 
 ProjectPageController = React.createClass
   displayName: 'ProjectPageController'

--- a/app/pages/project/project-page.cjsx
+++ b/app/pages/project/project-page.cjsx
@@ -1,4 +1,3 @@
-counterpart = require 'counterpart'
 React = require 'react'
 Translate = require 'react-translate-component'
 {IndexLink, Link} = require 'react-router'
@@ -8,30 +7,6 @@ Thumbnail = require('../../components/thumbnail').default
 classnames = require 'classnames'
 PotentialFieldGuide = require './potential-field-guide'
 `import SOCIAL_ICONS from '../../lib/social-icons'`
-
-counterpart.registerTranslations 'en',
-  project:
-    loading: 'Loading project'
-    disclaimer: "This project has been built using the Zooniverse Project Builder but is not yet an official Zooniverse project. Queries and issues relating to this project directed at the Zooniverse Team may not receive any response."
-    nav:
-      about: 'About'
-      classify: 'Classify'
-      talk: 'Talk'
-      collections: 'Collect'
-
-counterpart.registerTranslations 'it',
-{
-  project: {
-    disclaimer: "Questo progetto e' stato creato con il Project Builder di Zooniverse, ma non e' ancora un progetto ufficiale. Per questo motivo e' possibile che domande su questo progetto dirette al Team Zooniverse non ricevano una risposta.",
-    loading: "Caricamento progetto",
-    nav: {
-      about: "A proposito",
-      classify: "Classifica",
-      talk: "Forum",
-      collections: "Colleziona"
-    }
-  }
-}
 
 AVATAR_SIZE = 100
 

--- a/app/pages/project/project-page.cjsx
+++ b/app/pages/project/project-page.cjsx
@@ -19,6 +19,20 @@ counterpart.registerTranslations 'en',
       talk: 'Talk'
       collections: 'Collect'
 
+counterpart.registerTranslations 'it',
+{
+  project: {
+    disclaimer: "Questo progetto e' stato creato con il Project Builder di Zooniverse, ma non e' ancora un progetto ufficiale. Per questo motivo e' possibile che domande su questo progetto dirette al Team Zooniverse non ricevano una risposta.",
+    loading: "Caricamento progetto",
+    nav: {
+      about: "A proposito",
+      classify: "Classifica",
+      talk: "Forum",
+      collections: "Colleziona"
+    }
+  }
+}
+
 AVATAR_SIZE = 100
 
 ProjectPage = React.createClass

--- a/css/project-page.styl
+++ b/css/project-page.styl
@@ -456,7 +456,8 @@
   &-stat
     margin: 0 1vw
     text-align: center
-    :first-child
+    
+    > :first-child
       font-size: 2em
 
     &__value

--- a/css/project-page.styl
+++ b/css/project-page.styl
@@ -332,8 +332,6 @@
     .join-in
       border: 2px solid ZOONIVERSE_NAVY
       color: ZOONIVERSE_NAVY
-      width: 4em
-      width: fit-content
 
       &:hover
         background-color: ZOONIVERSE_NAVY


### PR DESCRIPTION
Extract all the English strings, in project UI, to counterpart.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://localise-projects.pfe-preview.zooniverse.org/
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?


## Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
