### PR TITLE
Add recent classifications to projects

### DIFF
--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -18,7 +18,8 @@ export default {
       about: 'About',
       classify: 'Classify',
       talk: 'Talk',
-      collections: 'Collect'
+      collections: 'Collect',
+      recents: 'Recents'
     },
     home: {
       researcher: 'Words from the researcher',

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -6,6 +6,7 @@ export default {
     done: 'Done',
     doneAndTalk: 'Done & Talk',
     next: 'Next',
+    recents: 'Your recent classifications',
     talk: 'Talk',
     tutorialButton: 'Show the project tutorial',
     miniCourseButton: 'Restart the project mini-course'

--- a/app/locales/it.js
+++ b/app/locales/it.js
@@ -6,6 +6,7 @@ export default {
     done: 'Done',
     doneAndTalk: 'Done & Talk',
     next: 'Next',
+    recents: 'Your recent classifications',
     talk: 'Talk',
     tutorialButton: 'Show the project tutorial',
     miniCourseButton: 'Restart the project mini-course'

--- a/app/locales/it.js
+++ b/app/locales/it.js
@@ -18,7 +18,8 @@ export default {
       about: 'A proposito',
       classify: 'Classifica',
       talk: 'Forum',
-      collections: 'Colleziona'
+      collections: 'Colleziona',
+      recents: 'Recents'
     },
     home: {
       researcher: 'Words from the researcher',

--- a/app/pages/profile/recents.jsx
+++ b/app/pages/profile/recents.jsx
@@ -26,30 +26,32 @@ class Recents extends React.Component {
   render() {
     const { project } = this.props;
     return (
-      <div className="secondary-page has-project-context">
+      <div className="collections-page secondary-page has-project-context">
         <div className="hero collections-hero">
           <div className="hero-container">
             <Translate content="classifier.recents" component="h1" />
           </div>
         </div>
-        <ul className="collections-card-list">
-          {this.state.recents.map((recent) => {
-            const { type, format, src } = getSubjectLocation(recent);
-            return (
-              <li key={recent.id} className="collection-card">
-                <Link to={`/projects/${project.slug}/talk/subjects/${recent.links.subject}`}>
-                  <Thumbnail
-                    alt={`Subject ${recent.links.subject}`}
-                    src={src}
-                    type={type}
-                    format={format}
-                    height={250}
-                  />
-                </Link>
-              </li>
-            );
-          })}
-        </ul>
+        <div className="content-container collection-page-with-project-context">
+          <ul className="collections-show">
+            {this.state.recents.map((recent) => {
+              const { type, format, src } = getSubjectLocation(recent);
+              return (
+                <li key={recent.id} className="collection-subject-viewer">
+                  <Link to={`/projects/${project.slug}/talk/subjects/${recent.links.subject}`}>
+                    <Thumbnail
+                      alt={`Subject ${recent.links.subject}`}
+                      src={src}
+                      type={type}
+                      format={format}
+                      height={250}
+                    />
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
       </div>
     );
   }

--- a/app/pages/profile/recents.jsx
+++ b/app/pages/profile/recents.jsx
@@ -15,7 +15,7 @@ class Recents extends React.Component {
 
   componentDidMount() {
     const { user } = this.props;
-    user.get('recents', { project_id: this.props.project.id, sort: '-created_at' })
+    !!user && user.get('recents', { project_id: this.props.project.id, sort: '-created_at' })
     .then(recents => this.setState({ recents }));
   }
 

--- a/app/pages/profile/recents.jsx
+++ b/app/pages/profile/recents.jsx
@@ -55,4 +55,13 @@ class Recents extends React.Component {
   }
 }
 
+Recents.propTypes = {
+  project: React.PropTypes.shape({
+    id: React.PropTypes.string
+  }).isRequired,
+  user: React.PropTypes.shape({
+    get: React.PropTypes.func
+  }).isRequired
+};
+
 export default Recents;

--- a/app/pages/profile/recents.jsx
+++ b/app/pages/profile/recents.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Link } from 'react-router';
 import Translate from 'react-translate-component';
 import Thumbnail from '../../components/thumbnail';
+import getSubjectLocation from '../../lib/get-subject-location';
 
 class Recents extends React.Component {
   constructor() {
@@ -32,18 +33,22 @@ class Recents extends React.Component {
           </div>
         </div>
         <ul className="collections-card-list">
-          {this.state.recents.map(recent => (
-            <li key={recent.id} className="collection-card">
-              <Link to={`/projects/${project.slug}/talk/subjects/${recent.links.subject}`}>
-                <Thumbnail
-                  alt={`Subject ${recent.links.subject}`}
-                  src={recent.locations[0]['image/jpeg']}
-                  height={250}
-                />
-              </Link>
-            </li>
-            )
-          )}
+          {this.state.recents.map((recent) => {
+            const { type, format, src } = getSubjectLocation(recent);
+            return (
+              <li key={recent.id} className="collection-card">
+                <Link to={`/projects/${project.slug}/talk/subjects/${recent.links.subject}`}>
+                  <Thumbnail
+                    alt={`Subject ${recent.links.subject}`}
+                    src={src}
+                    type={type}
+                    format={format}
+                    height={250}
+                  />
+                </Link>
+              </li>
+            );
+          })}
         </ul>
       </div>
     );

--- a/app/pages/profile/recents.jsx
+++ b/app/pages/profile/recents.jsx
@@ -32,26 +32,28 @@ class Recents extends React.Component {
             <Translate content="classifier.recents" component="h1" />
           </div>
         </div>
-        <div className="content-container collection-page-with-project-context">
-          <ul className="collections-show">
-            {this.state.recents.map((recent) => {
-              const { type, format, src } = getSubjectLocation(recent);
-              return (
-                <li key={recent.id} className="collection-subject-viewer">
-                  <Link to={`/projects/${project.slug}/talk/subjects/${recent.links.subject}`}>
-                    <Thumbnail
-                      alt={`Subject ${recent.links.subject}`}
-                      src={src}
-                      type={type}
-                      format={format}
-                      height={250}
-                    />
-                  </Link>
-                </li>
-              );
-            })}
-          </ul>
-        </div>
+        {(this.state.recents.length > 0) &&
+          <div className="content-container collection-page-with-project-context">
+            <ul className="collections-show">
+              {this.state.recents.map((recent) => {
+                const { type, format, src } = getSubjectLocation(recent);
+                return (
+                  <li key={recent.id} className="collection-subject-viewer">
+                    <Link to={`/projects/${project.slug}/talk/subjects/${recent.links.subject}`}>
+                      <Thumbnail
+                        alt={`Subject ${recent.links.subject}`}
+                        src={src}
+                        type={type}
+                        format={format}
+                        height={250}
+                      />
+                    </Link>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        }
       </div>
     );
   }

--- a/app/pages/profile/recents.jsx
+++ b/app/pages/profile/recents.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { Link } from 'react-router';
+import Translate from 'react-translate-component';
+import Thumbnail from '../../components/thumbnail';
+
+class Recents extends React.Component {
+  constructor() {
+    super();
+    this.state = {
+      recents: []
+    };
+  }
+
+  componentDidMount() {
+    const { user } = this.props;
+    user.get('recents', { project_id: this.props.project.id, sort: '-created_at' })
+    .then(recents => this.setState({ recents }));
+  }
+
+  render() {
+    const { project } = this.props;
+    return (
+      <div className="secondary-page">
+        <h2><Translate content="classifier.recents" /></h2>
+        {this.state.recents.map(recent => (
+          <Link to={`/projects/${project.slug}/talk/subjects/${recent.links.subject}`}>
+            <Thumbnail alt={`Subject ${recent.links.subject}`} src={recent.locations[0]['image/jpeg']} width={150} />
+          </Link>
+          )
+        )}
+      </div>
+    );
+  }
+}
+
+export default Recents;

--- a/app/pages/profile/recents.jsx
+++ b/app/pages/profile/recents.jsx
@@ -20,7 +20,7 @@ class Recents extends React.Component {
   }
 
   componentWillUnmount() {
-    document.documentElement.classList.add('on-secondary-page');
+    document.documentElement.classList.remove('on-secondary-page');
   }
 
   render() {

--- a/app/pages/profile/recents.jsx
+++ b/app/pages/profile/recents.jsx
@@ -9,6 +9,7 @@ class Recents extends React.Component {
     this.state = {
       recents: []
     };
+    document.documentElement.classList.add('on-secondary-page');
   }
 
   componentDidMount() {
@@ -17,17 +18,33 @@ class Recents extends React.Component {
     .then(recents => this.setState({ recents }));
   }
 
+  componentWillUnmount() {
+    document.documentElement.classList.add('on-secondary-page');
+  }
+
   render() {
     const { project } = this.props;
     return (
-      <div className="secondary-page">
-        <h2><Translate content="classifier.recents" /></h2>
-        {this.state.recents.map(recent => (
-          <Link to={`/projects/${project.slug}/talk/subjects/${recent.links.subject}`}>
-            <Thumbnail alt={`Subject ${recent.links.subject}`} src={recent.locations[0]['image/jpeg']} width={150} />
-          </Link>
-          )
-        )}
+      <div className="secondary-page has-project-context">
+        <div className="hero collections-hero">
+          <div className="hero-container">
+            <Translate content="classifier.recents" component="h1" />
+          </div>
+        </div>
+        <ul className="collections-card-list">
+          {this.state.recents.map(recent => (
+            <li key={recent.id} className="collection-card">
+              <Link to={`/projects/${project.slug}/talk/subjects/${recent.links.subject}`}>
+                <Thumbnail
+                  alt={`Subject ${recent.links.subject}`}
+                  src={recent.locations[0]['image/jpeg']}
+                  height={250}
+                />
+              </Link>
+            </li>
+            )
+          )}
+        </ul>
       </div>
     );
   }

--- a/app/pages/profile/recents.jsx
+++ b/app/pages/profile/recents.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router';
 import Translate from 'react-translate-component';
+import SubjectViewer from '../../components/subject-viewer';
 import Thumbnail from '../../components/thumbnail';
 import getSubjectLocation from '../../lib/get-subject-location';
 
@@ -24,7 +25,7 @@ class Recents extends React.Component {
   }
 
   render() {
-    const { project } = this.props;
+    const { user, project } = this.props;
     return (
       <div className="collections-page secondary-page has-project-context">
         <div className="hero collections-hero">
@@ -37,17 +38,30 @@ class Recents extends React.Component {
             <ul className="collections-show">
               {this.state.recents.map((recent) => {
                 const { type, format, src } = getSubjectLocation(recent);
+                const fakeSubject = {
+                  id: recent.links.subject,
+                  locations: recent.locations
+                };
                 return (
                   <li key={recent.id} className="collection-subject-viewer">
-                    <Link to={`/projects/${project.slug}/talk/subjects/${recent.links.subject}`}>
-                      <Thumbnail
-                        alt={`Subject ${recent.links.subject}`}
-                        src={src}
-                        type={type}
-                        format={format}
-                        height={250}
-                      />
-                    </Link>
+                    <SubjectViewer
+                      project={project}
+                      subject={fakeSubject}
+                      user={user}
+                    >
+                      <Link
+                        className="subject-link"
+                        to={`/projects/${project.slug}/talk/subjects/${recent.links.subject}`}
+                      >
+                        <Thumbnail
+                          alt={`Subject ${recent.links.subject}`}
+                          src={src}
+                          type={type}
+                          format={format}
+                          height={250}
+                        />
+                      </Link>
+                    </SubjectViewer>
                   </li>
                 );
               })}

--- a/app/pages/profile/recents.jsx
+++ b/app/pages/profile/recents.jsx
@@ -40,7 +40,7 @@ class Recents extends React.Component {
                 const { type, format, src } = getSubjectLocation(recent);
                 const fakeSubject = {
                   id: recent.links.subject,
-                  locations: recent.locations
+                  locations: [{ [`${type}/${format}`]: src }]
                 };
                 return (
                   <li key={recent.id} className="collection-subject-viewer">

--- a/app/pages/project/project-page.cjsx
+++ b/app/pages/project/project-page.cjsx
@@ -158,6 +158,12 @@ ProjectPage = React.createClass
           <Translate content="project.nav.collections" />
         </Link>
 
+        {if @props.user
+           <Link to="#{projectPath}/recents" activeClassName="active" className="tabbed-content-tab">
+            <Translate content="project.nav.recents" />
+          </Link>
+        }
+
         {rearrangedLinks.map ({label, url}, i) =>
           unless !!label
             for pattern, icon of SOCIAL_ICONS

--- a/app/router.cjsx
+++ b/app/router.cjsx
@@ -33,6 +33,7 @@ React = require 'react'
 `import SignInPage from './pages/sign-in';`
 `import NotFoundPage from './pages/not-found';`
 `import ResetPasswordPage from './pages/reset-password/reset-password';`
+`import Recents from './pages/profile/recents';`
 
 # <Redirect from="home" to="/" /> doesn't work.
 ONE_UP_REDIRECT = React.createClass
@@ -162,6 +163,7 @@ module.exports =
         <Route path="collections" component={require('./pages/collections/collections-list')} />
         <Route path="message" component={require './pages/profile/private-message'} />
       </Route>
+      <Route path="recents" component={Recents} />
     </Route>
 
     <Route path="organizations/:owner/:name" component={(require './pages/organizations/organization-container').default}>


### PR DESCRIPTION
Add a /recents route to projects 
eg. https://recents.pfe-preview.zooniverse.org/projects/sandiegozooglobal/wildwatch-kenya/recents?env=production
Add a basic component to render subjects from the user recents API endpoint.

Allows volunteers to see their recently classified subjects and link through to Talk.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://recents.pfe-preview.zooniverse.org/
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?


## Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
