### PR TITLE
Reset PanZoom on subject change

### DIFF
--- a/app/components/frame-viewer.jsx
+++ b/app/components/frame-viewer.jsx
@@ -60,7 +60,12 @@ export default class FrameViewer extends React.Component {
     const ProgressMarker = this.props.progressMarker;
     if (FrameWrapper) {
       return (
-        <PanZoom ref={(c) => { this.panZoom = c; }} enabled={zoomEnabled} frameDimensions={this.state.frameDimensions}>
+        <PanZoom
+          ref={(c) => { this.panZoom = c; }}
+          enabled={zoomEnabled}
+          frameDimensions={this.state.frameDimensions}
+          subject={this.props.subject}
+        >
           <FrameWrapper
             frame={this.props.frame}
             naturalWidth={this.state.frameDimensions.width || 0}

--- a/app/components/pan-zoom.jsx
+++ b/app/components/pan-zoom.jsx
@@ -1,29 +1,18 @@
 /* eslint no-unused-expressions: ["error", { "allowTernary": true }] */
 import React from 'react';
 
-const PanZoom = React.createClass({
-
-  propTypes: {
-    children: React.PropTypes.node,
-    enabled: React.PropTypes.bool,
-    frameDimensions: React.PropTypes.shape({
-      height: React.PropTypes.number,
-      width: React.PropTypes.number
-    })
-  },
-
-  getDefaultProps() {
-    return {
-      enabled: false,
-      frameDimensions: {
-        height: 0,
-        width: 0
-      }
-    };
-  },
-
-  getInitialState() {
-    return {
+class PanZoom extends React.Component {
+  constructor() {
+    super();
+    this.frameKeyPan = this.frameKeyPan.bind(this);
+    this.panByDrag = this.panByDrag.bind(this);
+    this.rotateClockwise = this.rotateClockwise.bind(this);
+    this.stopZoom = this.stopZoom.bind(this);
+    this.togglePanOn = this.togglePanOn.bind(this);
+    this.togglePanOff = this.togglePanOff.bind(this);
+    this.wheelZoom = this.wheelZoom.bind(this);
+    this.zoomReset = this.zoomReset.bind(this);
+    this.state = {
       panEnabled: false,
       viewBoxDimensions: {
         x: 0,
@@ -36,7 +25,8 @@ const PanZoom = React.createClass({
       rotation: 0,
       transform: ''
     };
-  },
+  }
+
 
   componentDidMount() {
     // these events enable a user to navigate an image using arrows, +, and - keys,
@@ -45,7 +35,7 @@ const PanZoom = React.createClass({
       this.root.addEventListener('keydown', this.frameKeyPan);
       this.root.addEventListener('wheel', this.wheelZoom);
     }
-  },
+  }
 
   componentWillUpdate(newProps) {
     if (newProps.frameDimensions === this.props.frameDimensions) return;
@@ -57,103 +47,32 @@ const PanZoom = React.createClass({
         y: 0
       }
     });
-  },
+  }
 
   componentWillUnmount() {
     this.root.removeEventListener('keydown', this.frameKeyPan);
     this.root.removeEventListener('wheel', this.wheelZoom);
-  },
-
-  render() {
-    const children = React.Children.map(this.props.children, (child) => {
-      return React.cloneElement(child, {
-        viewBoxDimensions: this.state.viewBoxDimensions,
-        panByDrag: this.panByDrag,
-        panEnabled: this.state.panEnabled,
-        transform: this.state.transform,
-        rotation: this.state.rotation
-      });
-    });
-    return (
-      <div ref={(element) => { this.root = element; }}>
-        {children}
-        {this.props.enabled ?
-          <div className="pan-zoom-controls" >
-            <div className="draw-pan-toggle" >
-              <div className={this.state.panEnabled ? '' : 'active'} >
-                <button title="annotate" className="fa fa-mouse-pointer" onClick={this.togglePanOff} />
-              </div>
-              <div className={this.state.panEnabled ? 'active' : ''}>
-                <button
-                  title="pan"
-                  ref={(element) => { this.pan = element; }}
-                  className="fa fa-arrows"
-                  onClick={this.handleFocus.bind(this, 'pan')}
-                  onFocus={this.togglePanOn} onBlur={this.togglePanOff}
-                />
-              </div>
-            </div>
-            <div>
-              <button
-                title="zoom out"
-                ref={(element) => { this.zoomOut = element; }}
-                className={`zoom-out fa fa-minus ${this.cannotZoomOut() ? 'disabled' : ''}`}
-                onMouseDown={this.continuousZoom.bind(this, 1.1)}
-                onMouseUp={this.stopZoom}
-                onMouseOut={this.stopZoom}
-                onKeyDown={this.keyDownZoomButton.bind(this, 1.1)}
-                onKeyUp={this.stopZoom}
-                onFocus={this.togglePanOn}
-                onBlur={this.togglePanOff}
-                onClick={this.handleFocus.bind(this, 'zoomOut')}
-              />
-            </div>
-            <div>
-              <button
-                title="zoom in"
-                ref={(element) => { this.zoomIn = element; }}
-                className="zoom-in fa fa-plus"
-                onMouseDown={this.continuousZoom.bind(this, 0.9)}
-                onMouseUp={this.stopZoom}
-                onMouseOut={this.stopZoom}
-                onKeyDown={this.keyDownZoomButton.bind(this, 0.9)}
-                onKeyUp={this.stopZoom}
-                onFocus={this.togglePanOn}
-                onBlur={this.togglePanOff}
-                onClick={this.handleFocus.bind(this, 'zoomIn')}
-              />
-            </div>
-            <div>
-              <button title="rotate" className={'rotate fa fa-repeat'} onClick={this.rotateClockwise} />
-            </div>
-            <div>
-              <button title="reset zoom levels" className={'reset fa fa-refresh' + (this.cannotResetZoomRotate() ? ' disabled' : '')} onClick={this.zoomReset} />
-            </div>
-          </div>
-          : ''
-        }
-      </div>
-    );
-  },
+  }
 
   handleFocus(ref) {
     this[ref].focus();
     this.togglePanOn();
-  },
+  }
 
   cannotZoomOut() {
-    return this.props.frameDimensions.width === this.state.viewBoxDimensions.width && this.props.frameDimensions.height === this.state.viewBoxDimensions.height;
-  },
+    return this.props.frameDimensions.width === this.state.viewBoxDimensions.width &&
+    this.props.frameDimensions.height === this.state.viewBoxDimensions.height;
+  }
 
   cannotResetZoomRotate() {
-    return this.cannotZoomOut() && this.state.rotation === 0
-  },
+    return this.cannotZoomOut() && this.state.rotation === 0;
+  }
 
   continuousZoom(change) {
     this.clearZoomingTimeout();
     if (change === 0) return;
     this.setState({ zooming: true }, () => {
-      let zoomNow = () => {
+      const zoomNow = () => {
         // if !this.state.zooming, we don't want to continuously call setTimeout.
         // !this.state.zooming will be the case after a user creates a mouseup event.
         if (!this.state.zooming) return;
@@ -163,13 +82,13 @@ const PanZoom = React.createClass({
       };
       zoomNow();
     });
-  },
+  }
 
   clearZoomingTimeout() {
     if (this.state.zoomingTimeoutId) {
       clearTimeout(this.state.zoomingTimeoutId);
     }
-  },
+  }
 
   zoom(change) {
     this.clearZoomingTimeout();
@@ -180,7 +99,8 @@ const PanZoom = React.createClass({
     const newNaturalX = this.state.viewBoxDimensions.x - ((newNaturalWidth - this.state.viewBoxDimensions.width) / 2);
     const newNaturalY = this.state.viewBoxDimensions.y - ((newNaturalHeight - this.state.viewBoxDimensions.height) / 2);
 
-    if ((newNaturalWidth > this.props.frameDimensions.width) || (newNaturalHeight * change > this.props.frameDimensions.height)) {
+    if ((newNaturalWidth > this.props.frameDimensions.width) ||
+    (newNaturalHeight * change > this.props.frameDimensions.height)) {
       this.zoomReset();
     } else {
       this.setState({
@@ -192,7 +112,7 @@ const PanZoom = React.createClass({
         }
       });
     }
-  },
+  }
 
   keyDownZoomButton(change, e) {
     // only zoom if a user presses enter on the zoom button.
@@ -201,13 +121,13 @@ const PanZoom = React.createClass({
         this.zoom(change);
       });
     }
-  },
+  }
 
   stopZoom(e) {
     e.stopPropagation();
     this.setState({ zooming: false });
     this.continuousZoom(0);
-  },
+  }
 
   zoomReset() {
     this.setState({
@@ -220,30 +140,32 @@ const PanZoom = React.createClass({
       rotation: 0,
       transform: `rotate(${0} ${this.props.frameDimensions.width / 2} ${this.props.frameDimensions.height / 2})`
     });
-  },
+  }
 
   togglePanOn() {
     if (!this.state.panEnabled) this.setState({ panEnabled: true });
-  },
+  }
 
   togglePanOff() {
     this.setState({ panEnabled: false });
-  },
+  }
 
   toggleKeyPanZoom() {
     this.setState({ keyPanZoomEnabled: !this.state.keyPanZoomEnabled });
-  },
+  }
 
   panByDrag(e, d) {
     if (!this.state.panEnabled) return;
 
-    const maximumX = (this.props.frameDimensions.width - this.state.viewBoxDimensions.width) + (this.props.frameDimensions.width * 0.6);
+    const maximumX = (this.props.frameDimensions.width - this.state.viewBoxDimensions.width) +
+    (this.props.frameDimensions.width * 0.6);
     const minumumX = -(this.props.frameDimensions.width * 0.6);
-    const changedX = this.state.viewBoxDimensions.x -= d.x;
+    const changedX = this.state.viewBoxDimensions.x - d.x;
 
-    const maximumY = (this.props.frameDimensions.height - this.state.viewBoxDimensions.height) + (this.props.frameDimensions.height * 0.6);
+    const maximumY = (this.props.frameDimensions.height - this.state.viewBoxDimensions.height) +
+    (this.props.frameDimensions.height * 0.6);
     const minimumY = -(this.props.frameDimensions.height * 0.6);
-    const changedY = this.state.viewBoxDimensions.y -= d.y;
+    const changedY = this.state.viewBoxDimensions.y - d.y;
 
     this.setState({
       viewBoxDimensions: {
@@ -253,7 +175,7 @@ const PanZoom = React.createClass({
         height: this.state.viewBoxDimensions.height
       }
     });
-  },
+  }
 
   frameKeyPan(e) {
     if (!this.state.panEnabled) return;
@@ -295,17 +217,18 @@ const PanZoom = React.createClass({
         break;
       // no default
     }
-  },
+  }
 
   wheelZoom(e) {
     if (!this.state.panEnabled) return;
     e.preventDefault();
     this.setState({ zooming: true });
     (e.deltaY > 0) ? this.zoom(1.1) : this.zoom(0.9);
-  },
+  }
 
   panHorizontal(direction) {
-    const maximumX = (this.props.frameDimensions.width - this.state.viewBoxDimensions.width) + (this.props.frameDimensions.width * 0.6);
+    const maximumX = (this.props.frameDimensions.width - this.state.viewBoxDimensions.width) +
+    (this.props.frameDimensions.width * 0.6);
     const minumumX = -(this.props.frameDimensions.width * 0.6);
     const changedX = this.state.viewBoxDimensions.x + direction;
     this.setState({
@@ -316,10 +239,11 @@ const PanZoom = React.createClass({
         height: this.state.viewBoxDimensions.height
       }
     });
-  },
+  }
 
   panVertical(direction) {
-    const maximumY = (this.props.frameDimensions.height - this.state.viewBoxDimensions.height) + (this.props.frameDimensions.height * 0.6);
+    const maximumY = (this.props.frameDimensions.height - this.state.viewBoxDimensions.height) +
+    (this.props.frameDimensions.height * 0.6);
     const minimumY = -(this.props.frameDimensions.height * 0.6);
     const changedY = this.state.viewBoxDimensions.y + direction;
     this.setState({
@@ -330,7 +254,7 @@ const PanZoom = React.createClass({
         height: this.state.viewBoxDimensions.height
       }
     });
-  },
+  }
 
   rotateClockwise() {
     const newRotation = this.state.rotation + 90;
@@ -339,6 +263,100 @@ const PanZoom = React.createClass({
       transform: `rotate(${newRotation} ${this.props.frameDimensions.width / 2} ${this.props.frameDimensions.height / 2})`
     });
   }
-});
+
+  render() {
+    const children = React.Children.map(this.props.children, child =>
+      React.cloneElement(child, {
+        viewBoxDimensions: this.state.viewBoxDimensions,
+        panByDrag: this.panByDrag,
+        panEnabled: this.state.panEnabled,
+        transform: this.state.transform,
+        rotation: this.state.rotation
+      })
+    );
+    return (
+      <div ref={(element) => { this.root = element; }}>
+        {children}
+        {this.props.enabled ?
+          <div className="pan-zoom-controls" >
+            <div className="draw-pan-toggle" >
+              <div className={this.state.panEnabled ? '' : 'active'} >
+                <button title="annotate" className="fa fa-mouse-pointer" onClick={this.togglePanOff} />
+              </div>
+              <div className={this.state.panEnabled ? 'active' : ''}>
+                <button
+                  title="pan"
+                  ref={(element) => { this.pan = element; }}
+                  className="fa fa-arrows"
+                  onClick={this.handleFocus.bind(this, 'pan')}
+                  onFocus={this.togglePanOn}
+                  onBlur={this.togglePanOff}
+                />
+              </div>
+            </div>
+            <div>
+              <button
+                title="zoom out"
+                ref={(element) => { this.zoomOut = element; }}
+                className={`zoom-out fa fa-minus ${this.cannotZoomOut() ? 'disabled' : ''}`}
+                onMouseDown={this.continuousZoom.bind(this, 1.1)}
+                onMouseUp={this.stopZoom}
+                onMouseOut={this.stopZoom}
+                onKeyDown={this.keyDownZoomButton.bind(this, 1.1)}
+                onKeyUp={this.stopZoom}
+                onFocus={this.togglePanOn}
+                onBlur={this.togglePanOff}
+                onClick={this.handleFocus.bind(this, 'zoomOut')}
+              />
+            </div>
+            <div>
+              <button
+                title="zoom in"
+                ref={(element) => { this.zoomIn = element; }}
+                className="zoom-in fa fa-plus"
+                onMouseDown={this.continuousZoom.bind(this, 0.9)}
+                onMouseUp={this.stopZoom}
+                onMouseOut={this.stopZoom}
+                onKeyDown={this.keyDownZoomButton.bind(this, 0.9)}
+                onKeyUp={this.stopZoom}
+                onFocus={this.togglePanOn}
+                onBlur={this.togglePanOff}
+                onClick={this.handleFocus.bind(this, 'zoomIn')}
+              />
+            </div>
+            <div>
+              <button title="rotate" className={'rotate fa fa-repeat'} onClick={this.rotateClockwise} />
+            </div>
+            <div>
+              <button
+                title="reset zoom levels"
+                className={`reset fa fa-refresh ${this.cannotResetZoomRotate() ? ' disabled' : ''}`}
+                onClick={this.zoomReset}
+              />
+            </div>
+          </div>
+          : ''
+        }
+      </div>
+    );
+  }
+}
+
+PanZoom.propTypes = {
+  children: React.PropTypes.node,
+  enabled: React.PropTypes.bool,
+  frameDimensions: React.PropTypes.shape({
+    height: React.PropTypes.number,
+    width: React.PropTypes.number
+  })
+};
+
+PanZoom.defaultProps = {
+  enabled: false,
+  frameDimensions: {
+    height: 0,
+    width: 0
+  }
+};
 
 export default PanZoom;

--- a/app/components/pan-zoom.jsx
+++ b/app/components/pan-zoom.jsx
@@ -37,18 +37,6 @@ class PanZoom extends React.Component {
     }
   }
 
-  componentWillUpdate(newProps) {
-    if (newProps.frameDimensions === this.props.frameDimensions) return;
-    this.setState({
-      viewBoxDimensions: {
-        width: newProps.frameDimensions.width,
-        height: newProps.frameDimensions.height,
-        x: 0,
-        y: 0
-      }
-    });
-  }
-
   componentWillUnmount() {
     this.root.removeEventListener('keydown', this.frameKeyPan);
     this.root.removeEventListener('wheel', this.wheelZoom);

--- a/app/components/pan-zoom.jsx
+++ b/app/components/pan-zoom.jsx
@@ -35,6 +35,15 @@ class PanZoom extends React.Component {
       this.root.addEventListener('keydown', this.frameKeyPan);
       this.root.addEventListener('wheel', this.wheelZoom);
     }
+    this.zoomReset();
+  }
+
+  componentDidUpdate(oldProps) {
+    const newSubject = oldProps.subject !== this.props.subject;
+    const imgLoaded = oldProps.frameDimensions.width === 0 && this.props.frameDimensions.width > 0;
+    if (newSubject || imgLoaded) {
+      this.zoomReset();
+    }
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
Fixes #4034.

Describe your changes.
Removes React.createClass from `PanZoom`.
Deletes the old `componentWillUpdate` method.
Resets the zoom level and rotation if subject or frame width change.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://pan-zoom.pfe-preview.zooniverse.org/
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?


## Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
