### PR TITLE
Fix a couple of pan zoom bugs

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -15,7 +15,7 @@
     "comma-dangle": ["warn", "never"],
     "import/extensions": "off",
     "import/no-unresolved": "off",
-    "indent": ["warn", 2],
+    "indent": ["warn", 2, {"SwitchCase": 1}],
     "react/jsx-no-bind": "off",
     "max-len": [1, 120, 2, {
       "ignoreUrls": true,

--- a/app/components/pan-zoom.jsx
+++ b/app/components/pan-zoom.jsx
@@ -128,7 +128,7 @@ class PanZoom extends React.Component {
   }
 
   zoomReset(props) {
-    props = props ? props : this.props;
+    props = props || this.props;
     this.setState({
       viewBoxDimensions: {
         width: props.frameDimensions.width,
@@ -342,12 +342,15 @@ class PanZoom extends React.Component {
 }
 
 PanZoom.propTypes = {
-  children: React.PropTypes.node,
+  children: React.PropTypes.node.isRequired,
   enabled: React.PropTypes.bool,
   frameDimensions: React.PropTypes.shape({
     height: React.PropTypes.number,
     width: React.PropTypes.number
-  })
+  }),
+  subject: React.PropTypes.shape({
+    id: React.PropTypes.string
+  }).isRequired
 };
 
 PanZoom.defaultProps = {

--- a/app/components/pan-zoom.jsx
+++ b/app/components/pan-zoom.jsx
@@ -11,7 +11,7 @@ class PanZoom extends React.Component {
     this.togglePanOn = this.togglePanOn.bind(this);
     this.togglePanOff = this.togglePanOff.bind(this);
     this.wheelZoom = this.wheelZoom.bind(this);
-    this.zoomReset = this.zoomReset.bind(this);
+    this.onReset = this.onReset.bind(this);
     this.state = {
       panEnabled: false,
       viewBoxDimensions: {
@@ -125,6 +125,10 @@ class PanZoom extends React.Component {
     e.stopPropagation();
     this.setState({ zooming: false });
     this.continuousZoom(0);
+  }
+
+  onReset() {
+    this.zoomReset();
   }
 
   zoomReset(props) {
@@ -330,7 +334,7 @@ class PanZoom extends React.Component {
               <button
                 title="reset zoom levels"
                 className={`reset fa fa-refresh ${this.cannotResetZoomRotate() ? ' disabled' : ''}`}
-                onClick={this.zoomReset}
+                onClick={this.onReset}
               />
             </div>
           </div>

--- a/app/components/pan-zoom.jsx
+++ b/app/components/pan-zoom.jsx
@@ -346,7 +346,7 @@ class PanZoom extends React.Component {
 }
 
 PanZoom.propTypes = {
-  children: React.PropTypes.node.isRequired,
+  children: React.PropTypes.node,
   enabled: React.PropTypes.bool,
   frameDimensions: React.PropTypes.shape({
     height: React.PropTypes.number,
@@ -354,14 +354,18 @@ PanZoom.propTypes = {
   }),
   subject: React.PropTypes.shape({
     id: React.PropTypes.string
-  }).isRequired
+  })
 };
 
 PanZoom.defaultProps = {
+  children: null,
   enabled: false,
   frameDimensions: {
     height: 0,
     width: 0
+  },
+  subject: {
+    id: ''
   }
 };
 

--- a/app/components/pan-zoom.jsx
+++ b/app/components/pan-zoom.jsx
@@ -38,11 +38,11 @@ class PanZoom extends React.Component {
     this.zoomReset();
   }
 
-  componentDidUpdate(oldProps) {
-    const newSubject = oldProps.subject !== this.props.subject;
-    const imgLoaded = oldProps.frameDimensions.width === 0 && this.props.frameDimensions.width > 0;
+  componentWillUpdate(newProps) {
+    const newSubject = newProps.subject !== this.props.subject;
+    const imgLoaded = newProps.frameDimensions.width > 0 && this.props.frameDimensions.width === 0;
     if (newSubject || imgLoaded) {
-      this.zoomReset();
+      this.zoomReset(newProps);
     }
   }
 
@@ -126,16 +126,17 @@ class PanZoom extends React.Component {
     this.continuousZoom(0);
   }
 
-  zoomReset() {
+  zoomReset(props) {
+    props = props ? props : this.props;
     this.setState({
       viewBoxDimensions: {
-        width: this.props.frameDimensions.width,
-        height: this.props.frameDimensions.height,
+        width: props.frameDimensions.width,
+        height: props.frameDimensions.height,
         x: 0,
         y: 0
       },
       rotation: 0,
-      transform: `rotate(${0} ${this.props.frameDimensions.width / 2} ${this.props.frameDimensions.height / 2})`
+      transform: `rotate(${0} ${props.frameDimensions.width / 2} ${props.frameDimensions.height / 2})`
     });
   }
 

--- a/app/components/pan-zoom.jsx
+++ b/app/components/pan-zoom.jsx
@@ -40,8 +40,9 @@ class PanZoom extends React.Component {
 
   componentWillUpdate(newProps) {
     const newSubject = newProps.subject !== this.props.subject;
-    const imgLoaded = newProps.frameDimensions.width > 0 && this.props.frameDimensions.width === 0;
-    if (newSubject || imgLoaded) {
+    const widthChanged = newProps.frameDimensions.width !== this.props.frameDimensions.width;
+    const heightChanged = newProps.frameDimensions.height !== this.props.frameDimensions.height;
+    if (newSubject || widthChanged || heightChanged) {
       this.zoomReset(newProps);
     }
   }


### PR DESCRIPTION
Checks image height and width for changes before resetting zoom for a new subject.

Fixes some eslint warnings.

Adds an eslint rule for switch/case indentation.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://pan-zoom.pfe-preview.zooniverse.org/
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?


## Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
