### PR TITLE
refactor slider to stateless component

### DIFF
--- a/app/classifier/tasks/index.jsx
+++ b/app/classifier/tasks/index.jsx
@@ -8,7 +8,7 @@ import SliderTask from './slider/';
 import TextTask from './text/';
 import DropdownTask from './dropdown/';
 import ShortcutTask from './shortcut';
-import Highlighter from './highlighter/'
+import Highlighter from './highlighter/';
 
 const tasks = {
   combo: ComboTask,

--- a/app/classifier/tasks/index.spec.js
+++ b/app/classifier/tasks/index.spec.js
@@ -7,14 +7,14 @@ for (const key in tasks) {
   const TaskComponent = tasks[key];
   describe('Task ' + key, function() {
     let wrapper;
-  
+
     it('should render with default props', function() {
       wrapper = shallow(<TaskComponent />);
     });
-  
+
     it('should update on annotation change', function() {
       wrapper = shallow(<TaskComponent />);
-      let annotation = TaskComponent.getDefaultAnnotation()
+      let annotation = TaskComponent.getDefaultAnnotation(tasks[key])
       wrapper.setProps({annotation});
     });
   });

--- a/app/classifier/tasks/index.spec.js
+++ b/app/classifier/tasks/index.spec.js
@@ -2,10 +2,12 @@ import { shallow } from 'enzyme';
 import React from 'react';
 import assert from 'assert';
 import tasks from './';
+import { workflow } from '../../pages/dev-classifier/mock-data';
 
-for (const key in tasks) {
-  const TaskComponent = tasks[key];
-  describe('Task ' + key, function() {
+for (const key in workflow.tasks) {
+  const task = workflow.tasks[key];
+  const TaskComponent = tasks[task.type];
+  describe('Task ' + task.type, function() {
     let wrapper;
 
     it('should render with default props', function() {
@@ -14,7 +16,7 @@ for (const key in tasks) {
 
     it('should update on annotation change', function() {
       wrapper = shallow(<TaskComponent />);
-      let annotation = TaskComponent.getDefaultAnnotation(tasks[key])
+      let annotation = TaskComponent.getDefaultAnnotation(task, workflow, tasks);
       wrapper.setProps({annotation});
     });
   });

--- a/app/classifier/tasks/slider/index.jsx
+++ b/app/classifier/tasks/slider/index.jsx
@@ -5,6 +5,16 @@ import SliderTaskEditor from './editor';
 
 const NOOP = Function.prototype;
 
+const SLIDERTASKDEFAULT = {
+  defaultValue: '0',
+  help: '',
+  instruction: 'Enter an Instruction.',
+  max: '1',
+  min: '0',
+  step: '0.1',
+  type: 'slider'
+};
+
 const SliderSummary = (props) => {
   let answer = 'No answer';
   if (props.annotation.value !== null) {
@@ -32,7 +42,10 @@ SliderSummary.propTypes = {
   ).isRequired,
   annotation: React.PropTypes.shape(
     {
-      value: React.PropTypes.string
+      value: React.PropTypes.oneOfType([
+        React.PropTypes.string,
+        React.PropTypes.number
+      ])
     }
   ).isRequired
 };
@@ -51,7 +64,7 @@ const SliderTask = ({ task, annotation, onChange, autoFocus }) => {
       <GenericTask
         question={task.instruction}
         help={task.help}
-        required={task.required}
+        required={false}
       >
         <div className="slider-task-container full ">
           <div className="slider-task-range">
@@ -61,7 +74,7 @@ const SliderTask = ({ task, annotation, onChange, autoFocus }) => {
                   className="standard-input"
                   type="range"
                   autoFocus={autoFocus}
-                  onChange={handleChange.bind(this)}
+                  onChange={handleChange}
                   max={task.max}
                   min={task.min}
                   step={task.step}
@@ -82,7 +95,7 @@ const SliderTask = ({ task, annotation, onChange, autoFocus }) => {
             <input
               className="standard-input"
               type="number"
-              onChange={handleChange.bind(this)}
+              onChange={handleChange}
               max={task.max}
               min={task.min}
               step={task.step}
@@ -99,60 +112,42 @@ SliderTask.displayName = 'SliderTask';
 SliderTask.Editor = SliderTaskEditor;
 SliderTask.Summary = SliderSummary;
 SliderTask.getDefaultTask = () => {
-  return {
-    type: 'slider',
-    instruction: 'Enter an Instruction.',
-    help: '',
-    min: '0',
-    max: '1',
-    step: '0.1',
-    defaultValue: '0'
-  };
+  return SLIDERTASKDEFAULT;
 };
 SliderTask.getTaskText = (task) => {
   return task.instruction;
 };
-SliderTask.getDefaultAnnotation = () => {
-  return { value: null };
+SliderTask.getDefaultAnnotation = (task) => {
+  return { value: task.defaultValue };
 };
 SliderTask.isAnnotationComplete = (task, annotation) => {
-  return (!task.required || annotation.value !== null);
+  return (annotation.value !== null);
 };
+
 SliderTask.propTypes = {
-  task: React.PropTypes.shape(
-    {
-      answers: React.PropTypes.array,
-      help: React.PropTypes.string,
-      instruction: React.PropTypes.string,
-      required: React.PropTypes.bool,
-      max: React.PropTypes.string,
-      min: React.PropTypes.string,
-      step: React.PropTypes.string,
-      defaultValue: React.PropTypes.string
-    }
-  ),
   annotation: React.PropTypes.shape({
     value: React.PropTypes.oneOfType([
       React.PropTypes.string,
       React.PropTypes.number
     ])
   }),
+  autoFocus: React.PropTypes.bool,
   onChange: React.PropTypes.func,
-  autoFocus: React.PropTypes.bool
+  task: React.PropTypes.shape({
+    answers: React.PropTypes.array,
+    defaultValue: React.PropTypes.string,
+    help: React.PropTypes.string,
+    instruction: React.PropTypes.string,
+    max: React.PropTypes.string,
+    min: React.PropTypes.string,
+    step: React.PropTypes.string
+  })
 };
 
 SliderTask.defaultProps = {
-  task: {
-    help: '',
-    instruction: '',
-    required: false,
-    max: '1',
-    min: '0',
-    step: '0.1',
-    defaultValue: '0'
-  },
   annotation: { value: null },
-  onChange: NOOP
+  onChange: NOOP,
+  task: SLIDERTASKDEFAULT
 };
 
 export default SliderTask;

--- a/app/classifier/tasks/slider/index.jsx
+++ b/app/classifier/tasks/slider/index.jsx
@@ -22,7 +22,7 @@ const SliderSummary = (props) => {
       </div>
     </div>
   );
-}
+};
 
 SliderSummary.propTypes = {
   task: React.PropTypes.shape(
@@ -37,94 +37,64 @@ SliderSummary.propTypes = {
   ).isRequired
 };
 
-class SliderTask extends React.Component {
-  constructor(props) {
-    super(props);
-    let value = this.props.task.defaultValue;
-    if (this.props.annotation.value !== null) {
-      value = this.props.annotation.value;
-    }
-    this.state = { value };
-    this.handleChange = this.handleChange.bind(this);
-  }
-
-  componentDidMount() {
-    const newAnnotation = Object.assign({}, this.props.annotation, { value: this.props.task.defaultValue });
-    this.props.onChange(newAnnotation);
-  }
-
-  componentWillReceiveProps(nextProps) {
-    if (this.props.annotation.value === null) {
-      const newAnnotation = Object.assign({}, this.props.annotation, { value: this.props.task.defaultValue });
-      this.props.onChange(newAnnotation);
-    } else if (this.props.annotation.value !== this.state.value) {
-      this.setState({ value: nextProps.annotation.value });
-    }
-  }
-
-  handleChange(e) {
+const SliderTask = ({ task, annotation, onChange, autoFocus }) => {
+  function handleChange(e) {
     let value = e.target.value;
-    if (parseFloat(value, 10) > parseFloat(this.props.task.max, 10)) {
-      value = this.props.task.max;
-    } else if (parseFloat(value, 10) < parseFloat(this.props.task.min, 10)) {
-      value = this.props.task.min;
-    }
-    this.setState({ value });
-    const newAnnotation = Object.assign({}, this.props.annotation, { value });
-    this.props.onChange(newAnnotation);
+    value = Math.min(parseFloat(value, 10), parseFloat(task.max, 10));
+    value = Math.max(parseFloat(value, 10), parseFloat(task.min, 10));
+    const newAnnotation = Object.assign({}, annotation, { value });
+    onChange(newAnnotation);
   }
 
-  render() {
-    return (
-      <div>
-        <GenericTask
-          question={this.props.task.instruction}
-          help={this.props.task.help}
-          required={this.props.task.required}
-        >
-          <div className="slider-task-container full ">
-            <div className="slider-task-range">
-              <label className="answer">
-                <div>
-                  <input
-                    className="standard-input"
-                    type="range"
-                    autoFocus={this.props.autoFocus}
-                    onChange={this.handleChange}
-                    max={this.props.task.max}
-                    min={this.props.task.min}
-                    step={this.props.task.step}
-                    value={this.state.value}
-                  />
+  return (
+    <div>
+      <GenericTask
+        question={task.instruction}
+        help={task.help}
+        required={task.required}
+      >
+        <div className="slider-task-container full ">
+          <div className="slider-task-range">
+            <label className="answer">
+              <div>
+                <input
+                  className="standard-input"
+                  type="range"
+                  autoFocus={autoFocus}
+                  onChange={handleChange.bind(this)}
+                  max={task.max}
+                  min={task.min}
+                  step={task.step}
+                  value={annotation.value === null ? task.defaultValue : annotation.value}
+                />
+              </div>
+              <div className="slider-task-range__label-container">
+                <div className="slider-task-range__label-container__left">
+                  {task.min}
                 </div>
-                <div className="slider-task-range__label-container">
-                  <div className="slider-task-range__label-container__left">
-                    {this.props.task.min}
-                  </div>
-                  <div className="slider-task-range__label-container__right">
-                    {this.props.task.max}
-                  </div>
+                <div className="slider-task-range__label-container__right">
+                  {task.max}
                 </div>
-              </label>
-            </div>
-            <label className="answer slider-task-number">
-              <input
-                className="standard-input"
-                type="number"
-                autoFocus={this.props.autoFocus}
-                onChange={this.handleChange}
-                max={this.props.task.max}
-                min={this.props.task.min}
-                step={this.props.task.step}
-                value={this.state.value}
-              />
+              </div>
             </label>
           </div>
-        </GenericTask>
-      </div>
-    );
-  }
-}
+          <label className="answer slider-task-number">
+            <input
+              className="standard-input"
+              type="number"
+              onChange={handleChange.bind(this)}
+              max={task.max}
+              min={task.min}
+              step={task.step}
+              value={annotation.value === null ? task.defaultValue : annotation.value}
+            />
+          </label>
+        </div>
+      </GenericTask>
+    </div>
+  );
+};
+
 SliderTask.displayName = 'SliderTask';
 SliderTask.Editor = SliderTaskEditor;
 SliderTask.Summary = SliderSummary;
@@ -161,9 +131,12 @@ SliderTask.propTypes = {
       defaultValue: React.PropTypes.string
     }
   ),
-  annotation: React.PropTypes.shape(
-    { value: React.PropTypes.string }
-  ),
+  annotation: React.PropTypes.shape({
+    value: React.PropTypes.oneOfType([
+      React.PropTypes.string,
+      React.PropTypes.number
+    ])
+  }),
   onChange: React.PropTypes.func,
   autoFocus: React.PropTypes.bool
 };

--- a/app/classifier/tasks/slider/slider.spec.js
+++ b/app/classifier/tasks/slider/slider.spec.js
@@ -1,6 +1,7 @@
 /* eslint prefer-arrow-callback: 0, func-names: 0, 'react/jsx-boolean-value': ['error', 'always'], 'react/jsx-filename-extension': 0 */
 /* global describe, it, beforeEach */
 import { mount } from 'enzyme';
+import sinon from 'sinon';
 import React from 'react';
 import assert from 'assert';
 import SliderTask from './index';
@@ -21,9 +22,12 @@ const annotation = {
 
 describe('SliderTask', function () {
   let wrapper;
+  let onChangeSpy;
 
   beforeEach(function () {
-    wrapper = mount(<SliderTask task={task} annotation={annotation} />);
+    onChangeSpy = sinon.spy();
+
+    wrapper = mount(<SliderTask task={task} annotation={annotation} onChange={onChangeSpy} />);
   });
 
   it('should render without crashing', function () {
@@ -60,6 +64,27 @@ describe('SliderTask', function () {
     it('should have the correct step value', function () {
       assert.equal(slider.node.step, task.step);
     });
+
+    it('should call onChange with a value selected within range', function () {
+      slider.simulate('change', { target: { value: 0.3 }});
+      assert(onChangeSpy.calledWith({
+        value: 0.3
+      }));
+    });
+
+    it('should call onChange with the min value if below range', function () {
+      slider.simulate('change', { target: { value: -1 }});
+      assert(onChangeSpy.calledWith({
+        value: 0
+      }));
+    });
+
+    it('should call onChange with the max value if above range', function () {
+      slider.simulate('change', { target: { value: 2 }});
+      assert(onChangeSpy.calledWith({
+        value: 1
+      }));
+    });
   });
 
   describe('the number input', function () {
@@ -87,6 +112,27 @@ describe('SliderTask', function () {
 
     it('should have the correct step value', function () {
       assert.equal(number.node.step, task.step);
+    });
+
+    it('should call onChange with a value selected within range', function () {
+      number.simulate('change', { target: { value: 0.3 }});
+      assert(onChangeSpy.calledWith({
+        value: 0.3
+      }));
+    });
+
+    it('should call onChange with the min value if below range', function () {
+      number.simulate('change', { target: { value: -1 }});
+      assert(onChangeSpy.calledWith({
+        value: 0
+      }));
+    });
+
+    it('should call onChange with the max value if above range', function () {
+      number.simulate('change', { target: { value: 2 }});
+      assert(onChangeSpy.calledWith({
+        value: 1
+      }));
     });
   });
 

--- a/app/classifier/tasks/slider/slider.spec.js
+++ b/app/classifier/tasks/slider/slider.spec.js
@@ -12,12 +12,7 @@ const task = {
   min: '0',
   max: '1',
   step: '0.1',
-  defaultValue: '0',
-  required: true
-};
-
-const annotation = {
-  value: '0.2'
+  defaultValue: '0.5'
 };
 
 describe('SliderTask', function () {
@@ -27,7 +22,7 @@ describe('SliderTask', function () {
   beforeEach(function () {
     onChangeSpy = sinon.spy();
 
-    wrapper = mount(<SliderTask task={task} annotation={annotation} onChange={onChangeSpy} />);
+    wrapper = mount(<SliderTask task={task} onChange={onChangeSpy} />);
   });
 
   it('should render without crashing', function () {
@@ -37,6 +32,10 @@ describe('SliderTask', function () {
     const instruction = wrapper.find('.question');
     assert.equal(instruction.length, 1);
   });
+
+  // it('should have the defaultValue as the initial annotation value', function () {
+  //   const annotation = wrapper.
+  // });
 
   describe('the slider input', function () {
     let slider;
@@ -49,8 +48,8 @@ describe('SliderTask', function () {
       assert.equal(slider.length, 1);
     });
 
-    it('should have the annotation value', function () {
-      assert.equal(slider.node.value, annotation.value);
+    it('should have the default value as the initial slider value', function () {
+      assert.equal(slider.node.value, task.defaultValue);
     });
 
     it('should have the correct max value', function () {
@@ -98,8 +97,8 @@ describe('SliderTask', function () {
       assert.equal(number.length, 1);
     });
 
-    it('should have the annotation value', function () {
-      assert.equal(number.node.value, annotation.value);
+    it('should have the default value as the initial number value', function () {
+      assert.equal(number.node.value, task.defaultValue);
     });
 
     it('should have the correct max value', function () {
@@ -136,41 +135,21 @@ describe('SliderTask', function () {
     });
   });
 
-  describe('when annotation is null', function () {
-    beforeEach(function () {
-      wrapper = mount(<SliderTask task={task} annotation={{ value: null }} />);
-    });
-
-    it('should have the default value for the slider input', function () {
-      const slider = wrapper.find('input[type="range"]');
-      assert.equal(slider.node.value, task.defaultValue);
-    });
-
-    it('should have the default value for the number input', function () {
-      const number = wrapper.find('input[type="number"]');
-      assert.equal(number.node.value, task.defaultValue);
-    });
-  });
-
   describe('static methods', function () {
-    it('should be complete', function () {
-      assert.equal(SliderTask.isAnnotationComplete(task, annotation), true);
+    it('should be complete with valid annotation', function () {
+      assert.equal(SliderTask.isAnnotationComplete(task, { value: '0.7' }), true);
     });
 
     it('should not be complete when the annotation is null', function () {
       assert.equal(SliderTask.isAnnotationComplete(task, { value: null }), false);
     });
 
-    it('should be complete when task is not required', function () {
-      assert.equal(SliderTask.isAnnotationComplete(Object.assign({}, task, { required: false }), { value: null }), true);
-    });
-
     it('should have the correct instruction text', function () {
       assert.equal(SliderTask.getTaskText(task), task.instruction);
     });
 
-    it('should have the correct default annoation', function () {
-      assert.equal(SliderTask.getDefaultAnnotation().value, null);
+    it('should have the correct default annotation', function () {
+      assert.equal(SliderTask.getDefaultAnnotation(task).value, task.defaultValue);
     });
   });
 });
@@ -179,7 +158,7 @@ describe('SliderSummary', function () {
   let summary;
 
   beforeEach(function () {
-    summary = mount(<SliderTask.Summary task={task} annotation={annotation} />);
+    summary = mount(<SliderTask.Summary task={task} annotation={{ value: '0.7' }} />);
   });
 
   it('should render without crashing', function () {
@@ -195,14 +174,8 @@ describe('SliderSummary', function () {
     assert.equal(answers.length, 1);
   });
 
-  it('should return "No answer" when annotation is null', function () {
-    summary = mount(<SliderTask.Summary task={task} annotation={{ value: null }} />);
-    const answers = summary.find('.answer');
-    assert.equal(answers.text(), 'No answer');
-  });
-
-  it('should have the correct answer label when the value if falsy (i.e. 0)', function () {
-    summary = mount(<SliderTask.Summary task={task} annotation={{ value: '' }} />);
+  it('should have the correct answer label when the value is falsy (i.e. 0)', function () {
+    summary = mount(<SliderTask.Summary task={task} annotation={{ value: '0' }} />);
     const answers = summary.find('.answer');
     assert.notEqual(answers.text(), 'No answer');
   });


### PR DESCRIPTION
Refactor slider task to stateless component. Mentioning @eatyourgreens, @tingard and @CKrawczyk. 

IMPORTANT - see PR #4004 for original comments and notes.

Had trouble creating tests to make sure annotation properly updated, related to controlled vs uncontrolled component comments. Added tests for `onChange`, though I'm unsure if that's sufficient. If we can't be comfortable annotation is properly updated with this stateless component, I say we scrap this and leave slider task as is (with state).

I see tests for if task is required, but don't see ability to toggle required in editor?

If there are two slider tasks back to back in a workflow, the second doesn't receive intended focus, unsure how to fix, though I don't think necessary and unrelated to this PR's specific scope, happy to add if simple solution.

Staging workflow I've been tinkering on: https://refactor-slider-stateless.pfe-preview.zooniverse.org/projects/markb-panoptes/focus-testing-project/classify?reload=0&workflow=3030

# Review Checklist

- [x] Does it work in all major browsers: ~~Firefox~~, ~~Chrome~~, Edge, ~~Safari~~?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? - https://refactor-slider-stateless.pfe-preview.zooniverse.org/
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?


## Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [x] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
