### PR TITLE
Update readme testing text.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ While editing, do your best to follow style and architecture conventions already
 ### Testing
 
 If you write a new component, write a test. Each component should have its own `.spec.js` file. The test runner is [Mocha](https://mochajs.org/) and [Enzyme](http://airbnb.io/enzyme/) is available for testing React components.
-You can run the tests with `npm test`. 
+Mocha throws an error (`Illegal import declaration`) when compiling coffeescript files that contain ES6 import statements with template strings. Convert these imports to `require` statements.
+You can run the tests with `npm test`.
 
 ### It doesn't run
 


### PR DESCRIPTION
Describe your changes.
- Update readme testing section to address error when Mocha compiles coffeescript files that contain ES6 import statements with template strings.
- Related: https://github.com/zooniverse/Panoptes-Front-End/pull/3428, https://github.com/zooniverse/Panoptes-Front-End/issues/3349


# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?


## Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
