### PR TITLE
Fix audio player SVG rendering

### DIFF
--- a/app/classifier/annotation-renderer/svg.jsx
+++ b/app/classifier/annotation-renderer/svg.jsx
@@ -161,7 +161,6 @@ export default class SVGRenderer extends React.Component {
 
     return (
       <div>
-        {this.props.children}
         <div className="subject svg-subject">
           <svg
             ref={(element) => { if (element) this.svgSubjectArea = element; }}
@@ -197,6 +196,7 @@ export default class SVGRenderer extends React.Component {
           </svg>
         </div>
         {(showFeedback) && (<SVGToolTipLayer getScreenCTM={this.getScreenCurrentTransformationMatrix} />)}
+        {this.props.children}
       </div>
     );
   }

--- a/app/components/file-viewer/audio-player.jsx
+++ b/app/components/file-viewer/audio-player.jsx
@@ -107,7 +107,7 @@ class AudioPlayer extends React.Component {
       );
     }
     return (
-      <div>
+      <div className="subject-audio-frame">
         {imageElement}
         <div className="audio-player-component">
           <audio
@@ -123,8 +123,6 @@ class AudioPlayer extends React.Component {
           >
             Your browser does not support the audio format. Please upgrade your browser.
           </audio>
-
-          {this.props.children}
         </div>
       </div>
     );
@@ -133,7 +131,6 @@ class AudioPlayer extends React.Component {
 }
 
 AudioPlayer.propTypes = {
-  children: React.PropTypes.node,
   format: React.PropTypes.oneOfType([React.PropTypes.array, React.PropTypes.string]),
   frame: React.PropTypes.number,
   onLoad: React.PropTypes.func,

--- a/app/components/file-viewer/audio-player.jsx
+++ b/app/components/file-viewer/audio-player.jsx
@@ -11,9 +11,12 @@ class AudioPlayer extends React.Component {
     this.endAudio = this.endAudio.bind(this);
     this.playAudio = this.playAudio.bind(this);
     this.onAudioLoad = this.onAudioLoad.bind(this);
+    this.onImageLoad = this.onImageLoad.bind(this);
     this.updateProgress = this.updateProgress.bind(this);
 
     this.state = {
+      naturalHeight: 0,
+      naturalWidth: 0,
       playing: false,
       progressPosition: 0,
       trackDuration: 0
@@ -27,6 +30,12 @@ class AudioPlayer extends React.Component {
   onAudioLoad(e) {
     e.stopPropagation();
     this.state.trackDuration = this.player.duration;
+  }
+
+  onImageLoad(e) {
+    const { naturalHeight, naturalWidth } = e.target;
+    this.setState({ naturalHeight, naturalWidth });
+    this.props.onLoad(e);
   }
 
   imageSrc() {
@@ -91,15 +100,16 @@ class AudioPlayer extends React.Component {
         <ProgressIndicator
           progressPosition={this.state.progressPosition}
           progressRange={[0, this.state.trackDuration]}
-          naturalWidth={100}
-          naturalHeight={100}
+          naturalWidth={this.state.naturalWidth}
+          naturalHeight={this.state.naturalHeight}
+          src={imageSrc}
         >
           <ImageViewer
             src={imageSrc}
             type={this.imageTypeString()}
             format={this.imageFormatString()}
             frame={this.props.frame}
-            onLoad={this.props.onLoad}
+            onLoad={this.onImageLoad}
             onFocus={this.props.onFocus}
             onBlur={this.props.onBlur}
           />

--- a/app/components/file-viewer/audio-player.jsx
+++ b/app/components/file-viewer/audio-player.jsx
@@ -83,43 +83,32 @@ class AudioPlayer extends React.Component {
     this.setState({ playing: false });
   }
 
-  renderProgressMarker() {
-    return (
-      <ProgressIndicator
-        progressPosition={this.state.progressPosition}
-        progressRange={[0, this.state.trackDuration]}
-        naturalWidth={100}
-        naturalHeight={100}
-      />
-    );
-  }
-
   render() {
     const imageSrc = this.imageSrc();
     let imageElement = null;
     if (imageSrc) {
       imageElement = (
-        <div>
-          {this.renderProgressMarker()}
-          <div className="audio-image-component">
-            <ImageViewer
-              src={imageSrc}
-              type={this.imageTypeString()}
-              format={this.imageFormatString()}
-              frame={this.props.frame}
-              onLoad={this.props.onLoad}
-              onFocus={this.props.onFocus}
-              onBlur={this.props.onBlur}
-            />
-          </div>
-        </div>
+        <ProgressIndicator
+          progressPosition={this.state.progressPosition}
+          progressRange={[0, this.state.trackDuration]}
+          naturalWidth={100}
+          naturalHeight={100}
+        >
+          <ImageViewer
+            src={imageSrc}
+            type={this.imageTypeString()}
+            format={this.imageFormatString()}
+            frame={this.props.frame}
+            onLoad={this.props.onLoad}
+            onFocus={this.props.onFocus}
+            onBlur={this.props.onBlur}
+          />
+        </ProgressIndicator>
       );
     }
     return (
       <div>
-        <div>
-          {imageElement}
-        </div>
+        {imageElement}
         <div className="audio-player-component">
           <audio
             className="subject"

--- a/app/components/file-viewer/progress-indicator.jsx
+++ b/app/components/file-viewer/progress-indicator.jsx
@@ -25,7 +25,15 @@ class ProgressIndicator extends React.Component {
     // console.log(points);
 
     return (
-      <svg className="progress-marker">
+      <svg
+        className="progress-marker"
+        viewBox={`0 0 ${this.props.naturalWidth} ${this.props.naturalHeight}`}
+      >
+        <image
+          xlinkHref={this.props.src}
+          width={this.props.naturalWidth}
+          height={this.props.naturalHeight}
+        />
         <g {...progressMarkerStyle}>
           <line {...points} />
         </g>
@@ -46,12 +54,17 @@ class ProgressIndicator extends React.Component {
 
 ProgressIndicator.propTypes = {
   children: React.PropTypes.node,
+  naturalHeight: React.PropTypes.number,
+  naturalWidth: React.PropTypes.number,
   progressPosition: React.PropTypes.number,
-  progressRange: React.PropTypes.arrayOf(React.PropTypes.number)
+  progressRange: React.PropTypes.arrayOf(React.PropTypes.number),
+  src: React.PropTypes.string.isRequired
 };
 
 ProgressIndicator.defaultProps = {
   children: null,
+  naturalHeight: 0,
+  naturalWidth: 0,
   progressPosition: 0,
   progressRange: [0, 1]
 };

--- a/app/components/file-viewer/progress-indicator.jsx
+++ b/app/components/file-viewer/progress-indicator.jsx
@@ -1,13 +1,10 @@
 import React from 'react';
 
 class ProgressIndicator extends React.Component {
-  constructor(props) {
-    super(props);
-  }
 
   progressAsPercentString() {
     // TODO: Implement correct range handling.
-    return `${ 100 * (this.props.progressPosition / this.props.progressRange[1])}%`
+    return `${100 * (this.props.progressPosition / this.props.progressRange[1])}%`;
   }
 
   renderProgressMarker() {
@@ -29,17 +26,18 @@ class ProgressIndicator extends React.Component {
 
     return (
       <svg>
-        <g id='progress_marker' {...progressMarkerStyle}>
-          <line {...points}/>
+        <g {...progressMarkerStyle}>
+          <line {...points} />
         </g>
       </svg>
-    )
+    );
   }
 
   render() {
-    return ( <div className='progress-marker'>
-      {this.renderProgressMarker()}
-      {this.props.children}
+    return (
+      <div className="progress-marker">
+        {this.renderProgressMarker()}
+        {this.props.children}
       </div>
     );
   }
@@ -49,17 +47,13 @@ class ProgressIndicator extends React.Component {
 ProgressIndicator.propTypes = {
   children: React.PropTypes.node,
   progressPosition: React.PropTypes.number,
-  progressRange: React.PropTypes.array,
-  naturalWidth: React.PropTypes.number,
-  naturalHeight: React.PropTypes.number,
-  frame: React.PropTypes.number
+  progressRange: React.PropTypes.arrayOf(React.PropTypes.number)
 };
 
 ProgressIndicator.defaultProps = {
-  progressPosition : 0,
-  progressRange : [0, 1],
-  naturalWidth : '100%',
-  naturalHeight : '100%'
+  children: null,
+  progressPosition: 0,
+  progressRange: [0, 1]
 };
 
 export default ProgressIndicator;

--- a/app/components/file-viewer/progress-indicator.jsx
+++ b/app/components/file-viewer/progress-indicator.jsx
@@ -25,7 +25,7 @@ class ProgressIndicator extends React.Component {
     // console.log(points);
 
     return (
-      <svg>
+      <svg className="progress-marker">
         <g {...progressMarkerStyle}>
           <line {...points} />
         </g>
@@ -35,7 +35,7 @@ class ProgressIndicator extends React.Component {
 
   render() {
     return (
-      <div className="progress-marker">
+      <div>
         {this.renderProgressMarker()}
         {this.props.children}
       </div>

--- a/app/components/file-viewer/video-player.jsx
+++ b/app/components/file-viewer/video-player.jsx
@@ -88,7 +88,6 @@ class VideoPlayer extends React.Component {
             </span>
           </span>
         )}
-        {this.props.children}
       </div>
     );
   }
@@ -96,7 +95,6 @@ class VideoPlayer extends React.Component {
 }
 
 VideoPlayer.propTypes = {
-  children: React.PropTypes.node,
   format: React.PropTypes.string,
   frame: React.PropTypes.number,
   onLoad: React.PropTypes.func,

--- a/app/components/subject-viewer.cjsx
+++ b/app/components/subject-viewer.cjsx
@@ -111,10 +111,10 @@ module.exports = React.createClass
     mainDisplay = ''
     {type, format, src} = getSubjectLocation @props.subject, @state.frame
     subjectLocations = getSubjectLocations @props.subject
-    if @state.inFlipbookMode
+    if subjectIsLikelyAudioPlusImage @props.subject
+          mainDisplay = @renderFrame @state.frame, {subjectLocations : subjectLocations, isAudioPlusImage : true}
+    else if @state.inFlipbookMode
       mainDisplay = @renderFrame @state.frame
-    else if subjectIsLikelyAudioPlusImage @props.subject
-      mainDisplay = @renderFrame @state.frame, {subjectLocations : subjectLocations, isAudioPlusImage : true}
     else
       mainDisplay = @props.subject.locations.map (frame, index) =>
         @renderFrame index, {key: "frame-#{index}"}
@@ -157,7 +157,7 @@ module.exports = React.createClass
 
       <div className="subject-tools">
         <span>{tools}</span>
-        {if @props.subject?.locations.length >= 2 and @state.inFlipbookMode
+        {if @props.subject?.locations.length >= 2 and not subjectIsLikelyAudioPlusImage(@props.subject) and @state.inFlipbookMode
           <span>
             <span className="subject-frame-pips">
               {for i in [0...@props.subject?.locations.length ? 0]

--- a/css/subject-viewer.styl
+++ b/css/subject-viewer.styl
@@ -132,10 +132,9 @@
   top: 0
   width: 100%
   height: 100%
-  
-  svg
-    width: 100%
-    height: 100%
+    
+  image
+    opacity: .2
 
 .audio-player-component
   width: 100%

--- a/css/subject-viewer.styl
+++ b/css/subject-viewer.styl
@@ -131,7 +131,7 @@
   left: 0
   top: 0
   width: 100%
-  height: 100%
+  max-height: 100%
     
   image
     opacity: .2

--- a/css/subject-viewer.styl
+++ b/css/subject-viewer.styl
@@ -125,7 +125,17 @@
       margin-right: 0.5em
 
 .progress-marker
+  background: transparent
   pointer-events none
+  position: absolute
+  left: 0
+  top: 0
+  width: 100%
+  height: 100%
+  
+  svg
+    width: 100%
+    height: 100%
 
 .audio-player-component
   position absolute

--- a/css/subject-viewer.styl
+++ b/css/subject-viewer.styl
@@ -138,7 +138,7 @@
     height: 100%
 
 .audio-player-component
-  position absolute
-  bottom -70
-  left auto
-  right auto
+  width: 100%
+  
+  audio
+    width: 100%


### PR DESCRIPTION
Fixes #4054 
Fixes #4067 

Describe your changes.
Reverses one of the changes in #3995 so that the subject frame viewer is rendered after the SVG marking surface in the DOM.

I'm not 100% sure why this works, so it may need careful checking.

This PR also fixes ESLint warnings in the `ProgressIndicator` component and removes some redundant HTML from the audio player.

Some if logic is also reversed in the subject viewer so that we check for a mixed media audio file before deciding to render the flipbook slideshow. This fixes audio subject rendering on Talk.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://fix-audio-player.pfe-preview.zooniverse.org/
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?


## Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
