### PR TITLE
Add down-arrow on user homepage.

### DIFF
--- a/app/pages/home-for-user/index.jsx
+++ b/app/pages/home-for-user/index.jsx
@@ -281,8 +281,12 @@ export default class HomePageForUser extends React.Component {
                 onClose={this.deselectSection}
               />
             )}
-          </div>
 
+            <div className="home-page-for-user__down-arrow">
+              <i className="fa fa-arrow-down fa-2x" aria-hidden="true" />
+            </div>
+
+          </div>
         </div>
 
         <FeaturedProject />

--- a/app/pages/home-for-user/index.jsx
+++ b/app/pages/home-for-user/index.jsx
@@ -282,9 +282,8 @@ export default class HomePageForUser extends React.Component {
               />
             )}
 
-            <div className="home-page-for-user__down-arrow">
-              <i className="fa fa-arrow-down fa-2x" aria-hidden="true" />
-            </div>
+            {!OpenSectionComponent &&
+              <i className="home-page-for-user__down-arrow fa fa-arrow-down" aria-hidden="true" />}
 
           </div>
         </div>

--- a/css/home-page-for-user.styl
+++ b/css/home-page-for-user.styl
@@ -37,7 +37,7 @@ GRAY = #EFF2F5
     margin: 1em 2em 0 2em
 
   &__down-arrow
-    margin: 0.75em 0 2em 0
+    margin: 1.875em 0 2em 0
 
   &__menu-column
     display: flex

--- a/css/home-page-for-user.styl
+++ b/css/home-page-for-user.styl
@@ -34,8 +34,10 @@ GRAY = #EFF2F5
   &__menu
     display: inline-flex
     flex-wrap: wrap
-    margin: 1em 2em
-    margin-bottom: 5em
+    margin: 1em 2em 0 2em
+
+  &__down-arrow
+    margin: 0.75em 0 2em 0
 
   &__menu-column
     display: flex
@@ -150,3 +152,4 @@ GRAY = #EFF2F5
   margin-bottom: 0.5em
   padding: 0.1em 1em
   text-decoration: none
+


### PR DESCRIPTION
Fixes #3664.

Describe your changes.
- Adds a FontAwesome down arrow to user homepage, at bottom of content section, to indicate the presence of featured projects below the content section (13 inch displays only show a small portion of the featured project section).
- I modified the margin on both `home-page-for-user__menu` and `home-page-for-user__down-arrow`, to get the look of an arrow vertically centered between "my collections" and the bottom of the teal box. I played around with other margin adjustments, eg no bottom-margin on `__menu` and identical top- and bottom-margins on `__down-arrow`, and went with what's currently on this branch as what I thought looked best - but happy to change if anyone prefers otherwise.
- Staged [here](https://scroll-down-arrow.pfe-preview.zooniverse.org/).


# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?


## Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
