### PR TITLE
increase highlighter tool label color options

### DIFF
--- a/app/classifier/tasks/generic-editor.cjsx
+++ b/app/classifier/tasks/generic-editor.cjsx
@@ -124,13 +124,14 @@ module.exports = React.createClass
                         <select style={{background: choice.color}} name="#{@props.taskPrefix}.#{choicesKey}.#{index}.color" value={choice.color} onChange={handleChange}>
                           <option style={{background: "#ff6639"}} value="#ff6639">Red</option>
                           <option style={{background: "#ffa539"}} value="#ffa539">Orange</option>
+                          <option style={{background: "#F5D76E"}} value="#F5D76E">Yellow</option>
                           <option style={{background: "#FC6399"}} value="#FC6399">Pink</option>
                           <option style={{background: "#C9F227"}} value="#C9F227">Yellow Green</option>
-                          <option style={{background: "#38b978"}} value="#38b978">Green</option>
+                          <option style={{background: "#35D056"}} value="#35D056">Green</option>
                           <option style={{background: "#00FF7F"}} value="#00FF7F">Seafoam</option>
-                          <option style={{background: "#19B5FE"}} value="#19B5FE">Blue</option>
+                          <option style={{background: "#57c4f7"}} value="#57c4f7">Blue</option>
                           <option style={{background: "#DCC6E0"}} value="#DCC6E0">Light Purple</option>
-                          <option style={{background: "#7E8BFE"}} value="#7E8BFE">Purple</option>
+                          <option style={{background: "#BAC1ff"}} value="#BAC1ff">Violet</option>
                           <option style={{background: "#00ffff"}} value="#00ffff">Cyan</option>
                         </select>
                       </AutoSave>

--- a/app/classifier/tasks/generic-editor.cjsx
+++ b/app/classifier/tasks/generic-editor.cjsx
@@ -121,15 +121,17 @@ module.exports = React.createClass
                     <div className="workflow-choice-setting" >
                       <AutoSave resource={@props.workflow} >
                         Color{' '}
-                        <select name="#{@props.taskPrefix}.#{choicesKey}.#{index}.color" value={choice.color} onChange={handleChange}>
-                          <option value="#ff6639">Red</option>
-                          <option value="#ffa539">Yellow</option>
-                          <option value="#38b978">Green</option>
-                          <option value="#43bcfd">Blue</option>
-                          <option value="#5364fd">Violet</option>
-                          <option value="#00ffff">Cyan</option>
-                          <option value="#000000">Black</option>
-                          <option value="#ffffff">White</option>
+                        <select style={{background: choice.color}} name="#{@props.taskPrefix}.#{choicesKey}.#{index}.color" value={choice.color} onChange={handleChange}>
+                          <option style={{background: "#ff6639"}} value="#ff6639">Red</option>
+                          <option style={{background: "#ffa539"}} value="#ffa539">Orange</option>
+                          <option style={{background: "#FC6399"}} value="#FC6399">Pink</option>
+                          <option style={{background: "#C9F227"}} value="#C9F227">Yellow Green</option>
+                          <option style={{background: "#38b978"}} value="#38b978">Green</option>
+                          <option style={{background: "#00FF7F"}} value="#00FF7F">Seafoam</option>
+                          <option style={{background: "#19B5FE"}} value="#19B5FE">Blue</option>
+                          <option style={{background: "#DCC6E0"}} value="#DCC6E0">Light Purple</option>
+                          <option style={{background: "#7E8BFE"}} value="#7E8BFE">Purple</option>
+                          <option style={{background: "#00ffff"}} value="#00ffff">Cyan</option>
                         </select>
                       </AutoSave>
                     </div>

--- a/css/highlighter-task.styl
+++ b/css/highlighter-task.styl
@@ -3,7 +3,7 @@
 
   > div
     padding: 2%
-    background-color: #fff
+    background-color: #ececec
     color: #000000
     whitespace: pre-wrap
     width: 40ch

--- a/css/highlighter-task.styl
+++ b/css/highlighter-task.styl
@@ -3,7 +3,8 @@
 
   > div
     padding: 2%
-    color: #efefef
+    background-color: #fff
+    color: #000000
     whitespace: pre-wrap
     width: 40ch
     

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,5 @@
 {
   "name": "panoptes-front-end",
-  "requires": true,
   "lockfileVersion": 1,
   "dependencies": {
     "abab": {


### PR DESCRIPTION
**Describe your changes.**
This PR increases and changes the color options available for highlighter tool labels. In order to provide more high contrast options, I switched the background and text colors for subjects. I also added a color preview to the workflow editor label selection dropdown.

@eatyourgreens, will these changes work for the Diagnosis London project?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch? https://highlighter-task-label-colors.pfe-preview.zooniverse.org/projects/scribe-2/demo-for-text-selection/classify
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?


## Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
