### PR TITLE
Fix survey filters

### DIFF
--- a/app/classifier/tasks/survey/chooser.jsx
+++ b/app/classifier/tasks/survey/chooser.jsx
@@ -30,7 +30,7 @@ class Chooser extends React.Component {
       let rejected = false;
       Object.keys(this.props.filters).map((characteristicId) => {
         const valueId = this.props.filters[characteristicId];
-        if (choice.characteristics[characteristicId].indexOf(valueId) > -1) {
+        if (choice.characteristics[characteristicId].indexOf(valueId) === -1) {
           rejected = true;
         }
       });

--- a/app/classifier/tasks/survey/chooser.jsx
+++ b/app/classifier/tasks/survey/chooser.jsx
@@ -91,24 +91,24 @@ class Chooser extends React.Component {
     const index = this.choiceButtons.indexOf(document.activeElement);
     let newIndex;
     switch (e.which) {
-    case BACKSPACE:
-      this.props.onRemove(choiceId);
-      e.preventDefault();
-      break;
-    case UP:
-      newIndex = index - 1;
-      if (newIndex === -1) {
-        newIndex = this.choiceButtons.length - 1;
-      }
-      this.choiceButtons[newIndex].focus();
-      e.preventDefault();
-      break;
-    case DOWN:
-      newIndex = (index + 1) % this.choiceButtons.length;
-      this.choiceButtons[newIndex].focus();
-      e.preventDefault();
-      break;
-    default:
+      case BACKSPACE:
+        this.props.onRemove(choiceId);
+        e.preventDefault();
+        break;
+      case UP:
+        newIndex = index - 1;
+        if (newIndex === -1) {
+          newIndex = this.choiceButtons.length - 1;
+        }
+        this.choiceButtons[newIndex].focus();
+        e.preventDefault();
+        break;
+      case DOWN:
+        newIndex = (index + 1) % this.choiceButtons.length;
+        this.choiceButtons[newIndex].focus();
+        e.preventDefault();
+        break;
+      default:
     }
   }
 


### PR DESCRIPTION
Fixes a typo when I converted the survey task Chooser, which inverted the true/false logic for filtering by characteristics.

Describe your changes.
Rejects a choice if the filter value is _not_ in the choice characteristics.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://fix-survey-filters.pfe-preview.zooniverse.org
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?


## Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
