### PR TITLE
If workflow request 404s, clear out from prefs and try again

### DIFF
--- a/app/pages/project/index.cjsx
+++ b/app/pages/project/index.cjsx
@@ -216,9 +216,13 @@ ProjectPageController = React.createClass
       query['active'] = true
     apiClient.type('workflows').get(query)
       .catch (error) =>
-        console.error error
         # TODO: Handle 404 once json-api-client error handling is fixed.
-        @setState({ error: error, loadingSelectedWorkflow: false })
+        if error.status is 404
+          @clearInactiveWorkflow(selectedWorkflowID)
+            .then(@getSelectedWorkflow(@state.project, @state.preferences))
+        else
+          console.error error
+          @setState({ error: error, loadingSelectedWorkflow: false })
       .then ([workflow]) =>
         if workflow
           @setState({ loadingSelectedWorkflow: false, workflow })

--- a/app/pages/project/index.cjsx
+++ b/app/pages/project/index.cjsx
@@ -216,7 +216,6 @@ ProjectPageController = React.createClass
       query['active'] = true
     apiClient.type('workflows').get(query)
       .catch (error) =>
-        # TODO: Handle 404 once json-api-client error handling is fixed.
         if error.status is 404
           @clearInactiveWorkflow(selectedWorkflowID)
             .then(@getSelectedWorkflow(@state.project, @state.preferences))


### PR DESCRIPTION
Fixes #4056.

If a selected workflow 404s, then it is cleared out of the user project preferences and selection is attempted again. 

I checked the project builder and it is removing deleted workflows from project default already: 

https://github.com/zooniverse/Panoptes-Front-End/blob/4a6719f3acbcbd175e655eb730e39e13c8bea2c6/app/pages/lab/workflow.cjsx#L687-L689

So this was only an issue on the volunteer side. 

Staged: https://fix-4056.pfe-preview.zooniverse.org/

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?


## Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
