### PR TITLE
Validate user group membership

### DIFF
--- a/app/pages/project/classify.cjsx
+++ b/app/pages/project/classify.cjsx
@@ -318,7 +318,6 @@ module.exports = React.createClass
   validateUserGroup: (props) ->
     if props.location.query?.group? and props.user?
       apiClient.type('user_groups').get(props.location.query.group).then (group) =>
-        console.log(group, group and group.links.users.includes(props.user.id))
         @setState({ validUserGroup: group and group.links.users.includes(props.user.id) })
 
 # For debugging:

--- a/app/pages/project/classify.cjsx
+++ b/app/pages/project/classify.cjsx
@@ -145,8 +145,8 @@ module.exports = React.createClass
           workflow: workflow.id
           subjects: [subject.id]
 
-      if @props.location.query?.group?
-        classification.update({ 'metadata.user_group': @props.location.query.group })
+      # if @validateUserGroup()
+      #   classification.update({ 'metadata.user_group': @props.location.query.group })
 
       # If the user hasn't interacted with a classification resource before,
       # we won't know how to resolve its links, so attach these manually.
@@ -213,8 +213,7 @@ module.exports = React.createClass
       {if @props.projectIsComplete
         <FinishedBanner project={@props.project} />}
 
-      {if @props.location.query?.group?
-        <p className="anouncement-banner--group">You are classifying as a student of your classroom.</p>}
+
       {if @state.classification?
         <Classifier
           {...@props}
@@ -309,6 +308,15 @@ module.exports = React.createClass
             props.preferences.update
               'preferences.selected_workflow': props.preferences.settings.workflow_id
             props.preferences.save()
+
+  validateUserGroup: ->
+    valid = false
+    console.log(@props.location.query.group)
+    if @props.location.query?.group? and @props.user?
+      apiClient.type('user_groups').get(@props.location.query.group).then (group) =>
+        console.log(group, group and group.links.users.includes(@props.user.id))
+        valid = group and group.links.users.includes(@props.user.id)
+    valid
 
 
 # For debugging:

--- a/app/pages/project/classify.cjsx
+++ b/app/pages/project/classify.cjsx
@@ -70,6 +70,7 @@ module.exports = React.createClass
     demoMode: sessionDemoMode
     promptWorkflowAssignmentDialog: false
     rejected: null
+    validUserGroup: false
 
   componentDidMount: () ->
     Split.classifierVisited();


### PR DESCRIPTION
Picks up from my last PR that added the user group id to the classification metadata in #3979. The group id from the query param will now be checked with API to see if the group exists and if the logged in user is a member of the group.

For manual testing, the easiest to use to test is your own user group since all users are also member of their own group. It can be retrieved in the javascript console:

`zooAPI.type('user_groups').get({name: 'yourUserLogin'})`

And then just add your user group id as a query param to the classify page of a project: `?group=groupID`

Staged at: https://validate-user-group-membership.pfe-preview.zooniverse.org/

The only thing I'm unsure about is the naming part. I made the query param simple `group` but it's specifically the `user_group` that is being worked with. Any thoughts on the naming? I definitely can change the query param to use `user-group` instead.

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?


## Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
