### PR TITLE
convert all stats API times to UTC

### DIFF
--- a/app/pages/project/stats/charts.jsx
+++ b/app/pages/project/stats/charts.jsx
@@ -57,10 +57,10 @@ export class Graph extends React.Component {
     };
 
     this.formatLabel = {
-      hour: (date) => { return moment(date).format('MMM-DD hh:mm A'); },
-      day: (date) => { return moment(date).format('MMM-DD-YYYY'); },
-      week: (date) => { return moment(date).format('MMM-DD-YYYY'); },
-      month: (date) => { return moment(date).format('MMM-DD-YYYY'); },
+      hour: (date) => { return moment.utc(date).format('MMM-DD hh:mm A'); },
+      day: (date) => { return moment.utc(date).format('MMM-DD-YYYY'); },
+      week: (date) => { return moment.utc(date).format('MMM-DD-YYYY'); },
+      month: (date) => { return moment.utc(date).format('MMM-DD-YYYY'); },
     };
 
     const data = this.processData(props.data, props.by);
@@ -186,11 +186,11 @@ export class Graph extends React.Component {
     for (const { label, value } of inputData) {
       if (idx > 0) {
         // fill in bins wint zero as a value
-        const dateDiff = moment(label).diff(moment(previousLabel));
+        const dateDiff = moment.utc(label).diff(moment.utc(previousLabel));
         const difference = Math.floor(moment.duration(dateDiff)[this.formatDiff[binBy]]());
         if (difference > 1) {
           for (let jdx = 1; jdx < difference; jdx += 1) {
-            const shouldBe = moment(previousLabel).add(jdx, `${binBy}s`).format();
+            const shouldBe = moment.utc(previousLabel).add(jdx, `${binBy}s`).format();
             data.labels.push(this.formatLabel[binBy](shouldBe));
             data.series[0].push(0);
           }

--- a/app/pages/project/stats/stats.jsx
+++ b/app/pages/project/stats/stats.jsx
@@ -339,20 +339,20 @@ export class ProjectStatsPage extends React.Component {
     if (this.props.startDate) {
       start = (
         <div className="project-metadata-stat">
-          <div>{moment(this.props.startDate).format('MMM-DD-YYYY')}</div>
+          <div>{moment.utc(this.props.startDate).format('MMM-DD-YYYY')}</div>
           <div>Launch Date</div>
         </div>
       );
     }
     let classificationFootnoteMarker;
     let classificationFootnote;
-    if (moment(this.props.startDate) <= moment(classificationGap[1])) {
+    if (moment.utc(this.props.startDate) <= moment.utc(classificationGap[1])) {
       classificationFootnoteMarker = <span><sup>&#8224;</sup></span>;
       classificationFootnote = (
         <span className="project-stats-footer">
          {classificationFootnoteMarker}
          Due to an issue with our stats server all data before
-         {' '}{moment(classificationGap[1]).format('MMM-DD-YYYY')} is
+         {' '}{moment.utc(classificationGap[1]).format('MMM-DD-YYYY')} is
          {' '}currently unavailable.  We are currently working to resolve this issue.
          {' '}<b>No</b> classifications were lost in this time.
         </span>
@@ -360,13 +360,13 @@ export class ProjectStatsPage extends React.Component {
     }
     let talkFootnoteMarker;
     let talkFootnote;
-    if (moment(this.props.startDate) <= moment(talkGap[1])) {
+    if (moment.utc(this.props.startDate) <= moment.utc(talkGap[1])) {
       talkFootnoteMarker = <span><sup>&#8225;</sup></span>;
       talkFootnote = (
         <span className="project-stats-footer">
           {talkFootnoteMarker}
           Due to an issue with our stats server all data before
-          {' '}{moment(talkGap[1]).format('MMM-DD-YYYY')} is
+          {' '}{moment.utc(talkGap[1]).format('MMM-DD-YYYY')} is
           {' '}currently unavailable.  We are currently working to resolve this issue.
           {' '}<b>No</b> talk comments were lost in this time.
         </span>


### PR DESCRIPTION
avoid converting to the client / browsers timezone, use UTC for consistency in reporting the event times.

Fixes issue report on talk - https://www.zooniverse.org/talk/17/441417?comment=736400

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [X] Did you deploy a staging branch? https://utc-stats-labels.pfe-preview.zooniverse.org/projects/birgus2/western-shield-camera-watch/stats?env=production
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

## Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
