### PR TITLE
Fix create discussion site hang

### DIFF
--- a/app/subjects/comment-form.cjsx
+++ b/app/subjects/comment-form.cjsx
@@ -80,18 +80,20 @@ module.exports = React.createClass
     if @state.boards.length < 1
       @renderTab()
     else
-      <div>
+      <div className="tabbed-content">
         <div className="tabbed-content-tabs">
-          <div className="tabbed-content-tab #{if @state.tab is 0 then 'active' else ''}" onClick={=> @setState({tab: 0})}>
-            <button className="link-style create-discussion-or-comment">
-              Add a note about this subject
-            </button>
-          </div>
+          <div className="subject-page-tabs">
+            <div className="tabbed-content-tab #{if @state.tab is 0 then 'active' else ''}" onClick={=> @setState({tab: 0})}>
+              <button className="link-style">
+                Add a note about this subject
+              </button>
+            </div>
 
-          <div className="tabbed-content-tab #{if @state.tab is 1 then 'active' else ''}" onClick={=> @setState({tab: 1})}>
-            <button className="link-style create-discussion-or-comment">
-              Start a new discussion
-            </button>
+            <div className="tabbed-content-tab #{if @state.tab is 1 then 'active' else ''}" onClick={=> @setState({tab: 1})}>
+              <button className="link-style">
+                Start a new discussion
+              </button>
+            </div>
           </div>
         </div>
         {@renderTab()}

--- a/app/subjects/comment-form.cjsx
+++ b/app/subjects/comment-form.cjsx
@@ -81,17 +81,17 @@ module.exports = React.createClass
       @renderTab()
     else
       <div>
-        <div className="tabbed-content">
-          <div className="tabbed-content-tabs">
-            <div className="subject-page-tabs">
-              <button type="button" className="create-discussion-or-comment #{if @state.tab is 0 then 'active' else ''}" onClick={=> @setState({tab: 0})}>
-                Add a note about this subject
-              </button>
+        <div className="tabbed-content-tabs">
+          <div className="tabbed-content-tab #{if @state.tab is 0 then 'active' else ''}" onClick={=> @setState({tab: 0})}>
+            <button className="link-style create-discussion-or-comment">
+              Add a note about this subject
+            </button>
+          </div>
 
-              <button type="button" className="create-discussion-or-comment #{if @state.tab is 1 then 'active' else ''}" onClick={=> @setState({tab: 1})}>
-                Start a new discussion
-              </button>
-            </div>
+          <div className="tabbed-content-tab #{if @state.tab is 1 then 'active' else ''}" onClick={=> @setState({tab: 1})}>
+            <button className="link-style create-discussion-or-comment">
+              Start a new discussion
+            </button>
           </div>
         </div>
         {@renderTab()}

--- a/app/subjects/comment-form.cjsx
+++ b/app/subjects/comment-form.cjsx
@@ -58,11 +58,7 @@ module.exports = React.createClass
     if @state.subjectDefaultBoard
       <QuickSubjectCommentForm {...@props} subject={@props.subject} user={@props.user} />
     else
-      <p>
-        There is no default board for subject comments setup yet, Please{' '}
-        <button className="link-style" onClick={=> @setState(tab: 1)}>start a new discussion</button>{' '}
-        or {@linkToClassifier('return to classifying')}
-      </p>
+      @notSetup() # The project has not initialized default boards. Therefore render the notSetup message.
 
   startDiscussion: ->
     <NewDiscussionForm
@@ -89,7 +85,7 @@ module.exports = React.createClass
               Add a note about this subject
             </div>
 
-            <div className="tabbed-content-tab #{if @state.tab is 1 then 'active' else ''}" onClick={=> @setState({tab: 1})}>
+            <div className="tabbed-content-tab #{if @state.boards.length < 1 then 'hidden'} #{if @state.tab is 1 then 'active' else ''}" onClick={=> @setState({tab: 1})}>
               Start a new discussion
             </div>
           </div>

--- a/app/subjects/comment-form.cjsx
+++ b/app/subjects/comment-form.cjsx
@@ -51,14 +51,14 @@ module.exports = React.createClass
       to contribute to subject discussions
     </p>
 
-  notSetup: ->
-    <p>There are no discussion boards setup for this project yet. Check back soon!</p>
+  noDefaultBoardMessage: ->
+    <p>There are no discussion boards setup for this project yet. Please check back soon or {@linkToClassifier('return to classifying')}.</p>
 
   quickComment: ->
     if @state.subjectDefaultBoard
       <QuickSubjectCommentForm {...@props} subject={@props.subject} user={@props.user} />
     else
-      @notSetup() # The project has not initialized default boards. Therefore render the notSetup message.
+      @noDefaultBoardMessage()
 
   startDiscussion: ->
     <NewDiscussionForm
@@ -74,23 +74,25 @@ module.exports = React.createClass
 
   render: ->
     return <Loading /> if @state.loading
-    return @notSetup() unless @state.boards
+    return @noDefaultBoardMessage() unless @state.boards
     return @loginPrompt() unless @props.user
 
-    <div>
-      <div className="tabbed-content">
-        <div className="tabbed-content-tabs">
-          <div className="subject-page-tabs">
-            <div className="tabbed-content-tab #{if @state.tab is 0 then 'active' else ''}" onClick={=> @setState({tab: 0})}>
-              Add a note about this subject
-            </div>
+    if @state.boards.length < 1
+      @renderTab()
+    else
+      <div>
+        <div className="tabbed-content">
+          <div className="tabbed-content-tabs">
+            <div className="subject-page-tabs">
+              <button type="button" className="create-discussion-or-comment #{if @state.tab is 0 then 'active' else ''}" onClick={=> @setState({tab: 0})}>
+                Add a note about this subject
+              </button>
 
-            <div className="tabbed-content-tab #{if @state.boards.length < 1 then 'hidden'} #{if @state.tab is 1 then 'active' else ''}" onClick={=> @setState({tab: 1})}>
-              Start a new discussion
+              <button type="button" className="create-discussion-or-comment #{if @state.tab is 1 then 'active' else ''}" onClick={=> @setState({tab: 1})}>
+                Start a new discussion
+              </button>
             </div>
           </div>
         </div>
+        {@renderTab()}
       </div>
-
-      {@renderTab()}
-    </div>

--- a/app/subjects/index.jsx
+++ b/app/subjects/index.jsx
@@ -36,7 +36,7 @@ export default class SubjectPageContainer extends React.Component {
 
   setSubject() {
     const subjectId = this.props.params.id.toString();
-    apiClient.type('subjects').get(subjectId)
+    apiClient.type('subjects').get(subjectId, { include: 'project' })
       .then((subject) => {
         this.setState({ subject });
         this.getCollections(subject, this.props.location.query.collections_page);

--- a/css/tabbed-content.styl
+++ b/css/tabbed-content.styl
@@ -70,8 +70,8 @@
 
 .tabbed-content .subject-page-tabs
   button.link-style
-    text-decoration: none
     color: COPY_GREY_DARK
+    text-decoration: none
     text-transform: uppercase
     &:focus
       outline: none

--- a/css/tabbed-content.styl
+++ b/css/tabbed-content.styl
@@ -67,6 +67,3 @@
 
   &.social-icon
     padding: 0.5em
-
-  &.hidden
-    display: none

--- a/css/tabbed-content.styl
+++ b/css/tabbed-content.styl
@@ -67,3 +67,12 @@
 
   &.social-icon
     padding: 0.5em
+
+  button.link-style
+    &.create-discussion-or-comment
+      text-decoration: none
+      color: COPY_GREY_DARK
+      text-transform: uppercase
+
+      &:focus
+        outline: none

--- a/css/tabbed-content.styl
+++ b/css/tabbed-content.styl
@@ -68,11 +68,10 @@
   &.social-icon
     padding: 0.5em
 
+.tabbed-content .subject-page-tabs
   button.link-style
-    &.create-discussion-or-comment
-      text-decoration: none
-      color: COPY_GREY_DARK
-      text-transform: uppercase
-
-      &:focus
-        outline: none
+    text-decoration: none
+    color: COPY_GREY_DARK
+    text-transform: uppercase
+    &:focus
+      outline: none

--- a/css/tabbed-content.styl
+++ b/css/tabbed-content.styl
@@ -67,3 +67,6 @@
 
   &.social-icon
     padding: 0.5em
+
+  &.hidden
+    display: none

--- a/css/talk.styl
+++ b/css/talk.styl
@@ -88,9 +88,6 @@
       color: white
       border-color: MAIN_HIGHLIGHT
 
-    &.create-discussion-or-comment
-      margin: 0 0.5em
-
   select
     border: 2px solid LIGHT_GREY
     background: #fff

--- a/css/talk.styl
+++ b/css/talk.styl
@@ -88,6 +88,9 @@
       color: white
       border-color: MAIN_HIGHLIGHT
 
+    &.create-discussion-or-comment
+      margin: 0 0.5em
+
   select
     border: 2px solid LIGHT_GREY
     background: #fff
@@ -460,7 +463,7 @@
       img
         max-width: 100%
     .subject-tools
-      span > 
+      span >
         button
         .button
           margin-right: 2px


### PR DESCRIPTION
Fixes #3849.
- Related: https://github.com/zooniverse/Panoptes-Front-End/issues/3425

Describe your changes.
- Disable functionality for user to create a discussion for a subject if the project team has not enabled additional discussion boards.
- If additional discussion boards have been created, display them as radio buttons, one of which must be selected to create the discussion.
  - Defaults to first button being selected.
  - A bug was fixed in this PR, where on initial landing on the `talk/subject/{subjectId}` page from the classifier, the Subject GET request was not returning the linked project. On refresh, the Subject GET request does return the linked project. Adding `{ include: 'project' }` to the `setSubject` GET request renders the additional Boards that a user can pick from on initial landing.
    - To recreate this issue on the live site, make sure your project has additional boards created, and follow the steps laid out in #3849, up to Step 4. On landing, note that no radio buttons are displayed beneath Board in the Create Discussion form. Hit refresh, and note that the radio buttons are displayed.
- I added a `.hidden` CSS selector that conditionally hides the Create Discussion tab if the project team has not created additional boards (ie, no radio buttons for the user to choose from.)
- I altered the statement displayed if the project team has not created default boards, which previously invited the user to click a link leading to Create Discussion (which the user cannot do if there are no additional boards to choose from). I'm not sure if it's possible for the project team to create *additional* boards but have default boards disabled - this seems like an obscure or perhaps nonsensical scenario. Rather than designing for that functionality, I displayed the `notSetup` message.
- [Staged here](https://hide-create-discussion-tab.pfe-preview.zooniverse.org).

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?


## Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [x] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
