### PR TITLE
dropdown subTask

### DIFF
--- a/app/classifier/drawing-tools/root.cjsx
+++ b/app/classifier/drawing-tools/root.cjsx
@@ -70,6 +70,7 @@ module.exports = React.createClass
               <TaskComponent autoFocus={i is 0} key={detailTask._key} task={detailTask} annotation={toolProps.mark.details[i]} onChange={@handleDetailsChange.bind this, i} />}
             <hr />
             <p style={textAlign: 'center'}>
+              {# The tabIndex is set on the button as a workaround to allow the OK button to gain focus when the subtask is a dropdown.}
               <button tabIndex="0" autoFocus={toolProps.details[0].type in ['single', 'multiple']} type="submit" className="standard-button" disabled={not detailsAreComplete}>OK</button>
             </p>
           </ModalFocus>

--- a/app/classifier/drawing-tools/root.cjsx
+++ b/app/classifier/drawing-tools/root.cjsx
@@ -70,7 +70,7 @@ module.exports = React.createClass
               <TaskComponent autoFocus={i is 0} key={detailTask._key} task={detailTask} annotation={toolProps.mark.details[i]} onChange={@handleDetailsChange.bind this, i} />}
             <hr />
             <p style={textAlign: 'center'}>
-              <button autoFocus={toolProps.details[0].type in ['single', 'multiple']} type="submit" className="standard-button" disabled={not detailsAreComplete}>OK</button>
+              <button tabIndex="0" autoFocus={toolProps.details[0].type in ['single', 'multiple']} type="submit" className="standard-button" disabled={not detailsAreComplete}>OK</button>
             </p>
           </ModalFocus>
         </StickyModalForm>}

--- a/app/classifier/tasks/drawing-task-details-editor.cjsx
+++ b/app/classifier/tasks/drawing-task-details-editor.cjsx
@@ -97,12 +97,14 @@ module.exports = React.createClass
                 <br />
                 <small><strong>Text</strong></small>
               </button>{' '}
-
-              <button type="submit" className="minor-button" onClick={@handleAddTask.bind this, 'dropdown'} title="Dropdown tasks: the volunteer selects a text label from a list.">
-                <i className="fa fa-list fa-2x"></i>
-                <br />
-                <small><strong>Dropdown</strong></small>
-              </button>
+              {
+                if 'dropdown' in @props.project.experimental_tools
+                  <button type="submit" className="minor-button" onClick={@handleAddTask.bind this, 'dropdown'} title="Dropdown tasks: the volunteer selects a text label from a list.">
+                    <i className="fa fa-list fa-2x"></i>
+                    <br />
+                    <small><strong>Dropdown</strong></small>
+                  </button>
+              }
           </TriggeredModalForm>
         </p>
       </div>

--- a/app/classifier/tasks/drawing-task-details-editor.cjsx
+++ b/app/classifier/tasks/drawing-task-details-editor.cjsx
@@ -3,6 +3,7 @@ AutoSave = require '../../components/auto-save'
 TriggeredModalForm = require 'modal-form/triggered'
 TextTaskEditor = require './text/editor'
 SliderTaskEditor = require('./slider/editor').default
+DropdownEditor = require './dropdown/editor'
 
 
 module.exports = React.createClass
@@ -39,6 +40,15 @@ module.exports = React.createClass
                   />
                 else if subtask.type is 'slider'
                   <SliderTaskEditor
+                    workflow={@props.workflow}
+                    task={subtask}
+                    taskPrefix="#{@props.toolPath}.details.#{i}"
+                    isSubtask={true}
+                    onChange={@handleSubtaskChange.bind this, i}
+                    onDelete={@handleSubtaskDelete.bind this, i}
+                  />
+                else if subtask.type is 'dropdown'
+                  <DropdownEditor
                     workflow={@props.workflow}
                     task={subtask}
                     taskPrefix="#{@props.toolPath}.details.#{i}"
@@ -86,6 +96,12 @@ module.exports = React.createClass
                 <i className="fa fa-file-text-o fa-2x"></i>
                 <br />
                 <small><strong>Text</strong></small>
+              </button>{' '}
+
+              <button type="submit" className="minor-button" onClick={@handleAddTask.bind this, 'dropdown'} title="Dropdown tasks: the volunteer selects a text label from a list.">
+                <i className="fa fa-list fa-2x"></i>
+                <br />
+                <small><strong>Dropdown</strong></small>
               </button>
           </TriggeredModalForm>
         </p>
@@ -103,6 +119,8 @@ module.exports = React.createClass
         TaskChoice = require './text'
       when 'slider'
         TaskChoice = require('./slider').default
+      when 'dropdown'
+        TaskChoice = require './dropdown'
     @props.task.tools[@props.toolIndex].details.push TaskChoice.getDefaultTask()
     @props.workflow.update 'tasks'
     @props.workflow.save()

--- a/css/modal-form.styl
+++ b/css/modal-form.styl
@@ -29,6 +29,7 @@
   color: black
   font-size: 14px
   margin: 0.5em 3vw
+  max-width: 65%
   padding: 0.5em 1em
 
   &.site-nav__modal


### PR DESCRIPTION
Fixes #3962.

**Describe your changes.**
This PR adds the dropdown task as a possible drawing subTask. The dropdown subTask can only be added to a workflow if the dropdown task is enabled for the project.

You can try it out with this demo project: https://dropdown-subtask.pfe-preview.zooniverse.org/projects/scribe-2/demo-for-dropdown-subtask/classify

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://dropdown-subtask.pfe-preview.zooniverse.org
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?


## Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
