### PR TITLE
Allow to draw concave polygons.

### DIFF
--- a/app/classifier/drawing-tools/polygon.cjsx
+++ b/app/classifier/drawing-tools/polygon.cjsx
@@ -67,9 +67,9 @@ module.exports = React.createClass
 
     deleteButtonPosition = @getDeletePosition(firstPoint, secondPoint)
 
-    <DrawingToolRoot tool={this}>
+    <DrawingToolRoot tool={this} pointerEvents='painted'>
       <Draggable onDrag={@handleMainDrag} onEnd={deleteIfOutOfBounds.bind null, this} disabled={@props.disabled}>
-        <polyline points={points} fill={'none' unless @props.mark.closed} />
+        <polyline  points={points} fill={'none' unless @props.mark.closed} />
       </Draggable>
 
       {if @props.selected
@@ -116,7 +116,7 @@ module.exports = React.createClass
       true
 
     @setState
-      mouseX: newCoord.x 
+      mouseX: newCoord.x
       mouseY: newCoord.y
       mouseWithinViewer: mouseWithinViewer
 


### PR DESCRIPTION
Fixes #3983.

Describe your changes.
Adds `pointerEvents='painted'` prop to drawing tool.

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://allow-concave-polygon.pfe-preview.zooniverse.org/projects/ghthomas/project-plumage?env=production (needs Admin mode)
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

Note: Haven't tested Edge.
