### PR TITLE
Update modal focus

### DIFF
--- a/app/classifier/drawing-tools/root.cjsx
+++ b/app/classifier/drawing-tools/root.cjsx
@@ -70,8 +70,7 @@ module.exports = React.createClass
               <TaskComponent autoFocus={i is 0} key={detailTask._key} task={detailTask} annotation={toolProps.mark.details[i]} onChange={@handleDetailsChange.bind this, i} />}
             <hr />
             <p style={textAlign: 'center'}>
-              {# The tabIndex is set on the button as a workaround to allow the OK button to gain focus when the subtask is a dropdown.}
-              <button tabIndex="0" autoFocus={toolProps.details[0].type in ['single', 'multiple']} type="submit" className="standard-button" disabled={not detailsAreComplete}>OK</button>
+              <button autoFocus={toolProps.details[0].type in ['single', 'multiple']} type="submit" className="standard-button" disabled={not detailsAreComplete}>OK</button>
             </p>
           </ModalFocus>
         </StickyModalForm>}

--- a/app/components/modal-focus.jsx
+++ b/app/components/modal-focus.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 
-const FOCUSABLES = 'a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), iframe, object, embed, *[tabindex], *[contenteditable]';
+const FOCUSABLES = 'a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), iframe, object, embed, *[contenteditable]';
 
 const ESC_KEY = 27;
 const TAB_KEY = 9;

--- a/app/components/modal-focus.jsx
+++ b/app/components/modal-focus.jsx
@@ -9,13 +9,8 @@ const TAB_KEY = 9;
 class ModalFocus extends React.Component {
   constructor(props) {
     super(props);
-    this.focusables = [];
     this.previousActiveElement = document.activeElement;
     this.handleKeyDown = this.handleKeyDown.bind(this);
-  }
-
-  componentDidMount() {
-    this.focusables = ReactDOM.findDOMNode(this).querySelectorAll(FOCUSABLES);
   }
 
   componentWillUnmount() {
@@ -24,7 +19,7 @@ class ModalFocus extends React.Component {
 
   handleKeyDown(e) {
     const { shiftKey, target } = e;
-    const { focusables } = this;
+    const focusables = ReactDOM.findDOMNode(this).querySelectorAll(FOCUSABLES);
     switch (e.keyCode) {
       case ESC_KEY:
         this.props.onEscape();


### PR DESCRIPTION
Fixes a focus bug found in #4075 

Describe your changes.
ModalFocus ignores disabled form controls, but doesn't update if those controls switch disabled state.

This PR updates the component to query the DOM on keydown, so that the list of focusable elements is always up-to-date. It also removes the tabindex that was added as a workaround in #4075

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://update-modal-focus.pfe-preview.zooniverse.org/
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?


## Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
