### PR TITLE
Make lab image-selector always clickable

### DIFF
--- a/css/image-selector.styl
+++ b/css/image-selector.styl
@@ -2,4 +2,5 @@
   background: rgba(gray, 0.2)
   border: 1px solid rgba(gray, 0.4)
   border-radius: 5px
+  min-height: 30px
   overflow: hidden


### PR DESCRIPTION
Fixes #4077.

Describe your changes.
Add a `min-height` to `image-selector` CSS class.
Stages [here](https://fix-image-selector.pfe-preview.zooniverse.org/).
# Review Checklist
- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?
