### PR TITLE
Move shortcut summary into its own file

### DIFF
--- a/app/classifier/tasks/shortcut/index.jsx
+++ b/app/classifier/tasks/shortcut/index.jsx
@@ -1,56 +1,5 @@
 import React from 'react';
-import { Markdown } from 'markdownz';
-import Translate from 'react-translate-component';
-
-class Summary extends React.Component {
-  render() {
-    let answer;
-
-    if (this.props.annotation.value != null) {
-      answer = this.props.annotation.value.map((index) => {
-        return (
-          <div key={index} className="answer">
-            <i className="fa fa-check-circle-o fa-fw" />
-            <Markdown tag="span" inline={true}>{this.props.task.answers[index].label}</Markdown>
-          </div>
-        );
-      });
-    } else {
-      answer = <div className="answer"><Translate content="tasks.shortcut.noAnswer" /></div>;
-    }
-
-    return (
-      <div>
-        <div className="question">
-          {this.props.task.question}
-        </div>
-        <div className="answers">
-          {answer}
-        </div>
-      </div>
-    );
-  }
-}
-
-Summary.propTypes = {
-  annotation: React.PropTypes.shape(
-    { value: React.PropTypes.array }
-  ).isRequired,
-  task: React.PropTypes.shape(
-    {
-      answers: React.PropTypes.array,
-      question: React.PropTypes.string
-    }
-  )
-};
-
-Summary.defaultProps = {
-  annotation: { },
-  task: {
-    answers: [],
-    question: ''
-  }
-};
+import Summary from './summary';
 
 export default class Shortcut extends React.Component {
 

--- a/app/classifier/tasks/shortcut/summary.jsx
+++ b/app/classifier/tasks/shortcut/summary.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { Markdown } from 'markdownz';
+import Translate from 'react-translate-component';
+
+class Summary extends React.Component {
+  render() {
+    let answer;
+
+    if (this.props.annotation.value != null) {
+      answer = this.props.annotation.value.map(index =>
+        (<div key={index} className="answer">
+          <i className="fa fa-check-circle-o fa-fw" />
+          <Markdown tag="span" inline={true}>{this.props.task.answers[index].label}</Markdown>
+        </div>)
+      );
+    } else {
+      answer = <div className="answer"><Translate content="tasks.shortcut.noAnswer" /></div>;
+    }
+
+    return (
+      <div>
+        <div className="question">
+          {this.props.task.question}
+        </div>
+        <div className="answers">
+          {answer}
+        </div>
+      </div>
+    );
+  }
+}
+
+Summary.propTypes = {
+  annotation: React.PropTypes.shape(
+    { value: React.PropTypes.array }
+  ).isRequired,
+  task: React.PropTypes.shape(
+    {
+      answers: React.PropTypes.array,
+      question: React.PropTypes.string
+    }
+  )
+};
+
+Summary.defaultProps = {
+  annotation: { },
+  task: {
+    answers: [],
+    question: ''
+  }
+};
+
+export default Summary;


### PR DESCRIPTION
Sorry, I missed this in #4084

Describe your changes.
Moves the shortcut summary component  into its own file.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://shortcut-summary.pfe-preview.zooniverse.org/
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?


## Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
