### PR TITLE
Expand survey task summary tests

### DIFF
--- a/app/classifier/tasks/survey/summary.spec.js
+++ b/app/classifier/tasks/survey/summary.spec.js
@@ -8,38 +8,48 @@ import enLocale from '../../../locales/en';
 
 counterpart.registerTranslations('en', enLocale);
 
-const annotation = { 
+const annotation = {
   value: [{
     "choice": "ar",
     "answers": {
+      "ho": "one",
+      "be": [
+        "mo"
+      ]
+    },
+    "filters": {}
+    }, {
+    "choice": "to",
+    "answers": {
       "ho": "two",
       "be": [
-        "mo",
         "ea"
-      ]
+      ],
+      "in": "n",
+      "bt": "Y"
     },
     "filters": {}
   }]
 };
-const task = workflow.tasks.survey
-const expectedSummary = 'Armadillo: 2; Moving, Eating';
+const task = workflow.tasks.survey;
+const expectedSummary = 'Tortoise: 2; Eating; Nope; HECK YES';
 
 describe('Survey task summary, not expanded', function() {
   const wrapper = mount(<Summary annotation={annotation} task={task} />);
   const question = wrapper.find('.question span').first();
   const answers = wrapper.find('.answers .answer');
 
-  it('should summarise the survey task', function(){
+  it('should summarise the survey task', function() {
     const count = task.choicesOrder.length;
     assert.equal(`Survey of ${count}`, question.text());
   });
 
-  it('should show one answer node', function(){
+  it('should show one answer node', function() {
     assert.equal(answers.length, 1);
   });
 
   it('should summarise the number of identifications', function() {
-    assert.equal(answers.text(), '1 identification');
+    assert.equal(answers.text(), '2 identifications');
   });
 });
 
@@ -48,15 +58,15 @@ describe('Survey task summary, expanded', function() {
   const question = wrapper.find('.question span').first();
   const answers = wrapper.find('.answers .answer');
 
-  it('should summarise the survey task', function(){
+  it('should summarise the survey task', function() {
     const count = task.choicesOrder.length;
     assert.equal(`Survey of ${count}`, question.text());
   });
 
-  it('should show two answer nodes', function(){
-    assert.equal(answers.length, 2);
+  it('should show three answer nodes', function() {
+    assert.equal(answers.length, 3);
   });
-  
+
   it('should summarise the identification and questions', function() {
     assert.equal(answers.last().text(), expectedSummary);
   });

--- a/app/classifier/tasks/survey/summary.spec.js
+++ b/app/classifier/tasks/survey/summary.spec.js
@@ -51,7 +51,7 @@ const task = workflow.tasks.survey;
 const oneExpectedSummary = 'Armadillo: 2; Moving, Eating';
 const twoExpectedSummary = ['Armadillo: 1; Moving', 'Tortoise: 2; Eating; Nope; HECK YES'];
 
-describe('Survey task summary, not expanded', function() {
+describe('Survey task summary, no identifications, not expanded', function() {
   const wrapper = mount(<Summary annotation={noIdentification} task={task} />);
   const question = wrapper.find('.question span').first();
   const answers = wrapper.find('.answers .answer');
@@ -70,7 +70,7 @@ describe('Survey task summary, not expanded', function() {
   });
 });
 
-describe('Survey task summary, expanded', function() {
+describe('Survey task summary, no identifications, expanded', function() {
   const wrapper = mount(<Summary annotation={noIdentification} task={task} />);
   const question = wrapper.find('.question span').first();
   const answers = wrapper.find('.answers .answer');
@@ -89,7 +89,7 @@ describe('Survey task summary, expanded', function() {
   });
 });
 
-describe('Survey task summary, not expanded', function() {
+describe('Survey task summary, one identification, not expanded', function() {
   const wrapper = mount(<Summary annotation={oneIdentification} task={task} />);
   const question = wrapper.find('.question span').first();
   const answers = wrapper.find('.answers .answer');
@@ -108,7 +108,7 @@ describe('Survey task summary, not expanded', function() {
   });
 });
 
-describe('Survey task summary, expanded', function() {
+describe('Survey task summary, one identification, expanded', function() {
   const wrapper = mount(<Summary annotation={oneIdentification} task={task} expanded={true} />);
   const question = wrapper.find('.question span').first();
   const answers = wrapper.find('.answers .answer');
@@ -127,7 +127,7 @@ describe('Survey task summary, expanded', function() {
   });
 });
 
-describe('Survey task summary, not expanded', function() {
+describe('Survey task summary, two identifications, not expanded', function() {
   const wrapper = mount(<Summary annotation={twoIdentifications} task={task} />);
   const question = wrapper.find('.question span').first();
   const answers = wrapper.find('.answers .answer');
@@ -146,7 +146,7 @@ describe('Survey task summary, not expanded', function() {
   });
 });
 
-describe('Survey task summary, expanded', function() {
+describe('Survey task summary, two identifications, expanded', function() {
   const wrapper = mount(<Summary annotation={twoIdentifications} task={task} expanded={true} />);
   const question = wrapper.find('.question span').first();
   const answers = wrapper.find('.answers .answer');

--- a/app/classifier/tasks/survey/summary.spec.js
+++ b/app/classifier/tasks/survey/summary.spec.js
@@ -32,7 +32,7 @@ const annotation = {
   }]
 };
 const task = workflow.tasks.survey;
-const expectedSummary = 'Tortoise: 2; Eating; Nope; HECK YES';
+const expectedSummary = ['Armadillo: 1; Moving', 'Tortoise: 2; Eating; Nope; HECK YES'];
 
 describe('Survey task summary, not expanded', function() {
   const wrapper = mount(<Summary annotation={annotation} task={task} />);
@@ -68,6 +68,8 @@ describe('Survey task summary, expanded', function() {
   });
 
   it('should summarise the identification and questions', function() {
-    assert.equal(answers.last().text(), expectedSummary);
+    assert.equal(answers.at(0).text(), '2 identifications');
+    assert.equal(answers.at(1).text(), expectedSummary[0]);
+    assert.equal(answers.at(2).text(), expectedSummary[1]);
   });
-})
+});

--- a/app/classifier/tasks/survey/summary.spec.js
+++ b/app/classifier/tasks/survey/summary.spec.js
@@ -7,8 +7,23 @@ import { workflow } from '../../../pages/dev-classifier/mock-data';
 import enLocale from '../../../locales/en';
 
 counterpart.registerTranslations('en', enLocale);
+const noIdentification = { value: [] };
 
-const annotation = {
+const oneIdentification = {
+  value: [{
+    "choice": "ar",
+    "answers": {
+      "ho": "two",
+      "be": [
+        "mo",
+        "ea"
+      ]
+    },
+    "filters": {}
+  }]
+};
+
+const twoIdentifications = {
   value: [{
     "choice": "ar",
     "answers": {
@@ -31,11 +46,89 @@ const annotation = {
     "filters": {}
   }]
 };
+
 const task = workflow.tasks.survey;
-const expectedSummary = ['Armadillo: 1; Moving', 'Tortoise: 2; Eating; Nope; HECK YES'];
+const oneExpectedSummary = 'Armadillo: 2; Moving, Eating';
+const twoExpectedSummary = ['Armadillo: 1; Moving', 'Tortoise: 2; Eating; Nope; HECK YES'];
 
 describe('Survey task summary, not expanded', function() {
-  const wrapper = mount(<Summary annotation={annotation} task={task} />);
+  const wrapper = mount(<Summary annotation={noIdentification} task={task} />);
+  const question = wrapper.find('.question span').first();
+  const answers = wrapper.find('.answers .answer');
+
+  it('should summarise the survey task', function() {
+    const count = task.choicesOrder.length;
+    assert.equal(`Survey of ${count}`, question.text());
+  });
+
+  it('should show one answer node', function() {
+    assert.equal(answers.length, 1);
+  });
+
+  it('should summarise the number of identifications', function() {
+    assert.equal(answers.text(), 'No identifications');
+  });
+});
+
+describe('Survey task summary, expanded', function() {
+  const wrapper = mount(<Summary annotation={noIdentification} task={task} />);
+  const question = wrapper.find('.question span').first();
+  const answers = wrapper.find('.answers .answer');
+
+  it('should summarise the survey task', function() {
+    const count = task.choicesOrder.length;
+    assert.equal(`Survey of ${count}`, question.text());
+  });
+
+  it('should show one answer node', function() {
+    assert.equal(answers.length, 1);
+  });
+
+  it('should summarise the number of identifications', function() {
+    assert.equal(answers.text(), 'No identifications');
+  });
+});
+
+describe('Survey task summary, not expanded', function() {
+  const wrapper = mount(<Summary annotation={oneIdentification} task={task} />);
+  const question = wrapper.find('.question span').first();
+  const answers = wrapper.find('.answers .answer');
+
+  it('should summarise the survey task', function() {
+    const count = task.choicesOrder.length;
+    assert.equal(`Survey of ${count}`, question.text());
+  });
+
+  it('should show one answer node', function() {
+    assert.equal(answers.length, 1);
+  });
+
+  it('should summarise the number of identifications', function() {
+    assert.equal(answers.text(), '1 identification');
+  });
+});
+
+describe('Survey task summary, expanded', function() {
+  const wrapper = mount(<Summary annotation={oneIdentification} task={task} expanded={true} />);
+  const question = wrapper.find('.question span').first();
+  const answers = wrapper.find('.answers .answer');
+
+  it('should summarise the survey task', function() {
+    const count = task.choicesOrder.length;
+    assert.equal(`Survey of ${count}`, question.text());
+  });
+
+  it('should show two answer nodes', function() {
+    assert.equal(answers.length, 2);
+  });
+
+  it('should summarise the identification and questions', function() {
+    assert.equal(answers.last().text(), oneExpectedSummary);
+  });
+});
+
+describe('Survey task summary, not expanded', function() {
+  const wrapper = mount(<Summary annotation={twoIdentifications} task={task} />);
   const question = wrapper.find('.question span').first();
   const answers = wrapper.find('.answers .answer');
 
@@ -54,7 +147,7 @@ describe('Survey task summary, not expanded', function() {
 });
 
 describe('Survey task summary, expanded', function() {
-  const wrapper = mount(<Summary annotation={annotation} task={task} expanded={true} />);
+  const wrapper = mount(<Summary annotation={twoIdentifications} task={task} expanded={true} />);
   const question = wrapper.find('.question span').first();
   const answers = wrapper.find('.answers .answer');
 
@@ -69,7 +162,7 @@ describe('Survey task summary, expanded', function() {
 
   it('should summarise the identification and questions', function() {
     assert.equal(answers.at(0).text(), '2 identifications');
-    assert.equal(answers.at(1).text(), expectedSummary[0]);
-    assert.equal(answers.at(2).text(), expectedSummary[1]);
+    assert.equal(answers.at(1).text(), twoExpectedSummary[0]);
+    assert.equal(answers.at(2).text(), twoExpectedSummary[1]);
   });
 });


### PR DESCRIPTION
Describe your changes.
Adds test cases for no, one or two identifications to the survey task summary.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://expand-tests.pfe-preview.zooniverse.org/
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?
