### PR TITLE
add message in lab if project linked to organization

### DIFF
--- a/app/pages/lab/project-details.cjsx
+++ b/app/pages/lab/project-details.cjsx
@@ -43,8 +43,12 @@ module.exports = React.createClass
       apiClient.type('users').get(scientists).then (researchers) =>
         @setState({ researchers })
 
-    @props.project.get('organization').then (organization) =>
-      @setState({ organization })
+    if @props.project.links?.organization
+      @props.project.get('organization')
+        .then (organization) =>
+          @setState({ organization })
+        .catch (error) =>
+          console.error error
 
     @updateImage 'avatar'
     @updateImage 'background'
@@ -115,10 +119,13 @@ module.exports = React.createClass
         </div>
 
         <div className="column">
-          {if @state.organization
+          {if @props.project.links?.organization
             <div>
-              <p>This project is part of the <Link to={"/organizations/#{@state.organization.slug}"}>{@state.organization.display_name}</Link> organization.</p>
-              <p><button onClick={@handleOrganizationUnlink}>Unlink</button> this project from the organization.</p>
+              {if @state.organization
+                <p>This project is part of the <Link to={"/organizations/#{@state.organization.slug}"}>{@state.organization.display_name}</Link> organization.</p>
+              else
+                <p>This project is linked to <strong>Organization #{@props.project.links.organization}</strong>.</p>}
+              <p>If you are not a collaborator on the organization, please coordinate with this project's other collaborators for additional information regarding the affiliated organization.</p>
             </div>}
 
           <DisplayNameSlugEditor resource={@props.project} resourceType="project" />
@@ -221,13 +228,6 @@ module.exports = React.createClass
         </div>
       </div>
     </div>
-
-  handleOrganizationUnlink: () ->
-    @state.organization.removeLink 'projects', @props.project.id
-      .then =>
-        @props.project.uncacheLink 'organizations'
-        @props.project.refresh()
-        @setState({ organization: null })
 
   handleDisciplineTagChange: (options) ->
     newTags = options.map (option) ->

--- a/app/pages/lab/project-details.cjsx
+++ b/app/pages/lab/project-details.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+{Link} = require 'react-router'
 AutoSave = require '../../components/auto-save'
 handleInputChange = require '../../lib/handle-input-change'
 ImageSelector = require '../../components/image-selector'
@@ -32,6 +33,7 @@ module.exports = React.createClass
     researchers: []
     avatar: null
     background: null
+    organization: null
     error: null
 
   componentWillMount: ->
@@ -40,6 +42,9 @@ module.exports = React.createClass
         role.links.owner.id
       apiClient.type('users').get(scientists).then (researchers) =>
         @setState({ researchers })
+
+    @props.project.get('organization').then (organization) =>
+      @setState({ organization })
 
     @updateImage 'avatar'
     @updateImage 'background'
@@ -110,6 +115,12 @@ module.exports = React.createClass
         </div>
 
         <div className="column">
+          {if @state.organization
+            <div>
+              <p>This project is part of the <Link to={"/organizations/#{@state.organization.slug}"}>{@state.organization.display_name}</Link> organization.</p>
+              <p><button onClick={@handleOrganizationUnlink}>Unlink</button> this project from the organization.</p>
+            </div>}
+
           <DisplayNameSlugEditor resource={@props.project} resourceType="project" />
 
           <p>
@@ -210,6 +221,13 @@ module.exports = React.createClass
         </div>
       </div>
     </div>
+
+  handleOrganizationUnlink: () ->
+    @state.organization.removeLink 'projects', @props.project.id
+      .then =>
+        @props.project.uncacheLink 'organizations'
+        @props.project.refresh()
+        @setState({ organization: null })
 
   handleDisciplineTagChange: (options) ->
     newTags = options.map (option) ->


### PR DESCRIPTION
Closes #4103.

Adds message to top of project's Details section in the Project Builder if project is linked to an organization.

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? - https://project-lab-show-org-link.pfe-preview.zooniverse.org/
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?


## Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
