### PR TITLE
add project sub-nav link to org, display org title above description

### DIFF
--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -24,6 +24,7 @@ export default {
       adminPage: 'Admin page'
     },
     home: {
+      organization: 'Organization',
       researcher: 'Words from the researcher',
       about: 'About %(title)s',
       metadata: {

--- a/app/pages/project/home/index.jsx
+++ b/app/pages/project/home/index.jsx
@@ -95,6 +95,7 @@ export default class ProjectHomeContainer extends React.Component {
         activeWorkflows={this.state.activeWorkflows}
         background={this.props.background}
         onChangePreferences={this.props.onChangePreferences}
+        organization={this.props.organization}
         preferences={this.props.preferences}
         project={this.props.project}
         projectAvatar={this.props.projectAvatar}
@@ -116,10 +117,11 @@ ProjectHomeContainer.contextTypes = {
 };
 
 ProjectHomeContainer.defaultProps = {
-  onChangePreferences: () => {},
   background: {
     src: ''
   },
+  onChangePreferences: () => {},
+  organization: null,
   preferences: {},
   project: {},
   projectAvatar: {
@@ -141,6 +143,10 @@ ProjectHomeContainer.propTypes = {
     src: React.PropTypes.string
   }),
   onChangePreferences: React.PropTypes.func.isRequired,
+  organization: React.PropTypes.shape({
+    display_name: React.PropTypes.string,
+    slug: React.PropTypes.string
+  }),
   preferences: React.PropTypes.object,
   projectAvatar: React.PropTypes.shape({
     src: React.PropTypes.string

--- a/app/pages/project/home/project-home.jsx
+++ b/app/pages/project/home/project-home.jsx
@@ -20,7 +20,7 @@ const ProjectHomePage = (props) => {
   const renderTalkSubjectsPreview = props.talkSubjects.length > 2;
   return (
     <div className="project-home-page">
-      <div className="project-background" style={{ backgroundImage: `radial-gradient(rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0.8)), url(${props.background.src})` }}>
+      <div className="project-page project-background" style={{ backgroundImage: `radial-gradient(rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0.8)), url(${props.background.src})` }}>
         <ProjectNavbar {...props} />
 
         {props.projectIsComplete &&

--- a/app/pages/project/home/project-home.jsx
+++ b/app/pages/project/home/project-home.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router';
+import classnames from 'classnames';
 import { Markdown } from 'markdownz';
 import Translate from 'react-translate-component';
 import getSubjectLocation from '../../../lib/get-subject-location.coffee';
@@ -12,20 +13,35 @@ import ProjectNavbar from '../project-navbar';
 
 const ProjectHomePage = (props) => {
   const avatarSrc = props.researcherAvatar || '/assets/simple-avatar.png';
+  const descriptionClass = classnames(
+    'project-home-page__description',
+    { 'project-home-page__description--top-padding': !props.organization }
+  );
   const renderTalkSubjectsPreview = props.talkSubjects.length > 2;
   return (
     <div className="project-home-page">
       <div className="project-background" style={{ backgroundImage: `radial-gradient(rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0.8)), url(${props.background.src})` }}>
         <ProjectNavbar {...props} />
+
         {props.projectIsComplete &&
           (<div className="call-to-action-container">
             <FinishedBanner project={props.project} />
           </div>)}
+
         {props.project.configuration && props.project.configuration.announcement &&
           (<div className="informational project-announcement-banner">
             <Markdown>{props.project.configuration.announcement}</Markdown>
           </div>)}
-        <div className="project-home-page__description">
+
+        {props.organization &&
+          <Link
+            to={`/organizations/${props.organization.slug}`}
+            className="project-home-page__organization"
+          >
+            <Translate content="project.home.organization" />: {props.organization.display_name}
+          </Link>}
+
+        <div className={descriptionClass}>
           {props.translation.description}
         </div>
 
@@ -40,6 +56,7 @@ const ProjectHomePage = (props) => {
           splits={props.splits}
         />
       </div>
+
       {renderTalkSubjectsPreview && (
         <div className="project-home-page__container">
           {props.talkSubjects.map((subject) => {
@@ -110,6 +127,7 @@ ProjectHomePage.contextTypes = {
 ProjectHomePage.defaultProps = {
   activeWorkflows: [],
   onChangePreferences: () => {},
+  organization: null,
   preferences: {},
   project: {},
   projectIsComplete: false,
@@ -124,6 +142,10 @@ ProjectHomePage.propTypes = {
     src: React.PropTypes.string
   }).isRequired,
   onChangePreferences: React.PropTypes.func.isRequired,
+  organization: React.PropTypes.shape({
+    display_name: React.PropTypes.string,
+    slug: React.PropTypes.string
+  }),
   preferences: React.PropTypes.object,
   project: React.PropTypes.shape({
     configuration: React.PropTypes.object,

--- a/app/pages/project/index.cjsx
+++ b/app/pages/project/index.cjsx
@@ -40,6 +40,7 @@ ProjectPageController = React.createClass
     guideIcons: {}
     loading: false
     loadingSelectedWorkflow: false
+    organization: null
     owner: null
     preferences: null
     project: null
@@ -115,6 +116,13 @@ ProjectPageController = React.createClass
           # Use apiClient with cached resources from include to get out of cache
           awaitBackground = apiClient.type('backgrounds').get(project.links.background.id).catch((error) => [])
 
+          if project.links?.organization?
+            awaitOrganization = project.get('organization', { listed: true })
+              .catch((error) => [])
+              .then((response) => if response?.display_name then response else null)
+          else
+            awaitOrganization = null
+
           awaitOwner = apiClient.type('users').get(project.links.owner.id).catch((error) => console.error(error))
 
           awaitPages = project.get('pages').catch((error) => []) # does not appear in project links?
@@ -129,6 +137,7 @@ ProjectPageController = React.createClass
 
           Promise.all([
             awaitBackground,
+            awaitOrganization,
             awaitOwner,
             awaitPages,
             awaitProjectAvatar,
@@ -136,8 +145,8 @@ ProjectPageController = React.createClass
             awaitProjectRoles,
             awaitPreferences,
             this.props.actions.translations.load('project', project.id, this.props.translations.locale)
-          ]).then(([background, owner, pages, projectAvatar, projectIsComplete, projectRoles, preferences]) =>
-              @setState({ background, owner, pages, projectAvatar, projectIsComplete, projectRoles, preferences })
+          ]).then(([background, organization, owner, pages, projectAvatar, projectIsComplete, projectRoles, preferences]) =>
+              @setState({ background, organization, owner, pages, projectAvatar, projectIsComplete, projectRoles, preferences })
               @getSelectedWorkflow(project, preferences)
               @loadFieldGuide(project.id)
             ).catch((error) => @setState({ error }); console.error(error); );
@@ -146,6 +155,7 @@ ProjectPageController = React.createClass
           @setState
             background: null
             error: new Error 'NOT_FOUND'
+            organization: null
             owner: null
             pages: null
             preferences: null
@@ -317,6 +327,7 @@ ProjectPageController = React.createClass
             loading={@state.loading}
             loadingSelectedWorkflow={@state.loadingSelectedWorkflow}
             onChangePreferences={@handlePreferencesChange}
+            organization={@state.organization}
             owner={@state.owner}
             pages={@state.pages}
             preferences={@state.preferences}

--- a/app/pages/project/index.cjsx
+++ b/app/pages/project/index.cjsx
@@ -121,7 +121,7 @@ ProjectPageController = React.createClass
               .catch((error) => [])
               .then((response) => if response?.display_name then response else null)
           else
-            awaitOrganization = null
+            awaitOrganization = Promise.resolve(null)
 
           awaitOwner = apiClient.type('users').get(project.links.owner.id).catch((error) => console.error(error))
 

--- a/app/pages/project/project-navbar.jsx
+++ b/app/pages/project/project-navbar.jsx
@@ -177,6 +177,21 @@ function LabTab({ project, projectRoles, user }) {
   );
 }
 
+function OrgTab({ organization }) {
+  return (
+    organization ?
+      <Link
+        to={`/organizations/${organization.slug}`}
+        className="tabbed-content-tab"
+      >
+        {organization.display_name}
+        {' '}
+        <i className="fa fa-external-link fa-fw" />
+      </Link> :
+      null
+  );
+}
+
 function ExternalLinks({ project }) {
   if (project.urls) {
     const externalLinks = project.urls.filter(url => !url.path);
@@ -235,6 +250,7 @@ function SocialLinks({ project }) {
 
 const ProjectNavbar = ({
   loading,
+  organization,
   project,
   projectAvatar,
   projectRoles,
@@ -321,6 +337,9 @@ const ProjectNavbar = ({
       <AdminTab
         project={project}
       />
+      <OrgTab
+        organization={organization}
+      />
       <ExternalLinks
         project={project}
       />
@@ -333,6 +352,7 @@ const ProjectNavbar = ({
 
 ProjectNavbar.defaultProps = {
   loading: false,
+  organization: null,
   project: {
     id: '',
     display_name: '',
@@ -356,6 +376,10 @@ ProjectNavbar.contextTypes = {
 
 ProjectNavbar.propTypes = {
   loading: React.PropTypes.bool,
+  organization: React.PropTypes.shape({
+    display_name: React.PropTypes.string,
+    slug: React.PropTypes.string
+  }),
   project: React.PropTypes.shape({
     id: React.PropTypes.string,
     display_name: React.PropTypes.string,

--- a/app/pages/project/project-page.cjsx
+++ b/app/pages/project/project-page.cjsx
@@ -26,6 +26,7 @@ ProjectPage = React.createClass
     guide: null
     guideIcons: null
     loading: false
+    organization: null
     owner: {}
     preferences: null
     pages: null
@@ -85,6 +86,7 @@ ProjectPage = React.createClass
         background: @props.background
         loadingSelectedWorkflow: @props.loadingSelectedWorkflow
         onChangePreferences: @props.onChangePreferences
+        organization: @props.organization
         owner: @props.owner
         pages: @props.pages
         preferences: @props.preferences

--- a/css/project-page.styl
+++ b/css/project-page.styl
@@ -190,8 +190,9 @@
     text-decoration: none
     text-transform: uppercase
 
+    &:focus,
     &:hover
-      color: ZOONIVERSE_TEAL
+      color: TEAL_MID
 
   &__description
     font-size: 2em

--- a/css/project-page.styl
+++ b/css/project-page.styl
@@ -181,15 +181,29 @@
       border: 2px solid white
       outline: none
 
+  &__organization
+    color: white
+    letter-spacing: .2em
+    margin: 15vh auto .8em
+    max-width: 500px
+    text-align: center
+    text-decoration: none
+    text-transform: uppercase
+
+    &:hover
+      color: ZOONIVERSE_TEAL
+
   &__description
     font-size: 2em
     font-weight: 600
     line-height: 1.5em
     margin: 0 auto
     max-width: 500px
-    padding-top: 15vh
     text-align: center
     width: 100%
+
+    &--top-padding
+      padding-top: 15vh
 
   &__content
     color: #0f7481
@@ -439,7 +453,7 @@
   &-stat
     margin: 0 1vw
     text-align: center
-    
+
     > :first-child
       font-size: 2em
 


### PR DESCRIPTION
Closes #3968.

If project linked to organization with `listed: true`, adds project sub-nav link to organization, display organization title above project description.

- https://project-landing-org-links.pfe-preview.zooniverse.org/projects/markb-panoptes/nfnorgtest-moths
- (with announcement banner) https://project-landing-org-links.pfe-preview.zooniverse.org/projects/markb-panoptes/nfnorgtest-wedigflplants

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? - https://project-landing-org-links.pfe-preview.zooniverse.org/
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?


## Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
