### PR TITLE
Refactor about team page to use project roles from parent. Fixes #4111

### DIFF
--- a/app/pages/project/about/index.jsx
+++ b/app/pages/project/about/index.jsx
@@ -62,22 +62,20 @@ class AboutProject extends Component {
   }
 
   getTeam() {
-    return this.props.project.get('project_roles')
-      .then(projectRoles => {
-        const userIds = projectRoles.map(role => role.links.owner.id);
-        return apiClient.type('users').get(userIds)
-          .then(users => this.constructTeamData(projectRoles, users))
-          .catch((error) => console.error('Error retrieving project team users', error));
-      })
-      .then(team => this.setState({ team }))
-      .catch(error => console.error('Error retrieving project team data', error));
+    if (this.props.projectRoles.length > 0) {
+      const userIds = this.props.projectRoles.map(role => role.links.owner.id);
+      return apiClient.type('users').get(userIds)
+        .then(users => this.constructTeamData(this.props.projectRoles, users))
+        .catch((error) => console.error('Error retrieving project team users', error));
+    }
   }
 
   constructTeamData(roles, users) {
-    return users.map(user => ({
-      userResource: user,
-      roles: roles.find(role => user.id === role.links.owner.id).roles,
-    }));
+    Promise.resolve(
+      users.map(user => ({
+        userResource: user,
+        roles: roles.find(role => user.id === role.links.owner.id).roles
+      }))).then(team => this.setState({ team }));
   }
 
   render() {
@@ -94,7 +92,7 @@ class AboutProject extends Component {
         <AboutNav pages={pages} projectPath={`/projects/${project.slug}`} />
         {React.cloneElement(children, {project, pages, team})}
       </div>
-    )
+    );
   }
 }
 

--- a/app/pages/project/index.cjsx
+++ b/app/pages/project/index.cjsx
@@ -307,6 +307,7 @@ ProjectPageController = React.createClass
           project={@state.project}
           projectAvatar={@state.projectAvatar}
           projectIsComplete={@state.projectIsComplete}
+          projectRoles={@state.projectRoles}
           splits={@state.splits}
           workflow={@state.workflow}
         />


### PR DESCRIPTION
Fixes #4111.

This uses the side loaded project roles already requested in the `ProjectPageController` parent and passes it down as props, rather than request for the project roles again. The side loaded project roles has all 32 roles.

https://fix-4111.pfe-preview.zooniverse.org/projects/penguintom79/seabirdwatch/about/team?env=production

As a side note, it seems we need to do a review of the API calls on the about pages to make sure we're being efficient and not making unnecessary API calls. 

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?


## Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
