### PR TITLE
Always listen for keyboard events with the pan-zoom tool

### DIFF
--- a/app/components/pan-zoom.jsx
+++ b/app/components/pan-zoom.jsx
@@ -181,7 +181,7 @@ class PanZoom extends React.Component {
   }
 
   frameKeyPan(e) {
-    if (!this.state.panEnabled) return;
+
     const keypress = e.which;
     switch (keypress) {
       // left


### PR DESCRIPTION
In response to feedback from Seabird Watch, this removes the check on `panEnabled` from the keydown handler for pan/zoom. The keyboard controls should work as long as the pan-zoom component has focus.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://keyboard-pan.pfe-preview.zooniverse.org/
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?


## Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
