### PR TITLE
Set a sane default for confusion choices

### DIFF
--- a/app/classifier/tasks/survey/choice.jsx
+++ b/app/classifier/tasks/survey/choice.jsx
@@ -91,7 +91,7 @@ class Choice extends React.Component {
               <Translate content="tasks.survey.confused" />
               {' '}
               {choice.confusionsOrder.map((otherChoiceID, i) => {
-                const otherChoice = this.props.task.choices[otherChoiceID];
+                const otherChoice = this.props.task.choices[otherChoiceID] || {label: '', images: []};
                 return (
                   <span key={otherChoiceID}>
                     <TriggeredModalForm

--- a/app/classifier/tasks/survey/choice.jsx
+++ b/app/classifier/tasks/survey/choice.jsx
@@ -91,7 +91,7 @@ class Choice extends React.Component {
               <Translate content="tasks.survey.confused" />
               {' '}
               {choice.confusionsOrder.map((otherChoiceID, i) => {
-                const otherChoice = this.props.task.choices[otherChoiceID] || {label: '', images: []};
+                const otherChoice = this.props.task.choices[otherChoiceID] || { label: '', images: [] };
                 return (
                   <span key={otherChoiceID}>
                     <TriggeredModalForm
@@ -136,7 +136,7 @@ class Choice extends React.Component {
 
           {!choice.noQuestions &&
             Utility.getQuestionIDs(this.props.task, this.props.choiceID).map((questionId) => {
-              const question = this.props.task.questions[questionId];
+              const question = this.props.task.questions[questionId] || { answers: {}, answersOrder: [] };
               const inputType = question.multiple ? 'checkbox' : 'radio';
               return (
                 <div key={questionId} className="survey-task-choice-question" data-multiple={question.multiple || null}>

--- a/app/classifier/tasks/survey/chooser.jsx
+++ b/app/classifier/tasks/survey/chooser.jsx
@@ -30,7 +30,7 @@ class Chooser extends React.Component {
       let rejected = false;
       Object.keys(this.props.filters).map((characteristicId) => {
         const valueId = this.props.filters[characteristicId];
-        if (choice.characteristics[characteristicId].indexOf(valueId) === -1) {
+        if (choice.characteristics[characteristicId] && choice.characteristics[characteristicId].indexOf(valueId) === -1) {
           rejected = true;
         }
       });


### PR DESCRIPTION
Fixes a bug where undefined confusions in a survey task choice would cause the interface to hang.

Sets a default choice object if `otherChoiceID` does not correspond to a valid choice.

Also fixes a bug where the filter components would hang if choice characteristics were undefined (possibly due to a typo in the `characteristicID`.)

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch? https://fix-survey-confusions.pfe-preview.zooniverse.org/
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?


## Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
