### PR TITLE
increase visibility of the cursor icon for the highlighter tool

### DIFF
--- a/css/highlighter-task.styl
+++ b/css/highlighter-task.styl
@@ -10,3 +10,6 @@
     
     &.text-viewer.invisible
       display: none;
+      
+.fa-i-cursor
+  font-weight bolder

--- a/css/highlighter-task.styl
+++ b/css/highlighter-task.styl
@@ -12,4 +12,4 @@
       display: none;
       
 .fa-i-cursor
-  font-weight bolder
+  font-weight: bolder


### PR DESCRIPTION
This PR increases the font-weight property of the cursor icon for the highlighter tool in order to increase the visibility of the icon against the task area background. These changes are motivated from feedback received during the DCW highlighter tool beta test.

**Describe your changes.**
Assigns a `font-weight` property of `bolder` to the cursor icons.

Current Cursor Icon
<img width="169" alt="current cursor icon" src="https://user-images.githubusercontent.com/7684729/32017853-a3743366-b98d-11e7-88b4-3d487853ad08.png">
Bolder Cursor Icon
<img width="163" alt="bolder cursor icon" src="https://user-images.githubusercontent.com/7684729/32017856-a652ea14-b98d-11e7-88c8-24ea3ab565a0.png">


# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch? https://increase-highlighter-icon-visibility.pfe-preview.zooniverse.org/
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?


## Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
