### PR TITLE
Allow drawing tools to receive focus

### DIFF
--- a/app/classifier/drawing-tools/root.cjsx
+++ b/app/classifier/drawing-tools/root.cjsx
@@ -24,6 +24,9 @@ module.exports = React.createClass
 
   getInitialState: ->
     destroying: false
+  
+  componentDidMount: ->
+    @root?.focus()
 
   render: ->
     toolProps = @props.tool.props
@@ -45,10 +48,12 @@ module.exports = React.createClass
         STROKE_WIDTH / scale
 
     unless toolProps.disabled
-      startHandler = toolProps.onSelect
+      startHandler = (e) =>
+        @root?.focus()
+        toolProps.onSelect(e)
 
     <g className="drawing-tool" {...rootProps} {...@props}>
-      <g className="drawing-tool-main" {...mainStyle} onMouseDown={startHandler} onTouchStart={startHandler}>
+      <g className="drawing-tool-main" ref={(element) => @root = element} {...mainStyle} onMouseDown={startHandler} onTouchStart={startHandler} tabIndex=-1>
         {@props.children}
       </g>
 


### PR DESCRIPTION
Focus them when they are first created, and whenever they are selected.

Allows keyboard events from the drawing tools to bubble up to containing elements, in turn allowing the pan-zoom keys to continue working while you are drawing.

Makes Seabird Watch much, much easier and is the first step towards implementing keyboard shortcuts for drawing (#3369)

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://focus-drawing-tools.pfe-preview.zooniverse.org
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?


## Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
