### PR TITLE
Revert "Allow drawing tools to receive focus"

### DIFF
--- a/app/classifier/drawing-tools/root.cjsx
+++ b/app/classifier/drawing-tools/root.cjsx
@@ -24,9 +24,6 @@ module.exports = React.createClass
 
   getInitialState: ->
     destroying: false
-  
-  componentDidMount: ->
-    @root?.focus()
 
   render: ->
     toolProps = @props.tool.props
@@ -48,12 +45,10 @@ module.exports = React.createClass
         STROKE_WIDTH / scale
 
     unless toolProps.disabled
-      startHandler = (e) =>
-        @root?.focus()
-        toolProps.onSelect(e)
+      startHandler = toolProps.onSelect
 
     <g className="drawing-tool" {...rootProps} {...@props}>
-      <g className="drawing-tool-main" ref={(element) => @root = element} {...mainStyle} onMouseDown={startHandler} onTouchStart={startHandler} tabIndex=-1>
+      <g className="drawing-tool-main" {...mainStyle} onMouseDown={startHandler} onTouchStart={startHandler}>
         {@props.children}
       </g>
 


### PR DESCRIPTION
This PR would temporarily revert zooniverse/Panoptes-Front-End#4122 to solve #4123. 

I think allowing the drawing tools to gain focus upon creation and selection is the right way to go, but the current implementation is interacting oddly with subject images and the classification interface for some drawing tasks.

Is reverting #4122 an option until we can fix the issues specified in #4123? Is there an easier/better fix than reverting? How adversely will reverting this affect Seabird Watch?

cc: @eatyourgreens, @mcbouslog 
