### PR TITLE
Add method #focusDrawingTool to maintain the window scroll

### DIFF
--- a/app/classifier/drawing-tools/root.cjsx
+++ b/app/classifier/drawing-tools/root.cjsx
@@ -25,8 +25,10 @@ module.exports = React.createClass
   getInitialState: ->
     destroying: false
   
+  # In Chrome, refocusing the drawing tool without keeping track of scrollX and scrollY
+  # would scroll volunteers to the top of an image upon drawing tool creation, selection, and deletion.
   componentDidMount: ->
-    @root?.focus()
+    @focusDrawingTool()
 
   render: ->
     toolProps = @props.tool.props
@@ -49,7 +51,7 @@ module.exports = React.createClass
 
     unless toolProps.disabled
       startHandler = (e) =>
-        @root?.focus()
+        @focusDrawingTool()
         toolProps.onSelect(e)
 
     <g className="drawing-tool" {...rootProps} {...@props}>
@@ -91,3 +93,9 @@ module.exports = React.createClass
   handleDetailsFormClose: ->
     # TODO: Check if the details tasks are complete.
     @props.tool.props.onDeselect?()
+  
+  focusDrawingTool: ->
+    x = window.scrollX
+    y = window.scrollY
+    @root?.focus()
+    window.scrollTo(x, y)


### PR DESCRIPTION
Add #focusDrawingTool() to maintain the window scroll when drawing tools are created, selected, or deleted.

Fixes #4123 and closes #4124.

**Describe your changes.**
 #focusDrawingTool() records the window scroll position before a drawing tool is focused, then applies the scroll position after focusing the drawing tool. 

In the future, we should look into how `ModalFocus` returns focus to the previously active element.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://fix-4123.pfe-preview.zooniverse.org/
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?


## Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
