### PR TITLE
Focus drawing tools

### DIFF
--- a/app/classifier/drawing-tools/root.cjsx
+++ b/app/classifier/drawing-tools/root.cjsx
@@ -49,9 +49,11 @@ module.exports = React.createClass
       else
         STROKE_WIDTH / scale
 
+    openDetails = toolProps.selected and not toolProps.mark._inProgress and toolProps.details? and toolProps.details.length isnt 0
     unless toolProps.disabled
       startHandler = (e) =>
-        @focusDrawingTool()
+        unless openDetails
+          @focusDrawingTool()
         toolProps.onSelect(e)
 
     <g className="drawing-tool" {...rootProps} {...@props}>
@@ -59,7 +61,7 @@ module.exports = React.createClass
         {@props.children}
       </g>
 
-      {if toolProps.selected and not toolProps.mark._inProgress and toolProps.details? and toolProps.details.length isnt 0
+      {if openDetails
         tasks = require('../tasks').default
 
         detailsAreComplete = toolProps.details.every (detailTask, i) =>
@@ -93,6 +95,7 @@ module.exports = React.createClass
   handleDetailsFormClose: ->
     # TODO: Check if the details tasks are complete.
     @props.tool.props.onDeselect?()
+    @focusDrawingTool()
   
   focusDrawingTool: ->
     x = window.scrollX

--- a/css/drawing-tool.styl
+++ b/css/drawing-tool.styl
@@ -4,6 +4,7 @@
 
 .drawing-tool
   .drawing-tool-main
+    outline: none
     transform-origin: 50% 50%
     transition:
       opacity 0.3s,


### PR DESCRIPTION
Follow-up to #4122 

Describe your changes.
Remove the blue focus ring from the selected mark. We can style the selected mark to make it obvious that it has focus, if it isn't obvious already.

Returns focus to the current mark when the details form closes.

Checks whether the details form is open before assigning focus, since keyboard focus should go to that form if it is open.

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://focus-drawing-tools.pfe-preview.zooniverse.org/
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?


## Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
