### PR TITLE
ProjectStatus unit tests

### DIFF
--- a/app/pages/admin/project-status.spec.js
+++ b/app/pages/admin/project-status.spec.js
@@ -32,7 +32,7 @@ const workflows = [
   }
 ];
 
-describe.only('ProjectStatus', () => {
+describe('ProjectStatus', () => {
   let wrapper;
   let loadingIndicator;
   let onChangeWorkflowLevelSpy;
@@ -103,11 +103,12 @@ describe.only('ProjectStatus', () => {
     });
 
     it('renders the WorkflowDefaultDialog component when dialogIsOpen state is true', () => {
-      wrapper.setState({ dialogIsOpen: true });
+      wrapper.setState({
+        defaultWorkflowId: '1',
+        dialogIsOpen: true
+      });
       const workflowDefaultDialog = wrapper.find('WorkflowDefaultDialog');
-      // TODO: Refactor ProjectStatus to only render one WorkflowDefaultDialog component
-      assert.equal(workflowDefaultDialog.length, workflows.length);
-      wrapper.setState({ dialogIsOpen: false });
+      assert.equal(workflowDefaultDialog.length, 1);
     });
 
     it('calls #onChangeWorkflowLevel when a user changes a workflow\'s configuration level', () => {

--- a/app/pages/admin/project-status.spec.js
+++ b/app/pages/admin/project-status.spec.js
@@ -90,8 +90,8 @@ describe('ProjectStatus', () => {
     });
 
     it('renders a no workflows found message when no workflow is in component state', () => {
-      const noWorkflowsMessage = wrapper.find('div[children="No workflows found"]');
-      assert.equal(noWorkflowsMessage.length, 1);
+      const noWorkflowsMessage = wrapper.find('.project-status__section').at(1).children().find('div');
+      assert.equal(noWorkflowsMessage.text(), 'No workflows found');
     });
   });
 

--- a/app/pages/admin/project-status.spec.js
+++ b/app/pages/admin/project-status.spec.js
@@ -1,0 +1,114 @@
+import React from 'react';
+import assert from 'assert';
+import { shallow } from 'enzyme';
+import sinon from 'sinon';
+import ProjectStatus from './project-status';
+
+const project = {
+  name: 'Test Project',
+  configuration: {
+    default_workflow: '1'
+  }
+};
+
+const workflows = [
+  {
+    active: true,
+    configuration: {},
+    display_name: 'Test Workflow 1',
+    id: '1'
+  },
+  {
+    active: true,
+    configuration: {},
+    display_name: 'Test Workflow 2',
+    id: '2'
+  },
+  {
+    active: false,
+    configuration: {},
+    display_name: 'Test Workflow 3',
+    id: '3'
+  }
+];
+
+describe('ProjectStatus', () => {
+  let wrapper;
+  let handleWorkflowToggleSpy;
+
+  before(() => {
+    handleWorkflowToggleSpy = sinon.spy();
+
+    wrapper = shallow(<ProjectStatus handleToggle={handleWorkflowToggleSpy} />);
+
+    wrapper.setState({
+      project,
+      workflows
+    });
+  });
+
+  it('renders without crashing', () => {
+    const ProjectStatusContainer = wrapper.find('div.project-status');
+    assert.equal(ProjectStatusContainer.length, 1);
+  });
+
+  describe('page layout', () => {
+    it('renders the ProjectIcon component', () => {
+      const projectIconComponent = wrapper.find('ProjectIcon');
+      assert.equal(projectIconComponent.length, 1);
+    });
+
+    it('renders a list of basic info about a project\'s status', () => {
+      const projectStatusInfo = wrapper.find('div.project-status__section').find('ul').first().children();
+      assert.equal(projectStatusInfo.length, 5);
+    });
+
+    it('renders a list of visibility settings', () => {
+      const visibilitySettings = wrapper.find('ul.project-status__section-list').first().children();
+      assert.equal(visibilitySettings.length, 6);
+    });
+
+    it('renders the ExperimentalFeatures component', () => {
+      const experimentalFeaturesComponent = wrapper.find('ExperimentalFeatures');
+      assert.equal(experimentalFeaturesComponent.length, 1);
+    });
+
+    it('renders workflows when they are present', () => {
+      const workflowList = wrapper.find('li.section-list__item');
+      assert.equal(workflowList.length, workflows.length);
+    });
+
+    it('renders the VersionList component', () => {
+      const versionListComponent = wrapper.find('VersionList');
+      assert.equal(versionListComponent.length, 1);
+    });
+  });
+
+  describe('Workflow Settings', () => {
+    it('displays an asterisk next to the default workflow, if one is set', () => {
+      const defaultWorkflow = wrapper.find('li.section-list__item').first().text();
+      assert.ok(defaultWorkflow.match(' * '), true);
+    });
+
+    it('does not display an asterisk next to a workflow that is not the default workflow', () => {
+      const defaultWorkflow = wrapper.find('li.section-list__item').last().text();
+      assert.ok(defaultWorkflow.match(' * '), false);
+    });
+
+    it('renders a WorkflowToggle component for each workflow', () => {
+      const workflowToggleComponents = wrapper.find('WorkflowToggle');
+      assert.equal(workflowToggleComponents.length, workflows.length);
+    });
+
+    it('renders a WorkflowDefaultDialog component when a user toggles a default workflow to inactive', () => {
+      // RFC: is this necessary/good practice? or out of scope of this component?
+      // TODO: this test is currently failing.
+      // wrapper.find('WorkflowToggle').first().simulate('change');
+      // sinon.assert.calledOnce(handleWorkflowToggleSpy);
+    });
+
+    it('handles onCancel functionality for modal dialog', () => {
+      // RFC: is this necessary/good practice? or out of scope of this component?
+    });
+  });
+});

--- a/app/pages/admin/project-status.spec.js
+++ b/app/pages/admin/project-status.spec.js
@@ -36,9 +36,17 @@ describe('ProjectStatus', () => {
   let wrapper;
   let loadingIndicator;
   let onChangeWorkflowLevelSpy;
+  let handleDialogCancelSpy;
+  let handleDialogSuccessSpy;
+  let handleToggleSpy;
+  let event;
+
 
   before(() => {
     onChangeWorkflowLevelSpy = sinon.stub(ProjectStatus.prototype, 'onChangeWorkflowLevel');
+    handleDialogCancelSpy = sinon.stub(ProjectStatus.prototype, 'handleDialogCancel');
+    handleDialogSuccessSpy = sinon.stub(ProjectStatus.prototype, 'handleDialogSuccess');
+    handleToggleSpy = sinon.stub(ProjectStatus.prototype, 'handleToggle');
 
     wrapper = shallow(<ProjectStatus />);
 
@@ -102,18 +110,33 @@ describe('ProjectStatus', () => {
       assert.equal(workflowToggleComponents.length, workflows.length);
     });
 
-    it('renders the WorkflowDefaultDialog component when dialogIsOpen state is true', () => {
-      wrapper.setState({
-        defaultWorkflowId: '1',
-        dialogIsOpen: true
-      });
-      const workflowDefaultDialog = wrapper.find('WorkflowDefaultDialog');
-      assert.equal(workflowDefaultDialog.length, 1);
+    it('calls #handleToggle when a user clicks the active toggle on a workflow', () => {
+      const notDefaultWorkflow = wrapper.find('WorkflowToggle').last();
+      notDefaultWorkflow.simulate('click', event);
+      sinon.assert.calledOnce(handleToggleSpy);
     });
 
     it('calls #onChangeWorkflowLevel when a user changes a workflow\'s configuration level', () => {
       wrapper.find('select').first().simulate('change');
       sinon.assert.calledOnce(onChangeWorkflowLevelSpy);
+    });
+
+    it('renders the WorkflowDefaultDialog component when dialogIsOpen state is true', () => {
+      wrapper.setState({ dialogIsOpen: true });
+      const workflowDefaultDialog = wrapper.find('WorkflowDefaultDialog');
+      assert.equal(workflowDefaultDialog.length, 1);
+    });
+
+    it('calls #handleDialogCancel when a user cancels the WorkflowDefaultDialog modal', () => {
+      const workflowDefaultDialog = wrapper.find('WorkflowDefaultDialog');
+      workflowDefaultDialog.simulate('cancel');
+      sinon.assert.calledOnce(handleDialogCancelSpy);
+    });
+
+    it('calls #handleDialogSuccess when a user clicks ok on the WorkflowDefaultDialog modal', () => {
+      const workflowDefaultDialog = wrapper.find('WorkflowDefaultDialog');
+      workflowDefaultDialog.simulate('success');
+      sinon.assert.calledOnce(handleDialogSuccessSpy);
     });
   });
 });

--- a/app/pages/admin/project-status.spec.js
+++ b/app/pages/admin/project-status.spec.js
@@ -33,68 +33,73 @@ const workflows = [
 ];
 
 describe('ProjectStatus', () => {
-  let wrapper;
+  let handleDialogCancelStub;
+  let handleDialogSuccessStub;
   let loadingIndicator;
-  let onChangeWorkflowLevelSpy;
-  let handleDialogCancelSpy;
-  let handleDialogSuccessSpy;
-  let handleToggleSpy;
-  let event;
-
+  let onChangeWorkflowLevelStub;
+  let wrapper;
 
   before(() => {
-    onChangeWorkflowLevelSpy = sinon.stub(ProjectStatus.prototype, 'onChangeWorkflowLevel');
-    handleDialogCancelSpy = sinon.stub(ProjectStatus.prototype, 'handleDialogCancel');
-    handleDialogSuccessSpy = sinon.stub(ProjectStatus.prototype, 'handleDialogSuccess');
-    handleToggleSpy = sinon.stub(ProjectStatus.prototype, 'handleToggle');
+    onChangeWorkflowLevelStub = sinon.stub(ProjectStatus.prototype, 'onChangeWorkflowLevel');
+    handleDialogCancelStub = sinon.stub(ProjectStatus.prototype, 'handleDialogCancel');
+    handleDialogSuccessStub = sinon.stub(ProjectStatus.prototype, 'handleDialogSuccess');
 
     wrapper = shallow(<ProjectStatus />);
-
-    wrapper.setState({
-      project,
-      workflows
-    });
   });
 
   it('renders without crashing', () => {
     assert.equal(wrapper, wrapper);
   });
 
-  describe('custom components', () => {
-    it('LoadingIndicator renders if project is not in state', () => {
-      wrapper.setState({ project: null });
+  describe('when no project is in component state', () => {
+    it('renders Loading Indicator component', () => {
       loadingIndicator = wrapper.find('LoadingIndicator');
       assert.equal(loadingIndicator.length, 1);
     });
+  });
 
-    it('LoadingIndicator does not render if project is in state', () => {
+  describe('when project is in component state', () => {
+    before(() => {
       wrapper.setState({ project });
+    });
+
+    it('does not render the LoadingIndicator component', () => {
       loadingIndicator = wrapper.find('LoadingIndicator');
       assert.equal(loadingIndicator.length, 0);
     });
 
-    it('ProjectIcon renders', () => {
+    it('renders a ProjectIcon component', () => {
+      wrapper.setState({ project });
       const projectIconComponent = wrapper.find('ProjectIcon');
       assert.equal(projectIconComponent.length, 1);
     });
 
-    it('RedirectToggle renders', () => {
+    it('renders a RedirectToggle component', () => {
       const redirectToggleComponent = wrapper.find('RedirectToggle');
       assert.equal(redirectToggleComponent.length, 1);
     });
 
-    it('ExperimentalFeatures renders', () => {
+    it('renders a ExperimentalFeatures component', () => {
       const experimentalFeaturesComponent = wrapper.find('ExperimentalFeatures');
       assert.equal(experimentalFeaturesComponent.length, 1);
     });
 
-    it('VersionList renders', () => {
+    it('renders a VersionList component', () => {
       const versionListComponent = wrapper.find('VersionList');
       assert.equal(versionListComponent.length, 1);
     });
+
+    it('renders a no workflows found message when no workflow is in component state', () => {
+      const noWorkflowsMessage = wrapper.find('div[children="No workflows found"]');
+      assert.equal(noWorkflowsMessage.length, 1);
+    });
   });
 
-  describe('workflow settings', () => {
+  describe('when workflow is in component state', () => {
+    before(() => {
+      wrapper.setState({ workflows });
+    });
+
     it('displays an asterisk next to the default workflow, if one is set', () => {
       const defaultWorkflow = wrapper.find('li.section-list__item').first().text();
       assert.ok(defaultWorkflow.match(' * '), true);
@@ -110,15 +115,9 @@ describe('ProjectStatus', () => {
       assert.equal(workflowToggleComponents.length, workflows.length);
     });
 
-    it('calls #handleToggle when a user clicks the active toggle on a workflow', () => {
-      const notDefaultWorkflow = wrapper.find('WorkflowToggle').last();
-      notDefaultWorkflow.simulate('click', event);
-      sinon.assert.calledOnce(handleToggleSpy);
-    });
-
     it('calls #onChangeWorkflowLevel when a user changes a workflow\'s configuration level', () => {
       wrapper.find('select').first().simulate('change');
-      sinon.assert.calledOnce(onChangeWorkflowLevelSpy);
+      sinon.assert.calledOnce(onChangeWorkflowLevelStub);
     });
 
     it('renders the WorkflowDefaultDialog component when dialogIsOpen state is true', () => {
@@ -130,13 +129,13 @@ describe('ProjectStatus', () => {
     it('calls #handleDialogCancel when a user cancels the WorkflowDefaultDialog modal', () => {
       const workflowDefaultDialog = wrapper.find('WorkflowDefaultDialog');
       workflowDefaultDialog.simulate('cancel');
-      sinon.assert.calledOnce(handleDialogCancelSpy);
+      sinon.assert.calledOnce(handleDialogCancelStub);
     });
 
     it('calls #handleDialogSuccess when a user clicks ok on the WorkflowDefaultDialog modal', () => {
       const workflowDefaultDialog = wrapper.find('WorkflowDefaultDialog');
       workflowDefaultDialog.simulate('success');
-      sinon.assert.calledOnce(handleDialogSuccessSpy);
+      sinon.assert.calledOnce(handleDialogSuccessStub);
     });
   });
 });

--- a/app/pages/admin/project-status.spec.js
+++ b/app/pages/admin/project-status.spec.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import assert from 'assert';
+import sinon from 'sinon';
 import { shallow } from 'enzyme';
 import ProjectStatus from './project-status';
 
@@ -31,11 +32,14 @@ const workflows = [
   }
 ];
 
-describe('ProjectStatus', () => {
+describe.only('ProjectStatus', () => {
   let wrapper;
   let loadingIndicator;
+  let onChangeWorkflowLevelSpy;
 
   before(() => {
+    onChangeWorkflowLevelSpy = sinon.stub(ProjectStatus.prototype, 'onChangeWorkflowLevel');
+
     wrapper = shallow(<ProjectStatus />);
 
     wrapper.setState({
@@ -48,57 +52,67 @@ describe('ProjectStatus', () => {
     assert.equal(wrapper, wrapper);
   });
 
-  it('renders a loading indicator if project is not in state', () => {
-    wrapper.setState({ project: null });
-    loadingIndicator = wrapper.find('LoadingIndicator');
-    assert.equal(loadingIndicator.length, 1);
+  describe('custom components', () => {
+    it('LoadingIndicator renders if project is not in state', () => {
+      wrapper.setState({ project: null });
+      loadingIndicator = wrapper.find('LoadingIndicator');
+      assert.equal(loadingIndicator.length, 1);
+    });
+
+    it('LoadingIndicator does not render if project is in state', () => {
+      wrapper.setState({ project });
+      loadingIndicator = wrapper.find('LoadingIndicator');
+      assert.equal(loadingIndicator.length, 0);
+    });
+
+    it('ProjectIcon renders', () => {
+      const projectIconComponent = wrapper.find('ProjectIcon');
+      assert.equal(projectIconComponent.length, 1);
+    });
+
+    it('RedirectToggle renders', () => {
+      const redirectToggleComponent = wrapper.find('RedirectToggle');
+      assert.equal(redirectToggleComponent.length, 1);
+    });
+
+    it('ExperimentalFeatures renders', () => {
+      const experimentalFeaturesComponent = wrapper.find('ExperimentalFeatures');
+      assert.equal(experimentalFeaturesComponent.length, 1);
+    });
+
+    it('VersionList renders', () => {
+      const versionListComponent = wrapper.find('VersionList');
+      assert.equal(versionListComponent.length, 1);
+    });
   });
 
-  it('does not render a loading indicator if project is in state', () => {
-    wrapper.setState({ project });
-    loadingIndicator = wrapper.find('LoadingIndicator');
-    assert.equal(loadingIndicator.length, 0);
-  });
+  describe('workflow settings', () => {
+    it('displays an asterisk next to the default workflow, if one is set', () => {
+      const defaultWorkflow = wrapper.find('li.section-list__item').first().text();
+      assert.ok(defaultWorkflow.match(' * '), true);
+    });
 
-  it('renders the ProjectIcon component', () => {
-    const projectIconComponent = wrapper.find('ProjectIcon');
-    assert.equal(projectIconComponent.length, 1);
-  });
+    it('does not display an asterisk next to a workflow that is not the default workflow', () => {
+      const notDefaultWorkflow = wrapper.find('li.section-list__item').last().text();
+      assert.ok(notDefaultWorkflow.match(' * '), false);
+    });
 
-  it('renders the RedirectToggle component', () => {
-    const redirectToggleComponent = wrapper.find('RedirectToggle');
-    assert.equal(redirectToggleComponent.length, 1);
-  });
+    it('renders a WorkflowToggle component for each workflow', () => {
+      const workflowToggleComponents = wrapper.find('WorkflowToggle');
+      assert.equal(workflowToggleComponents.length, workflows.length);
+    });
 
-  it('renders the ExperimentalFeatures component', () => {
-    const experimentalFeaturesComponent = wrapper.find('ExperimentalFeatures');
-    assert.equal(experimentalFeaturesComponent.length, 1);
-  });
+    it('renders the WorkflowDefaultDialog component when dialogIsOpen state is true', () => {
+      wrapper.setState({ dialogIsOpen: true });
+      const workflowDefaultDialog = wrapper.find('WorkflowDefaultDialog');
+      // TODO: Refactor ProjectStatus to only render one WorkflowDefaultDialog component
+      assert.equal(workflowDefaultDialog.length, workflows.length);
+      wrapper.setState({ dialogIsOpen: false });
+    });
 
-  it('renders the VersionList component', () => {
-    const versionListComponent = wrapper.find('VersionList');
-    assert.equal(versionListComponent.length, 1);
-  });
-
-  it('displays an asterisk next to the default workflow, if one is set', () => {
-    const defaultWorkflow = wrapper.find('li.section-list__item').first().text();
-    assert.ok(defaultWorkflow.match(' * '), true);
-  });
-
-  it('does not display an asterisk next to a workflow that is not the default workflow', () => {
-    const defaultWorkflow = wrapper.find('li.section-list__item').last().text();
-    assert.ok(defaultWorkflow.match(' * '), false);
-  });
-
-  it('renders a WorkflowToggle component for each workflow', () => {
-    const workflowToggleComponents = wrapper.find('WorkflowToggle');
-    assert.equal(workflowToggleComponents.length, workflows.length);
-  });
-
-  it('renders the WorkflowDefaultDialog component when dialogIsOpen state is true', () => {
-    wrapper.setState({ dialogIsOpen: true });
-    const workflowDefaultDialog = wrapper.find('WorkflowDefaultDialog');
-    // TODO: Refactor ProjectStatus to only render one WorkflowDefaultDialog component
-    assert.equal(workflowDefaultDialog.length, workflows.length);
+    it('calls #onChangeWorkflowLevel when a user changes a workflow\'s configuration level', () => {
+      wrapper.find('select').first().simulate('change');
+      sinon.assert.calledOnce(onChangeWorkflowLevelSpy);
+    });
   });
 });

--- a/app/pages/admin/project-status.spec.js
+++ b/app/pages/admin/project-status.spec.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import assert from 'assert';
 import { shallow } from 'enzyme';
-import sinon from 'sinon';
 import ProjectStatus from './project-status';
 
 const project = {
@@ -34,12 +33,10 @@ const workflows = [
 
 describe('ProjectStatus', () => {
   let wrapper;
-  let handleWorkflowToggleSpy;
+  let loadingIndicator;
 
   before(() => {
-    handleWorkflowToggleSpy = sinon.spy();
-
-    wrapper = shallow(<ProjectStatus handleToggle={handleWorkflowToggleSpy} />);
+    wrapper = shallow(<ProjectStatus />);
 
     wrapper.setState({
       project,
@@ -48,67 +45,60 @@ describe('ProjectStatus', () => {
   });
 
   it('renders without crashing', () => {
-    const ProjectStatusContainer = wrapper.find('div.project-status');
-    assert.equal(ProjectStatusContainer.length, 1);
+    assert.equal(wrapper, wrapper);
   });
 
-  describe('page layout', () => {
-    it('renders the ProjectIcon component', () => {
-      const projectIconComponent = wrapper.find('ProjectIcon');
-      assert.equal(projectIconComponent.length, 1);
-    });
-
-    it('renders a list of basic info about a project\'s status', () => {
-      const projectStatusInfo = wrapper.find('div.project-status__section').find('ul').first().children();
-      assert.equal(projectStatusInfo.length, 5);
-    });
-
-    it('renders a list of visibility settings', () => {
-      const visibilitySettings = wrapper.find('ul.project-status__section-list').first().children();
-      assert.equal(visibilitySettings.length, 6);
-    });
-
-    it('renders the ExperimentalFeatures component', () => {
-      const experimentalFeaturesComponent = wrapper.find('ExperimentalFeatures');
-      assert.equal(experimentalFeaturesComponent.length, 1);
-    });
-
-    it('renders workflows when they are present', () => {
-      const workflowList = wrapper.find('li.section-list__item');
-      assert.equal(workflowList.length, workflows.length);
-    });
-
-    it('renders the VersionList component', () => {
-      const versionListComponent = wrapper.find('VersionList');
-      assert.equal(versionListComponent.length, 1);
-    });
+  it('renders a loading indicator if project is not in state', () => {
+    wrapper.setState({ project: null });
+    loadingIndicator = wrapper.find('LoadingIndicator');
+    assert.equal(loadingIndicator.length, 1);
   });
 
-  describe('Workflow Settings', () => {
-    it('displays an asterisk next to the default workflow, if one is set', () => {
-      const defaultWorkflow = wrapper.find('li.section-list__item').first().text();
-      assert.ok(defaultWorkflow.match(' * '), true);
-    });
+  it('does not render a loading indicator if project is in state', () => {
+    wrapper.setState({ project });
+    loadingIndicator = wrapper.find('LoadingIndicator');
+    assert.equal(loadingIndicator.length, 0);
+  });
 
-    it('does not display an asterisk next to a workflow that is not the default workflow', () => {
-      const defaultWorkflow = wrapper.find('li.section-list__item').last().text();
-      assert.ok(defaultWorkflow.match(' * '), false);
-    });
+  it('renders the ProjectIcon component', () => {
+    const projectIconComponent = wrapper.find('ProjectIcon');
+    assert.equal(projectIconComponent.length, 1);
+  });
 
-    it('renders a WorkflowToggle component for each workflow', () => {
-      const workflowToggleComponents = wrapper.find('WorkflowToggle');
-      assert.equal(workflowToggleComponents.length, workflows.length);
-    });
+  it('renders the RedirectToggle component', () => {
+    const redirectToggleComponent = wrapper.find('RedirectToggle');
+    assert.equal(redirectToggleComponent.length, 1);
+  });
 
-    it('renders a WorkflowDefaultDialog component when a user toggles a default workflow to inactive', () => {
-      // RFC: is this necessary/good practice? or out of scope of this component?
-      // TODO: this test is currently failing.
-      // wrapper.find('WorkflowToggle').first().simulate('change');
-      // sinon.assert.calledOnce(handleWorkflowToggleSpy);
-    });
+  it('renders the ExperimentalFeatures component', () => {
+    const experimentalFeaturesComponent = wrapper.find('ExperimentalFeatures');
+    assert.equal(experimentalFeaturesComponent.length, 1);
+  });
 
-    it('handles onCancel functionality for modal dialog', () => {
-      // RFC: is this necessary/good practice? or out of scope of this component?
-    });
+  it('renders the VersionList component', () => {
+    const versionListComponent = wrapper.find('VersionList');
+    assert.equal(versionListComponent.length, 1);
+  });
+
+  it('displays an asterisk next to the default workflow, if one is set', () => {
+    const defaultWorkflow = wrapper.find('li.section-list__item').first().text();
+    assert.ok(defaultWorkflow.match(' * '), true);
+  });
+
+  it('does not display an asterisk next to a workflow that is not the default workflow', () => {
+    const defaultWorkflow = wrapper.find('li.section-list__item').last().text();
+    assert.ok(defaultWorkflow.match(' * '), false);
+  });
+
+  it('renders a WorkflowToggle component for each workflow', () => {
+    const workflowToggleComponents = wrapper.find('WorkflowToggle');
+    assert.equal(workflowToggleComponents.length, workflows.length);
+  });
+
+  it('renders the WorkflowDefaultDialog component when dialogIsOpen state is true', () => {
+    wrapper.setState({ dialogIsOpen: true });
+    const workflowDefaultDialog = wrapper.find('WorkflowDefaultDialog');
+    // TODO: Refactor ProjectStatus to only render one WorkflowDefaultDialog component
+    assert.equal(workflowDefaultDialog.length, workflows.length);
   });
 });


### PR DESCRIPTION
## Describe your changes
- Adds tests for the ProjectStatus component in Admin.
- Tests are divided into a group that checks the presence of the basic page layout elements, and a group that focuses on the Workflow Settings section (where I've recently implemented changes  regarding toggling active status of default workflows)
  - RFC: Not sure if testing page layout elements is necessary, or a good practice. Happy to remove if not needed/wanted.
- RFC: So far I haven't been able to write tests that simulate a user clicking the WorkflowToggle checkbox, getting the WorkflowDefaultDialog modal to open, and testing its functionality.
  - Are tests of the modal functionality (eg, user clicks the 'active' toggle for a default workflow, modal opens, user clicks 'ok', and default_workflow gets removed from project) outside the scope of testing the ProjectStatus component?
  - Would appreciate input on a) are tests of modal functionality necessary/desired/good practice? b) if yes, any suggestions on where my syntax is off? 
    - Is there anywhere in the PFE codebase where we use Enzyme to test modal dialogs being triggered in parent components?
    - I thought perhaps I needed to use `mount` instead of `shallow` render, but haven't had success with mount either.
    - Do I need to use a `stub` instead of a `spy`, and control/force the code down a specific path (ie, to click the toggle for a default workflow, then force 'ok'/'cancel')
  - Is it possible that testing modals in Enzyme is difficult/buggy? some SO and github issues I've found while trying to get modal tests working:
    - https://github.com/airbnb/enzyme/issues/252
    - https://stackoverflow.com/questions/45644244/content-of-react-modal-dialogs-is-not-available-to-enzyme-tests-using-mount
    - https://github.com/airbnb/enzyme/issues/535
- Related PRs (my recent work related to ProjectStatus component and toggling default workflow status):
  - #4118 (default workflow existential check)
  - #4100 (default workflow dialog alert)
  - #4092 (WorkflowToggle ES6 conversion)

## Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?


## Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
