### PR TITLE
add categories to organization landing

### DIFF
--- a/app/pages/organizations/organization-container.jsx
+++ b/app/pages/organizations/organization-container.jsx
@@ -67,6 +67,9 @@ class OrganizationContainer extends React.Component {
     if (collaboratorView) {
       delete query.launch_approved;
     }
+    if (this.props.location.query && this.props.location.query.category) {
+      query.tags = this.props.location.query.category;
+    }
     organization.get('projects', query)
       .then(organizationProjects => this.setState({ fetchingProjects: false, organizationProjects }))
       .catch((error) => {
@@ -131,6 +134,11 @@ class OrganizationContainer extends React.Component {
       });
   }
 
+  updateQuery(category) {
+    // TODO projects/index goes here
+    console.log(category);
+  }
+
   render() {
     if (this.state.organization && (this.state.organization.listed || isAdmin() || this.isCollaborator())) {
       return (
@@ -139,6 +147,7 @@ class OrganizationContainer extends React.Component {
           collaboratorView={this.state.collaboratorView}
           errorFetchingProjects={this.state.errorFetchingProjects}
           fetchingProjects={this.state.fetchingProjects}
+          onChangeQuery={this.updateQuery}
           organization={this.state.organization}
           organizationAvatar={this.state.organizationAvatar}
           organizationBackground={this.state.organizationBackground}
@@ -193,6 +202,11 @@ OrganizationContainer.contextTypes = {
 };
 
 OrganizationContainer.propTypes = {
+  location: React.PropTypes.shape({
+    query: React.PropTypes.shape({
+      category: React.PropTypes.string
+    })
+  }),
   params: React.PropTypes.shape({
     name: React.PropTypes.string,
     owner: React.PropTypes.string

--- a/app/pages/organizations/organization-container.jsx
+++ b/app/pages/organizations/organization-container.jsx
@@ -76,7 +76,6 @@ class OrganizationContainer extends React.Component {
       return results;
     });
     const newLocation = Object.assign({}, this.props.location, { query });
-    // UNSURE OF PURPOSE OF newLocation.search = '';
     newLocation.search = '';
     browserHistory.push(newLocation);
   }

--- a/app/pages/organizations/organization-container.jsx
+++ b/app/pages/organizations/organization-container.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { browserHistory } from 'react-router';
 import apiClient from 'panoptes-client/lib/api-client';
 import Translate from 'react-translate-component';
 import isAdmin from '../../lib/is-admin';
@@ -69,15 +68,14 @@ class OrganizationContainer extends React.Component {
   updateQuery(newParams) {
     const query = Object.assign({}, this.props.location.query, newParams);
     const results = [];
-    Object.keys(query).map((key) => {
+    Object.keys(query).forEach((key) => {
       if (query[key] === '') {
         results.push(delete query[key]);
       }
-      return results;
     });
     const newLocation = Object.assign({}, this.props.location, { query });
     newLocation.search = '';
-    browserHistory.push(newLocation);
+    this.context.router.push(newLocation);
   }
 
   fetchProjects(organization, collaboratorView, locationQuery = this.props.location.query) {
@@ -213,6 +211,7 @@ class OrganizationContainer extends React.Component {
 
 OrganizationContainer.contextTypes = {
   initialLoadComplete: React.PropTypes.bool,
+  router: React.PropTypes.object.isRequired,
   user: React.PropTypes.shape({
     id: React.PropTypes.string
   })

--- a/app/pages/organizations/organization-container.jsx
+++ b/app/pages/organizations/organization-container.jsx
@@ -46,7 +46,7 @@ class OrganizationContainer extends React.Component {
     }
 
     if (this.state.organization && (nextProps.location.query !== this.props.location.query)) {
-      this.fetchProjects(this.state.organization, (isAdmin() || this.isCollaborator()), nextProps.location.query);
+      this.fetchProjects(this.state.organization, this.state.collaboratorView, nextProps.location.query);
     }
   }
 
@@ -80,7 +80,7 @@ class OrganizationContainer extends React.Component {
     browserHistory.push(newLocation);
   }
 
-  fetchProjects(organization, collaboratorView, locationQuery) {
+  fetchProjects(organization, collaboratorView, locationQuery = this.props.location.query) {
     this.setState({ errorFetchingProjects: null, fetchingProjects: true });
     const query = { cards: true, launch_approved: true };
 

--- a/app/pages/organizations/organization-container.spec.js
+++ b/app/pages/organizations/organization-container.spec.js
@@ -14,9 +14,10 @@ const params = {
 };
 
 export const organization = {
-  id: '9876',
+  categories: ['Plants', 'Bugs', 'Butterflies'],
   display_name: 'Test Org',
   description: 'A brief test description',
+  id: '9876',
   introduction: 'A brief test introduction',
   urls: [
     {

--- a/app/pages/organizations/organization-container.spec.js
+++ b/app/pages/organizations/organization-container.spec.js
@@ -49,7 +49,7 @@ describe('OrganizationContainer', function () {
   let wrapper;
 
   beforeEach(function () {
-    wrapper = shallow(<OrganizationContainer params={params} />);
+    wrapper = shallow(<OrganizationContainer params={params} />, { context: { router: {}}});
   });
 
   it('should render without crashing', function () {

--- a/app/pages/organizations/organization-page.jsx
+++ b/app/pages/organizations/organization-page.jsx
@@ -63,6 +63,10 @@ class OrganizationPage extends React.Component {
     this.setState({ readMore: !this.state.readMore });
   }
 
+  handleCategoryChange(category) {
+    this.props.onChangeQuery(category);
+  }
+
   render() {
     const [aboutPage] = this.props.organizationPages.filter(page => page.url_key === 'about');
     let rearrangedLinks = [];
@@ -110,6 +114,17 @@ class OrganizationPage extends React.Component {
               />
               <Translate content="organization.home.viewToggle" />
             </label>}
+          {this.props.organization.categories &&
+            <div className="organization-page__categories">
+              {this.props.organization.categories.map(category =>
+                <button
+                  key={category}
+                  className="button"
+                  onClick={this.handleCategoryChange.bind(this, category)}
+                >
+                  {category}
+                </button>)}
+            </div>}
           <OrganizationProjectCards
             errorFetchingProjects={this.props.errorFetchingProjects}
             fetchingProjects={this.props.fetchingProjects}
@@ -230,6 +245,7 @@ OrganizationPage.defaultProps = {
   collaboratorView: true,
   errorFetchingProjects: {},
   fetchingProjects: false,
+  onChangeQuery: () => {},
   organization: {},
   organizationAvatar: {},
   organizationBackground: {},
@@ -245,7 +261,11 @@ OrganizationPage.propTypes = {
     message: React.PropTypes.string
   }),
   fetchingProjects: React.PropTypes.bool,
+  onChangeQuery: React.PropTypes.func,
   organization: React.PropTypes.shape({
+    categories: React.PropTypes.arrayOf(
+      React.PropTypes.string
+    ),
     description: React.PropTypes.string,
     display_name: React.PropTypes.string,
     id: React.PropTypes.string,

--- a/app/pages/organizations/organization-page.jsx
+++ b/app/pages/organizations/organization-page.jsx
@@ -127,7 +127,6 @@ class OrganizationPage extends React.Component {
           {this.props.organization.categories && this.props.organization.categories.length > 0 &&
             <div className="organization-page__categories">
               <button
-                key="all"
                 className={this.calculateClasses('All')}
                 onClick={this.handleCategoryChange.bind(this, '')}
               >

--- a/app/pages/organizations/organization-page.jsx
+++ b/app/pages/organizations/organization-page.jsx
@@ -64,7 +64,17 @@ class OrganizationPage extends React.Component {
   }
 
   handleCategoryChange(category) {
-    this.props.onChangeQuery(category);
+    this.props.onChangeQuery({ category });
+  }
+
+  calculateClasses(category) {
+    const list = classnames(
+      'standard-button',
+      'organization-page__category-button',
+      { 'organization-page__category-button--active':
+        (category === this.props.category) || (!this.props.category && (category === 'All')) }
+    );
+    return list;
   }
 
   render() {
@@ -116,10 +126,17 @@ class OrganizationPage extends React.Component {
             </label>}
           {this.props.organization.categories &&
             <div className="organization-page__categories">
+              <button
+                key="all"
+                className={this.calculateClasses('All')}
+                onClick={this.handleCategoryChange.bind(this, '')}
+              >
+                All
+              </button>
               {this.props.organization.categories.map(category =>
                 <button
                   key={category}
-                  className="button"
+                  className={this.calculateClasses(category)}
                   onClick={this.handleCategoryChange.bind(this, category)}
                 >
                   {category}
@@ -241,6 +258,7 @@ class OrganizationPage extends React.Component {
 }
 
 OrganizationPage.defaultProps = {
+  category: false,
   collaborator: false,
   collaboratorView: true,
   errorFetchingProjects: {},
@@ -255,6 +273,10 @@ OrganizationPage.defaultProps = {
 };
 
 OrganizationPage.propTypes = {
+  category: React.PropTypes.oneOfType([
+    React.PropTypes.bool,
+    React.PropTypes.string
+  ]),
   collaborator: React.PropTypes.bool,
   collaboratorView: React.PropTypes.bool,
   errorFetchingProjects: React.PropTypes.shape({

--- a/app/pages/organizations/organization-page.jsx
+++ b/app/pages/organizations/organization-page.jsx
@@ -124,7 +124,7 @@ class OrganizationPage extends React.Component {
               />
               <Translate content="organization.home.viewToggle" />
             </label>}
-          {this.props.organization.categories &&
+          {this.props.organization.categories && this.props.organization.categories.length > 0 &&
             <div className="organization-page__categories">
               <button
                 key="all"

--- a/app/pages/organizations/organization-page.spec.js
+++ b/app/pages/organizations/organization-page.spec.js
@@ -119,6 +119,20 @@ describe('OrganizationPage', function () {
     assert.equal(cards.length, organizationProjects.length);
   });
 
+  it('should show category buttons if the organization has categories', function () {
+    const wrapper = shallow(<OrganizationPage organization={organization} />);
+    const categories = wrapper.find('.organization-page__category-button');
+    assert.equal(categories.length, organization.categories.length + 1);
+  });
+
+  it('should not show category buttons if the organization does not have categories', function () {
+    const noCategoriesOrg = organization;
+    delete noCategoriesOrg.categories;
+    const wrapper = shallow(<OrganizationPage organization={noCategoriesOrg} />);
+    const categories = wrapper.find('.organization-page__category-button');
+    assert.equal(categories.length, 0);
+  });
+
   describe('with pages about content', function () {
     let wrapper;
     let aboutPage;

--- a/css/organization-page.styl
+++ b/css/organization-page.styl
@@ -27,11 +27,12 @@
 
   &__category-button
     background: white
-    border: 1px white
+    border: 1px #EBEBEB
+    border-radius: 0
     color: TEAL_MID
     font-weight: bold
-    margin: .8em
-    min-width: 100px
+    margin: .8em .5em
+    width: 150px
 
     &:focus,
     &:hover
@@ -42,7 +43,7 @@
     &--active
       background: TEAL_DARK
       border: 1px TEAL_DARK
-      color: white 
+      color: white
 
 .organization-hero
   background-size: cover

--- a/css/organization-page.styl
+++ b/css/organization-page.styl
@@ -23,7 +23,26 @@
 
   &__categories
     display: flex
-    flex: 1 0 auto    
+    justify-content: center
+
+  &__category-button
+    background: white
+    border: 1px white
+    color: TEAL_MID
+    font-weight: bold
+    margin: .8em
+    min-width: 100px
+
+    &:focus,
+    &:hover
+      background: TEAL_DARK
+      border: 1px TEAL_DARK
+      color: white
+
+    &--active
+      background: TEAL_DARK
+      border: 1px TEAL_DARK
+      color: white 
 
 .organization-hero
   background-size: cover

--- a/css/organization-page.styl
+++ b/css/organization-page.styl
@@ -21,6 +21,10 @@
     color: TEAL_DARK
     margin-left: 2em
 
+  &__categories
+    display: flex
+    flex: 1 0 auto    
+
 .organization-hero
   background-size: cover
   min-height: 400px


### PR DESCRIPTION
Towards #2970.
Related to https://github.com/zooniverse/pfe-lab/pull/137.

If categories added to an organization, shows category buttons on organization landing.

If no categories on an organization, organization landing shows no category buttons.

On initial load the "All" button should be active, then when a category is clicked the projects should be filtered by the category selected.

https://org-categories.pfe-preview.zooniverse.org/organizations/markb-panoptes/nfnorgtest

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? - https://org-categories.pfe-preview.zooniverse.org
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?


## Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
