### PR TITLE
Remove redux-devtools-extension

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8079,11 +8079,6 @@
         "symbol-observable": "1.0.4"
       }
     },
-    "redux-devtools-extension": {
-      "version": "2.13.2",
-      "resolved": "https://registry.npmjs.org/redux-devtools-extension/-/redux-devtools-extension-2.13.2.tgz",
-      "integrity": "sha1-4Pmo6N/KfBe+kscSSVijuU6ykR0="
-    },
     "redux-thunk": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "react-swipe": "~5.0.3",
     "react-translate-component": "~0.13.0",
     "redux": "~3.6.0",
-    "redux-devtools-extension": "~2.13.0",
     "redux-thunk": "~2.2.0",
     "seven-ten": "~3.1.0",
     "shortid": "~2.2.8",


### PR DESCRIPTION
Turns out the npm package is only needed for simplifying any advanced config, [we don't actually need it](https://github.com/zalmoxisus/redux-devtools-extension#13-use-redux-devtools-extension-package-from-npm).

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?


## Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
