### PR TITLE
Group drawing tool radio buttons

### DIFF
--- a/app/classifier/tasks/drawing/index.cjsx
+++ b/app/classifier/tasks/drawing/index.cjsx
@@ -94,7 +94,7 @@ module.exports = React.createClass
       count = (true for mark in @props.annotation.value when mark.tool is i).length
       <div>
         <label key={tool._key} >
-          <input name={i} autoFocus={@props.autoFocus and i is 0} type="radio" className="drawing-tool-button-input" checked={i is (@props.annotation._toolIndex ? 0)} onChange={@handleChange.bind this, i} />
+          <input name="drawing-tool" autoFocus={@props.autoFocus and i is 0} type="radio" className="drawing-tool-button-input" checked={i is (@props.annotation._toolIndex ? 0)} onChange={@handleChange.bind this, i} />
           <div className="minor-button answer-button #{if i is (@props.annotation._toolIndex ? 0) then 'active' else ''}">
             <div className="answer-button-icon-container">
               <span className="drawing-tool-button-icon" style={color: tool.color}>{icons[tool.type]}</span>


### PR DESCRIPTION
Group all drawing tool radio buttons as a single `drawing-tool` input field, so that they can be selected using the cursor keys.


# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://name-drawing-tools.pfe-preview.zooniverse.org
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?


## Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
