### PR TITLE
clarify project external link url requirements

### DIFF
--- a/app/pages/lab/project-details.cjsx
+++ b/app/pages/lab/project-details.cjsx
@@ -212,6 +212,7 @@ module.exports = React.createClass
               the about, classify, talk, and collect tabs. You can rearrange the
               displayed order by clicking and dragging on the left gray tab next
               to each link below.
+              The URL must begin with "<code>https://</code>" or "<code>http://</code>".
             </small>
             <ExternalLinksEditor project={@props.project} />
             <div className="edit-social-links">

--- a/app/pages/lab/project-details.cjsx
+++ b/app/pages/lab/project-details.cjsx
@@ -212,6 +212,9 @@ module.exports = React.createClass
               the about, classify, talk, and collect tabs. You can rearrange the
               displayed order by clicking and dragging on the left gray tab next
               to each link below.
+            </small>
+            <br />
+            <small className="form-help">
               The URL must begin with "<code>https://</code>" or "<code>http://</code>".
             </small>
             <ExternalLinksEditor project={@props.project} />


### PR DESCRIPTION
A few project builders have had the issue where they've added an external link for their project's subnav, and mistakenly omitted `https://` or `http://` which throws no warning or error, and instead of a sub-nav link to `https://example.com/` it is `https://www.zooniverse.org/projects/markb-panoptes/example.com/`.

This PR adds an additional sentence to the External Links instructions to hopefully reduce the instances of the issue noted.

https://external-links-instruction.pfe-preview.zooniverse.org/

Not sure if https:// and http:// should be wrapped in quotes or `<code>` tags, open to suggestion!

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?


## Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
