### PR TITLE
Clear out user group query and state on sign out

### DIFF
--- a/app/pages/project/classify.cjsx
+++ b/app/pages/project/classify.cjsx
@@ -323,13 +323,16 @@ module.exports = React.createClass
 
   validateUserGroup: (props, context) ->
     if props.location.query?.group? and props.user?
-      apiClient.type('user_groups').get(props.location.query.group).then (group) =>
-        isUserMemberOfGroup = group.links?.users?.includes(props.user.id)
-        @setState({ validUserGroup: group and isUserMemberOfGroup })
+      apiClient.type('user_groups').get(props.location.query.group)
+        .then (group) =>
+          isUserMemberOfGroup = group.links?.users?.includes(props.user.id)
+          @setState({ validUserGroup: group and isUserMemberOfGroup })
 
-        if not isUserMemberOfGroup or not group
-          console.log('not group')
-          @clearUserGroupForClassification(props, context)
+          if not isUserMemberOfGroup or not group
+            @clearUserGroupForClassification(props, context)
+        .catch (error) =>
+          if error.status is 404
+            @clearUserGroupForClassification(props, context)
 
   clearUserGroupForClassification: (props, context) ->
     if (props.location.query?.group)
@@ -337,9 +340,8 @@ module.exports = React.createClass
       @setState({ validUserGroup: false })
 
       Object.keys(query).forEach (key) =>
-        if query[key] is 'group'
+        if key is 'group'
           delete query[key]
-      console.log('clearing query', query)
 
       newLocation = Object.assign({}, props.location, { query })
       newLocation.search = ''


### PR DESCRIPTION
This is follow up to #4061 and in support of the Intro2Astro use of projects with classroom user groups. If the user signs out, the group state should be set to false and the query param cleared.

I am a bit unsure about clearing the query param in case the student first arrives to the project not signed in and it may be difficult to remind them to make sure to use the project URL with the correct query param so they get credit for their classification. For now, I'll try it out with the query param cleared too.

This can be tested using the zootester1 account and at this staged path:

https://clear-user-group-on-logout.pfe-preview.zooniverse.org/projects/srallen086/intro2astro-hubble-testing/classify?group=1326233

I can share the account credentials in person when you're ready to test.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?


## Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
