### PR TITLE
Remove aggregation dumps

### DIFF
--- a/app/pages/lab/data-dumps.cjsx
+++ b/app/pages/lab/data-dumps.cjsx
@@ -8,7 +8,6 @@ Dialog = require 'modal-form/dialog'
 counterpart.registerTranslations 'en',
   projectDetails:
     classificationExport: "Request new classification export"
-    aggregationExport: "Experimental - Request new aggregation export"
     subjectExport: "Request new subject export"
     workflowExport: "Request new workflow export"
     workflowContentsExport: "Request new workflow contents export"
@@ -73,15 +72,6 @@ module.exports = React.createClass
               project={@props.project}
               buttonKey="projectDetails.workflowContentsExport"
               exportType="workflow_contents_export"  />
-          </div>
-          <div className="row">
-            <DataExportButton
-              project={@props.project}
-              buttonKey="projectDetails.aggregationExport"
-              contentType="application/x-gzip"
-              exportType="aggregations_export"
-              newFeature=true
-            />
           </div>
           <hr />
 

--- a/app/partials/data-export-button.cjsx
+++ b/app/partials/data-export-button.cjsx
@@ -42,35 +42,33 @@ module.exports = React.createClass
 
   render: ->
     <div>
-      { if (@props.exportType isnt 'aggregations_export' or @state?.mostRecent?.metadata?.state?)
-        <div>
-          { if @props.newFeature
-            <i className="fa fa-cog fa-lg fa-fw"></i> }
-          <button type="button" disabled={@state.exportRequested or @props.exportType is "aggregations_export"} onClick={@requestDataExport}>
-            <Translate content={@props.buttonKey} />
-          </button> {' '}
-          <small className="form-help">
-            CSV format.{' '}
-            { if @recentAndReady(@state.mostRecent)
-                <span>
-                  Most recent data available requested{' '}
-                  <a href={@state.mostRecent.src}>{moment(@state.mostRecent.updated_at).fromNow()}</a>.
-                </span>
-              else if @pending(@state.mostRecent)
-                <span>
-                  Processing your request.
-                </span>
-              else
-                <span>Never previously requested.</span>}
-            <br />
-          </small>
+      <div>
+        { if @props.newFeature
+          <i className="fa fa-cog fa-lg fa-fw"></i> }
+        <button type="button" disabled={@state.exportRequested} onClick={@requestDataExport}>
+          <Translate content={@props.buttonKey} />
+        </button> {' '}
+        <small className="form-help">
+          CSV format.{' '}
+          { if @recentAndReady(@state.mostRecent)
+              <span>
+                Most recent data available requested{' '}
+                <a href={@state.mostRecent.src}>{moment(@state.mostRecent.updated_at).fromNow()}</a>.
+              </span>
+            else if @pending(@state.mostRecent)
+              <span>
+                Processing your request.
+              </span>
+            else
+              <span>Never previously requested.</span>}
+          <br />
+        </small>
 
-          {if @state.exportError?
-             <div className="form-help error">{@state.exportError.toString()}</div>
-           else if @state.exportRequested
-             <div className="form-help success">
-               We’ve received your request, check your email for a link to your data soon!
-             </div>}
-        </div> }
+        {if @state.exportError?
+            <div className="form-help error">{@state.exportError.toString()}</div>
+          else if @state.exportRequested
+            <div className="form-help success">
+              We’ve received your request, check your email for a link to your data soon!
+            </div>}
+      </div>
     </div>
-


### PR DESCRIPTION
Related backend issue: https://github.com/zooniverse/Panoptes/pull/2521

This removes aggregation dumps entirely, rather than leaving them unrequestable but still downloadable.

Since all I did was delete a few bits of code, and not write a single line of new code, I left these files as CoffeeScript. If that's unacceptable let me know.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?


## Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
