### PR TITLE
Fix Talk popular tags for empty array

### DIFF
--- a/app/talk/popular-tags.jsx
+++ b/app/talk/popular-tags.jsx
@@ -75,7 +75,7 @@ export default class PopularTags extends React.Component {
 
     return (
       <div className="talk-popular-tags">
-        {this.state.tags.length && (
+        {!!this.state.tags.length && (
           <div>
             {this.props.header ? this.props.header : null}
             <section>

--- a/app/talk/popular-tags.jsx
+++ b/app/talk/popular-tags.jsx
@@ -78,9 +78,9 @@ export default class PopularTags extends React.Component {
         {!!this.state.tags.length && (
           <div>
             {this.props.header ? this.props.header : null}
-            <section>
+            <p>
               {this.state.tags.map(tag => tagType(tag))}
-            </section>
+            </p>
           </div>
         )}
       </div>


### PR DESCRIPTION
Fixes #3791.

Describe your changes.
Converts the array length to a boolean, rather than just rendering array length in the HTML.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://talk-popular-tags.pfe-preview.zooniverse.org/
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?


## Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
