### PR TITLE
add lab and admin page links

### DIFF
--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -19,7 +19,9 @@ export default {
       classify: 'Classify',
       talk: 'Talk',
       collections: 'Collect',
-      recents: 'Recents'
+      recents: 'Recents',
+      lab: 'Lab',
+      adminPage: 'Admin page'
     },
     home: {
       researcher: 'Words from the researcher',

--- a/app/locales/es.js
+++ b/app/locales/es.js
@@ -17,7 +17,10 @@ export default {
       about: 'About',
       classify: 'Classify',
       talk: 'Talk',
-      collections: 'Collect'
+      collections: 'Collect',
+      recents: 'Recents',
+      lab: 'Lab',
+      adminPage: 'Admin page'
     },
     home: {
       researcher: 'Words from the researcher',

--- a/app/locales/it.js
+++ b/app/locales/it.js
@@ -19,7 +19,9 @@ export default {
       classify: 'Classifica',
       talk: 'Forum',
       collections: 'Colleziona',
-      recents: 'Recents'
+      recents: 'Recents',
+      lab: 'Lab',
+      adminPage: 'Admin page'
     },
     home: {
       researcher: 'Words from the researcher',

--- a/app/pages/project/project-page.cjsx
+++ b/app/pages/project/project-page.cjsx
@@ -7,6 +7,7 @@ Thumbnail = require('../../components/thumbnail').default
 classnames = require 'classnames'
 PotentialFieldGuide = require './potential-field-guide'
 `import SOCIAL_ICONS from '../../lib/social-icons'`
+`import isAdmin from '../../lib/is-admin';`
 
 AVATAR_SIZE = 100
 
@@ -83,10 +84,16 @@ ProjectPage = React.createClass
     else
       @props.project.display_name
 
+  userHasLabAccess: ->
+    userRoles = @props.projectRoles.some ({roles}) =>
+      roles.includes('owner') || roles.includes('collaborator')
+
   render: ->
     rearrangedLinks = @props.project.urls.sort (a, b) => a.path? & !b.path? ? 1 : 0
     betaApproved = @props.project.beta_approved
     projectPath = "/projects/#{@props.project.slug}"
+    labPath = "/lab/#{@props.project.id}"
+    adminPath = "/admin/project_status/#{@props.project.slug}"
     onHomePage = @props.routes[2].path is undefined
     avatarClasses = classnames('tabbed-content-tab', {
       'beta-approved': betaApproved
@@ -161,6 +168,18 @@ ProjectPage = React.createClass
         {if @props.user
            <Link to="#{projectPath}/recents" activeClassName="active" className="tabbed-content-tab">
             <Translate content="project.nav.recents" />
+          </Link>
+        }
+
+        {if @props.user && this.userHasLabAccess()
+           <Link to="#{labPath}/" activeClassName="active" className="tabbed-content-tab">
+            <Translate content="project.nav.lab" />
+          </Link>
+        }
+
+        {if isAdmin()
+           <Link to="#{adminPath}/" activeClassName="active" className="tabbed-content-tab">
+            <Translate content="project.nav.adminPage" />
           </Link>
         }
 


### PR DESCRIPTION
Fixes #3363 -  adds top level links to lab for project owner / collabs and the admin page for admin mode users. 

I'm not keen on the extra nav tabs but couldn't think of a nice place to put these..thoughts appreciated.

Please don't make me rewrite this so it's not coffescript, even though it made me :sadpanda:

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?


## Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
