### PR TITLE
actually check i am the user with the roles for lab links

### DIFF
--- a/app/pages/project/project-page.cjsx
+++ b/app/pages/project/project-page.cjsx
@@ -85,8 +85,9 @@ ProjectPage = React.createClass
       @props.project.display_name
 
   userHasLabAccess: ->
-    userRoles = @props.projectRoles.some ({roles}) =>
-      roles.includes('owner') || roles.includes('collaborator')
+    userRoles = @props.projectRoles.some (role) =>
+      if role.links.owner.id == @props.user.id
+        role.roles.includes('owner') || role.roles.includes('collaborator')
 
   render: ->
     rearrangedLinks = @props.project.urls.sort (a, b) => a.path? & !b.path? ? 1 : 0


### PR DESCRIPTION
Fixes #4151 changes that show the lab link to people that don't have rights. Only show the lab links to users that possess the roles, not just if those roles exist you muppet cam.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?


## Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
