### PR TITLE
correctly show the count of unread conversations

### DIFF
--- a/app/layout/account-bar.jsx
+++ b/app/layout/account-bar.jsx
@@ -55,9 +55,11 @@ export default class AccountBar extends React.Component {
       unread: true,
       page_size: 1
     }).then((conversations) => {
+      const unread_messages = conversations.length > 0;
+      const unread_count = unread_messages ? conversations[0].getMeta().count : 0;
       this.setState({
-        messageCount: conversations.length,
-        unread: conversations.length > 0
+        messageCount: unread_count,
+        unread: unread_messages
       });
     });
   }


### PR DESCRIPTION
Fixes a bug reported on email by @yshish. 

don’t show the count of the limited page_size (1), show the count of the number of unread conversations. Noting that notifications deals with this already in https://github.com/zooniverse/Panoptes-Front-End/blob/7b0427857765f6a41e477f0f8c0e3ef1764795d9/app/lib/notifications-counter.js#L59

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?


## Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
