### PR TITLE
Rename "Archive" to "Delete"

### DIFF
--- a/app/talk/inbox-conversation.cjsx
+++ b/app/talk/inbox-conversation.cjsx
@@ -109,7 +109,7 @@ module.exports = React.createClass
               }
           </div>
           }
-        <SingleSubmitButton className="delete-conversation" onClick={@handleDelete}>Archive this conversation</SingleSubmitButton>
+        <SingleSubmitButton className="delete-conversation" onClick={@handleDelete}>Delete this conversation</SingleSubmitButton>
         <div>{@state.messages.map (message) -> <Message data={message} key={message.id} />}</div>
         <CommentBox
           header={"Send a message..."}


### PR DESCRIPTION
I know this has been discussed before, but it still bugs me that this button is labelled "archive" when it does nothing of the sort. "Archive" implies that there is an actual archive where you can find old messages and refer back to them, but in this case messages are gone forever unless the other user happens to reply again.

In my opinion "delete" is an accurate description of what this does. I'd also settle for "remove" or something along those lines.

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?


## Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?