### PR TITLE
Upgrade moment to 2.18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6305,9 +6305,9 @@
       "integrity": "sha1-L3kPrdD38jASHjYdnvKEjNYVqJ0="
     },
     "moment": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.9.0.tgz",
-      "integrity": "sha1-d+wRdfopT0JifxDI5t5jAsA29tU="
+      "version": "2.18.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
+      "integrity": "sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8="
     },
     "mout": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lodash": "~4.17.4",
     "markdownz": "~7.3.1",
     "modal-form": "~2.4",
-    "moment": "~2.9.0",
+    "moment": "~2.18.1",
     "panoptes-client": "~2.7",
     "papaparse": "mholt/PapaParse#cada171",
     "pusher-js": "~3.2.1",


### PR DESCRIPTION
Fixes a security vulnerability in moment 2.9.0

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Did you deploy a staging branch? https://moment.pfe-preview.zooniverse.org
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?


## Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
