### PR TITLE
Missing project avatar

### DIFF
--- a/app/pages/project/index.cjsx
+++ b/app/pages/project/index.cjsx
@@ -119,7 +119,7 @@ ProjectPageController = React.createClass
 
           awaitPages = project.get('pages').catch((error) => []) # does not appear in project links?
 
-          awaitProjectAvatar = apiClient.type('avatars').get(project.links.avatar.id).catch((error) => [])
+          awaitProjectAvatar = apiClient.type('avatars').get(project.links.avatar.id).catch((error) => null)
 
           awaitProjectCompleteness = Promise.resolve(project.completeness is 1.0)
 

--- a/app/pages/project/project-navbar.spec.js
+++ b/app/pages/project/project-navbar.spec.js
@@ -13,7 +13,14 @@ describe('ProjectNavbar', () => {
 
   it('should have nav as container', () => {
     const wrapper = shallow(<ProjectNavbar project={project} workflow={workflow} />);
-    const navElement = wrapper.find('<nav').first();
-    expect(navElement).to.have.length(1);
+    const navElement = wrapper.find('nav').first();
+    expect(navElement).to.have.lengthOf(1);
+  });
+
+  it('should conditionally render the project avatar', function() {
+    const wrapper = shallow(<ProjectNavbar project={project} workflow={workflow} />);
+    expect(wrapper.find('Thumbnail')).to.have.lengthOf(0);
+    wrapper.setProps({ projectAvatar: { src: '' }});
+    expect(wrapper.find('Thumbnail')).to.have.lengthOf(1);
   });
 });


### PR DESCRIPTION
I noticed this while working on something else using a staged project. This fixes a PropType warning being thrown when a project doesn't have an avatar. Adds test for it. 

Just a side note:
- I don't think using the Thumbnail component is really necessary for the avatar. The upload process for the avatar already limits the image to 50KB. 
- Chai API prefers the use of its `lengthOf` over `length`

https://missing-project-avatar.pfe-preview.zooniverse.org/

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Did you deploy a staging branch?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?


## Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
