### PR TITLE
Tests for user email settings form

### DIFF
--- a/app/lib/handle-input-change.coffee
+++ b/app/lib/handle-input-change.coffee
@@ -11,7 +11,7 @@ module.exports = (e) ->
 
   value = e.target[valueProperty]
 
-  if e.target.dataset.jsonValue
+  if e.target.dataset?.jsonValue
     value = JSON.parse value
 
   changes = {}

--- a/app/pages/settings/email.spec.js
+++ b/app/pages/settings/email.spec.js
@@ -25,10 +25,25 @@ const project = {
   title: 'A test project'
 };
 
+const anotherProject = {
+  display_name: 'Another test project',
+  title: 'Another test project'
+};
+
 const preferences = [
   {
+    email_communication: true,
     get() {
       return Promise.resolve(project);
+    },
+    getMeta() {
+      return {};
+    }
+  },
+  {
+    email_communication: false,
+    get() {
+      return Promise.resolve(anotherProject);
     },
     getMeta() {
       return {};
@@ -47,11 +62,7 @@ const user = {
 };
 
 describe('EmailSettings', () => {
-  let wrapper;
-
-  before(() => {
-    wrapper = shallow(<EmailSettings user={user} />);
-  });
+  const wrapper = shallow(<EmailSettings user={user} />);
 
   beforeEach(() => wrapper.update());
 
@@ -73,5 +84,37 @@ describe('EmailSettings', () => {
   it('shows beta email preference correctly', () => {
     const betaEmail = wrapper.find('input[name="beta_email_communication"]');
     assert.equal(betaEmail.prop('checked'), user.beta_email_communication);
+  });
+
+  describe('project listing', () => {
+    let projects;
+
+    beforeEach(() => {
+      projects = wrapper.update().find('table').last().find('tbody tr');
+    });
+
+    it('lists two projects (plus pagination)', () => {
+      assert.equal(projects.length, 3);
+    });
+
+    it('shows the first project email input correctly', () => {
+      const email = projects.first().find('td').first();
+      assert.equal(email.find('input').prop('checked'), preferences[0].email_communication);
+    });
+
+    it('shows the first project name correctly', () => {
+      const name = projects.first().find('td').last();
+      assert.equal(name.text(), project.display_name);
+    });
+
+    it('shows the second project email input correctly', () => {
+      const email = projects.at(1).find('td').first();
+      assert.equal(email.find('input').prop('checked'), preferences[1].email_communication);
+    });
+
+    it('shows the second project name correctly', () => {
+      const name = projects.at(1).find('td').last();
+      assert.equal(name.text(), anotherProject.display_name);
+    });
   });
 });

--- a/app/pages/settings/email.spec.js
+++ b/app/pages/settings/email.spec.js
@@ -1,0 +1,77 @@
+import React from 'react';
+import assert from 'assert';
+import { shallow } from 'enzyme';
+import talkClient from 'panoptes-client/lib/talk-client';
+import EmailSettings from './email';
+
+const subscriptionPreferences = [
+  {
+    id: 1,
+    category: 'participating_discussions',
+    email_digest: 'daily'
+  }
+];
+
+talkClient.type = () => {
+  return {
+    get() {
+      return Promise.resolve(subscriptionPreferences);
+    }
+  };
+};
+
+const project = {
+  display_name: 'A test project',
+  title: 'A test project'
+};
+
+const preferences = [
+  {
+    get() {
+      return Promise.resolve(project);
+    },
+    getMeta() {
+      return {};
+    }
+  }
+];
+
+const user = {
+  email: 'An email address',
+  beta_email_communication: false,
+  global_email_communication: true,
+  project_email_communication: true,
+  get() {
+    return Promise.resolve(preferences);
+  }
+};
+
+describe('EmailSettings', () => {
+  let wrapper;
+
+  before(() => {
+    wrapper = shallow(<EmailSettings user={user} />);
+  });
+
+  beforeEach(() => wrapper.update());
+
+  it('renders the email address', () => {
+    const email = wrapper.find('input[name="email"]');
+    assert.equal(email.prop('value'), user.email);
+  });
+
+  it('shows global email preference correctly', () => {
+    const projectEmail = wrapper.find('input[name="global_email_communication"]');
+    assert.equal(projectEmail.prop('checked'), user.project_email_communication);
+  });
+
+  it('shows project email preference correctly', () => {
+    const projectEmail = wrapper.find('input[name="project_email_communication"]');
+    assert.equal(projectEmail.prop('checked'), user.project_email_communication);
+  });
+
+  it('shows beta email preference correctly', () => {
+    const betaEmail = wrapper.find('input[name="beta_email_communication"]');
+    assert.equal(betaEmail.prop('checked'), user.beta_email_communication);
+  });
+});

--- a/app/pages/settings/email.spec.js
+++ b/app/pages/settings/email.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import assert from 'assert';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import talkClient from 'panoptes-client/lib/talk-client';
 import EmailSettings from './email';
 
@@ -9,6 +9,31 @@ const subscriptionPreferences = [
     id: 1,
     category: 'participating_discussions',
     email_digest: 'daily'
+  },
+  {
+    id: 2,
+    category: 'followed_discussions',
+    email_digest: 'daily'
+  },
+  {
+    id: 3,
+    category: 'mentions',
+    email_digest: 'immediate'
+  },
+  {
+    id: 4,
+    category: 'group_mentions',
+    email_digest: 'immediate'
+  },
+  {
+    id: 5,
+    category: 'messages',
+    email_digest: 'never'
+  },
+  {
+    id: 6,
+    category: 'started_discussions',
+    email_digest: 'weekly'
   }
 ];
 
@@ -62,7 +87,7 @@ const user = {
 };
 
 describe('EmailSettings', () => {
-  const wrapper = shallow(<EmailSettings user={user} />);
+  const wrapper = mount(<EmailSettings user={user} />);
 
   beforeEach(() => wrapper.update());
 
@@ -115,6 +140,23 @@ describe('EmailSettings', () => {
     it('shows the second project name correctly', () => {
       const name = projects.at(1).find('td').last();
       assert.equal(name.text(), anotherProject.display_name);
+    });
+  });
+
+  describe('Talk email preferences', () => {
+    let talkPreferences;
+
+    beforeEach(() => {
+      talkPreferences = wrapper.update().find('table').first().find('tbody tr');
+    });
+
+    it('lists Talk preferences correctly', () => {
+      talkPreferences.forEach((preference, i) => {
+        const subscriptionPreference = subscriptionPreferences[i];
+        const selector = `input[name="${subscriptionPreference.category}"][value="${subscriptionPreference.email_digest}"]`;
+        const input = preference.find(selector);
+        assert.equal(input.prop('checked'), true);
+      });
     });
   });
 });

--- a/app/pages/settings/email.spec.js
+++ b/app/pages/settings/email.spec.js
@@ -8,32 +8,56 @@ const subscriptionPreferences = [
   {
     id: 1,
     category: 'participating_discussions',
-    email_digest: 'daily'
+    email_digest: 'daily',
+    update(changes) {
+      subscriptionPreferences[0] = Object.assign(subscriptionPreferences[0], changes);
+      return { save: () => null };
+    }
   },
   {
     id: 2,
     category: 'followed_discussions',
-    email_digest: 'daily'
+    email_digest: 'daily',
+    update(changes) {
+      subscriptionPreferences[1] = Object.assign(subscriptionPreferences[1], changes);
+      return { save: () => null };
+    }
   },
   {
     id: 3,
     category: 'mentions',
-    email_digest: 'immediate'
+    email_digest: 'immediate',
+    update(changes) {
+      subscriptionPreferences[2] = Object.assign(subscriptionPreferences[2], changes);
+      return { save: () => null };
+    }
   },
   {
     id: 4,
     category: 'group_mentions',
-    email_digest: 'immediate'
+    email_digest: 'immediate',
+    update(changes) {
+      subscriptionPreferences[3] = Object.assign(subscriptionPreferences[3], changes);
+      return { save: () => null };
+    }
   },
   {
     id: 5,
     category: 'messages',
-    email_digest: 'never'
+    email_digest: 'never',
+    update(changes) {
+      subscriptionPreferences[4] = Object.assign(subscriptionPreferences[4], changes);
+      return { save: () => null };
+    }
   },
   {
     id: 6,
     category: 'started_discussions',
-    email_digest: 'weekly'
+    email_digest: 'weekly',
+    update(changes) {
+      subscriptionPreferences[5] = Object.assign(subscriptionPreferences[5], changes);
+      return { save: () => null };
+    }
   }
 ];
 
@@ -156,6 +180,14 @@ describe('EmailSettings', () => {
         const selector = `input[name="${subscriptionPreference.category}"][value="${subscriptionPreference.email_digest}"]`;
         const input = preference.find(selector);
         assert.equal(input.prop('checked'), true);
+      });
+    });
+
+    subscriptionPreferences.forEach((preference) => {
+      it(`${preference.category} updates correctly when preferences are changed`, () => {
+        const selector = `input[name="${preference.category}"][value="never"]`;
+        wrapper.find(selector).simulate('change');
+        assert.equal(preference.email_digest, 'never');
       });
     });
   });

--- a/app/pages/settings/email.spec.js
+++ b/app/pages/settings/email.spec.js
@@ -98,7 +98,7 @@ describe('EmailSettings', () => {
 
   it('shows global email preference correctly', () => {
     const projectEmail = wrapper.find('input[name="global_email_communication"]');
-    assert.equal(projectEmail.prop('checked'), user.project_email_communication);
+    assert.equal(projectEmail.prop('checked'), user.global_email_communication);
   });
 
   it('shows project email preference correctly', () => {

--- a/app/pages/settings/email.spec.js
+++ b/app/pages/settings/email.spec.js
@@ -5,12 +5,12 @@ import talkClient from 'panoptes-client/lib/talk-client';
 import EmailSettings from './email';
 
 const subscriptionPreferences = [
-  talkClient.type('subscription_preferences').create({ category: 'participating_discussions', email_digest: 'immediately' }),
-  talkClient.type('subscription_preferences').create({ category: 'followed_discussions', email_digest: 'daily' }),
-  talkClient.type('subscription_preferences').create({ category: 'mentions', email_digest: 'immediate' }),
-  talkClient.type('subscription_preferences').create({ category: 'group_mentions', email_digest: 'immediate' }),
-  talkClient.type('subscription_preferences').create({ category: 'messages', email_digest: 'daily' }),
-  talkClient.type('subscription_preferences').create({ category: 'started_discussions', email_digest: 'weekly' })
+  talkClient.type('subscription_preferences').create({ id: 0, category: 'participating_discussions', email_digest: 'immediate' }),
+  talkClient.type('subscription_preferences').create({ id: 1, category: 'followed_discussions', email_digest: 'daily' }),
+  talkClient.type('subscription_preferences').create({ id: 2, category: 'mentions', email_digest: 'immediate' }),
+  talkClient.type('subscription_preferences').create({ id: 3, category: 'group_mentions', email_digest: 'immediate' }),
+  talkClient.type('subscription_preferences').create({ id: 4, category: 'messages', email_digest: 'daily' }),
+  talkClient.type('subscription_preferences').create({ id: 5, category: 'started_discussions', email_digest: 'weekly' })
 ];
 
 talkClient.type = () => {
@@ -121,7 +121,7 @@ describe('EmailSettings', () => {
 
   describe('Talk email preferences', () => {
 
-    subscriptionPreferences.forEach((preference) => {
+    subscriptionPreferences.forEach((preference, i) => {
       it(`lists ${preference.category} preferences correctly`, () => {
         const selector = `input[name="${preference.category}"][value="${preference.email_digest}"]`;
         assert.equal(wrapper.find(selector).prop('checked'), true);

--- a/app/pages/settings/email.spec.js
+++ b/app/pages/settings/email.spec.js
@@ -5,60 +5,12 @@ import talkClient from 'panoptes-client/lib/talk-client';
 import EmailSettings from './email';
 
 const subscriptionPreferences = [
-  {
-    id: 1,
-    category: 'participating_discussions',
-    email_digest: 'daily',
-    update(changes) {
-      subscriptionPreferences[0] = Object.assign(subscriptionPreferences[0], changes);
-      return { save: () => null };
-    }
-  },
-  {
-    id: 2,
-    category: 'followed_discussions',
-    email_digest: 'daily',
-    update(changes) {
-      subscriptionPreferences[1] = Object.assign(subscriptionPreferences[1], changes);
-      return { save: () => null };
-    }
-  },
-  {
-    id: 3,
-    category: 'mentions',
-    email_digest: 'immediate',
-    update(changes) {
-      subscriptionPreferences[2] = Object.assign(subscriptionPreferences[2], changes);
-      return { save: () => null };
-    }
-  },
-  {
-    id: 4,
-    category: 'group_mentions',
-    email_digest: 'immediate',
-    update(changes) {
-      subscriptionPreferences[3] = Object.assign(subscriptionPreferences[3], changes);
-      return { save: () => null };
-    }
-  },
-  {
-    id: 5,
-    category: 'messages',
-    email_digest: 'never',
-    update(changes) {
-      subscriptionPreferences[4] = Object.assign(subscriptionPreferences[4], changes);
-      return { save: () => null };
-    }
-  },
-  {
-    id: 6,
-    category: 'started_discussions',
-    email_digest: 'weekly',
-    update(changes) {
-      subscriptionPreferences[5] = Object.assign(subscriptionPreferences[5], changes);
-      return { save: () => null };
-    }
-  }
+  talkClient.type('subscription_preferences').create({ category: 'participating_discussions', email_digest: 'immediately' }),
+  talkClient.type('subscription_preferences').create({ category: 'followed_discussions', email_digest: 'daily' }),
+  talkClient.type('subscription_preferences').create({ category: 'mentions', email_digest: 'immediate' }),
+  talkClient.type('subscription_preferences').create({ category: 'group_mentions', email_digest: 'immediate' }),
+  talkClient.type('subscription_preferences').create({ category: 'messages', email_digest: 'daily' }),
+  talkClient.type('subscription_preferences').create({ category: 'started_discussions', email_digest: 'weekly' })
 ];
 
 talkClient.type = () => {
@@ -168,18 +120,11 @@ describe('EmailSettings', () => {
   });
 
   describe('Talk email preferences', () => {
-    let talkPreferences;
 
-    beforeEach(() => {
-      talkPreferences = wrapper.update().find('table').first().find('tbody tr');
-    });
-
-    it('lists Talk preferences correctly', () => {
-      talkPreferences.forEach((preference, i) => {
-        const subscriptionPreference = subscriptionPreferences[i];
-        const selector = `input[name="${subscriptionPreference.category}"][value="${subscriptionPreference.email_digest}"]`;
-        const input = preference.find(selector);
-        assert.equal(input.prop('checked'), true);
+    subscriptionPreferences.forEach((preference) => {
+      it(`lists ${preference.category} preferences correctly`, () => {
+        const selector = `input[name="${preference.category}"][value="${preference.email_digest}"]`;
+        assert.equal(wrapper.find(selector).prop('checked'), true);
       });
     });
 

--- a/app/pages/settings/email.spec.js
+++ b/app/pages/settings/email.spec.js
@@ -14,13 +14,12 @@ const subscriptionPreferences = [
   talkClient.type('subscription_preferences').create({ id: 5, category: 'started_discussions', email_digest: 'weekly' })
 ];
 
-talkClient.type = () => {
-  return {
-    get() {
-      return Promise.resolve(subscriptionPreferences);
-    }
-  };
+const fakeRequest = {
+  get() {
+    return Promise.resolve(subscriptionPreferences);
+  }
 };
+talkClient.type = () => fakeRequest;
 
 const projects = [
   apiClient.type('projects').create({ display_name: 'A test project', title: 'A test project' }),
@@ -106,8 +105,7 @@ describe('EmailSettings', () => {
   });
 
   describe('Talk email preferences', () => {
-
-    subscriptionPreferences.forEach((preference, i) => {
+    subscriptionPreferences.forEach((preference) => {
       it(`lists ${preference.category} preferences correctly`, () => {
         const selector = `input[name="${preference.category}"][value="${preference.email_digest}"]`;
         assert.equal(wrapper.find(selector).prop('checked'), true);

--- a/app/pages/settings/email.spec.js
+++ b/app/pages/settings/email.spec.js
@@ -21,21 +21,22 @@ talkClient.type = () => {
   };
 };
 
-const project = {
-  display_name: 'A test project',
-  title: 'A test project'
-};
+const projects = [
+  {
+    display_name: 'A test project',
+    title: 'A test project'
+  },
+  {
+    display_name: 'Another test project',
+    title: 'Another test project'
+  }
+];
 
-const anotherProject = {
-  display_name: 'Another test project',
-  title: 'Another test project'
-};
-
-const preferences = [
+const projectPreferences = [
   {
     email_communication: true,
     get() {
-      return Promise.resolve(project);
+      return Promise.resolve(projects[0]);
     },
     getMeta() {
       return {};
@@ -44,7 +45,7 @@ const preferences = [
   {
     email_communication: false,
     get() {
-      return Promise.resolve(anotherProject);
+      return Promise.resolve(projects[1]);
     },
     getMeta() {
       return {};
@@ -58,7 +59,7 @@ const user = {
   global_email_communication: true,
   project_email_communication: true,
   get() {
-    return Promise.resolve(preferences);
+    return Promise.resolve(projectPreferences);
   }
 };
 
@@ -88,34 +89,26 @@ describe('EmailSettings', () => {
   });
 
   describe('project listing', () => {
-    let projects;
+    let projectSettings;
 
     beforeEach(() => {
-      projects = wrapper.update().find('table').last().find('tbody tr');
+      projectSettings = wrapper.update().find('table').last().find('tbody tr');
     });
 
     it('lists two projects (plus pagination)', () => {
-      assert.equal(projects.length, 3);
+      assert.equal(projectSettings.length, 3);
     });
 
-    it('shows the first project email input correctly', () => {
-      const email = projects.first().find('td').first();
-      assert.equal(email.find('input').prop('checked'), preferences[0].email_communication);
-    });
+    projects.forEach((project, i) => {
+      it(`shows project ${i} email input correctly`, () => {
+        const email = projectSettings.at(i).find('td').first();
+        assert.equal(email.find('input').prop('checked'), projectPreferences[i].email_communication);
+      });
 
-    it('shows the first project name correctly', () => {
-      const name = projects.first().find('td').last();
-      assert.equal(name.text(), project.display_name);
-    });
-
-    it('shows the second project email input correctly', () => {
-      const email = projects.at(1).find('td').first();
-      assert.equal(email.find('input').prop('checked'), preferences[1].email_communication);
-    });
-
-    it('shows the second project name correctly', () => {
-      const name = projects.at(1).find('td').last();
-      assert.equal(name.text(), anotherProject.display_name);
+      it(`shows project ${i} name correctly`, () => {
+        const name = projectSettings.at(i).find('td').last();
+        assert.equal(name.text(), project.display_name);
+      });
     });
   });
 


### PR DESCRIPTION
Staging branch URL: https://email-settings.pfe-preview.zooniverse.org/

Adds tests for the email settings page, as part of the work towards rewriting it for #3216

Specifically, this loads a mock user with Talk and project preferences, then tests that the user details, Talk preferences and project email preferences are displayed correctly.

EDIT: also tests for changes to project and Talk email preferences.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
