### PR TITLE
Add an option to remove tutorials and mini-courses

### DIFF
--- a/app/pages/lab/workflow.cjsx
+++ b/app/pages/lab/workflow.cjsx
@@ -527,14 +527,19 @@ EditWorkflowPage = React.createClass
     <PromiseRenderer promise={projectAndWorkflowTutorials}>{([projectTutorials, workflowTutorials]) =>
       # Backwards compatibility with tutorials with null kind values
       tutorials = projectTutorials.filter((value)-> value if value.kind is 'tutorial' or value.kind is null)
+      workflowTutorial = tutorials.filter((value) -> value if value in workflowTutorials)[0]
       if tutorials.length > 0
         <form className="workflow-link-tutorials-form">
           <span className="form-label">Tutorials</span>
+          <label>
+            <input name="tutorial" type="radio" value="" checked={!workflowTutorial} onChange={@removeTutorial.bind this, workflowTutorial, workflowTutorials} />
+            No tutorial
+          </label>
           {for tutorial in tutorials
-            assignedTutorial = tutorial in workflowTutorials
+            assignedTutorial = tutorial is workflowTutorial
             toggleTutorial = @handleTutorialToggle.bind this, tutorial, workflowTutorials
             <label key={tutorial.id}>
-              <input type={if tutorials.length is 1 then "checkbox" else "radio"} checked={assignedTutorial} onChange={toggleTutorial} />
+              <input name="tutorial" type="radio" checked={assignedTutorial} value={tutorial.id} onChange={toggleTutorial} />
               Tutorial #{tutorial.id} {" - #{tutorial.display_name}" if tutorial.display_name}
             </label>}
         </form>
@@ -548,14 +553,19 @@ EditWorkflowPage = React.createClass
       apiClient.type('tutorials').get workflow_id: @props.workflow.id, page_size: 100, kind: 'mini-course'
     ]
     <PromiseRenderer promise={projectAndWorkflowTutorials}>{([projectTutorials, workflowTutorials]) =>
+      workflowMiniCourse = projectTutorials.filter((value) -> value if value in workflowTutorials)[0]
       if projectTutorials.length > 0
         <form className="workflow-link-tutorials-form">
           <span className="form-label">Mini-Courses</span>
+          <label>
+            <input name="minicourse" type="radio" value="" checked={!workflowMiniCourse} onChange={@removeTutorial.bind this, workflowMiniCourse, workflowTutorials} />
+            No mini-course
+          </label>
           {for tutorial in projectTutorials
-            assignedTutorial = tutorial in workflowTutorials
+            assignedTutorial = tutorial is workflowMiniCourse
             toggleTutorial = @handleTutorialToggle.bind this, tutorial, workflowTutorials
             <label key={tutorial.id}>
-              <input type={if projectTutorials.length is 1 then "checkbox" else "radio"} checked={assignedTutorial} onChange={toggleTutorial} />
+              <input name="minicourse" type="radio" checked={assignedTutorial} onChange={toggleTutorial} />
               Mini-Course #{tutorial.id} {" - #{tutorial.display_name}" if tutorial.display_name}
             </label>}
         </form>
@@ -671,6 +681,8 @@ EditWorkflowPage = React.createClass
         else
           @props.workflow.removeLink 'tutorials', tutorial.id
 
+  removeTutorial: (tutorial, workflowTutorials, e) ->
+    @props.workflow.removeLink 'tutorials', tutorial.id
 
   addDemoSubjectSet: ->
     @props.project.uncacheLink 'subject_sets'


### PR DESCRIPTION
Staging branch URL: https://fix-4155.pfe-preview.zooniverse.org

Fixes #4155 .

Lists all tutorials and mini-courses as radio buttons in the workflow editor, where the first button is the 'No linked tutorial' option.

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [x] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
