### PR TITLE
Ignore pointer events when the polygon tool is disabled

### DIFF
--- a/app/classifier/drawing-tools/polygon.cjsx
+++ b/app/classifier/drawing-tools/polygon.cjsx
@@ -66,8 +66,9 @@ module.exports = React.createClass
     points = points.join '\n'
 
     deleteButtonPosition = @getDeletePosition(firstPoint, secondPoint)
+    pointerEvents = if @props.disabled then 'none' else 'painted'
 
-    <DrawingToolRoot tool={this} pointerEvents='painted'>
+    <DrawingToolRoot tool={this} pointerEvents={pointerEvents}>
       <Draggable onDrag={@handleMainDrag} onEnd={deleteIfOutOfBounds.bind null, this} disabled={@props.disabled}>
         <polyline  points={points} fill={'none' unless @props.mark.closed} />
       </Draggable>


### PR DESCRIPTION
Staging branch URL: https://fix-4165.pfe-preview.zooniverse.org

Fixes #4165 .

Describe your changes.
Checks whether the polygon tool is disabled or not before setting `pointerEvents` to `painted`.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
