### PR TITLE
fix announcement banner on project home

### DIFF
--- a/app/pages/project/home/project-home.jsx
+++ b/app/pages/project/home/project-home.jsx
@@ -21,6 +21,10 @@ const ProjectHomePage = (props) => {
           (<div className="call-to-action-container">
             <FinishedBanner project={props.project} />
           </div>)}
+        {props.project.configuration && props.project.configuration.announcement &&
+          (<div className="informational project-announcement-banner">
+            <Markdown>{props.project.configuration.announcement}</Markdown>
+          </div>)}
         <div className="project-home-page__description">
           {props.translation.description}
         </div>

--- a/app/pages/project/project-page.cjsx
+++ b/app/pages/project/project-page.cjsx
@@ -73,11 +73,12 @@ ProjectPage = React.createClass
 
     <div className="project-page project-background" style={backgroundStyle}>
       {if !onHomePage
-        <ProjectNavbar {...@props} />}
-
-      {if !!@props.project.configuration?.announcement
-        <div className="informational project-announcement-banner">
-          <Markdown>{@props.project.configuration.announcement}</Markdown>
+        <div>
+          <ProjectNavbar {...@props} />
+          {if !!@props.project.configuration?.announcement
+            <div className="informational project-announcement-banner">
+              <Markdown>{@props.project.configuration.announcement}</Markdown>
+            </div>}
         </div>}
 
       {React.cloneElement @props.children,


### PR DESCRIPTION
Staging branch URL: https://project-announcement-fix.pfe-preview.zooniverse.org/projects/markb-panoptes/survey-task-test-project

Moves announcement banner below project sub-nav on project home.

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [x] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
