### PR TITLE
Fix evergreen user profile tests

### DIFF
--- a/app/pages/settings/profile.spec.js
+++ b/app/pages/settings/profile.spec.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import assert from 'assert';
+import sinon from 'sinon';
 import { shallow } from 'enzyme';
 import CustomiseProfile from './profile';
 
@@ -22,12 +23,17 @@ const user = {
 
 describe('CustomiseProfile', () => {
   let wrapper;
+  let clearMediaSpy;
 
   before(() => {
     wrapper = shallow(<CustomiseProfile user={user} />);
+    clearMediaSpy = sinon.spy(CustomiseProfile.prototype, 'handleMediaClear');
   });
 
-  beforeEach(() => wrapper.update());
+  beforeEach(() => {
+    wrapper.update();
+    clearMediaSpy.reset();
+  });
 
   it('renders the user avatar', () => {
     const avatar = wrapper.find('ImageSelector[src="//zooniverse.org/images/avatar.jpg"]');
@@ -41,11 +47,13 @@ describe('CustomiseProfile', () => {
 
   it('deletes the avatar when Clear Avatar is pressed', () => {
     wrapper.find('button').first().simulate('click');
-    setTimeout(() => assert.equal(wrapper.update().state().avatar, {}));
+    sinon.assert.calledOnce(clearMediaSpy);
+    sinon.assert.calledWith(clearMediaSpy, 'avatar');
   });
 
   it('deletes the profile header when Clear Header is pressed', () => {
     wrapper.find('button').last().simulate('click');
-    setTimeout(() => assert.equal(wrapper.update().state().profile_header, {}));
+    sinon.assert.calledOnce(clearMediaSpy);
+    sinon.assert.calledWith(clearMediaSpy, 'profile_header');
   });
 });


### PR DESCRIPTION
Add sinon.
Test that the clear media buttons call the clear handler with the correct arguments.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
