### PR TITLE
Allow drawing on audio subjects

### DIFF
--- a/app/classifier/annotation-renderer/index.jsx
+++ b/app/classifier/annotation-renderer/index.jsx
@@ -15,6 +15,7 @@ DefaultRenderer.propTypes = {
 };
 
 const VIEWERS = {
+  audio: SVGRenderer,
   image: SVGRenderer,
   text: TextRenderer
 };

--- a/app/classifier/annotation-renderer/svg.jsx
+++ b/app/classifier/annotation-renderer/svg.jsx
@@ -161,7 +161,7 @@ export default class SVGRenderer extends React.Component {
 
     return (
       <div>
-        <div className="subject svg-subject">
+        <div className={`subject svg-subject ${this.props.type}`}>
           <svg
             ref={(element) => { if (element) this.svgSubjectArea = element; }}
             viewBox={createdViewBox}

--- a/css/frame-annotator.styl
+++ b/css/frame-annotator.styl
@@ -13,6 +13,9 @@
     height: 100%
     overflow: hidden
     
+    &.audio
+      background: transparent
+    
     svg
       width: 100%
       height: 100%


### PR DESCRIPTION
Staging branch URL: https://audio-drawing-task.pfe-preview.zooniverse.org

Describe your changes.
Add the SVG marking renderer for annotations on audio subjects.
Make the SVG background transparent for audio subjects.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
