### PR TITLE
Project page controller tests

### DIFF
--- a/app/pages/project/index.cjsx
+++ b/app/pages/project/index.cjsx
@@ -376,4 +376,7 @@ mapDispatchToProps = (dispatch) -> ({
   }
 });
 
-module.exports = connect(mapStateToProps, mapDispatchToProps, null, { pure: false })(ProjectPageController)
+module.exports = {
+    default: connect(mapStateToProps, mapDispatchToProps, null, { pure: false })(ProjectPageController)
+    ProjectPageController
+  }

--- a/app/pages/project/index.cjsx
+++ b/app/pages/project/index.cjsx
@@ -282,7 +282,7 @@ ProjectPageController = React.createClass
     currentUserRoleSets = @state.projectRoles.filter((roleSet) => roleSet.links.owner.id is user?.id)
     roles = currentUserRoleSets[0]?.roles or []
 
-    isAdmin() or 'owner' in roles or 'collaborator' in roles
+    isAdmin() or 'owner' in roles or 'collaborator' in roles or 'tester' in roles
 
   listenToPreferences: (preferences) ->
     @_listenedToPreferences?.stopListening 'change', @_boundForceUpdate

--- a/app/pages/project/index.spec.js
+++ b/app/pages/project/index.spec.js
@@ -57,7 +57,7 @@ const project = apiClient.type('projects').create({
     return Promise.resolve(resources[type]);
   },
   links: {
-    active_workflows: [1, 2, 3, 4, 5],
+    active_workflows: ['1', '2', '3', '4', '5'],
     avatar: { id: '1' },
     background: { id: '1' },
     owner: { id: '1' }

--- a/app/pages/project/index.spec.js
+++ b/app/pages/project/index.spec.js
@@ -170,4 +170,21 @@ describe('ProjectPageController', () => {
       sinon.assert.calledWith(workflowSpy, '2', true);
     });
   });
+
+  describe('without a saved workflow', () => {
+    beforeEach(() => {
+      location.query = {};
+      project.update({ 'configuration.default_workflow': '1' });
+      preferences.update({ settings: {}, preferences: {}});
+      const user = apiClient.type('users').create({ id: '4' });
+      wrapper.setProps({ user });
+    });
+
+    it('should load the project default workflow', () => {
+      wrapper.setState({ project, preferences });
+      controller.getSelectedWorkflow(project, preferences);
+      sinon.assert.calledOnce(workflowSpy);
+      sinon.assert.calledWith(workflowSpy, '1', true);
+    });
+  });
 });

--- a/app/pages/project/index.spec.js
+++ b/app/pages/project/index.spec.js
@@ -80,9 +80,6 @@ const preferences = apiClient.type('project_preferences').create({
   preferences: {},
   links: {
     project: project.id
-  },
-  save() {
-    Promise.resolve(preferences);
   }
 });
 

--- a/app/pages/project/index.spec.js
+++ b/app/pages/project/index.spec.js
@@ -78,11 +78,14 @@ const projectAvatar = apiClient.type('avatars').create({
   id: project.links.avatar.id
 });
 
-const preferences = {
+const preferences = apiClient.type('project_preferences').create({
   preferences: {
     selected_workflow_id: '6'
+  },
+  links: {
+    project: project.id
   }
-};
+});
 
 describe('ProjectPageController', () => {
   const wrapper = shallow(<ProjectPageController params={params} project={project} location={location} />, { context });

--- a/app/pages/project/index.spec.js
+++ b/app/pages/project/index.spec.js
@@ -39,6 +39,14 @@ const resources = {
           id: '2'
         }
       }
+    },
+    {
+      roles: ['tester'],
+      links: {
+        owner: {
+          id: '3'
+        }
+      }
     }
   ]
 };
@@ -112,6 +120,13 @@ describe('ProjectPageController', () => {
 
   it('should load the specified workflow for a collaborator', () => {
     wrapper.setProps({ user: { id: '2' }}).update();
+    controller.getSelectedWorkflow(project, preferences);
+    sinon.assert.calledOnce(workflowSpy);
+    sinon.assert.calledWith(workflowSpy, '6', false);
+  });
+
+  it('should load the specified workflow for a tester', () => {
+    wrapper.setProps({ user: { id: '3' }}).update();
     controller.getSelectedWorkflow(project, preferences);
     sinon.assert.calledOnce(workflowSpy);
     sinon.assert.calledWith(workflowSpy, '6', false);

--- a/app/pages/project/index.spec.js
+++ b/app/pages/project/index.spec.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import assert from 'assert';
+import { shallow } from 'enzyme';
+import apiClient from 'panoptes-client/lib/api-client';
+import { ProjectPageController } from './';
+
+const location = {
+  query: {}
+};
+
+const context = {
+  initialLoadComplete: true,
+  router: {}
+};
+
+const resources = {
+  pages: [],
+  project_roles: []
+};
+
+const project = apiClient.type('projects').create({
+  display_name: 'A test project',
+  get(type) {
+    return Promise.resolve(resources[type]);
+  },
+  links: {
+    avatar: { id: '1' },
+    background: { id: '1' },
+    owner: { id: '1' }
+  }
+});
+
+const background = apiClient.type('backgrounds').create({
+  id: project.links.background.id
+});
+
+const owner = apiClient.type('users').create({
+  id: project.links.owner.id
+});
+
+const projectAvatar = apiClient.type('avatars').create({
+  id: project.links.avatar.id
+});
+
+describe('ProjectPageController', () => {
+  const wrapper = shallow(<ProjectPageController project={project} location={location} />, { context });
+  const controller = wrapper.instance();
+
+  beforeEach(() => {
+    wrapper.setState({
+      loading: false,
+      project,
+      background,
+      owner,
+      pages: resources.pages,
+      projectAvatar,
+      projectRoles: resources.project_roles
+    });
+    wrapper.update();
+  });
+});

--- a/app/pages/project/index.spec.js
+++ b/app/pages/project/index.spec.js
@@ -124,14 +124,16 @@ describe('ProjectPageController', () => {
     });
 
     it('should load the specified workflow for a collaborator', () => {
-      wrapper.setProps({ user: { id: '2' }}).update();
+      const user = apiClient.type('users').create({ id: '2' });
+      wrapper.setProps({ user }).update();
       controller.getSelectedWorkflow(project, preferences);
       sinon.assert.calledOnce(workflowSpy);
       sinon.assert.calledWith(workflowSpy, '6', false);
     });
 
     it('should load the specified workflow for a tester', () => {
-      wrapper.setProps({ user: { id: '3' }}).update();
+      const user = apiClient.type('users').create({ id: '3' });
+      wrapper.setProps({ user }).update();
       controller.getSelectedWorkflow(project, preferences);
       sinon.assert.calledOnce(workflowSpy);
       sinon.assert.calledWith(workflowSpy, '6', false);

--- a/app/pages/project/index.spec.js
+++ b/app/pages/project/index.spec.js
@@ -84,6 +84,9 @@ const preferences = apiClient.type('project_preferences').create({
   },
   links: {
     project: project.id
+  },
+  save() {
+    Promise.resolve(preferences)
   }
 });
 
@@ -120,7 +123,8 @@ describe('ProjectPageController', () => {
     });
 
     it('should load the specified workflow for the project owner', () => {
-      wrapper.setProps({ user: owner }).update();
+      wrapper.setProps({ user: owner });
+      wrapper.setState({ preferences });
       controller.getSelectedWorkflow(project, preferences);
       sinon.assert.calledOnce(workflowSpy);
       sinon.assert.calledWith(workflowSpy, '6', false);
@@ -128,7 +132,8 @@ describe('ProjectPageController', () => {
 
     it('should load the specified workflow for a collaborator', () => {
       const user = apiClient.type('users').create({ id: '2' });
-      wrapper.setProps({ user }).update();
+      wrapper.setProps({ user });
+      wrapper.setState({ preferences });
       controller.getSelectedWorkflow(project, preferences);
       sinon.assert.calledOnce(workflowSpy);
       sinon.assert.calledWith(workflowSpy, '6', false);
@@ -136,7 +141,8 @@ describe('ProjectPageController', () => {
 
     it('should load the specified workflow for a tester', () => {
       const user = apiClient.type('users').create({ id: '3' });
-      wrapper.setProps({ user }).update();
+      wrapper.setProps({ user });
+      wrapper.setState({ preferences });
       controller.getSelectedWorkflow(project, preferences);
       sinon.assert.calledOnce(workflowSpy);
       sinon.assert.calledWith(workflowSpy, '6', false);

--- a/app/pages/project/index.spec.js
+++ b/app/pages/project/index.spec.js
@@ -11,9 +11,7 @@ const params = {
 };
 
 const location = {
-  query: {
-    workflow: '6'
-  }
+  query: {}
 };
 
 const context = {
@@ -79,14 +77,12 @@ const projectAvatar = apiClient.type('avatars').create({
 });
 
 const preferences = apiClient.type('project_preferences').create({
-  preferences: {
-    selected_workflow_id: '6'
-  },
+  preferences: {},
   links: {
     project: project.id
   },
   save() {
-    Promise.resolve(preferences)
+    Promise.resolve(preferences);
   }
 });
 
@@ -120,6 +116,7 @@ describe('ProjectPageController', () => {
   describe('with a logged-in user', () => {
     beforeEach(() => {
       controller.setupSplits = () => null;
+      location.query.workflow = '6';
     });
 
     it('should load the specified workflow for the project owner', () => {
@@ -146,6 +143,31 @@ describe('ProjectPageController', () => {
       controller.getSelectedWorkflow(project, preferences);
       sinon.assert.calledOnce(workflowSpy);
       sinon.assert.calledWith(workflowSpy, '6', false);
+    });
+  });
+
+  describe('with a workflow saved in preferences', () => {
+    beforeEach(() => {
+      location.query = {};
+      preferences.update({ preferences: {}});
+      const user = apiClient.type('users').create({ id: '4' });
+      wrapper.setProps({ user });
+    });
+
+    it('should try to load the stored workflow', () => {
+      preferences.update({ 'preferences.selected_workflow': '4' });
+      wrapper.setState({ preferences });
+      controller.getSelectedWorkflow(project, preferences);
+      sinon.assert.calledOnce(workflowSpy);
+      sinon.assert.calledWith(workflowSpy, '4', true);
+    });
+
+    it('should try to load a stored project workflow', () => {
+      preferences.update({ 'settings.workflow_id': '2' });
+      wrapper.setState({ preferences });
+      controller.getSelectedWorkflow(project, preferences);
+      sinon.assert.calledOnce(workflowSpy);
+      sinon.assert.calledWith(workflowSpy, '2', true);
     });
   });
 });

--- a/app/pages/project/index.spec.js
+++ b/app/pages/project/index.spec.js
@@ -111,24 +111,30 @@ describe('ProjectPageController', () => {
     assert.notEqual(project.links.active_workflows.indexOf(selectedWorkflowID), -1);
   });
 
-  it('should load the specified workflow for the project owner', () => {
-    wrapper.setProps({ user: owner }).update();
-    controller.getSelectedWorkflow(project, preferences);
-    sinon.assert.calledOnce(workflowSpy);
-    sinon.assert.calledWith(workflowSpy, '6', false);
-  });
+  describe('with a logged-in user', () => {
+    beforeEach(() => {
+      controller.setupSplits = () => null;
+    });
 
-  it('should load the specified workflow for a collaborator', () => {
-    wrapper.setProps({ user: { id: '2' }}).update();
-    controller.getSelectedWorkflow(project, preferences);
-    sinon.assert.calledOnce(workflowSpy);
-    sinon.assert.calledWith(workflowSpy, '6', false);
-  });
+    it('should load the specified workflow for the project owner', () => {
+      wrapper.setProps({ user: owner }).update();
+      controller.getSelectedWorkflow(project, preferences);
+      sinon.assert.calledOnce(workflowSpy);
+      sinon.assert.calledWith(workflowSpy, '6', false);
+    });
 
-  it('should load the specified workflow for a tester', () => {
-    wrapper.setProps({ user: { id: '3' }}).update();
-    controller.getSelectedWorkflow(project, preferences);
-    sinon.assert.calledOnce(workflowSpy);
-    sinon.assert.calledWith(workflowSpy, '6', false);
+    it('should load the specified workflow for a collaborator', () => {
+      wrapper.setProps({ user: { id: '2' }}).update();
+      controller.getSelectedWorkflow(project, preferences);
+      sinon.assert.calledOnce(workflowSpy);
+      sinon.assert.calledWith(workflowSpy, '6', false);
+    });
+
+    it('should load the specified workflow for a tester', () => {
+      wrapper.setProps({ user: { id: '3' }}).update();
+      controller.getSelectedWorkflow(project, preferences);
+      sinon.assert.calledOnce(workflowSpy);
+      sinon.assert.calledWith(workflowSpy, '6', false);
+    });
   });
 });

--- a/app/pages/project/project-page.cjsx
+++ b/app/pages/project/project-page.cjsx
@@ -4,7 +4,7 @@ Translate = require 'react-translate-component'
 {Markdown} = require 'markdownz'
 {sugarClient} = require 'panoptes-client/lib/sugar'
 PotentialFieldGuide = require './potential-field-guide'
-`import ProjectNavbar from './project-navbar';`
+ProjectNavbar = require('./project-navbar').default
 
 AVATAR_SIZE = 100
 

--- a/app/router.cjsx
+++ b/app/router.cjsx
@@ -115,7 +115,7 @@ module.exports =
       <IndexRoute component={FilteredProjectsList} />
     </Route>
 
-    <Route path="projects/:owner/:name" component={require './pages/project'}>
+    <Route path="projects/:owner/:name" component={require('./pages/project').default}>
       <IndexRoute component={ProjectHomePage} />
       <Route path="home" component={ONE_UP_REDIRECT} />
       <Route path="classify" component={require './pages/project/classify'} />


### PR DESCRIPTION
Staging URL: https://project-page-controller.pfe-preview.zooniverse.org

Adds tests for some workflow selection cases in the project page controller.
Adds 'tester' to the roles that are allowed to load inactive workflows.
Fixes #4180
 
# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
