### PR TITLE
Fix lab and recent links

### DIFF
--- a/app/pages/project/home/index.jsx
+++ b/app/pages/project/home/index.jsx
@@ -99,12 +99,14 @@ export default class ProjectHomeContainer extends React.Component {
         project={this.props.project}
         projectAvatar={this.props.projectAvatar}
         projectIsComplete={this.props.projectIsComplete}
+        projectRoles={this.props.projectRoles}
         researcherAvatar={this.state.researcherAvatar}
         showWorkflowButtons={this.state.showWorkflowButtons}
         splits={this.props.splits}
         talkSubjects={this.state.talkSubjects}
         translation={this.props.translation}
         workflow={this.props.workflow}
+        user={this.props.user}
       />
     );
   }
@@ -126,6 +128,7 @@ ProjectHomeContainer.defaultProps = {
     src: ''
   },
   projectIsComplete: false,
+  projectRoles: [],
   splits: {},
   translation: {
     description: '',
@@ -133,7 +136,8 @@ ProjectHomeContainer.defaultProps = {
     introduction: '',
     researcher_quote: '',
     title: ''
-  }
+  },
+  user: null
 };
 
 ProjectHomeContainer.propTypes = {
@@ -155,6 +159,7 @@ ProjectHomeContainer.propTypes = {
     researcher_quote: React.PropTypes.string
   }).isRequired,
   projectIsComplete: React.PropTypes.bool.isRequired,
+  projectRoles: React.PropTypes.array,
   splits: React.PropTypes.object,
   translation: React.PropTypes.shape({
     description: React.PropTypes.string,
@@ -165,5 +170,8 @@ ProjectHomeContainer.propTypes = {
   }),
   workflow: React.PropTypes.shape({
     id: React.PropTypes.string
-  })
+  }),
+  user: React.PropTypes.shape({
+    id: React.PropTypes.string
+  }).isRequired
 };


### PR DESCRIPTION
Staging branch URL: https://fix-navbar-links.pfe-preview.zooniverse.org/

Describe your changes.
Pass `user` and `projectRoles` to the home page component. That's needed Because the project homepage navigation bar is rendered separately from the other page, which tbh isn't great.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
