### PR TITLE
Org projects request refactor

### DIFF
--- a/app/pages/organizations/organization-container.jsx
+++ b/app/pages/organizations/organization-container.jsx
@@ -95,9 +95,13 @@ class OrganizationContainer extends React.Component {
       .then((organizationProjects) => {
         this.setState({ fetchingProjects: false, organizationProjects });
         const avatarRequests = organizationProjects
-          .filter(project => project.links.avatar.id)
+          .filter(project => project.links.avatar && project.links.avatar.id)
           .map(project => apiClient.type('avatars').get(project.links.avatar.id)
-            .catch(error => console.error('error loading project avatar', error))); // eslint-disable-line no-console)
+            .catch((error) => {
+              if (error.status !== 404) {
+                console.error('error loading project avatar', error); // eslint-disable-line no-console
+              }
+            }));
         Promise.all(avatarRequests)
           .then((projectAvatars) => {
             this.setState({ fetchingProjectAvatars: false, projectAvatars });

--- a/app/pages/organizations/organization-page.jsx
+++ b/app/pages/organizations/organization-page.jsx
@@ -8,7 +8,7 @@ import ProjectCard from '../../partials/project-card';
 
 const AVATAR_SIZE = 100;
 
-export const OrganizationProjectCards = ({ errorFetchingProjects, fetchingProjects, projects }) => {
+export const OrganizationProjectCards = ({ errorFetchingProjects, fetchingProjects, projects, projectAvatars }) => {
   if (fetchingProjects) {
     return (
       <div className="organization-page__projects-status">
@@ -30,9 +30,14 @@ export const OrganizationProjectCards = ({ errorFetchingProjects, fetchingProjec
   } else {
     return (
       <div className="project-card-list">
-        {projects.map(project =>
-          <ProjectCard key={project.id} project={project} />
-        )}
+        {projects.map((project) => {
+          let projectAvatar = projectAvatars.find(avatar => avatar.links.linked.id === project.id);
+          if (!projectAvatar) {
+            projectAvatar = { src: '' };
+          }
+          return (
+            <ProjectCard key={project.id} project={project} imageSrc={projectAvatar.src} />);
+        })}
       </div>);
   }
 };
@@ -46,6 +51,12 @@ OrganizationProjectCards.propTypes = {
     React.PropTypes.shape({
       id: React.PropTypes.string,
       display_name: React.PropTypes.string
+    })
+  ),
+  projectAvatars: React.PropTypes.arrayOf(
+    React.PropTypes.shape({
+      id: React.PropTypes.string,
+      src: React.PropTypes.string
     })
   )
 };
@@ -145,6 +156,7 @@ class OrganizationPage extends React.Component {
             errorFetchingProjects={this.props.errorFetchingProjects}
             fetchingProjects={this.props.fetchingProjects}
             projects={this.props.organizationProjects}
+            projectAvatars={this.props.projectAvatars}
           />
         </section>
 
@@ -268,6 +280,7 @@ OrganizationPage.defaultProps = {
   organizationBackground: {},
   organizationPages: [],
   organizationProjects: [],
+  projectAvatars: [],
   toggleCollaboratorView: () => {}
 };
 
@@ -312,6 +325,12 @@ OrganizationPage.propTypes = {
     React.PropTypes.shape({
       id: React.PropTypes.string,
       display_name: React.PropTypes.string
+    })
+  ),
+  projectAvatars: React.PropTypes.arrayOf(
+    React.PropTypes.shape({
+      id: React.PropTypes.string,
+      src: React.PropTypes.string
     })
   ),
   toggleCollaboratorView: React.PropTypes.func

--- a/app/pages/organizations/organization-page.spec.js
+++ b/app/pages/organizations/organization-page.spec.js
@@ -114,6 +114,7 @@ describe('OrganizationPage', function () {
       <OrganizationProjectCards
         fetchingProjects={false}
         projects={organizationProjects}
+        projectAvatars={[]}
       />);
     const cards = wrapper.find('ProjectCard');
     assert.equal(cards.length, organizationProjects.length);


### PR DESCRIPTION
Staging branch URLs:
- org with projects (all have avatars): https://org-projects-request-refactor.pfe-preview.zooniverse.org/organizations/markb-panoptes/nfnorgtest
- org with projects (one does not have an avatar): https://org-projects-request-refactor.pfe-preview.zooniverse.org/organizations/markb-panoptes/mborgtest
- org with no projects: https://org-projects-request-refactor.pfe-preview.zooniverse.org/organizations/markb-panoptes/noavnoback

Refactors organization affiliated projects request from project `card: true` to full project resource, with include for projects' avatars.

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [x] Can you post a talk comment?

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
