### PR TITLE
Extract functional components

### DIFF
--- a/app/pages/settings/email.jsx
+++ b/app/pages/settings/email.jsx
@@ -124,7 +124,7 @@ Pagination.defaultProps = {
   meta: {
     page_count: 1
   },
-  page: '1'
+  page: 1
 };
 
 class EmailSettingsPage extends React.Component {

--- a/app/pages/settings/email.jsx
+++ b/app/pages/settings/email.jsx
@@ -70,7 +70,7 @@ function ProjectPreferences({ projects, projectPreferences, onChange }) {
                   type="checkbox"
                   name="email_communication"
                   checked={projectPreference.email_communication}
-                  onChange={(e) => onChange(i, e)}
+                  onChange={e => onChange(i, e)}
                 />
               </td>
               <td>
@@ -124,8 +124,8 @@ Pagination.defaultProps = {
   meta: {
     page_count: 1
   },
-  page: 1
-}
+  page: '1'
+};
 
 class EmailSettingsPage extends React.Component {
   constructor(props) {
@@ -294,7 +294,10 @@ class EmailSettingsPage extends React.Component {
               <Translate component="th" content="emailSettings.talk.frequency.never" />
             </tr>
           </thead>
-          <TalkPreferences talkPreferences={this.state.talkPreferences} onChange={this.handleTalkPreferenceChange} />
+          <TalkPreferences
+            talkPreferences={this.state.talkPreferences}
+            onChange={this.handleTalkPreferenceChange}
+          />
         </table>
 
         <p>
@@ -312,7 +315,7 @@ class EmailSettingsPage extends React.Component {
             </tr>
           </thead>
           <ProjectPreferences
-              projects={this.state.projects}
+            projects={this.state.projects}
             projectPreferences={this.state.projectPreferences}
             onChange={this.handleProjectPreferenceChange}
           />
@@ -339,6 +342,10 @@ EmailSettingsPage.defaultProps = {
 
 EmailSettingsPage.propTypes = {
   user: React.PropTypes.shape({
+    email: React.PropTypes.string,
+    beta_email_communication: React.PropTypes.bool,
+    project_email_communication: React.PropTypes.bool,
+    global_email_communication: React.PropTypes.bool,
     get: React.PropTypes.func
   })
 };

--- a/app/pages/settings/email.jsx
+++ b/app/pages/settings/email.jsx
@@ -116,7 +116,7 @@ Pagination.propTypes = {
   meta: React.PropTypes.shape({
     page_count: React.PropTypes.number
   }),
-  page: React.PropTypes.string,
+  page: React.PropTypes.number,
   onChange: React.PropTypes.func
 };
 
@@ -124,14 +124,14 @@ Pagination.defaultProps = {
   meta: {
     page_count: 1
   },
-  page: '1'
+  page: 1
 }
 
 class EmailSettingsPage extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      page: '1',
+      page: 1,
       projects: [],
       projectPreferences: [],
       talkPreferences: []
@@ -322,7 +322,7 @@ class EmailSettingsPage extends React.Component {
                 <Pagination
                   meta={this.state.meta}
                   page={this.state.page}
-                  onChange={e => this.setState({ page: e.target.value })}
+                  onChange={e => this.setState({ page: parseInt(e.target.value, 10) })}
                 />
               </td>
             </tr>

--- a/app/pages/settings/email.jsx
+++ b/app/pages/settings/email.jsx
@@ -5,11 +5,133 @@ import talkClient from 'panoptes-client/lib/talk-client';
 import AutoSave from '../../components/auto-save';
 import handleInputChange from '../../lib/handle-input-change';
 
+function TalkPreferenceOption({ preference, index, digest, onChange }) {
+  return (
+    <td className="option">
+      <input
+        type="radio"
+        name={preference.category}
+        value={digest}
+        checked={preference.email_digest === digest}
+        onChange={e => onChange(index, e)}
+      />
+    </td>
+  );
+}
+
+TalkPreferenceOption.propTypes = {
+  digest: React.PropTypes.string.isRequired,
+  index: React.PropTypes.number.isRequired,
+  onChange: React.PropTypes.func,
+  preference: React.PropTypes.shape({
+    email_digest: React.PropTypes.string
+  }).isRequired
+};
+
+function TalkPreferences(props) {
+  const { talkPreferences, onChange } = props;
+  return (
+    (talkPreferences.length > 0) ?
+      <tbody>
+        {talkPreferences.map((pref, i) => {
+          if (pref.category !== 'system' && pref.category !== 'moderation_reports') {
+            return (
+              <tr key={pref.id}>
+                <Translate component="td" content={`emailSettings.talk.options.${pref.category}`} />
+                <TalkPreferenceOption preference={pref} index={i} digest="immediate" onChange={onChange} />
+                <TalkPreferenceOption preference={pref} index={i} digest="daily" onChange={onChange} />
+                <TalkPreferenceOption preference={pref} index={i} digest="weekly" onChange={onChange} />
+                <TalkPreferenceOption preference={pref} index={i} digest="never" onChange={onChange} />
+              </tr>
+            );
+          } else {
+            return null;
+          }
+        })}
+      </tbody> :
+      <tbody />
+  );
+}
+
+TalkPreferences.propTypes = {
+  onChange: React.PropTypes.func,
+  talkPreferences: React.PropTypes.arrayOf(React.PropTypes.object).isRequired
+};
+
+function ProjectPreferences({ projects, projectPreferences, onChange }) {
+  return (
+    <tbody>
+      {projectPreferences.map((projectPreference, i) => {
+        if (projects[i]) {
+          return (
+            <tr key={projectPreference.id}>
+              <td>
+                <input
+                  type="checkbox"
+                  name="email_communication"
+                  checked={projectPreference.email_communication}
+                  onChange={(e) => onChange(i, e)}
+                />
+              </td>
+              <td>
+                {projects[i].display_name}
+              </td>
+            </tr>
+          );
+        } else {
+          return null;
+        }
+      })}
+    </tbody>
+  );
+}
+
+ProjectPreferences.propTypes = {
+  projects: React.PropTypes.arrayOf(React.PropTypes.object).isRequired,
+  projectPreferences: React.PropTypes.arrayOf(React.PropTypes.object).isRequired,
+  onChange: React.PropTypes.func
+};
+
+function Pagination({ meta, page, onChange }) {
+  if (meta) {
+    return (
+      <nav className="pagination">{'Page'}
+        <select
+          value={page}
+          disabled={meta.page_count < 2}
+          onChange={onChange}
+        >
+          {Array.from(Array(meta.page_count), (p, i) => {
+            return <option key={i} value={i + 1}>{i + 1}</option>;
+          })}
+        </select> {' of '} {meta.page_count || '?'}
+      </nav>
+    );
+  } else {
+    return null;
+  }
+}
+
+Pagination.propTypes = {
+  meta: React.PropTypes.shape({
+    page_count: React.PropTypes.number
+  }),
+  page: React.PropTypes.string,
+  onChange: React.PropTypes.func
+};
+
+Pagination.defaultProps = {
+  meta: {
+    page_count: 1
+  },
+  page: '1'
+}
+
 class EmailSettingsPage extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      page: 1,
+      page: '1',
       projects: [],
       projectPreferences: [],
       talkPreferences: []
@@ -29,9 +151,8 @@ class EmailSettingsPage extends React.Component {
   getTalkPreferences() {
     talkClient.type('subscription_preferences').get()
     .then((preferences) => {
-      this.setState({
-        talkPreferences: preferences
-      });
+      const talkPreferences = this.sortPreferences(preferences);
+      this.setState({ talkPreferences });
     });
   }
 
@@ -82,86 +203,6 @@ class EmailSettingsPage extends React.Component {
       talkPreferences[index] = updatedPref;
       this.setState({ talkPreferences });
     });
-  }
-
-  renderProjectPreferences() {
-    const { projects, projectPreferences } = this.state;
-    return projectPreferences.map((projectPreference, i) => {
-      if (projects[i]) {
-        return (
-          <tr key={projectPreference.id}>
-            <td>
-              <input
-                type="checkbox"
-                name="email_communication"
-                checked={projectPreference.email_communication}
-                onChange={this.handleProjectPreferenceChange.bind(this, i)}
-              />
-            </td>
-            <td>
-              {projects[i].display_name}
-            </td>
-          </tr>
-        );
-      }
-    });
-  }
-
-  renderPagination() {
-    const { meta, page } = this.state;
-    if (meta) {
-      return (
-        <nav className="pagination">{'Page'}
-          <select
-            value={page}
-            disabled={meta.page_count < 2}
-            onChange={e => this.setState({ page: e.target.value })}
-          >
-            {Array.from(Array(meta.page_count), (p, i) => {
-              return <option key={i} value={i + 1}>{i + 1}</option>;
-            })}
-          </select> {' of '} {meta.page_count || '?'}
-        </nav>
-      );
-    }
-  }
-
-  renderTalkPreferences() {
-    const { talkPreferences } = this.state;
-    const sortedPrefs = this.sortPreferences(talkPreferences);
-    return (
-      (sortedPrefs.length > 0) ?
-        <tbody>
-          {sortedPrefs.map((pref, i) => {
-            if (pref.category !== 'system' && pref.category !== 'moderation_reports') {
-              return (
-                <tr key={pref.id}>
-                  <Translate component="td" content={`emailSettings.talk.options.${pref.category}`} />
-                  {this.talkPreferenceOption(pref, i, 'immediate')}
-                  {this.talkPreferenceOption(pref, i, 'daily')}
-                  {this.talkPreferenceOption(pref, i, 'weekly')}
-                  {this.talkPreferenceOption(pref, i, 'never')}
-                </tr>
-              );
-            }
-          })}
-        </tbody> :
-        <tbody />
-    );
-  }
-
-  talkPreferenceOption(preference, index, digest) {
-    return (
-      <td className="option">
-        <input
-          type="radio"
-          name={preference.category}
-          value={digest}
-          checked={preference.email_digest === digest}
-          onChange={this.handleTalkPreferenceChange.bind(this, index)}
-        />
-      </td>
-    );
   }
 
   sortPreferences(preferences) {
@@ -253,7 +294,7 @@ class EmailSettingsPage extends React.Component {
               <Translate component="th" content="emailSettings.talk.frequency.never" />
             </tr>
           </thead>
-          {this.renderTalkPreferences()}
+          <TalkPreferences talkPreferences={this.state.talkPreferences} onChange={this.handleTalkPreferenceChange} />
         </table>
 
         <p>
@@ -270,14 +311,22 @@ class EmailSettingsPage extends React.Component {
               <Translate component="th" content="emailSettings.project.header" />
             </tr>
           </thead>
-          <tbody>
-            {this.renderProjectPreferences(this.state.projectPreferences)}
+          <ProjectPreferences
+              projects={this.state.projects}
+            projectPreferences={this.state.projectPreferences}
+            onChange={this.handleProjectPreferenceChange}
+          />
+          <tfoot>
             <tr>
               <td colSpan="2">
-                {this.renderPagination()}
+                <Pagination
+                  meta={this.state.meta}
+                  page={this.state.page}
+                  onChange={e => this.setState({ page: e.target.value })}
+                />
               </td>
             </tr>
-          </tbody>
+          </tfoot>
         </table>
       </div>
     );

--- a/app/pages/settings/email.spec.js
+++ b/app/pages/settings/email.spec.js
@@ -133,7 +133,7 @@ describe('EmailSettings', () => {
 
   describe('Project pagination', () => {
     it('defaults to page 1', () => {
-      assert.equal(wrapper.state().page, '1');
+      assert.equal(wrapper.state().page, 1);
     });
 
     it('should be disabled with less than one page of projects', () => {
@@ -156,11 +156,11 @@ describe('EmailSettings', () => {
       const pageSelector = wrapper.find('nav.pagination select');
       const fakeEvent = {
         target: {
-          value: '3'
+          value: 3
         }
       };
       pageSelector.simulate('change', fakeEvent);
-      assert.equal(wrapper.state().page, '3');
+      assert.equal(wrapper.state().page, 3);
     });
 
     it('should update the project list on change', () => {
@@ -169,12 +169,12 @@ describe('EmailSettings', () => {
       const pageSelector = wrapper.find('nav.pagination select');
       const fakeEvent = {
         target: {
-          value: '5'
+          value: 5
         }
       };
       pageSelector.simulate('change', fakeEvent);
       wrapper.update();
-      assert.equal(wrapper.state().page, '5');
+      assert.equal(wrapper.state().page, 5);
       sinon.assert.calledOnce(projectPreferenceSpy);
     });
   });

--- a/app/pages/settings/email.spec.js
+++ b/app/pages/settings/email.spec.js
@@ -83,8 +83,8 @@ describe('EmailSettings', () => {
       projectSettings = wrapper.find('table').last().find('tbody tr');
     });
 
-    it('lists two projects (plus pagination)', () => {
-      assert.equal(projectSettings.length, 3);
+    it('lists two projects', () => {
+      assert.equal(projectSettings.length, 2);
     });
 
     projects.forEach((project, i) => {
@@ -133,7 +133,7 @@ describe('EmailSettings', () => {
 
   describe('Project pagination', () => {
     it('defaults to page 1', () => {
-      assert.equal(wrapper.state().page, 1);
+      assert.equal(wrapper.state().page, '1');
     });
 
     it('should be disabled with less than one page of projects', () => {


### PR DESCRIPTION
Extracts components for Talk preferences, project preferences and pagination.
Fixes array sort being called more than once for Talk preferences.
Adds a footer to the project listing table.
Fixes page number being passed as a string, instead of a number, in the page change event handler.