### PR TITLE
add TaskTranslations to combo task render

### DIFF
--- a/app/classifier/tasks/combo/index.cjsx
+++ b/app/classifier/tasks/combo/index.cjsx
@@ -1,6 +1,7 @@
 React = require 'react'
 SVGRenderer = require('../../annotation-renderer/svg').default
 MarkingsRenderer = require('./markings-renderer').default
+TaskTranslations = require('../translations').default
 
 ComboTask = React.createClass
   statics:
@@ -114,7 +115,12 @@ ComboTask = React.createClass
                 <strong>This task might not work as part of a combo at this time.</strong>
               </small>
             </div>}
-          <TaskComponent {...@props} autoFocus={i is 0} task={taskDescription} annotation={annotation} onChange={@handleChange.bind this, i} />
+          <TaskTranslations
+            taskKey={annotation.task}
+            task={taskDescription}
+          >
+            <TaskComponent {...@props} autoFocus={i is 0} task={taskDescription} annotation={annotation} onChange={@handleChange.bind this, i} />
+          </TaskTranslations>
         </div>}
     </div>
 

--- a/app/classifier/tasks/combo/summary.jsx
+++ b/app/classifier/tasks/combo/summary.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import TaskTranslations from '../translations';
 import tasks from '..';
 
 const ComboTaskSummary = (props) => {
@@ -13,7 +14,12 @@ const ComboTaskSummary = (props) => {
       const SummaryComponent = tasks[task.type].Summary;
       body.push(
         <div key={annotation._key} className="classification-task-summary">
-          <SummaryComponent task={task} annotation={annotation} onToggle={props.onToggle} />
+          <TaskTranslations
+            taskKey={annotation.task}
+            task={task}
+          >
+            <SummaryComponent task={task} annotation={annotation} onToggle={props.onToggle} />
+          </TaskTranslations>
         </div>
       );
     });


### PR DESCRIPTION
Staging branch URL: https://fix-4195.pfe-preview.zooniverse.org/projects/markb-panoptes/test-project-3-mb/classify?reload=0&workflow=3120

Fixes #4195.

Add TaskTranslations component around TaskComponent in combo task render.

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [x] Can you post a talk comment?

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [x] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
