### PR TITLE
Update task translations

### DIFF
--- a/app/classifier/tasks/translations.jsx
+++ b/app/classifier/tasks/translations.jsx
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 
 function TaskTranslations(props) {
   const { task } = props;
-  const taskStrings = props.translations.strings.workflow.tasks;
+  const taskStrings = props.translations.strings.workflow;
   let translation = merge({}, task);
 
   function explodeTranslationKey(translationKey, value) {
@@ -21,8 +21,8 @@ function TaskTranslations(props) {
 
   Object.keys(taskStrings).map((translationKey) => {
     const newTranslation = explodeTranslationKey(translationKey, taskStrings[translationKey]);
-    if (newTranslation[props.taskKey]) {
-      translation = merge(translation, newTranslation[props.taskKey]);
+    if (newTranslation.tasks && newTranslation.tasks[props.taskKey]) {
+      translation = merge(translation, newTranslation.tasks[props.taskKey]);
     }
   });
 

--- a/app/classifier/tasks/translations.spec.js
+++ b/app/classifier/tasks/translations.spec.js
@@ -11,19 +11,16 @@ function StubTask() {
 
 const initialTranslations = {
   strings: {
-    workflow: {
-      tasks: { }
-    }
+    workflow: {}
   }
 };
 
 const translations = {
   strings: {
     workflow: {
-      tasks: {
-        'survey.choices.ar.label': 'Translated Armadillo',
-        'survey.questions.ho.answers.one.label': 'Translated 1'
-      }
+      display_name: 'A test workflow',
+      'tasks.survey.choices.ar.label': 'Translated Armadillo',
+      'tasks.survey.questions.ho.answers.one.label': 'Translated 1'
     }
   }
 };


### PR DESCRIPTION
https://update-task-translations.pfe-preview.zooniverse.org

Workflow translations are now flat dictionaries of the form
```
{
      display_name: 'A test workflow',
      'tasks.survey.choices.ar.label': 'Translated Armadillo',
      'tasks.survey.questions.ho.answers.one.label': 'Translated 1'
}
```
This PR updates the tests to reflect the new format, and updates the task translation component to extract task strings properly from the translations object.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
