### PR TITLE
Add project state radio buttons to admin

### DIFF
--- a/app/pages/admin/project-status.jsx
+++ b/app/pages/admin/project-status.jsx
@@ -188,7 +188,7 @@ class ProjectStatus extends Component {
     if (!this.state.project) {
       return <LoadingIndicator />;
     }
-    console.info(this)
+
     return (
       <div className="project-status">
         <ProjectIcon project={this.state.project} />

--- a/app/pages/admin/project-status.jsx
+++ b/app/pages/admin/project-status.jsx
@@ -199,6 +199,7 @@ class ProjectStatus extends Component {
             <label htmlFor="project-state-active">
               <input
                 id="project-state-active"
+                name="project-state-buttons"
                 type="radio"
                 value=""
                 checked={this.state.project.state === ''}
@@ -209,6 +210,7 @@ class ProjectStatus extends Component {
             <label htmlFor="project-state-paused">
               <input
                 id="project-state-paused"
+                name="project-state-buttons"
                 type="radio"
                 value="paused"
                 checked={this.state.project.state === 'paused'}
@@ -219,6 +221,7 @@ class ProjectStatus extends Component {
             <label htmlFor="project-state-finished">
               <input
                 id="project-state-finished"
+                name="project-state-buttons"
                 type="radio"
                 value="finished"
                 checked={this.state.project.state === 'finished'}

--- a/app/pages/admin/project-status.jsx
+++ b/app/pages/admin/project-status.jsx
@@ -23,6 +23,7 @@ class ProjectStatus extends Component {
     this.getProjectAndWorkflows = this.getProjectAndWorkflows.bind(this);
     this.handleDialogCancel = this.handleDialogCancel.bind(this);
     this.handleDialogSuccess = this.handleDialogSuccess.bind(this);
+    this.handleProjectStateChange = this.handleProjectStateChange.bind(this);
 
     this.state = {
       dialogIsOpen: false,
@@ -105,6 +106,12 @@ class ProjectStatus extends Component {
       .catch(error => this.setState({ error }));
   }
 
+  handleProjectStateChange({ target }) {
+    this.state.project.update({ state: target.value });
+    this.state.project.save()
+      .catch(error => this.setState({ error }));
+  }
+
   handleToggle(event, workflow) {
     this.setState({ error: null });
     const isChecked = event.target.checked;
@@ -181,10 +188,47 @@ class ProjectStatus extends Component {
     if (!this.state.project) {
       return <LoadingIndicator />;
     }
-
+    console.info(this)
     return (
       <div className="project-status">
         <ProjectIcon project={this.state.project} />
+
+        <div className="project-status__section project-status__section--state">
+          <h4>Project State</h4>
+          <fieldset>
+            <label htmlFor="project-state-active">
+              <input
+                id="project-state-active"
+                type="radio"
+                value=""
+                checked={this.state.project.state === ''}
+                onChange={this.handleProjectStateChange}
+              />
+              Active
+            </label>
+            <label htmlFor="project-state-paused">
+              <input
+                id="project-state-paused"
+                type="radio"
+                value="paused"
+                checked={this.state.project.state === 'paused'}
+                onChange={this.handleProjectStateChange}
+              />
+              Paused
+            </label>
+            <label htmlFor="project-state-finished">
+              <input
+                id="project-state-finished"
+                type="radio"
+                value="finished"
+                checked={this.state.project.state === 'finished'}
+                onChange={this.handleProjectStateChange}
+              />
+              Finished
+            </label>
+          </fieldset>
+        </div>
+
         <div className="project-status__section">
           <h4>Information</h4>
           <ul>

--- a/app/pages/admin/project-status.jsx
+++ b/app/pages/admin/project-status.jsx
@@ -202,7 +202,7 @@ class ProjectStatus extends Component {
                 name="project-state-buttons"
                 type="radio"
                 value=""
-                checked={this.state.project.state === 'live'}
+                checked={this.state.project.state === ''}
                 onChange={this.handleProjectStateChange}
               />
               Active

--- a/app/pages/admin/project-status.jsx
+++ b/app/pages/admin/project-status.jsx
@@ -202,7 +202,7 @@ class ProjectStatus extends Component {
                 name="project-state-buttons"
                 type="radio"
                 value=""
-                checked={this.state.project.state === ''}
+                checked={this.state.project.state === 'live'}
                 onChange={this.handleProjectStateChange}
               />
               Active

--- a/app/pages/admin/project-status.spec.js
+++ b/app/pages/admin/project-status.spec.js
@@ -90,7 +90,7 @@ describe('ProjectStatus', () => {
     });
 
     it('renders a no workflows found message when no workflow is in component state', () => {
-      const noWorkflowsMessage = wrapper.find('.project-status__section').at(1).children().find('div');
+      const noWorkflowsMessage = wrapper.find('.project-status__section').at(2).children().find('div');
       assert.equal(noWorkflowsMessage.text(), 'No workflows found');
     });
   });

--- a/css/admin-page.styl
+++ b/css/admin-page.styl
@@ -15,3 +15,15 @@
     &__org-project-list-item
       list-style-type: disc
       margin-left: 1.5em
+
+    &__section--state
+      fieldset
+        border: 0
+        margin: 0
+        padding: 0
+
+      input
+        margin-right: 0.5em
+
+      label
+        margin-right: 1em


### PR DESCRIPTION
Staging branch URL: https://project-status-admin.pfe-preview.zooniverse.org/

Fixes @mrniaboc and @camallen eyeballing me as soon as I entered the office this morning.

Adds some radio buttons to the project admin page so an admin can set a project's state to either live (`''`), paused (`'paused'`) or finished (`'finished'`)

I found some other states on projects on the staging server, e.g. `'live'` and `'development'`. Should these be supported as well @camallen?

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
