### PR TITLE
[WIP] Use user passed as a prop consistently

### DIFF
--- a/app/pages/project/home/home-workflow-buttons.jsx
+++ b/app/pages/project/home/home-workflow-buttons.jsx
@@ -14,9 +14,6 @@ counterpart.registerTranslations('en', {
 export default class ProjectHomeWorkflowButtons extends React.Component {
   constructor(props) {
     super(props);
-    this.state = {
-      showWorkflows: false
-    };
 
     this.shouldWorkflowBeDisabled = this.shouldWorkflowBeDisabled.bind(this);
     this.renderRedirectLink = this.renderRedirectLink.bind(this);
@@ -24,14 +21,8 @@ export default class ProjectHomeWorkflowButtons extends React.Component {
     this.toggleWorkflows = this.toggleWorkflows.bind(this);
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.showWorkflowButtons === true && !this.state.showWorkflows) {
-      this.setState({ showWorkflows: true });
-    }
-  }
-
   shouldWorkflowBeDisabled(workflow) {
-    if (this.context.user && workflow.configuration.level && this.props.preferences && this.props.preferences.settings) {
+    if (this.props.user && workflow.configuration.level && this.props.preferences && this.props.preferences.settings) {
       const currentWorkflowAtLevel = this.props.activeWorkflows.filter((activeWorkflow) => {
         return (activeWorkflow.id === this.props.preferences.settings.workflow_id) ? activeWorkflow : null;
       });
@@ -81,7 +72,7 @@ export default class ProjectHomeWorkflowButtons extends React.Component {
   }
 
   render() {
-    const paddingBottom = this.state.showWorkflows ? { paddingBottom: '3em' } : {};
+    const paddingBottom = this.props.showWorkflowButtons ? { paddingBottom: '3em' } : {};
 
     let getStarted = (
       <Link
@@ -117,18 +108,13 @@ export default class ProjectHomeWorkflowButtons extends React.Component {
           {getStarted}
         </div>
 
-        {this.state.showWorkflows && (
+        {this.props.showWorkflowButtons && (
           this.renderWorkflowButtons()
         )}
       </div>
     );
   }
 }
-
-ProjectHomeWorkflowButtons.contextTypes = {
-  geordi: React.PropTypes.object,
-  user: React.PropTypes.object
-};
 
 ProjectHomeWorkflowButtons.defaultProps = {
   activeWorkflows: [],
@@ -137,6 +123,7 @@ ProjectHomeWorkflowButtons.defaultProps = {
   project: {},
   showWorkflowButtons: false,
   splits: {},
+  user: null,
   workflowAssignment: false
 };
 
@@ -154,5 +141,6 @@ ProjectHomeWorkflowButtons.propTypes = {
   }).isRequired,
   showWorkflowButtons: React.PropTypes.bool.isRequired,
   splits: React.PropTypes.object,
+  user: React.PropTypes.object,
   workflowAssignment: React.PropTypes.bool
 };

--- a/app/pages/project/home/home-workflow-buttons.spec.js
+++ b/app/pages/project/home/home-workflow-buttons.spec.js
@@ -37,8 +37,14 @@ describe('ProjectHomeWorkflowButtons', function() {
   describe('if workflow assignment is true', function() {
     beforeEach(function () {
       wrapper = mount(
-        <ProjectHomeWorkflowButtons activeWorkflows={testWorkflows} preferences={testUserPreferences} showWorkflowButtons={true} workflowAssignment={true} splits={null} />,
-        { context: { user: { id: 1 } } }
+        <ProjectHomeWorkflowButtons
+          activeWorkflows={testWorkflows}
+          preferences={testUserPreferences}
+          showWorkflowButtons={true}
+          workflowAssignment={true}
+          splits={null}
+          user={{ user: { id: 1 }}}
+        />,
       );
       wrapper.setState({ showWorkflows: true });
     });

--- a/app/pages/project/home/index.jsx
+++ b/app/pages/project/home/index.jsx
@@ -20,14 +20,14 @@ export default class ProjectHomeContainer extends React.Component {
   }
 
   componentDidMount() {
-    this.showWorkflowButtons(this.props, this.context);
+    this.showWorkflowButtons(this.props);
     this.fetchResearcherAvatar(this.props);
     this.fetchTalkSubjects(this.props);
   }
 
-  componentWillReceiveProps(nextProps, nextContext) {
-    if (this.context.user !== nextContext.user) {
-      this.showWorkflowButtons(nextProps, nextContext);
+  componentWillReceiveProps(nextProps) {
+    if (this.props.user !== nextProps.user) {
+      this.showWorkflowButtons(nextProps);
     }
 
     if (this.props.project !== nextProps.project) {
@@ -78,11 +78,11 @@ export default class ProjectHomeContainer extends React.Component {
     }
   }
 
-  showWorkflowButtons(props, context) {
+  showWorkflowButtons(props) {
     const workflowAssignment = this.props.project.experimental_tools.includes('workflow assignment');
 
     if ((props.project.configuration && props.project.configuration.user_chooses_workflow && !workflowAssignment) ||
-      (workflowAssignment && context.user)) {
+      (workflowAssignment && props.user)) {
       this.setState({ showWorkflowButtons: true }, this.fetchAllWorkflows.bind(this, this.props, { active: true, fields: 'active,completeness,configuration,display_name' }));
     } else {
       this.setState({ showWorkflowButtons: false });
@@ -112,11 +112,6 @@ export default class ProjectHomeContainer extends React.Component {
     );
   }
 }
-
-ProjectHomeContainer.contextTypes = {
-  geordi: React.PropTypes.object,
-  user: React.PropTypes.object
-};
 
 ProjectHomeContainer.defaultProps = {
   background: {
@@ -179,5 +174,5 @@ ProjectHomeContainer.propTypes = {
   }),
   user: React.PropTypes.shape({
     id: React.PropTypes.string
-  }).isRequired
+  })
 };

--- a/app/pages/project/home/project-home.jsx
+++ b/app/pages/project/home/project-home.jsx
@@ -54,6 +54,7 @@ const ProjectHomePage = (props) => {
           showWorkflowButtons={props.showWorkflowButtons}
           workflowAssignment={props.project.experimental_tools.includes('workflow assignment')}
           splits={props.splits}
+          user={props.user}
         />
       </div>
 


### PR DESCRIPTION
Staging branch URL: https://use-user-prop.pfe-preview.zooniverse.org/

Fixes a prop type warning and a bug found while reviewing another PR

I refactored a couple of project home components to consistently use the user prop instead of using a mix of the user passed as a prop and passed around in context. I also fixed a Gravity Spy related bug. I found that if you are on the Gravity Spy project home page and you sign out, that the workflow buttons were not only still available, but all the buttons were enabled. What should have happened is that the buttons should be hidden, so this regression may have been introduced during a coffeescript -> ES6 conversion or other refactoring at some point.

How to test:
Camera Catalog is an example of a project that does not use workflow promotion and allows users to choose their workflow. The buttons should be available regardless of the presence of a signed in user: https://use-user-prop.pfe-preview.zooniverse.org/projects/panthera-research/camera-catalogue?env=production 

Gravity Spy uses workflow promotion. When a user is signed in, the buttons should be visible and only the workflows the user has access to are enabled. When there isn't a user, the buttons should not be rendered: https://use-user-prop.pfe-preview.zooniverse.org/projects/zooniverse/gravity-spy?env=production

And any other projects that do not use workflow promotion and do not have the "Allow user choose workflow" setting set should not have the buttons visible.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
