### PR TITLE
Project workflow buttons refactor

### DIFF
--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -61,7 +61,8 @@ export default {
       },
       joinIn: 'Join in',
       learnMore: 'Learn more',
-      getStarted: 'Get started'
+      getStarted: 'Get started',
+      workflowAssignment: 'You\'ve unlocked level %(workflowDisplayName)s'
     }
   },
   organization: {

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -59,7 +59,9 @@ export default {
         one: '<strong>1</strong> person is talking about <strong>%(title)s</strong> right now.',
         other: '<strong>%(count)s</strong> people are talking about <strong>%(title)s</strong> right now.'
       },
-      joinIn: 'Join in'
+      joinIn: 'Join in',
+      learnMore: 'Learn more',
+      getStarted: 'Get started'
     }
   },
   organization: {

--- a/app/pages/project/home/home-workflow-button.jsx
+++ b/app/pages/project/home/home-workflow-button.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router';
 import classnames from 'classnames';
-
+import Translate from 'react-translate-component';
 
 export default class ProjectHomeWorkflowButton extends React.Component {
   constructor(props) {
@@ -22,9 +22,8 @@ export default class ProjectHomeWorkflowButton extends React.Component {
     // To disable the anchor tag, use class to set pointer-events: none style.
     // Except IE, which supports a disabled attribute instead.
     const linkClasses = classnames({
-      'call-to-action': true,
-      'standard-button': true,
-      'call-to-action-button--disabled': this.props.disabled
+      'project-home-page__button': true,
+      'project-home-page__button--disabled': this.props.disabled
     });
 
     if (this.props.disabled) {
@@ -47,7 +46,9 @@ export default class ProjectHomeWorkflowButton extends React.Component {
         className={linkClasses}
         onClick={this.handleWorkflowSelection}
       >
-        {(this.props.workflowAssignment && !this.props.disabled) ? `You've unlocked level ${this.props.workflow.display_name}` : this.props.workflow.display_name}
+        {(this.props.workflowAssignment && !this.props.disabled) ?
+          <Translate content="project.home.workflowAssignment" with={{ workflowDisplayName: this.props.workflow.display_name }} /> :
+          this.props.workflow.display_name}
       </Link>
     );
   }

--- a/app/pages/project/home/home-workflow-button.spec.js
+++ b/app/pages/project/home/home-workflow-button.spec.js
@@ -2,7 +2,7 @@ import React from 'react';
 import assert from 'assert';
 import { shallow } from 'enzyme';
 import sinon from 'sinon';
-import ProjectHomeWorkflowButton from 'home-workflow-button';
+import ProjectHomeWorkflowButton from './home-workflow-button';
 
 const testWorkflowWithLevel = {
   id: '2342',
@@ -22,9 +22,11 @@ const testProject = {
 
 describe('ProjectHomeWorkflowButton', function() {
   let wrapper;
+  let handleWorkflowSelectionSpy;
+  let onChangePreferencesSpy;
   before(function() {
-    const handleWorkflowSelectionSpy = sinon.spy(ProjectHomeWorkflowButton.prototype, handleWorkflowSelection);
-    const onChangePreferencesSpy = sinon.spy();
+    handleWorkflowSelectionSpy = sinon.spy(ProjectHomeWorkflowButton.prototype, 'handleWorkflowSelection');
+    onChangePreferencesSpy = sinon.spy();
     wrapper = shallow(
       <ProjectHomeWorkflowButton
         disabled={false}
@@ -34,5 +36,76 @@ describe('ProjectHomeWorkflowButton', function() {
         workflowAssignment={false}
       />
     );
+  });
+
+  it('renders without crashing', function() {});
+
+  it('renders a Link component', function() {
+    assert.equal(wrapper.find('Link').length, 1);
+    assert.equal(wrapper.find('span').length, 0);
+  });
+
+  it('renders the workflow display name as the Link text', function() {
+    assert.equal(wrapper.render().text(), testWorkflowWithoutLevel.display_name);
+  });
+
+  it('calls handleWorkflowSelection onClick', function() {
+    wrapper.find('Link').simulate('click');
+    assert.equal(handleWorkflowSelectionSpy.calledOnce, true);
+    assert.equal(onChangePreferencesSpy.calledOnce, true);
+  });
+
+  it('uses the project slug in the Link href', function() {
+    assert.equal(wrapper.find('Link').props().to.includes(testProject.slug), true);
+  });
+
+  describe('when props.disabled is true', function() {
+    before(function() {
+      wrapper = shallow(
+        <ProjectHomeWorkflowButton
+          disabled={true}
+          onChangePreferences={onChangePreferencesSpy}
+          project={testProject}
+          workflow={testWorkflowWithoutLevel}
+          workflowAssignment={false}
+        />
+      );
+    });
+
+    it('renders a span instead of a Link component', function() {
+      assert.equal(wrapper.find('span').length, 1);
+      assert.equal(wrapper.find('Link').length, 0);
+    });
+
+    it('applies the call-to-action-button--disabled class', function() {
+      assert.equal(wrapper.hasClass('project-home-page__button--disabled'), true);
+    });
+  });
+
+  describe('when props.workflowAssignment is true', function() {
+    before(function() {
+      wrapper = shallow(
+        <ProjectHomeWorkflowButton
+          disabled={false}
+          onChangePreferences={onChangePreferencesSpy}
+          project={testProject}
+          workflow={testWorkflowWithoutLevel}
+          workflowAssignment={true}
+        />
+      );
+    });
+
+    it('renders null when the workflow does not have a level set in its configuration', function() {
+      assert.equal(wrapper.isEmptyRender(), true);
+    });
+
+    it('renders a Link when the workflow has a level set in its configuration', function() {
+      wrapper.setProps({ workflow: testWorkflowWithLevel });
+      assert.equal(wrapper.find('Link').length, 1);
+    });
+
+    it('renders a Translate component for the Link text', function() {
+      assert.equal(wrapper.find('Translate').length, 1);
+    });
   });
 });

--- a/app/pages/project/home/home-workflow-button.spec.js
+++ b/app/pages/project/home/home-workflow-button.spec.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import assert from 'assert';
+import { shallow } from 'enzyme';
+import sinon from 'sinon';
+import ProjectHomeWorkflowButton from 'home-workflow-button';
+
+const testWorkflowWithLevel = {
+  id: '2342',
+  configuration: { level: '1' },
+  display_name: 'Beginner Workflow'
+};
+
+const testWorkflowWithoutLevel = {
+  id: '6757',
+  configuration: { },
+  display_name: 'Active, no level workflow'
+};
+
+const testProject = {
+  slug: 'zooniverse/project'
+};
+
+describe('ProjectHomeWorkflowButton', function() {
+  let wrapper;
+  before(function() {
+    const handleWorkflowSelectionSpy = sinon.spy(ProjectHomeWorkflowButton.prototype, handleWorkflowSelection);
+    const onChangePreferencesSpy = sinon.spy();
+    wrapper = shallow(
+      <ProjectHomeWorkflowButton
+        disabled={false}
+        onChangePreferences={onChangePreferencesSpy}
+        project={testProject}
+        workflow={testWorkflowWithoutLevel}
+        workflowAssignment={false}
+      />
+    );
+  });
+});

--- a/app/pages/project/home/home-workflow-buttons.jsx
+++ b/app/pages/project/home/home-workflow-buttons.jsx
@@ -1,15 +1,8 @@
 import React from 'react';
 import { Link } from 'react-router';
 import Translate from 'react-translate-component';
-import counterpart from 'counterpart';
 import ProjectHomeWorkflowButton from './home-workflow-button';
 import LoadingIndicator from '../../../components/loading-indicator';
-
-counterpart.registerTranslations('en', {
-  buttons: {
-
-  }
-});
 
 export default class ProjectHomeWorkflowButtons extends React.Component {
   constructor(props) {
@@ -32,11 +25,9 @@ export default class ProjectHomeWorkflowButtons extends React.Component {
   }
 
   render() {
-    const paddingBottom = this.props.showWorkflowButtons ? { paddingBottom: '3em' } : {};
-
     if (this.props.project && this.props.project.redirect) {
       return (
-        <a href={this.props.project.redirect} className="standard-button">
+        <a href={this.props.project.redirect} className="project-home-page__button">
           <strong>Visit the project</strong><br />
           <small>at {this.props.project.redirect}</small>
         </a>
@@ -44,29 +35,16 @@ export default class ProjectHomeWorkflowButtons extends React.Component {
     }
 
     return (
-      <div>
-        <div className="project-home-page__centering" style={paddingBottom}>
-          <Link to={`/projects/${this.props.project.slug}/about`} className="standard-button learn-more">
-            <Translate content="project.home.learnMore" />
-          </Link>
-          {!this.props.showWorkflowButtons &&
-            <Link
-              to={`/projects/${this.props.project.slug}/classify`}
-              className="standard-button get-started"
-            >
-              <Translate content="project.home.getStarted" />
-            </Link>}
-        </div>
-
+      <div className="project-home-workflow-buttons">
         {this.props.showWorkflowButtons && this.props.activeWorkflows.length > 0 && this.props.preferences &&
-          (<div className="project-home-page__container workflow-choice">
+          (<div className="project-home-page__container project-home-workflow-buttons__workflow-choice-container">
             <div className="project-home-page__content">
-              <h3>
-                <Translate content="project.home.getStarted" />
+              <h3 className="workflow-choice-container__call-to-action">
+                <Translate content="project.home.getStarted" />{' '}
                 <i className="fa fa-arrow-down" aria-hidden="true" />
               </h3>
               {this.props.project.workflow_description && (
-                <h4>{this.props.project.workflow_description}</h4>
+                <p className="workflow-choice-container__description">{this.props.project.workflow_description}</p>
               )}
               {this.props.activeWorkflows.map((workflow) => {
                 return (

--- a/app/pages/project/home/home-workflow-buttons.jsx
+++ b/app/pages/project/home/home-workflow-buttons.jsx
@@ -14,9 +14,6 @@ counterpart.registerTranslations('en', {
 export default class ProjectHomeWorkflowButtons extends React.Component {
   constructor(props) {
     super(props);
-    this.state = {
-      showWorkflows: false
-    };
 
     this.shouldWorkflowBeDisabled = this.shouldWorkflowBeDisabled.bind(this);
     this.renderRedirectLink = this.renderRedirectLink.bind(this);
@@ -24,14 +21,8 @@ export default class ProjectHomeWorkflowButtons extends React.Component {
     this.toggleWorkflows = this.toggleWorkflows.bind(this);
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.showWorkflowButtons === true && !this.state.showWorkflows) {
-      this.setState({ showWorkflows: true });
-    }
-  }
-
   shouldWorkflowBeDisabled(workflow) {
-    if (this.context.user && workflow.configuration.level && this.props.preferences && this.props.preferences.settings) {
+    if (this.props.user && workflow.configuration.level && this.props.preferences && this.props.preferences.settings) {
       const currentWorkflowAtLevel = this.props.activeWorkflows.filter((activeWorkflow) => {
         return (activeWorkflow.id === this.props.preferences.settings.workflow_id) ? activeWorkflow : null;
       });
@@ -81,7 +72,7 @@ export default class ProjectHomeWorkflowButtons extends React.Component {
   }
 
   render() {
-    const paddingBottom = this.state.showWorkflows ? { paddingBottom: '3em' } : {};
+    const paddingBottom = this.props.showWorkflowButtons ? { paddingBottom: '3em' } : {};
 
     let getStarted = (
       <Link
@@ -117,18 +108,13 @@ export default class ProjectHomeWorkflowButtons extends React.Component {
           {getStarted}
         </div>
 
-        {this.state.showWorkflows && (
+        {this.props.showWorkflowButtons && (
           this.renderWorkflowButtons()
         )}
       </div>
     );
   }
 }
-
-ProjectHomeWorkflowButtons.contextTypes = {
-  geordi: React.PropTypes.object,
-  user: React.PropTypes.object
-};
 
 ProjectHomeWorkflowButtons.defaultProps = {
   activeWorkflows: [],
@@ -137,6 +123,7 @@ ProjectHomeWorkflowButtons.defaultProps = {
   project: {},
   showWorkflowButtons: false,
   splits: {},
+  user: null,
   workflowAssignment: false
 };
 
@@ -154,5 +141,6 @@ ProjectHomeWorkflowButtons.propTypes = {
   }).isRequired,
   showWorkflowButtons: React.PropTypes.bool.isRequired,
   splits: React.PropTypes.object,
+  user: React.PropTypes.object,
   workflowAssignment: React.PropTypes.bool
 };

--- a/app/pages/project/home/home-workflow-buttons.jsx
+++ b/app/pages/project/home/home-workflow-buttons.jsx
@@ -3,11 +3,11 @@ import { Link } from 'react-router';
 import Translate from 'react-translate-component';
 import counterpart from 'counterpart';
 import ProjectHomeWorkflowButton from './home-workflow-button';
+import LoadingIndicator from '../../../components/loading-indicator';
 
 counterpart.registerTranslations('en', {
   buttons: {
-    learnMore: 'Learn more',
-    getStarted: 'Get started'
+
   }
 });
 
@@ -16,9 +16,6 @@ export default class ProjectHomeWorkflowButtons extends React.Component {
     super(props);
 
     this.shouldWorkflowBeDisabled = this.shouldWorkflowBeDisabled.bind(this);
-    this.renderRedirectLink = this.renderRedirectLink.bind(this);
-    this.renderWorkflowButtons = this.renderWorkflowButtons.bind(this);
-    this.toggleWorkflows = this.toggleWorkflows.bind(this);
   }
 
   shouldWorkflowBeDisabled(workflow) {
@@ -34,83 +31,59 @@ export default class ProjectHomeWorkflowButtons extends React.Component {
     return false;
   }
 
-  toggleWorkflows() {
-    this.setState({ showWorkflows: !this.state.showWorkflows });
-  }
-
-  renderRedirectLink() {
-    return (<a href={this.props.project.redirect} className="standard-button">
-      <strong>Visit the project</strong><br />
-      <small>at {this.props.project.redirect}</small>
-    </a>);
-  }
-
-  renderWorkflowButtons() {
-    if (this.props.activeWorkflows.length > 0 && this.props.preferences) {
-      return (
-        <div className="project-home-page__container workflow-choice">
-          <div className="project-home-page__content">
-            {this.props.project.workflow_description && (
-              <h4>{this.props.project.workflow_description}</h4>
-            )}
-            {this.props.activeWorkflows.map((workflow) => {
-              return (
-                <ProjectHomeWorkflowButton
-                  key={workflow.id}
-                  disabled={this.shouldWorkflowBeDisabled(workflow)}
-                  onChangePreferences={this.props.onChangePreferences}
-                  project={this.props.project}
-                  workflow={workflow}
-                  workflowAssignment={this.props.workflowAssignment}
-                />);
-            })
-          }</div>
-        </div>);
-    }
-
-    return (<span>Loading...</span>);
-  }
-
   render() {
     const paddingBottom = this.props.showWorkflowButtons ? { paddingBottom: '3em' } : {};
 
-    let getStarted = (
-      <Link
-        to={`/projects/${this.props.project.slug}/classify`}
-        className="standard-button get-started"
-      >
-        <Translate content="buttons.getStarted" />
-      </Link>
-    );
-
-    const learnMore = (
-      <Link to={`/projects/${this.props.project.slug}/about`} className="standard-button learn-more">
-        <Translate content="buttons.learnMore" />
-      </Link>
-    );
-
-    if (this.props.project.redirect) {
-      return this.renderRedirectLink();
-    }
-
-    if (this.props.showWorkflowButtons) {
-      getStarted = (
-        <button className="standard-button get-started" onClick={this.toggleWorkflows}>
-          <Translate content="buttons.getStarted" />
-        </button>
+    if (this.props.project && this.props.project.redirect) {
+      return (
+        <a href={this.props.project.redirect} className="standard-button">
+          <strong>Visit the project</strong><br />
+          <small>at {this.props.project.redirect}</small>
+        </a>
       );
     }
 
     return (
       <div>
-        <div id="projectLandingIntro" className="project-home-page__centering" style={paddingBottom}>
-          {learnMore}
-          {getStarted}
+        <div className="project-home-page__centering" style={paddingBottom}>
+          <Link to={`/projects/${this.props.project.slug}/about`} className="standard-button learn-more">
+            <Translate content="project.home.learnMore" />
+          </Link>
+          {!this.props.showWorkflowButtons &&
+            <Link
+              to={`/projects/${this.props.project.slug}/classify`}
+              className="standard-button get-started"
+            >
+              <Translate content="project.home.getStarted" />
+            </Link>}
         </div>
 
-        {this.props.showWorkflowButtons && (
-          this.renderWorkflowButtons()
-        )}
+        {this.props.showWorkflowButtons && this.props.activeWorkflows.length > 0 && this.props.preferences &&
+          (<div className="project-home-page__container workflow-choice">
+            <div className="project-home-page__content">
+              <h3>
+                <Translate content="project.home.getStarted" />
+                <i className="fa fa-arrow-down" aria-hidden="true" />
+              </h3>
+              {this.props.project.workflow_description && (
+                <h4>{this.props.project.workflow_description}</h4>
+              )}
+              {this.props.activeWorkflows.map((workflow) => {
+                return (
+                  <ProjectHomeWorkflowButton
+                    key={workflow.id}
+                    disabled={this.shouldWorkflowBeDisabled(workflow)}
+                    onChangePreferences={this.props.onChangePreferences}
+                    project={this.props.project}
+                    workflow={workflow}
+                    workflowAssignment={this.props.workflowAssignment}
+                  />);
+              })
+            }</div>
+          </div>)}
+
+        {this.props.showWorkflowButtons && this.props.activeWorkflows.length === 0 &&
+          <div className="project-home-page__container workflow-choice"><LoadingIndicator /></div>}
       </div>
     );
   }

--- a/app/pages/project/home/home-workflow-buttons.spec.js
+++ b/app/pages/project/home/home-workflow-buttons.spec.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import assert from 'assert';
+import { shallow } from 'enzyme';
 import ProjectHomeWorkflowButtons from './home-workflow-buttons';
-import { render, mount } from 'enzyme';
 
 
 const testWorkflows = [
@@ -16,10 +16,6 @@ const testWorkflows = [
   { id: '4321',
     configuration: { level: '3' },
     display_name: 'Advanced Workflow'
-  },
-  { id: '6757',
-    configuration: { },
-    display_name: 'Active, no level workflow'
   }
 ];
 
@@ -31,12 +27,12 @@ const testProject = {
   redirect: 'www.testproject.com'
 };
 
-describe('ProjectHomeWorkflowButtons', function() {
+describe.only('ProjectHomeWorkflowButtons', function() {
   let wrapper;
 
-  describe('if workflow assignment is true', function() {
-    beforeEach(function () {
-      wrapper = mount(
+  describe('if workflow assignment is true and props.showWorkflowButtons is true', function() {
+    before(function() {
+      wrapper = shallow(
         <ProjectHomeWorkflowButtons
           activeWorkflows={testWorkflows}
           preferences={testUserPreferences}
@@ -46,36 +42,31 @@ describe('ProjectHomeWorkflowButtons', function() {
           user={{ user: { id: 1 }}}
         />,
       );
-      wrapper.setState({ showWorkflows: true });
     });
 
     it('should render active workflow button options that have a level', function() {
-      assert.equal(wrapper.find('.standard-button').length, 5);
+      assert.equal(wrapper.find('ProjectHomeWorkflowButton').length, 3);
     });
 
-    it('should render spans for levels that user has not reached', function() {
-      assert.equal(wrapper.find('.standard-button').last().matchesElement(
-        <span>Advanced Workflow</span>
-      ), true);
+    it('should disable the button levels that user has not reached', function() {
+      assert.equal(wrapper.find('ProjectHomeWorkflowButton').first().props().disabled, false);
+      assert.equal(wrapper.find('ProjectHomeWorkflowButton').at(1).props().disabled, false);
+      assert.equal(wrapper.find('ProjectHomeWorkflowButton').last().props().disabled, true);
     });
   });
 
-  describe('if user chooses workflow assignment', function() {
-    beforeEach(function () {
-      wrapper = mount(
+  describe('if user chooses workflow is enabled for the project', function() {
+    it('should render workflow button options', function() {
+      wrapper = shallow(
         <ProjectHomeWorkflowButtons activeWorkflows={testWorkflows} showWorkflowButtons={true} />
       );
-      wrapper.setState({ showWorkflows: true });
-    });
-
-    it('should render workflow button options', function() {
-      assert.equal(wrapper.find('.standard-button').length, 6);
+      assert.equal(wrapper.find('ProjectHomeWorkflowButton').length, 3);
     });
   });
 
-  describe('if user cannot choose workflow assignment', function() {
-    beforeEach(function () {
-      wrapper = render(
+  describe('if user chooses workflow is disabled for the project', function() {
+    before(function() {
+      wrapper = shallow(
         <ProjectHomeWorkflowButtons activeWorkflows={testWorkflows} showWorkflowButtons={false} />
       );
     });
@@ -84,14 +75,18 @@ describe('ProjectHomeWorkflowButtons', function() {
       assert.equal(wrapper.find('.standard-button').length, 2);
     });
 
-    it('should have text "Get started!"', function() {
-      assert.equal(wrapper.find('.get-started').text(), 'Get started');
-    })
+    it('should use Translate for the button texts"', function() {
+      assert.equal(wrapper.find('Translate').length, 2);
+    });
+
+    it('should not render the workflow buttons', function() {
+      assert.equal(wrapper.find('ProjectHomeWorkflowButton').length, 0);
+    });
   });
 
   describe('if project has a redirect', function() {
-    beforeEach(function () {
-      wrapper = render(
+    before(function() {
+      wrapper = shallow(
         <ProjectHomeWorkflowButtons project={testProject} />
       );
     });

--- a/app/pages/project/home/home-workflow-buttons.spec.js
+++ b/app/pages/project/home/home-workflow-buttons.spec.js
@@ -27,7 +27,7 @@ const testProject = {
   redirect: 'www.testproject.com'
 };
 
-describe.only('ProjectHomeWorkflowButtons', function() {
+describe('ProjectHomeWorkflowButtons', function() {
   let wrapper;
 
   describe('if workflow assignment is true and props.showWorkflowButtons is true', function() {
@@ -69,14 +69,6 @@ describe.only('ProjectHomeWorkflowButtons', function() {
       wrapper = shallow(
         <ProjectHomeWorkflowButtons activeWorkflows={testWorkflows} showWorkflowButtons={false} />
       );
-    });
-
-    it('should render the learn more and get started buttons', function() {
-      assert.equal(wrapper.find('.standard-button').length, 2);
-    });
-
-    it('should use Translate for the button texts"', function() {
-      assert.equal(wrapper.find('Translate').length, 2);
     });
 
     it('should not render the workflow buttons', function() {

--- a/app/pages/project/home/home-workflow-buttons.spec.js
+++ b/app/pages/project/home/home-workflow-buttons.spec.js
@@ -37,8 +37,14 @@ describe('ProjectHomeWorkflowButtons', function() {
   describe('if workflow assignment is true', function() {
     beforeEach(function () {
       wrapper = mount(
-        <ProjectHomeWorkflowButtons activeWorkflows={testWorkflows} preferences={testUserPreferences} showWorkflowButtons={true} workflowAssignment={true} splits={null} />,
-        { context: { user: { id: 1 } } }
+        <ProjectHomeWorkflowButtons
+          activeWorkflows={testWorkflows}
+          preferences={testUserPreferences}
+          showWorkflowButtons={true}
+          workflowAssignment={true}
+          splits={null}
+          user={{ user: { id: 1 }}}
+        />,
       );
       wrapper.setState({ showWorkflows: true });
     });

--- a/app/pages/project/home/index.jsx
+++ b/app/pages/project/home/index.jsx
@@ -20,14 +20,14 @@ export default class ProjectHomeContainer extends React.Component {
   }
 
   componentDidMount() {
-    this.showWorkflowButtons(this.props, this.context);
+    this.showWorkflowButtons(this.props);
     this.fetchResearcherAvatar(this.props);
     this.fetchTalkSubjects(this.props);
   }
 
-  componentWillReceiveProps(nextProps, nextContext) {
-    if (this.context.user !== nextContext.user) {
-      this.showWorkflowButtons(nextProps, nextContext);
+  componentWillReceiveProps(nextProps) {
+    if (this.props.user !== nextProps.user) {
+      this.showWorkflowButtons(nextProps);
     }
 
     if (this.props.project !== nextProps.project) {
@@ -78,11 +78,11 @@ export default class ProjectHomeContainer extends React.Component {
     }
   }
 
-  showWorkflowButtons(props, context) {
+  showWorkflowButtons(props) {
     const workflowAssignment = this.props.project.experimental_tools.includes('workflow assignment');
 
     if ((props.project.configuration && props.project.configuration.user_chooses_workflow && !workflowAssignment) ||
-      (workflowAssignment && context.user)) {
+      (workflowAssignment && props.user)) {
       this.setState({ showWorkflowButtons: true }, this.fetchAllWorkflows.bind(this, this.props, { active: true, fields: 'active,completeness,configuration,display_name' }));
     } else {
       this.setState({ showWorkflowButtons: false });
@@ -112,11 +112,6 @@ export default class ProjectHomeContainer extends React.Component {
     );
   }
 }
-
-ProjectHomeContainer.contextTypes = {
-  geordi: React.PropTypes.object,
-  user: React.PropTypes.object
-};
 
 ProjectHomeContainer.defaultProps = {
   background: {

--- a/app/pages/project/home/project-home.jsx
+++ b/app/pages/project/home/project-home.jsx
@@ -54,6 +54,7 @@ const ProjectHomePage = (props) => {
           showWorkflowButtons={props.showWorkflowButtons}
           workflowAssignment={props.project.experimental_tools.includes('workflow assignment')}
           splits={props.splits}
+          user={props.user}
         />
       </div>
 

--- a/app/pages/project/home/project-home.jsx
+++ b/app/pages/project/home/project-home.jsx
@@ -24,7 +24,7 @@ const ProjectHomePage = (props) => {
         <ProjectNavbar {...props} />
 
         {props.projectIsComplete &&
-          (<div className="call-to-action-container">
+          (<div className="project-home-page__finished-banner-container">
             <FinishedBanner project={props.project} />
           </div>)}
 
@@ -43,6 +43,19 @@ const ProjectHomePage = (props) => {
 
         <div className={descriptionClass}>
           {props.translation.description}
+        </div>
+
+        <div className="project-home-page__call-to-action">
+          <Link to={`/projects/${props.project.slug}/about`} className="project-home-page__button call-to-action__button call-to-action__button--learn-more">
+            <Translate content="project.home.learnMore" />
+          </Link>
+          {!props.showWorkflowButtons &&
+            <Link
+              to={`/projects/${props.project.slug}/classify`}
+              className="project-home-page__button call-to-action__button call-to-action__button--get-started"
+            >
+              <Translate content="project.home.getStarted" />
+            </Link>}
         </div>
 
         <ProjectHomeWorkflowButtons
@@ -94,7 +107,7 @@ const ProjectHomePage = (props) => {
       <div className="project-home-page__container">
         {props.project.researcher_quote && (
           <div className="project-home-page__researcher-words">
-            <h4><Translate content="project.home.researcher" /></h4>
+            <h4 className="project-home-page__small-header"><Translate content="project.home.researcher" /></h4>
 
             <div>
               <img role="presentation" src={avatarSrc} />
@@ -103,7 +116,7 @@ const ProjectHomePage = (props) => {
           </div>)}
 
         <div className="project-home-page__about-text">
-          <h4>
+          <h4 className="project-home-page__small-header">
             <Translate
               content="project.home.about"
               with={{
@@ -134,7 +147,8 @@ ProjectHomePage.defaultProps = {
   projectIsComplete: false,
   showWorkflowButtons: false,
   splits: {},
-  talkSubjects: []
+  talkSubjects: [],
+  user: null
 };
 
 ProjectHomePage.propTypes = {
@@ -155,7 +169,8 @@ ProjectHomePage.propTypes = {
     experimental_tools: React.PropTypes.arrayOf(React.PropTypes.string),
     id: React.PropTypes.string,
     introduction: React.PropTypes.string,
-    researcher_quote: React.PropTypes.string
+    researcher_quote: React.PropTypes.string,
+    slug: React.PropTypes.string
   }).isRequired,
   projectIsComplete: React.PropTypes.bool.isRequired,
   researcherAvatar: React.PropTypes.string,
@@ -168,7 +183,8 @@ ProjectHomePage.propTypes = {
     introduction: React.PropTypes.string,
     researcher_quote: React.PropTypes.string,
     title: React.PropTypes.string
-  }).isRequired
+  }).isRequired,
+  user: React.PropTypes.object
 };
 
 export default ProjectHomePage;

--- a/app/pages/project/home/talk-status.jsx
+++ b/app/pages/project/home/talk-status.jsx
@@ -38,7 +38,7 @@ export default class TalkStatus extends React.Component {
           unsafe={true}
         />
         <div>
-          <Link to={`/projects/${this.props.project.slug}/talk`} className="join-in standard-button">
+          <Link to={`/projects/${this.props.project.slug}/talk`} className="join-in project-home-page__button">
             <Translate content="project.home.joinIn" />
           </Link>
         </div>

--- a/app/pages/project/index.cjsx
+++ b/app/pages/project/index.cjsx
@@ -114,7 +114,10 @@ ProjectPageController = React.createClass
 
         if project?
           # Use apiClient with cached resources from include to get out of cache
-          awaitBackground = apiClient.type('backgrounds').get(project.links.background.id).catch((error) => [])
+          awaitBackground = apiClient.type('backgrounds').get(project.links.background.id)
+          .catch((error) =>
+            if error.status is 404 then { src: '' } else console.error(error)
+          )
 
           if project.links?.organization?
             awaitOrganization = project.get('organization', { listed: true })

--- a/css/project-page.styl
+++ b/css/project-page.styl
@@ -119,23 +119,28 @@
   flex: 1 0 auto
   justify-content: center
 
-  button, a.standard-button
+  &__button, a.project-home-page__button
     background: white
     border: 2px solid #00979d
     border-radius: .5em
     color: #00979d
+    display: inline-block
+    font-weight: 700
+    line-height: 1.7em
     margin-right: 1.5em
+    margin-top: 10px
     padding: 0.8em 1.4vw
+    text-decoration: none
 
-    &:hover
+    &:hover, &:focus
       background: #00979d
       border: 2px solid #00979d
       color: white
 
-  h4
+  &__small-header
     text-transform: uppercase
 
-  .call-to-action-container
+  &__finished-banner-container
     align-items: center
     display flex
     flex: 1 0 auto
@@ -163,23 +168,25 @@
     display: flex
     flex-flow: row wrap
 
-  &__centering
+  &__call-to-action
     text-align: center
     padding: 5vh 10vw 15vh 10vw
-
-    .learn-more
-      background: transparent
+    
+    .call-to-action__button
       border: 2px solid white
-      color: white
 
-      &:hover
-        background-color: white
+      &--learn-more
+        background: transparent
+        color: white
+
+        &:hover
+          background-color: white
+          border: 2px solid white
+          color: #00979d
+
+      &--get-started
         border: 2px solid white
-        color: #00979d
-
-    .get-started
-      border: 2px solid white
-      outline: none
+        outline: none
 
   &__organization
     color: white
@@ -210,16 +217,26 @@
     color: #0f7481
     padding: 5vh 10vw
 
-  .call-to-action-button--disabled
-    background: white
-    border: 2px solid #00979d
-    border-radius: .5em
-    color: #00979d
-    cursor: not-allowed
-    margin-right: 1.5em
-    padding: 0.8em 1.4vw
-    pointer-events: none
-    opacity: 0.4
+  .project-home-workflow-buttons
+    &__workflow-choice-container
+      background-color: white
+      box-shadow: 0 3px 3px 0px rgb(239,242,245)
+      position: relative
+      
+      .workflow-choice-container__call-to-action
+        display: block
+
+    .project-home-page__button, a.project-home-page__button
+      &--disabled
+        background: white
+        border: 2px solid #00979d
+        border-radius: .5em
+        color: #00979d
+        cursor: not-allowed
+        margin-right: 1.5em
+        padding: 0.8em 1.4vw
+        pointer-events: none
+        opacity: 0.4
 
   &__researcher-words
     background-color: white
@@ -343,32 +360,6 @@
     border-bottom: 12px solid transparent
     border-right: 25px solid white
     border-top: 12px solid transparent
-
-  .workflow-choice
-    background-color: white
-    box-shadow: 0 3px 3px 0px rgb(239,242,245)
-    position: relative
-    z-index: 1
-
-    h4
-      margin-bottom: 1em
-      text-transform: none
-
-  .workflow-choice:before
-    position: absolute
-    left: 55%
-    bottom: 100%
-    width: 0
-    height: 0
-    content: " "
-    border-bottom: 20px solid white
-    border-left: 10px solid transparent
-    border-right: 10px solid transparent
-
-  .standard-button
-    margin-top: 10px
-    font-weight: 700
-    line-height: 1.7em
 
   .markdown
     line-height: 1.4em


### PR DESCRIPTION
Fixes a Gravity Spy bug found while reviewing another PR. When on the Gravity Spy home page, you should see the workflow buttons, but if you click to log out, the buttons aren't correctly hidden.

I took a pass at refactoring to fix this bug, make sure the user prop is used consistently over context, setup translations, added some new tests, refactored some of the CSS classes to be more BEM-like, and also consulted with @beckyrother to get rid of the inconsistent behavior of Get Started button styled link. 

Can be manually tested by going to the staging URL for Gravity Spy:
https://project-workflow-buttons-refactor.pfe-preview.zooniverse.org/projects/zooniverse/gravity-spy?env=production @beckyrother is the Get Started header above the workflow buttons ok?

If you're signed in, you should see the workflow buttons with any levels you don't have access to yet disabled.

If you sign out, the workflow selection buttons are hidden and the Get Started button should be available.

For other projects:

When the project lets the user pick their workflow, you should see the workflow buttons and the Get Started button is hidden: https://project-workflow-buttons-refactor.pfe-preview.zooniverse.org/projects/panthera-research/camera-catalogue?env=production

When the project uses a default workflow or random workflow selection (doesn't let the user choose), the Get Started button links them to the classify page: https://project-workflow-buttons-refactor.pfe-preview.zooniverse.org/projects/ianc2/exoplanet-explorers?env=production

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
