### PR TITLE
add organization researcher quote section

### DIFF
--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -43,23 +43,24 @@ export default {
     }
   },
   organization: {
-    loading: 'Loading organization',
     error: 'There was an error retrieving organization',
-    notFound: 'organization not found.',
-    notPermission: 'If you\'re sure the URL is correct, you might not have permission to view this organization.',
-    pleaseWait: 'Please wait...',
     home: {
+      introduction: 'Introduction',
+      links: 'Links',
       projects: {
-        loading: 'Loading organization projects...',
         error: 'There was an error loading organization projects.',
+        loading: 'Loading organization projects...',
         none: 'There are no projects associated with this organization.'
       },
-      viewToggle: 'View As Volunteer',
-      introduction: 'Introduction',
-      readMore: 'Read More',
       readLess: 'Read Less',
-      links: 'Links'
+      readMore: 'Read More',
+      researcher: 'Words from a researcher',
+      viewToggle: 'View As Volunteer'
     },
+    loading: 'Loading organization',
+    notFound: 'organization not found.',
+    notPermission: 'If you\'re sure the URL is correct, you might not have permission to view this organization.',
+    pleaseWait: 'Please wait...'
   },
   tasks: {
     less: 'Less',

--- a/app/pages/organizations/organization-container.jsx
+++ b/app/pages/organizations/organization-container.jsx
@@ -21,7 +21,8 @@ class OrganizationContainer extends React.Component {
       organizationRoles: [],
       organizationPages: [],
       organizationProjects: [],
-      projectAvatars: []
+      projectAvatars: [],
+      quoteObject: {}
     };
 
     this.toggleCollaboratorView = this.toggleCollaboratorView.bind(this);
@@ -80,6 +81,40 @@ class OrganizationContainer extends React.Component {
     this.context.router.push(newLocation);
   }
 
+  fetchResearcherQuote() {
+    const quotableProjects = this.state.organizationProjects
+      .filter(project => project.researcher_quote);
+    const project = quotableProjects[Math.floor(Math.random() * quotableProjects.length)];
+    if (project.configuration && project.configuration.researcherID) {
+      if (project.configuration.researcherID === project.display_name) {
+        const projectAvatar = this.state.projectAvatars.find(avatar => avatar.links.linked.id === project.id);
+        if (projectAvatar && projectAvatar.src) {
+          this.setState({ quoteObject: {
+            display_name: project.display_name,
+            quote: project.researcher_quote,
+            researcherAvatar: projectAvatar.src,
+            slug: project.slug
+          }});
+        }
+      } else {
+        apiClient.type('users').get(project.configuration.researcherID)
+          .then((researcher) => {
+            researcher.get('avatar').then(([avatar]) => {
+              if (avatar.src) {
+                this.setState({ quoteObject: {
+                  display_name: project.display_name,
+                  quote: project.researcher_quote,
+                  researcherAvatar: avatar.src,
+                  slug: project.slug
+                }});
+              }
+            });
+          })
+          .catch(error => console.error(error)); // eslint-disable-line no-console
+      }
+    }
+  }
+
   fetchProjects(organization, collaboratorView, locationQuery = this.props.location.query) {
     this.setState({ errorFetchingProjects: null, fetchingProjects: true, fetchingProjectAvatars: true });
     const query = { launch_approved: true, include: 'avatar' };
@@ -105,6 +140,7 @@ class OrganizationContainer extends React.Component {
         Promise.all(avatarRequests)
           .then((projectAvatars) => {
             this.setState({ fetchingProjectAvatars: false, projectAvatars });
+            this.fetchResearcherQuote();
           })
           .catch((error) => {
             console.error('error loading project avatars', error); // eslint-disable-line no-console
@@ -189,6 +225,7 @@ class OrganizationContainer extends React.Component {
           organizationPages={this.state.organizationPages}
           organizationProjects={this.state.organizationProjects}
           projectAvatars={this.state.projectAvatars}
+          quoteObject={this.state.quoteObject}
           toggleCollaboratorView={this.toggleCollaboratorView}
         />);
     } else if (this.state.fetchingOrganization) {

--- a/app/pages/organizations/organization-container.jsx
+++ b/app/pages/organizations/organization-container.jsx
@@ -90,7 +90,7 @@ class OrganizationContainer extends React.Component {
         const projectAvatar = this.state.projectAvatars.find(avatar => avatar.links.linked.id === project.id);
         if (projectAvatar && projectAvatar.src) {
           this.setState({ quoteObject: {
-            display_name: project.display_name,
+            displayName: project.display_name,
             quote: project.researcher_quote,
             researcherAvatar: projectAvatar.src,
             slug: project.slug
@@ -102,7 +102,7 @@ class OrganizationContainer extends React.Component {
             researcher.get('avatar').then(([avatar]) => {
               if (avatar.src) {
                 this.setState({ quoteObject: {
-                  display_name: project.display_name,
+                  displayName: project.display_name,
                   quote: project.researcher_quote,
                   researcherAvatar: avatar.src,
                   slug: project.slug

--- a/app/pages/organizations/organization-page.jsx
+++ b/app/pages/organizations/organization-page.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import classnames from 'classnames';
 import { Markdown } from 'markdownz';
+import { Link } from 'react-router';
 import Translate from 'react-translate-component';
 import Thumbnail from '../../components/thumbnail';
 import SocialIcons from '../../lib/social-icons';
@@ -89,7 +90,13 @@ class OrganizationPage extends React.Component {
   }
 
   render() {
+    const avatarSrc = this.props.quoteObject.researcherAvatar || '/assets/simple-avatar.png';
+
     const [aboutPage] = this.props.organizationPages.filter(page => page.url_key === 'about');
+    const aboutContentClass = classnames(
+      'organization-details__about-content',
+      { 'organization-details__about-content--expanded': this.state.readMore });
+
     let rearrangedLinks = [];
     if (this.props.organization.urls) {
       rearrangedLinks = this.props.organization.urls.sort((a, b) => {
@@ -99,10 +106,6 @@ class OrganizationPage extends React.Component {
         return 0;
       });
     }
-
-    const aboutContentClass = classnames(
-      'organization-details__about-content',
-      { 'organization-details__about-content--expanded': this.state.readMore });
 
     return (
       <div className="organization-page">
@@ -162,21 +165,28 @@ class OrganizationPage extends React.Component {
 
         <section className="organization-details">
           <div className="organization-page__container">
-            <div className="organization-researcher-words">
-              <Translate className="organization-details__heading" content="project.home.researcher" />
-              <div className="organization-researcher-words__container">
-                <img
-                  className="organization-researcher-words__avatar"
-                  role="presentation"
-                  src="/assets/simple-avatar.png"
-                />
-                <span
-                  className="organization-researcher-words__quote"
+            {this.props.quoteObject && this.props.quoteObject.quote &&
+              <div className="organization-researcher-words">
+                <Translate className="organization-details__heading" content="organization.home.researcher" />
+                <div className="organization-researcher-words__container">
+                  <img
+                    className="organization-researcher-words__avatar"
+                    role="presentation"
+                    src={avatarSrc}
+                  />
+                  <span
+                    className="organization-researcher-words__quote"
+                  >
+                    &quot;{this.props.quoteObject.quote}&quot;
+                  </span>
+                </div>
+                <Link
+                  className="organization-researcher-words__attribution"
+                  to={this.props.quoteObject.slug}
                 >
-                  &quot;{'Sample quote from researcher with call to action!'}&quot;
-                </span>
-              </div>
-            </div>
+                  - {this.props.quoteObject.display_name}
+                </Link>
+              </div>}
             <div className="organization-details__content">
               <h4 className="organization-details__heading">
                 {this.props.organization.display_name} <Translate content="organization.home.introduction" />
@@ -281,6 +291,7 @@ OrganizationPage.defaultProps = {
   organizationPages: [],
   organizationProjects: [],
   projectAvatars: [],
+  quoteObject: {},
   toggleCollaboratorView: () => {}
 };
 
@@ -333,6 +344,12 @@ OrganizationPage.propTypes = {
       src: React.PropTypes.string
     })
   ),
+  quoteObject: React.PropTypes.shape({
+    display_name: React.PropTypes.string,
+    researcherAvatar: React.PropTypes.string,
+    quote: React.PropTypes.string,
+    slug: React.PropTypes.string
+  }),
   toggleCollaboratorView: React.PropTypes.func
 };
 

--- a/app/pages/organizations/organization-page.jsx
+++ b/app/pages/organizations/organization-page.jsx
@@ -244,32 +244,30 @@ class OrganizationPage extends React.Component {
                   </button>
                 </div>}
             </div>
-            <div className="organization-researcher-words">
+            <div className="organization-details__links">
               <h4 className="organization-details__heading"><Translate content="organization.home.links" /></h4>
-              <div className="organization-details__links">
-                {(rearrangedLinks.length > 0) && rearrangedLinks.map((link, i) => {
-                  let iconForLabel;
-                  let label;
-                  if (link.path) {
-                    iconForLabel = SocialIcons[link.site] || 'external-link';
-                    label = <span> - @{link.path}</span>;
-                  } else {
-                    iconForLabel = 'external-link';
-                    label = <span> - {link.label}</span>;
-                  }
-                  return (
-                    <a
-                      key={link.key || link.path}
-                      className="organization-details__link"
-                      href={`${link.url}`}
-                      target={`${this.props.organization.id}${link.url}`}
-                      rel="noopener noreferrer"
-                    >
-                      <i className={`fa fa-${iconForLabel} fa-fw fa-2x organization-details__icon`} />
-                      {label}
-                    </a>);
-                })}
-              </div>
+              {(rearrangedLinks.length > 0) && rearrangedLinks.map((link, i) => {
+                let iconForLabel;
+                let label;
+                if (link.path) {
+                  iconForLabel = SocialIcons[link.site] || 'external-link';
+                  label = <span> - @{link.path}</span>;
+                } else {
+                  iconForLabel = 'external-link';
+                  label = <span> - {link.label}</span>;
+                }
+                return (
+                  <a
+                    key={link.key || link.path}
+                    className="organization-details__link"
+                    href={`${link.url}`}
+                    target={`${this.props.organization.id}${link.url}`}
+                    rel="noopener noreferrer"
+                  >
+                    <i className={`fa fa-${iconForLabel} fa-fw fa-2x organization-details__icon`} />
+                    {label}
+                  </a>);
+              })}
             </div>
           </div>
         </section>

--- a/app/pages/organizations/organization-page.jsx
+++ b/app/pages/organizations/organization-page.jsx
@@ -184,7 +184,7 @@ class OrganizationPage extends React.Component {
                   className="organization-researcher-words__attribution"
                   to={this.props.quoteObject.slug}
                 >
-                  - {this.props.quoteObject.display_name}
+                  - {this.props.quoteObject.displayName}
                 </Link>
               </div>}
             <div className="organization-details__content">
@@ -343,7 +343,7 @@ OrganizationPage.propTypes = {
     })
   ),
   quoteObject: React.PropTypes.shape({
-    display_name: React.PropTypes.string,
+    displayName: React.PropTypes.string,
     researcherAvatar: React.PropTypes.string,
     quote: React.PropTypes.string,
     slug: React.PropTypes.string

--- a/app/pages/organizations/organization-page.spec.js
+++ b/app/pages/organizations/organization-page.spec.js
@@ -19,6 +19,13 @@ const organizationPages = [{
   url_key: 'about'
 }];
 
+const quoteObject = {
+  displayName: 'Project 2',
+  researcherAvatar: 'https://panoptes-uploads.zooniverse.org/staging/user_avatar/test.jpeg',
+  quote: 'Project 2 call to action!',
+  slug: 'owner/project-2'
+};
+
 describe('OrganizationPage', function () {
   it('should render without crashing', function () {
     shallow(<OrganizationPage organization={organization} />);
@@ -132,6 +139,18 @@ describe('OrganizationPage', function () {
     const wrapper = shallow(<OrganizationPage organization={noCategoriesOrg} />);
     const categories = wrapper.find('.organization-page__category-button');
     assert.equal(categories.length, 0);
+  });
+
+  it('should show a project researcher quote if quoteObject prop provided', function () {
+    const wrapper = shallow(<OrganizationPage organization={organization} quoteObject={quoteObject} />);
+    const quote = wrapper.find('.organization-researcher-words');
+    assert.equal(quote.length, 1);
+  });
+
+  it('should not show a project researcher quote if quoteObject prop not provided', function () {
+    const wrapper = shallow(<OrganizationPage organization={organization} />);
+    const quote = wrapper.find('.organization-researcher-words');
+    assert.equal(quote.length, 0);
   });
 
   describe('with pages about content', function () {

--- a/css/organization-page.styl
+++ b/css/organization-page.styl
@@ -173,3 +173,9 @@
     font-style: italic
     overflow: auto
     word-wrap: break-word
+
+  &__attribution
+    color: ZOONIVERSE_NAVY
+    font-size: 1.5em
+    margin: 2em auto
+    text-decoration: none

--- a/css/organization-page.styl
+++ b/css/organization-page.styl
@@ -126,8 +126,13 @@
       background: TEAL_LIGHT
 
   &__links
+    background-color: white
+    color: ZOONIVERSE_NAVY
     display: flex
+    flex: 2 0 auto
     flex-direction: column
+    padding: 3em 4vw
+    width: 250px
 
   &__link
     align-items: center
@@ -154,7 +159,6 @@
   flex: 2 0 auto
   flex-direction: column
   padding: 3em 4vw
-  position: relative
   width: 250px
 
   &__container
@@ -170,12 +174,12 @@
 
   &__quote
     font-size: 1.75em
-    font-style: italic
+    line-height: 1.2em
     overflow: auto
     word-wrap: break-word
 
   &__attribution
     color: ZOONIVERSE_NAVY
-    font-size: 1.5em
-    margin: 2em auto
+    font-size: 1em
+    margin: 1em auto
     text-decoration: none


### PR DESCRIPTION
Staging branch URLs:
- with projects with quotes: https://org-researcher-quote.pfe-preview.zooniverse.org/organizations/markb-panoptes/nfnorgtest
- without projects with quotes: https://org-researcher-quote.pfe-preview.zooniverse.org/organizations/markb-panoptes/mborgtest

Towards #4089.

Add researcher quote section to organization landing page. Randomly selects organization affiliated project with `.researcher_quote` attribute defined, or doesn't render section. Researcher quote displayed similarly to project landing page.

Open Items
- [x] add test(s)

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [x] Can you post a talk comment?

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
