### PR TITLE
Add translations for project page content

### DIFF
--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -19,6 +19,16 @@ export default {
   project: {
     loading: 'Loading project',
     disclaimer: 'This project has been built using the Zooniverse Project Builder but is not yet an official Zooniverse project. Queries and issues relating to this project directed at the Zooniverse Team may not receive any response.',
+    about: {
+      header: 'About',
+      nav: {
+        research: 'Research',
+        results: 'Results',
+        faq: 'FAQ',
+        education: 'Education',
+        team: 'The Team',
+      }
+    },
     nav: {
       about: 'About',
       classify: 'Classify',

--- a/app/locales/es.js
+++ b/app/locales/es.js
@@ -18,6 +18,16 @@ export default {
   project: {
     loading: 'Loading project',
     disclaimer: 'This project has been built using the Zooniverse Project Builder but is not yet an official Zooniverse project. Queries and issues relating to this project directed at the Zooniverse Team may not receive any response.',
+    about: {
+      header: 'About',
+      nav: {
+        research: 'Research',
+        results: 'Results',
+        faq: 'FAQ',
+        education: 'Education',
+        team: 'The Team',
+      }
+    },
     nav: {
       about: 'About',
       classify: 'Classify',

--- a/app/locales/it.js
+++ b/app/locales/it.js
@@ -19,6 +19,16 @@ export default {
   project: {
     disclaimer: "Questo progetto e' stato creato con il Project Builder di Zooniverse, ma non e' ancora un progetto ufficiale. Per questo motivo e' possibile che domande su questo progetto dirette al Team Zooniverse non ricevano una risposta.",
     loading: 'Caricamento progetto',
+    about: {
+      header: 'About',
+      nav: {
+        research: 'Research',
+        results: 'Results',
+        faq: 'FAQ',
+        education: 'Education',
+        team: 'The Team',
+      }
+    },
     nav: {
       about: 'A proposito',
       classify: 'Classifica',

--- a/app/locales/nl.js
+++ b/app/locales/nl.js
@@ -51,6 +51,16 @@ export default {
   project: {
     loading: 'Project wordt geladen',
     disclaimer: 'Dit project is gemaakt met de Zooniverse projectbouwer maar is not niet een officieel Zooniverseproject. Vragen en problemen met betrekking tot dit project die gestuurd worden aan het Zooniverseteam krijgen mogelijk geen reactie.',
+    about: {
+      header: 'About',
+      nav: {
+        research: 'Research',
+        results: 'Results',
+        faq: 'FAQ',
+        education: 'Education',
+        team: 'The Team',
+      }
+    },
     nav: {
       about: 'Over',
       classify: 'Classificeer',

--- a/app/pages/project/about/about-nav.jsx
+++ b/app/pages/project/about/about-nav.jsx
@@ -1,17 +1,6 @@
 import React, { PropTypes } from 'react';
 import { Link } from 'react-router';
 import Translate from 'react-translate-component';
-import counterpart from 'counterpart';
-
-counterpart.registerTranslations('en', {
-  nav: {
-    research: 'Research',
-    results: 'Results',
-    faq: 'FAQ',
-    education: 'Education',
-    team: 'The Team',
-  }
-});
 
 const AboutNav = ({ pages, projectPath }) => (
   <span>
@@ -20,7 +9,7 @@ const AboutNav = ({ pages, projectPath }) => (
         to={`${projectPath}/about/${page.slug}`} 
         activeClassName="active"
         className="about-tabs">
-        <Translate content={`nav.${page.slug}`} />
+        <Translate content={`project.about.nav.${page.slug}`} />
       </Link>
     )}
   </span>

--- a/app/pages/project/about/index.jsx
+++ b/app/pages/project/about/index.jsx
@@ -15,11 +15,6 @@ const SLUG_MAP = {
 class AboutProject extends Component {
   constructor(props) {
     super(props);
-    this.renderAbout = this.renderAbout.bind(this);
-    this.getPages = this.getPages.bind(this);
-    this.constructPagesData = this.constructPagesData.bind(this);
-    this.getTeam = this.getTeam.bind(this);
-    this.constructTeamData = this.constructTeamData.bind(this);
     this.state = {
       pages: [],
       team: [],
@@ -31,11 +26,11 @@ class AboutProject extends Component {
     this.getPages();
   }
 
-  constructPagesData(apiResponse) {
+  constructPagesData() {
     const availablePages = [];
 
     for (const url_key in SLUG_MAP) {
-      const matchingPage = apiResponse.find(page => page.url_key === url_key);
+      const matchingPage = this.props.pages.find(page => page.url_key === url_key);
       if (matchingPage && matchingPage.content && matchingPage.content !== '') {
         availablePages.push({
           slug: SLUG_MAP[url_key],
@@ -52,13 +47,10 @@ class AboutProject extends Component {
 
   getPages() {
     this.getTeam();
-    return this.props.project.get('pages')
-      .then(this.constructPagesData)
-      .then(availablePages => this.setState({
-        pages: availablePages,
-        loaded: true,
-      }))
-      .catch(error => console.error('Error retrieving project pages', error));
+    this.setState({
+      pages: this.constructPagesData(),
+      loaded: true
+    });
   }
 
   getTeam() {

--- a/app/pages/project/about/index.jsx
+++ b/app/pages/project/about/index.jsx
@@ -43,11 +43,11 @@ class AboutProject extends Component {
       const { pages, translations } = this.props;
       const matchingPage = pages.find(page => page.url_key === url_key);
       const pageTranslations = translations ? translations.strings.project_page : [];
-      const [matchingTranslation] = pageTranslations.filter(page => page.translated_id === parseInt(matchingPage.id));
+      const [matchingTranslation] = pageTranslations.filter(page => page.translated_id === parseInt(matchingPage.id, 10));
       const { content } = (matchingTranslation && matchingTranslation.strings) ?
         matchingTranslation.strings :
         matchingPage;
-      if (content && content !== '') {
+      if (content) {
         availablePages.push({
           slug: SLUG_MAP[url_key],
           title: matchingPage.title,

--- a/app/pages/project/about/index.jsx
+++ b/app/pages/project/about/index.jsx
@@ -96,7 +96,7 @@ class AboutProject extends Component {
     const { state: { pages, team }, props: { children, project } } = this;
     return (
       <div className="project-about-page">
-        <Helmet title={`${this.props.translation.display_name} » ${counterpart('about.header')}`} />
+        <Helmet title={`${this.props.translation.display_name} » ${counterpart('project.about.header')}`} />
         <AboutNav pages={pages} projectPath={`/projects/${project.slug}`} />
         {React.cloneElement(children, {project, pages, team})}
       </div>

--- a/app/pages/project/index.cjsx
+++ b/app/pages/project/index.cjsx
@@ -149,6 +149,7 @@ ProjectPageController = React.createClass
               @setState({ background, organization, owner, pages, projectAvatar, projectIsComplete, projectRoles, preferences })
               @getSelectedWorkflow(project, preferences)
               @loadFieldGuide(project.id)
+              this.props.actions.translations.loadTranslations('project_page', pages.map((page) => page.id), this.props.translations.locale)
             ).catch((error) => @setState({ error }); console.error(error); );
 
         else

--- a/app/redux/ducks/translations.js
+++ b/app/redux/ducks/translations.js
@@ -52,6 +52,13 @@ export function load(resource_type, translated_id, language) {
               [resource_type]: translation.strings
             }
           });
+        } else {
+          dispatch({
+            type: SET_STRINGS,
+            payload: {
+              [resource_type]: {}
+            }
+          });
         }
       })
       .catch(error => {

--- a/app/redux/ducks/translations.js
+++ b/app/redux/ducks/translations.js
@@ -16,7 +16,8 @@ const initialState = {
     project: {},
     workflow: {},
     tutorial: {},
-    minicourse: {}
+    minicourse: {},
+    project_page: []
   }
 };
 
@@ -49,6 +50,42 @@ export function load(resource_type, translated_id, language) {
             type: SET_STRINGS,
             payload: {
               [resource_type]: translation.strings
+            }
+          });
+        }
+      })
+      .catch(error => {
+        console.warn(
+          translated_type,
+          translated_id,
+          `(${language})`,
+          error.status,
+          'translation fetch error:',
+          error.message
+        );
+        dispatch({ type: ERROR, payload: error });
+      });
+  };
+}
+
+export function loadTranslations(translated_type, translated_id, language) {
+  counterpart.setLocale(language);
+  return (dispatch) => {
+    dispatch({
+      type: LOAD,
+      translated_type,
+      translated_id,
+      language
+    });
+    apiClient
+      .type('translations')
+      .get({ translated_type, translated_id, language })
+      .then((translations) => {
+        if (translations) {
+          dispatch({
+            type: SET_STRINGS,
+            payload: {
+              [translated_type]: translations
             }
           });
         }


### PR DESCRIPTION
Staging branch URL: https://translations-project-pages.pfe-preview.zooniverse.org/

Loads project page translations after pages have loaded. Connects the project about page container to the redux store and loads in translations, where available, for page content. Should fall back to using existing page content for projects that are not using translations.

Also fixes a small bug where project pages were being requested again from the API, rather than using the prop passed down from the project page container.

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
