### PR TITLE
Add field guide translations

### DIFF
--- a/app/pages/project/field-guide.cjsx
+++ b/app/pages/project/field-guide.cjsx
@@ -67,7 +67,8 @@ module.exports = React.createClass
     </div>
 
   render: ->
-    {icon, title, content, items} = @props
+    {icon, title, content} = @props
+    { items } = @props.translation
     implicitRootItem = {icon, title, content, items}
 
     if implicitRootItem.items?.length is 1

--- a/app/pages/project/index.cjsx
+++ b/app/pages/project/index.cjsx
@@ -307,7 +307,9 @@ ProjectPageController = React.createClass
 
   loadFieldGuide: (projectId) ->
     apiClient.type('field_guides').get(project_id: projectId).then ([guide]) =>
+      { actions, translations } = this.props;
       @setState {guide}
+      actions.translations.load('field_guide', guide.id, translations.locale)
       guide?.get('attached_images', page_size: 100)?.then (images) =>
         guideIcons = {}
         for image in images

--- a/app/pages/project/potential-field-guide.cjsx
+++ b/app/pages/project/potential-field-guide.cjsx
@@ -2,6 +2,7 @@ React = require 'react'
 apiClient = require 'panoptes-client/lib/api-client'
 Pullout = require 'react-pullout'
 FieldGuide = require './field-guide'
+Translations = require('../../classifier/translations').default
 
 module.exports = React.createClass
   displayName: 'PotentialFieldGuide'
@@ -16,6 +17,7 @@ module.exports = React.createClass
 
   contextTypes:
     geordi: React.PropTypes.object
+    store: React.PropTypes.object
 
   logClick: (type) ->
     @context?.geordi?.logEvent
@@ -35,7 +37,9 @@ module.exports = React.createClass
         <button type="button" className="field-guide-pullout-toggle" onClick={@toggleFieldGuide}>
           <strong>Field guide</strong>
         </button>
-        <FieldGuide items={@props.guide.items} icons={@props.guideIcons} onClickClose={@toggleFieldGuide} />
+        <Translations original={@props.guide} type="field_guide" store={@context.store}>
+          <FieldGuide items={@props.guide.items} icons={@props.guideIcons} onClickClose={@toggleFieldGuide} />
+        </Translations>
       </Pullout>
     else
       null

--- a/app/redux/ducks/translations.js
+++ b/app/redux/ducks/translations.js
@@ -17,6 +17,7 @@ const initialState = {
     workflow: {},
     tutorial: {},
     minicourse: {},
+    field_guide: {},
     project_page: []
   }
 };


### PR DESCRIPTION
Staging branch URL: https://translations-fieldguides.pfe-preview.zooniverse.org/

Connect up field guides to the translations API, using the classifier's Translations component.
Render field guide items from the translations prop.


# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
