### PR TITLE
edit org project query to beta_approved

### DIFF
--- a/app/pages/organizations/organization-container.jsx
+++ b/app/pages/organizations/organization-container.jsx
@@ -117,10 +117,10 @@ class OrganizationContainer extends React.Component {
 
   fetchProjects(organization, collaboratorView, locationQuery = this.props.location.query) {
     this.setState({ errorFetchingProjects: null, fetchingProjects: true, fetchingProjectAvatars: true });
-    const query = { launch_approved: true, include: 'avatar' };
+    const query = { beta_approved: true, include: 'avatar' };
 
     if (collaboratorView) {
-      delete query.launch_approved;
+      delete query.beta_approved;
     }
     if (locationQuery && locationQuery.category) {
       query.tags = locationQuery.category;


### PR DESCRIPTION
Staging branch URL: https://org-projects-in-beta.pfe-preview.zooniverse.org/organizations/markb-panoptes/nfnorgtest

**IMPORTANT** - see [Panoptes issue 2573](https://github.com/zooniverse/Panoptes/issues/2573) and PFE issue #3977 for additional details.

This PR changes the organization project query from `launch_approved` to `beta_approved`,  `: true`.

This PR will allow Snapshot Serengeti to beta test it's projects as well as organization. 
However, this change will likely need to be reverted before an organization is fully launched and featured on zooniverse.org/projects or equivalent, as I believe our intent is to only show `launch_approved` projects in a fully launched organization. 

Mentioning @trouille, @camallen.  

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
