### PR TITLE
Change a couple of headers in the email settings layout

### DIFF
--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -191,7 +191,9 @@ export default {
     general: {
       section: 'Zooniverse email preferences',
       updates: 'Get general Zooniverse email updates',
-      classify: 'Get email updates from the Projects you classify on',
+      classify: 'Subscribe to email updates when you first classify on a project',
+      note: 'Note: Unticking the box does not unsubscribe you from any of the projects',
+      manual: 'Choose a project from the list to receive updates on it',
       beta: 'Get beta project email updates and become a beta tester'
     },
     talk: {

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -192,7 +192,6 @@ export default {
       section: 'Zooniverse email preferences',
       updates: 'Get general Zooniverse email updates',
       classify: 'Subscribe to email updates when you first classify on a project',
-      note: 'Note: Unticking the box does not unsubscribe you from any of the projects',
       manual: 'Choose a project from the list to receive updates on it',
       beta: 'Get beta project email updates and become a beta tester'
     },

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -191,9 +191,9 @@ export default {
     general: {
       section: 'Zooniverse email preferences',
       updates: 'Get general Zooniverse email updates',
-      classify: 'Get updates on all projects you classify on',
-      note: 'Note: Unticking the box will unsubscribe you from all projects you\'ve classified on',
-      manual: 'Or manage projects individually',
+      classify: 'Get email updates when you first classify on a project',
+      note: 'Note: Unticking the box will not unsubscribe you from any of the projects',
+      manual: 'Manage projects individually',
       beta: 'Get beta project email updates and become a beta tester'
     },
     talk: {

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -191,8 +191,9 @@ export default {
     general: {
       section: 'Zooniverse email preferences',
       updates: 'Get general Zooniverse email updates',
-      classify: 'Subscribe to email updates when you first classify on a project',
-      manual: 'Choose a project from the list to receive updates on it',
+      classify: 'Get updates on all projects you classify on',
+      note: 'Note: Unticking the box will unsubscribe you from all projects you\'ve classified on',
+      manual: 'Or manage projects individually',
       beta: 'Get beta project email updates and become a beta tester'
     },
     talk: {

--- a/app/pages/settings/email.jsx
+++ b/app/pages/settings/email.jsx
@@ -274,18 +274,6 @@ class EmailSettingsPage extends React.Component {
             <label>
               <input
                 type="checkbox"
-                name="project_email_communication"
-                checked={this.props.user.project_email_communication}
-                onChange={handleInputChange.bind(this.props.user)}
-              />{' '}
-              <Translate content="emailSettings.general.classify" />
-            </label>
-          </AutoSave>
-          <br />
-          <AutoSave resource={this.props.user}>
-            <label>
-              <input
-                type="checkbox"
                 name="beta_email_communication"
                 checked={this.props.user.beta_email_communication}
                 onChange={handleInputChange.bind(this.props.user)}
@@ -321,15 +309,18 @@ class EmailSettingsPage extends React.Component {
             <Translate content="emailSettings.project.section" />
           </strong>
         </p>
+        <AutoSave resource={this.props.user}>
+          <label>
+            <input
+              type="checkbox"
+              name="project_email_communication"
+              checked={this.props.user.project_email_communication}
+              onChange={handleInputChange.bind(this.props.user)}
+            />{' '}
+            <Translate content="emailSettings.general.classify" />
+          </label>
+        </AutoSave>
         <table>
-          <thead>
-            <tr>
-              <th>
-                <i className="fa fa-envelope-o fa-fw" />
-              </th>
-              <Translate component="th" content="emailSettings.project.header" />
-            </tr>
-          </thead>
           <ProjectPreferences
             projects={this.state.projects}
             projectPreferences={this.state.projectPreferences}

--- a/app/pages/settings/email.jsx
+++ b/app/pages/settings/email.jsx
@@ -318,14 +318,16 @@ class EmailSettingsPage extends React.Component {
               onChange={handleInputChange.bind(this.props.user)}
             />{' '}
             <Translate content="emailSettings.general.classify" />
-            <Translate component="p" content="emailSettings.general.note" />
             <Translate component="p" content="emailSettings.general.manual" />
           </label>
         </AutoSave>
-        <table>
+        <table className="standard-table">
           <thead>
             <tr>
-              <th />
+              <th>
+                <i className="fa fa-envelope-o fa-fw" />
+              </th>
+              <Translate component="th" content="emailSettings.project.header"/>
             </tr>
           </thead>
           <ProjectPreferences

--- a/app/pages/settings/email.jsx
+++ b/app/pages/settings/email.jsx
@@ -318,6 +318,7 @@ class EmailSettingsPage extends React.Component {
               onChange={handleInputChange.bind(this.props.user)}
             />{' '}
             <Translate content="emailSettings.general.classify" />
+            <Translate component="p" content="emailSettings.general.note" />
             <Translate component="p" content="emailSettings.general.manual" />
           </label>
         </AutoSave>

--- a/app/pages/settings/email.jsx
+++ b/app/pages/settings/email.jsx
@@ -318,9 +318,16 @@ class EmailSettingsPage extends React.Component {
               onChange={handleInputChange.bind(this.props.user)}
             />{' '}
             <Translate content="emailSettings.general.classify" />
+            <Translate component="p" content="emailSettings.general.note" />
+            <Translate component="p" content="emailSettings.general.manual" />
           </label>
         </AutoSave>
         <table>
+          <thead>
+            <tr>
+              <th />
+            </tr>
+          </thead>
           <ProjectPreferences
             projects={this.state.projects}
             projectPreferences={this.state.projectPreferences}

--- a/app/pages/settings/email.jsx
+++ b/app/pages/settings/email.jsx
@@ -318,10 +318,10 @@ class EmailSettingsPage extends React.Component {
               onChange={handleInputChange.bind(this.props.user)}
             />{' '}
             <Translate content="emailSettings.general.classify" />
-            <Translate component="p" content="emailSettings.general.note" />
-            <Translate component="p" content="emailSettings.general.manual" />
           </label>
         </AutoSave>
+        <Translate component="p" content="emailSettings.general.note" />
+        <Translate component="p" content="emailSettings.general.manual" />
         <table className="standard-table">
           <thead>
             <tr>


### PR DESCRIPTION
Staging branch URL: https://layout-email-settings.pfe-preview.zooniverse.org/settings/email

Fixes #4220.

Describe your changes.
From the issue:
>Move the "Get email updates from the Projects you classify on" tick box option to be directly above the "Project email preferences" section so people realise they can choose to get emails from specific projects and not from others.
>Remove the 'Project' header from the 'Project email preferences section'. It's in the wrong place and isn't really useful.
# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
