### PR TITLE
Fix fatal project page bug

### DIFF
--- a/app/pages/project/about/index.jsx
+++ b/app/pages/project/about/index.jsx
@@ -41,7 +41,7 @@ class AboutProject extends Component {
 
     for (const url_key in SLUG_MAP) {
       const { pages, translations } = this.props;
-      const matchingPage = pages.find(page => page.url_key === url_key);
+      const matchingPage = pages.find(page => page.url_key === url_key) || {};
       const pageTranslations = translations ? translations.strings.project_page : [];
       const [matchingTranslation] = pageTranslations.filter(page => page.translated_id === parseInt(matchingPage.id, 10));
       const { content } = (matchingTranslation && matchingTranslation.strings) ?

--- a/app/pages/project/about/index.jsx
+++ b/app/pages/project/about/index.jsx
@@ -124,7 +124,9 @@ AboutProject.defaultProps = {
   projectRoles: [],
   translation: {},
   translations: {
-    strings: {}
+    strings: {
+      project_page: []
+    }
   }
 };
 

--- a/app/pages/project/about/index.spec.js
+++ b/app/pages/project/about/index.spec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import { expect } from 'chai';
 import { AboutProject } from './';
 
@@ -17,12 +17,11 @@ describe('AboutProject', () => {
     });
   });
   describe('with a child page', () => {
-    const wrapper = shallow(
+    const wrapper = mount(
       <AboutProject>
         <Page />
       </AboutProject>
     );
-    wrapper.setState({ loaded: true });
     const page = wrapper.update().find('Page');
     it('should render', () => {
       expect(wrapper.instance()).to.be.instanceOf(AboutProject);

--- a/app/pages/project/about/index.spec.js
+++ b/app/pages/project/about/index.spec.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+import { AboutProject } from './';
+
+function Page() {
+  return (
+    <p>Hello world!</p>
+  );
+}
+
+describe('AboutProject', () => {
+  describe('with only default props', () => {
+    it('should render', () => {
+      const wrapper = shallow(<AboutProject />);
+      expect(wrapper.instance()).to.be.instanceOf(AboutProject);
+    });
+  });
+  describe('with a child page', () => {
+    const wrapper = shallow(
+      <AboutProject>
+        <Page />
+      </AboutProject>
+    );
+    wrapper.setState({ loaded: true });
+    const page = wrapper.update().find('Page');
+    it('should render', () => {
+      expect(wrapper.instance()).to.be.instanceOf(AboutProject);
+    });
+    it('should pass pages and team arrays to the child page', () => {
+      expect(page.props().pages).to.equal(wrapper.state().pages);
+      expect(page.props().pages).to.be.instanceOf(Array);
+      expect(page.props().team).to.equal(wrapper.state().team);
+      expect(page.props().team).to.be.instanceOf(Array);
+    });
+  });
+});


### PR DESCRIPTION
Staging branch URL: https://empty-project-pages.pfe-preview.zooniverse.org

Fixes a bug where projects stop working if you navigate to a page that hasn't yet been created in the project builder.

Describe your changes.
Defaults a project page to an empty object, if no matching page is found in Panoptes.
Adds some tests that render the `AboutProject` component for a project with no pages.
Cleans up linter warnings and defines sensible default props for `AboutProject`.

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
