### PR TITLE
Fix three (mostly minor) warnings

### DIFF
--- a/app/pages/project/home/index.jsx
+++ b/app/pages/project/home/index.jsx
@@ -179,5 +179,5 @@ ProjectHomeContainer.propTypes = {
   }),
   user: React.PropTypes.shape({
     id: React.PropTypes.string
-  }).isRequired
+  })
 };

--- a/app/pages/project/index.cjsx
+++ b/app/pages/project/index.cjsx
@@ -309,7 +309,7 @@ ProjectPageController = React.createClass
     apiClient.type('field_guides').get(project_id: projectId).then ([guide]) =>
       { actions, translations } = this.props;
       @setState {guide}
-      actions.translations.load('field_guide', guide.id, translations.locale)
+      actions.translations.load('field_guide', guide?.id, translations.locale)
       guide?.get('attached_images', page_size: 100)?.then (images) =>
         guideIcons = {}
         for image in images

--- a/app/pages/project/project-page.jsx
+++ b/app/pages/project/project-page.jsx
@@ -31,7 +31,7 @@ export default class ProjectPage extends React.Component {
   componentWillUnmount() {
     document.documentElement.classList.remove('on-project-page');
     this.updateSugarSubscription(null);
-    this.context.geordi.forget(['projectToken']);
+    this.context.geordi && this.context.geordi.forget(['projectToken']);
   }
 
   updateSugarSubscription(project) {


### PR DESCRIPTION
## PR Overview
This PR fixes three mostly minor (mostly non-breaking) warnings/errors when using the PFE Classifier. These warnings/errors mostly appear in the console and is mostly invisible to users (except for the last one).

**Issue 1:** Projects with no Field Guide have a console error saying, "Cannot read property 'id' of undefined"

![screen shot 2017-12-14 at 17 51 30](https://user-images.githubusercontent.com/13952701/34007613-4d215b12-e0fa-11e7-8f13-59a5c8af1455.png)

Analysis: This line - `actions.translations.load('field_guide', guide.id, translations.locale)` doesn't confirm the existence of `guide` before calling `guide.id`

Solution: `guide?.id`

Impact: minimal.

Testing:
- On production's [WildCam Darien](https://fix-warnings.pfe-preview.zooniverse.org/projects/wildcam/wildcam-darien/classify?env=production) (which does not have a Field Guide), the warning should not appear.
- On production's [Elephant Expedition](https://fix-warnings.pfe-preview.zooniverse.org/projects/anabellecardoso/elephant-expedition/classify?env=production) (which does have a Field Guide), the Field Guide should appear as normal.

**Issue 2:** On development, Project pages have a "The prop 'user' is marked as required..." warning.

![screen shot 2017-12-14 at 17 53 06](https://user-images.githubusercontent.com/13952701/34007725-bc63a0c0-e0fa-11e7-980a-a7baed40f96a.png)

Analysis: `ProjectHomeContainer` marks `props.user` as `isRequired`, but this unfortunately doesn't account for non-logged-in users (or when first loading the page and the login check is being performed.)

Solution: remove `user.isRequired`

Impact: super minimal.

**Issue 3:** When Geordi is unavailable, it takes TWO CLICKS to move away from a Project page. Console reads: "Cannot read property 'forget' of undefined."

![screen shot 2017-12-14 at 17 51 51](https://user-images.githubusercontent.com/13952701/34007759-dbf69ad2-e0fa-11e7-8b9f-67d72844fe35.png)
_While on the WildCam Darien project page, I click the 'Project' top navi link. Instead of navigating to the Zoo Projects page, I remain on the same page. Note that the browser URL has changed to /projects._

Analysis: `ProjectPage` componentWillUnmount doesn't check for geordi's existence before calling `this.context.geordi.forget(['projectToken']);`

Solution: `this.context.geordi && this.context.geordi.forget(['projectToken']); `

Impact: Small but significant? It doesn't break the website but users might go "WTF dude" when they need to click twice to get out of a Project page.

Testing: _(requires Geordi to be unavailable)_
- Go to https://www.zooniverse.org/projects/wildcam/wildcam-darien
- Click on 'Projects' at the Zooniverse top navi.
- Expected: You're taken to the Zooniverse Projects page.
- Actual: You stay at the WildCam Darien page. The URL changes, however. In the console, the warning appears. Clicking the 'Projects' link again navigates properly.

For comparison, go to fix-warnings.pfe-preview.zooniverse.org/projects/wildcam/wildcam-darien/?env=production and repeat the process above. You should be able to access the Zooniverse Projects page in one click.

### Status
Ready for review.

### Required Manual Testing
Testing URL: https://fix-warnings.pfe-preview.zooniverse.org/

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

### Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?
