### PR TITLE
Ensure consistent sugar project channel subscriptions for project pages

### DIFF
--- a/app/pages/project/project-page.jsx
+++ b/app/pages/project/project-page.jsx
@@ -6,11 +6,6 @@ import ProjectNavbar from './project-navbar';
 import PotentialFieldGuide from './potential-field-guide';
 
 export default class ProjectPage extends React.Component {
-  constructor() {
-    super();
-    this.lastSugarSubscribedID = null;
-  }
-
   getChildContext() {
     return this.context.geordi;
   }
@@ -30,17 +25,16 @@ export default class ProjectPage extends React.Component {
 
   componentWillUnmount() {
     document.documentElement.classList.remove('on-project-page');
-    this.updateSugarSubscription(null);
+    this.removeSugarSubscription(this.props.project)
     this.context.geordi && this.context.geordi.forget(['projectToken']);
   }
 
   updateSugarSubscription(project) {
-    if (this.lastSugarSubscribedID) {
-      sugarClient.unsubscribeFrom(`project-${this.lastSugarSubscribedID}`);
-    }
-    if (project) {
-      sugarClient.subscribeTo(`project-${project.id}`);
-    }
+    sugarClient.subscribeTo(`project-${project.id}`);
+  }
+
+  removeSugarSubscription(project) {
+    sugarClient.unsubscribeFrom(`project-${project.id}`);
   }
 
   render() {

--- a/app/pages/project/project-page.jsx
+++ b/app/pages/project/project-page.jsx
@@ -18,6 +18,7 @@ export default class ProjectPage extends React.Component {
 
   componentWillReceiveProps(nextProps) {
     if (nextProps.project !== this.props.project) {
+      this.removeSugarSubscription(this.props.project);
       this.updateSugarSubscription(nextProps.project);
       this.context.geordi && this.context.geordi.remember({ projectToken: nextProps.project.slug });
     }

--- a/app/pages/project/project-page.jsx
+++ b/app/pages/project/project-page.jsx
@@ -39,7 +39,7 @@ export default class ProjectPage extends React.Component {
       sugarClient.unsubscribeFrom(`project-${this.lastSugarSubscribedID}`);
     }
     if (project) {
-      sugarClient.subscribeTo(`project-${this.lastSugarSubscribedID}`);
+      sugarClient.subscribeTo(`project-${project.id}`);
     }
   }
 

--- a/app/pages/project/project-page.jsx
+++ b/app/pages/project/project-page.jsx
@@ -26,7 +26,7 @@ export default class ProjectPage extends React.Component {
 
   componentWillUnmount() {
     document.documentElement.classList.remove('on-project-page');
-    this.removeSugarSubscription(this.props.project)
+    this.removeSugarSubscription(this.props.project);
     this.context.geordi && this.context.geordi.forget(['projectToken']);
   }
 

--- a/app/pages/project/project-page.spec.js
+++ b/app/pages/project/project-page.spec.js
@@ -154,5 +154,13 @@ describe('ProjectPage', () => {
       wrapper.unmount();
       expect(sugarClientUnsubscribeSpy.calledWith(channel)).to.equal(true);
     });
+
+    it('unsubscribes old project and subscribes new project on project change', () => {
+      let newProject = {id: '999', title: 'fake project', slug: 'owner/name'}
+      const newChannel = `project-${project.id}`
+      wrapper.setProps({ project: newProject });
+      expect(sugarClientSubscribeSpy.calledWith(newChannel)).to.equal(true);
+      expect(sugarClientUnsubscribeSpy.calledWith(channel)).to.equal(true);
+    });
   });
 });

--- a/app/pages/project/project-page.spec.js
+++ b/app/pages/project/project-page.spec.js
@@ -152,18 +152,24 @@ describe('ProjectPage', () => {
     });
 
     it('subscribes the user to the sugar project channel on mount', () => {
+      expect(sugarClientSubscribeSpy.calledOnce).to.equal(true);
       expect(sugarClientSubscribeSpy.calledWith(channel)).to.equal(true);
     });
 
     it('unsubscribes the user from the sugar project channel on unmount', () => {
       wrapper.unmount();
+      expect(sugarClientUnsubscribeSpy.calledOnce).to.equal(true);
       expect(sugarClientUnsubscribeSpy.calledWith(channel)).to.equal(true);
     });
 
     it('unsubscribes old project and subscribes new project on project change', () => {
       const newProject = {id: '999', title: 'fake project', slug: 'owner/name'};
       const newChannel = `project-${newProject.id}`;
+      sugarClientSubscribeSpy.reset();
+      sugarClientUnsubscribeSpy.reset();
       wrapper.setProps({ project: newProject });
+      expect(sugarClientSubscribeSpy.calledOnce).to.equal(true);
+      expect(sugarClientUnsubscribeSpy.calledOnce).to.equal(true);
       expect(sugarClientSubscribeSpy.calledWith(newChannel)).to.equal(true);
       expect(sugarClientUnsubscribeSpy.calledWith(channel)).to.equal(true);
     });

--- a/app/pages/project/project-page.spec.js
+++ b/app/pages/project/project-page.spec.js
@@ -133,7 +133,7 @@ describe('ProjectPage', () => {
     });
   });
 
-  describe.only('on component lifecycle', () => {
+  describe('on component lifecycle', () => {
     const sugarClientSubscribeSpy = sinon.spy(sugarClient, 'subscribeTo');
     const sugarClientUnsubscribeSpy = sinon.spy(sugarClient, 'unsubscribeFrom');
     const channel = `project-${project.id}`

--- a/app/pages/project/project-page.spec.js
+++ b/app/pages/project/project-page.spec.js
@@ -146,6 +146,11 @@ describe('ProjectPage', () => {
       );
     });
 
+    afterEach(() => {
+      sugarClientSubscribeSpy.reset();
+      sugarClientUnsubscribeSpy.reset();
+    });
+
     it('subscribes the user to the sugar project channel on mount', () => {
       expect(sugarClientSubscribeSpy.calledWith(channel)).to.equal(true);
     });
@@ -158,7 +163,6 @@ describe('ProjectPage', () => {
     it('unsubscribes old project and subscribes new project on project change', () => {
       const newProject = {id: '999', title: 'fake project', slug: 'owner/name'};
       const newChannel = `project-${newProject.id}`;
-      sugarClientSubscribeSpy.reset()
       wrapper.setProps({ project: newProject });
       expect(sugarClientSubscribeSpy.calledWith(newChannel)).to.equal(true);
       expect(sugarClientUnsubscribeSpy.calledWith(channel)).to.equal(true);

--- a/app/pages/project/project-page.spec.js
+++ b/app/pages/project/project-page.spec.js
@@ -1,8 +1,11 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import { expect } from 'chai';
 import { project, workflow } from '../dev-classifier/mock-data';
 import ProjectPage from './project-page';
+import { sugarClient } from 'panoptes-client/lib/sugar';
+import sinon from 'sinon';
+import assert from 'assert';
 
 function Page() {
   return (
@@ -128,6 +131,39 @@ describe('ProjectPage', () => {
     it('should show the field guide', () => {
       const fieldguide = wrapper.find('PotentialFieldGuide');
       expect(fieldguide).to.have.lengthOf(1);
+    });
+  });
+
+  describe.only('on component mount', () => {
+    let wrapper;
+    beforeEach(() => {
+      project.slug = 'test/project';
+      const mockLocation = {
+        pathname: `/projects/${project.slug}`
+      };
+      const routes = [];
+      routes[2] = {};
+      wrapper = mount(
+        <ProjectPage
+          location={mockLocation}
+          routes={routes}
+          project={project}
+        >
+          <Page />
+        </ProjectPage>
+      );
+    });
+
+    it('subscribes the user to the sugar project channel', () => {
+      const spy = sinon.spy(ProjectPage.prototype, 'updateSugarSubscription');
+      // const spy = sinon.spy(sugarClient.prototype, 'subscribeTo');
+      // expect(sugarClient.prototype.subscribeTo.calledOnce).to.equal(true);
+
+      console.log(project)
+      expect(ProjectPage.prototype.updateSugarSubscription.calledOnce).to.equal(true);
+      // assert(ProjectPage.prototype.updateSugarSubscription.calledWith(project));
+
+      spy.reset();
     });
   });
 });

--- a/app/pages/project/project-page.spec.js
+++ b/app/pages/project/project-page.spec.js
@@ -138,40 +138,51 @@ describe('ProjectPage', () => {
     const sugarClientUnsubscribeSpy = sinon.spy(sugarClient, 'unsubscribeFrom');
     const channel = `project-${project.id}`;
     let wrapper;
-    beforeEach(() => {
-      wrapper = mount(
-        <ProjectPage project={project}>
-          <Page />
-        </ProjectPage>
-      );
-    });
 
     afterEach(() => {
       sugarClientSubscribeSpy.reset();
       sugarClientUnsubscribeSpy.reset();
     });
 
-    it('subscribes the user to the sugar project channel on mount', () => {
-      expect(sugarClientSubscribeSpy.calledOnce).to.equal(true);
-      expect(sugarClientSubscribeSpy.calledWith(channel)).to.equal(true);
+    describe('on mount/unmount', () => {
+      beforeEach(() => {
+        wrapper = mount(
+          <ProjectPage project={project}>
+            <Page />
+          </ProjectPage>
+        );
+      });
+
+      it('subscribes the user to the sugar project channel on mount', () => {
+        expect(sugarClientSubscribeSpy.calledOnce).to.equal(true);
+        expect(sugarClientSubscribeSpy.calledWith(channel)).to.equal(true);
+      });
+
+      it('unsubscribes the user from the sugar project channel on unmount', () => {
+        wrapper.unmount();
+        expect(sugarClientUnsubscribeSpy.calledOnce).to.equal(true);
+        expect(sugarClientUnsubscribeSpy.calledWith(channel)).to.equal(true);
+      });
     });
 
-    it('unsubscribes the user from the sugar project channel on unmount', () => {
-      wrapper.unmount();
-      expect(sugarClientUnsubscribeSpy.calledOnce).to.equal(true);
-      expect(sugarClientUnsubscribeSpy.calledWith(channel)).to.equal(true);
-    });
+    describe('on project props change', () => {
+      beforeEach(() => {
+        wrapper = shallow(
+          <ProjectPage project={project}>
+            <Page />
+          </ProjectPage>
+        );
+      });
 
-    it('unsubscribes old project and subscribes new project on project change', () => {
-      const newProject = {id: '999', title: 'fake project', slug: 'owner/name'};
-      const newChannel = `project-${newProject.id}`;
-      sugarClientSubscribeSpy.reset();
-      sugarClientUnsubscribeSpy.reset();
-      wrapper.setProps({ project: newProject });
-      expect(sugarClientSubscribeSpy.calledOnce).to.equal(true);
-      expect(sugarClientUnsubscribeSpy.calledOnce).to.equal(true);
-      expect(sugarClientSubscribeSpy.calledWith(newChannel)).to.equal(true);
-      expect(sugarClientUnsubscribeSpy.calledWith(channel)).to.equal(true);
+      it('unsubscribes old project and subscribes new project', () => {
+        const newProject = {id: '999', title: 'fake project', slug: 'owner/name'};
+        const newChannel = `project-${newProject.id}`;
+        wrapper.setProps({ project: newProject });
+        expect(sugarClientSubscribeSpy.calledOnce).to.equal(true);
+        expect(sugarClientUnsubscribeSpy.calledOnce).to.equal(true);
+        expect(sugarClientSubscribeSpy.calledWith(newChannel)).to.equal(true);
+        expect(sugarClientUnsubscribeSpy.calledWith(channel)).to.equal(true);
+      });
     });
   });
 });

--- a/app/pages/project/project-page.spec.js
+++ b/app/pages/project/project-page.spec.js
@@ -133,36 +133,27 @@ describe('ProjectPage', () => {
     });
   });
 
-  describe.only('on component mount', () => {
+  describe.only('on component lifecycle', () => {
+    // const subscriptionSpy = sinon.spy(ProjectPage.prototype, 'updateSugarSubscription');
+    const sugarClientSubscribeSpy = sinon.spy(sugarClient, 'subscribeTo');
+    const sugarClientUnsubscribeSpy = sinon.spy(sugarClient, 'unsubscribeFrom');
+    const channel = `project-${project.id}`
     let wrapper;
     beforeEach(() => {
-      project.slug = 'test/project';
-      const mockLocation = {
-        pathname: `/projects/${project.slug}`
-      };
-      const routes = [];
-      routes[2] = {};
       wrapper = mount(
-        <ProjectPage
-          location={mockLocation}
-          routes={routes}
-          project={project}
-        >
+        <ProjectPage project={project}>
           <Page />
         </ProjectPage>
       );
     });
 
-    it('subscribes the user to the sugar project channel', () => {
-      const spy = sinon.spy(ProjectPage.prototype, 'updateSugarSubscription');
-      // const spy = sinon.spy(sugarClient.prototype, 'subscribeTo');
-      // expect(sugarClient.prototype.subscribeTo.calledOnce).to.equal(true);
+    it('subscribes the user to the sugar project channel on mount', () => {
+      expect(sugarClientSubscribeSpy.calledWith(channel)).to.equal(true);
+    });
 
-      console.log(project)
-      expect(ProjectPage.prototype.updateSugarSubscription.calledOnce).to.equal(true);
-      // assert(ProjectPage.prototype.updateSugarSubscription.calledWith(project));
-
-      spy.reset();
+    it('unsubscribes the user from the sugar project channel on unmount', () => {
+      wrapper.unmount();
+      expect(sugarClientUnsubscribeSpy.calledWith(channel)).to.equal(true);
     });
   });
 });

--- a/app/pages/project/project-page.spec.js
+++ b/app/pages/project/project-page.spec.js
@@ -136,7 +136,7 @@ describe('ProjectPage', () => {
   describe('on component lifecycle', () => {
     const sugarClientSubscribeSpy = sinon.spy(sugarClient, 'subscribeTo');
     const sugarClientUnsubscribeSpy = sinon.spy(sugarClient, 'unsubscribeFrom');
-    const channel = `project-${project.id}`
+    const channel = `project-${project.id}`;
     let wrapper;
     beforeEach(() => {
       wrapper = mount(
@@ -156,8 +156,8 @@ describe('ProjectPage', () => {
     });
 
     it('unsubscribes old project and subscribes new project on project change', () => {
-      let newProject = {id: '999', title: 'fake project', slug: 'owner/name'}
-      const newChannel = `project-${project.id}`
+      const newProject = {id: '999', title: 'fake project', slug: 'owner/name'};
+      const newChannel = `project-${project.id}`;
       wrapper.setProps({ project: newProject });
       expect(sugarClientSubscribeSpy.calledWith(newChannel)).to.equal(true);
       expect(sugarClientUnsubscribeSpy.calledWith(channel)).to.equal(true);

--- a/app/pages/project/project-page.spec.js
+++ b/app/pages/project/project-page.spec.js
@@ -166,22 +166,25 @@ describe('ProjectPage', () => {
     });
 
     describe('on project props change', () => {
+      const newProject = {id: '999', title: 'fake project', slug: 'owner/name'};
+      const newChannel = `project-${newProject.id}`;
       beforeEach(() => {
         wrapper = shallow(
           <ProjectPage project={project}>
             <Page />
           </ProjectPage>
         );
+        wrapper.setProps({ project: newProject });
       });
 
-      it('unsubscribes old project and subscribes new project', () => {
-        const newProject = {id: '999', title: 'fake project', slug: 'owner/name'};
-        const newChannel = `project-${newProject.id}`;
-        wrapper.setProps({ project: newProject });
-        expect(sugarClientSubscribeSpy.calledOnce).to.equal(true);
+      it('unsubscribes old project', () => {
         expect(sugarClientUnsubscribeSpy.calledOnce).to.equal(true);
-        expect(sugarClientSubscribeSpy.calledWith(newChannel)).to.equal(true);
         expect(sugarClientUnsubscribeSpy.calledWith(channel)).to.equal(true);
+      });
+
+      it('subscribes new project', () => {
+        expect(sugarClientSubscribeSpy.calledOnce).to.equal(true);
+        expect(sugarClientSubscribeSpy.calledWith(newChannel)).to.equal(true);
       });
     });
   });

--- a/app/pages/project/project-page.spec.js
+++ b/app/pages/project/project-page.spec.js
@@ -134,7 +134,6 @@ describe('ProjectPage', () => {
   });
 
   describe.only('on component lifecycle', () => {
-    // const subscriptionSpy = sinon.spy(ProjectPage.prototype, 'updateSugarSubscription');
     const sugarClientSubscribeSpy = sinon.spy(sugarClient, 'subscribeTo');
     const sugarClientUnsubscribeSpy = sinon.spy(sugarClient, 'unsubscribeFrom');
     const channel = `project-${project.id}`

--- a/app/pages/project/project-page.spec.js
+++ b/app/pages/project/project-page.spec.js
@@ -157,7 +157,8 @@ describe('ProjectPage', () => {
 
     it('unsubscribes old project and subscribes new project on project change', () => {
       const newProject = {id: '999', title: 'fake project', slug: 'owner/name'};
-      const newChannel = `project-${project.id}`;
+      const newChannel = `project-${newProject.id}`;
+      sugarClientSubscribeSpy.reset()
       wrapper.setProps({ project: newProject });
       expect(sugarClientSubscribeSpy.calledWith(newChannel)).to.equal(true);
       expect(sugarClientUnsubscribeSpy.calledWith(channel)).to.equal(true);

--- a/app/pages/project/project-page.spec.js
+++ b/app/pages/project/project-page.spec.js
@@ -5,7 +5,6 @@ import { project, workflow } from '../dev-classifier/mock-data';
 import ProjectPage from './project-page';
 import { sugarClient } from 'panoptes-client/lib/sugar';
 import sinon from 'sinon';
-import assert from 'assert';
 
 function Page() {
   return (


### PR DESCRIPTION
Closes #4228 - Ensure consistent sugar project channel subscriptions on notifications.zooniverse.org. 

Lifecycle methods:
1. Mount: subscribe to project page channel
0. Unmount unsubscribe from the project channel
0. On new props unsubscribe the previous project channel and subscribe on the new project channel.

Staging branch URL: https://sugar-section-notification.pfe-preview.zooniverse.org/

# Required Manual Testing

- [X] Does the non-logged in home page render correctly?
- [X] Does the logged in home page render correctly?
- [X] Does the projects page render correctly?
- [X] Can you load project home pages?
- [X] Can you load the classification page?
- [X] Can you submit a classification?
- [X] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
