### PR TITLE
Change "End of classification" to "Next subject"

### DIFF
--- a/app/classifier/tasks/next-task-selector.cjsx
+++ b/app/classifier/tasks/next-task-selector.cjsx
@@ -18,7 +18,7 @@ module.exports = React.createClass
     tasks = require('.').default # Work around circular dependency.
 
     <select name={@props.name} value={@props.value} onChange={@props.onChange}>
-      <option value="">(Next subject)</option>
+      <option value="">(Submit classification and load next subject)</option>
       {for key, definition of @props.workflow.tasks
         unless definition.type is 'shortcut'
           text = tasks[definition.type].getTaskText definition

--- a/app/classifier/tasks/next-task-selector.cjsx
+++ b/app/classifier/tasks/next-task-selector.cjsx
@@ -18,7 +18,7 @@ module.exports = React.createClass
     tasks = require('.').default # Work around circular dependency.
 
     <select name={@props.name} value={@props.value} onChange={@props.onChange}>
-      <option value="">(End of classification!)</option>
+      <option value="">(Next subject)</option>
       {for key, definition of @props.workflow.tasks
         unless definition.type is 'shortcut'
           text = tasks[definition.type].getTaskText definition


### PR DESCRIPTION
Staging branch URL: https://next-task-reword.pfe-preview.zooniverse.org/

It might not be clear what "End of classification" means in the "next task" option in the workflow editor -- some people might interpret that as meaning the user will exit the classification page. This changes it to say "next subject" instead.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?