### PR TITLE
Fix Sign-in Prompt from Subject Preview

### DIFF
--- a/app/pages/lab/subject-set.cjsx
+++ b/app/pages/lab/subject-set.cjsx
@@ -65,6 +65,9 @@ SubjectSetListingTable = React.createClass
 SubjectSetListing = React.createClass
   displayName: 'SubjectSetListing'
 
+  contextTypes:
+    user: React.PropTypes.object
+
   getDefaultProps: ->
     subjectSet: {}
 
@@ -123,7 +126,7 @@ SubjectSetListing = React.createClass
 
   previewSubject: (subject) ->
     alert <div className="content-container subject-preview">
-      <SubjectViewer subject={subject} />
+      <SubjectViewer subject={subject} user={@context.user} />
     </div>
 
   removeSubject: (subject) ->

--- a/app/pages/lab/subject-set.cjsx
+++ b/app/pages/lab/subject-set.cjsx
@@ -65,9 +65,6 @@ SubjectSetListingTable = React.createClass
 SubjectSetListing = React.createClass
   displayName: 'SubjectSetListing'
 
-  contextTypes:
-    user: React.PropTypes.object
-
   getDefaultProps: ->
     subjectSet: {}
 
@@ -126,7 +123,7 @@ SubjectSetListing = React.createClass
 
   previewSubject: (subject) ->
     alert <div className="content-container subject-preview">
-      <SubjectViewer subject={subject} user={@context.user} />
+      <SubjectViewer subject={subject} user={@props.user} />
     </div>
 
   removeSubject: (subject) ->
@@ -199,7 +196,7 @@ EditSubjectSetPage = React.createClass
       <hr />
 
       This set contains {@props.subjectSet.set_member_subjects_count} subjects:<br />
-      <SubjectSetListing subjectSet={@props.subjectSet} page={@state.page} newPage={@newPage} />
+      <SubjectSetListing subjectSet={@props.subjectSet} page={@state.page} newPage={@newPage} user={@props.user} />
 
       <hr />
 


### PR DESCRIPTION
Staging branch URL: https://fix-4239.pfe-preview.zooniverse.org/

Fixes #4239  .

Describe your changes.
The issue above concerns the wiggling "you should sign-in" prompt from appearing in the project builder's subject preview. The issue was that we were reusing the `SubjectViewer` component for the preview without passing in the user prop, so the SV had no idea if a user was present or not. 

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [x] Can you post a talk comment?

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
