### PR TITLE
Allow Subject to Be Added to Empty Collection

### DIFF
--- a/app/collections/collections-manager.jsx
+++ b/app/collections/collections-manager.jsx
@@ -34,7 +34,10 @@ class CollectionsManager extends React.Component {
     const promises = collections.map((searchResult) => {
       const collection = searchResult.collection;
       const subjectsToAdd = this.props.subjectIDs.filter((id) => {
-        return !collection.links.subjects.includes(id);
+        if (collection.links.subjects) {
+          return !collection.links.subjects.includes(id);
+        }
+        return true;
       });
 
       if (subjectsToAdd.length === 0) {

--- a/app/collections/collections-manager.spec.js
+++ b/app/collections/collections-manager.spec.js
@@ -2,18 +2,35 @@ import React from 'react';
 import assert from 'assert';
 import { shallow } from 'enzyme';
 import sinon from 'sinon';
+import apiClient from 'panoptes-client/lib/api-client';
 import CollectionsManager from './collections-manager';
 
 const project = {
   id: '342'
 };
 
+const selectedCollection = [{
+  collection: apiClient.type('collections').create({
+    display_name: 'test collection',
+    description: '',
+    private: false,
+    links: { project: '1234' }
+  })
+}];
+
+const subjectIDs = ['1234'];
+
+const searchNode = {
+  getSelected() { return selectedCollection; }
+};
+
 describe('<CollectionsManager />', function() {
   let wrapper;
   let addToCollectionsSpy;
   before(function() {
-    addToCollectionsSpy = sinon.stub(CollectionsManager.prototype, 'addToCollections');
-    wrapper = shallow(<CollectionsManager project={project} />);
+    CollectionsManager.prototype.search = searchNode;
+    addToCollectionsSpy = sinon.spy(CollectionsManager.prototype, 'addToCollections');
+    wrapper = shallow(<CollectionsManager subjectIDs={subjectIDs} project={project} />);
   });
 
   it('should render without crashing', function() {
@@ -46,5 +63,10 @@ describe('<CollectionsManager />', function() {
     const addButton = wrapper.find('.search-button');
     addButton.simulate('click');
     sinon.assert.calledOnce(addToCollectionsSpy);
+  });
+
+  it('can add a subject to an empty collection', function() {
+    const addButton = wrapper.find('.search-button');
+    addButton.simulate('click');
   });
 });

--- a/app/collections/collections-manager.spec.js
+++ b/app/collections/collections-manager.spec.js
@@ -27,10 +27,12 @@ const searchNode = {
 describe('<CollectionsManager />', function() {
   let wrapper;
   let addToCollectionsSpy;
+  let addButton;
   before(function() {
     CollectionsManager.prototype.search = searchNode;
     addToCollectionsSpy = sinon.spy(CollectionsManager.prototype, 'addToCollections');
     wrapper = shallow(<CollectionsManager subjectIDs={subjectIDs} project={project} />);
+    addButton = wrapper.find('.search-button');
   });
 
   it('should render without crashing', function() {
@@ -60,13 +62,14 @@ describe('<CollectionsManager />', function() {
   });
 
   it('calls addToCollections when the add button is clicked', function() {
-    const addButton = wrapper.find('.search-button');
     addButton.simulate('click');
     sinon.assert.calledOnce(addToCollectionsSpy);
   });
 
   it('can add a subject to an empty collection', function() {
-    const addButton = wrapper.find('.search-button');
+    const collection = wrapper.instance().search.getSelected()[0].collection;
+    const spyGuy = sinon.spy(collection, 'addLink');
     addButton.simulate('click');
+    sinon.assert.calledWith(spyGuy, 'subjects', ['1234']);
   });
 });

--- a/app/collections/show-list.cjsx
+++ b/app/collections/show-list.cjsx
@@ -134,6 +134,7 @@ module.exports = React.createClass
     project: React.PropTypes.object
 
   componentWillMount: ->
+    console.log @props
     @fetchCollectionSubjects pick @props.location.query, VALID_COLLECTION_MEMBER_SUBJECTS_PARAMS
       .then (subjects) =>
         error = null

--- a/app/collections/show-list.cjsx
+++ b/app/collections/show-list.cjsx
@@ -134,7 +134,6 @@ module.exports = React.createClass
     project: React.PropTypes.object
 
   componentWillMount: ->
-    console.log @props
     @fetchCollectionSubjects pick @props.location.query, VALID_COLLECTION_MEMBER_SUBJECTS_PARAMS
       .then (subjects) =>
         error = null

--- a/app/collections/show.jsx
+++ b/app/collections/show.jsx
@@ -209,7 +209,6 @@ const CollectionPageWrapper = React.createClass({
         });
       }
     }).then(([collection]) => {
-      console.log(collection);
       collection.listen('change', this.listenToCollection);
       this.fetchAllCollectionRoles(collection);
       this.fetchCollectionOwner(collection)

--- a/app/collections/show.jsx
+++ b/app/collections/show.jsx
@@ -79,7 +79,7 @@ const CollectionPage = React.createClass({
   },
 
   render() {
-    const title = `${this.props.collection.display_name} (${this.props.collection.links.subjects ? this.props.collection.links.subjects.length : null})`;
+    const title = `${this.props.collection.display_name} (${this.props.collection.links.subjects ? this.props.collection.links.subjects.length : 0})`;
     const baseType = this.props.collection.favorite ? 'favorites' : 'collections';
     let baseLink = '';
     if (!!this.props.project) {
@@ -209,6 +209,7 @@ const CollectionPageWrapper = React.createClass({
         });
       }
     }).then(([collection]) => {
+      console.log(collection);
       collection.listen('change', this.listenToCollection);
       this.fetchAllCollectionRoles(collection);
       this.fetchCollectionOwner(collection)


### PR DESCRIPTION
Staging branch URL: https://fix-4070.pfe-preview.zooniverse.org/

Fixes #4070  .

Describe your changes.
The linked issue concerns the inability to add a subject to an empty collections set. This branch solves the issue, however, there seems to also be a caching issue affecting how the collections page is updated. This seemed to be a bigger issue (which I saved for another PR), but I can look into it more with this PR if desired. 

The additional bug mentioned above appears to have already been documented as #4039.

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [x] Can you post a talk comment?

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
