### PR TITLE
Mock Panoptes resources in email settings tests

### DIFF
--- a/app/pages/settings/email.spec.js
+++ b/app/pages/settings/email.spec.js
@@ -6,23 +6,113 @@ import apiClient from 'panoptes-client/lib/api-client';
 import talkClient from 'panoptes-client/lib/talk-client';
 import EmailSettings from './email';
 
+function mockTalkResource(type, options) {
+  const resource = talkClient.type(type).create(options);
+  sinon.stub(resource, 'save', () => Promise.resolve(resource));
+  sinon.stub(resource, 'get');
+  sinon.stub(resource, 'delete');
+  return resource;
+}
+
+function mockPanoptesResource(type, options) {
+  const resource = apiClient.type(type).create(options);
+  sinon.stub(resource, 'save', () => Promise.resolve(resource));
+  sinon.stub(resource, 'get');
+  sinon.stub(resource, 'delete');
+  return resource;
+}
+
 const talkPreferences = [
-  talkClient.type('subscription_preferences').create({ id: 0, category: 'participating_discussions', email_digest: 'immediate' }),
-  talkClient.type('subscription_preferences').create({ id: 1, category: 'followed_discussions', email_digest: 'daily' }),
-  talkClient.type('subscription_preferences').create({ id: 2, category: 'mentions', email_digest: 'immediate' }),
-  talkClient.type('subscription_preferences').create({ id: 3, category: 'group_mentions', email_digest: 'immediate' }),
-  talkClient.type('subscription_preferences').create({ id: 4, category: 'messages', email_digest: 'daily' }),
-  talkClient.type('subscription_preferences').create({ id: 5, category: 'started_discussions', email_digest: 'weekly' })
+  mockTalkResource(
+    'subscription_preferences',
+    {
+      id: 0,
+      category: 'participating_discussions',
+      email_digest: 'immediate'
+    }
+  ),
+  mockTalkResource(
+    'subscription_preferences',
+    {
+      id: 1,
+      category: 'followed_discussions',
+      email_digest: 'daily'
+    }
+  ),
+  mockTalkResource(
+    'subscription_preferences',
+    {
+      id: 2,
+      category: 'mentions',
+      email_digest: 'immediate'
+    }
+  ),
+  mockTalkResource(
+    'subscription_preferences',
+    {
+      id: 3,
+      category: 'group_mentions',
+      email_digest: 'immediate'
+    }
+  ),
+  mockTalkResource(
+    'subscription_preferences',
+    {
+      id: 4,
+      category: 'messages',
+      email_digest: 'daily'
+    }
+  ),
+  mockTalkResource(
+    'subscription_preferences',
+    {
+      id: 5,
+      category: 'started_discussions',
+      email_digest: 'weekly'
+    }
+  )
 ];
 
 const projects = [
-  apiClient.type('projects').create({ id: 'a', display_name: 'A test project', title: 'A test project' }),
-  apiClient.type('projects').create({ id: 'b', display_name: 'Another test project', title: 'Another test project' })
+  mockPanoptesResource(
+    'projects',
+    {
+      id: 'a',
+      display_name: 'A test project',
+      title: 'A test project'
+    }
+  ),
+  mockPanoptesResource(
+    'projects',
+    {
+      id: 'b',
+      display_name: 'Another test project',
+      title: 'Another test project'
+    }
+  )
 ];
 
 const projectPreferences = [
-  apiClient.type('project_preferences').create({ id: '1', email_communication: true, links: { project: 'a' } }),
-  apiClient.type('project_preferences').create({ id: '2', email_communication: false, links: { project: 'b' } })
+  mockPanoptesResource(
+    'project_preferences',
+    {
+      id: '1',
+      email_communication: true,
+      links: {
+        project: 'a'
+      }
+    }
+  ),
+  mockPanoptesResource(
+    'project_preferences',
+    {
+      id: '2',
+      email_communication: false,
+      links: {
+        project: 'b'
+      }
+    }
+  )
 ];
 
 const user = {
@@ -66,7 +156,7 @@ describe('EmailSettings', () => {
 
   describe('project listing', () => {
     let projectSettings;
-    
+
     before(() => {
       wrapper.setState({ meta: {}, projectPreferences, projects, talkPreferences });
       wrapper.update();


### PR DESCRIPTION
Stub out resource methods so that the tests don't make API requests.
Clean up the spec file a bit.

Staging branch URL:

Fixes # .

Describe your changes.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
