### PR TITLE
Fix warnings from workflow tests

### DIFF
--- a/app/pages/project/index.spec.js
+++ b/app/pages/project/index.spec.js
@@ -19,7 +19,7 @@ const context = {
   router: {}
 };
 
-const resources = {
+const RESOURCES = {
   pages: [],
   project_roles: [
     {
@@ -53,7 +53,7 @@ function mockPanoptesResource(type, options) {
   const resource = apiClient.type(type).create(options);
   if (!resource.save.restore) {
     sinon.stub(resource, 'save', () => Promise.resolve(resource));
-    sinon.stub(resource, 'get', resourceType => Promise.resolve(resources[resourceType]));
+    sinon.stub(resource, 'get', resourceType => Promise.resolve(RESOURCES[resourceType]));
     sinon.stub(resource, 'delete');
   }
   return resource;
@@ -150,10 +150,10 @@ describe('ProjectPageController', () => {
       project,
       background,
       owner,
-      pages: resources.pages,
+      pages: RESOURCES.pages,
       preferences: {},
       projectAvatar,
-      projectRoles: resources.project_roles
+      projectRoles: RESOURCES.project_roles
     });
     wrapper.update();
   });

--- a/app/pages/project/index.spec.js
+++ b/app/pages/project/index.spec.js
@@ -127,6 +127,7 @@ describe('ProjectPageController', () => {
 
   before(() => {
     sinon.stub(apiClient, 'request', (method, url, payload) => {
+      let response = [];
       if (url === '/workflows') {
         const workflow = mockPanoptesResource(
           'workflows',
@@ -135,10 +136,9 @@ describe('ProjectPageController', () => {
             tasks: []
           }
         );
-        return Promise.resolve([workflow]);
-      } else {
-        return Promise.resolve([]);
+        response = [workflow];
       }
+      return Promise.resolve(response);
     });
   });
 

--- a/app/pages/project/index.spec.js
+++ b/app/pages/project/index.spec.js
@@ -51,11 +51,10 @@ const RESOURCES = {
 
 function mockPanoptesResource(type, options) {
   const resource = apiClient.type(type).create(options);
-  if (!resource.save.restore) {
-    sinon.stub(resource, 'save', () => Promise.resolve(resource));
-    sinon.stub(resource, 'get', resourceType => Promise.resolve(RESOURCES[resourceType]));
-    sinon.stub(resource, 'delete');
-  }
+  apiClient._typesCache = {};
+  sinon.stub(resource, 'save', () => Promise.resolve(resource));
+  sinon.stub(resource, 'get', resourceType => Promise.resolve(RESOURCES[resourceType]));
+  sinon.stub(resource, 'delete');
   return resource;
 }
 

--- a/app/pages/settings/email.spec.js
+++ b/app/pages/settings/email.spec.js
@@ -16,11 +16,10 @@ function mockTalkResource(type, options) {
 
 function mockPanoptesResource(type, options) {
   const resource = apiClient.type(type).create(options);
-  if (!resource.save.restore) {
-    sinon.stub(resource, 'save', () => Promise.resolve(resource));
-    sinon.stub(resource, 'get');
-    sinon.stub(resource, 'delete');
-  }
+  apiClient._typesCache = {};
+  sinon.stub(resource, 'save', () => Promise.resolve(resource));
+  sinon.stub(resource, 'get');
+  sinon.stub(resource, 'delete');
   return resource;
 }
 

--- a/app/pages/settings/email.spec.js
+++ b/app/pages/settings/email.spec.js
@@ -127,13 +127,21 @@ const user = {
 };
 
 describe('EmailSettings', () => {
-  const wrapper = mount(<EmailSettings user={user} />);
-  const projectPreferenceSpy = sinon.spy(wrapper.instance(), 'getProjectForPreferences');
+  let wrapper;
+  let projectPreferenceSpy;
+
+  before(() => {
+    sinon.stub(apiClient, 'request', () => Promise.resolve([]));
+    wrapper = mount(<EmailSettings user={user} />);
+    projectPreferenceSpy = sinon.spy(wrapper.instance(), 'getProjectForPreferences');
+  });
 
   beforeEach(() => {
     projectPreferenceSpy.reset();
     wrapper.update();
   });
+
+  after(() => apiClient.request.restore());
 
   it('renders the email address', () => {
     const email = wrapper.find('input[name="email"]');

--- a/app/pages/settings/email.spec.js
+++ b/app/pages/settings/email.spec.js
@@ -16,9 +16,11 @@ function mockTalkResource(type, options) {
 
 function mockPanoptesResource(type, options) {
   const resource = apiClient.type(type).create(options);
-  sinon.stub(resource, 'save', () => Promise.resolve(resource));
-  sinon.stub(resource, 'get');
-  sinon.stub(resource, 'delete');
+  if (!resource.save.restore) {
+    sinon.stub(resource, 'save', () => Promise.resolve(resource));
+    sinon.stub(resource, 'get');
+    sinon.stub(resource, 'delete');
+  }
   return resource;
 }
 


### PR DESCRIPTION
Mock Panoptes resources to stub out API method calls.
Stub API client requests during the tests.
Clean up the test code.

Staging branch URL:

Fixes various API warnings that are echoed to the console when the tests run.

Describe your changes.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
