### PR TITLE
Stub Talk requests during email settings tests

### DIFF
--- a/app/pages/settings/email.spec.js
+++ b/app/pages/settings/email.spec.js
@@ -132,6 +132,7 @@ describe('EmailSettings', () => {
 
   before(() => {
     sinon.stub(apiClient, 'request', () => Promise.resolve([]));
+    sinon.stub(talkClient, 'request', () => Promise.resolve([]));
     wrapper = mount(<EmailSettings user={user} />);
     projectPreferenceSpy = sinon.spy(wrapper.instance(), 'getProjectForPreferences');
   });
@@ -141,7 +142,10 @@ describe('EmailSettings', () => {
     wrapper.update();
   });
 
-  after(() => apiClient.request.restore());
+  after(() => {
+    apiClient.request.restore();
+    talkClient.request.restore();
+  });
 
   it('renders the email address', () => {
     const email = wrapper.find('input[name="email"]');


### PR DESCRIPTION
Missed in #4253. This should fix the `Error: not allowed to index this SubscriptionPreference` warning that appears when running the email settings tests.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
