### PR TITLE
Keyboard focus now working/looking better on home-page for app store icons and project cards

### DIFF
--- a/app/pages/settings/email.spec.js
+++ b/app/pages/settings/email.spec.js
@@ -132,6 +132,7 @@ describe('EmailSettings', () => {
 
   before(() => {
     sinon.stub(apiClient, 'request', () => Promise.resolve([]));
+    sinon.stub(talkClient, 'request', () => Promise.resolve([]));
     wrapper = mount(<EmailSettings user={user} />);
     projectPreferenceSpy = sinon.spy(wrapper.instance(), 'getProjectForPreferences');
   });
@@ -141,7 +142,10 @@ describe('EmailSettings', () => {
     wrapper.update();
   });
 
-  after(() => apiClient.request.restore());
+  after(() => {
+    apiClient.request.restore();
+    talkClient.request.restore();
+  });
 
   it('renders the email address', () => {
     const email = wrapper.find('input[name="email"]');

--- a/css/home-page.styl
+++ b/css/home-page.styl
@@ -172,9 +172,11 @@ $flex-section
       min-width: 50%
 
       a
+        display: inline-block
+        max-height: 2em
+        margin-right: 1em
         img
           max-height: 2em
-          margin-right: 1em
 
       button[class=primary-button]
         color: black
@@ -186,6 +188,7 @@ $flex-section
     max-height: 24em
     max-width: 18em
     width: 18em
+    margin: 0
 
     .details
       height: 50%
@@ -224,9 +227,6 @@ $flex-section
   @media (min-width: 1440px)
     border-left: 1px solid LIGHT_GREY
     border-right: 1px solid LIGHT_GREY
-
-  *:focus
-    outline: none
 
   section
     @extends $flex-section
@@ -427,6 +427,11 @@ $flex-section
 
       > div
         margin: 0 0.5em
+
+        > a
+          margin: 1em
+          margin-top: 0
+          display: inline-block
 
     &__content
       display: flex


### PR DESCRIPTION
…ck for nicer keyboard focus. Fixes #4105

Staging branch URL:

Fixes #4105 .

Describe your changes.

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [x] Can you post a talk comment?

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
