### PR TITLE
Add task translations to drawing subtasks

### DIFF
--- a/app/classifier/drawing-tools/root.cjsx
+++ b/app/classifier/drawing-tools/root.cjsx
@@ -1,6 +1,7 @@
 React = require 'react'
 StickyModalForm = require 'modal-form/sticky'
 ModalFocus = require('../../components/modal-focus').default
+TaskTranslations = require('../tasks/translations').default
 
 STROKE_WIDTH = 1.5
 SELECTED_STROKE_WIDTH = 2.5
@@ -14,6 +15,9 @@ SEMI_MODAL_UNDERLAY_STYLE =
 
 module.exports = React.createClass
   displayName: 'DrawingToolRoot'
+
+  contextTypes:
+    store: React.PropTypes.object
 
   statics:
     distance: (x1, y1, x2, y2) ->
@@ -76,7 +80,9 @@ module.exports = React.createClass
             {for detailTask, i in toolProps.details
               detailTask._key ?= Math.random()
               TaskComponent = tasks[detailTask.type]
-              <TaskComponent autoFocus={i is 0} key={detailTask._key} task={detailTask} translation={detailTask} annotation={toolProps.mark.details[i]} onChange={@handleDetailsChange.bind this, i} />}
+              <TaskTranslations key={detailTask._key} taskKey={"TASK-KEY.tools.TOOL-INDEX.details.#{i}"} task={detailTask} store={@context.store}>
+                <TaskComponent autoFocus={i is 0} task={detailTask} annotation={toolProps.mark.details[i]} onChange={@handleDetailsChange.bind this, i} />
+              </TaskTranslations>}
             <hr />
             <p style={textAlign: 'center'}>
               <button autoFocus={toolProps.details[0].type in ['single', 'multiple']} type="submit" className="standard-button" disabled={not detailsAreComplete}>OK</button>

--- a/app/classifier/drawing-tools/root.cjsx
+++ b/app/classifier/drawing-tools/root.cjsx
@@ -80,7 +80,13 @@ module.exports = React.createClass
             {for detailTask, i in toolProps.details
               detailTask._key ?= Math.random()
               TaskComponent = tasks[detailTask.type]
-              <TaskTranslations key={detailTask._key} taskKey={"TASK-KEY.tools.TOOL-INDEX.details.#{i}"} task={detailTask} store={@context.store}>
+              taskKey = "#{toolProps.taskKey}.tools.#{toolProps.mark.tool}.details.#{i}"
+              <TaskTranslations
+                key={detailTask._key}
+                taskKey={taskKey}
+                task={detailTask}
+                store={@context.store}
+              >
                 <TaskComponent autoFocus={i is 0} task={detailTask} annotation={toolProps.mark.details[i]} onChange={@handleDetailsChange.bind this, i} />
               </TaskTranslations>}
             <hr />

--- a/app/classifier/tasks/drawing/markings-renderer.cjsx
+++ b/app/classifier/tasks/drawing/markings-renderer.cjsx
@@ -69,6 +69,7 @@ module.exports = React.createClass
                 preferences: @props.preferences
 
               toolProps =
+                taskKey: annotation.task
                 classification: @props.classification
                 mark: mark
                 details: details


### PR DESCRIPTION
Staging branch URL: https://subtask-translations.pfe-preview.zooniverse.org/

Connects up drawing subtasks to the translations API, by wrapping the task component in a translations wrapper.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
