### PR TITLE
Match project pref and project correctly

### DIFF
--- a/app/pages/settings/email.jsx
+++ b/app/pages/settings/email.jsx
@@ -63,11 +63,7 @@ function ProjectPreferences({ projects, projectPreferences, onChange }) {
   projects.map(project => projectNames[project.id] = project.display_name);
   const projectIDs = projects.map(proj => proj.id);
   function filterPrefs() {
-    return projectPreferences.filter(pref => {
-      if (projectIDs.includes(pref.links.project)) {
-        return pref;
-      }
-    });
+    return projectPreferences.filter(pref => projectIDs.includes(pref.links.project));
   }
 
   return (

--- a/app/pages/settings/email.jsx
+++ b/app/pages/settings/email.jsx
@@ -59,6 +59,8 @@ TalkPreferences.propTypes = {
 };
 
 function ProjectPreferences({ projects, projectPreferences, onChange }) {
+  const projectNames = [];
+  projects.map(project => projectNames[project.id] = project.display_name);
   return (
     <tbody>
       {projectPreferences.map((projectPreference, i) => {
@@ -74,7 +76,7 @@ function ProjectPreferences({ projects, projectPreferences, onChange }) {
                 />
               </td>
               <td>
-                {projects[i].display_name}
+                {projectNames[projectPreference.links.project]}
               </td>
             </tr>
           );

--- a/app/pages/settings/email.jsx
+++ b/app/pages/settings/email.jsx
@@ -59,11 +59,22 @@ TalkPreferences.propTypes = {
 };
 
 function ProjectPreferences({ projects, projectPreferences, onChange }) {
-  const projectNames = [];
+  const projectNames = {};
   projects.map(project => projectNames[project.id] = project.display_name);
+  const projectIDs = projects.map(proj => proj.id);
+  function filterPrefs() {
+    const newPrefs = [];
+    return projectPreferences.filter(pref => {
+      if (projectIDs.includes(pref.links.project)) {
+        newPrefs.push(pref);
+        return newPrefs;
+      }
+    });
+  }
+
   return (
     <tbody>
-      {projectPreferences.map((projectPreference, i) => {
+      {filterPrefs().map((projectPreference, i) => {
         if (projects[i]) {
           return (
             <tr key={projectPreference.id}>

--- a/app/pages/settings/email.jsx
+++ b/app/pages/settings/email.jsx
@@ -63,11 +63,9 @@ function ProjectPreferences({ projects, projectPreferences, onChange }) {
   projects.map(project => projectNames[project.id] = project.display_name);
   const projectIDs = projects.map(proj => proj.id);
   function filterPrefs() {
-    const newPrefs = [];
     return projectPreferences.filter(pref => {
       if (projectIDs.includes(pref.links.project)) {
-        newPrefs.push(pref);
-        return newPrefs;
+        return pref;
       }
     });
   }


### PR DESCRIPTION
Staging branch URL: https://email-proj-prefs.pfe-preview.zooniverse.org/

Fixes #4263 .

Describe your changes.
It displays project names keyed with `projectPref.links.project`

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
