### PR TITLE
Adjust Width of Items in Social Section

### DIFF
--- a/css/home-page.styl
+++ b/css/home-page.styl
@@ -478,7 +478,12 @@ $flex-section
         background-position: center
         height: 14em
         margin: 0.5em 1em 0.5em 0
-        width: 18em
+        width: 16em
+
+        @media(max-width: 400px)
+          height: 10em
+          margin: 1em auto
+          width: 12em
 
       div:nth-child(2)
         flex: 2 0 0%
@@ -521,6 +526,9 @@ $flex-section
       margin-top: 1.5vh
       overflow: hidden
       width: 20em
+
+      @media(max-width: 400px)
+        width: 15em
 
       i
         color: TEAL_MID
@@ -572,6 +580,9 @@ $flex-section
       margin-right: 3em
       max-width: 100%
       min-width: 16em
+
+      @media(max-width: 400px)
+        margin-right: 0
 
       div, span
         width: 100%


### PR DESCRIPTION
Staging branch URL: https://landing-page-width.pfe-preview.zooniverse.org/

Fixes #4262  .

Describe your changes.
This was a tricky little CSS bug to figure out. Looks like there were some items in the social section that were keeping the page from shrinking.

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [x] Can you post a talk comment?

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
