### PR TITLE
Fix broken SVG rendering in Firefox

### DIFF
--- a/app/classifier/annotation-renderer/svg.jsx
+++ b/app/classifier/annotation-renderer/svg.jsx
@@ -30,8 +30,10 @@ export default class SVGRenderer extends React.Component {
 
   getScale() {
     const sizeRect = this.getSizeRect();
-    const horizontal = sizeRect ? sizeRect.width / this.props.naturalWidth : 0;
-    const vertical = sizeRect ? sizeRect.height / this.props.naturalHeight : 0;
+    let horizontal = this.props.naturalWidth ? sizeRect.width / this.props.naturalWidth : 0.001;
+    let vertical = this.props.naturalHeight ? sizeRect.height / this.props.naturalHeight : 0.001;
+    horizontal = Math.max(horizontal, 0.001);
+    vertical = Math.max(vertical, 0.001);
 
     return { horizontal, vertical };
   }

--- a/app/classifier/drawing-tools/delete-button.cjsx
+++ b/app/classifier/drawing-tools/delete-button.cjsx
@@ -23,6 +23,7 @@ module.exports = React.createClass
 
   render: ->
     matrix = @props.getScreenCurrentTransformationMatrix()
+    return null unless matrix?
     transform = "
       translate(#{@props.x}, #{@props.y})
       rotate(#{@props.rotate})

--- a/app/classifier/drawing-tools/drag-handle.cjsx
+++ b/app/classifier/drawing-tools/drag-handle.cjsx
@@ -9,6 +9,7 @@ module.exports = React.createClass
 
   render: ->
     matrix = @props.getScreenCurrentTransformationMatrix()
+    return null unless matrix?
     className = "drag-handle"
     if @props.className?
       className += " #{@props.className}"

--- a/app/classifier/tasks/drawing/markings-renderer.cjsx
+++ b/app/classifier/tasks/drawing/markings-renderer.cjsx
@@ -60,9 +60,15 @@ module.exports = React.createClass
               else
                 details = null
 
+              if isFinite(@props.scale.horizontal)
+                { scale } = @props
+              else
+                scale =
+                  horizontal: 0
+                  vertical: 0
               toolEnv =
                 containerRect: @props.containerRect
-                scale: @props.scale
+                scale: scale
                 disabled: isPriorAnnotation
                 selected: mark is @state.selection and not isPriorAnnotation
                 getEventOffset: @props.getEventOffset

--- a/app/classifier/tasks/drawing/markings-renderer.cjsx
+++ b/app/classifier/tasks/drawing/markings-renderer.cjsx
@@ -60,7 +60,7 @@ module.exports = React.createClass
               else
                 details = null
 
-              if isFinite(@props.scale.horizontal)
+              if isFinite(@props.scale.horizontal + @props.scale.vertical)
                 { scale } = @props
               else
                 scale =

--- a/app/classifier/tasks/drawing/markings-renderer.cjsx
+++ b/app/classifier/tasks/drawing/markings-renderer.cjsx
@@ -64,8 +64,8 @@ module.exports = React.createClass
                 { scale } = @props
               else
                 scale =
-                  horizontal: 0
-                  vertical: 0
+                  horizontal: 0.001
+                  vertical: 0.001
               toolEnv =
                 containerRect: @props.containerRect
                 scale: scale

--- a/app/components/subject-viewer.cjsx
+++ b/app/components/subject-viewer.cjsx
@@ -122,13 +122,23 @@ module.exports = React.createClass
       when 'image'
         if not @state.inFlipbookMode or @props.subject?.locations.length < 2 or subjectHasMixedLocationTypes @props.subject
           if @props.workflow?.configuration.enable_switching_flipbook_and_separate
-            <button className="secret-button" aria-label="Toggle flipbook mode" title="Toggle flipbook mode" onClick={@toggleInFlipbookMode}>
+            <button
+              className="secret-button"
+              aria-label="Toggle flipbook mode"
+              title="Toggle flipbook mode"
+              onClick={@toggleInFlipbookMode}
+            >
               <i className={"fa fa-fw " + if @state.inFlipbookMode then "fa-th-large" else "fa-film"}></i>
             </button>
         else
           <span className="tools">
             {if @props.workflow?.configuration.enable_switching_flipbook_and_separate
-              <button className="secret-button" aria-label="Toggle flipbook mode" title="Toggle flipbook mode" onClick={@toggleInFlipbookMode}>
+              <button
+                className="secret-button"
+                aria-label="Toggle flipbook mode"
+                title="Toggle flipbook mode"
+                onClick={@toggleInFlipbookMode}
+              >
                 <i className={"fa fa-fw " + if @state.inFlipbookMode then "fa-th-large" else "fa-film"}></i>
               </button>}
 

--- a/app/components/subject-viewer.cjsx
+++ b/app/components/subject-viewer.cjsx
@@ -127,6 +127,7 @@ module.exports = React.createClass
               aria-label="Toggle flipbook mode"
               title="Toggle flipbook mode"
               onClick={@toggleInFlipbookMode}
+              disabled={@state.loading}
             >
               <i className={"fa fa-fw " + if @state.inFlipbookMode then "fa-th-large" else "fa-film"}></i>
             </button>
@@ -138,6 +139,7 @@ module.exports = React.createClass
                 aria-label="Toggle flipbook mode"
                 title="Toggle flipbook mode"
                 onClick={@toggleInFlipbookMode}
+                disabled={@state.loading}
               >
                 <i className={"fa fa-fw " + if @state.inFlipbookMode then "fa-th-large" else "fa-film"}></i>
               </button>}


### PR DESCRIPTION
Staging branch URL: https://fix-4266.pfe-preview.zooniverse.org/

Fixes #4266 .

Describe your changes.
Tries to set sensible defaults for non-finite image scaling, and holds off rendering delete buttons and drag handles until the screen transformation matrix is defined. Also disables the flipbook buttons until the subject has loaded.

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [x] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?

  