### PR TITLE
Renamed user_group to selected_user_group_id

### DIFF
--- a/app/pages/project/classify.cjsx
+++ b/app/pages/project/classify.cjsx
@@ -157,7 +157,7 @@ module.exports = React.createClass
           subjects: [subject.id]
 
       if @state.validUserGroup
-        classification.update({ 'metadata.user_group': @props.location.query.group })
+        classification.update({ 'metadata.selected_user_group_id': @props.location.query.group })
 
       # If the user hasn't interacted with a classification resource before,
       # we won't know how to resolve its links, so attach these manually.


### PR DESCRIPTION
Staging branch URL: https://rename-user-group-metadata.pfe-preview.zooniverse.org/

Requested in zooniverse/education-api#86. This updates the metadata property name that is added to the classification if a user is classifying as a part of a user group. I2A classrooms use this feature. In debugging the classification counts done by the education api, we found that Panoptes updates the classification metadata with an array of user group ids that the user is a part of ([see here](https://github.com/zooniverse/Panoptes/blob/d77b16687bf8be1cebe91468e81f7a0683430b11/lib/classification_lifecycle.rb#L117-L120)). This is used by the education api for the Wildcam projects, however, with the I2A projects we want to know specifically which user group the user classified as. This renaming clarifies the intention of this metadata and differentiates it from the `user_group_ids` that Panoptes adds.

@amyrebecca could we coordinate tomorrow to test this with the staging I2A projects and caesar configs and if it's working, then merge and update the caesar configs on production?

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
