### PR TITLE
Remove classification change listener

### DIFF
--- a/app/classifier/classifier.jsx
+++ b/app/classifier/classifier.jsx
@@ -217,8 +217,7 @@ class Classifier extends React.Component {
   handleAnnotationChange(classification, newAnnotation) {
     const annotations  = classification.annotations.slice();
     annotations[annotations.length - 1] = newAnnotation;
-    classification.update({ annotations });
-    this.setState({ annotations });
+    this.updateAnnotations(annotations);
   }
 
   completeClassification() {

--- a/app/classifier/classifier.jsx
+++ b/app/classifier/classifier.jsx
@@ -304,6 +304,7 @@ class Classifier extends React.Component {
               task={currentTask}
               annotation={currentAnnotation}
               subjectLoading={this.state.subjectLoading}
+              updateAnnotations={this.updateAnnotations}
             /> :
             <ClassificationSummary
               project={this.props.project}

--- a/app/classifier/classifier.jsx
+++ b/app/classifier/classifier.jsx
@@ -48,7 +48,6 @@ class Classifier extends React.Component {
   }
 
   componentWillMount() {
-    this.props.classification.listen('change', this.updateAnnotations);
     this.updateAnnotations();
   }
 
@@ -85,8 +84,6 @@ class Classifier extends React.Component {
     const prevAnnotation = prevState.annotations[prevState.annotations.length - 1];
 
     if (prevProps.classification !== this.props.classification) {
-      prevProps.classification.stopListening('change', this.updateAnnotations);
-      this.props.classification.listen('change', this.updateAnnotations);
       this.updateAnnotations();
     }
 
@@ -96,7 +93,6 @@ class Classifier extends React.Component {
   }
 
   componentWillUnmount() {
-    this.props.classification.stopListening('change', this.updateAnnotations);
     try {
       !!this.context.geordi && this.context.geordi.forget(['subjectID']);
     } catch (err) {
@@ -151,6 +147,7 @@ class Classifier extends React.Component {
   updateAnnotations(annotations) {
     annotations = annotations || this.props.classification.annotations.slice();
     this.setState({ annotations });
+    this.props.classification.update({ annotations });
     if (this.props.feedback.active) {
       this.updateFeedback();
     }

--- a/app/classifier/classifier.jsx
+++ b/app/classifier/classifier.jsx
@@ -234,6 +234,7 @@ class Classifier extends React.Component {
           this.props.onComplete()
             .catch(error => console.error(error));
         }
+        this.setState({ annotations: [{}] });
       });
   }
 

--- a/app/classifier/classifier.jsx
+++ b/app/classifier/classifier.jsx
@@ -148,8 +148,8 @@ class Classifier extends React.Component {
       }));
   }
 
-  updateAnnotations() {
-    const annotations = this.props.classification.annotations.slice();
+  updateAnnotations(annotations) {
+    annotations = annotations || this.props.classification.annotations.slice();
     this.setState({ annotations });
     if (this.props.feedback.active) {
       this.updateFeedback();
@@ -331,6 +331,7 @@ class Classifier extends React.Component {
             subject={this.props.subject}
             task={currentTask}
             workflow={this.props.workflow}
+            updateAnnotations={this.updateAnnotations}
           >
             {!!this.props.expertClassifier &&
               <ExpertOptions

--- a/app/classifier/task-nav.jsx
+++ b/app/classifier/task-nav.jsx
@@ -51,8 +51,9 @@ class TaskNav extends React.Component {
       }
     }
 
-    classification.annotations.push(annotation);
-    classification.update('annotations');
+    const annotations = classification.annotations.slice();
+    annotations.push(annotation);
+    this.props.updateAnnotations(annotations);
   }
 
   // Done
@@ -97,8 +98,9 @@ class TaskNav extends React.Component {
     const { workflow, classification } = this.props;
     const lastAnnotation = classification.annotations[classification.annotations.length - 1];
 
-    classification.annotations.pop();
-    classification.update('annotations');
+    const annotations = classification.annotations.slice();
+    annotations.pop();
+    this.props.updateAnnotations(annotations);
 
     if (workflow.configuration.persist_annotations) {
       CacheClassification.update(lastAnnotation);
@@ -253,6 +255,7 @@ TaskNav.propTypes = {
   task: React.PropTypes.shape({
     type: React.PropTypes.string
   }),
+  updateAnnotations: React.PropTypes.func,
   workflow: React.PropTypes.shape({
     id: React.PropTypes.string,
     configuration: React.PropTypes.object,
@@ -262,7 +265,8 @@ TaskNav.propTypes = {
 };
 
 TaskNav.defaultProps = {
-  disabled: false
+  disabled: false,
+  updateAnnotations: () => null
 };
 
 export default TaskNav;

--- a/app/classifier/task.jsx
+++ b/app/classifier/task.jsx
@@ -11,8 +11,9 @@ class Task extends React.Component {
 
   handleAnnotationChange(newAnnotation) {
     const { classification } = this.props;
-    classification.annotations[classification.annotations.length - 1] = newAnnotation;
-    classification.update('annotations');
+    const annotations = classification.annotations.slice();
+    annotations[annotations.length - 1] = newAnnotation;
+    this.props.updateAnnotations(annotations);
   }
 
   render() {
@@ -122,12 +123,17 @@ Task.propTypes = {
   task: React.PropTypes.shape({
     type: React.PropTypes.string
   }),
+  updateAnnotations: React.PropTypes.func,
   user: React.PropTypes.shape({
     id: React.PropTypes.string
   }),
   workflow: React.PropTypes.shape({
     id: React.PropTypes.string
   })
+};
+
+Task.defaultProps = {
+  updateAnnotations: () => null
 };
 
 export default Task;

--- a/app/classifier/task.jsx
+++ b/app/classifier/task.jsx
@@ -47,7 +47,7 @@ class Task extends React.Component {
       taskTypes: tasks,
       workflow,
       classification,
-      onChange: () => classification.update()
+      onChange: () => this.handleAnnotationChange
     };
 
     return (

--- a/app/classifier/tasks/crop/initializer.cjsx
+++ b/app/classifier/tasks/crop/initializer.cjsx
@@ -42,7 +42,7 @@ module.exports = React.createClass
     {x, y} = @props.getEventOffset e
     _start = {x, y}
     @props.annotation.value = {x, y, width: 0, height: 0, _start}
-    @props.classification.update 'annotation'
+    @props.onChange @props.annotation
 
   handleInitDrag: (e) ->
     {x, y} = @props.getEventOffset e
@@ -53,7 +53,7 @@ module.exports = React.createClass
     @props.annotation.value.y = Math.min _start.y, y
     @props.annotation.value.width = Math.abs _start.x - x
     @props.annotation.value.height = Math.abs _start.y - y
-    @props.classification.update 'annotation'
+    @props.onChange @props.annotation
 
   handleBoxDrag: (e, d) ->
     difference = @props.normalizeDifference(e, d)
@@ -61,7 +61,7 @@ module.exports = React.createClass
     maxY = (@props.containerRect.height / @props.scale.vertical) - @props.annotation.value.height
     @props.annotation.value.x = Math.max 0, Math.min maxX, @props.annotation.value.x += difference.x
     @props.annotation.value.y = Math.max 0, Math.min maxY, @props.annotation.value.y += difference.y
-    @props.classification.update 'annotations'
+    @props.onChange @props.annotation
 
   handleStartHandle: (e) ->
     mouse = @props.getEventOffset e
@@ -78,7 +78,7 @@ module.exports = React.createClass
     diff = _start.mouse[coord] - mouse[coord]
     @props.annotation.value[coord] = Math.min _start.mouse[coord] + _start.rect[dimension], mouse[coord]
     @props.annotation.value[dimension] = Math.abs _start.rect[dimension] + diff
-    @props.classification.update 'annotation'
+    @props.onChange @props.annotation
 
   handleDragFar: (coord, e) ->
     dimension = {x: 'width', y: 'height'}[coord]
@@ -89,4 +89,4 @@ module.exports = React.createClass
     diff = _start.mouse[coord] - mouse[coord]
     @props.annotation.value[coord] = Math.min _start.rect[coord], mouse[coord]
     @props.annotation.value[dimension] = Math.abs _start.rect[dimension] - diff
-    @props.classification.update 'annotation'
+    @props.onChange @props.annotation

--- a/app/classifier/tasks/drawing/marking-initializer.cjsx
+++ b/app/classifier/tasks/drawing/marking-initializer.cjsx
@@ -63,7 +63,7 @@ module.exports = React.createClass
       for key, value of initValues
         mark[key] = value
 
-    @props.classification.update 'annotations'
+    @props.onChange @props.annotation
 
   handleInitDrag: (e) ->
     taskDescription = @props.workflow.tasks[@props.annotation.task]
@@ -76,7 +76,7 @@ module.exports = React.createClass
       for key, value of initMoveValues
         mark[key] = value
 
-    @props.classification.update 'annotations'
+    @props.onChange @props.annotation
 
   handleInitRelease: (e) ->
     pref = @props.preferences.preferences
@@ -101,7 +101,7 @@ module.exports = React.createClass
         unless MarkComponent.initValid multiple, @props
           @destroyMark @props.annotation, multiple
 
-    @props.classification.update 'annotations'
+    @props.onChange @props.annotation
 
     if MarkComponent.initValid?
       unless MarkComponent.initValid mark, @props
@@ -112,4 +112,4 @@ module.exports = React.createClass
       @setState selectedMark: null
     markIndex = annotation.value.indexOf mark
     annotation.value.splice markIndex, 1
-    @props.classification.update 'annotations'
+    @props.onChange annotation

--- a/app/classifier/tasks/drawing/markings-renderer.cjsx
+++ b/app/classifier/tasks/drawing/markings-renderer.cjsx
@@ -113,7 +113,7 @@ module.exports = React.createClass
     markIndex = annotation.value.indexOf mark
     annotation.value.splice markIndex, 1
     annotation.value.push mark
-    @props.classification.update 'annotations'
+    @props.onChange annotation
 
   handleDeselect: ->
     @setState selection: null
@@ -123,11 +123,11 @@ module.exports = React.createClass
       @setState selection: null
     markIndex = annotation.value.indexOf mark
     annotation.value.splice markIndex, 1
-    @props.classification.update 'annotations'
+    @props.onChange annotation
     if mark.templateID
       index = []
       for cell in annotation.value
         if cell.templateID is mark.templateID
           index.push(annotation.value.indexOf cell)
       annotation.value.splice index[0], index.length
-      @props.classification.update 'annotations'
+      @props.onChange annotation

--- a/app/classifier/tasks/highlighter/label-editor.jsx
+++ b/app/classifier/tasks/highlighter/label-editor.jsx
@@ -4,7 +4,7 @@ export default function LabelEditor(props) {
   function deleteAnnotation(annotation) {
     const index = props.annotation.value.indexOf(annotation);
     props.annotation.value.splice(index, 1);
-    props.classification.update('annotations');
+    props.onChange(props.annotation);
   }
 
   function onClick(e) {

--- a/app/classifier/tasks/survey/annotation-view.cjsx
+++ b/app/classifier/tasks/survey/annotation-view.cjsx
@@ -32,4 +32,4 @@ module.exports = React.createClass
 
   handleRemove: (index) ->
     @props.annotation.value.splice index, 1
-    @props.classification.update 'annotations'
+    @props.onChange @props.annotation


### PR DESCRIPTION
Staging branch URL: https://classification-update.pfe-preview.zooniverse.org/

This builds on #4272 (which needs to be merged first.)

Removes the classification change listener from the classifier. Tasks are updated to modify annotations via the `onChange` callback, instead of calling `classification.update('annotations')`.

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [x] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [x] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
