### PR TITLE
Only show redirect button for projects with redirect

### DIFF
--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -62,7 +62,8 @@ export default {
       joinIn: 'Join in',
       learnMore: 'Learn more',
       getStarted: 'Get started',
-      workflowAssignment: 'You\'ve unlocked level %(workflowDisplayName)s'
+      workflowAssignment: 'You\'ve unlocked level %(workflowDisplayName)s',
+      visitLink: 'Visit the project'
     }
   },
   organization: {

--- a/app/locales/es.js
+++ b/app/locales/es.js
@@ -52,7 +52,11 @@ export default {
         one: '<strong>1</strong> person is talking about <strong>%(title)s</strong> right now.',
         other: '<strong>%(count)s</strong> people are talking about <strong>%(title)s</strong> right now.'
       },
-      joinIn: 'Join in'
+      joinIn: 'Join in',
+      learnMore: 'Learn more',
+      getStarted: 'Get started',
+      workflowAssignment: 'You\'ve unlocked level %(workflowDisplayName)s',
+      visitLink: 'Visit the project'
     }
   },
   organization: {

--- a/app/locales/it.js
+++ b/app/locales/it.js
@@ -53,7 +53,11 @@ export default {
         one: '<strong>1</strong> persona sta parlando di <strong>%(title)s</strong> in questo momento.',
         other: '<strong>%(count)s</strong> persone stanno parlando di <strong>%(title)s</strong> in questo momento.'
       },
-      joinIn: 'Partecipa'
+      joinIn: 'Partecipa',
+      learnMore: 'Learn more',
+      getStarted: 'Get started',
+      workflowAssignment: 'You\'ve unlocked level %(workflowDisplayName)s',
+      visitLink: 'Visit the project'
     }
   },
   tasks: {

--- a/app/locales/nl.js
+++ b/app/locales/nl.js
@@ -85,7 +85,11 @@ export default {
         one: '<strong>1</strong> persoon praat over <strong>%(title)s</strong> op dit moment.',
         other: '<strong>%(count)s</strong> mensen praten over <strong>%(title)s</strong> op dit moment.'
       },
-      joinIn: 'Doe mee'
+      joinIn: 'Doe mee',
+      learnMore: 'Learn more',
+      getStarted: 'Get started',
+      workflowAssignment: 'You\'ve unlocked level %(workflowDisplayName)s',
+      visitLink: 'Visit the project'
     }
   },
   organization: {

--- a/app/pages/project/home/home-workflow-buttons.jsx
+++ b/app/pages/project/home/home-workflow-buttons.jsx
@@ -26,12 +26,7 @@ export default class ProjectHomeWorkflowButtons extends React.Component {
 
   render() {
     if (this.props.project && this.props.project.redirect) {
-      return (
-        <a href={this.props.project.redirect} className="project-home-page__button">
-          <strong>Visit the project</strong><br />
-          <small>at {this.props.project.redirect}</small>
-        </a>
-      );
+      return null;
     }
 
     return (

--- a/app/pages/project/home/home-workflow-buttons.spec.js
+++ b/app/pages/project/home/home-workflow-buttons.spec.js
@@ -23,10 +23,6 @@ const testUserPreferences = {
   settings: { workflow_id: '1234' }
 };
 
-const testProject = {
-  redirect: 'www.testproject.com'
-};
-
 describe('ProjectHomeWorkflowButtons', function() {
   let wrapper;
 
@@ -73,22 +69,6 @@ describe('ProjectHomeWorkflowButtons', function() {
 
     it('should not render the workflow buttons', function() {
       assert.equal(wrapper.find('ProjectHomeWorkflowButton').length, 0);
-    });
-  });
-
-  describe('if project has a redirect', function() {
-    before(function() {
-      wrapper = shallow(
-        <ProjectHomeWorkflowButtons project={testProject} />
-      );
-    });
-
-    it('should render a redirect link', function() {
-      assert.equal(wrapper.find('a').length, 1);
-    });
-
-    it('should have href equal to project redirect', function() {
-      assert.equal(wrapper.find('a').prop('href'), testProject.redirect);
     });
   });
 });

--- a/app/pages/project/home/project-home.jsx
+++ b/app/pages/project/home/project-home.jsx
@@ -46,16 +46,22 @@ const ProjectHomePage = (props) => {
         </div>
 
         <div className="project-home-page__call-to-action">
-          <Link to={`/projects/${props.project.slug}/about`} className="project-home-page__button call-to-action__button call-to-action__button--learn-more">
-            <Translate content="project.home.learnMore" />
-          </Link>
-          {!props.showWorkflowButtons &&
+          {props.project && !props.project.redirect &&
+            <Link to={`/projects/${props.project.slug}/about`} className="project-home-page__button call-to-action__button call-to-action__button--learn-more">
+              <Translate content="project.home.learnMore" />
+            </Link>}
+          {!props.showWorkflowButtons && props.project && !props.project.redirect &&
             <Link
               to={`/projects/${props.project.slug}/classify`}
               className="project-home-page__button call-to-action__button call-to-action__button--get-started"
             >
               <Translate content="project.home.getStarted" />
             </Link>}
+          {props.project && props.project.redirect &&
+            <a href={props.project.redirect} className="project-home-page__button">
+              <strong><Translate content="project.home.visitLink" /></strong><br />
+              <small>at {props.project.redirect}</small>
+            </a>}
         </div>
 
         <ProjectHomeWorkflowButtons
@@ -169,6 +175,7 @@ ProjectHomePage.propTypes = {
     experimental_tools: React.PropTypes.arrayOf(React.PropTypes.string),
     id: React.PropTypes.string,
     introduction: React.PropTypes.string,
+    redirect: React.PropTypes.string,
     researcher_quote: React.PropTypes.string,
     slug: React.PropTypes.string
   }).isRequired,

--- a/app/pages/project/home/project-home.spec.js
+++ b/app/pages/project/home/project-home.spec.js
@@ -1,0 +1,254 @@
+import React from 'react';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { shallow, mount } from 'enzyme';
+import ProjectHome from './project-home';
+
+const activeWorkflows = [
+  { active: true, id: '34' }
+];
+
+const background = { src: 'background.jpg' };
+
+const organization = { display_name: 'My organization', slug: 'zooniverse/my-organization' };
+
+const preferences = {};
+
+const project = {
+  configuration: {},
+  description: 'Project description',
+  display_name: 'Identify Animals',
+  experimental_tools: [''],
+  id: '123',
+  slug: 'zooniverse/identify-animals'
+};
+
+const talkSubjects = [
+  { id: '1', locations: [{ 'image/png': 'subject1.png' }] },
+  { id: '2', locations: [{ 'image/png': 'subject2.png' }] },
+  { id: '3', locations: [{ 'image/png': 'subject3.png' }] }
+];
+
+const translation = {
+  description: 'translated description',
+  display_name: 'translated display_name',
+  researcher_quote: 'translated researcher_quote',
+  title: 'translated title'
+};
+
+const user = {
+  id: '242'
+};
+
+describe('ProjectHome', function() {
+  let wrapper;
+  before(function() {
+    wrapper = shallow(
+      <ProjectHome
+        activeWorkflows={activeWorkflows}
+        background={background}
+        project={project}
+        researcherAvatar={''}
+        translation={translation}
+      />
+    );
+  });
+
+  it('should render without crashing', function() {});
+
+  it('should render ProjectNavbar', function() {
+    expect(wrapper.find('ProjectNavbar')).to.have.lengthOf(1);
+  });
+
+  it('should render ProjectHomeWorkflowButtons', function() {
+    expect(wrapper.find('ProjectHomeWorkflowButtons')).to.have.lengthOf(1);
+  });
+
+  it('should render ProjectMetadata', function() {
+    expect(wrapper.find('ProjectMetadata')).to.have.lengthOf(1);
+  });
+
+  describe('when the project is not complete', function() {
+    it('should not render FinishedBanner', function() {
+      expect(wrapper.find('FinishedBanner')).to.have.lengthOf(0);
+    });
+  });
+
+  describe('when the project is complete', function() {
+    before(function() {
+      wrapper.setProps({ projectIsComplete: true });
+    });
+    after(function() {
+      wrapper.setProps({ projectIsComplete: false });
+    });
+
+    it('should render FinishedBanner if props.projectIsComplete is true', function() {
+      expect(wrapper.find('FinishedBanner')).to.have.lengthOf(1);
+    });
+  });
+
+  describe('when the project does not have an announcement', function() {
+    it('should not render a Markdown component', function() {
+      expect(wrapper.find('Markdown')).to.have.lengthOf(0);
+    });
+  });
+
+  describe('when the project has an announcement', function() {
+    before(function() {
+      const projectWithAnnouncement = Object.assign({}, project, { configuration: { announcement: 'Big announcement!' }});
+      wrapper.setProps({ project: projectWithAnnouncement });
+    });
+
+    it('should render a Markdown component', function() {
+      const markdown = wrapper.find('Markdown');
+      expect(markdown).to.have.lengthOf(1);
+      expect(markdown.children().text()).to.equal('Big announcement!');
+    });
+  });
+
+  describe('when the project is not linked to an organization', function() {
+    it('should not render a Link component linking to the organization', function() {
+      expect(wrapper.find({ to: `/organizations/${organization.slug}` })).to.have.lengthOf(0);
+    });
+
+    it('should use the class .project-home-page__description--top-padding', function() {
+      expect(wrapper.find('.project-home-page__description--top-padding')).to.have.lengthOf(1);
+    });
+  });
+
+  describe('when the project is linked to an organization', function() {
+    before(function() {
+      wrapper.setProps({ organization });
+    });
+
+    it('should render a Link component linking to the organization', function() {
+      expect(wrapper.find({ to: `/organizations/${organization.slug}` })).to.have.lengthOf(1);
+    });
+
+    it('should not use the class .project-home-page__description--top-padding', function() {
+      expect(wrapper.find('.project-home-page__description--top-padding')).to.have.lengthOf(0);
+    });
+
+    it('should render a Translation component for the Link text', function() {
+      const link = wrapper.find({ to: `/organizations/${organization.slug}` });
+      expect(link.find('Translate')).to.have.lengthOf(1);
+    });
+  });
+
+  describe('when the project does not have a redirect', function() {
+    it('should render a Link component to the project about page', function() {
+      expect(wrapper.find({ to: `/projects/${project.slug}/about` })).to.have.lengthOf(1);
+    });
+
+    it('should render a Translate component for the about page Link text', function() {
+      expect(wrapper.find({ to: `/projects/${project.slug}/about` }).find('Translate')).to.have.lengthOf(1);
+    });
+
+    it('should render a Link component to the classify page if props.showWorkflowButtons is false', function() {
+      expect(wrapper.find({ to: `/projects/${project.slug}/classify` })).to.have.lengthOf(1);
+    });
+
+    it('should render a Translate component for the about page Link text', function() {
+      expect(wrapper.find({ to: `/projects/${project.slug}/classify` }).find('Translate')).to.have.lengthOf(1);
+    });
+  });
+
+  describe('when the project does have a redirect', function() {
+    before(function() {
+      const projectWithRedirect = Object.assign({}, project, { redirect: 'https://identifyanimals.org' });
+      wrapper.setProps({ project: projectWithRedirect });
+    });
+
+    it('should not render a Link component to the project about page', function() {
+      expect(wrapper.find({ to: `/projects/${project.slug}/about` })).to.have.lengthOf(0);
+    });
+
+    it('should not render a Link component to the classify page', function() {
+      expect(wrapper.find({ to: `/projects/${project.slug}/classify` })).to.have.lengthOf(0);
+    });
+
+    it('should render an html anchor tag linked to the redirect url', function() {
+      expect(wrapper.find('a.project-home-page__button')).to.have.lengthOf(1);
+    });
+
+    it('should render a Translate component for the anchor tag text', function() {
+      expect(wrapper.find('a.project-home-page__button').find('Translate')).to.have.lengthOf(1);
+    });
+  });
+
+  describe('when there are not talk subject', function() {
+    it('should not render subject talk divs', function() {
+      expect(wrapper.find('.project-home-page__talk-image')).to.have.lengthOf(0);
+    });
+  });
+
+  describe('when there are talk subjects', function() {
+    before(function() {
+      wrapper.setProps({ talkSubjects });
+    });
+
+    it('should render 3 subject talk divs', function() {
+      expect(wrapper.find('.project-home-page__talk-image')).to.have.lengthOf(3);
+    });
+
+    it('should render 3 Link components for each subject', function() {
+      talkSubjects.forEach((subject) => {
+        expect(wrapper.find({ to: `/projects/${project.slug}/talk/subjects/${subject.id}` })).to.have.lengthOf(1);
+      });
+    });
+
+    it('should render 3 Thumbnail components for each subject', function() {
+      talkSubjects.forEach((subject) => {
+        expect(wrapper.find({ src: subject.locations[0]['image/png'] })).to.have.lengthOf(1);
+      });
+    });
+
+    it('should render a TalkStatus component', function() {
+      expect(wrapper.find('TalkStatus')).to.have.lengthOf(1);
+    });
+  });
+
+  describe('when a project does not have a researcher quote', function() {
+    it('should not render the researcher quote div', function() {
+      expect(wrapper.find('.project-home-page__researcher-words')).to.have.lengthOf(0);
+    });
+  });
+
+  describe('when a project does have a researcher quote', function() {
+    before(function() {
+      const projectWithResearcherQuote = Object.assign({}, project, { researcher_quote: 'Important thoughts!' });
+      wrapper.setProps({ project: projectWithResearcherQuote });
+    });
+
+    it('should render the researcher quote div', function() {
+      expect(wrapper.find('.project-home-page__researcher-words')).to.have.lengthOf(1);
+    });
+
+    it('should use the default avatar if props.researcherAvatar is not defined', function() {
+      expect(wrapper.find({ src: '/assets/simple-avatar.png' })).to.have.lengthOf(1);
+    });
+
+    it('should use props.researcherAvatar if it is defined', function() {
+      const researcherAvatar = 'researcher.png';
+      wrapper.setProps({ researcherAvatar });
+      expect(wrapper.find({ src: researcherAvatar })).to.have.lengthOf(1);
+    });
+  });
+
+  describe('the project about section', function() {
+    it('should render a Translate component', function() {
+      expect(wrapper.find({ content: 'project.home.about' })).to.have.lengthOf(1);
+    });
+
+    it('should not render a Markdown component if there is no project introduction', function() {
+      expect(wrapper.find('.project-home-page__about-text').find('Markdown')).to.have.lengthOf(0);
+    });
+
+    it('should render a Markdown component if there is a project introduction', function() {
+      const projectWithIntroduction = Object.assign({}, project, { introduction: 'Please help our project' });
+
+      wrapper.setProps({ project: projectWithIntroduction });
+      expect(wrapper.find('.project-home-page__about-text').find('Markdown')).to.have.lengthOf(1);
+    });
+  });
+});


### PR DESCRIPTION
Staging branch URL: https://fix-redirect-home-button.pfe-preview.zooniverse.org/

Fixes an issue found while debugging Anti-slavery Manuscripts. If the project has a redirect, then only the button for that redirect should be visible on its PFE home page. I also added unit tests for all the conditionals for this component and fixed a missing translation.

https://fix-redirect-home-button.pfe-preview.zooniverse.org/projects/bostonpubliclibrary/anti-slavery-manuscripts/?env=production

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [x] Can you post a talk comment?

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
