### PR TITLE
Use Provider to pass the Redux store to modals

### DIFF
--- a/app/classifier/drawing-tools/root.cjsx
+++ b/app/classifier/drawing-tools/root.cjsx
@@ -1,5 +1,6 @@
 React = require 'react'
 StickyModalForm = require 'modal-form/sticky'
+{ Provider } = require('react-redux')
 ModalFocus = require('../../components/modal-focus').default
 TaskTranslations = require('../tasks/translations').default
 
@@ -76,24 +77,25 @@ module.exports = React.createClass
             true
 
         <StickyModalForm ref="detailsForm" style={SEMI_MODAL_FORM_STYLE} underlayStyle={SEMI_MODAL_UNDERLAY_STYLE} onSubmit={@handleDetailsFormClose} onCancel={@handleDetailsFormClose}>
-          <ModalFocus onEscape={@handleDetailsFormClose} preserveFocus={false}>
-            {for detailTask, i in toolProps.details
-              detailTask._key ?= Math.random()
-              TaskComponent = tasks[detailTask.type]
-              taskKey = "#{toolProps.taskKey}.tools.#{toolProps.mark.tool}.details.#{i}"
-              <TaskTranslations
-                key={detailTask._key}
-                taskKey={taskKey}
-                task={detailTask}
-                store={@context.store}
-              >
-                <TaskComponent autoFocus={i is 0} task={detailTask} annotation={toolProps.mark.details[i]} onChange={@handleDetailsChange.bind this, i} />
-              </TaskTranslations>}
-            <hr />
-            <p style={textAlign: 'center'}>
-              <button autoFocus={toolProps.details[0].type in ['single', 'multiple']} type="submit" className="standard-button" disabled={not detailsAreComplete}>OK</button>
-            </p>
-          </ModalFocus>
+          <Provider store={@context.store}>
+            <ModalFocus onEscape={@handleDetailsFormClose} preserveFocus={false}>
+              {for detailTask, i in toolProps.details
+                detailTask._key ?= Math.random()
+                TaskComponent = tasks[detailTask.type]
+                taskKey = "#{toolProps.taskKey}.tools.#{toolProps.mark.tool}.details.#{i}"
+                <TaskTranslations
+                  key={detailTask._key}
+                  taskKey={taskKey}
+                  task={detailTask}
+                >
+                  <TaskComponent autoFocus={i is 0} task={detailTask} annotation={toolProps.mark.details[i]} onChange={@handleDetailsChange.bind this, i} />
+                </TaskTranslations>}
+              <hr />
+              <p style={textAlign: 'center'}>
+                <button autoFocus={toolProps.details[0].type in ['single', 'multiple']} type="submit" className="standard-button" disabled={not detailsAreComplete}>OK</button>
+              </p>
+            </ModalFocus>
+          </Provider>
         </StickyModalForm>}
     </g>
 

--- a/app/classifier/mini-course.cjsx
+++ b/app/classifier/mini-course.cjsx
@@ -4,6 +4,7 @@ Translate = require 'react-translate-component'
 MediaCard = require '../components/media-card'
 {Markdown} = require 'markdownz'
 apiClient = require 'panoptes-client/lib/api-client'
+{ Provider } = require('react-redux')
 Translations = require('./translations').default
 
 minicoursesCompletedThisSession = {}
@@ -39,10 +40,12 @@ module.exports = React.createClass
               mediaByID
 
         awaitMiniCourseMedia.then (mediaByID) =>
-          minicourseContent = 
-            <Translations original={minicourse} type="minicourse" store={store}>
-              <MiniCourseComponent projectPreferences={projectPreferences} user={user} minicourse={minicourse} media={mediaByID} geordi={geordi} />
-            </Translations>
+          minicourseContent =
+            <Provider store={store}>
+              <Translations original={minicourse} type="minicourse">
+                <MiniCourseComponent projectPreferences={projectPreferences} user={user} minicourse={minicourse} media={mediaByID} geordi={geordi} />
+              </Translations>
+            </Provider>
           Dialog.alert(minicourseContent, {
             className: 'mini-course-dialog',
             required: true,

--- a/app/classifier/tutorial.cjsx
+++ b/app/classifier/tutorial.cjsx
@@ -4,6 +4,7 @@ Translate = require 'react-translate-component'
 MediaCard = require '../components/media-card'
 {Markdown} = require 'markdownz'
 apiClient = require 'panoptes-client/lib/api-client'
+{ Provider } = require('react-redux')
 
 StepThrough = require('../components/step-through').default
 Translations = require('./translations').default
@@ -56,10 +57,12 @@ module.exports = React.createClass
             mediaByID
 
         awaitTutorialMedia.then (mediaByID) =>
-          tutorialContent = 
-            <Translations original={tutorial} type="tutorial" store={store}>
-              <TutorialComponent tutorial={tutorial} media={mediaByID} preferences={preferences} user={user} geordi={geordi} />
-            </Translations>
+          tutorialContent =
+            <Provider store={store}>
+              <Translations original={tutorial} type="tutorial">
+                <TutorialComponent tutorial={tutorial} media={mediaByID} preferences={preferences} user={user} geordi={geordi} />
+              </Translations>
+            </Provider>
           Dialog.alert(tutorialContent, {
             className: 'tutorial-dialog',
             required: true,

--- a/app/pages/project/potential-field-guide.cjsx
+++ b/app/pages/project/potential-field-guide.cjsx
@@ -1,6 +1,7 @@
 React = require 'react'
 apiClient = require 'panoptes-client/lib/api-client'
 Pullout = require 'react-pullout'
+{ Provider } = require('react-redux')
 FieldGuide = require './field-guide'
 Translations = require('../../classifier/translations').default
 
@@ -37,9 +38,11 @@ module.exports = React.createClass
         <button type="button" className="field-guide-pullout-toggle" onClick={@toggleFieldGuide}>
           <strong>Field guide</strong>
         </button>
-        <Translations original={@props.guide} type="field_guide" store={@context.store}>
-          <FieldGuide items={@props.guide.items} icons={@props.guideIcons} onClickClose={@toggleFieldGuide} />
-        </Translations>
+        <Provider store={@context.store}>
+          <Translations original={@props.guide} type="field_guide">
+            <FieldGuide items={@props.guide.items} icons={@props.guideIcons} onClickClose={@toggleFieldGuide} />
+          </Translations>
+        </Provider>
       </Pullout>
     else
       null


### PR DESCRIPTION
Staging branch URL: https://redux-provider.pfe-preview.zooniverse.org/

Alternative to #4280.

Passes the Redux store to field guides, mini courses and tutorials by wrapping them in a `Provider` that takes the current store as a prop.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
