### PR TITLE
Replace React.PropTypes with prop-types module

### DIFF
--- a/app/classifier/annotation-renderer/index.jsx
+++ b/app/classifier/annotation-renderer/index.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import SVGRenderer from './svg';
 import TextRenderer from './text';
@@ -11,7 +12,7 @@ function DefaultRenderer(props) {
 }
 
 DefaultRenderer.propTypes = {
-  children: React.PropTypes.node
+  children: PropTypes.node
 };
 
 const VIEWERS = {
@@ -31,8 +32,8 @@ function AnnotationRenderer(props) {
 }
 
 AnnotationRenderer.propTypes = {
-  children: React.PropTypes.node,
-  type: React.PropTypes.string
+  children: PropTypes.node,
+  type: PropTypes.string
 };
 
 export default AnnotationRenderer;

--- a/app/classifier/annotation-renderer/svg.jsx
+++ b/app/classifier/annotation-renderer/svg.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import Draggable from '../../lib/draggable';
 import tasks from '../tasks';
@@ -86,7 +87,7 @@ export default class SVGRenderer extends React.Component {
 
     if (this.props.annotation.task) {
       taskDescription = this.props.workflow.tasks[this.props.annotation.task];
-      ({ InsideSubject } = tasks[taskDescription.type]);
+      (({ InsideSubject } = tasks[taskDescription.type]));
     }
 
     const { annotations } = this.props.classification;
@@ -198,37 +199,37 @@ export default class SVGRenderer extends React.Component {
 }
 
 SVGRenderer.propTypes = {
-  annotation: React.PropTypes.shape({
-    task: React.PropTypes.string
+  annotation: PropTypes.shape({
+    task: PropTypes.string
   }),
-  children: React.PropTypes.node,
-  classification: React.PropTypes.shape({
-    annotations: React.PropTypes.array,
-    loading: React.PropTypes.bool
+  children: PropTypes.node,
+  classification: PropTypes.shape({
+    annotations: PropTypes.array,
+    loading: PropTypes.bool
   }),
-  frame: React.PropTypes.number,
-  modification: React.PropTypes.object,
-  naturalHeight: React.PropTypes.number,
-  naturalWidth: React.PropTypes.number,
-  onChange: React.PropTypes.func,
-  panByDrag: React.PropTypes.func,
-  panEnabled: React.PropTypes.bool,
-  preferences: React.PropTypes.object,
-  subject: React.PropTypes.shape({
-    already_seen: React.PropTypes.bool,
-    retired: React.PropTypes.bool
+  frame: PropTypes.number,
+  modification: PropTypes.object,
+  naturalHeight: PropTypes.number,
+  naturalWidth: PropTypes.number,
+  onChange: PropTypes.func,
+  panByDrag: PropTypes.func,
+  panEnabled: PropTypes.bool,
+  preferences: PropTypes.object,
+  subject: PropTypes.shape({
+    already_seen: PropTypes.bool,
+    retired: PropTypes.bool
   }),
-  transform: React.PropTypes.string,
-  viewBoxDimensions: React.PropTypes.shape({
-    height: React.PropTypes.number,
-    width: React.PropTypes.number,
-    x: React.PropTypes.number,
-    y: React.PropTypes.number
+  transform: PropTypes.string,
+  viewBoxDimensions: PropTypes.shape({
+    height: PropTypes.number,
+    width: PropTypes.number,
+    x: PropTypes.number,
+    y: PropTypes.number
   }),
-  workflow: React.PropTypes.shape({
-    tasks: React.PropTypes.object
+  workflow: PropTypes.shape({
+    tasks: PropTypes.object
   }),
-  progressMarker: React.PropTypes.func
+  progressMarker: PropTypes.func
 };
 
 SVGRenderer.defaultProps = {

--- a/app/classifier/annotation-renderer/text.jsx
+++ b/app/classifier/annotation-renderer/text.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import tasks from '../tasks';
 import getSubjectLocation from '../../lib/get-subject-location';
@@ -11,7 +12,7 @@ export default class TextRenderer extends React.Component {
 
     if (this.props.annotation.task) {
       taskDescription = this.props.workflow.tasks[this.props.annotation.task];
-      ({ InsideSubject } = tasks[taskDescription.type]);
+      (({ InsideSubject } = tasks[taskDescription.type]));
     }
 
 
@@ -57,7 +58,7 @@ export default class TextRenderer extends React.Component {
       children = <InsideSubject key="inside" src={src} {...hookProps}>{children}</InsideSubject>;
     }
     if (children.length === 0) {
-      ({ children } = this.props);
+      (({ children } = this.props));
     }
 
     return (
@@ -69,23 +70,23 @@ export default class TextRenderer extends React.Component {
 }
 
 TextRenderer.propTypes = {
-  annotation: React.PropTypes.shape({
-    task: React.PropTypes.string
+  annotation: PropTypes.shape({
+    task: PropTypes.string
   }),
-  children: React.PropTypes.node,
-  classification: React.PropTypes.shape({
-    annotations: React.PropTypes.array,
-    loading: React.PropTypes.bool
+  children: PropTypes.node,
+  classification: PropTypes.shape({
+    annotations: PropTypes.array,
+    loading: PropTypes.bool
   }),
-  frame: React.PropTypes.number,
-  onChange: React.PropTypes.func,
-  preferences: React.PropTypes.object,
-  subject: React.PropTypes.shape({
-    already_seen: React.PropTypes.bool,
-    retired: React.PropTypes.bool
+  frame: PropTypes.number,
+  onChange: PropTypes.func,
+  preferences: PropTypes.object,
+  subject: PropTypes.shape({
+    already_seen: PropTypes.bool,
+    retired: PropTypes.bool
   }),
-  workflow: React.PropTypes.shape({
-    tasks: React.PropTypes.object
+  workflow: PropTypes.shape({
+    tasks: PropTypes.object
   })
 };
 

--- a/app/classifier/classification-summary.jsx
+++ b/app/classifier/classification-summary.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import DefaultClassificationSummary from './default-classification-summary';
@@ -106,19 +107,19 @@ class ClassificationSummary extends React.Component {
 }
 
 ClassificationSummary.propTypes = {
-  project: React.PropTypes.shape({
-    experimental_tools: React.PropTypes.array
+  project: PropTypes.shape({
+    experimental_tools: PropTypes.array
   }).isRequired,
-  workflow: React.PropTypes.shape({
-    configuration: React.PropTypes.object
+  workflow: PropTypes.shape({
+    configuration: PropTypes.object
   }).isRequired,
-  subject: React.PropTypes.object.isRequired,
-  classification: React.PropTypes.object.isRequired,
-  expertClassification: React.PropTypes.object,
-  splits: React.PropTypes.object,
-  classificationCount: React.PropTypes.number,
-  hasGSGoldStandard: React.PropTypes.bool,
-  toggleExpertClassification: React.PropTypes.func
+  subject: PropTypes.object.isRequired,
+  classification: PropTypes.object.isRequired,
+  expertClassification: PropTypes.object,
+  splits: PropTypes.object,
+  classificationCount: PropTypes.number,
+  hasGSGoldStandard: PropTypes.bool,
+  toggleExpertClassification: PropTypes.func
 };
 
 export default ClassificationSummary;

--- a/app/classifier/classifier.jsx
+++ b/app/classifier/classifier.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import apiClient from 'panoptes-client/lib/api-client';
 import { VisibilitySplit } from 'seven-ten';
@@ -411,70 +412,70 @@ class Classifier extends React.Component {
 }
 
 Classifier.contextTypes = {
-  geordi: React.PropTypes.object,
-  store: React.PropTypes.object
+  geordi: PropTypes.object,
+  store: PropTypes.object
 };
 
 Classifier.propTypes = {
-  actions: React.PropTypes.shape({
-    feedback: React.PropTypes.shape({
-      init: React.PropTypes.func,
-      update: React.PropTypes.func
+  actions: PropTypes.shape({
+    feedback: PropTypes.shape({
+      init: PropTypes.func,
+      update: PropTypes.func
     })
   }),
-  classification: React.PropTypes.shape({
-    annotations: React.PropTypes.array,
-    completed: React.PropTypes.bool,
-    gold_standard: React.PropTypes.bool,
-    id: React.PropTypes.string,
-    listen: React.PropTypes.func,
-    stopListening: React.PropTypes.func,
-    update: React.PropTypes.func
+  classification: PropTypes.shape({
+    annotations: PropTypes.array,
+    completed: PropTypes.bool,
+    gold_standard: PropTypes.bool,
+    id: PropTypes.string,
+    listen: PropTypes.func,
+    stopListening: PropTypes.func,
+    update: PropTypes.func
   }),
-  classificationCount: React.PropTypes.number,
-  demoMode: React.PropTypes.bool,
-  expertClassifier: React.PropTypes.bool,
-  feedback: React.PropTypes.shape({
-    active: React.PropTypes.bool,
-    rules: React.PropTypes.object
+  classificationCount: PropTypes.number,
+  demoMode: PropTypes.bool,
+  expertClassifier: PropTypes.bool,
+  feedback: PropTypes.shape({
+    active: PropTypes.bool,
+    rules: PropTypes.object
   }),
-  minicourse: React.PropTypes.shape({
-    id: React.PropTypes.string,
-    steps: React.PropTypes.array
+  minicourse: PropTypes.shape({
+    id: PropTypes.string,
+    steps: PropTypes.array
   }),
-  preferences: React.PropTypes.shape({
-    id: React.PropTypes.string
+  preferences: PropTypes.shape({
+    id: PropTypes.string
   }),
-  project: React.PropTypes.shape({
-    experimental_tools: React.PropTypes.array,
-    id: React.PropTypes.string,
-    slug: React.PropTypes.string
+  project: PropTypes.shape({
+    experimental_tools: PropTypes.array,
+    id: PropTypes.string,
+    slug: PropTypes.string
   }),
-  onChangeDemoMode: React.PropTypes.func,
-  onClickNext: React.PropTypes.func,
-  onComplete: React.PropTypes.func,
-  onCompleteAndLoadAnotherSubject: React.PropTypes.func,
-  onLoad: React.PropTypes.func,
-  splits: React.PropTypes.shape({
-    subject: React.PropTypes.object
+  onChangeDemoMode: PropTypes.func,
+  onClickNext: PropTypes.func,
+  onComplete: PropTypes.func,
+  onCompleteAndLoadAnotherSubject: PropTypes.func,
+  onLoad: PropTypes.func,
+  splits: PropTypes.shape({
+    subject: PropTypes.object
   }),
-  subject: React.PropTypes.shape({
-    favorite: React.PropTypes.bool,
-    id: React.PropTypes.string,
-    metadata: React.PropTypes.object
+  subject: PropTypes.shape({
+    favorite: PropTypes.bool,
+    id: PropTypes.string,
+    metadata: PropTypes.object
   }),
-  tutorial: React.PropTypes.shape({
-    id: React.PropTypes.string,
-    steps: React.PropTypes.array
+  tutorial: PropTypes.shape({
+    id: PropTypes.string,
+    steps: PropTypes.array
   }),
-  user: React.PropTypes.shape({
-    id: React.PropTypes.string
+  user: PropTypes.shape({
+    id: PropTypes.string
   }),
-  userRoles: React.PropTypes.array,
-  workflow: React.PropTypes.shape({
-    configuration: React.PropTypes.object,
-    id: React.PropTypes.string,
-    tasks: React.PropTypes.object
+  userRoles: PropTypes.array,
+  workflow: PropTypes.shape({
+    configuration: PropTypes.object,
+    id: PropTypes.string,
+    tasks: PropTypes.object
   })
 };
 

--- a/app/classifier/custom-sign-in-prompt.jsx
+++ b/app/classifier/custom-sign-in-prompt.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 const PROMPT_CUSTOM_SIGN_IN_EVERY = 5;
@@ -40,11 +41,11 @@ export default class CustomSignInPrompt extends React.Component {
 }
 
 CustomSignInPrompt.propTypes = {
-  children: React.PropTypes.oneOfType([
-    React.PropTypes.arrayOf(React.PropTypes.node).isRequired,
-    React.PropTypes.node.isRequired,
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node).isRequired,
+    PropTypes.node.isRequired,
   ]),
-  classificationsThisSession: React.PropTypes.number.isRequired,
+  classificationsThisSession: PropTypes.number.isRequired,
 };
 
 CustomSignInPrompt.defaultProps = {

--- a/app/classifier/default-classification-summary.jsx
+++ b/app/classifier/default-classification-summary.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { TextSplit } from 'seven-ten';
 import tasks from './tasks';
@@ -55,11 +56,11 @@ DefaultClassificationSummary.defaultProps = {
 };
 
 DefaultClassificationSummary.propTypes = {
-  workflow: React.PropTypes.object,
-  classification: React.PropTypes.object,
-  classificationCount: React.PropTypes.number,
-  onToggle: React.PropTypes.func,
-  splits: React.PropTypes.object
+  workflow: PropTypes.object,
+  classification: PropTypes.object,
+  classificationCount: PropTypes.number,
+  onToggle: PropTypes.func,
+  splits: PropTypes.object
 };
 
 export default DefaultClassificationSummary;

--- a/app/classifier/drawing-tools/root.cjsx
+++ b/app/classifier/drawing-tools/root.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 StickyModalForm = require 'modal-form/sticky'
 ModalFocus = require('../../components/modal-focus').default
@@ -18,7 +19,7 @@ module.exports = createReactClass
   displayName: 'DrawingToolRoot'
 
   contextTypes:
-    store: React.PropTypes.object
+    store: PropTypes.object
 
   statics:
     distance: (x1, y1, x2, y2) ->

--- a/app/classifier/expert-options.jsx
+++ b/app/classifier/expert-options.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import TriggeredModalForm from 'modal-form/triggered';
 import isAdmin from '../lib/is-admin';
@@ -47,13 +48,13 @@ function ExpertOptions(props) {
 }
 
 ExpertOptions.propTypes = {
-  classification: React.PropTypes.shape({
-    update: React.PropTypes.func,
-    gold_standard: React.PropTypes.bool
+  classification: PropTypes.shape({
+    update: PropTypes.func,
+    gold_standard: PropTypes.bool
   }),
-  demoMode: React.PropTypes.bool,
-  onChangeDemoMode: React.PropTypes.func,
-  userRoles: React.PropTypes.arrayOf(React.PropTypes.string)
+  demoMode: PropTypes.bool,
+  onChangeDemoMode: PropTypes.func,
+  userRoles: PropTypes.arrayOf(PropTypes.string)
 };
 
 export default ExpertOptions;

--- a/app/classifier/feedback/feedback-point.jsx
+++ b/app/classifier/feedback/feedback-point.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 const FeedbackPoint = ({ point }) => {
   const statusClass = (point.success) ? 'feedback-points__point--success' : 'feedback-points__point--failure';

--- a/app/classifier/feedback/feedback-summary-container.jsx
+++ b/app/classifier/feedback/feedback-summary-container.jsx
@@ -3,7 +3,9 @@
   react/forbid-prop-types: 0
 */
 
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+
+import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import FeedbackSummary from './feedback-summary';

--- a/app/classifier/feedback/feedback-summary.jsx
+++ b/app/classifier/feedback/feedback-summary.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import Translate from 'react-translate-component';
 import counterpart from 'counterpart';
@@ -46,10 +47,10 @@ const FeedbackSummary = ({ feedback }) => {
 };
 
 FeedbackSummary.propTypes = {
-  feedback: React.PropTypes.arrayOf(React.PropTypes.shape({
-    target: React.PropTypes.string,
-    question: React.PropTypes.string,
-    messages: React.PropTypes.arrayOf(React.PropTypes.string)
+  feedback: PropTypes.arrayOf(PropTypes.shape({
+    target: PropTypes.string,
+    question: PropTypes.string,
+    messages: PropTypes.arrayOf(PropTypes.string)
   }))
 };
 

--- a/app/classifier/feedback/svg-feedback-viewer.jsx
+++ b/app/classifier/feedback/svg-feedback-viewer.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { connect } from 'react-redux';
 import FeedbackPoint from './feedback-point';
 

--- a/app/classifier/feedback/svg-tooltip-layer.jsx
+++ b/app/classifier/feedback/svg-tooltip-layer.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { connect } from 'react-redux';
 import Tooltip from './tooltip';
 

--- a/app/classifier/feedback/tooltip.jsx
+++ b/app/classifier/feedback/tooltip.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 const Tooltip = ({ item }) => {
   const position = {

--- a/app/classifier/frame-annotator.jsx
+++ b/app/classifier/frame-annotator.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import tasks from './tasks';
 import seenThisSession from '../lib/seen-this-session';
@@ -49,7 +50,7 @@ export default class FrameAnnotator extends React.Component {
 
     if (this.props.annotation.task) {
       taskDescription = this.props.workflow.tasks[this.props.annotation.task];
-      ({ BeforeSubject, AfterSubject } = tasks[taskDescription.type]);
+      (({ BeforeSubject, AfterSubject } = tasks[taskDescription.type]));
     }
 
     if (this.state.alreadySeen) {
@@ -109,27 +110,27 @@ export default class FrameAnnotator extends React.Component {
 }
 
 FrameAnnotator.propTypes = {
-  annotation: React.PropTypes.shape({
-    task: React.PropTypes.string
+  annotation: PropTypes.shape({
+    task: PropTypes.string
   }),
-  children: React.PropTypes.node,
-  classification: React.PropTypes.shape({
-    annotations: React.PropTypes.array,
-    loading: React.PropTypes.bool
+  children: PropTypes.node,
+  classification: PropTypes.shape({
+    annotations: PropTypes.array,
+    loading: PropTypes.bool
   }),
-  frame: React.PropTypes.number,
-  naturalHeight: React.PropTypes.number,
-  naturalWidth: React.PropTypes.number,
-  onChange: React.PropTypes.func,
-  preferences: React.PropTypes.shape({
-    id: React.PropTypes.string
+  frame: PropTypes.number,
+  naturalHeight: PropTypes.number,
+  naturalWidth: PropTypes.number,
+  onChange: PropTypes.func,
+  preferences: PropTypes.shape({
+    id: PropTypes.string
   }),
-  subject: React.PropTypes.shape({
-    already_seen: React.PropTypes.bool,
-    retired: React.PropTypes.bool
+  subject: PropTypes.shape({
+    already_seen: PropTypes.bool,
+    retired: PropTypes.bool
   }),
-  workflow: React.PropTypes.shape({
-    tasks: React.PropTypes.object
+  workflow: PropTypes.shape({
+    tasks: PropTypes.object
   })
 };
 

--- a/app/classifier/gs-gold-standard-summary.jsx
+++ b/app/classifier/gs-gold-standard-summary.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Markdown } from 'markdownz';
 
@@ -50,9 +51,9 @@ const GSGoldStandardSummary = ({ classification, subject, workflow }) => {
 };
 
 GSGoldStandardSummary.propTypes = {
-  classification: React.PropTypes.object,
-  subject: React.PropTypes.object,
-  workflow: React.PropTypes.object
+  classification: PropTypes.object,
+  subject: PropTypes.object,
+  workflow: PropTypes.object
 };
 
 export default GSGoldStandardSummary;

--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 apiClient = require 'panoptes-client/lib/api-client'
 Classifier = require('./classifier').default
@@ -28,17 +29,17 @@ ClassifierWrapper = createReactClass
   displayName: 'ClassifierWrapper'
 
   contextTypes:
-    geordi: React.PropTypes.object
-    store: React.PropTypes.object
+    geordi: PropTypes.object
+    store: PropTypes.object
 
   propTypes:
-    classification: React.PropTypes.object
-    onLoad: React.PropTypes.func
-    onComplete: React.PropTypes.func
-    onCompleteAndLoadAnotherSubject: React.PropTypes.func
-    onClickNext: React.PropTypes.func
-    workflow: React.PropTypes.object
-    user: React.PropTypes.object
+    classification: PropTypes.object
+    onLoad: PropTypes.func
+    onComplete: PropTypes.func
+    onCompleteAndLoadAnotherSubject: PropTypes.func
+    onClickNext: PropTypes.func
+    workflow: PropTypes.object
+    user: PropTypes.object
 
   getDefaultProps: ->
     classification: {}

--- a/app/classifier/restart-button.jsx
+++ b/app/classifier/restart-button.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 const RestartButton = ({ children, className, start, shouldRender, style }) => {
@@ -13,7 +14,7 @@ const RestartButton = ({ children, className, start, shouldRender, style }) => {
 };
 
 RestartButton.contextTypes = {
-  geordi: React.PropTypes.object
+  geordi: PropTypes.object
 };
 
 RestartButton.defaultProps = {
@@ -25,13 +26,13 @@ RestartButton.defaultProps = {
 };
 
 RestartButton.propTypes = {
-  children: React.PropTypes.node,
-  className: React.PropTypes.string,
-  start: React.PropTypes.func,
-  shouldRender: React.PropTypes.bool,
-  style: React.PropTypes.object,
-  user: React.PropTypes.object,
-  workflow: React.PropTypes.object
+  children: PropTypes.node,
+  className: PropTypes.string,
+  start: PropTypes.func,
+  shouldRender: PropTypes.bool,
+  style: PropTypes.object,
+  user: PropTypes.object,
+  workflow: PropTypes.object
 };
 
 export default RestartButton;

--- a/app/classifier/task-nav.jsx
+++ b/app/classifier/task-nav.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Link } from 'react-router';
 import Translate from 'react-translate-component';
@@ -9,13 +10,13 @@ import { isFeedbackActive, isThereFeedback } from './feedback/helpers';
 
 /* eslint-disable multiline-ternary, no-nested-ternary, react/jsx-no-bind */
 
-const BackButtonWarning = () => {
-  return (
-    <p className="back-button-warning" >
-      <Translate content="classifier.backButtonWarning" />
-    </p>
-  );
-};
+const BackButtonWarning = () =>
+   (
+     <p className="back-button-warning" >
+       <Translate content="classifier.backButtonWarning" />
+     </p>
+  )
+;
 
 class TaskNav extends React.Component {
   constructor(props) {
@@ -124,7 +125,7 @@ class TaskNav extends React.Component {
 
     const disableTalk = this.props.classification.metadata.subject_flagged ||
     (isFeedbackActive(this.props.project) && isThereFeedback(this.props.subject, this.props.workflow));
-    const visibleTasks = Object.keys(this.props.workflow.tasks).filter((key) => { return this.props.workflow.tasks[key].type !== 'shortcut'; });
+    const visibleTasks = Object.keys(this.props.workflow.tasks).filter(key => this.props.workflow.tasks[key].type !== 'shortcut');
     const TaskComponent = tasks[task.type];
 
     // Should we disable the "Back" button?
@@ -227,37 +228,37 @@ class TaskNav extends React.Component {
 }
 
 TaskNav.propTypes = {
-  annotation: React.PropTypes.shape({
-    shortcut: React.PropTypes.object,
-    value: React.PropTypes.any
+  annotation: PropTypes.shape({
+    shortcut: PropTypes.object,
+    value: PropTypes.any
   }),
-  children: React.PropTypes.node,
-  classification: React.PropTypes.shape({
-    annotations: React.PropTypes.array,
-    completed: React.PropTypes.bool,
-    gold_standard: React.PropTypes.bool,
-    id: React.PropTypes.string,
-    metadata: React.PropTypes.object
+  children: PropTypes.node,
+  classification: PropTypes.shape({
+    annotations: PropTypes.array,
+    completed: PropTypes.bool,
+    gold_standard: PropTypes.bool,
+    id: PropTypes.string,
+    metadata: PropTypes.object
   }),
-  completeClassification: React.PropTypes.func,
-  disabled: React.PropTypes.bool,
-  nextSubject: React.PropTypes.func,
-  demoMode: React.PropTypes.bool,
-  project: React.PropTypes.shape({
-    id: React.PropTypes.string,
-    slug: React.PropTypes.string
+  completeClassification: PropTypes.func,
+  disabled: PropTypes.bool,
+  nextSubject: PropTypes.func,
+  demoMode: PropTypes.bool,
+  project: PropTypes.shape({
+    id: PropTypes.string,
+    slug: PropTypes.string
   }),
-  subject: React.PropTypes.shape({
-    id: React.PropTypes.string
+  subject: PropTypes.shape({
+    id: PropTypes.string
   }),
-  task: React.PropTypes.shape({
-    type: React.PropTypes.string
+  task: PropTypes.shape({
+    type: PropTypes.string
   }),
-  workflow: React.PropTypes.shape({
-    id: React.PropTypes.string,
-    configuration: React.PropTypes.object,
-    first_task: React.PropTypes.string,
-    tasks: React.PropTypes.object
+  workflow: PropTypes.shape({
+    id: PropTypes.string,
+    configuration: PropTypes.object,
+    first_task: PropTypes.string,
+    tasks: PropTypes.object
   })
 };
 

--- a/app/classifier/task.jsx
+++ b/app/classifier/task.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import tasks from './tasks';
 import Shortcut from './tasks/shortcut';
@@ -104,29 +105,29 @@ class Task extends React.Component {
 }
 
 Task.propTypes = {
-  annotation: React.PropTypes.shape({
-    shortcut: React.PropTypes.object,
-    value: React.PropTypes.any
+  annotation: PropTypes.shape({
+    shortcut: PropTypes.object,
+    value: PropTypes.any
   }),
-  children: React.PropTypes.node,
-  classification: React.PropTypes.shape({
-    id: React.PropTypes.string
+  children: PropTypes.node,
+  classification: PropTypes.shape({
+    id: PropTypes.string
   }),
-  preferences: React.PropTypes.shape({
-    id: React.PropTypes.string
+  preferences: PropTypes.shape({
+    id: PropTypes.string
   }),
-  project: React.PropTypes.shape({
-    id: React.PropTypes.string
+  project: PropTypes.shape({
+    id: PropTypes.string
   }),
-  subjectLoading: React.PropTypes.bool,
-  task: React.PropTypes.shape({
-    type: React.PropTypes.string
+  subjectLoading: PropTypes.bool,
+  task: PropTypes.shape({
+    type: PropTypes.string
   }),
-  user: React.PropTypes.shape({
-    id: React.PropTypes.string
+  user: PropTypes.shape({
+    id: PropTypes.string
   }),
-  workflow: React.PropTypes.shape({
-    id: React.PropTypes.string
+  workflow: PropTypes.shape({
+    id: PropTypes.string
   })
 };
 

--- a/app/classifier/tasks/combo/markings-renderer.jsx
+++ b/app/classifier/tasks/combo/markings-renderer.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import SVGRenderer from '../../annotation-renderer/svg';
 
@@ -66,11 +67,11 @@ export default function MarkingsRenderer(props) {
 }
 
 MarkingsRenderer.propTypes = {
-  classification: React.PropTypes.shape({
-    annotations: React.PropTypes.array
+  classification: PropTypes.shape({
+    annotations: PropTypes.array
   }),
-  taskTypes: React.PropTypes.object,
-  workflow: React.PropTypes.shape({
-    tasks: React.PropTypes.object
+  taskTypes: PropTypes.object,
+  workflow: PropTypes.shape({
+    tasks: PropTypes.object
   })
 };

--- a/app/classifier/tasks/combo/summary.jsx
+++ b/app/classifier/tasks/combo/summary.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import TaskTranslations from '../translations';
 import tasks from '..';
@@ -32,10 +33,10 @@ const ComboTaskSummary = (props) => {
 };
 
 ComboTaskSummary.propTypes = {
-  annotation: React.PropTypes.shape(
-    { value: React.PropTypes.array }
+  annotation: PropTypes.shape(
+    { value: PropTypes.array }
   ).isRequired,
-  onToggle: React.PropTypes.func
+  onToggle: PropTypes.func
 };
 
 export default ComboTaskSummary;

--- a/app/classifier/tasks/drawing/marking-initializer.cjsx
+++ b/app/classifier/tasks/drawing/marking-initializer.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 Draggable = require '../../../lib/draggable'
 drawingTools = require '../../drawing-tools'
@@ -7,7 +8,7 @@ module.exports = createReactClass
   displayName: 'MarkingInitializer'
 
   contextTypes:
-    geordi: React.PropTypes.object
+    geordi: PropTypes.object
 
   getDefaultProps: ->
     annotation: null

--- a/app/classifier/tasks/drawing/min-max-editor.jsx
+++ b/app/classifier/tasks/drawing/min-max-editor.jsx
@@ -1,11 +1,12 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import AutoSave from '../../../components/auto-save';
 
 class MinMaxEditor extends React.Component {
   static propTypes = {
-    name: React.PropTypes.string,
-    choice: React.PropTypes.object,
-    workflow: React.PropTypes.object,
+    name: PropTypes.string,
+    choice: PropTypes.object,
+    workflow: PropTypes.object,
   };
 
   state = {

--- a/app/classifier/tasks/generic.jsx
+++ b/app/classifier/tasks/generic.jsx
@@ -1,4 +1,5 @@
 import { Markdown } from 'markdownz';
+import PropTypes from 'prop-types';
 import React from 'react';
 import alert from '../../lib/alert';
 
@@ -89,15 +90,15 @@ export default class GenericTask extends React.Component {
 }
 
 GenericTask.propTypes = {
-  autoFocus: React.PropTypes.bool,
-  children: React.PropTypes.node,
-  question: React.PropTypes.string,
-  help: React.PropTypes.string,
-  required: React.PropTypes.oneOfType([
-    React.PropTypes.number,
-    React.PropTypes.bool
+  autoFocus: PropTypes.bool,
+  children: PropTypes.node,
+  question: PropTypes.string,
+  help: PropTypes.string,
+  required: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.bool
   ]),
-  answers: React.PropTypes.arrayOf(React.PropTypes.node)
+  answers: PropTypes.arrayOf(PropTypes.node)
 };
 
 GenericTask.defaultProps = {

--- a/app/classifier/tasks/highlighter/index.jsx
+++ b/app/classifier/tasks/highlighter/index.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Markdown } from 'markdownz';
 import GenericTaskEditor from '../generic-editor';
@@ -142,28 +143,28 @@ Highlighter.defaultProps = {
 };
 
 Highlighter.propTypes = {
-  annotation: React.PropTypes.shape({
-    _toolIndex: React.PropTypes.number,
-    task: React.PropTypes.shape({
-      help: React.PropTypes.string,
-      highlighterLabels: React.PropTypes.array,
-      instruction: React.PropTypes.string,
-      required: React.PropTypes.bool,
-      tools: React.PropTypes.array,
-      type: React.PropTypes.string
+  annotation: PropTypes.shape({
+    _toolIndex: PropTypes.number,
+    task: PropTypes.shape({
+      help: PropTypes.string,
+      highlighterLabels: PropTypes.array,
+      instruction: PropTypes.string,
+      required: PropTypes.bool,
+      tools: PropTypes.array,
+      type: PropTypes.string
     }),
-    tools: React.PropTypes.array
+    tools: PropTypes.array
   }),
-  onChange: React.PropTypes.func,
-  task: React.PropTypes.shape({
-    help: React.PropTypes.string,
-    highlighterLabels: React.PropTypes.array,
-    instruction: React.PropTypes.string,
-    required: React.PropTypes.bool,
-    tools: React.PropTypes.array,
-    type: React.PropTypes.string
+  onChange: PropTypes.func,
+  task: PropTypes.shape({
+    help: PropTypes.string,
+    highlighterLabels: PropTypes.array,
+    instruction: PropTypes.string,
+    required: PropTypes.bool,
+    tools: PropTypes.array,
+    type: PropTypes.string
   }),
-  workflow: React.PropTypes.shape({
-    tasks: React.PropTypes.object
+  workflow: PropTypes.shape({
+    tasks: PropTypes.object
   })
 };

--- a/app/classifier/tasks/highlighter/label-editor.jsx
+++ b/app/classifier/tasks/highlighter/label-editor.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 export default function LabelEditor(props) {
@@ -33,5 +34,5 @@ export default function LabelEditor(props) {
 }
 
 LabelEditor.propTypes = {
-  children: React.PropTypes.node
+  children: PropTypes.node
 };

--- a/app/classifier/tasks/highlighter/label-renderer.jsx
+++ b/app/classifier/tasks/highlighter/label-renderer.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import Selection from './selection';
 
@@ -63,12 +64,12 @@ export default class LabelRenderer extends React.Component {
 }
 
 LabelRenderer.propTypes = {
-  annotation: React.PropTypes.shape({
-    value: React.PropTypes.array
+  annotation: PropTypes.shape({
+    value: PropTypes.array
   }),
-  children: React.PropTypes.element,
-  disabled: React.PropTypes.bool,
-  onLoad: React.PropTypes.func
+  children: PropTypes.element,
+  disabled: PropTypes.bool,
+  onLoad: PropTypes.func
 };
 
 LabelRenderer.defaultProps = {

--- a/app/classifier/tasks/highlighter/selection.jsx
+++ b/app/classifier/tasks/highlighter/selection.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 export default function Selection(props) {
@@ -25,11 +26,11 @@ export default function Selection(props) {
 }
 
 Selection.propTypes = {
-  annotation: React.PropTypes.shape({
-    labelInformation: React.PropTypes.object,
-    text: React.PropTypes.string
+  annotation: PropTypes.shape({
+    labelInformation: PropTypes.object,
+    text: PropTypes.string
   }),
-  disabled: React.PropTypes.bool
+  disabled: PropTypes.bool
 };
 
 Selection.defaultProps = {

--- a/app/classifier/tasks/highlighter/summary.jsx
+++ b/app/classifier/tasks/highlighter/summary.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 export default class HighlighterSummary extends React.Component {
@@ -19,8 +20,7 @@ export default class HighlighterSummary extends React.Component {
 }
 
 HighlighterSummary.propTypes = {
-  annotation: React.PropTypes.shape({
-    value: React.PropTypes.array
+  annotation: PropTypes.shape({
+    value: PropTypes.array
   })
 };
-

--- a/app/classifier/tasks/multiple/index.jsx
+++ b/app/classifier/tasks/multiple/index.jsx
@@ -1,4 +1,5 @@
 import { Markdown } from 'markdownz';
+import PropTypes from 'prop-types';
 import React from 'react';
 import GenericTask from '../generic';
 import GenericTaskEditor from '../generic-editor';
@@ -89,26 +90,26 @@ MultipleChoiceTask.isAnnotationComplete = (task, annotation) => {
 };
 
 MultipleChoiceTask.propTypes = {
-  task: React.PropTypes.shape(
+  task: PropTypes.shape(
     {
-      answers: React.PropTypes.array,
-      question: React.PropTypes.string,
-      help: React.PropTypes.string,
-      required: React.PropTypes.oneOfType([
-        React.PropTypes.number,
-        React.PropTypes.bool
+      answers: PropTypes.array,
+      question: PropTypes.string,
+      help: PropTypes.string,
+      required: PropTypes.oneOfType([
+        PropTypes.number,
+        PropTypes.bool
       ])
     }
   ),
-  translation: React.PropTypes.shape({
-    characteristics: React.PropTypes.object,
-    choices: React.PropTypes.object,
-    questions: React.PropTypes.object
+  translation: PropTypes.shape({
+    characteristics: PropTypes.object,
+    choices: PropTypes.object,
+    questions: PropTypes.object
   }).isRequired,
-  annotation: React.PropTypes.shape(
-    { value: React.PropTypes.array }
+  annotation: PropTypes.shape(
+    { value: PropTypes.array }
   ),
-  onChange: React.PropTypes.func
+  onChange: PropTypes.func
 };
 
 MultipleChoiceTask.defaultProps = {

--- a/app/classifier/tasks/multiple/summary.jsx
+++ b/app/classifier/tasks/multiple/summary.jsx
@@ -1,4 +1,5 @@
 import { Markdown } from 'markdownz';
+import PropTypes from 'prop-types';
 import React from 'react';
 
 class MultipleChoiceSummary extends React.Component {
@@ -69,21 +70,21 @@ class MultipleChoiceSummary extends React.Component {
 }
 
 MultipleChoiceSummary.propTypes = {
-  task: React.PropTypes.shape(
+  task: PropTypes.shape(
     {
-      answers: React.PropTypes.array,
-      question: React.PropTypes.string
+      answers: PropTypes.array,
+      question: PropTypes.string
     }
   ),
-  translation: React.PropTypes.shape({
-    characteristics: React.PropTypes.object,
-    choices: React.PropTypes.object,
-    questions: React.PropTypes.object
+  translation: PropTypes.shape({
+    characteristics: PropTypes.object,
+    choices: PropTypes.object,
+    questions: PropTypes.object
   }).isRequired,
-  annotation: React.PropTypes.shape(
-    { value: React.PropTypes.array }
+  annotation: PropTypes.shape(
+    { value: PropTypes.array }
   ).isRequired,
-  expanded: React.PropTypes.bool
+  expanded: PropTypes.bool
 };
 
 MultipleChoiceSummary.defaultProps = {

--- a/app/classifier/tasks/shortcut/editor.jsx
+++ b/app/classifier/tasks/shortcut/editor.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import AutoSave from '../../../components/auto-save';
 import handleInputChange from '../../../lib/handle-input-change';
@@ -115,17 +116,17 @@ export default class ShortcutEditor extends React.Component {
 }
 
 ShortcutEditor.propTypes = {
-  children: React.PropTypes.node,
-  task: React.PropTypes.shape(
+  children: PropTypes.node,
+  task: PropTypes.shape(
     {
-      question: React.PropTypes.string,
-      unlinkedTask: React.PropTypes.string
+      question: PropTypes.string,
+      unlinkedTask: PropTypes.string
     }
   ),
-  workflow: React.PropTypes.shape(
+  workflow: PropTypes.shape(
     {
-      tasks: React.PropTypes.object,
-      update: React.PropTypes.func
+      tasks: PropTypes.object,
+      update: PropTypes.func
     }
   )
 };

--- a/app/classifier/tasks/shortcut/index.jsx
+++ b/app/classifier/tasks/shortcut/index.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import Summary from './summary';
 
@@ -75,21 +76,21 @@ Shortcut.getDefaultAnnotation = () => {
 };
 
 Shortcut.propTypes = {
-  annotation: React.PropTypes.shape(
+  annotation: PropTypes.shape(
     {
-      shortcut: React.PropTypes.object,
-      task: React.PropTypes.string
+      shortcut: PropTypes.object,
+      task: PropTypes.string
     }
   ),
-  onChange: React.PropTypes.func,
-  task: React.PropTypes.shape(
-    { unlinkedTask: React.PropTypes.string }
+  onChange: PropTypes.func,
+  task: PropTypes.shape(
+    { unlinkedTask: PropTypes.string }
   ),
-  translation: React.PropTypes.shape({
-    answers: React.PropTypes.array
+  translation: PropTypes.shape({
+    answers: PropTypes.array
   }),
-  workflow: React.PropTypes.shape(
-    { tasks: React.PropTypes.object }
+  workflow: PropTypes.shape(
+    { tasks: PropTypes.object }
   )
 };
 

--- a/app/classifier/tasks/shortcut/summary.jsx
+++ b/app/classifier/tasks/shortcut/summary.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Markdown } from 'markdownz';
 import Translate from 'react-translate-component';
@@ -31,13 +32,13 @@ function ShortcutSummary(props) {
 }
 
 ShortcutSummary.propTypes = {
-  annotation: React.PropTypes.shape(
+  annotation: PropTypes.shape(
     {
-      task: React.PropTypes.string,
-      value: React.PropTypes.array
+      task: PropTypes.string,
+      value: PropTypes.array
     }
   ).isRequired,
-  translation: React.PropTypes.object.isRequired
+  translation: PropTypes.object.isRequired
 };
 
 ShortcutSummary.defaultProps = {

--- a/app/classifier/tasks/single/index.jsx
+++ b/app/classifier/tasks/single/index.jsx
@@ -1,4 +1,5 @@
 import { Markdown } from 'markdownz';
+import PropTypes from 'prop-types';
 import React from 'react';
 import GenericTask from '../generic';
 import GenericTaskEditor from '../generic-editor';
@@ -81,23 +82,23 @@ SingleChoiceTask.isAnnotationComplete = (task, annotation) => {
 };
 
 SingleChoiceTask.propTypes = {
-  task: React.PropTypes.shape(
+  task: PropTypes.shape(
     {
-      answers: React.PropTypes.array,
-      question: React.PropTypes.string,
-      help: React.PropTypes.string,
-      required: React.PropTypes.bool
+      answers: PropTypes.array,
+      question: PropTypes.string,
+      help: PropTypes.string,
+      required: PropTypes.bool
     }
   ),
-  translation: React.PropTypes.shape({
-    characteristics: React.PropTypes.object,
-    choices: React.PropTypes.object,
-    questions: React.PropTypes.object
+  translation: PropTypes.shape({
+    characteristics: PropTypes.object,
+    choices: PropTypes.object,
+    questions: PropTypes.object
   }).isRequired,
-  annotation: React.PropTypes.shape(
-    { value: React.PropTypes.number }
+  annotation: PropTypes.shape(
+    { value: PropTypes.number }
   ),
-  onChange: React.PropTypes.func
+  onChange: PropTypes.func
 };
 
 SingleChoiceTask.defaultProps = {

--- a/app/classifier/tasks/single/summary.jsx
+++ b/app/classifier/tasks/single/summary.jsx
@@ -1,4 +1,5 @@
 import { Markdown } from 'markdownz';
+import PropTypes from 'prop-types';
 import React from 'react';
 
 class SingleChoiceSummary extends React.Component {
@@ -67,21 +68,21 @@ class SingleChoiceSummary extends React.Component {
 }
 
 SingleChoiceSummary.propTypes = {
-  task: React.PropTypes.shape(
+  task: PropTypes.shape(
     {
-      answers: React.PropTypes.array,
-      question: React.PropTypes.string
+      answers: PropTypes.array,
+      question: PropTypes.string
     }
   ),
-  translation: React.PropTypes.shape({
-    characteristics: React.PropTypes.object,
-    choices: React.PropTypes.object,
-    questions: React.PropTypes.object
+  translation: PropTypes.shape({
+    characteristics: PropTypes.object,
+    choices: PropTypes.object,
+    questions: PropTypes.object
   }).isRequired,
-  annotation: React.PropTypes.shape(
-    { value: React.PropTypes.number }
+  annotation: PropTypes.shape(
+    { value: PropTypes.number }
   ).isRequired,
-  expanded: React.PropTypes.bool
+  expanded: PropTypes.bool
 };
 
 SingleChoiceSummary.defaultProps = {

--- a/app/classifier/tasks/slider/editor.jsx
+++ b/app/classifier/tasks/slider/editor.jsx
@@ -1,4 +1,5 @@
 import { MarkdownEditor, MarkdownHelp } from 'markdownz';
+import PropTypes from 'prop-types';
 import React from 'react';
 import alert from '../../../lib/alert';
 import AutoSave from '../../../components/auto-save';
@@ -130,18 +131,18 @@ const SliderTaskEditor = (props) => {
 };
 
 SliderTaskEditor.propTypes = {
-  isSubtask: React.PropTypes.bool,
-  workflow: React.PropTypes.object,
-  taskPrefix: React.PropTypes.string,
-  task: React.PropTypes.shape(
+  isSubtask: PropTypes.bool,
+  workflow: PropTypes.object,
+  taskPrefix: PropTypes.string,
+  task: PropTypes.shape(
     {
-      next: React.PropTypes.string,
-      instruction: React.PropTypes.string,
-      help: React.PropTypes.string,
-      min: React.PropTypes.string,
-      max: React.PropTypes.string,
-      defaultValue: React.PropTypes.string,
-      step: React.PropTypes.string
+      next: PropTypes.string,
+      instruction: PropTypes.string,
+      help: PropTypes.string,
+      min: PropTypes.string,
+      max: PropTypes.string,
+      defaultValue: PropTypes.string,
+      step: PropTypes.string
     }
   )
 };

--- a/app/classifier/tasks/slider/index.jsx
+++ b/app/classifier/tasks/slider/index.jsx
@@ -1,4 +1,5 @@
 import { Markdown } from 'markdownz';
+import PropTypes from 'prop-types';
 import React from 'react';
 import GenericTask from '../generic';
 import SliderTaskEditor from './editor';
@@ -35,16 +36,16 @@ const SliderSummary = (props) => {
 };
 
 SliderSummary.propTypes = {
-  task: React.PropTypes.shape(
+  task: PropTypes.shape(
     {
-      instruction: React.PropTypes.string
+      instruction: PropTypes.string
     }
   ).isRequired,
-  annotation: React.PropTypes.shape(
+  annotation: PropTypes.shape(
     {
-      value: React.PropTypes.oneOfType([
-        React.PropTypes.string,
-        React.PropTypes.number
+      value: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.number
       ])
     }
   ).isRequired
@@ -124,22 +125,22 @@ SliderTask.isAnnotationComplete = (task, annotation) => {
   return (annotation.value !== null);
 };
 SliderTask.propTypes = {
-  annotation: React.PropTypes.shape({
-    value: React.PropTypes.oneOfType([
-      React.PropTypes.string,
-      React.PropTypes.number
+  annotation: PropTypes.shape({
+    value: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number
     ])
   }),
-  autoFocus: React.PropTypes.bool,
-  onChange: React.PropTypes.func,
-  task: React.PropTypes.shape({
-    answers: React.PropTypes.array,
-    defaultValue: React.PropTypes.string,
-    help: React.PropTypes.string,
-    instruction: React.PropTypes.string,
-    max: React.PropTypes.string,
-    min: React.PropTypes.string,
-    step: React.PropTypes.string
+  autoFocus: PropTypes.bool,
+  onChange: PropTypes.func,
+  task: PropTypes.shape({
+    answers: PropTypes.array,
+    defaultValue: PropTypes.string,
+    help: PropTypes.string,
+    instruction: PropTypes.string,
+    max: PropTypes.string,
+    min: PropTypes.string,
+    step: PropTypes.string
   })
 };
 

--- a/app/classifier/tasks/survey/choice.jsx
+++ b/app/classifier/tasks/survey/choice.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import TriggeredModalForm from 'modal-form/triggered';
 import { Markdown } from 'markdownz';
@@ -202,24 +203,24 @@ class Choice extends React.Component {
 }
 
 Choice.propTypes = {
-  annotationValue: React.PropTypes.shape({
-    answers: React.PropTypes.object,
-    choice: React.PropTypes.string,
-    filters: React.PropTypes.object
+  annotationValue: PropTypes.shape({
+    answers: PropTypes.object,
+    choice: PropTypes.string,
+    filters: PropTypes.object
   }),
-  choiceID: React.PropTypes.string,
-  onCancel: React.PropTypes.func,
-  onConfirm: React.PropTypes.func,
-  onSwitch: React.PropTypes.func,
-  task: React.PropTypes.shape({
-    choices: React.PropTypes.object,
-    images: React.PropTypes.object,
-    questions: React.PropTypes.object
+  choiceID: PropTypes.string,
+  onCancel: PropTypes.func,
+  onConfirm: PropTypes.func,
+  onSwitch: PropTypes.func,
+  task: PropTypes.shape({
+    choices: PropTypes.object,
+    images: PropTypes.object,
+    questions: PropTypes.object
   }),
-  translation: React.PropTypes.shape({
-    characteristics: React.PropTypes.object,
-    choices: React.PropTypes.object,
-    questions: React.PropTypes.object
+  translation: PropTypes.shape({
+    characteristics: PropTypes.object,
+    choices: PropTypes.object,
+    questions: PropTypes.object
   }).isRequired
 };
 

--- a/app/classifier/tasks/survey/chooser.jsx
+++ b/app/classifier/tasks/survey/chooser.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import sortIntoColumns from 'sort-into-columns';
 import Translate from 'react-translate-component';
@@ -261,28 +262,28 @@ class Chooser extends React.Component {
 }
 
 Chooser.propTypes = {
-  annotation: React.PropTypes.shape({
-    task: React.PropTypes.string,
-    value: React.PropTypes.array
+  annotation: PropTypes.shape({
+    task: PropTypes.string,
+    value: PropTypes.array
   }),
-  filters: React.PropTypes.object,
-  focusedChoice: React.PropTypes.string,
-  onChoose: React.PropTypes.func,
-  onFilter: React.PropTypes.func,
-  onRemove: React.PropTypes.func,
-  task: React.PropTypes.shape({
-    alwaysShowThumbnails: React.PropTypes.bool,
-    characteristics: React.PropTypes.object,
-    characteristicsOrder: React.PropTypes.array,
-    choices: React.PropTypes.object,
-    choicesOrder: React.PropTypes.array,
-    images: React.PropTypes.object,
-    questions: React.PropTypes.object
+  filters: PropTypes.object,
+  focusedChoice: PropTypes.string,
+  onChoose: PropTypes.func,
+  onFilter: PropTypes.func,
+  onRemove: PropTypes.func,
+  task: PropTypes.shape({
+    alwaysShowThumbnails: PropTypes.bool,
+    characteristics: PropTypes.object,
+    characteristicsOrder: PropTypes.array,
+    choices: PropTypes.object,
+    choicesOrder: PropTypes.array,
+    images: PropTypes.object,
+    questions: PropTypes.object
   }),
-  translation: React.PropTypes.shape({
-    characteristics: React.PropTypes.object,
-    choices: React.PropTypes.object,
-    questions: React.PropTypes.object
+  translation: PropTypes.shape({
+    characteristics: PropTypes.object,
+    choices: PropTypes.object,
+    questions: PropTypes.object
   }).isRequired
 };
 

--- a/app/classifier/tasks/survey/image-flipper.jsx
+++ b/app/classifier/tasks/survey/image-flipper.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 const PRELOAD_STYLE = {
@@ -64,7 +65,7 @@ class ImageFlipper extends React.Component {
 }
 
 ImageFlipper.propTypes = {
-  images: React.PropTypes.arrayOf(React.PropTypes.string)
+  images: PropTypes.arrayOf(PropTypes.string)
 };
 
 ImageFlipper.defaultProps = {

--- a/app/classifier/tasks/survey/summary.jsx
+++ b/app/classifier/tasks/survey/summary.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import Translate from 'react-translate-component';
 
@@ -63,19 +64,19 @@ class SurveySummary extends React.Component {
 }
 
 SurveySummary.propTypes = {
-  annotation: React.PropTypes.shape({
-    value: React.PropTypes.array
+  annotation: PropTypes.shape({
+    value: PropTypes.array
   }),
-  expanded: React.PropTypes.bool,
-  task: React.PropTypes.shape({
-    choices: React.PropTypes.object,
-    choicesOrder: React.PropTypes.array,
-    questions: React.PropTypes.object
+  expanded: PropTypes.bool,
+  task: PropTypes.shape({
+    choices: PropTypes.object,
+    choicesOrder: PropTypes.array,
+    questions: PropTypes.object
   }),
-  translation: React.PropTypes.shape({
-    characteristics: React.PropTypes.object,
-    choices: React.PropTypes.object,
-    questions: React.PropTypes.object
+  translation: PropTypes.shape({
+    characteristics: PropTypes.object,
+    choices: PropTypes.object,
+    questions: PropTypes.object
   }).isRequired
 };
 

--- a/app/classifier/tasks/translations.jsx
+++ b/app/classifier/tasks/translations.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import merge from 'lodash/merge';
 import { connect } from 'react-redux';
@@ -30,12 +31,12 @@ function TaskTranslations(props) {
 }
 
 TaskTranslations.propTypes = {
-  children: React.PropTypes.node,
-  task: React.PropTypes.shape({
-    answers: React.PropTypes.array,
-    question: React.PropTypes.string
+  children: PropTypes.node,
+  task: PropTypes.shape({
+    answers: PropTypes.array,
+    question: PropTypes.string
   }),
-  taskKey: React.PropTypes.string
+  taskKey: PropTypes.string
 };
 
 const mapStateToProps = state => ({

--- a/app/classifier/translations.jsx
+++ b/app/classifier/translations.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import merge from 'lodash/merge';
 import { connect } from 'react-redux';
@@ -28,9 +29,9 @@ function Translations(props) {
 }
 
 Translations.propTypes = {
-  children: React.PropTypes.node,
-  original: React.PropTypes.shape({}),
-  type: React.PropTypes.string
+  children: PropTypes.node,
+  original: PropTypes.shape({}),
+  type: PropTypes.string
 };
 
 const mapStateToProps = state => ({

--- a/app/classifier/tutorial.cjsx
+++ b/app/classifier/tutorial.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 Dialog = require 'modal-form/dialog'
 Translate = require 'react-translate-component'
@@ -71,17 +72,17 @@ module.exports = createReactClass
               null # We don't really care if the user canceled or completed the tutorial.
 
   propTypes:
-    geordi: React.PropTypes.object
-    preferences: React.PropTypes.shape
-      preferences: React.PropTypes.object
-    tutorial: React.PropTypes.shape
-      steps: React.PropTypes.arrayOf React.PropTypes.shape
-        media: React.PropTypes.string
-        content: React.PropTypes.string
-    translation: React.PropTypes.shape
-      steps: React.PropTypes.arrayOf React.PropTypes.shape
-        content: React.PropTypes.string
-    user: React.PropTypes.object
+    geordi: PropTypes.object
+    preferences: PropTypes.shape
+      preferences: PropTypes.object
+    tutorial: PropTypes.shape
+      steps: PropTypes.arrayOf PropTypes.shape
+        media: PropTypes.string
+        content: PropTypes.string
+    translation: PropTypes.shape
+      steps: PropTypes.arrayOf PropTypes.shape
+        content: PropTypes.string
+    user: PropTypes.object
 
   getDefaultProps: ->
     geordi: {}

--- a/app/classifier/warning-banner.jsx
+++ b/app/classifier/warning-banner.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import TriggeredModalForm from 'modal-form/triggered';
 
@@ -10,8 +11,8 @@ const WarningBanner = (props) => {
 };
 
 WarningBanner.propTypes = {
-  label: React.PropTypes.string.isRequired,
-  children: React.PropTypes.node.isRequired
+  label: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired
 };
 
 export default WarningBanner;

--- a/app/classifier/world-wide-telescope.jsx
+++ b/app/classifier/world-wide-telescope.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import getSubjectLocation from '../lib/get-subject-location';
 
@@ -497,13 +498,13 @@ export default class WorldWideTelescope extends React.Component {
 }
 
 WorldWideTelescope.propTypes = {
-  annotations: React.PropTypes.arrayOf(React.PropTypes.object),
-  subject: React.PropTypes.shape({
-    locations: React.PropTypes.array,
-    metadata: React.PropTypes.object
+  annotations: PropTypes.arrayOf(PropTypes.object),
+  subject: PropTypes.shape({
+    locations: PropTypes.array,
+    metadata: PropTypes.object
   }),
-  workflow: React.PropTypes.shape({
-    tasks: React.PropTypes.object
+  workflow: PropTypes.shape({
+    tasks: PropTypes.object
   })
 };
 

--- a/app/collections/collaborators.jsx
+++ b/app/collections/collaborators.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import apiClient from 'panoptes-client/lib/api-client';
 import classNames from 'classnames';
@@ -140,10 +141,10 @@ RoleCreator.defaultProps = {
 };
 
 RoleCreator.propTypes = {
-  collection: React.PropTypes.shape({
-    id: React.PropTypes.string
+  collection: PropTypes.shape({
+    id: PropTypes.string
   }),
-  onAdd: React.PropTypes.func
+  onAdd: PropTypes.func
 };
 
 export class RoleRow extends React.Component {
@@ -258,12 +259,12 @@ export class RoleRow extends React.Component {
 }
 
 RoleRow.propTypes = {
-  onRemove: React.PropTypes.func,
-  roleSet: React.PropTypes.shape({
-    delete: React.PropTypes.func,
-    get: React.PropTypes.func,
-    roles: React.PropTypes.array,
-    update: React.PropTypes.func
+  onRemove: PropTypes.func,
+  roleSet: PropTypes.shape({
+    delete: PropTypes.func,
+    get: PropTypes.func,
+    roles: PropTypes.array,
+    update: PropTypes.func
   })
 };
 
@@ -373,21 +374,21 @@ export class CollectionCollaborators extends React.Component {
 }
 
 CollectionCollaborators.contextTypes = {
-  router: React.PropTypes.object.isRequired
+  router: PropTypes.object.isRequired
 };
 
 CollectionCollaborators.propTypes = {
-  collection: React.PropTypes.shape({
-    get: React.PropTypes.func,
-    id: React.PropTypes.string,
-    uncacheLink: React.PropTypes.func
+  collection: PropTypes.shape({
+    get: PropTypes.func,
+    id: PropTypes.string,
+    uncacheLink: PropTypes.func
   }),
-  owner: React.PropTypes.shape({
-    display_name: React.PropTypes.string,
-    id: React.PropTypes.string
+  owner: PropTypes.shape({
+    display_name: PropTypes.string,
+    id: PropTypes.string
   }),
-  user: React.PropTypes.shape({
-    id: React.PropTypes.string
+  user: PropTypes.shape({
+    id: PropTypes.string
   })
 };
 

--- a/app/collections/collection-search.cjsx
+++ b/app/collections/collection-search.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 Select = require('react-select').default
 apiClient = require 'panoptes-client/lib/api-client'
@@ -7,8 +8,8 @@ module.exports = createReactClass
   displayName: 'CollectionSearch'
 
   propTypes:
-    multi: React.PropTypes.bool.isRequired
-    onChange: React.PropTypes.func
+    multi: PropTypes.bool.isRequired
+    onChange: PropTypes.func
 
   getDefaultProps: ->
     multi: false

--- a/app/collections/collections-create-form.jsx
+++ b/app/collections/collections-create-form.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import Translate from 'react-translate-component';
 import apiClient from 'panoptes-client/lib/api-client';
@@ -129,12 +130,12 @@ CollectionsCreateForm.defaultProps = {
 };
 
 CollectionsCreateForm.propTypes = {
-  onSubmit: React.PropTypes.func,
-  project: React.PropTypes.shape({
-    display_name: React.PropTypes.string,
-    id: React.PropTypes.string
+  onSubmit: PropTypes.func,
+  project: PropTypes.shape({
+    display_name: PropTypes.string,
+    id: PropTypes.string
   }),
-  subjectIDs: React.PropTypes.arrayOf(React.PropTypes.string)
+  subjectIDs: PropTypes.arrayOf(PropTypes.string)
 };
 
 export default CollectionsCreateForm;

--- a/app/collections/collections-manager.jsx
+++ b/app/collections/collections-manager.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import CollectionsCreateForm from './collections-create-form';
 import CollectionSearch from './collection-search';
@@ -111,11 +112,11 @@ CollectionsManager.defaultProps = {
 };
 
 CollectionsManager.propTypes = {
-  onSuccess: React.PropTypes.func,
-  project: React.PropTypes.shape({
-    id: React.PropTypes.string
+  onSuccess: PropTypes.func,
+  project: PropTypes.shape({
+    id: PropTypes.string
   }),
-  subjectIDs: React.PropTypes.arrayOf(React.PropTypes.string)
+  subjectIDs: PropTypes.arrayOf(PropTypes.string)
 };
 
 export default CollectionsManager;

--- a/app/collections/favorites-button.jsx
+++ b/app/collections/favorites-button.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import apiClient from 'panoptes-client/lib/api-client';
 import classnames from 'classnames';
@@ -167,18 +168,18 @@ FavoritesButton.defaultProps = {
 };
 
 FavoritesButton.propTypes = {
-  className: React.PropTypes.string,
-  isFavorite: React.PropTypes.bool,
-  subject: React.PropTypes.shape({ id: React.PropTypes.string }).isRequired,
-  project: React.PropTypes.shape({
-    id: React.PropTypes.string,
-    slug: React.PropTypes.string
+  className: PropTypes.string,
+  isFavorite: PropTypes.bool,
+  subject: PropTypes.shape({ id: PropTypes.string }).isRequired,
+  project: PropTypes.shape({
+    id: PropTypes.string,
+    slug: PropTypes.string
   }),
-  user: React.PropTypes.shape({
-    login: React.PropTypes.string
+  user: PropTypes.shape({
+    login: PropTypes.string
   })
 };
 
 FavoritesButton.contextTypes = {
-  geordi: React.PropTypes.object
+  geordi: PropTypes.object
 };

--- a/app/collections/manager-icon.jsx
+++ b/app/collections/manager-icon.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import Dialog from 'modal-form/dialog';
 import CollectionsManager from './collections-manager';
@@ -52,12 +53,12 @@ CollectionsManagerIcon.defaultProps = {
 };
 
 CollectionsManagerIcon.propTypes = {
-  className: React.PropTypes.string,
-  project: React.PropTypes.object,
-  subject: React.PropTypes.shape({
-    id: React.PropTypes.string
+  className: PropTypes.string,
+  project: PropTypes.object,
+  subject: PropTypes.shape({
+    id: PropTypes.string
   }),
-  user: React.PropTypes.object
+  user: PropTypes.object
 };
 
 export default CollectionsManagerIcon;

--- a/app/collections/settings.jsx
+++ b/app/collections/settings.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import alert from '../lib/alert';
 import AutoSave from '../components/auto-save';
@@ -200,7 +201,7 @@ export default class CollectionSettings extends React.Component {
 }
 
 CollectionSettings.contextTypes = {
-  router: React.PropTypes.object.isRequired
+  router: PropTypes.object.isRequired
 };
 
 CollectionSettings.defaultProps = {
@@ -209,11 +210,10 @@ CollectionSettings.defaultProps = {
 };
 
 CollectionSettings.propTypes = {
-  canCollaborate: React.PropTypes.bool,
-  collection: React.PropTypes.shape({
-    default_subject_src: React.PropTypes.string,
-    description: React.PropTypes.string,
-    private: React.PropTypes.bool
+  canCollaborate: PropTypes.bool,
+  collection: PropTypes.shape({
+    default_subject_src: PropTypes.string,
+    description: PropTypes.string,
+    private: PropTypes.bool
   })
 };
-

--- a/app/collections/show-list.cjsx
+++ b/app/collections/show-list.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 {Link} = require 'react-router'
 Translate = require 'react-translate-component'
@@ -24,7 +25,7 @@ counterpart.registerTranslations 'en',
 SubjectNode = createReactClass
 
   contextTypes:
-    geordi: React.PropTypes.object.isRequired
+    geordi: PropTypes.object.isRequired
 
   getInitialState: ->
     isFavorite: false
@@ -119,8 +120,8 @@ module.exports = createReactClass
   displayName: 'CollectionShowList'
 
   contextTypes:
-    geordi: React.PropTypes.object.isRequired
-    router: React.PropTypes.object.isRequired
+    geordi: PropTypes.object.isRequired
+    router: PropTypes.object.isRequired
 
   getInitialState: ->
     subjects: null
@@ -132,7 +133,7 @@ module.exports = createReactClass
     project: null
 
   propTypes:
-    project: React.PropTypes.object
+    project: PropTypes.object
 
   componentWillMount: ->
     @fetchCollectionSubjects pick @props.location.query, VALID_COLLECTION_MEMBER_SUBJECTS_PARAMS

--- a/app/collections/show.jsx
+++ b/app/collections/show.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { IndexLink, Link } from 'react-router';
 import Translate from 'react-translate-component';
@@ -22,15 +23,15 @@ counterpart.registerTranslations('en', {
 
 class CollectionPage extends React.Component {
   static propTypes = {
-    user: React.PropTypes.object,
-    collection: React.PropTypes.object.isRequired,
-    project: React.PropTypes.object,
-    children: React.PropTypes.node,
-    roles: React.PropTypes.array
+    user: PropTypes.object,
+    collection: PropTypes.object.isRequired,
+    project: PropTypes.object,
+    children: PropTypes.node,
+    roles: PropTypes.array
   };
 
   static contextTypes = {
-    geordi: React.PropTypes.object
+    geordi: PropTypes.object
   };
 
   static defaultProps = {
@@ -143,12 +144,12 @@ class CollectionPage extends React.Component {
 
 class CollectionPageWrapper extends React.Component {
   static propTypes = {
-    children: React.PropTypes.node,
-    project: React.PropTypes.object,
-    user: React.PropTypes.object,
-    params: React.PropTypes.shape({
-      collection_owner: React.PropTypes.string,
-      collection_name: React.PropTypes.string
+    children: PropTypes.node,
+    project: PropTypes.object,
+    user: PropTypes.object,
+    params: PropTypes.shape({
+      collection_owner: PropTypes.string,
+      collection_name: PropTypes.string
     })
   };
 

--- a/app/components/admin-only.jsx
+++ b/app/components/admin-only.jsx
@@ -5,14 +5,14 @@ import isAdmin from '../lib/is-admin';
 
 class AdminOnly extends React.Component {
   static contextTypes = {
-    user: React.PropTypes.object,
+    user: React.PropTypes.object
   };
 
   static defaultProps = {
-    whenActive: false,
+    whenActive: false
   };
 
-  refreshing: bool = false;
+  refreshing = (false: boolean);
 
   componentDidMount() {
     apiClient.listen('change', this.handleClientChange);
@@ -44,7 +44,7 @@ class AdminOnly extends React.Component {
     if (!!this.context.user && this.context.user.admin && (!this.props.whenActive || isAdmin())) {
       if (this.refreshing) {
         // Return null during refresh force re-render the child.
-        return null
+        return null;
       } else {
         return this.props.children;
       }

--- a/app/components/admin-only.jsx
+++ b/app/components/admin-only.jsx
@@ -1,11 +1,12 @@
 import counterpart from 'counterpart';
 import React from 'react';
+import PropTypes from 'prop-types';
 import apiClient from 'panoptes-client/lib/api-client';
 import isAdmin from '../lib/is-admin';
 
 class AdminOnly extends React.Component {
   static contextTypes = {
-    user: React.PropTypes.object
+    user: PropTypes.object
   };
 
   static defaultProps = {

--- a/app/components/char-limit.jsx
+++ b/app/components/char-limit.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 const CharLimit = ({ limit, string }) => {
   const remaining = limit - string.length;
@@ -11,12 +12,12 @@ const CharLimit = ({ limit, string }) => {
 
 CharLimit.propTypes = {
   limit: PropTypes.number.isRequired,
-  string: PropTypes.string.isRequired,
+  string: PropTypes.string.isRequired
 };
 
 CharLimit.defaultProps = {
   limit: 0,
-  string: '',
+  string: ''
 };
 
 export default CharLimit;

--- a/app/components/collapsable-section.jsx
+++ b/app/components/collapsable-section.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import updateQueryParams from '../talk/lib/update-query-params.coffee';
 
@@ -14,13 +15,13 @@ export default class CollapsableSection extends Component {
   }
 
   render() {
-    const children = React.Children.map(this.props.children, (child) => {
-      return React.cloneElement(child, {
-        toggleSection: this.onSectionToggle,
-        expanded: this.props.expanded,
-        section: this.props.section,
-      });
-    });
+    const children = React.Children.map(this.props.children, child =>
+       React.cloneElement(child, {
+         toggleSection: this.onSectionToggle,
+         expanded: this.props.expanded,
+         section: this.props.section
+       })
+    );
     return (
       <div>
         {children}
@@ -30,16 +31,16 @@ export default class CollapsableSection extends Component {
 }
 
 CollapsableSection.propTypes = {
-  callbackParent: React.PropTypes.func,
-  children: React.PropTypes.node,
-  expanded: React.PropTypes.bool,
-  section: React.PropTypes.string,
+  callbackParent: PropTypes.func,
+  children: PropTypes.node,
+  expanded: PropTypes.bool,
+  section: PropTypes.string
 };
 
 CollapsableSection.contextTypes = {
-  router: React.PropTypes.object.isRequired,
+  router: PropTypes.object.isRequired
 };
 
 CollapsableSection.defaultProps = {
-  expanded: false,
+  expanded: false
 };

--- a/app/components/dialog.jsx
+++ b/app/components/dialog.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import ModalFocus from './modal-focus';
 
@@ -50,9 +51,9 @@ class Dialog extends React.Component {
 }
 
 Dialog.propTypes = {
-  children: React.PropTypes.node,
-  controls: React.PropTypes.node,
-  onEscape: React.PropTypes.func
+  children: PropTypes.node,
+  controls: PropTypes.node,
+  onEscape: PropTypes.func
 };
 
 Dialog.defaultProps = {
@@ -62,4 +63,3 @@ Dialog.defaultProps = {
 };
 
 export default Dialog;
-

--- a/app/components/file-viewer/audio-player.jsx
+++ b/app/components/file-viewer/audio-player.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import ImageViewer from './image-viewer';
 import ProgressIndicator from './progress-indicator';
@@ -141,13 +142,13 @@ class AudioPlayer extends React.Component {
 }
 
 AudioPlayer.propTypes = {
-  format: React.PropTypes.oneOfType([React.PropTypes.array, React.PropTypes.string]),
-  frame: React.PropTypes.number,
-  onLoad: React.PropTypes.func,
-  onFocus: React.PropTypes.func,
-  onBlur: React.PropTypes.func,
-  src: React.PropTypes.oneOfType([React.PropTypes.array, React.PropTypes.string]),
-  type: React.PropTypes.oneOfType([React.PropTypes.array, React.PropTypes.string])
+  format: PropTypes.oneOfType([PropTypes.array, PropTypes.string]),
+  frame: PropTypes.number,
+  onLoad: PropTypes.func,
+  onFocus: PropTypes.func,
+  onBlur: PropTypes.func,
+  src: PropTypes.oneOfType([PropTypes.array, PropTypes.string]),
+  type: PropTypes.oneOfType([PropTypes.array, PropTypes.string])
 };
 
 AudioPlayer.defaultProps = {};

--- a/app/components/file-viewer/image-viewer.jsx
+++ b/app/components/file-viewer/image-viewer.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import LoadingIndicator from '../loading-indicator';
 
@@ -31,12 +32,12 @@ class ImageViewer extends React.Component {
 }
 
 ImageViewer.propTypes = {
-  onBlur: React.PropTypes.func,
-  onFocus: React.PropTypes.func,
-  onLoad: React.PropTypes.func,
-  overlayStyle: React.PropTypes.object,
-  src: React.PropTypes.string,
-  style: React.PropTypes.object
+  onBlur: PropTypes.func,
+  onFocus: PropTypes.func,
+  onLoad: PropTypes.func,
+  overlayStyle: PropTypes.object,
+  src: PropTypes.string,
+  style: PropTypes.object
 };
 
 export default ImageViewer;

--- a/app/components/file-viewer/index.jsx
+++ b/app/components/file-viewer/index.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import VideoPlayer from './video-player';
 import AudioPlayer from './audio-player';
@@ -13,7 +14,7 @@ function DefaultViewer(props) {
 }
 
 DefaultViewer.propTypes = {
-  type: React.PropTypes.string
+  type: PropTypes.string
 };
 
 const VIEWERS = {
@@ -52,23 +53,23 @@ function FileViewer(props) {
 }
 
 FileViewer.propTypes = {
-  className: React.PropTypes.string,
-  format: React.PropTypes.oneOfType([
-    React.PropTypes.array,
-    React.PropTypes.string
+  className: PropTypes.string,
+  format: PropTypes.oneOfType([
+    PropTypes.array,
+    PropTypes.string
   ]),
-  frame: React.PropTypes.number,
-  onBlur: React.PropTypes.func,
-  onFocus: React.PropTypes.func,
-  onLoad: React.PropTypes.func,
-  src: React.PropTypes.oneOfType([
-    React.PropTypes.array,
-    React.PropTypes.string
+  frame: PropTypes.number,
+  onBlur: PropTypes.func,
+  onFocus: PropTypes.func,
+  onLoad: PropTypes.func,
+  src: PropTypes.oneOfType([
+    PropTypes.array,
+    PropTypes.string
   ]),
-  style: React.PropTypes.object,
-  type: React.PropTypes.oneOfType([
-    React.PropTypes.array,
-    React.PropTypes.string
+  style: PropTypes.object,
+  type: PropTypes.oneOfType([
+    PropTypes.array,
+    PropTypes.string
   ])
 };
 

--- a/app/components/file-viewer/progress-indicator.jsx
+++ b/app/components/file-viewer/progress-indicator.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 class ProgressIndicator extends React.Component {
@@ -53,12 +54,12 @@ class ProgressIndicator extends React.Component {
 }
 
 ProgressIndicator.propTypes = {
-  children: React.PropTypes.node,
-  naturalHeight: React.PropTypes.number,
-  naturalWidth: React.PropTypes.number,
-  progressPosition: React.PropTypes.number,
-  progressRange: React.PropTypes.arrayOf(React.PropTypes.number),
-  src: React.PropTypes.string.isRequired
+  children: PropTypes.node,
+  naturalHeight: PropTypes.number,
+  naturalWidth: PropTypes.number,
+  progressPosition: PropTypes.number,
+  progressRange: PropTypes.arrayOf(PropTypes.number),
+  src: PropTypes.string.isRequired
 };
 
 ProgressIndicator.defaultProps = {

--- a/app/components/file-viewer/text-viewer.jsx
+++ b/app/components/file-viewer/text-viewer.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classnames from 'classnames';
 
@@ -79,11 +80,11 @@ class TextViewer extends Component {
 }
 
 TextViewer.propTypes = {
-  src: React.PropTypes.string.isRequired,
-  type: React.PropTypes.string,
-  format: React.PropTypes.string,
-  onLoad: React.PropTypes.func,
-  style: React.PropTypes.object
+  src: PropTypes.string.isRequired,
+  type: PropTypes.string,
+  format: PropTypes.string,
+  onLoad: PropTypes.func,
+  style: PropTypes.object
 };
 
 TextViewer.defaultProps = {

--- a/app/components/file-viewer/video-player.jsx
+++ b/app/components/file-viewer/video-player.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 class VideoPlayer extends React.Component {
@@ -95,12 +96,12 @@ class VideoPlayer extends React.Component {
 }
 
 VideoPlayer.propTypes = {
-  format: React.PropTypes.string,
-  frame: React.PropTypes.number,
-  onLoad: React.PropTypes.func,
-  showControls: React.PropTypes.bool,
-  src: React.PropTypes.string,
-  type: React.PropTypes.string
+  format: PropTypes.string,
+  frame: PropTypes.number,
+  onLoad: PropTypes.func,
+  showControls: PropTypes.bool,
+  src: PropTypes.string,
+  type: PropTypes.string
 };
 
 VideoPlayer.defaultProps = {

--- a/app/components/filmstrip.jsx
+++ b/app/components/filmstrip.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import DISCIPLINES from '../constants/disciplines';
 
@@ -106,10 +107,10 @@ export default class Filmstrip extends React.Component {
 }
 
 Filmstrip.propTypes = {
-  filterCards: React.PropTypes.arrayOf(React.PropTypes.object),
-  increment: React.PropTypes.number.isRequired,
-  onChange: React.PropTypes.func.isRequired,
-  value: React.PropTypes.string.isRequired
+  filterCards: PropTypes.arrayOf(PropTypes.object),
+  increment: PropTypes.number.isRequired,
+  onChange: PropTypes.func.isRequired,
+  value: PropTypes.string.isRequired
 };
 
 Filmstrip.defaultProps = {

--- a/app/components/flexible-link.jsx
+++ b/app/components/flexible-link.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Link } from 'react-router';
 
@@ -18,15 +19,15 @@ export default class FlexibleLink extends React.Component {
 }
 
 FlexibleLink.contextTypes = {
-  geordi: React.PropTypes.object
+  geordi: PropTypes.object
 };
 
 FlexibleLink.propTypes = {
-  children: React.PropTypes.node,
-  className: React.PropTypes.string,
-  geordiHandler: React.PropTypes.string,
-  logText: React.PropTypes.string,
-  to: React.PropTypes.string.isRequired
+  children: PropTypes.node,
+  className: PropTypes.string,
+  geordiHandler: PropTypes.string,
+  logText: PropTypes.string,
+  to: PropTypes.string.isRequired
 };
 
 FlexibleLink.defaultProps = {

--- a/app/components/frame-viewer.jsx
+++ b/app/components/frame-viewer.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import getSubjectLocation from '../lib/get-subject-location';
 import getSubjectLocations from '../lib/get-subject-locations';
@@ -54,7 +55,7 @@ export default class FrameViewer extends React.Component {
         return subjectLocations[locationKey][1];
       });
     }else{
-      ({ type, format, src } = getSubjectLocation(this.props.subject, this.props.frame));
+      (({ type, format, src } = getSubjectLocation(this.props.subject, this.props.frame)));
     }
     const zoomEnabled = this.props.workflow && this.props.workflow.configuration.pan_and_zoom && (type === 'image' || this.props.isAudioPlusImage);
     const ProgressMarker = this.props.progressMarker;
@@ -109,25 +110,25 @@ export default class FrameViewer extends React.Component {
 }
 
 FrameViewer.propTypes = {
-  annotation: React.PropTypes.shape(
-    { id: React.PropTypes.string }
+  annotation: PropTypes.shape(
+    { id: PropTypes.string }
   ),
-  classification: React.PropTypes.shape(
-    { annotations: React.PropTypes.array }
+  classification: PropTypes.shape(
+    { annotations: PropTypes.array }
   ),
-  frame: React.PropTypes.number,
-  frameWrapper: React.PropTypes.func,
-  modification: React.PropTypes.object,
-  onChange: React.PropTypes.func,
-  onLoad: React.PropTypes.func,
-  preferences: React.PropTypes.shape(
-    { id: React.PropTypes.string }
+  frame: PropTypes.number,
+  frameWrapper: PropTypes.func,
+  modification: PropTypes.object,
+  onChange: PropTypes.func,
+  onLoad: PropTypes.func,
+  preferences: PropTypes.shape(
+    { id: PropTypes.string }
   ),
-  subject: React.PropTypes.shape(
-    { id: React.PropTypes.string }
+  subject: PropTypes.shape(
+    { id: PropTypes.string }
   ),
-  workflow: React.PropTypes.shape(
-    { configuration: React.PropTypes.object }
+  workflow: PropTypes.shape(
+    { configuration: PropTypes.object }
   )
 };
 

--- a/app/components/modal-focus.jsx
+++ b/app/components/modal-focus.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import ReactDOM from 'react-dom';
 
@@ -48,10 +49,10 @@ class ModalFocus extends React.Component {
 }
 
 ModalFocus.propTypes = {
-  children: React.PropTypes.node,
-  className: React.PropTypes.string,
-  onEscape: React.PropTypes.func,
-  preserveFocus: React.PropTypes.bool
+  children: PropTypes.node,
+  className: PropTypes.string,
+  onEscape: PropTypes.func,
+  preserveFocus: PropTypes.bool
 };
 
 ModalFocus.defaultProps = {

--- a/app/components/model-renderer.jsx
+++ b/app/components/model-renderer.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Markdown } from 'markdownz';
 import { Model } from './modelling';
@@ -123,15 +124,15 @@ class ModelRenderer extends React.Component {
 }
 /* eslint-disable react/forbid-prop-types */
 ModelRenderer.propTypes = {
-  classification: React.PropTypes.shape({
-    annotations: React.PropTypes.Array
+  classification: PropTypes.shape({
+    annotations: PropTypes.Array
   }),
-  subject: React.PropTypes.shape({
-    locations: React.PropTypes.Array,
+  subject: PropTypes.shape({
+    locations: PropTypes.Array,
     // this is handled by the specific model renderer used, so can vary
-    metadata: React.PropTypes.object
+    metadata: PropTypes.object
   }),
-  onRender: React.PropTypes.func
+  onRender: PropTypes.func
 };
 /* eslint-enable react/forbid-prop-types */
 
@@ -146,7 +147,7 @@ const ModelRendererWrapper = (props) => {
 
 /* eslint-disable react/forbid-prop-types */
 ModelRendererWrapper.propTypes = {
-  modellingEnabled: React.PropTypes.bool
+  modellingEnabled: PropTypes.bool
 };
 /* eslint-enable react/forbid-prop-types */
 

--- a/app/components/modelling/galaxyScore.jsx
+++ b/app/components/modelling/galaxyScore.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 // grabs the model score (calculated in modelCanvas) and displays it with a
@@ -20,7 +21,7 @@ const ModelScore = (props) => {
 
 /* eslint-disable react/forbid-prop-types */
 ModelScore.propTypes = {
-  score: React.PropTypes.number
+  score: PropTypes.number
 };
 /* eslint-enable react/forbid-prop-types */
 
@@ -35,7 +36,7 @@ const ModelScoreWrapper = (props) => {
 
 /* eslint-disable react/forbid-prop-types */
 ModelScoreWrapper.propTypes = {
-  modellingEnabled: React.PropTypes.bool
+  modellingEnabled: PropTypes.bool
 };
 /* eslint-enable react/forbid-prop-types */
 

--- a/app/components/pan-zoom.jsx
+++ b/app/components/pan-zoom.jsx
@@ -1,4 +1,6 @@
 /* eslint no-unused-expressions: ["error", { "allowTernary": true }] */
+import PropTypes from 'prop-types';
+
 import React from 'react';
 
 class PanZoom extends React.Component {
@@ -346,14 +348,14 @@ class PanZoom extends React.Component {
 }
 
 PanZoom.propTypes = {
-  children: React.PropTypes.node,
-  enabled: React.PropTypes.bool,
-  frameDimensions: React.PropTypes.shape({
-    height: React.PropTypes.number,
-    width: React.PropTypes.number
+  children: PropTypes.node,
+  enabled: PropTypes.bool,
+  frameDimensions: PropTypes.shape({
+    height: PropTypes.number,
+    width: PropTypes.number
   }),
-  subject: React.PropTypes.shape({
-    id: React.PropTypes.string
+  subject: PropTypes.shape({
+    id: PropTypes.string
   })
 };
 

--- a/app/components/pass-context.cjsx
+++ b/app/components/pass-context.cjsx
@@ -1,25 +1,26 @@
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 {routerShape} = require 'react-router/lib/PropTypes'
 
 module.exports = createReactClass
   contextTypes:
-    initialLoadComplete: React.PropTypes.bool
+    initialLoadComplete: PropTypes.bool
     router: routerShape
-    user: React.PropTypes.object
-    geordi: React.PropTypes.object
-    notificationsCounter: React.PropTypes.object
-    unreadNotificationsCount: React.PropTypes.number
-    pusher: React.PropTypes.object
+    user: PropTypes.object
+    geordi: PropTypes.object
+    notificationsCounter: PropTypes.object
+    unreadNotificationsCount: PropTypes.number
+    pusher: PropTypes.object
 
   childContextTypes:
-    initialLoadComplete: React.PropTypes.bool
+    initialLoadComplete: PropTypes.bool
     router: routerShape
-    user: React.PropTypes.object
-    geordi: React.PropTypes.object
-    notificationsCounter: React.PropTypes.object
-    unreadNotificationsCount: React.PropTypes.number
-    pusher: React.PropTypes.object
+    user: PropTypes.object
+    geordi: PropTypes.object
+    notificationsCounter: PropTypes.object
+    unreadNotificationsCount: PropTypes.number
+    pusher: PropTypes.object
 
   getChildContext: ->
     @props.context

--- a/app/components/project-icon.jsx
+++ b/app/components/project-icon.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import ProjectCard from '../partials/project-card';
 
@@ -11,9 +12,9 @@ const ProjectIcon = (props) => {
 };
 
 ProjectIcon.propTypes = {
-  project: React.PropTypes.object,
-  badge: React.PropTypes.number,
-  linkTo: React.PropTypes.string
+  project: PropTypes.object,
+  badge: PropTypes.number,
+  linkTo: PropTypes.string
 };
 
 export default ProjectIcon;

--- a/app/components/step-through.jsx
+++ b/app/components/step-through.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
 import ReactSwipe from 'react-swipe';
@@ -140,7 +141,7 @@ class StepThrough extends Component {
 }
 
 StepThrough.propTypes = {
-  defaultStep: React.PropTypes.number,
+  defaultStep: PropTypes.number,
 }
 
 StepThrough.defaultProps = {

--- a/app/components/subject-viewer.cjsx
+++ b/app/components/subject-viewer.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 `import FavoritesButton from '../collections/favorites-button';`
 Dialog = require 'modal-form/dialog'
@@ -40,7 +41,7 @@ module.exports = createReactClass
   displayName: 'SubjectViewer'
 
   contextTypes:
-    geordi: React.PropTypes.object
+    geordi: PropTypes.object
 
   signInAttentionTimeout: NaN
 

--- a/app/components/svg-image.jsx
+++ b/app/components/svg-image.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 const FILTERS = {
@@ -62,10 +63,10 @@ class SVGImage extends React.Component {
   }
 }
 SVGImage.propTypes = {
-  src: React.PropTypes.string.isRequired,
-  height: React.PropTypes.number.isRequired,
-  width: React.PropTypes.number.isRequired,
-  modification: React.PropTypes.object,
+  src: PropTypes.string.isRequired,
+  height: PropTypes.number.isRequired,
+  width: PropTypes.number.isRequired,
+  modification: PropTypes.object,
 };
 
 SVGImage.defaultProps = {

--- a/app/components/tag-search.cjsx
+++ b/app/components/tag-search.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 Select = require('react-select').default
 apiClient = require 'panoptes-client/lib/api-client'
@@ -7,8 +8,8 @@ module.exports = createReactClass
   displayName: 'TagSearch'
 
   propTypes:
-    multi: React.PropTypes.bool
-    value: React.PropTypes.array
+    multi: PropTypes.bool
+    value: PropTypes.array
 
   getDefaultProps: ->
     multi: true

--- a/app/components/thumbnail.jsx
+++ b/app/components/thumbnail.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 const MAX_THUMBNAIL_DIMENSION = 999;
@@ -73,10 +74,10 @@ Thumbnail.defaultProps = {
 };
 
 Thumbnail.propTypes = {
-  controls: React.PropTypes.bool,
-  format: React.PropTypes.string,
-  height: React.PropTypes.number,
-  origin: React.PropTypes.string,
-  src: React.PropTypes.string,
-  width: React.PropTypes.number
+  controls: PropTypes.bool,
+  format: PropTypes.string,
+  height: PropTypes.number,
+  origin: PropTypes.string,
+  src: PropTypes.string,
+  width: PropTypes.number
 };

--- a/app/components/user-search.cjsx
+++ b/app/components/user-search.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 Select = require('react-select').default
 apiClient = require 'panoptes-client/lib/api-client'
@@ -12,8 +13,8 @@ module.exports = createReactClass
   queryTimeout: NaN
 
   propTypes:
-    multi: React.PropTypes.bool
-    debounce: React.PropTypes.number
+    multi: PropTypes.bool
+    debounce: PropTypes.number
 
   getDefaultProps: ->
     multi: true

--- a/app/components/workflow-assignment-dialog.jsx
+++ b/app/components/workflow-assignment-dialog.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import Dialog from 'modal-form/dialog';
 import ReactDOM from 'react-dom';
@@ -72,10 +73,10 @@ class WorkflowAssignmentDialog extends React.Component {
 }
 
 WorkflowAssignmentDialog.propTypes = {
-  project: React.PropTypes.shape({
-    id: React.PropTypes.id
+  project: PropTypes.shape({
+    id: PropTypes.id
   }),
-  splits: React.PropTypes.object
+  splits: PropTypes.object
 };
 
 export default WorkflowAssignmentDialog;

--- a/app/components/workflow-toggle.jsx
+++ b/app/components/workflow-toggle.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import Translate from 'react-translate-component';
 
@@ -24,12 +25,12 @@ WorkflowToggle.defaultProps = {
 };
 
 WorkflowToggle.propTypes = {
-  checked: React.PropTypes.bool,
-  handleToggle: React.PropTypes.func,
-  name: React.PropTypes.string,
-  workflow: React.PropTypes.shape({
-    display_name: React.PropTypes.string,
-    id: React.PropTypes.string
+  checked: PropTypes.bool,
+  handleToggle: PropTypes.func,
+  name: PropTypes.string,
+  workflow: PropTypes.shape({
+    display_name: PropTypes.string,
+    id: PropTypes.string
   }).isRequired
 };
 

--- a/app/components/wrapped-markdown.jsx
+++ b/app/components/wrapped-markdown.jsx
@@ -1,12 +1,13 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Markdown } from 'markdownz';
 import { browserHistory } from 'react-router';
 
 class WrappedMarkdown extends React.Component {
   static propTypes = {
-    content: React.PropTypes.string,
-    project: React.PropTypes.object,
-    header: React.PropTypes.string,
+    content: PropTypes.string,
+    project: PropTypes.object,
+    header: PropTypes.string,
   };
 
   onClick = (e) => {

--- a/app/features/feedback/classifier/components/feedback-modal.jsx
+++ b/app/features/feedback/classifier/components/feedback-modal.jsx
@@ -1,5 +1,5 @@
-
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import Translate from 'react-translate-component';
 import counterpart from 'counterpart';
 import SubjectViewer from '../../../../components/subject-viewer';

--- a/app/features/feedback/lab/components/feedback-section.jsx
+++ b/app/features/feedback/lab/components/feedback-section.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import Translate from 'react-translate-component';
 import counterpart from 'counterpart';
 

--- a/app/features/feedback/lab/components/rule-editor-modal.jsx
+++ b/app/features/feedback/lab/components/rule-editor-modal.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import counterpart from 'counterpart';
 import Translate from 'react-translate-component';
 import _ from 'lodash';

--- a/app/features/feedback/lab/containers/feedback-section-container.jsx
+++ b/app/features/feedback/lab/containers/feedback-section-container.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import ModalFormDialog from 'modal-form/dialog';
 import _ from 'lodash';
 import FeedbackSection from '../components/feedback-section';
@@ -72,7 +73,7 @@ FeedbackSectionContainer.propTypes = {
       enabled: PropTypes.bool
     })
   }),
-  saveFn: React.PropTypes.func
+  saveFn: PropTypes.func
 };
 
 export default FeedbackSectionContainer;

--- a/app/features/feedback/lab/containers/rule-editor-modal-container.jsx
+++ b/app/features/feedback/lab/containers/rule-editor-modal-container.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import _ from 'lodash';
 import RuleEditorModal from '../components/rule-editor-modal';
 import defaultValidations from '../helpers/default-validations';

--- a/app/features/feedback/shared/components/checkbox-input.jsx
+++ b/app/features/feedback/shared/components/checkbox-input.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import uuidv4 from 'uuid/v4';
 
 

--- a/app/features/feedback/shared/components/select-input.jsx
+++ b/app/features/feedback/shared/components/select-input.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import Select from 'react-select';
 import uuidv4 from 'uuid/v4';
 

--- a/app/features/feedback/shared/components/text-input.jsx
+++ b/app/features/feedback/shared/components/text-input.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import uuidv4 from 'uuid/v4';
 
 function TextInput({ title, help, onChange, name, type = 'text', required = false, value }) {

--- a/app/features/feedback/shared/strategies/radial/feedback-mark.jsx
+++ b/app/features/feedback/shared/strategies/radial/feedback-mark.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 function FeedbackMark({ rule }) {
   const color = (rule.success) ? 'green' : 'red';

--- a/app/features/feedback/shared/strategies/radial/lab-component.jsx
+++ b/app/features/feedback/shared/strategies/radial/lab-component.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import counterpart from 'counterpart';
 import TextInput from '../../components/text-input';
 

--- a/app/layout/account-bar.jsx
+++ b/app/layout/account-bar.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { routerShape } from 'react-router/lib/PropTypes';
 import { Link } from 'react-router';
@@ -198,12 +199,12 @@ export default class AccountBar extends React.Component {
 }
 
 AccountBar.contextTypes = {
-  user: React.PropTypes.object,
+  user: PropTypes.object,
   router: routerShape,
-  geordi: React.PropTypes.object
+  geordi: PropTypes.object
 };
 
 AccountBar.propTypes = {
-  params: React.PropTypes.object,
-  isMobile: React.PropTypes.bool
+  params: PropTypes.object,
+  isMobile: PropTypes.bool
 };

--- a/app/layout/expandable-menu.jsx
+++ b/app/layout/expandable-menu.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import TriggeredModalForm from 'modal-form/triggered';
@@ -54,10 +55,10 @@ class ExpandableMenu extends React.Component {
 }
 
 ExpandableMenu.propTypes = {
-  children: React.PropTypes.node,
-  className: React.PropTypes.string,
-  trigger: React.PropTypes.node,
-  triggerProps: React.PropTypes.object
+  children: PropTypes.node,
+  className: PropTypes.string,
+  trigger: PropTypes.node,
+  triggerProps: PropTypes.object
 };
 
 ExpandableMenu.defaultProps = {

--- a/app/layout/index.jsx
+++ b/app/layout/index.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
 import AdminOnly from '../components/admin-only';
@@ -6,11 +7,11 @@ import SiteFooter from './site-footer';
 
 class AppLayout extends React.Component {
   static propTypes = {
-    children: React.PropTypes.node
+    children: PropTypes.node
   };
 
   static childContextTypes = {
-    setAppHeaderVariant: React.PropTypes.func
+    setAppHeaderVariant: PropTypes.func
   };
 
   state = {

--- a/app/layout/login-bar.jsx
+++ b/app/layout/login-bar.jsx
@@ -1,4 +1,5 @@
 import counterpart from 'counterpart';
+import PropTypes from 'prop-types';
 import React from 'react';
 import Translate from 'react-translate-component';
 import alert from '../lib/alert';
@@ -13,7 +14,7 @@ counterpart.registerTranslations('en', {
 
 class LoginBar extends React.Component {
   static contextTypes = {
-    geordi: React.PropTypes.object
+    geordi: PropTypes.object
   };
 
   showDialog = (event) => {

--- a/app/layout/site-footer.jsx
+++ b/app/layout/site-footer.jsx
@@ -1,5 +1,6 @@
 import counterpart from 'counterpart';
 import Translate from 'react-translate-component';
+import PropTypes from 'prop-types';
 import React from 'react';
 import ZooniverseLogotype from '../partials/zooniverse-logotype';
 import AdminOnly from '../components/admin-only';
@@ -41,12 +42,12 @@ counterpart.registerTranslations('en', {
 
 class AppFooter extends React.Component {
   static contextTypes = {
-    geordi: React.PropTypes.object,
+    geordi: PropTypes.object,
   };
 
   static propTypes = {
-    user: React.PropTypes.shape({
-      admin: React.PropTypes.bool,
+    user: PropTypes.shape({
+      admin: PropTypes.bool,
     }),
   };
 

--- a/app/layout/site-nav.jsx
+++ b/app/layout/site-nav.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
 import counterpart from 'counterpart';
@@ -35,10 +36,10 @@ const SiteNav = createReactClass({
   resizeTimeout: NaN,
 
   contextTypes: {
-    initialLoadComplete: React.PropTypes.bool,
-    user: React.PropTypes.object,
+    initialLoadComplete: PropTypes.bool,
+    user: PropTypes.object,
     router: routerShape,
-    geordi: React.PropTypes.object
+    geordi: PropTypes.object
   },
 
   getInitialState() {

--- a/app/layout/site-subnav.jsx
+++ b/app/layout/site-subnav.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import ExpandableMenu from './expandable-menu';
 
@@ -24,8 +25,8 @@ class SiteSubnav extends React.Component {
 }
 
 SiteSubnav.propTypes = {
-  isMobile: React.PropTypes.bool,
-  children: React.PropTypes.node
+  isMobile: PropTypes.bool,
+  children: PropTypes.node
 };
 
 export default SiteSubnav;

--- a/app/lib/draggable.cjsx
+++ b/app/lib/draggable.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 
 module.exports = createReactClass
@@ -7,13 +8,13 @@ module.exports = createReactClass
   _previousEventCoords: null
 
   propTypes:
-    onStart: React.PropTypes.oneOfType [
-      React.PropTypes.func
-      React.PropTypes.bool
+    onStart: PropTypes.oneOfType [
+      PropTypes.func
+      PropTypes.bool
     ]
-    onDrag: React.PropTypes.func
-    onEnd: React.PropTypes.func
-    disabled: React.PropTypes.bool
+    onDrag: PropTypes.func
+    onEnd: PropTypes.func
+    disabled: PropTypes.bool
 
   render: ->
     childProps =

--- a/app/pages/about/index.jsx
+++ b/app/pages/about/index.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import counterpart from 'counterpart';
 import Translate from 'react-translate-component';
@@ -83,11 +84,11 @@ class AboutPage extends React.Component {
 }
 
 AboutPage.contextTypes = {
-  geordi: React.PropTypes.object
+  geordi: PropTypes.object
 };
 
 AboutPage.propTypes = {
-  children: React.PropTypes.node
+  children: PropTypes.node
 };
 
 AboutPage.defaultProps = {

--- a/app/pages/admin.jsx
+++ b/app/pages/admin.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import counterpart from 'counterpart';
 import Translate from 'react-translate-component';
@@ -78,9 +79,9 @@ AdminPage.defaultProps = {
 };
 
 AdminPage.propTypes = {
-  children: React.PropTypes.node,
-  user: React.PropTypes.shape({
-    admin: React.PropTypes.bool
+  children: PropTypes.node,
+  user: PropTypes.shape({
+    admin: PropTypes.bool
   })
 };
 

--- a/app/pages/admin/grantbot/components/retirement-rules.jsx
+++ b/app/pages/admin/grantbot/components/retirement-rules.jsx
@@ -1,5 +1,6 @@
+import PropTypes from 'prop-types';
 import React from 'react';
-  
+
 function RetirementRules({ data }) {
   return (
     <section>
@@ -16,10 +17,10 @@ function RetirementRules({ data }) {
 }
 
 RetirementRules.propTypes = {
-  data: React.PropTypes.arrayOf(React.PropTypes.shape({
-    id: React.PropTypes.string.isRequired,
-    name: React.PropTypes.string.isRequired,
-    retirementHasBeenChanged: React.PropTypes.bool.isRequired,
+  data: PropTypes.arrayOf(PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    name: PropTypes.string.isRequired,
+    retirementHasBeenChanged: PropTypes.bool.isRequired,
   })),
 };
 

--- a/app/pages/admin/grantbot/containers/project-search-container.jsx
+++ b/app/pages/admin/grantbot/containers/project-search-container.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Async as SelectAsync } from 'react-select';
 import apiClient from 'panoptes-client/lib/api-client';
@@ -76,7 +77,7 @@ class ProjectSearch extends React.Component {
 }
 
 ProjectSearch.propTypes = {
-  onSelect: React.PropTypes.func,
+  onSelect: PropTypes.func,
 };
 
 export default ProjectSearch;

--- a/app/pages/admin/project-status/experimental-features.jsx
+++ b/app/pages/admin/project-status/experimental-features.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import AutoSave from '../../../components/auto-save';
 
@@ -86,7 +87,7 @@ class ExperimentalFeatures extends Component {
 }
 
 ExperimentalFeatures.propTypes = {
-  project: React.PropTypes.object.isRequired
+  project: PropTypes.object.isRequired
 };
 
 ExperimentalFeatures.defaultProps = {

--- a/app/pages/admin/project-status/redirect-toggle.jsx
+++ b/app/pages/admin/project-status/redirect-toggle.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import AutoSave from '../../../components/auto-save';
 import handleInputChange from '../../../lib/handle-input-change';
@@ -53,9 +54,9 @@ class RedirectToggle extends Component {
 }
 
 RedirectToggle.propTypes = {
-  project: React.PropTypes.object.isRequired,
-  invalidUrl: React.PropTypes.string,
-  validUrlRegex: React.PropTypes.object // regex
+  project: PropTypes.object.isRequired,
+  invalidUrl: PropTypes.string,
+  validUrlRegex: PropTypes.object // regex
 };
 
 RedirectToggle.defaultProps = {

--- a/app/pages/admin/project-status/toggle.jsx
+++ b/app/pages/admin/project-status/toggle.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 
 class Toggle extends Component {
@@ -62,10 +63,10 @@ class Toggle extends Component {
 }
 
 Toggle.propTypes = {
-  project: React.PropTypes.object.isRequired,
-  field: React.PropTypes.string.isRequired,
-  trueLabel: React.PropTypes.string,
-  falseLabel: React.PropTypes.string
+  project: PropTypes.object.isRequired,
+  field: PropTypes.string.isRequired,
+  trueLabel: PropTypes.string,
+  falseLabel: PropTypes.string
 };
 
 Toggle.defaultProps = {

--- a/app/pages/admin/project-status/version-list.jsx
+++ b/app/pages/admin/project-status/version-list.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { Link } from 'react-router';
 import apiClient from 'panoptes-client/lib/api-client';
@@ -88,7 +89,7 @@ class VersionList extends Component {
 }
 
 VersionList.propTypes = {
-  project: React.PropTypes.object.isRequired
+  project: PropTypes.object.isRequired
 };
 
 export default VersionList;

--- a/app/pages/admin/user-settings-list.jsx
+++ b/app/pages/admin/user-settings-list.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { Redirect, Link } from 'react-router';
 import apiClient from 'panoptes-client/lib/api-client';
@@ -62,7 +63,7 @@ class UserSettingsList extends Component {
 }
 
 UserSettingsList.contextTypes = {
-  router: React.PropTypes.object.isRequired
+  router: PropTypes.object.isRequired
 };
 
 export default UserSettingsList;

--- a/app/pages/admin/user-settings.jsx
+++ b/app/pages/admin/user-settings.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import apiClient from 'panoptes-client/lib/api-client';
 
@@ -71,8 +72,8 @@ class UserSettings extends Component {
 }
 
 UserSettings.propTypes = {
-  user: React.PropTypes.object,
-  editUser: React.PropTypes.object
+  user: PropTypes.object,
+  editUser: PropTypes.object
 };
 
 UserSettings.defaultProps = {

--- a/app/pages/admin/user-settings/delete-user.jsx
+++ b/app/pages/admin/user-settings/delete-user.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 
 import LoadingIndicator from '../../../components/loading-indicator';
@@ -50,14 +51,14 @@ class DeleteUser extends Component {
           this.setState({deletionInProgress: false});
         })
   }
-};
+}
 
 DeleteUser.propTypes = {
-  user: React.PropTypes.object
+  user: PropTypes.object
 }
 
 DeleteUser.contextTypes = {
-  router: React.PropTypes.object.isRequired
+  router: PropTypes.object.isRequired
 };
 
 export default DeleteUser;

--- a/app/pages/admin/user-settings/limit-toggle.jsx
+++ b/app/pages/admin/user-settings/limit-toggle.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 
 import AutoSave from '../../../components/auto-save';
@@ -20,7 +21,7 @@ class LimitToggle extends Component {
 }
 
 LimitToggle.propTypes = {
-  editUser: React.PropTypes.object.isRequired
+  editUser: PropTypes.object.isRequired
 };
 
 LimitToggle.defaultProps = {

--- a/app/pages/admin/user-settings/projects.jsx
+++ b/app/pages/admin/user-settings/projects.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { Link } from 'react-router';
 import apiClient from 'panoptes-client/lib/api-client';
@@ -49,7 +50,7 @@ class Projects extends Component {
 }
 
 Projects.propTypes = {
-  user: React.PropTypes.object.isRequired
+  user: PropTypes.object.isRequired
 };
 
 export default Projects;

--- a/app/pages/admin/user-settings/properties.jsx
+++ b/app/pages/admin/user-settings/properties.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 import AutoSave from '../../../components/auto-save';
@@ -40,7 +41,7 @@ const UserProperties = (props) => {
 }
 
 UserProperties.propTypes = {
-  user: React.PropTypes.object
+  user: PropTypes.object
 }
 
 export default UserProperties;

--- a/app/pages/admin/workflow-default-dialog.jsx
+++ b/app/pages/admin/workflow-default-dialog.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import Dialog from 'modal-form/dialog';
 
@@ -29,8 +30,8 @@ WorkflowDefaultDialog.defaultProps = {
 };
 
 WorkflowDefaultDialog.propTypes = {
-  onCancel: React.PropTypes.func,
-  onSuccess: React.PropTypes.func
+  onCancel: PropTypes.func,
+  onSuccess: PropTypes.func
 };
 
 export default WorkflowDefaultDialog;

--- a/app/pages/collections/collection-card.jsx
+++ b/app/pages/collections/collection-card.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import FlexibleLink from '../../components/flexible-link';
 
@@ -65,17 +66,17 @@ export default class CollectionCard extends React.Component {
 }
 
 CollectionCard.propTypes = {
-  collection: React.PropTypes.shape({
-    default_subject_src: React.PropTypes.string,
-    display_name: React.PropTypes.string,
-    id: React.PropTypes.string,
-    links: React.PropTypes.object,
-    private: React.PropTypes.bool,
-    slug: React.PropTypes.string
+  collection: PropTypes.shape({
+    default_subject_src: PropTypes.string,
+    display_name: PropTypes.string,
+    id: PropTypes.string,
+    links: PropTypes.object,
+    private: PropTypes.bool,
+    slug: PropTypes.string
   }).isRequired,
-  linkTo: React.PropTypes.string.isRequired,
-  shared: React.PropTypes.bool,
-  translationObjectName: React.PropTypes.string.isRequired
+  linkTo: PropTypes.string.isRequired,
+  shared: PropTypes.bool,
+  translationObjectName: PropTypes.string.isRequired
 };
 
 CollectionCard.defaultProps = {

--- a/app/pages/collections/list.cjsx
+++ b/app/pages/collections/list.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 apiClient = require 'panoptes-client/lib/api-client'
 `import CollectionCard from './collection-card';`
@@ -18,7 +19,7 @@ List = createReactClass
   displayName: 'List'
 
   contextTypes:
-    router: React.PropTypes.object.isRequired
+    router: PropTypes.object.isRequired
 
   statics: {
     getPropsForList: (props,favorite)->

--- a/app/pages/collections/nav.cjsx
+++ b/app/pages/collections/nav.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 {Link, IndexLink} = require 'react-router'
 Translate = require 'react-translate-component'
@@ -8,7 +9,7 @@ CollectionsNav = createReactClass
   displayName: 'CollectionsNav'
 
   contextTypes:
-    geordi: React.PropTypes.object
+    geordi: PropTypes.object
 
   componentWillReceiveProps: (nextProps, nextContext)->
     @logClick = nextContext?.geordi?.makeHandler? 'collect-menu'

--- a/app/pages/get-involved/index.jsx
+++ b/app/pages/get-involved/index.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import counterpart from 'counterpart';
 import Translate from 'react-translate-component';
@@ -69,11 +70,11 @@ class GetInvolved extends React.Component {
 }
 
 GetInvolved.contextTypes = {
-  geordi: React.PropTypes.object
+  geordi: PropTypes.object
 };
 
 GetInvolved.propTypes = {
-  children: React.PropTypes.node
+  children: PropTypes.node
 };
 
 GetInvolved.defaultProps = {

--- a/app/pages/home-for-user/blurred-image.jsx
+++ b/app/pages/home-for-user/blurred-image.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 
@@ -17,11 +18,11 @@ function BlurredImage(props) {
 }
 
 BlurredImage.propTypes = {
-  className: React.PropTypes.string.isRequired,
-  style: React.PropTypes.object.isRequired,
-  src: React.PropTypes.string.isRequired,
-  position: React.PropTypes.string.isRequired,
-  blur: React.PropTypes.any,
+  className: PropTypes.string.isRequired,
+  style: PropTypes.object.isRequired,
+  src: PropTypes.string.isRequired,
+  position: PropTypes.string.isRequired,
+  blur: PropTypes.any,
 };
 
 BlurredImage.defaultProps = {

--- a/app/pages/home-for-user/circle-ribbon.jsx
+++ b/app/pages/home-for-user/circle-ribbon.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { browserHistory } from 'react-router';
 
@@ -9,16 +10,16 @@ function defaultHREFTemplate(project) {
 
 class CircleRibbon extends React.Component {
   static propTypes = {
-    size: React.PropTypes.string,
-    weight: React.PropTypes.number,
-    gap: React.PropTypes.number,
-    loading: React.PropTypes.bool,
-    data: React.PropTypes.array,
-    hrefTemplate: React.PropTypes.func,
-    onClick: React.PropTypes.func,
-    user: React.PropTypes.shape({
-      avatar_src: React.PropTypes.string,
-      login: React.PropTypes.string
+    size: PropTypes.string,
+    weight: PropTypes.number,
+    gap: PropTypes.number,
+    loading: PropTypes.bool,
+    data: PropTypes.array,
+    hrefTemplate: PropTypes.func,
+    onClick: PropTypes.func,
+    user: PropTypes.shape({
+      avatar_src: PropTypes.string,
+      login: PropTypes.string
     }).isRequired
   };
 

--- a/app/pages/home-for-user/generic-section.jsx
+++ b/app/pages/home-for-user/generic-section.jsx
@@ -1,13 +1,14 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Link } from 'react-router';
 
 class HomePageSection extends React.Component {
   static propTypes = {
-    title: React.PropTypes.string,
-    loading: React.PropTypes.bool,
-    error: React.PropTypes.object,
-    onClose: React.PropTypes.func,
-    children: React.PropTypes.node,
+    title: PropTypes.string,
+    loading: PropTypes.bool,
+    error: PropTypes.object,
+    onClose: PropTypes.func,
+    children: PropTypes.node,
   };
 
   render() {

--- a/app/pages/home-for-user/index.jsx
+++ b/app/pages/home-for-user/index.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Link } from 'react-router';
@@ -298,20 +299,20 @@ export default class HomePageForUser extends React.Component {
 }
 
 HomePageForUser.propTypes = {
-  actions: React.PropTypes.shape({
-    createLinkedResource: React.PropTypes.func,
-    uploadMedia: React.PropTypes.func
+  actions: PropTypes.shape({
+    createLinkedResource: PropTypes.func,
+    uploadMedia: PropTypes.func
   }),
-  user: React.PropTypes.shape({
-    display_name: React.PropTypes.string
+  user: PropTypes.shape({
+    display_name: PropTypes.string
   }),
-  location: React.PropTypes.shape({
-    hash: React.PropTypes.string
+  location: PropTypes.shape({
+    hash: PropTypes.string
   })
 };
 
 HomePageForUser.contextTypes = {
-  setAppHeaderVariant: React.PropTypes.func
+  setAppHeaderVariant: PropTypes.func
 };
 
 HomePageForUser.defaultProps = {

--- a/app/pages/home-for-user/my-builds.jsx
+++ b/app/pages/home-for-user/my-builds.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import apiClient from 'panoptes-client/lib/api-client';
 import HomePageSection from './generic-section';
@@ -6,11 +7,11 @@ import ProjectCard from '../../partials/project-card';
 
 class MyBuildsSection extends React.Component {
   static propTypes = {
-    onClose: React.PropTypes.func.isRequired,
+    onClose: PropTypes.func.isRequired,
   };
 
   static contextTypes = {
-    user: React.PropTypes.object.isRequired,
+    user: PropTypes.object.isRequired,
   };
 
   static defaultProps = {

--- a/app/pages/home-for-user/recent-collections.jsx
+++ b/app/pages/home-for-user/recent-collections.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import apiClient from 'panoptes-client/lib/api-client';
 import { Link } from 'react-router';
@@ -6,11 +7,11 @@ import CollectionCard from '../collections/collection-card';
 
 class RecentCollectionsSection extends React.Component {
   static propTypes = {
-    onClose: React.PropTypes.func
+    onClose: PropTypes.func
   };
 
   static contextTypes = {
-    user: React.PropTypes.object.isRequired
+    user: PropTypes.object.isRequired
   };
 
   state = {

--- a/app/pages/home-for-user/recent-messages.jsx
+++ b/app/pages/home-for-user/recent-messages.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import apiClient from 'panoptes-client/lib/api-client';
 import talkClient from 'panoptes-client/lib/talk-client';
@@ -11,11 +12,11 @@ const LOADER_BULLETS = '• • •';
 
 class RecentCollectionsSection extends React.Component {
   static propTypes = {
-    onClose: React.PropTypes.func,
+    onClose: PropTypes.func,
   };
 
   static contextTypes = {
-    user: React.PropTypes.object.isRequired,
+    user: PropTypes.object.isRequired,
   };
 
   state = {

--- a/app/pages/home-for-user/recent-projects.jsx
+++ b/app/pages/home-for-user/recent-projects.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import HomePageSection from './generic-section';
 import ProjectIcon from '../../components/project-icon';
@@ -60,8 +61,8 @@ class RecentProjectsSection extends React.Component {
 }
 
 RecentProjectsSection.propTypes = {
-  onClose: React.PropTypes.func.isRequired,
-  projects: React.PropTypes.array.isRequired
+  onClose: PropTypes.func.isRequired,
+  projects: PropTypes.array.isRequired
 };
 
 RecentProjectsSection.defaultProps = {

--- a/app/pages/home-for-user/string-truncator.jsx
+++ b/app/pages/home-for-user/string-truncator.jsx
@@ -1,13 +1,14 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 class StringTruncator extends React.Component {
   static propTypes = {
-    tag: React.PropTypes.node,
-    className: React.PropTypes.string,
-    children: React.PropTypes.string.isRequired,
-    splitter: React.PropTypes.instanceOf(RegExp),
-    chop: React.PropTypes.number,
-    ellipsis: React.PropTypes.element,
+    tag: PropTypes.node,
+    className: PropTypes.string,
+    children: PropTypes.string.isRequired,
+    splitter: PropTypes.instanceOf(RegExp),
+    chop: PropTypes.number,
+    ellipsis: PropTypes.element,
   };
 
   static defaultProps = {

--- a/app/pages/home-not-logged-in.jsx
+++ b/app/pages/home-not-logged-in.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Link } from 'react-router';
 import statsClient from 'panoptes-client/lib/stats-client';
@@ -158,5 +159,5 @@ export default class HomePage extends React.Component {
 }
 
 HomePage.contextTypes = {
-  geordi: React.PropTypes.object
+  geordi: PropTypes.object
 };

--- a/app/pages/home-not-logged-in/discover.jsx
+++ b/app/pages/home-not-logged-in/discover.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import Translate from 'react-translate-component';
 import counterpart from 'counterpart';
@@ -61,7 +62,7 @@ const HomePageDiscover = (({ showDialog }) =>
 );
 
 HomePageDiscover.propTypes = {
-  showDialog: React.PropTypes.func
+  showDialog: PropTypes.func
 };
 
 export default HomePageDiscover;

--- a/app/pages/home-not-logged-in/promoted.jsx
+++ b/app/pages/home-not-logged-in/promoted.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import Translate from 'react-translate-component';
 import counterpart from 'counterpart';
@@ -47,7 +48,7 @@ const HomePagePromoted = ({ promotedProjects }) => {
 };
 
 HomePagePromoted.propTypes = {
-  promotedProjects: React.PropTypes.arrayOf(React.PropTypes.object)
+  promotedProjects: PropTypes.arrayOf(PropTypes.object)
 };
 
 export default HomePagePromoted;

--- a/app/pages/home-not-logged-in/research.jsx
+++ b/app/pages/home-not-logged-in/research.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import Translate from 'react-translate-component';
 import counterpart from 'counterpart';
@@ -96,10 +97,10 @@ const HomePageResearch = (({ count, screenWidth, showDialog, volunteerCount }) =
 );
 
 HomePageResearch.propTypes = {
-  count: React.PropTypes.number,
-  screenWidth: React.PropTypes.number,
-  showDialog: React.PropTypes.func,
-  volunteerCount: React.PropTypes.number
+  count: PropTypes.number,
+  screenWidth: PropTypes.number,
+  showDialog: PropTypes.func,
+  volunteerCount: PropTypes.number
 };
 
 export default HomePageResearch;

--- a/app/pages/home.jsx
+++ b/app/pages/home.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import HomePageLoggedIn from './home-for-user';
 import HomePageNotLoggedIn from './home-not-logged-in';
@@ -18,11 +19,11 @@ const HomePageRoot = (props) => {
 };
 
 HomePageRoot.propTypes = {
-  user: React.PropTypes.shape({
-    display_name: React.PropTypes.string
+  user: PropTypes.shape({
+    display_name: PropTypes.string
   }),
-  location: React.PropTypes.shape({
-    hash: React.PropTypes.string
+  location: PropTypes.shape({
+    hash: PropTypes.string
   })
 };
 

--- a/app/pages/lab/apply-for-beta-form.jsx
+++ b/app/pages/lab/apply-for-beta-form.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import uniq from 'lodash/uniq';
 import apiClient from 'panoptes-client/lib/api-client';
 

--- a/app/pages/lab/export-workflows-dialog.jsx
+++ b/app/pages/lab/export-workflows-dialog.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import Moment from 'moment';
 import apiClient from 'panoptes-client/lib/api-client';
@@ -113,9 +114,9 @@ ExportWorkflowsDialog.defaultProps = {
 };
 
 ExportWorkflowsDialog.propTypes = {
-  project: React.PropTypes.shape({ links: React.PropTypes.object }).isRequired,
-  onSuccess: React.PropTypes.func.isRequired,
-  onFail: React.PropTypes.func.isRequired
+  project: PropTypes.shape({ links: PropTypes.object }).isRequired,
+  onSuccess: PropTypes.func.isRequired,
+  onFail: PropTypes.func.isRequired
 };
 
 const ExportWorkflowListItem = ({ workflow, media, onChange, workflowError }) => {
@@ -172,13 +173,13 @@ ExportWorkflowListItem.defaultProps = {
 };
 
 ExportWorkflowListItem.propTypes = {
-  workflow: React.PropTypes.shape({
-    id: React.PropTypes.string,
-    display_name: React.PropTypes.string
+  workflow: PropTypes.shape({
+    id: PropTypes.string,
+    display_name: PropTypes.string
   }).isRequired,
-  media: React.PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
-  onChange: React.PropTypes.func.isRequired,
-  workflowError: React.PropTypes.object // eslint-disable-line react/forbid-prop-types
+  media: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  onChange: PropTypes.func.isRequired,
+  workflowError: PropTypes.object // eslint-disable-line react/forbid-prop-types
 };
 
 export default ExportWorkflowsDialog;

--- a/app/pages/lab/external-links-editor.jsx
+++ b/app/pages/lab/external-links-editor.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import DragReorderable from 'drag-reorderable';
 import AutoSave from '../../components/auto-save.coffee';
@@ -134,9 +135,9 @@ ExternalLinksEditor.defaultProps = {
 };
 
 ExternalLinksEditor.propTypes = {
-  project: React.PropTypes.shape({
-    save: React.PropTypes.func,
-    update: React.PropTypes.func,
-    urls: React.PropTypes.array
+  project: PropTypes.shape({
+    save: PropTypes.func,
+    update: PropTypes.func,
+    urls: PropTypes.array
   })
 };

--- a/app/pages/lab/help/index.cjsx
+++ b/app/pages/lab/help/index.cjsx
@@ -1,5 +1,6 @@
 counterpart = require 'counterpart'
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 Translate = require 'react-translate-component'
 {Link, IndexLink} = require 'react-router'
@@ -16,7 +17,7 @@ module.exports = createReactClass
   displayName: 'HowTo'
 
   contextTypes:
-    geordi: React.PropTypes.object
+    geordi: PropTypes.object
 
   componentWillReceiveProps: (nextProps, nextContext)->
     @logClick = nextContext?.geordi?.makeHandler? 'about-menu'

--- a/app/pages/lab/media-area/drag-and-drop-target.jsx
+++ b/app/pages/lab/media-area/drag-and-drop-target.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 export default class DragAndDropTarget extends React.Component {
@@ -64,10 +65,10 @@ DragAndDropTarget.defaultProps = {
 };
 
 DragAndDropTarget.propTypes = {
-  children: React.PropTypes.node,
-  className: React.PropTypes.string,
-  onDragEnter: React.PropTypes.func,
-  onDragOver: React.PropTypes.func,
-  onDragLeave: React.PropTypes.func,
-  onDrop: React.PropTypes.func,
+  children: PropTypes.node,
+  className: PropTypes.string,
+  onDragEnter: PropTypes.func,
+  onDragOver: PropTypes.func,
+  onDragLeave: PropTypes.func,
+  onDrop: PropTypes.func,
 };

--- a/app/pages/lab/media-area/index.jsx
+++ b/app/pages/lab/media-area/index.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import apiClient from 'panoptes-client/lib/api-client';
 import MediaAreaView from './media-area-view';
@@ -71,30 +72,30 @@ MediaAreaController.defaultProps = {
 };
 
 MediaAreaController.propTypes = {
-  actions: React.PropTypes.shape({
-    fetchMedia: React.PropTypes.func,
-    handleDrop: React.PropTypes.func,
-    handleDelete: React.PropTypes.func,
-    handleFileSelection: React.PropTypes.func,
-    addFiles: React.PropTypes.func,
-    handleFile: React.PropTypes.func,
-    addFile: React.PropTypes.func,
-    createLinkedResource: React.PropTypes.func,
-    uploadMedia: React.PropTypes.func,
-    handleSuccess: React.PropTypes.func,
-    handleError: React.PropTypes.func,
-    removeFromPending: React.PropTypes.func
+  actions: PropTypes.shape({
+    fetchMedia: PropTypes.func,
+    handleDrop: PropTypes.func,
+    handleDelete: PropTypes.func,
+    handleFileSelection: PropTypes.func,
+    addFiles: PropTypes.func,
+    handleFile: PropTypes.func,
+    addFile: PropTypes.func,
+    createLinkedResource: PropTypes.func,
+    uploadMedia: PropTypes.func,
+    handleSuccess: PropTypes.func,
+    handleError: PropTypes.func,
+    removeFromPending: PropTypes.func
   }),
-  children: React.PropTypes.node,
-  className: React.PropTypes.string,
-  link: React.PropTypes.string,
-  metadata: React.PropTypes.object,
-  onAdd: React.PropTypes.func,
-  onDelete: React.PropTypes.func,
-  pageSize: React.PropTypes.number,
-  resource: React.PropTypes.shape({
-    _getURL: React.PropTypes.func,
-    get: React.PropTypes.func
+  children: PropTypes.node,
+  className: PropTypes.string,
+  link: PropTypes.string,
+  metadata: PropTypes.object,
+  onAdd: PropTypes.func,
+  onDelete: PropTypes.func,
+  pageSize: PropTypes.number,
+  resource: PropTypes.shape({
+    _getURL: PropTypes.func,
+    get: PropTypes.func
   }).isRequired,
-  style: React.PropTypes.object
+  style: PropTypes.object
 };

--- a/app/pages/lab/media-area/media-area-view.jsx
+++ b/app/pages/lab/media-area/media-area-view.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import DragAndDropTarget from './drag-and-drop-target';
 import FileButton from '../../../components/file-button';
@@ -105,14 +106,14 @@ MediaAreaView.defaultProps = {
 };
 
 MediaAreaView.propTypes = {
-  children: React.PropTypes.node,
-  className: React.PropTypes.string,
-  errors: React.PropTypes.array,
-  media: React.PropTypes.arrayOf(React.PropTypes.object),
-  onDelete: React.PropTypes.func,
-  onDrop: React.PropTypes.func,
-  onSelect: React.PropTypes.func,
-  pendingFiles: React.PropTypes.array,
-  pendingMedia: React.PropTypes.array,
-  style: React.PropTypes.object,
+  children: PropTypes.node,
+  className: PropTypes.string,
+  errors: PropTypes.array,
+  media: PropTypes.arrayOf(PropTypes.object),
+  onDelete: PropTypes.func,
+  onDrop: PropTypes.func,
+  onSelect: PropTypes.func,
+  pendingFiles: PropTypes.array,
+  pendingMedia: PropTypes.array,
+  style: PropTypes.object,
 };

--- a/app/pages/lab/media-area/media-icon.jsx
+++ b/app/pages/lab/media-area/media-icon.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import TriggeredModalForm from 'modal-form/triggered';
 import Thumbnail from '../../../components/thumbnail';
@@ -60,12 +61,12 @@ MediaIcon.defaultProps = {
 };
 
 MediaIcon.propTypes = {
-  height: React.PropTypes.number,
-  onDelete: React.PropTypes.func,
-  resource: React.PropTypes.shape({
-    delete: React.PropTypes.func,
-    id: React.PropTypes.string,
-    metadata: React.PropTypes.object,
-    src: React.PropTypes.string,
+  height: PropTypes.number,
+  onDelete: PropTypes.func,
+  resource: PropTypes.shape({
+    delete: PropTypes.func,
+    id: PropTypes.string,
+    metadata: PropTypes.object,
+    src: PropTypes.string,
   }),
 };

--- a/app/pages/lab/media.jsx
+++ b/app/pages/lab/media.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import MediaArea from './media-area';
 
@@ -39,6 +40,6 @@ EditMediaPage.defaultProps = {
 };
 
 EditMediaPage.propTypes = {
-  project: React.PropTypes.object,
-  validSubjectExtensions: React.PropTypes.arrayOf(React.PropTypes.string),
+  project: PropTypes.object,
+  validSubjectExtensions: PropTypes.arrayOf(PropTypes.string),
 };

--- a/app/pages/lab/project.cjsx
+++ b/app/pages/lab/project.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 {Link, IndexLink} = require 'react-router'
 PromiseRenderer = require '../../components/promise-renderer'
@@ -22,7 +23,7 @@ EditProjectPage = createReactClass
   displayName: 'EditProjectPage'
 
   contextTypes:
-    router: React.PropTypes.object.isRequired
+    router: PropTypes.object.isRequired
 
   getDefaultProps: ->
     project: id: '2'
@@ -145,7 +146,7 @@ module.exports = createReactClass
   displayName: 'EditProjectPageWrapper'
 
   contextTypes:
-    router: React.PropTypes.object.isRequired
+    router: PropTypes.object.isRequired
 
   componentWillReceiveProps: (nextProps) ->
     unless nextProps.user

--- a/app/pages/lab/social-links-editor.jsx
+++ b/app/pages/lab/social-links-editor.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import DragReorderable from 'drag-reorderable';
 import AutoSave from '../../components/auto-save.coffee';
@@ -127,9 +128,9 @@ SocialLinksEditor.defaultProps = {
 };
 
 SocialLinksEditor.propTypes = {
-  project: React.PropTypes.shape({
-    save: React.PropTypes.func,
-    update: React.PropTypes.func,
-    urls: React.PropTypes.array
+  project: PropTypes.shape({
+    save: PropTypes.func,
+    update: PropTypes.func,
+    urls: PropTypes.array
   })
 };

--- a/app/pages/lab/subject-set.cjsx
+++ b/app/pages/lab/subject-set.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 AutoSave = require '../../components/auto-save'
 handleInputChange = require '../../lib/handle-input-change'
@@ -145,7 +146,7 @@ EditSubjectSetPage = createReactClass
   displayName: 'EditSubjectSetPage'
 
   contextTypes:
-    router: React.PropTypes.object.isRequired
+    router: PropTypes.object.isRequired
 
   getDefaultProps: ->
     subjectSet: null

--- a/app/pages/lab/subject-sets-container.jsx
+++ b/app/pages/lab/subject-sets-container.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import apiClient from 'panoptes-client/lib/api-client';
 
@@ -93,7 +94,7 @@ export default class SubjectSetsContainer extends React.Component {
 }
 
 SubjectSetsContainer.contextTypes = {
-  router: React.PropTypes.object.isRequired
+  router: PropTypes.object.isRequired
 };
 
 SubjectSetsContainer.defaultProps = {
@@ -101,14 +102,14 @@ SubjectSetsContainer.defaultProps = {
 };
 
 SubjectSetsContainer.propTypes = {
-  children: React.PropTypes.node,
-  location: React.PropTypes.shape({
-    pathname: React.PropTypes.string,
-    query: React.PropTypes.object
+  children: PropTypes.node,
+  location: PropTypes.shape({
+    pathname: PropTypes.string,
+    query: PropTypes.object
   }),
-  project: React.PropTypes.shape({
-    get: React.PropTypes.func,
-    id: React.PropTypes.string,
-    uncacheLink: React.PropTypes.func
+  project: PropTypes.shape({
+    get: PropTypes.func,
+    id: PropTypes.string,
+    uncacheLink: PropTypes.func
   })
 };

--- a/app/pages/lab/subject-sets.jsx
+++ b/app/pages/lab/subject-sets.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Link } from 'react-router';
 import LoadingIndicator from '../../components/loading-indicator';
@@ -65,16 +66,16 @@ SubjectSetsPage.defaultProps = {
 };
 
 SubjectSetsPage.propTypes = {
-  createNewSubjectSet: React.PropTypes.func,
-  defaultSubjectSetName: React.PropTypes.string,
-  labPath: React.PropTypes.func,
-  loading: React.PropTypes.bool,
-  onPageChange: React.PropTypes.func,
-  subjectSetCreationError: React.PropTypes.shape({
-    message: React.PropTypes.string
+  createNewSubjectSet: PropTypes.func,
+  defaultSubjectSetName: PropTypes.string,
+  labPath: PropTypes.func,
+  loading: PropTypes.bool,
+  onPageChange: PropTypes.func,
+  subjectSetCreationError: PropTypes.shape({
+    message: PropTypes.string
   }),
-  subjectSetCreationInProgress: React.PropTypes.bool,
-  subjectSets: React.PropTypes.arrayOf(React.PropTypes.object)
+  subjectSetCreationInProgress: PropTypes.bool,
+  subjectSets: PropTypes.arrayOf(PropTypes.object)
 };
 
 export default SubjectSetsPage;

--- a/app/pages/lab/visibility.cjsx
+++ b/app/pages/lab/visibility.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 apiClient = require 'panoptes-client/lib/api-client'
 SetToggle = require '../../lib/set-toggle'
@@ -12,7 +13,7 @@ module.exports = createReactClass
   displayName: 'EditProjectVisibility'
 
   contextTypes:
-    router: React.PropTypes.object.isRequired
+    router: PropTypes.object.isRequired
 
   getDefaultProps: ->
     project: null

--- a/app/pages/lab/workflow-classification-export-button.jsx
+++ b/app/pages/lab/workflow-classification-export-button.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import Dialog from 'modal-form/dialog';
 import ExportWorkflowsDialog from './export-workflows-dialog';
@@ -42,7 +43,7 @@ class WorkflowClassificationExportButton extends React.Component {
 }
 
 WorkflowClassificationExportButton.propTypes = {
-  project: React.PropTypes.shape({ links: React.PropTypes.object }).isRequired
+  project: PropTypes.shape({ links: PropTypes.object }).isRequired
 };
 
 export default WorkflowClassificationExportButton;

--- a/app/pages/lab/workflow.cjsx
+++ b/app/pages/lab/workflow.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 handleInputChange = require '../../lib/handle-input-change'
 PromiseRenderer = require '../../components/promise-renderer'
@@ -27,7 +28,7 @@ EditWorkflowPage = createReactClass
   displayName: 'EditWorkflowPage'
 
   contextTypes:
-    router: React.PropTypes.object.isRequired
+    router: PropTypes.object.isRequired
 
   getDefaultProps: ->
     workflow: null

--- a/app/pages/lab/workflows-container.jsx
+++ b/app/pages/lab/workflows-container.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import getWorkflowsInOrder from '../../lib/get-workflows-in-order';
 
@@ -107,7 +108,7 @@ export default class WorkflowsContainer extends React.Component {
 }
 
 WorkflowsContainer.contextTypes = {
-  router: React.PropTypes.object.isRequired
+  router: PropTypes.object.isRequired
 };
 
 WorkflowsContainer.defaultProps = {
@@ -117,19 +118,19 @@ WorkflowsContainer.defaultProps = {
 };
 
 WorkflowsContainer.propTypes = {
-  children: React.PropTypes.node,
-  location: React.PropTypes.shape({
-    pathname: React.PropTypes.string,
-    query: React.PropTypes.object
+  children: PropTypes.node,
+  location: PropTypes.shape({
+    pathname: PropTypes.string,
+    query: PropTypes.object
   }),
-  project: React.PropTypes.shape({
-    get: React.PropTypes.func,
-    id: React.PropTypes.string,
-    links: React.PropTypes.shape({
-      workflows: React.PropTypes.arrayOf(React.PropTypes.string)
+  project: PropTypes.shape({
+    get: PropTypes.func,
+    id: PropTypes.string,
+    links: PropTypes.shape({
+      workflows: PropTypes.arrayOf(PropTypes.string)
     }),
-    save: React.PropTypes.func,
-    uncacheLink: React.PropTypes.func,
-    update: React.PropTypes.func
+    save: PropTypes.func,
+    uncacheLink: PropTypes.func,
+    update: PropTypes.func
   })
 };

--- a/app/pages/lab/workflows.jsx
+++ b/app/pages/lab/workflows.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Link } from 'react-router';
 import DragReorderable from 'drag-reorderable';
@@ -93,25 +94,25 @@ WorkflowsPage.defaultProps = {
 };
 
 WorkflowsPage.propTypes = {
-  hideCreateWorkflow: React.PropTypes.func,
-  handleWorkflowCreation: React.PropTypes.func,
-  handleWorkflowReorder: React.PropTypes.func,
-  labPath: React.PropTypes.func,
-  loading: React.PropTypes.bool,
-  onPageChange: React.PropTypes.func,
-  project: React.PropTypes.shape({
-    configuration: React.PropTypes.object,
-    id: React.PropTypes.string,
-    live: React.PropTypes.bool
+  hideCreateWorkflow: PropTypes.func,
+  handleWorkflowCreation: PropTypes.func,
+  handleWorkflowReorder: PropTypes.func,
+  labPath: PropTypes.func,
+  loading: PropTypes.bool,
+  onPageChange: PropTypes.func,
+  project: PropTypes.shape({
+    configuration: PropTypes.object,
+    id: PropTypes.string,
+    live: PropTypes.bool
   }),
-  reorder: React.PropTypes.bool,
-  showCreateWorkflow: React.PropTypes.func,
-  toggleReorder: React.PropTypes.func,
-  workflows: React.PropTypes.arrayOf(React.PropTypes.object),
-  workflowActions: React.PropTypes.shape({
-    createWorkflowForProject: React.PropTypes.func
+  reorder: PropTypes.bool,
+  showCreateWorkflow: PropTypes.func,
+  toggleReorder: PropTypes.func,
+  workflows: PropTypes.arrayOf(PropTypes.object),
+  workflowActions: PropTypes.shape({
+    createWorkflowForProject: PropTypes.func
   }),
-  workflowCreationInProgress: React.PropTypes.bool
+  workflowCreationInProgress: PropTypes.bool
 };
 
 export default WorkflowsPage;

--- a/app/pages/notifications/comment.cjsx
+++ b/app/pages/notifications/comment.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 {Markdown} = require 'markdownz'
 {Link} = require 'react-router'
@@ -10,10 +11,10 @@ module.exports = createReactClass
   displayName: 'CommentNotification'
 
   propTypes:
-    data: React.PropTypes.object.isRequired
-    notification: React.PropTypes.object
-    project: React.PropTypes.object
-    user: React.PropTypes.object.isRequired
+    data: PropTypes.object.isRequired
+    notification: PropTypes.object
+    project: PropTypes.object
+    user: PropTypes.object.isRequired
 
   getDefaultProps: ->
     startedDiscussion: false

--- a/app/pages/notifications/data-request.cjsx
+++ b/app/pages/notifications/data-request.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 moment = require 'moment'
 
@@ -6,10 +7,10 @@ module.exports = createReactClass
   displayName: 'DataRequestNotification'
 
   propTypes:
-    data: React.PropTypes.object.isRequired
-    notification: React.PropTypes.object.isRequired
-    project: React.PropTypes.object
-    user: React.PropTypes.object.isRequired
+    data: PropTypes.object.isRequired
+    notification: PropTypes.object.isRequired
+    project: PropTypes.object
+    user: PropTypes.object.isRequired
 
   stopPropagation: (e) ->
     e.stopPropagation()

--- a/app/pages/notifications/index.jsx
+++ b/app/pages/notifications/index.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import counterpart from 'counterpart';
 import Translate from 'react-translate-component';
@@ -151,14 +152,14 @@ export default class NotificationsPage extends React.Component {
 }
 
 NotificationsPage.propTypes = {
-  location: React.PropTypes.shape({
-    query: React.PropTypes.object
+  location: PropTypes.shape({
+    query: PropTypes.object
   }),
-  project: React.PropTypes.shape({
-    id: React.PropTypes.string
+  project: PropTypes.shape({
+    id: PropTypes.string
   }),
-  user: React.PropTypes.shape({
-    display_name: React.PropTypes.string,
-    login: React.PropTypes.string
+  user: PropTypes.shape({
+    display_name: PropTypes.string,
+    login: PropTypes.string
   })
 };

--- a/app/pages/notifications/message.cjsx
+++ b/app/pages/notifications/message.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 {Link} = require 'react-router'
 {Markdown} = require 'markdownz'
@@ -10,9 +11,9 @@ module.exports = createReactClass
   displayName: 'MessageNotification'
 
   propTypes:
-    project: React.PropTypes.object
-    user: React.PropTypes.object.isRequired
-    notification: React.PropTypes.object.isRequired
+    project: PropTypes.object
+    user: PropTypes.object.isRequired
+    notification: PropTypes.object.isRequired
 
   render: ->
     notification = @props.notification

--- a/app/pages/notifications/moderation.cjsx
+++ b/app/pages/notifications/moderation.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 {Link} = require 'react-router'
 {Markdown} = require 'markdownz'
@@ -10,10 +11,10 @@ module.exports = createReactClass
   displayName: 'ModerationNotification'
 
   propTypes:
-    data: React.PropTypes.object.isRequired
-    notification: React.PropTypes.object.isRequired
-    project: React.PropTypes.object
-    user: React.PropTypes.object.isRequired
+    data: PropTypes.object.isRequired
+    notification: PropTypes.object.isRequired
+    project: PropTypes.object
+    user: PropTypes.object.isRequired
 
   render: ->
     baseLink = ""

--- a/app/pages/notifications/notification-section.jsx
+++ b/app/pages/notifications/notification-section.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import apiClient from 'panoptes-client/lib/api-client';
 import talkClient from 'panoptes-client/lib/talk-client';
@@ -287,19 +288,19 @@ export default class NotificationSection extends Component {
 }
 
 NotificationSection.propTypes = {
-  expanded: React.PropTypes.bool,
-  projectID: React.PropTypes.string,
-  section: React.PropTypes.string,
-  slug: React.PropTypes.string,
-  toggleSection: React.PropTypes.func,
-  user: React.PropTypes.shape({
-    display_name: React.PropTypes.string,
-    login: React.PropTypes.string
+  expanded: PropTypes.bool,
+  projectID: PropTypes.string,
+  section: PropTypes.string,
+  slug: PropTypes.string,
+  toggleSection: PropTypes.func,
+  user: PropTypes.shape({
+    display_name: PropTypes.string,
+    login: PropTypes.string
   })
 };
 
 NotificationSection.contextTypes = {
-  notificationsCounter: React.PropTypes.object
+  notificationsCounter: PropTypes.object
 };
 
 NotificationSection.defaultProps = {

--- a/app/pages/notifications/notification.cjsx
+++ b/app/pages/notifications/notification.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 CommentNotification = require './comment'
 DataRequestNotification = require './data-request'
@@ -10,10 +11,10 @@ module.exports = createReactClass
   displayName: 'Notification'
 
   propTypes:
-    data: React.PropTypes.object.isRequired
-    notification: React.PropTypes.object.isRequired
-    project: React.PropTypes.object
-    user: React.PropTypes.object.isRequired
+    data: PropTypes.object.isRequired
+    notification: PropTypes.object.isRequired
+    project: PropTypes.object
+    user: PropTypes.object.isRequired
 
   renderNotification: ->
     switch @props.notification.source_type

--- a/app/pages/notifications/started-discussion.cjsx
+++ b/app/pages/notifications/started-discussion.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 {Link} = require 'react-router'
 Loading = require '../../components/loading-indicator'
@@ -8,10 +9,10 @@ module.exports = createReactClass
   displayName: 'StartedDiscussionNotification'
 
   propTypes:
-    data: React.PropTypes.object.isRequired
-    notification: React.PropTypes.object.isRequired
-    project: React.PropTypes.object
-    user: React.PropTypes.object.isRequired
+    data: PropTypes.object.isRequired
+    notification: PropTypes.object.isRequired
+    project: PropTypes.object
+    user: PropTypes.object.isRequired
 
   render: ->
     if @props.data.discussion

--- a/app/pages/organization/organization-container.jsx
+++ b/app/pages/organization/organization-container.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import apiClient from 'panoptes-client/lib/api-client';
 import Translate from 'react-translate-component';
@@ -268,22 +269,22 @@ class OrganizationContainer extends React.Component {
 }
 
 OrganizationContainer.contextTypes = {
-  initialLoadComplete: React.PropTypes.bool,
-  router: React.PropTypes.object.isRequired,
-  user: React.PropTypes.shape({
-    id: React.PropTypes.string
+  initialLoadComplete: PropTypes.bool,
+  router: PropTypes.object.isRequired,
+  user: PropTypes.shape({
+    id: PropTypes.string
   })
 };
 
 OrganizationContainer.propTypes = {
-  location: React.PropTypes.shape({
-    query: React.PropTypes.shape({
-      category: React.PropTypes.string
+  location: PropTypes.shape({
+    query: PropTypes.shape({
+      category: PropTypes.string
     })
   }),
-  params: React.PropTypes.shape({
-    name: React.PropTypes.string,
-    owner: React.PropTypes.string
+  params: PropTypes.shape({
+    name: PropTypes.string,
+    owner: PropTypes.string
   }).isRequired
 };
 

--- a/app/pages/organization/organization-metadata.jsx
+++ b/app/pages/organization/organization-metadata.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import Translate from 'react-translate-component';
 
@@ -58,11 +59,11 @@ export const OrganizationMetadata = ({ displayName, projects }) => {
 };
 
 OrganizationMetadata.propTypes = {
-  displayName: React.PropTypes.string,
-  projects: React.PropTypes.arrayOf(
-    React.PropTypes.shape({
-      id: React.PropTypes.string,
-      display_name: React.PropTypes.string
+  displayName: PropTypes.string,
+  projects: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string,
+      display_name: PropTypes.string
     })
   )
 };

--- a/app/pages/organization/organization-page.jsx
+++ b/app/pages/organization/organization-page.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
 import { Markdown } from 'markdownz';
@@ -219,61 +220,61 @@ OrganizationPage.defaultProps = {
 };
 
 OrganizationPage.propTypes = {
-  category: React.PropTypes.oneOfType([
-    React.PropTypes.bool,
-    React.PropTypes.string
+  category: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.string
   ]),
-  collaborator: React.PropTypes.bool,
-  collaboratorView: React.PropTypes.bool,
-  errorFetchingProjects: React.PropTypes.shape({
-    message: React.PropTypes.string
+  collaborator: PropTypes.bool,
+  collaboratorView: PropTypes.bool,
+  errorFetchingProjects: PropTypes.shape({
+    message: PropTypes.string
   }),
-  fetchingProjects: React.PropTypes.bool,
-  onChangeQuery: React.PropTypes.func,
-  organization: React.PropTypes.shape({
-    categories: React.PropTypes.arrayOf(
-      React.PropTypes.string
+  fetchingProjects: PropTypes.bool,
+  onChangeQuery: PropTypes.func,
+  organization: PropTypes.shape({
+    categories: PropTypes.arrayOf(
+      PropTypes.string
     ),
-    description: React.PropTypes.string,
-    display_name: React.PropTypes.string,
-    id: React.PropTypes.string,
-    introduction: React.PropTypes.string,
-    urls: React.PropTypes.arrayOf(
-      React.PropTypes.shape({
-        url: React.PropTypes.string
+    description: PropTypes.string,
+    display_name: PropTypes.string,
+    id: PropTypes.string,
+    introduction: PropTypes.string,
+    urls: PropTypes.arrayOf(
+      PropTypes.shape({
+        url: PropTypes.string
       })
     )
   }).isRequired,
-  organizationAvatar: React.PropTypes.shape({
-    src: React.PropTypes.string
+  organizationAvatar: PropTypes.shape({
+    src: PropTypes.string
   }),
-  organizationBackground: React.PropTypes.shape({
-    src: React.PropTypes.string
+  organizationBackground: PropTypes.shape({
+    src: PropTypes.string
   }),
-  organizationPages: React.PropTypes.arrayOf(
-    React.PropTypes.shape({
-      content: React.PropTypes.string
+  organizationPages: PropTypes.arrayOf(
+    PropTypes.shape({
+      content: PropTypes.string
     })
   ),
-  organizationProjects: React.PropTypes.arrayOf(
-    React.PropTypes.shape({
-      id: React.PropTypes.string,
-      display_name: React.PropTypes.string
+  organizationProjects: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string,
+      display_name: PropTypes.string
     })
   ),
-  projectAvatars: React.PropTypes.arrayOf(
-    React.PropTypes.shape({
-      id: React.PropTypes.string,
-      src: React.PropTypes.string
+  projectAvatars: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string,
+      src: PropTypes.string
     })
   ),
-  quoteObject: React.PropTypes.shape({
-    displayName: React.PropTypes.string,
-    researcherAvatar: React.PropTypes.string,
-    quote: React.PropTypes.string,
-    slug: React.PropTypes.string
+  quoteObject: PropTypes.shape({
+    displayName: PropTypes.string,
+    researcherAvatar: PropTypes.string,
+    quote: PropTypes.string,
+    slug: PropTypes.string
   }),
-  toggleCollaboratorView: React.PropTypes.func
+  toggleCollaboratorView: PropTypes.func
 };
 
 export default OrganizationPage;

--- a/app/pages/organization/organization-project-cards.jsx
+++ b/app/pages/organization/organization-project-cards.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import Translate from 'react-translate-component';
 import ProjectCard from '../../partials/project-card';
@@ -38,20 +39,20 @@ export const OrganizationProjectCards = ({ errorFetchingProjects, fetchingProjec
 };
 
 OrganizationProjectCards.propTypes = {
-  errorFetchingProjects: React.PropTypes.shape({
-    message: React.PropTypes.string
+  errorFetchingProjects: PropTypes.shape({
+    message: PropTypes.string
   }),
-  fetchingProjects: React.PropTypes.bool,
-  projects: React.PropTypes.arrayOf(
-    React.PropTypes.shape({
-      id: React.PropTypes.string,
-      display_name: React.PropTypes.string
+  fetchingProjects: PropTypes.bool,
+  projects: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string,
+      display_name: PropTypes.string
     })
   ),
-  projectAvatars: React.PropTypes.arrayOf(
-    React.PropTypes.shape({
-      id: React.PropTypes.string,
-      src: React.PropTypes.string
+  projectAvatars: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string,
+      src: PropTypes.string
     })
   )
 };

--- a/app/pages/profile/feed.cjsx
+++ b/app/pages/profile/feed.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 talkClient = require 'panoptes-client/lib/talk-client'
 Paginator = require '../../talk/lib/paginator'
@@ -8,7 +9,7 @@ module.exports = createReactClass
   displayName: 'UserProfileFeed'
 
   propTypes:
-    user: React.PropTypes.object
+    user: PropTypes.object
 
   getDefaultProps: ->
     location: query: page: 1

--- a/app/pages/profile/index.jsx
+++ b/app/pages/profile/index.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import apiClient from 'panoptes-client/lib/api-client';
 import LoadingIndicator from '../../components/loading-indicator';
 import ProfileUser from './user';

--- a/app/pages/profile/recents.jsx
+++ b/app/pages/profile/recents.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Link } from 'react-router';
 import Translate from 'react-translate-component';
@@ -74,11 +75,11 @@ class Recents extends React.Component {
 }
 
 Recents.propTypes = {
-  project: React.PropTypes.shape({
-    id: React.PropTypes.string
+  project: PropTypes.shape({
+    id: PropTypes.string
   }).isRequired,
-  user: React.PropTypes.shape({
-    get: React.PropTypes.func
+  user: PropTypes.shape({
+    get: PropTypes.func
   }).isRequired
 };
 

--- a/app/pages/profile/user.jsx
+++ b/app/pages/profile/user.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { Link, IndexLink } from 'react-router';
 import Translate from 'react-translate-component';
 import counterpart from 'counterpart';

--- a/app/pages/project/about/about-nav.jsx
+++ b/app/pages/project/about/about-nav.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { Link } from 'react-router';
 import Translate from 'react-translate-component';
 

--- a/app/pages/project/about/about-page-layout.jsx
+++ b/app/pages/project/about/about-page-layout.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { Markdown } from 'markdownz';
 
 const AboutPageLayout = ({ project, mainContent, aside }) => (

--- a/app/pages/project/about/index.jsx
+++ b/app/pages/project/about/index.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { Helmet } from 'react-helmet';
 import counterpart from 'counterpart';
@@ -105,15 +106,15 @@ class AboutProject extends Component {
 }
 
 AboutProject.propTypes = {
-  children: React.PropTypes.node,
-  pages: React.PropTypes.arrayOf(React.PropTypes.object),
-  project: React.PropTypes.shape({}),
-  projectRoles: React.PropTypes.arrayOf(React.PropTypes.object),
-  translation: React.PropTypes.shape({
-    display_name: React.PropTypes.string
+  children: PropTypes.node,
+  pages: PropTypes.arrayOf(PropTypes.object),
+  project: PropTypes.shape({}),
+  projectRoles: PropTypes.arrayOf(PropTypes.object),
+  translation: PropTypes.shape({
+    display_name: PropTypes.string
   }),
-  translations: React.PropTypes.shape({
-    strings: React.PropTypes.object
+  translations: PropTypes.shape({
+    strings: PropTypes.object
   })
 };
 

--- a/app/pages/project/about/simple-pages.jsx
+++ b/app/pages/project/about/simple-pages.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import AboutPageLayout from './about-page-layout';
 import Translate from 'react-translate-component';
 import counterpart from 'counterpart';

--- a/app/pages/project/about/team.jsx
+++ b/app/pages/project/about/team.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import { Link } from 'react-router';
 import Translate from 'react-translate-component';
 import counterpart from 'counterpart';

--- a/app/pages/project/classify.cjsx
+++ b/app/pages/project/classify.cjsx
@@ -1,5 +1,6 @@
 auth = require 'panoptes-client/lib/auth'
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 ReactDOM = require 'react-dom'
 { Helmet } = require 'react-helmet'
@@ -49,15 +50,15 @@ module.exports = createReactClass
 
 
   contextTypes:
-    geordi: React.PropTypes.object,
-    initialLoadComplete: React.PropTypes.bool,
-    router: React.PropTypes.object
+    geordi: PropTypes.object,
+    initialLoadComplete: PropTypes.bool,
+    router: PropTypes.object
 
   propTypes:
-    loadingSelectedWorkflow: React.PropTypes.bool
-    project: React.PropTypes.object
-    workflow: React.PropTypes.object
-    simulateSaveFailure: React.PropTypes.bool
+    loadingSelectedWorkflow: PropTypes.bool
+    project: PropTypes.object
+    workflow: PropTypes.object
+    simulateSaveFailure: PropTypes.bool
 
   getDefaultProps: ->
     loadingSelectedWorkflow: false

--- a/app/pages/project/finished-banner.jsx
+++ b/app/pages/project/finished-banner.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Link } from 'react-router';
 import getWorkflowsInOrder from '../../lib/get-workflows-in-order';
@@ -101,10 +102,10 @@ FinishedBanner.defaultProps = {
 };
 
 FinishedBanner.propTypes = {
-  dismissFor: React.PropTypes.number,
-  project: React.PropTypes.shape({
-    id: React.PropTypes.string,
-    slug: React.PropTypes.string,
+  dismissFor: PropTypes.number,
+  project: PropTypes.shape({
+    id: PropTypes.string,
+    slug: PropTypes.string,
   }),
-  projectIsComplete: React.PropTypes.bool
+  projectIsComplete: PropTypes.bool
 };

--- a/app/pages/project/home/home-workflow-button.jsx
+++ b/app/pages/project/home/home-workflow-button.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Link } from 'react-router';
 import classnames from 'classnames';
@@ -63,17 +64,17 @@ ProjectHomeWorkflowButton.defaultProps = {
 };
 
 ProjectHomeWorkflowButton.propTypes = {
-  disabled: React.PropTypes.bool,
-  onChangePreferences: React.PropTypes.func.isRequired,
-  project: React.PropTypes.shape({
-    slug: React.PropTypes.string
+  disabled: PropTypes.bool,
+  onChangePreferences: PropTypes.func.isRequired,
+  project: PropTypes.shape({
+    slug: PropTypes.string
   }).isRequired,
-  workflow: React.PropTypes.shape({
-    configuration: React.PropTypes.shape({
-      level: React.PropTypes.string
+  workflow: PropTypes.shape({
+    configuration: PropTypes.shape({
+      level: PropTypes.string
     }),
-    display_name: React.PropTypes.string,
-    id: React.PropTypes.string
+    display_name: PropTypes.string,
+    id: PropTypes.string
   }).isRequired,
-  workflowAssignment: React.PropTypes.bool
+  workflowAssignment: PropTypes.bool
 };

--- a/app/pages/project/home/home-workflow-buttons.jsx
+++ b/app/pages/project/home/home-workflow-buttons.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Link } from 'react-router';
 import Translate from 'react-translate-component';
@@ -74,19 +75,19 @@ ProjectHomeWorkflowButtons.defaultProps = {
 };
 
 ProjectHomeWorkflowButtons.propTypes = {
-  activeWorkflows: React.PropTypes.arrayOf(React.PropTypes.object).isRequired,
-  onChangePreferences: React.PropTypes.func.isRequired,
-  preferences: React.PropTypes.shape({
-    preferences: React.PropTypes.object,
-    settings: React.PropTypes.objectOf(React.PropTypes.string)
+  activeWorkflows: PropTypes.arrayOf(PropTypes.object).isRequired,
+  onChangePreferences: PropTypes.func.isRequired,
+  preferences: PropTypes.shape({
+    preferences: PropTypes.object,
+    settings: PropTypes.objectOf(PropTypes.string)
   }),
-  project: React.PropTypes.shape({
-    redirect: React.PropTypes.string,
-    slug: React.PropTypes.string,
-    workflow_description: React.PropTypes.string
+  project: PropTypes.shape({
+    redirect: PropTypes.string,
+    slug: PropTypes.string,
+    workflow_description: PropTypes.string
   }).isRequired,
-  showWorkflowButtons: React.PropTypes.bool.isRequired,
-  splits: React.PropTypes.object,
-  user: React.PropTypes.object,
-  workflowAssignment: React.PropTypes.bool
+  showWorkflowButtons: PropTypes.bool.isRequired,
+  splits: PropTypes.object,
+  user: PropTypes.object,
+  workflowAssignment: PropTypes.bool
 };

--- a/app/pages/project/home/index.jsx
+++ b/app/pages/project/home/index.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import apiClient from 'panoptes-client/lib/api-client';
 import talkClient from 'panoptes-client/lib/talk-client';
@@ -138,41 +139,41 @@ ProjectHomeContainer.defaultProps = {
 };
 
 ProjectHomeContainer.propTypes = {
-  background: React.PropTypes.shape({
-    src: React.PropTypes.string
+  background: PropTypes.shape({
+    src: PropTypes.string
   }),
-  onChangePreferences: React.PropTypes.func.isRequired,
-  organization: React.PropTypes.shape({
-    display_name: React.PropTypes.string,
-    slug: React.PropTypes.string
+  onChangePreferences: PropTypes.func.isRequired,
+  organization: PropTypes.shape({
+    display_name: PropTypes.string,
+    slug: PropTypes.string
   }),
-  preferences: React.PropTypes.object,
-  projectAvatar: React.PropTypes.shape({
-    src: React.PropTypes.string
+  preferences: PropTypes.object,
+  projectAvatar: PropTypes.shape({
+    src: PropTypes.string
   }),
-  project: React.PropTypes.shape({
-    configuration: React.PropTypes.object,
-    description: React.PropTypes.string,
-    display_name: React.PropTypes.string,
-    experimental_tools: React.PropTypes.arrayOf(React.PropTypes.string),
-    id: React.PropTypes.string,
-    introduction: React.PropTypes.string,
-    researcher_quote: React.PropTypes.string
+  project: PropTypes.shape({
+    configuration: PropTypes.object,
+    description: PropTypes.string,
+    display_name: PropTypes.string,
+    experimental_tools: PropTypes.arrayOf(PropTypes.string),
+    id: PropTypes.string,
+    introduction: PropTypes.string,
+    researcher_quote: PropTypes.string
   }).isRequired,
-  projectIsComplete: React.PropTypes.bool.isRequired,
-  projectRoles: React.PropTypes.array,
-  splits: React.PropTypes.object,
-  translation: React.PropTypes.shape({
-    description: React.PropTypes.string,
-    display_name: React.PropTypes.string,
-    introduction: React.PropTypes.string,
-    researcher_quote: React.PropTypes.string,
-    title: React.PropTypes.string
+  projectIsComplete: PropTypes.bool.isRequired,
+  projectRoles: PropTypes.array,
+  splits: PropTypes.object,
+  translation: PropTypes.shape({
+    description: PropTypes.string,
+    display_name: PropTypes.string,
+    introduction: PropTypes.string,
+    researcher_quote: PropTypes.string,
+    title: PropTypes.string
   }),
-  workflow: React.PropTypes.shape({
-    id: React.PropTypes.string
+  workflow: PropTypes.shape({
+    id: PropTypes.string
   }),
-  user: React.PropTypes.shape({
-    id: React.PropTypes.string
+  user: PropTypes.shape({
+    id: PropTypes.string
   })
 };

--- a/app/pages/project/home/metadata.jsx
+++ b/app/pages/project/home/metadata.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Link } from 'react-router';
 import Translate from 'react-translate-component';
@@ -15,8 +16,8 @@ class ProjectMetadataStat extends React.Component {
 }
 
 ProjectMetadataStat.propTypes = {
-  children: React.PropTypes.node.isRequired,
-  value: React.PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
+  value: PropTypes.string.isRequired,
 };
 
 export default class ProjectMetadata extends React.Component {
@@ -110,24 +111,24 @@ export default class ProjectMetadata extends React.Component {
 }
 
 ProjectMetadata.contextTypes = {
-  pusher: React.PropTypes.object,
+  pusher: PropTypes.object,
 };
 
 ProjectMetadata.propTypes = {
-  project: React.PropTypes.shape({
-    classifications_count: React.PropTypes.number,
-    completeness: React.PropTypes.number,
-    display_name: React.PropTypes.string,
-    id: React.PropTypes.id,
-    slug: React.PropTypes.string,
+  project: PropTypes.shape({
+    classifications_count: PropTypes.number,
+    completeness: PropTypes.number,
+    display_name: PropTypes.string,
+    id: PropTypes.id,
+    slug: PropTypes.string,
   }),
-  showTalkStatus: React.PropTypes.bool,
-  translation: React.PropTypes.shape({
-    description: React.PropTypes.string,
-    display_name: React.PropTypes.string,
-    introduction: React.PropTypes.string,
-    researcher_quote: React.PropTypes.string,
-    title: React.PropTypes.string
+  showTalkStatus: PropTypes.bool,
+  translation: PropTypes.shape({
+    description: PropTypes.string,
+    display_name: PropTypes.string,
+    introduction: PropTypes.string,
+    researcher_quote: PropTypes.string,
+    title: PropTypes.string
   }).isRequired
 };
 

--- a/app/pages/project/home/project-home.jsx
+++ b/app/pages/project/home/project-home.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Link } from 'react-router';
 import classnames from 'classnames';
@@ -141,7 +142,7 @@ const ProjectHomePage = (props) => {
 };
 
 ProjectHomePage.contextTypes = {
-  user: React.PropTypes.object
+  user: PropTypes.object
 };
 
 ProjectHomePage.defaultProps = {
@@ -158,40 +159,40 @@ ProjectHomePage.defaultProps = {
 };
 
 ProjectHomePage.propTypes = {
-  activeWorkflows: React.PropTypes.arrayOf(React.PropTypes.object).isRequired,
-  background: React.PropTypes.shape({
-    src: React.PropTypes.string
+  activeWorkflows: PropTypes.arrayOf(PropTypes.object).isRequired,
+  background: PropTypes.shape({
+    src: PropTypes.string
   }).isRequired,
-  onChangePreferences: React.PropTypes.func.isRequired,
-  organization: React.PropTypes.shape({
-    display_name: React.PropTypes.string,
-    slug: React.PropTypes.string
+  onChangePreferences: PropTypes.func.isRequired,
+  organization: PropTypes.shape({
+    display_name: PropTypes.string,
+    slug: PropTypes.string
   }),
-  preferences: React.PropTypes.object,
-  project: React.PropTypes.shape({
-    configuration: React.PropTypes.object,
-    description: React.PropTypes.string,
-    display_name: React.PropTypes.string,
-    experimental_tools: React.PropTypes.arrayOf(React.PropTypes.string),
-    id: React.PropTypes.string,
-    introduction: React.PropTypes.string,
-    redirect: React.PropTypes.string,
-    researcher_quote: React.PropTypes.string,
-    slug: React.PropTypes.string
+  preferences: PropTypes.object,
+  project: PropTypes.shape({
+    configuration: PropTypes.object,
+    description: PropTypes.string,
+    display_name: PropTypes.string,
+    experimental_tools: PropTypes.arrayOf(PropTypes.string),
+    id: PropTypes.string,
+    introduction: PropTypes.string,
+    redirect: PropTypes.string,
+    researcher_quote: PropTypes.string,
+    slug: PropTypes.string
   }).isRequired,
-  projectIsComplete: React.PropTypes.bool.isRequired,
-  researcherAvatar: React.PropTypes.string,
-  showWorkflowButtons: React.PropTypes.bool,
-  splits: React.PropTypes.object,
-  talkSubjects: React.PropTypes.arrayOf(React.PropTypes.object),
-  translation: React.PropTypes.shape({
-    description: React.PropTypes.string,
-    display_name: React.PropTypes.string,
-    introduction: React.PropTypes.string,
-    researcher_quote: React.PropTypes.string,
-    title: React.PropTypes.string
+  projectIsComplete: PropTypes.bool.isRequired,
+  researcherAvatar: PropTypes.string,
+  showWorkflowButtons: PropTypes.bool,
+  splits: PropTypes.object,
+  talkSubjects: PropTypes.arrayOf(PropTypes.object),
+  translation: PropTypes.shape({
+    description: PropTypes.string,
+    display_name: PropTypes.string,
+    introduction: PropTypes.string,
+    researcher_quote: PropTypes.string,
+    title: PropTypes.string
   }).isRequired,
-  user: React.PropTypes.object
+  user: PropTypes.object
 };
 
 export default ProjectHomePage;

--- a/app/pages/project/home/talk-status.jsx
+++ b/app/pages/project/home/talk-status.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { sugarApiClient } from 'panoptes-client/lib/sugar';
 import { Link } from 'react-router';
@@ -52,16 +53,16 @@ TalkStatus.defaultProps = {
 };
 
 TalkStatus.propTypes = {
-  project: React.PropTypes.shape({
-    display_name: React.PropTypes.string,
-    id: React.PropTypes.string,
-    slug: React.PropTypes.string
+  project: PropTypes.shape({
+    display_name: PropTypes.string,
+    id: PropTypes.string,
+    slug: PropTypes.string
   }).isRequired,
-  translation: React.PropTypes.shape({
-    description: React.PropTypes.string,
-    display_name: React.PropTypes.string,
-    introduction: React.PropTypes.string,
-    researcher_quote: React.PropTypes.string,
-    title: React.PropTypes.string
+  translation: PropTypes.shape({
+    description: PropTypes.string,
+    display_name: PropTypes.string,
+    introduction: PropTypes.string,
+    researcher_quote: PropTypes.string,
+    title: PropTypes.string
   }).isRequired
 };

--- a/app/pages/project/index.cjsx
+++ b/app/pages/project/index.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 { Helmet } = require 'react-helmet'
 apiClient = require 'panoptes-client/lib/api-client'
@@ -22,13 +23,13 @@ ProjectPageController = createReactClass
   displayName: 'ProjectPageController'
 
   contextTypes:
-    geordi: React.PropTypes.object
-    initialLoadComplete: React.PropTypes.bool
-    router: React.PropTypes.object.isRequired
+    geordi: PropTypes.object
+    initialLoadComplete: PropTypes.bool
+    router: PropTypes.object.isRequired
 
   propTypes:
-    params: React.PropTypes.object
-    user: React.PropTypes.object
+    params: PropTypes.object
+    user: PropTypes.object
 
   getDefaultProps: ->
     params: {}

--- a/app/pages/project/potential-field-guide.cjsx
+++ b/app/pages/project/potential-field-guide.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 apiClient = require 'panoptes-client/lib/api-client'
 Pullout = require 'react-pullout'
@@ -17,8 +18,8 @@ module.exports = createReactClass
     revealed: false
 
   contextTypes:
-    geordi: React.PropTypes.object
-    store: React.PropTypes.object
+    geordi: PropTypes.object
+    store: PropTypes.object
 
   logClick: (type) ->
     @context?.geordi?.logEvent

--- a/app/pages/project/project-navbar.jsx
+++ b/app/pages/project/project-navbar.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import Translate from 'react-translate-component';
 import { IndexLink, Link } from 'react-router';
@@ -371,33 +372,33 @@ ProjectNavbar.defaultProps = {
 };
 
 ProjectNavbar.contextTypes = {
-  geordi: React.PropTypes.object
+  geordi: PropTypes.object
 };
 
 ProjectNavbar.propTypes = {
-  loading: React.PropTypes.bool,
-  organization: React.PropTypes.shape({
-    display_name: React.PropTypes.string,
-    slug: React.PropTypes.string
+  loading: PropTypes.bool,
+  organization: PropTypes.shape({
+    display_name: PropTypes.string,
+    slug: PropTypes.string
   }),
-  project: React.PropTypes.shape({
-    id: React.PropTypes.string,
-    display_name: React.PropTypes.string,
-    slug: React.PropTypes.string
+  project: PropTypes.shape({
+    id: PropTypes.string,
+    display_name: PropTypes.string,
+    slug: PropTypes.string
   }),
-  projectAvatar: React.PropTypes.shape({
-    src: React.PropTypes.string
+  projectAvatar: PropTypes.shape({
+    src: PropTypes.string
   }),
-  projectRoles: React.PropTypes.array,
-  user: React.PropTypes.shape({
-    id: React.PropTypes.string
+  projectRoles: PropTypes.array,
+  user: PropTypes.shape({
+    id: PropTypes.string
   }),
-  routes: React.PropTypes.array,
-  translation: React.PropTypes.shape({
-    display_name: React.PropTypes.string
+  routes: PropTypes.array,
+  translation: PropTypes.shape({
+    display_name: PropTypes.string
   }),
-  workflow: React.PropTypes.shape({
-    id: React.PropTypes.string
+  workflow: PropTypes.shape({
+    id: PropTypes.string
   })
 };
 

--- a/app/pages/project/project-page.jsx
+++ b/app/pages/project/project-page.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import Translate from 'react-translate-component';
 import { Markdown } from 'markdownz';
@@ -146,32 +147,32 @@ ProjectPage.defaultProps = {
 };
 
 ProjectPage.childContextTypes = {
-  geordi: React.PropTypes.object
+  geordi: PropTypes.object
 };
 
 ProjectPage.propTypes = {
-  background: React.PropTypes.shape({
-    src: React.PropTypes.string
+  background: PropTypes.shape({
+    src: PropTypes.string
   }),
-  loading: React.PropTypes.bool,
-  pages: React.PropTypes.arrayOf(React.PropTypes.object),
-  project: React.PropTypes.shape({
-    id: React.PropTypes.string,
-    display_name: React.PropTypes.string,
-    slug: React.PropTypes.string
+  loading: PropTypes.bool,
+  pages: PropTypes.arrayOf(PropTypes.object),
+  project: PropTypes.shape({
+    id: PropTypes.string,
+    display_name: PropTypes.string,
+    slug: PropTypes.string
   }),
-  projectAvatar: React.PropTypes.shape({
-    src: React.PropTypes.string
+  projectAvatar: PropTypes.shape({
+    src: PropTypes.string
   }),
-  projectRoles: React.PropTypes.array,
-  user: React.PropTypes.shape({
-    id: React.PropTypes.string
+  projectRoles: PropTypes.array,
+  user: PropTypes.shape({
+    id: PropTypes.string
   }),
-  routes: React.PropTypes.array,
-  translation: React.PropTypes.shape({
-    display_name: React.PropTypes.string
+  routes: PropTypes.array,
+  translation: PropTypes.shape({
+    display_name: PropTypes.string
   }),
-  workflow: React.PropTypes.shape({
-    id: React.PropTypes.string
+  workflow: PropTypes.shape({
+    id: PropTypes.string
   })
 };

--- a/app/pages/project/project-translations.jsx
+++ b/app/pages/project/project-translations.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 
@@ -10,12 +11,12 @@ function ProjectTranslations(props) {
 }
 
 ProjectTranslations.propTypes = {
-  children: React.PropTypes.node,
-  project: React.PropTypes.shape({
-    display_name: React.PropTypes.string,
-    description: React.PropTypes.string,
-    introduction: React.PropTypes.string,
-    researcher_quote: React.PropTypes.string
+  children: PropTypes.node,
+  project: PropTypes.shape({
+    display_name: PropTypes.string,
+    description: PropTypes.string,
+    introduction: PropTypes.string,
+    researcher_quote: PropTypes.string
   }).isRequired
 };
 
@@ -25,4 +26,3 @@ const mapStateToProps = state => ({
 
 export default connect(mapStateToProps)(ProjectTranslations);
 export { ProjectTranslations };
-

--- a/app/pages/project/stats/charts.jsx
+++ b/app/pages/project/stats/charts.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ChartistGraph from 'react-chartist';
 import moment from 'moment';
+import PropTypes from 'prop-types';
 import Rcslider from 'rc-slider';
 
 export const Progress = (props) => {
@@ -32,8 +33,8 @@ Progress.defaultProps = {
 };
 
 Progress.propTypes = {
-  progress: React.PropTypes.number,
-  options: React.PropTypes.object,
+  progress: PropTypes.number,
+  options: PropTypes.object,
 };
 
 export class Graph extends React.Component {
@@ -321,13 +322,13 @@ Graph.defaultProps = {
 };
 
 Graph.propTypes = {
-  data: React.PropTypes.array,
-  by: React.PropTypes.string,
-  num: React.PropTypes.number,
-  options: React.PropTypes.object,
-  optionsSmall: React.PropTypes.object,
-  range: React.PropTypes.array,
-  handleRangeChange: React.PropTypes.func,
+  data: PropTypes.array,
+  by: PropTypes.string,
+  num: PropTypes.number,
+  options: PropTypes.object,
+  optionsSmall: PropTypes.object,
+  range: PropTypes.array,
+  handleRangeChange: PropTypes.func,
 };
 
 const DateRange = (props) => {
@@ -343,7 +344,7 @@ const DateRange = (props) => {
 };
 
 DateRange.propTypes = {
-  dateMin: React.PropTypes.string,
-  dateMax: React.PropTypes.string,
-  setDefaultRange: React.PropTypes.func,
+  dateMin: PropTypes.string,
+  dateMax: PropTypes.string,
+  setDefaultRange: PropTypes.func,
 };

--- a/app/pages/project/stats/index.jsx
+++ b/app/pages/project/stats/index.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import qs from 'qs';
 import { ProjectStatsPage } from './stats.jsx';
 import getWorkflowsInOrder from '../../../lib/get-workflows-in-order.coffee';
@@ -113,11 +114,11 @@ class ProjectStatsPageController extends React.Component {
   }
 }
 
-ProjectStatsPageController.contextTypes = { router: React.PropTypes.object };
+ProjectStatsPageController.contextTypes = { router: PropTypes.object };
 
 ProjectStatsPageController.propTypes = {
-  project: React.PropTypes.object,
-  params: React.PropTypes.object
+  project: PropTypes.object,
+  params: PropTypes.object
 };
 
 module.exports = ProjectStatsPageController;

--- a/app/pages/project/stats/stats.jsx
+++ b/app/pages/project/stats/stats.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import statsClient from 'panoptes-client/lib/stats-client';
 import moment from 'moment';
@@ -165,16 +166,16 @@ GraphSelect.defaultProps = {
 };
 
 GraphSelect.propTypes = {
-  by: React.PropTypes.string,
-  failedWorkflows: React.PropTypes.array,
-  projectId: React.PropTypes.string,
-  workflowId: React.PropTypes.string,
-  range: React.PropTypes.string,
-  type: React.PropTypes.string,
-  workflows: React.PropTypes.array,
-  handleGraphChange: React.PropTypes.func,
-  handleRangeChange: React.PropTypes.func,
-  handleWorkflowChange: React.PropTypes.func,
+  by: PropTypes.string,
+  failedWorkflows: PropTypes.array,
+  projectId: PropTypes.string,
+  workflowId: PropTypes.string,
+  range: PropTypes.string,
+  type: PropTypes.string,
+  workflows: PropTypes.array,
+  handleGraphChange: PropTypes.func,
+  handleRangeChange: PropTypes.func,
+  handleWorkflowChange: PropTypes.func,
 };
 
 export const Eta = (props) => {
@@ -190,7 +191,7 @@ export const Eta = (props) => {
 };
 
 Eta.propTypes = {
-  numDays: React.PropTypes.number,
+  numDays: PropTypes.number,
 };
 
 export class WorkflowProgress extends React.Component {
@@ -308,7 +309,7 @@ export class WorkflowProgress extends React.Component {
 }
 
 WorkflowProgress.propTypes = {
-  workflow: React.PropTypes.object,
+  workflow: PropTypes.object,
 };
 
 export class ProjectStatsPage extends React.Component {
@@ -446,18 +447,18 @@ ProjectStatsPage.defaultProps = {
 };
 
 ProjectStatsPage.propTypes = {
-  classificationRange: React.PropTypes.string,
-  classificationsBy: React.PropTypes.string,
-  commentsBy: React.PropTypes.string,
-  commentRange: React.PropTypes.string,
-  currentClassifications: React.PropTypes.number,
-  failedWorkflows: React.PropTypes.array,
-  projectId: React.PropTypes.string,
-  totalVolunteers: React.PropTypes.number,
-  workflows: React.PropTypes.array,
-  startDate: React.PropTypes.string,
-  handleGraphChange: React.PropTypes.func,
-  handleRangeChange: React.PropTypes.func,
-  handleWorkflowChange: React.PropTypes.func,
-  workflowId: React.PropTypes.string,
+  classificationRange: PropTypes.string,
+  classificationsBy: PropTypes.string,
+  commentsBy: PropTypes.string,
+  commentRange: PropTypes.string,
+  currentClassifications: PropTypes.number,
+  failedWorkflows: PropTypes.array,
+  projectId: PropTypes.string,
+  totalVolunteers: PropTypes.number,
+  workflows: PropTypes.array,
+  startDate: PropTypes.string,
+  handleGraphChange: PropTypes.func,
+  handleRangeChange: PropTypes.func,
+  handleWorkflowChange: PropTypes.func,
+  workflowId: PropTypes.string,
 };

--- a/app/pages/project/talk.cjsx
+++ b/app/pages/project/talk.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 {Link} = require 'react-router'
 { Helmet } = require 'react-helmet'
@@ -16,7 +17,7 @@ module.exports = createReactClass
   displayName: 'ProjectTalkPage'
 
   contextTypes:
-    geordi: React.PropTypes.object
+    geordi: PropTypes.object
 
   logGeordi: ->
     @context.geordi?.logEvent

--- a/app/pages/project/workflow-selection.jsx
+++ b/app/pages/project/workflow-selection.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import apiClient from 'panoptes-client/lib/api-client';
 import isAdmin from '../../lib/is-admin';
@@ -195,41 +196,41 @@ WorkflowSelection.defaultProps = {
 };
 
 WorkflowSelection.propTypes = {
-  actions: React.PropTypes.shape({
-    translations: React.PropTypes.shape({
-      load: React.PropTypes.func
+  actions: PropTypes.shape({
+    translations: PropTypes.shape({
+      load: PropTypes.func
     })
   }),
-  children: React.PropTypes.node,
-  location: React.PropTypes.shape({
-    query: React.PropTypes.shape({
-      workflow: React.PropTypes.string
+  children: PropTypes.node,
+  location: PropTypes.shape({
+    query: PropTypes.shape({
+      workflow: PropTypes.string
     })
   }),
-  onChangePreferences: React.PropTypes.func,
-  preferences: React.PropTypes.shape({
-    save: React.PropTypes.func,
-    update: React.PropTypes.func
+  onChangePreferences: PropTypes.func,
+  preferences: PropTypes.shape({
+    save: PropTypes.func,
+    update: PropTypes.func
   }),
-  project: React.PropTypes.shape({
-    id: React.PropTypes.string,
-    configuration: React.PropTypes.shape({
-      default_workflow: React.PropTypes.string
+  project: PropTypes.shape({
+    id: PropTypes.string,
+    configuration: PropTypes.shape({
+      default_workflow: PropTypes.string
     }),
-    slug: React.PropTypes.string,
-    uncacheLink: React.PropTypes.func
+    slug: PropTypes.string,
+    uncacheLink: PropTypes.func
   }).isRequired,
-  projectRoles: React.PropTypes.arrayOf(React.PropTypes.object),
-  translation: React.PropTypes.shape({
-    display_name: React.PropTypes.string
+  projectRoles: PropTypes.arrayOf(PropTypes.object),
+  translation: PropTypes.shape({
+    display_name: PropTypes.string
   }),
-  translations: React.PropTypes.shape({
-    locale: React.PropTypes.string
+  translations: PropTypes.shape({
+    locale: PropTypes.string
   })
 };
 
 WorkflowSelection.contextTypes = {
-  router: React.PropTypes.object.isRequired
+  router: PropTypes.object.isRequired
 };
 
 export default WorkflowSelection;

--- a/app/pages/projects/filtered-projects-list.jsx
+++ b/app/pages/projects/filtered-projects-list.jsx
@@ -1,5 +1,6 @@
 import counterpart from 'counterpart';
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 import ProjectFilteringInterface from './project-filtering-interface';
 

--- a/app/pages/projects/index.jsx
+++ b/app/pages/projects/index.jsx
@@ -1,5 +1,6 @@
 import counterpart from 'counterpart';
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import Translate from 'react-translate-component';
 import { browserHistory } from 'react-router';
 import { Helmet } from 'react-helmet';
@@ -81,13 +82,13 @@ class ProjectsPage extends Component {
 }
 
 ProjectsPage.childContextTypes = {
-  updateQuery: React.PropTypes.func
+  updateQuery: PropTypes.func
 };
 
 ProjectsPage.propTypes = {
   children: PropTypes.object.isRequired,
-  location: React.PropTypes.shape({
-    query: React.PropTypes.object
+  location: PropTypes.shape({
+    query: PropTypes.object
   })
 };
 

--- a/app/pages/projects/project-card-list.jsx
+++ b/app/pages/projects/project-card-list.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import ProjectCard from '../../partials/project-card';
 
 class ProjectCardList extends Component {

--- a/app/pages/projects/project-filtering-interface.jsx
+++ b/app/pages/projects/project-filtering-interface.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import apiClient from 'panoptes-client/lib/api-client';
 import Translate from 'react-translate-component';
 

--- a/app/pages/projects/projects-page-selector.jsx
+++ b/app/pages/projects/projects-page-selector.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 class PageSelector extends Component {
   constructor(props) {

--- a/app/pages/projects/projects-search-selector.jsx
+++ b/app/pages/projects/projects-search-selector.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import { browserHistory } from 'react-router';
 import apiClient from 'panoptes-client/lib/api-client';
 import Select from 'react-select';

--- a/app/pages/projects/projects-sort-selector.jsx
+++ b/app/pages/projects/projects-sort-selector.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import Select from 'react-select';
 
 import PROJECT_SORTS from './project-sorts';

--- a/app/pages/projects/status-link.jsx
+++ b/app/pages/projects/status-link.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 class StatusLink extends Component {
   constructor(props) {

--- a/app/pages/reset-password/new-password-form.jsx
+++ b/app/pages/reset-password/new-password-form.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import Translate from 'react-translate-component';
 
@@ -55,11 +56,11 @@ const NewPasswordForm = ({ onSubmit, disabled, inProgress, resetSuccess, resetEr
   );
 
 NewPasswordForm.propTypes = {
-  disabled: React.PropTypes.bool,
-  inProgress: React.PropTypes.bool,
-  onSubmit: React.PropTypes.func,
-  resetError: React.PropTypes.string,
-  resetSuccess: React.PropTypes.bool
+  disabled: PropTypes.bool,
+  inProgress: PropTypes.bool,
+  onSubmit: PropTypes.func,
+  resetError: PropTypes.string,
+  resetSuccess: PropTypes.bool
 };
 
 NewPasswordForm.defaultProps = {

--- a/app/pages/reset-password/reset-password.jsx
+++ b/app/pages/reset-password/reset-password.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import auth from 'panoptes-client/lib/auth';
 import Translate from 'react-translate-component';
 import alert from '../../lib/alert';
@@ -129,7 +130,7 @@ ResetPasswordPage.defaultProps = {
 };
 
 ResetPasswordPage.contextTypes = {
-  router: React.PropTypes.object.isRequired
+  router: PropTypes.object.isRequired
 };
 
 export default ResetPasswordPage;

--- a/app/pages/reset-password/submit-email-form.jsx
+++ b/app/pages/reset-password/submit-email-form.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import Translate from 'react-translate-component';
 
@@ -58,13 +59,13 @@ const SubmitEmailForm = ({ user, onSubmit, onChange, disabled, inProgress, email
 };
 
 SubmitEmailForm.propTypes = {
-  disabled: React.PropTypes.bool,
-  emailError: React.PropTypes.string,
-  emailSuccess: React.PropTypes.bool,
-  inProgress: React.PropTypes.bool,
-  onChange: React.PropTypes.func,
-  onSubmit: React.PropTypes.func,
-  user: React.PropTypes.object // eslint-disable-line react/forbid-prop-types
+  disabled: PropTypes.bool,
+  emailError: PropTypes.string,
+  emailSuccess: PropTypes.bool,
+  inProgress: PropTypes.bool,
+  onChange: PropTypes.func,
+  onSubmit: PropTypes.func,
+  user: PropTypes.object // eslint-disable-line react/forbid-prop-types
 };
 
 SubmitEmailForm.defaultProps = {

--- a/app/pages/settings/email.jsx
+++ b/app/pages/settings/email.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import Translate from 'react-translate-component';
 import apiClient from 'panoptes-client/lib/api-client';
@@ -20,11 +21,11 @@ function TalkPreferenceOption({ preference, index, digest, onChange }) {
 }
 
 TalkPreferenceOption.propTypes = {
-  digest: React.PropTypes.string.isRequired,
-  index: React.PropTypes.number.isRequired,
-  onChange: React.PropTypes.func,
-  preference: React.PropTypes.shape({
-    email_digest: React.PropTypes.string
+  digest: PropTypes.string.isRequired,
+  index: PropTypes.number.isRequired,
+  onChange: PropTypes.func,
+  preference: PropTypes.shape({
+    email_digest: PropTypes.string
   }).isRequired
 };
 
@@ -54,8 +55,8 @@ function TalkPreferences(props) {
 }
 
 TalkPreferences.propTypes = {
-  onChange: React.PropTypes.func,
-  talkPreferences: React.PropTypes.arrayOf(React.PropTypes.object).isRequired
+  onChange: PropTypes.func,
+  talkPreferences: PropTypes.arrayOf(PropTypes.object).isRequired
 };
 
 function ProjectPreferences({ projects, projectPreferences, onChange }) {
@@ -94,9 +95,9 @@ function ProjectPreferences({ projects, projectPreferences, onChange }) {
 }
 
 ProjectPreferences.propTypes = {
-  projects: React.PropTypes.arrayOf(React.PropTypes.object).isRequired,
-  projectPreferences: React.PropTypes.arrayOf(React.PropTypes.object).isRequired,
-  onChange: React.PropTypes.func
+  projects: PropTypes.arrayOf(PropTypes.object).isRequired,
+  projectPreferences: PropTypes.arrayOf(PropTypes.object).isRequired,
+  onChange: PropTypes.func
 };
 
 function Pagination({ meta, page, onChange }) {
@@ -120,11 +121,11 @@ function Pagination({ meta, page, onChange }) {
 }
 
 Pagination.propTypes = {
-  meta: React.PropTypes.shape({
-    page_count: React.PropTypes.number
+  meta: PropTypes.shape({
+    page_count: PropTypes.number
   }),
-  page: React.PropTypes.number,
-  onChange: React.PropTypes.func
+  page: PropTypes.number,
+  onChange: PropTypes.func
 };
 
 Pagination.defaultProps = {
@@ -351,12 +352,12 @@ EmailSettingsPage.defaultProps = {
 };
 
 EmailSettingsPage.propTypes = {
-  user: React.PropTypes.shape({
-    email: React.PropTypes.string,
-    beta_email_communication: React.PropTypes.bool,
-    project_email_communication: React.PropTypes.bool,
-    global_email_communication: React.PropTypes.bool,
-    get: React.PropTypes.func
+  user: PropTypes.shape({
+    email: PropTypes.string,
+    beta_email_communication: PropTypes.bool,
+    project_email_communication: PropTypes.bool,
+    global_email_communication: PropTypes.bool,
+    get: PropTypes.func
   })
 };
 

--- a/app/pages/settings/profile.jsx
+++ b/app/pages/settings/profile.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import apiClient from 'panoptes-client/lib/api-client';
 import ImageSelector from '../../components/image-selector';
@@ -125,8 +126,8 @@ CustomiseProfile.defaultProps = {
 };
 
 CustomiseProfile.propTypes = {
-  user: React.PropTypes.shape({
-    get: React.PropTypes.func
+  user: PropTypes.shape({
+    get: PropTypes.func
   })
 };
 

--- a/app/pages/sign-in.jsx
+++ b/app/pages/sign-in.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import counterpart from 'counterpart';
 import Translate from 'react-translate-component';
@@ -36,7 +37,7 @@ SignInPage.defaultProps = {
 };
 
 SignInPage.propTypes = {
-  children: React.PropTypes.node
+  children: PropTypes.node
 };
 
 export default SignInPage;

--- a/app/pages/unsubscribe.jsx
+++ b/app/pages/unsubscribe.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import auth from 'panoptes-client/lib/auth';
 
 

--- a/app/partials/app.cjsx
+++ b/app/partials/app.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 auth = require 'panoptes-client/lib/auth'
 { Helmet } = require 'react-helmet'
@@ -21,12 +22,12 @@ PanoptesApp = createReactClass
   geordiLogger: null # Maintains project and subject context for the Geordi client
 
   childContextTypes:
-    initialLoadComplete: React.PropTypes.bool
-    user: React.PropTypes.object
-    geordi: React.PropTypes.object
-    notificationsCounter: React.PropTypes.object
-    unreadNotificationsCount: React.PropTypes.number
-    pusher: React.PropTypes.object
+    initialLoadComplete: PropTypes.bool
+    user: PropTypes.object
+    geordi: PropTypes.object
+    notificationsCounter: PropTypes.object
+    unreadNotificationsCount: PropTypes.number
+    pusher: PropTypes.object
 
   getChildContext: ->
     initialLoadComplete: @state.initialLoadComplete

--- a/app/partials/avatar.cjsx
+++ b/app/partials/avatar.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 
 DEFAULT_AVATAR = '/assets/simple-avatar.png'
@@ -7,9 +8,9 @@ module.exports = createReactClass
   displayName: 'Avatar'
 
   propTypes:
-    user: React.PropTypes.object
-    size: React.PropTypes.any
-    className: React.PropTypes.string
+    user: PropTypes.object
+    size: PropTypes.any
+    className: PropTypes.string
 
   getDefaultProps: ->
     user: null

--- a/app/partials/display-name-slug-editor.jsx
+++ b/app/partials/display-name-slug-editor.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import AutoSave from '../components/auto-save';
 import handleInputChange from '../lib/handle-input-change';
 

--- a/app/partials/login-dialog.cjsx
+++ b/app/partials/login-dialog.cjsx
@@ -1,5 +1,6 @@
 counterpart = require 'counterpart'
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 Translate = require 'react-translate-component'
 SignInForm = require './sign-in-form'
@@ -22,7 +23,7 @@ module.exports = createReactClass
     which: @props.which
 
   childContextTypes:
-    geordi: React.PropTypes.object
+    geordi: PropTypes.object
 
   getChildContext: ->
     geordi: @props.contextRef?.geordi

--- a/app/partials/project-card.cjsx
+++ b/app/partials/project-card.cjsx
@@ -1,4 +1,5 @@
 React = require('react')
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 FlexibleLink = require('../components/flexible-link').default
 Translate = require 'react-translate-component'
@@ -6,7 +7,7 @@ Translate = require 'react-translate-component'
 ProjectCard = createReactClass
   displayName: 'ProjectCard'
   propTypes:
-    project: React.PropTypes.object.isRequired
+    project: PropTypes.object.isRequired
 
   getDefaultProps: ->
     className: ''

--- a/app/partials/register-form.cjsx
+++ b/app/partials/register-form.cjsx
@@ -1,5 +1,6 @@
 counterpart = require 'counterpart'
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 PromiseToSetState = require '../lib/promise-to-set-state'
 auth = require 'panoptes-client/lib/auth'
@@ -52,7 +53,7 @@ module.exports = createReactClass
     error: null
 
   contextTypes:
-    geordi: React.PropTypes.object
+    geordi: PropTypes.object
 
   render: ->
     {badNameChars, nameConflict, passwordTooShort, passwordsDontMatch, emailConflict} = @state

--- a/app/partials/sign-in-form.cjsx
+++ b/app/partials/sign-in-form.cjsx
@@ -1,5 +1,6 @@
 counterpart = require 'counterpart'
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 ReactDOM = require 'react-dom'
 Translate = require 'react-translate-component'
@@ -19,7 +20,7 @@ module.exports = createReactClass
   displayName: 'SignInForm'
 
   contextTypes:
-    geordi: React.PropTypes.object
+    geordi: PropTypes.object
 
   getInitialState: ->
     busy: false

--- a/app/subjects/comment-form.cjsx
+++ b/app/subjects/comment-form.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 {Link} = require 'react-router'
 talkClient = require 'panoptes-client/lib/talk-client'
@@ -12,7 +13,7 @@ module.exports = createReactClass
   displayName: 'SubjectCommentForm'
 
   contextTypes:
-    router: React.PropTypes.object.isRequired
+    router: PropTypes.object.isRequired
 
   componentWillMount: ->
     Promise.all([@getBoards(), @getSubjectDefaultBoard()]).then =>

--- a/app/subjects/index.jsx
+++ b/app/subjects/index.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import apiClient from 'panoptes-client/lib/api-client';
 import SubjectPage from './subject-page';
@@ -89,19 +90,19 @@ export default class SubjectPageContainer extends React.Component {
 }
 
 SubjectPageContainer.propTypes = {
-  location: React.PropTypes.shape({
-    query: React.PropTypes.shape({
-      collections_page: React.PropTypes.string
+  location: PropTypes.shape({
+    query: PropTypes.shape({
+      collections_page: PropTypes.string
     })
   }),
-  params: React.PropTypes.shape({
-    id: React.PropTypes.string
+  params: PropTypes.shape({
+    id: PropTypes.string
   }),
-  project: React.PropTypes.shape({
-    id: React.PropTypes.string
+  project: PropTypes.shape({
+    id: PropTypes.string
   }),
-  section: React.PropTypes.string,
-  user: React.PropTypes.shape({
-    id: React.PropTypes.string
+  section: PropTypes.string,
+  user: PropTypes.shape({
+    id: PropTypes.string
   })
 };

--- a/app/subjects/subject-collection-list.jsx
+++ b/app/subjects/subject-collection-list.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import Loading from '../components/loading-indicator';
 import CollectionCard from '../pages/collections/collection-card';
@@ -45,10 +46,10 @@ SubjectCollectionList.defaultProps = {
 };
 
 SubjectCollectionList.propTypes = {
-  collections: React.PropTypes.arrayOf(React.PropTypes.object),
-  onCollectionsPageChange: React.PropTypes.func,
-  project: React.PropTypes.shape({
-    slug: React.PropTypes.string
+  collections: PropTypes.arrayOf(PropTypes.object),
+  onCollectionsPageChange: PropTypes.func,
+  project: PropTypes.shape({
+    slug: PropTypes.string
   })
 };
 

--- a/app/subjects/subject-page.jsx
+++ b/app/subjects/subject-page.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import SubjectViewer from '../components/subject-viewer';
 import ActiveUsers from '../talk/active-users';
@@ -64,14 +65,14 @@ SubjectPage.defaultProps = {
 };
 
 SubjectPage.propTypes = {
-  collections: React.PropTypes.arrayOf(React.PropTypes.object),
-  isFavorite: React.PropTypes.bool,
-  project: React.PropTypes.object,
-  section: React.PropTypes.string,
-  subject: React.PropTypes.shape({
-    id: React.PropTypes.string
+  collections: PropTypes.arrayOf(PropTypes.object),
+  isFavorite: PropTypes.bool,
+  project: PropTypes.object,
+  section: PropTypes.string,
+  subject: PropTypes.shape({
+    id: PropTypes.string
   }),
-  user: React.PropTypes.object
+  user: PropTypes.object
 };
 
 export default SubjectPage;

--- a/app/talk/active-users.jsx
+++ b/app/talk/active-users.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import apiClient from 'panoptes-client/lib/api-client';
 import { sugarApiClient } from 'panoptes-client/lib/sugar';
 import { Link } from 'react-router';
@@ -172,7 +173,7 @@ export default class ActiveUsers extends React.Component {
 }
 
 ActiveUsers.contextTypes = {
-  geordi: React.PropTypes.object
+  geordi: PropTypes.object
 };
 
 ActiveUsers.defaultProps = {
@@ -181,8 +182,8 @@ ActiveUsers.defaultProps = {
 };
 
 ActiveUsers.propTypes = {
-  project: React.PropTypes.shape({
-    slug: React.PropTypes.string
+  project: PropTypes.shape({
+    slug: PropTypes.string
   }),
-  section: React.PropTypes.string
+  section: PropTypes.string
 };

--- a/app/talk/board-preview.cjsx
+++ b/app/talk/board-preview.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 {Link} = require 'react-router'
 resourceCount = require './lib/resource-count'
@@ -8,7 +9,7 @@ module.exports = createReactClass
   displayName: 'TalkBoardDisplay'
 
   propTypes:
-    data: React.PropTypes.object
+    data: PropTypes.object
 
   private: ->
     @props.data.permissions.read isnt 'all'

--- a/app/talk/board.cjsx
+++ b/app/talk/board.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 ReactDOM = require 'react-dom'
 {Link} = require 'react-router'
@@ -30,8 +31,8 @@ module.exports = createReactClass
   displayName: 'TalkBoard'
 
   contextTypes:
-    geordi: React.PropTypes.object
-    router: React.PropTypes.object.isRequired
+    geordi: PropTypes.object
+    router: PropTypes.object.isRequired
 
   getInitialState: ->
     discussions: []

--- a/app/talk/breadcrumbs.cjsx
+++ b/app/talk/breadcrumbs.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 talkClient = require 'panoptes-client/lib/talk-client'
 {Link} = require 'react-router'
@@ -19,7 +20,7 @@ module.exports = createReactClass
     @updateDiscussion newProps.params.discussion if newProps.params.discussion isnt @props.params.discussion
 
   contextTypes:
-    router: React.PropTypes.object.isRequired
+    router: PropTypes.object.isRequired
 
   crumbCatch: (e) ->
     if e.message.indexOf('not allowed to show') isnt -1

--- a/app/talk/comment-box.cjsx
+++ b/app/talk/comment-box.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 ToggleChildren = require './mixins/toggle-children'
 Feedback = require './mixins/feedback'
@@ -15,13 +16,13 @@ module.exports = createReactClass
   mixins: [ToggleChildren, Feedback]
 
   propTypes:
-    submit: React.PropTypes.string
-    user: React.PropTypes.object
-    header: React.PropTypes.string
-    placeholder: React.PropTypes.string
-    submitFeedback: React.PropTypes.string
-    onSubmitComment: React.PropTypes.func # called on submit and passed (e, textarea-content, subject), expected to return something thenable
-    onCancelClick: React.PropTypes.func # adds cancel button and calls callback on click if supplied
+    submit: PropTypes.string
+    user: PropTypes.object
+    header: PropTypes.string
+    placeholder: PropTypes.string
+    submitFeedback: PropTypes.string
+    onSubmitComment: PropTypes.func # called on submit and passed (e, textarea-content, subject), expected to return something thenable
+    onCancelClick: PropTypes.func # adds cancel button and calls callback on click if supplied
 
   getDefaultProps: ->
     submit: "Submit"
@@ -41,7 +42,7 @@ module.exports = createReactClass
     error: ''
 
   contextTypes:
-    geordi: React.PropTypes.object
+    geordi: PropTypes.object
 
   logPageClick: (clicked, button) ->
     @context?.geordi?.logEvent

--- a/app/talk/comment-link.cjsx
+++ b/app/talk/comment-link.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 talkConfig = require './config'
 {Link} = require 'react-router'
@@ -9,8 +10,8 @@ module.exports = createReactClass
   displayName: 'TalkCommentLink'
 
   propTypes:
-    comment: React.PropTypes.object  # Comment resource
-    pageSize: React.PropTypes.number # Optional: pass this in to override default PAGE_SIZE
+    comment: PropTypes.object  # Comment resource
+    pageSize: PropTypes.number # Optional: pass this in to override default PAGE_SIZE
 
   getDefaultProps: ->
     pageSize: PAGE_SIZE

--- a/app/talk/comment-preview.cjsx
+++ b/app/talk/comment-preview.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 {Markdown} = require 'markdownz'
 
@@ -6,8 +7,8 @@ module.exports = createReactClass
   displayName: 'TalkCommentPreview'
 
   propTypes:
-    content: React.PropTypes.string
-    header: React.PropTypes.string
+    content: PropTypes.string
+    header: PropTypes.string
 
   getDefaultProps: ->
     header: "Preview"

--- a/app/talk/comment-report-form.cjsx
+++ b/app/talk/comment-report-form.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 Feedback = require './mixins/feedback'
 talkClient = require 'panoptes-client/lib/talk-client'
@@ -9,7 +10,7 @@ module.exports = createReactClass
   mixins: [Feedback]
 
   propTypes:
-    comment: React.PropTypes.object
+    comment: PropTypes.object
 
   getInitialState: ->
     error: ''

--- a/app/talk/comment.cjsx
+++ b/app/talk/comment.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 ReactDOM = require 'react-dom'
 ToggleChildren = require './mixins/toggle-children'
@@ -25,17 +26,17 @@ module.exports = createReactClass
   mixins: [ToggleChildren, Feedback]
 
   propTypes:
-    data: React.PropTypes.object # Comment resource
-    onUpdateComment: React.PropTypes.func # passed (textContent, subject, commentId) on update submit
-    onDeleteComment: React.PropTypes.func # passed (commentId) on click
-    onLikeComment: React.PropTypes.func # passed (commentId) on like
-    onClickReply: React.PropTypes.func # passed (user, comment) on click
-    active: React.PropTypes.bool  # optional active switch: scroll window to comment and apply styling
-    user: React.PropTypes.object  # Current user
-    index: React.PropTypes.number # The index of the comment in a discussion
-    locked: React.PropTypes.bool  # disable action buttons
-    linked: React.PropTypes.bool
-    hideFocus: React.PropTypes.bool # Control visibility of focus (default: false)
+    data: PropTypes.object # Comment resource
+    onUpdateComment: PropTypes.func # passed (textContent, subject, commentId) on update submit
+    onDeleteComment: PropTypes.func # passed (commentId) on click
+    onLikeComment: PropTypes.func # passed (commentId) on like
+    onClickReply: PropTypes.func # passed (user, comment) on click
+    active: PropTypes.bool  # optional active switch: scroll window to comment and apply styling
+    user: PropTypes.object  # Current user
+    index: PropTypes.number # The index of the comment in a discussion
+    locked: PropTypes.bool  # disable action buttons
+    linked: PropTypes.bool
+    hideFocus: PropTypes.bool # Control visibility of focus (default: false)
 
   getDefaultProps: ->
     active: false
@@ -49,7 +50,7 @@ module.exports = createReactClass
     replies: []
 
   contextTypes:
-    geordi: React.PropTypes.object
+    geordi: PropTypes.object
 
   logItemClick: (itemClick) ->
     @context.geordi?.logEvent

--- a/app/talk/discussion-comment.jsx
+++ b/app/talk/discussion-comment.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Link } from 'react-router';
 import talkClient from 'panoptes-client/lib/talk-client';
@@ -90,14 +91,14 @@ class DiscussionComment extends React.Component {
 }
 
 DiscussionComment.propTypes = {
-  params: React.PropTypes.object,
-  project: React.PropTypes.object,
-  user: React.PropTypes.object,
-  roles: React.PropTypes.array,
-  discussion: React.PropTypes.object,
-  reply: React.PropTypes.object,
-  onSubmitComment: React.PropTypes.func,
-  onClearReply: React.PropTypes.func
+  params: PropTypes.object,
+  project: PropTypes.object,
+  user: PropTypes.object,
+  roles: PropTypes.array,
+  discussion: PropTypes.object,
+  reply: PropTypes.object,
+  onSubmitComment: PropTypes.func,
+  onClearReply: PropTypes.func
 };
 
 export default DiscussionComment;

--- a/app/talk/discussion-new-form.cjsx
+++ b/app/talk/discussion-new-form.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 ReactDOM = require 'react-dom'
 CommentBox = require './comment-box'
@@ -13,9 +14,9 @@ module.exports = createReactClass
   displayName: 'DiscussionNewForm'
 
   propTypes:
-    boardId: React.PropTypes.number
-    onCreateDiscussion: React.PropTypes.func
-    subject: React.PropTypes.object # subject response
+    boardId: PropTypes.number
+    onCreateDiscussion: PropTypes.func
+    subject: PropTypes.object # subject response
 
   getInitialState: ->
     discussionValidationErrors: []

--- a/app/talk/discussion-preview.cjsx
+++ b/app/talk/discussion-preview.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 {Link} = require 'react-router'
 resourceCount = require './lib/resource-count'
@@ -12,10 +13,10 @@ module.exports = createReactClass
   displayName: 'TalkDiscussionPreview'
 
   propTypes:
-    discussion: React.PropTypes.object
+    discussion: PropTypes.object
 
   contextTypes:
-    geordi: React.PropTypes.object
+    geordi: PropTypes.object
   
   getDefaultProps: ->
     project: {}

--- a/app/talk/discussion.cjsx
+++ b/app/talk/discussion.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 ReactDOM = require 'react-dom'
 Comment = require './comment'
@@ -26,7 +27,7 @@ module.exports = createReactClass
   displayName: 'TalkDiscussion'
 
   contextTypes:
-    router: React.PropTypes.object.isRequired
+    router: PropTypes.object.isRequired
 
   getInitialState: ->
     comments: []

--- a/app/talk/follow-board.cjsx
+++ b/app/talk/follow-board.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 talkClient = require 'panoptes-client/lib/talk-client'
 SingleSubmitButton = require '../components/single-submit-button'
@@ -7,8 +8,8 @@ module.exports = createReactClass
   displayName: 'FollowBoard'
 
   propTypes:
-    board: React.PropTypes.object.isRequired
-    user: React.PropTypes.object.isRequired
+    board: PropTypes.object.isRequired
+    user: PropTypes.object.isRequired
 
   getInitialState: ->
     digest: null

--- a/app/talk/follow-discussion.cjsx
+++ b/app/talk/follow-discussion.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 talkClient = require 'panoptes-client/lib/talk-client'
 SingleSubmitButton = require '../components/single-submit-button'
@@ -7,11 +8,11 @@ module.exports = createReactClass
   displayName: 'FollowDiscussion'
 
   contextTypes:
-    geordi: React.PropTypes.object
+    geordi: PropTypes.object
 
   propTypes:
-    discussion: React.PropTypes.object.isRequired
-    user: React.PropTypes.object.isRequired
+    discussion: PropTypes.object.isRequired
+    user: PropTypes.object.isRequired
 
   getInitialState: ->
     followed: null

--- a/app/talk/inbox-conversation.cjsx
+++ b/app/talk/inbox-conversation.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 talkClient = require 'panoptes-client/lib/talk-client'
 apiClient = require 'panoptes-client/lib/api-client'
@@ -42,7 +43,7 @@ module.exports = createReactClass
   mixins: [HandlePropChanges]
 
   contextTypes:
-    router: React.PropTypes.object.isRequired
+    router: PropTypes.object.isRequired
 
   getInitialState: ->
     messages: []

--- a/app/talk/inbox-form.cjsx
+++ b/app/talk/inbox-form.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 talkClient = require 'panoptes-client/lib/talk-client'
 UserSearch = require '../components/user-search'
@@ -11,11 +12,11 @@ module.exports = createReactClass
   displayName: 'InboxForm'
 
   propTypes:
-    user: React.PropTypes.object
+    user: PropTypes.object
 
   contextTypes:
-    geordi: React.PropTypes.object
-    router: React.PropTypes.object.isRequired
+    geordi: PropTypes.object
+    router: PropTypes.object.isRequired
 
   getInitialState: ->
     validationErrors: []

--- a/app/talk/inbox.cjsx
+++ b/app/talk/inbox.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 talkClient = require 'panoptes-client/lib/talk-client'
 apiClient = require 'panoptes-client/lib/api-client'
@@ -25,8 +26,8 @@ ConversationLink = createReactClass
   displayName: 'ConversationLink'
 
   propTypes:
-    user: React.PropTypes.object
-    conversation: React.PropTypes.object
+    user: PropTypes.object
+    conversation: PropTypes.object
 
   getInitialState: ->
     users: []
@@ -66,7 +67,7 @@ module.exports = createReactClass
   displayName: 'TalkInbox'
 
   contextTypes:
-    router: React.PropTypes.object.isRequired
+    router: PropTypes.object.isRequired
 
   getDefaultProps: ->
     location: query: page: 1

--- a/app/talk/index.cjsx
+++ b/app/talk/index.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 {Link} = require 'react-router'
 counterpart = require 'counterpart'
@@ -16,7 +17,7 @@ module.exports = createReactClass
   displayName: 'Talk'
 
   contextTypes:
-    geordi: React.PropTypes.object
+    geordi: PropTypes.object
 
   logTalkView: ->
     @context.geordi?.logEvent

--- a/app/talk/init.cjsx
+++ b/app/talk/init.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 BoardPreview = require './board-preview'
 apiClient = require 'panoptes-client/lib/api-client'
@@ -25,10 +26,10 @@ module.exports = createReactClass
   mixins: [HandlePropChanges]
 
   propTypes:
-    section: React.PropTypes.string # 'zooniverse' for main-talk, 'project_id' for projects
+    section: PropTypes.string # 'zooniverse' for main-talk, 'project_id' for projects
 
   contextTypes:
-    geordi: React.PropTypes.object
+    geordi: PropTypes.object
 
   logTalkClick: (talkItem) ->
     @context.geordi?.logEvent

--- a/app/talk/latest-comment-link.cjsx
+++ b/app/talk/latest-comment-link.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 talkClient = require 'panoptes-client/lib/talk-client'
 {timeAgo} = require './lib/time'
@@ -17,14 +18,14 @@ module.exports = createReactClass
   displayName: 'TalkLatestCommentLink'
 
   propTypes:
-    project: React.PropTypes.object
-    discussion: React.PropTypes.object
-    title: React.PropTypes.bool
-    preview: React.PropTypes.bool
+    project: PropTypes.object
+    discussion: PropTypes.object
+    title: PropTypes.bool
+    preview: PropTypes.bool
 
   contextTypes:
-    geordi: React.PropTypes.object
-    router: React.PropTypes.object.isRequired
+    geordi: PropTypes.object
+    router: PropTypes.object.isRequired
 
   getDefaultProps: ->
     title: false

--- a/app/talk/lib/create-board-form.cjsx
+++ b/app/talk/lib/create-board-form.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 ReactDOM = require 'react-dom'
 ROLES = require './roles'
@@ -22,9 +23,9 @@ module.exports = createReactClass
   displayName: 'CreateBoardForm'
 
   propTypes:
-    section: React.PropTypes.string
-    onSubmitBoard: React.PropTypes.func
-    user: React.PropTypes.object
+    section: PropTypes.string
+    onSubmitBoard: PropTypes.func
+    user: PropTypes.object
 
   getInitialState: ->
     error: ''

--- a/app/talk/lib/create-subject-default-button.cjsx
+++ b/app/talk/lib/create-subject-default-button.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 talkClient = require 'panoptes-client/lib/talk-client'
 SingleSubmitButton = require '../../components/single-submit-button'
@@ -11,8 +12,8 @@ module.exports = createReactClass
   displayName: 'CreateSubjectDefaultButton'
 
   propTypes:
-    section: React.PropTypes.string
-    onCreateBoard: React.PropTypes.func # passed (board) on create
+    section: PropTypes.string
+    onCreateBoard: PropTypes.func # passed (board) on create
 
   getInitialState: ->
     defaultBoard: null

--- a/app/talk/lib/display-roles.cjsx
+++ b/app/talk/lib/display-roles.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 uniq = require 'lodash/uniq'
 
@@ -21,7 +22,7 @@ DisplayRoles = createReactClass
   displayName: 'TalkDisplayRoles'
 
   propTypes:
-    roles: React.PropTypes.array # roles resources
+    roles: PropTypes.array # roles resources
 
   role: (role, i) ->
     zooTeamName = if zooniverseTeamRole(role) then 'zoo-team'

--- a/app/talk/lib/moderation.cjsx
+++ b/app/talk/lib/moderation.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 talkClient = require 'panoptes-client/lib/talk-client'
 userIsModerator = require './user-is-moderator'
@@ -7,8 +8,8 @@ module.exports = createReactClass
   displayName: 'Moderation'
 
   propTypes:
-    section: React.PropTypes.string.isRequired # talk section
-    user: React.PropTypes.object.isRequired
+    section: PropTypes.string.isRequired # talk section
+    user: PropTypes.object.isRequired
   
   getInitialState: ->
     roles: []

--- a/app/talk/lib/notifications-link.cjsx
+++ b/app/talk/lib/notifications-link.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 {Link} = require 'react-router'
 apiClient = require 'panoptes-client/lib/api-client'
@@ -15,7 +16,7 @@ module.exports = createReactClass
   displayName: 'NotificationsLink'
 
   contextTypes:
-    unreadNotificationsCount: React.PropTypes.number
+    unreadNotificationsCount: PropTypes.number
 
   label: ->
     unread = @context.unreadNotificationsCount

--- a/app/talk/lib/paginator.cjsx
+++ b/app/talk/lib/paginator.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 updateQueryParams = require './update-query-params'
 
@@ -6,17 +7,17 @@ module.exports = createReactClass
   displayName: 'Paginator'
 
   propTypes:
-    pageCount: React.PropTypes.number
-    page: React.PropTypes.number                  # page number
-    onPageChange: React.PropTypes.func.isRequired # passed (page) on change
-    firstAndLast: React.PropTypes.bool            # optional, add 'first' & 'last' buttons
-    pageSelector: React.PropTypes.bool            # show page selector?
-    itemCount: React.PropTypes.bool               # show number of items out of total
-    pageKey: React.PropTypes.string               # optional name for key param (defaults to 'page')
+    pageCount: PropTypes.number
+    page: PropTypes.number                  # page number
+    onPageChange: PropTypes.func.isRequired # passed (page) on change
+    firstAndLast: PropTypes.bool            # optional, add 'first' & 'last' buttons
+    pageSelector: PropTypes.bool            # show page selector?
+    itemCount: PropTypes.bool               # show number of items out of total
+    pageKey: PropTypes.string               # optional name for key param (defaults to 'page')
 
   contextTypes:
-    geordi: React.PropTypes.object
-    router: React.PropTypes.object.isRequired
+    geordi: PropTypes.object
+    router: PropTypes.object.isRequired
 
   getDefaultProps: ->
     page: 1

--- a/app/talk/lib/project-linker.cjsx
+++ b/app/talk/lib/project-linker.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 talkClient = require 'panoptes-client/lib/talk-client'
 {Link} = require 'react-router'
@@ -8,7 +9,7 @@ module.exports = createReactClass
   displayName: 'ProjectLinker'
 
   contextTypes:
-    geordi: React.PropTypes.object
+    geordi: PropTypes.object
 
   getInitialState: ->
     projects: []

--- a/app/talk/lib/zoo-team.cjsx
+++ b/app/talk/lib/zoo-team.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 talkClient = require 'panoptes-client/lib/talk-client'
 userIsZooniverseAdmin = require './user-is-zooniverse-admin'
@@ -7,8 +8,8 @@ module.exports = createReactClass
   displayName: 'ZooniverseTeam'
 
   propTypes:
-    section: React.PropTypes.string.isRequired # talk section
-    user: React.PropTypes.object.isRequired
+    section: PropTypes.string.isRequired # talk section
+    user: PropTypes.object.isRequired
 
   getInitialState: ->
     open: false

--- a/app/talk/moderation/actions.cjsx
+++ b/app/talk/moderation/actions.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 {Link} = require 'react-router'
 moment = require 'moment'
@@ -21,10 +22,10 @@ module.exports = createReactClass
   displayName: 'ModerationActions'
 
   propTypes:
-    moderation: React.PropTypes.object.isRequired
-    comment: React.PropTypes.object.isRequired
-    user: React.PropTypes.object.isRequired
-    updateModeration: React.PropTypes.func.isRequired
+    moderation: PropTypes.object.isRequired
+    comment: PropTypes.object.isRequired
+    user: PropTypes.object.isRequired
+    updateModeration: PropTypes.func.isRequired
 
   getInitialState: ->
     actions: null

--- a/app/talk/moderation/comment.cjsx
+++ b/app/talk/moderation/comment.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 {Link} = require 'react-router'
 talkClient = require 'panoptes-client/lib/talk-client'
@@ -11,9 +12,9 @@ module.exports = createReactClass
   displayName: 'ModerationComment'
 
   propTypes:
-    moderation: React.PropTypes.object.isRequired
-    user: React.PropTypes.object.isRequired
-    updateModeration: React.PropTypes.func.isRequired
+    moderation: PropTypes.object.isRequired
+    user: PropTypes.object.isRequired
+    updateModeration: PropTypes.func.isRequired
 
   getInitialState: ->
     comment: null

--- a/app/talk/moderation/reports.cjsx
+++ b/app/talk/moderation/reports.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 {Link} = require 'react-router'
 apiClient = require 'panoptes-client/lib/api-client'
@@ -8,7 +9,7 @@ module.exports = createReactClass
   displayName: 'ModerationActions'
 
   propTypes:
-    reports: React.PropTypes.array.isRequired
+    reports: PropTypes.array.isRequired
 
   getInitialState: ->
     reports: null

--- a/app/talk/moderations.cjsx
+++ b/app/talk/moderations.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 talkClient = require 'panoptes-client/lib/talk-client'
 auth = require 'panoptes-client/lib/auth'
@@ -12,7 +13,7 @@ module.exports = createReactClass
   displayName: 'TalkModerations'
 
   contextTypes:
-    router: React.PropTypes.object.isRequired
+    router: PropTypes.object.isRequired
 
   getInitialState: ->
     moderations: []

--- a/app/talk/popular-tags.jsx
+++ b/app/talk/popular-tags.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import talkClient from 'panoptes-client/lib/talk-client';
 import { Link } from 'react-router';
@@ -89,16 +90,16 @@ export default class PopularTags extends React.Component {
 }
 
 PopularTags.propTypes = {
-  header: React.PropTypes.shape({
-    props: React.PropTypes.object,
-    type: React.PropTypes.string
+  header: PropTypes.shape({
+    props: PropTypes.object,
+    type: PropTypes.string
   }),
-  project: React.PropTypes.shape({
-    slug: React.PropTypes.string
+  project: PropTypes.shape({
+    slug: PropTypes.string
   }),
-  section: React.PropTypes.string.isRequired
+  section: PropTypes.string.isRequired
 };
 
 PopularTags.contextTypes = {
-  geordi: React.PropTypes.object
+  geordi: PropTypes.object
 };

--- a/app/talk/private-message-form.cjsx
+++ b/app/talk/private-message-form.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 ReactDOM = require 'react-dom'
 apiClient = require 'panoptes-client/lib/api-client'
@@ -9,8 +10,8 @@ module.exports = createReactClass
   displayName: 'PrivateMessageForm'
 
   contextTypes:
-    geordi: React.PropTypes.object
-    router: React.PropTypes.object.isRequired
+    geordi: PropTypes.object
+    router: PropTypes.object.isRequired
 
   logClick: ->
     @context?.geordi?.logEvent

--- a/app/talk/quick-subject-comment-form.cjsx
+++ b/app/talk/quick-subject-comment-form.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 CommentBox = require './comment-box'
 talkClient = require 'panoptes-client/lib/talk-client'
@@ -21,15 +22,15 @@ module.exports = createReactClass
   displayName: 'TalkQuickSubjectCommentForm'
 
   propTypes:
-    params: React.PropTypes.shape({
-      name: React.PropTypes.string.isRequired,
-      owner: React.PropTypes.string.isRequired
+    params: PropTypes.shape({
+      name: PropTypes.string.isRequired,
+      owner: PropTypes.string.isRequired
     }).isRequired
-    subject: React.PropTypes.object
-    user: React.PropTypes.object
+    subject: PropTypes.object
+    user: PropTypes.object
 
   contextTypes:
-    router: React.PropTypes.object.isRequired
+    router: PropTypes.object.isRequired
 
   getInitialState: ->
     commentValidationErrors: []

--- a/app/talk/recents.cjsx
+++ b/app/talk/recents.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 Comment = require './comment'
 {Link} = require 'react-router'
@@ -13,7 +14,7 @@ module.exports = createReactClass
   displayName: 'TalkRecents'
 
   contextTypes:
-    router: React.PropTypes.object.isRequired
+    router: PropTypes.object.isRequired
 
   getInitialState: ->
     comments: []

--- a/app/talk/search-input.cjsx
+++ b/app/talk/search-input.cjsx
@@ -1,17 +1,18 @@
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 
 module.exports = createReactClass
   displayName: 'TalkSearchInput'
 
   propTypes:
-    params: React.PropTypes.object
-    query: React.PropTypes.object
-    placeholder: React.PropTypes.string
+    params: PropTypes.object
+    query: PropTypes.object
+    placeholder: PropTypes.string
 
   contextTypes:
-    geordi: React.PropTypes.object
-    router: React.PropTypes.object.isRequired
+    geordi: PropTypes.object
+    router: PropTypes.object.isRequired
 
   logSearch: (value) ->
     @context?.geordi?.logEvent

--- a/app/talk/search-result.jsx
+++ b/app/talk/search-result.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Markdown } from 'markdownz';
 import { Link } from 'react-router';
@@ -72,12 +73,12 @@ TalkSearchResult.defaultProps = {
 };
 
 TalkSearchResult.propTypes = {
-  data: React.PropTypes.shape({
-    board_id: React.PropTypes.string,
-    discussion_comments_count: React.PropTypes.number,
-    discussion_id: React.PropTypes.string,
-    discussion_title: React.PropTypes.string,
-    discussion_users_count: React.PropTypes.number
+  data: PropTypes.shape({
+    board_id: PropTypes.string,
+    discussion_comments_count: PropTypes.number,
+    discussion_id: PropTypes.string,
+    discussion_title: PropTypes.string,
+    discussion_users_count: PropTypes.number
   }),
-  project: React.PropTypes.object
+  project: PropTypes.object
 };

--- a/app/talk/search.cjsx
+++ b/app/talk/search.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 talkClient = require 'panoptes-client/lib/talk-client'
 Paginator = require './lib/paginator'
@@ -25,8 +26,8 @@ module.exports = createReactClass
   displayName: 'TalkSearch'
 
   contextTypes:
-    geordi: React.PropTypes.object
-    router: React.PropTypes.object.isRequired
+    geordi: PropTypes.object
+    router: PropTypes.object.isRequired
 
   goBack: (linkName) ->
     @context.router.goBack()

--- a/app/talk/suggester.cjsx
+++ b/app/talk/suggester.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 ReactDOM = require 'react-dom'
 talkClient = require 'panoptes-client/lib/talk-client'
@@ -9,8 +10,8 @@ module.exports = createReactClass
   displayName: 'Suggester'
 
   propTypes:
-    input: React.PropTypes.string.isRequired
-    onSelect: React.PropTypes.func
+    input: PropTypes.string.isRequired
+    onSelect: PropTypes.func
 
   getDefaultProps: ->
     onSelect: ->

--- a/app/talk/tags.cjsx
+++ b/app/talk/tags.cjsx
@@ -1,4 +1,5 @@
 React = require 'react'
+PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 {Link} = require 'react-router'
 talkClient = require 'panoptes-client/lib/talk-client'
@@ -17,7 +18,7 @@ module.exports = createReactClass
   displayName: 'TalkTags'
 
   contextTypes:
-    router: React.PropTypes.object.isRequired
+    router: PropTypes.object.isRequired
 
   getInitialState: ->
     tags: null

--- a/package-lock.json
+++ b/package-lock.json
@@ -7519,12 +7519,29 @@
       }
     },
     "prop-types": {
-      "version": "15.5.10",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.5.10.tgz",
-      "integrity": "sha1-J5ffwxJhguOpXj37suiT3ddFYVQ=",
+      "version": "15.6.0",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.0.tgz",
+      "integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
       "requires": {
-        "fbjs": "0.8.12",
-        "loose-envify": "1.3.1"
+        "fbjs": "0.8.16",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1"
+      },
+      "dependencies": {
+        "fbjs": {
+          "version": "0.8.16",
+          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
+          "integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
+          "requires": {
+            "core-js": "1.2.7",
+            "isomorphic-fetch": "2.2.1",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1",
+            "promise": "7.3.0",
+            "setimmediate": "1.0.5",
+            "ua-parser-js": "0.7.12"
+          }
+        }
       }
     },
     "proxy-addr": {
@@ -7735,7 +7752,7 @@
       "integrity": "sha1-2Dvat1YPAULnKj3h1JXatroiUkk=",
       "requires": {
         "dom-align": "1.6.2",
-        "prop-types": "15.5.10",
+        "prop-types": "15.6.0",
         "rc-util": "4.0.4"
       },
       "dependencies": {
@@ -7758,7 +7775,7 @@
       "requires": {
         "babel-runtime": "6.23.0",
         "css-animation": "1.3.2",
-        "prop-types": "15.5.10"
+        "prop-types": "15.6.0"
       }
     },
     "rc-slider": {
@@ -7778,7 +7795,7 @@
       "integrity": "sha1-7ZjeKntBLlJ8a9iiqX3d8Lq9LyE=",
       "requires": {
         "babel-runtime": "6.23.0",
-        "prop-types": "15.5.10",
+        "prop-types": "15.6.0",
         "rc-trigger": "1.11.2"
       }
     },
@@ -7789,7 +7806,7 @@
       "requires": {
         "babel-runtime": "6.23.0",
         "create-react-class": "15.6.0",
-        "prop-types": "15.5.10",
+        "prop-types": "15.6.0",
         "rc-align": "2.3.4",
         "rc-animate": "2.4.0",
         "rc-util": "4.0.4"
@@ -7873,7 +7890,7 @@
       "requires": {
         "deep-equal": "1.0.1",
         "object-assign": "4.1.1",
-        "prop-types": "15.5.10",
+        "prop-types": "15.6.0",
         "react-side-effect": "1.1.3"
       }
     },
@@ -7883,7 +7900,7 @@
       "integrity": "sha1-6SGQSXtAJsJ4CtDy/XA8g1ugPjM=",
       "requires": {
         "create-react-class": "15.6.0",
-        "prop-types": "15.5.10"
+        "prop-types": "15.6.0"
       }
     },
     "react-interpolate-component": {
@@ -7941,7 +7958,7 @@
         "lodash": "4.17.4",
         "lodash-es": "4.17.4",
         "loose-envify": "1.3.1",
-        "prop-types": "15.5.10"
+        "prop-types": "15.6.0"
       }
     },
     "react-router": {
@@ -7982,7 +7999,7 @@
       "integrity": "sha1-8Tc0YlD5JVyXn7+iGGCJmSh3I1A=",
       "requires": {
         "classnames": "2.2.5",
-        "prop-types": "15.5.10",
+        "prop-types": "15.6.0",
         "react-input-autosize": "2.0.1"
       }
     },
@@ -8008,7 +8025,7 @@
       "integrity": "sha1-lcrjHy104bSIbwH/y3KDezdbZus=",
       "requires": {
         "object-assign": "4.1.1",
-        "prop-types": "15.5.10",
+        "prop-types": "15.6.0",
         "swipe-js-iso": "2.0.3"
       }
     },

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "moment": "~2.18.1",
     "panoptes-client": "~2.7",
     "papaparse": "mholt/PapaParse#cada171",
+    "prop-types": "~15.6.0",
     "pusher-js": "~3.2.1",
     "qs": "~6.0.2",
     "rc-slider": "~3.3.2",


### PR DESCRIPTION
Staging branch URL:

Follow up to #4283 

Describe your changes.
Replace all instances of `React.PropTypes` with `PropTypes` from the `prop-types` module.

Made use of similar python script referenced in #4283 to replicate behaviour [of the react-codemod](https://github.com/reactjs/react-codemod#react-proptypes-to-prop-types) for coffeescript.

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
