### PR TITLE
Use External Link Icon on Redirect Button

### DIFF
--- a/app/pages/project/home/project-home.jsx
+++ b/app/pages/project/home/project-home.jsx
@@ -59,8 +59,8 @@ const ProjectHomePage = (props) => {
             </Link>}
           {props.project && props.project.redirect &&
             <a href={props.project.redirect} className="project-home-page__button">
+              <strong><Translate content="project.home.visitLink" /></strong>
               <i className="fa fa-external-link" />
-              <strong><Translate content="project.home.visitLink" /></strong><br />
             </a>}
         </div>
 

--- a/app/pages/project/home/project-home.jsx
+++ b/app/pages/project/home/project-home.jsx
@@ -59,8 +59,8 @@ const ProjectHomePage = (props) => {
             </Link>}
           {props.project && props.project.redirect &&
             <a href={props.project.redirect} className="project-home-page__button">
+              <i className="fa fa-external-link" />
               <strong><Translate content="project.home.visitLink" /></strong><br />
-              <small>at {props.project.redirect}</small>
             </a>}
         </div>
 

--- a/css/project-page.styl
+++ b/css/project-page.styl
@@ -171,7 +171,10 @@
   &__call-to-action
     text-align: center
     padding: 5vh 10vw 15vh 10vw
-    
+
+    i
+      margin-right: 0.25em
+
     .call-to-action__button
       border: 2px solid white
 
@@ -222,7 +225,7 @@
       background-color: white
       box-shadow: 0 3px 3px 0px rgb(239,242,245)
       position: relative
-      
+
       .workflow-choice-container__call-to-action
         display: block
 

--- a/css/project-page.styl
+++ b/css/project-page.styl
@@ -173,7 +173,7 @@
     padding: 5vh 10vw 15vh 10vw
 
     i
-      margin-right: 0.25em
+      margin-left: 0.5em
 
     .call-to-action__button
       border: 2px solid white


### PR DESCRIPTION
Staging branch URL: https://external-link-icon.pfe-preview.zooniverse.org/

Describe your changes.
After merging #4285, it was decided that an external link icon would be a better solution that a URL.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
