### PR TITLE
Revert "Remove classification change listener"

### DIFF
--- a/app/classifier/task-nav.jsx
+++ b/app/classifier/task-nav.jsx
@@ -51,9 +51,8 @@ class TaskNav extends React.Component {
       }
     }
 
-    const annotations = classification.annotations.slice();
-    annotations.push(annotation);
-    this.props.updateAnnotations(annotations);
+    classification.annotations.push(annotation);
+    classification.update('annotations');
   }
 
   // Done
@@ -98,9 +97,8 @@ class TaskNav extends React.Component {
     const { workflow, classification } = this.props;
     const lastAnnotation = classification.annotations[classification.annotations.length - 1];
 
-    const annotations = classification.annotations.slice();
-    annotations.pop();
-    this.props.updateAnnotations(annotations);
+    classification.annotations.pop();
+    classification.update('annotations');
 
     if (workflow.configuration.persist_annotations) {
       CacheClassification.update(lastAnnotation);
@@ -255,7 +253,6 @@ TaskNav.propTypes = {
   task: React.PropTypes.shape({
     type: React.PropTypes.string
   }),
-  updateAnnotations: React.PropTypes.func,
   workflow: React.PropTypes.shape({
     id: React.PropTypes.string,
     configuration: React.PropTypes.object,
@@ -265,8 +262,7 @@ TaskNav.propTypes = {
 };
 
 TaskNav.defaultProps = {
-  disabled: false,
-  updateAnnotations: () => null
+  disabled: false
 };
 
 export default TaskNav;

--- a/app/classifier/task.jsx
+++ b/app/classifier/task.jsx
@@ -11,9 +11,8 @@ class Task extends React.Component {
 
   handleAnnotationChange(newAnnotation) {
     const { classification } = this.props;
-    const annotations = classification.annotations.slice();
-    annotations[annotations.length - 1] = newAnnotation;
-    this.props.updateAnnotations(annotations);
+    classification.annotations[classification.annotations.length - 1] = newAnnotation;
+    classification.update('annotations');
   }
 
   render() {
@@ -47,7 +46,7 @@ class Task extends React.Component {
       taskTypes: tasks,
       workflow,
       classification,
-      onChange: () => this.handleAnnotationChange
+      onChange: () => classification.update()
     };
 
     return (
@@ -123,17 +122,12 @@ Task.propTypes = {
   task: React.PropTypes.shape({
     type: React.PropTypes.string
   }),
-  updateAnnotations: React.PropTypes.func,
   user: React.PropTypes.shape({
     id: React.PropTypes.string
   }),
   workflow: React.PropTypes.shape({
     id: React.PropTypes.string
   })
-};
-
-Task.defaultProps = {
-  updateAnnotations: () => null
 };
 
 export default Task;

--- a/app/classifier/tasks/crop/initializer.cjsx
+++ b/app/classifier/tasks/crop/initializer.cjsx
@@ -42,7 +42,7 @@ module.exports = React.createClass
     {x, y} = @props.getEventOffset e
     _start = {x, y}
     @props.annotation.value = {x, y, width: 0, height: 0, _start}
-    @props.onChange @props.annotation
+    @props.classification.update 'annotation'
 
   handleInitDrag: (e) ->
     {x, y} = @props.getEventOffset e
@@ -53,7 +53,7 @@ module.exports = React.createClass
     @props.annotation.value.y = Math.min _start.y, y
     @props.annotation.value.width = Math.abs _start.x - x
     @props.annotation.value.height = Math.abs _start.y - y
-    @props.onChange @props.annotation
+    @props.classification.update 'annotation'
 
   handleBoxDrag: (e, d) ->
     difference = @props.normalizeDifference(e, d)
@@ -61,7 +61,7 @@ module.exports = React.createClass
     maxY = (@props.containerRect.height / @props.scale.vertical) - @props.annotation.value.height
     @props.annotation.value.x = Math.max 0, Math.min maxX, @props.annotation.value.x += difference.x
     @props.annotation.value.y = Math.max 0, Math.min maxY, @props.annotation.value.y += difference.y
-    @props.onChange @props.annotation
+    @props.classification.update 'annotations'
 
   handleStartHandle: (e) ->
     mouse = @props.getEventOffset e
@@ -78,7 +78,7 @@ module.exports = React.createClass
     diff = _start.mouse[coord] - mouse[coord]
     @props.annotation.value[coord] = Math.min _start.mouse[coord] + _start.rect[dimension], mouse[coord]
     @props.annotation.value[dimension] = Math.abs _start.rect[dimension] + diff
-    @props.onChange @props.annotation
+    @props.classification.update 'annotation'
 
   handleDragFar: (coord, e) ->
     dimension = {x: 'width', y: 'height'}[coord]
@@ -89,4 +89,4 @@ module.exports = React.createClass
     diff = _start.mouse[coord] - mouse[coord]
     @props.annotation.value[coord] = Math.min _start.rect[coord], mouse[coord]
     @props.annotation.value[dimension] = Math.abs _start.rect[dimension] - diff
-    @props.onChange @props.annotation
+    @props.classification.update 'annotation'

--- a/app/classifier/tasks/drawing/marking-initializer.cjsx
+++ b/app/classifier/tasks/drawing/marking-initializer.cjsx
@@ -63,7 +63,7 @@ module.exports = React.createClass
       for key, value of initValues
         mark[key] = value
 
-    @props.onChange @props.annotation
+    @props.classification.update 'annotations'
 
   handleInitDrag: (e) ->
     taskDescription = @props.workflow.tasks[@props.annotation.task]
@@ -76,7 +76,7 @@ module.exports = React.createClass
       for key, value of initMoveValues
         mark[key] = value
 
-    @props.onChange @props.annotation
+    @props.classification.update 'annotations'
 
   handleInitRelease: (e) ->
     pref = @props.preferences.preferences
@@ -101,7 +101,7 @@ module.exports = React.createClass
         unless MarkComponent.initValid multiple, @props
           @destroyMark @props.annotation, multiple
 
-    @props.onChange @props.annotation
+    @props.classification.update 'annotations'
 
     if MarkComponent.initValid?
       unless MarkComponent.initValid mark, @props
@@ -112,4 +112,4 @@ module.exports = React.createClass
       @setState selectedMark: null
     markIndex = annotation.value.indexOf mark
     annotation.value.splice markIndex, 1
-    @props.onChange annotation
+    @props.classification.update 'annotations'

--- a/app/classifier/tasks/drawing/markings-renderer.cjsx
+++ b/app/classifier/tasks/drawing/markings-renderer.cjsx
@@ -113,7 +113,7 @@ module.exports = React.createClass
     markIndex = annotation.value.indexOf mark
     annotation.value.splice markIndex, 1
     annotation.value.push mark
-    @props.onChange annotation
+    @props.classification.update 'annotations'
 
   handleDeselect: ->
     @setState selection: null
@@ -123,11 +123,11 @@ module.exports = React.createClass
       @setState selection: null
     markIndex = annotation.value.indexOf mark
     annotation.value.splice markIndex, 1
-    @props.onChange annotation
+    @props.classification.update 'annotations'
     if mark.templateID
       index = []
       for cell in annotation.value
         if cell.templateID is mark.templateID
           index.push(annotation.value.indexOf cell)
       annotation.value.splice index[0], index.length
-      @props.onChange annotation
+      @props.classification.update 'annotations'

--- a/app/classifier/tasks/highlighter/label-editor.jsx
+++ b/app/classifier/tasks/highlighter/label-editor.jsx
@@ -4,7 +4,7 @@ export default function LabelEditor(props) {
   function deleteAnnotation(annotation) {
     const index = props.annotation.value.indexOf(annotation);
     props.annotation.value.splice(index, 1);
-    props.onChange(props.annotation);
+    props.classification.update('annotations');
   }
 
   function onClick(e) {

--- a/app/classifier/tasks/survey/annotation-view.cjsx
+++ b/app/classifier/tasks/survey/annotation-view.cjsx
@@ -32,4 +32,4 @@ module.exports = React.createClass
 
   handleRemove: (index) ->
     @props.annotation.value.splice index, 1
-    @props.onChange @props.annotation
+    @props.classification.update 'annotations'


### PR DESCRIPTION
Reverts zooniverse/Panoptes-Front-End#4277

This didn't handle shortcut tasks properly and thus broke some existing workflows, notably project plumage as reported here https://www.zooniverse.org/talk/18/522232?comment=867269 