### PR TITLE
Remove classification change listener

### DIFF
--- a/app/classifier/task-nav.jsx
+++ b/app/classifier/task-nav.jsx
@@ -52,8 +52,9 @@ class TaskNav extends React.Component {
       }
     }
 
-    classification.annotations.push(annotation);
-    classification.update('annotations');
+    const annotations = classification.annotations.slice();
+    annotations.push(annotation);
+    this.props.updateAnnotations(annotations);
   }
 
   // Done
@@ -98,8 +99,9 @@ class TaskNav extends React.Component {
     const { workflow, classification } = this.props;
     const lastAnnotation = classification.annotations[classification.annotations.length - 1];
 
-    classification.annotations.pop();
-    classification.update('annotations');
+    const annotations = classification.annotations.slice();
+    annotations.pop();
+    this.props.updateAnnotations(annotations);
 
     if (workflow.configuration.persist_annotations) {
       CacheClassification.update(lastAnnotation);
@@ -254,6 +256,7 @@ TaskNav.propTypes = {
   task: PropTypes.shape({
     type: PropTypes.string
   }),
+  updateAnnotations: PropTypes.func,
   workflow: PropTypes.shape({
     id: PropTypes.string,
     configuration: PropTypes.object,
@@ -263,7 +266,8 @@ TaskNav.propTypes = {
 };
 
 TaskNav.defaultProps = {
-  disabled: false
+  disabled: false,
+  updateAnnotations: () => null
 };
 
 export default TaskNav;

--- a/app/classifier/task.jsx
+++ b/app/classifier/task.jsx
@@ -48,15 +48,14 @@ class Task extends React.Component {
       taskTypes: tasks,
       workflow,
       classification,
-      onChange: () => this.handleAnnotationChange
+      onChange: this.handleAnnotationChange
     };
 
     return (
       <div className="task-container" style={this.props.subjectLoading ? disabledStyle : null}>
         <div className="coverable-task-container">
           {persistentHooksBeforeTask.map((HookComponent, i) => {
-            const key = i + Math.random();
-            return (<HookComponent key={key} {...taskHookProps} />);
+            return (<HookComponent key={i} {...taskHookProps} />);
           })}
 
           {!!annotation &&
@@ -77,8 +76,7 @@ class Task extends React.Component {
           }
 
           {persistentHooksAfterTask.map((HookComponent, i) => {
-            const key = i + Math.random();
-            return (<HookComponent key={key} {...taskHookProps} />);
+            return (<HookComponent key={i} {...taskHookProps} />);
           })}
 
           <hr />

--- a/app/classifier/task.jsx
+++ b/app/classifier/task.jsx
@@ -12,8 +12,9 @@ class Task extends React.Component {
 
   handleAnnotationChange(newAnnotation) {
     const { classification } = this.props;
-    classification.annotations[classification.annotations.length - 1] = newAnnotation;
-    classification.update('annotations');
+    const annotations = classification.annotations.slice();
+    annotations[annotations.length - 1] = newAnnotation;
+    this.props.updateAnnotations(annotations);
   }
 
   render() {
@@ -47,7 +48,7 @@ class Task extends React.Component {
       taskTypes: tasks,
       workflow,
       classification,
-      onChange: () => classification.update()
+      onChange: () => this.handleAnnotationChange
     };
 
     return (
@@ -123,12 +124,17 @@ Task.propTypes = {
   task: PropTypes.shape({
     type: PropTypes.string
   }),
+  updateAnnotations: PropTypes.func,
   user: PropTypes.shape({
     id: PropTypes.string
   }),
   workflow: PropTypes.shape({
     id: PropTypes.string
   })
+};
+
+Task.defaultProps = {
+  updateAnnotations: () => null
 };
 
 export default Task;

--- a/app/classifier/tasks/crop/initializer.cjsx
+++ b/app/classifier/tasks/crop/initializer.cjsx
@@ -43,7 +43,7 @@ module.exports = createReactClass
     {x, y} = @props.getEventOffset e
     _start = {x, y}
     @props.annotation.value = {x, y, width: 0, height: 0, _start}
-    @props.classification.update 'annotation'
+    @props.onChange @props.annotation
 
   handleInitDrag: (e) ->
     {x, y} = @props.getEventOffset e
@@ -54,7 +54,7 @@ module.exports = createReactClass
     @props.annotation.value.y = Math.min _start.y, y
     @props.annotation.value.width = Math.abs _start.x - x
     @props.annotation.value.height = Math.abs _start.y - y
-    @props.classification.update 'annotation'
+    @props.onChange @props.annotation
 
   handleBoxDrag: (e, d) ->
     difference = @props.normalizeDifference(e, d)
@@ -62,7 +62,7 @@ module.exports = createReactClass
     maxY = (@props.containerRect.height / @props.scale.vertical) - @props.annotation.value.height
     @props.annotation.value.x = Math.max 0, Math.min maxX, @props.annotation.value.x += difference.x
     @props.annotation.value.y = Math.max 0, Math.min maxY, @props.annotation.value.y += difference.y
-    @props.classification.update 'annotations'
+    @props.onChange @props.annotation
 
   handleStartHandle: (e) ->
     mouse = @props.getEventOffset e
@@ -79,7 +79,7 @@ module.exports = createReactClass
     diff = _start.mouse[coord] - mouse[coord]
     @props.annotation.value[coord] = Math.min _start.mouse[coord] + _start.rect[dimension], mouse[coord]
     @props.annotation.value[dimension] = Math.abs _start.rect[dimension] + diff
-    @props.classification.update 'annotation'
+    @props.onChange @props.annotation
 
   handleDragFar: (coord, e) ->
     dimension = {x: 'width', y: 'height'}[coord]
@@ -90,4 +90,4 @@ module.exports = createReactClass
     diff = _start.mouse[coord] - mouse[coord]
     @props.annotation.value[coord] = Math.min _start.rect[coord], mouse[coord]
     @props.annotation.value[dimension] = Math.abs _start.rect[dimension] - diff
-    @props.classification.update 'annotation'
+    @props.onChange @props.annotation

--- a/app/classifier/tasks/drawing/hide-previous-marks-toggle.cjsx
+++ b/app/classifier/tasks/drawing/hide-previous-marks-toggle.cjsx
@@ -15,7 +15,9 @@ HidePreviousMarksToggle = createReactClass
     @props.classification._hideMarksBefore = count
     checked = count > 0
     @setState { checked }
-    # this is a hack to force the parent to render again with marks hidden
+    @updateParent()
+
+  updateParent: () ->
     annotations = @props.classification.annotations.slice()
     annotation = annotations[annotations.length - 1]
     @props.onChange annotation

--- a/app/classifier/tasks/drawing/hide-previous-marks-toggle.cjsx
+++ b/app/classifier/tasks/drawing/hide-previous-marks-toggle.cjsx
@@ -8,18 +8,17 @@ HidePreviousMarksToggle = createReactClass
     classification: null
     onChange: ->
 
-  componentDidMount: ->
-    @_lastKnownAnnotationCount = @props.classification.annotations.length
-
-  componentWillReceiveProps: (nextProps) ->
-    # Automatically un-hide previous marks.
-    if nextProps.classification.annotations.length isnt @_lastKnownAnnotationCount
-      @setPreviousMarks 0
+  getInitialState: ->
+    checked: false
 
   setPreviousMarks: (count) ->
-    @_lastKnownAnnotationCount = @props.classification.annotations.length
     @props.classification._hideMarksBefore = count
-    @props.onChange @props.classification
+    checked = count > 0
+    @setState { checked }
+    # this is a hack to force the parent to render again with marks hidden
+    annotations = @props.classification.annotations.slice()
+    annotation = annotations[annotations.length - 1]
+    @props.onChange annotation
 
   render: ->
     annotations = @props.classification.annotations
@@ -29,8 +28,6 @@ HidePreviousMarksToggle = createReactClass
 
     DrawingTaskComponent = require '.' # Circular
 
-    currentlyHidingMarks = @props.classification._hideMarksBefore > 0
-
     marksCount = 0
     annotations.forEach (annotation) =>
       taskDescription = @props.workflow.tasks[annotation.task]
@@ -38,7 +35,7 @@ HidePreviousMarksToggle = createReactClass
       if TaskComponent is DrawingTaskComponent
         marksCount += annotation.value.length
 
-    nextValueToSet = if currentlyHidingMarks
+    nextValueToSet = if @state.checked
       0
     else
       marksCount
@@ -48,8 +45,8 @@ HidePreviousMarksToggle = createReactClass
       color: 'white'
 
     <div>
-      <label style={checkedStyle if currentlyHidingMarks}>
-        <input type="checkbox" checked={currentlyHidingMarks} disabled={marksCount is 0} onChange={@setPreviousMarks.bind this, nextValueToSet} />{' '}
+      <label style={checkedStyle if @state.checked}>
+        <input type="checkbox" checked={@state.checked} disabled={marksCount is 0} onChange={@setPreviousMarks.bind this, nextValueToSet} />{' '}
         Hide previous marks {if marksCount > 0 then '(' + marksCount + ')' }
       </label>
     </div>

--- a/app/classifier/tasks/drawing/marking-initializer.cjsx
+++ b/app/classifier/tasks/drawing/marking-initializer.cjsx
@@ -65,7 +65,7 @@ module.exports = createReactClass
       for key, value of initValues
         mark[key] = value
 
-    @props.onChange @props.annotation
+    @onChange()
 
   handleInitDrag: (e) ->
     taskDescription = @props.workflow.tasks[@props.annotation.task]
@@ -78,7 +78,7 @@ module.exports = createReactClass
       for key, value of initMoveValues
         mark[key] = value
 
-    @props.onChange @props.annotation
+    @onChange()
 
   handleInitRelease: (e) ->
     pref = @props.preferences.preferences
@@ -103,7 +103,7 @@ module.exports = createReactClass
         unless MarkComponent.initValid multiple, @props
           @destroyMark @props.annotation, multiple
 
-    @props.onChange @props.annotation
+    @onChange()
 
     if MarkComponent.initValid?
       unless MarkComponent.initValid mark, @props
@@ -114,4 +114,9 @@ module.exports = createReactClass
       @setState selectedMark: null
     markIndex = annotation.value.indexOf mark
     annotation.value.splice markIndex, 1
-    @props.onChange annotation
+    @onChange()
+  
+  onChange: () ->
+    annotations = @props.classification.annotations.slice()
+    newAnnotation = annotations[annotations.length - 1]
+    @props.onChange newAnnotation

--- a/app/classifier/tasks/drawing/marking-initializer.cjsx
+++ b/app/classifier/tasks/drawing/marking-initializer.cjsx
@@ -65,7 +65,7 @@ module.exports = createReactClass
       for key, value of initValues
         mark[key] = value
 
-    @props.classification.update 'annotations'
+    @props.onChange @props.annotation
 
   handleInitDrag: (e) ->
     taskDescription = @props.workflow.tasks[@props.annotation.task]
@@ -78,7 +78,7 @@ module.exports = createReactClass
       for key, value of initMoveValues
         mark[key] = value
 
-    @props.classification.update 'annotations'
+    @props.onChange @props.annotation
 
   handleInitRelease: (e) ->
     pref = @props.preferences.preferences
@@ -103,7 +103,7 @@ module.exports = createReactClass
         unless MarkComponent.initValid multiple, @props
           @destroyMark @props.annotation, multiple
 
-    @props.classification.update 'annotations'
+    @props.onChange @props.annotation
 
     if MarkComponent.initValid?
       unless MarkComponent.initValid mark, @props
@@ -114,4 +114,4 @@ module.exports = createReactClass
       @setState selectedMark: null
     markIndex = annotation.value.indexOf mark
     annotation.value.splice markIndex, 1
-    @props.classification.update 'annotations'
+    @props.onChange annotation

--- a/app/classifier/tasks/drawing/markings-renderer.cjsx
+++ b/app/classifier/tasks/drawing/markings-renderer.cjsx
@@ -114,7 +114,7 @@ module.exports = createReactClass
     markIndex = annotation.value.indexOf mark
     annotation.value.splice markIndex, 1
     annotation.value.push mark
-    @props.classification.update 'annotations'
+    @props.onChange annotation
 
   handleDeselect: ->
     @setState selection: null
@@ -124,11 +124,11 @@ module.exports = createReactClass
       @setState selection: null
     markIndex = annotation.value.indexOf mark
     annotation.value.splice markIndex, 1
-    @props.classification.update 'annotations'
+    @props.onChange annotation
     if mark.templateID
       index = []
       for cell in annotation.value
         if cell.templateID is mark.templateID
           index.push(annotation.value.indexOf cell)
       annotation.value.splice index[0], index.length
-      @props.classification.update 'annotations'
+      @props.onChange annotation

--- a/app/classifier/tasks/highlighter/label-editor.jsx
+++ b/app/classifier/tasks/highlighter/label-editor.jsx
@@ -5,7 +5,7 @@ export default function LabelEditor(props) {
   function deleteAnnotation(annotation) {
     const index = props.annotation.value.indexOf(annotation);
     props.annotation.value.splice(index, 1);
-    props.classification.update('annotations');
+    props.onChange(props.annotation);
   }
 
   function onClick(e) {

--- a/app/classifier/tasks/survey/annotation-view.cjsx
+++ b/app/classifier/tasks/survey/annotation-view.cjsx
@@ -33,4 +33,4 @@ module.exports = createReactClass
 
   handleRemove: (index) ->
     @props.annotation.value.splice index, 1
-    @props.classification.update 'annotations'
+    @props.onChange @props.annotation


### PR DESCRIPTION
Staging branch URL: https://classification-update.pfe-preview.zooniverse.org

Fixes #4296

Repeat of #4277 but this should properly account for drawing tasks when they are used as part of combo tasks.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
