### PR TITLE
Tear down tests properly

### DIFF
--- a/app/collections/collaborators.spec.js
+++ b/app/collections/collaborators.spec.js
@@ -47,15 +47,15 @@ const owner = {
   id: '3'
 };
 
-describe('<CollectionCollaborators />', function() {
+describe('<CollectionCollaborators />', function () {
   let wrapper;
   let addUserSpy;
   let deleteUserSpy;
-  let stub;
+  let componentDidMountStub;
   before(function () {
     addUserSpy = sinon.spy(RoleCreator.prototype, 'handleSubmit');
     deleteUserSpy = sinon.spy(RoleRow.prototype, 'confirmDelete');
-    stub = sinon.stub(CollectionCollaborators.prototype, 'componentDidMount');
+    componentDidMountStub = sinon.stub(CollectionCollaborators.prototype, 'componentDidMount');
     wrapper = mount(<CollectionCollaborators owner={owner} />, { context: { router: {} } });
     wrapper.setState({ hasSettingsRole: true, roleSets });
   });
@@ -63,7 +63,7 @@ describe('<CollectionCollaborators />', function() {
   after(() => {
     addUserSpy.restore();
     deleteUserSpy.restore();
-    stub.restore();
+    componentDidMountStub.restore();
   });
 
   it('should render without crashing', function() {

--- a/app/collections/collaborators.spec.js
+++ b/app/collections/collaborators.spec.js
@@ -51,13 +51,18 @@ describe('<CollectionCollaborators />', function() {
   let wrapper;
   let addUserSpy;
   let deleteUserSpy;
-
-  before(function() {
+  let stub;
+  before(function () {
     addUserSpy = sinon.spy(RoleCreator.prototype, 'handleSubmit');
     deleteUserSpy = sinon.spy(RoleRow.prototype, 'confirmDelete');
-    const stub = sinon.stub(CollectionCollaborators.prototype, 'componentDidMount');
+    stub = sinon.stub(CollectionCollaborators.prototype, 'componentDidMount');
     wrapper = mount(<CollectionCollaborators owner={owner} />, { context: { router: {} } });
     wrapper.setState({ hasSettingsRole: true, roleSets });
+  });
+
+  after(() => {
+    addUserSpy.restore();
+    deleteUserSpy.restore();
     stub.restore();
   });
 

--- a/app/collections/collections-create-form.spec.js
+++ b/app/collections/collections-create-form.spec.js
@@ -20,6 +20,12 @@ describe('<CollectionsCreateForm />', function () {
     wrapper = shallow(<CollectionsCreateForm />);
   });
 
+  after(() => {
+    handleDescriptionInputChangeStub.restore();
+    handleNameInputChangeStub.restore();
+    onSubmitStub.restore();
+  });
+
   it('should render without crashing', function () {
     assert.equal(wrapper, wrapper);
   });

--- a/app/collections/collections-manager.spec.js
+++ b/app/collections/collections-manager.spec.js
@@ -24,7 +24,7 @@ const searchNode = {
   getSelected() { return selectedCollection; }
 };
 
-describe('<CollectionsManager />', function() {
+describe('<CollectionsManager />', function () {
   let wrapper;
   let addToCollectionsSpy;
   let addButton;
@@ -33,6 +33,10 @@ describe('<CollectionsManager />', function() {
     addToCollectionsSpy = sinon.spy(CollectionsManager.prototype, 'addToCollections');
     wrapper = shallow(<CollectionsManager subjectIDs={subjectIDs} project={project} />);
     addButton = wrapper.find('.search-button');
+  });
+
+  after(() => {
+    addToCollectionsSpy.restore();
   });
 
   it('should render without crashing', function() {

--- a/app/collections/favorites-button.spec.js
+++ b/app/collections/favorites-button.spec.js
@@ -6,7 +6,7 @@ import FavoritesButton from './favorites-button';
 
 const subject = { id: '4' };
 
-describe('<Favorites Button />', function() {
+describe('<Favorites Button />', function () {
   let wrapper;
   let toggleFavoriteSpy;
   let button;
@@ -16,6 +16,10 @@ describe('<Favorites Button />', function() {
     wrapper = shallow(<FavoritesButton subject={subject} />);
     button = wrapper.find('button');
     icon = wrapper.find('i');
+  });
+
+  after(() => {
+    toggleFavoriteSpy.restore();
   });
 
   it('should render a button and an icon', function() {

--- a/app/collections/settings.spec.js
+++ b/app/collections/settings.spec.js
@@ -40,6 +40,10 @@ describe('<CollectionSettings />', function () {
     );
     deleteButton = wrapper.find('button.error');
   });
+  after(() => {
+    confirmationSpy.restore();
+    handleDescriptionInputChangeStub.restore();
+  });
 
   it('should render without crashing', function () {
     assert.equal(wrapper, wrapper);

--- a/app/components/filmstrip.spec.js
+++ b/app/components/filmstrip.spec.js
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import { mount } from 'enzyme';
 import Filmstrip from './filmstrip';
 
-describe('if loading an image subject', function() {
+describe('if loading an image subject', function () {
   let wrapper;
   let positionSpy;
   let filterChange;
@@ -13,6 +13,11 @@ describe('if loading an image subject', function() {
     filterChange = sinon.spy(Filmstrip.prototype, 'selectFilter');
     positionSpy = sinon.spy(Filmstrip.prototype, 'scrollRight');
     wrapper = mount(<Filmstrip increment={350} onChange={function (a) { return a; }} value={''} />);
+  });
+
+  after(() => {
+    filterChange.restore();
+    positionSpy.restore();
   });
 
   it('will show all disciplines without a filter value', function () {

--- a/app/pages/admin/project-status.spec.js
+++ b/app/pages/admin/project-status.spec.js
@@ -47,6 +47,12 @@ describe('ProjectStatus', () => {
     wrapper = shallow(<ProjectStatus />);
   });
 
+  after(() => {
+    onChangeWorkflowLevelStub.restore();
+    handleDialogCancelStub.restore();
+    handleDialogSuccessStub.restore();
+  });
+
   it('renders without crashing', () => {
     assert.equal(wrapper, wrapper);
   });

--- a/app/pages/project/home/home-workflow-button.spec.js
+++ b/app/pages/project/home/home-workflow-button.spec.js
@@ -37,10 +37,13 @@ describe('ProjectHomeWorkflowButton', function() {
       />
     );
   });
+  after(() => {
+    handleWorkflowSelectionSpy.restore();
+  });
 
-  it('renders without crashing', function() {});
+  it('renders without crashing', function () {});
 
-  it('renders a Link component', function() {
+  it('renders a Link component', function () {
     assert.equal(wrapper.find('Link').length, 1);
     assert.equal(wrapper.find('span').length, 0);
   });

--- a/app/pages/project/project-page.spec.js
+++ b/app/pages/project/project-page.spec.js
@@ -144,6 +144,11 @@ describe('ProjectPage', () => {
       sugarClientUnsubscribeSpy.resetHistory();
     });
 
+    after(() => {
+      sugarClientSubscribeSpy.restore();
+      sugarClientUnsubscribeSpy.restore();
+    });
+
     describe('on mount/unmount', () => {
       beforeEach(() => {
         wrapper = mount(

--- a/app/pages/settings/email.spec.js
+++ b/app/pages/settings/email.spec.js
@@ -8,6 +8,7 @@ import EmailSettings from './email';
 
 function mockTalkResource(type, options) {
   const resource = talkClient.type(type).create(options);
+  talkClient._typesCache = {};
   sinon.stub(resource, 'save').callsFake(() => Promise.resolve(resource));
   sinon.stub(resource, 'get');
   sinon.stub(resource, 'delete');

--- a/app/pages/settings/profile.spec.js
+++ b/app/pages/settings/profile.spec.js
@@ -34,6 +34,9 @@ describe('CustomiseProfile', () => {
     wrapper.update();
     clearMediaSpy.resetHistory();
   });
+  after(() => {
+    clearMediaSpy.restore();
+  });
 
   it('renders the user avatar', () => {
     const avatar = wrapper.find('ImageSelector[src="//zooniverse.org/images/avatar.jpg"]');

--- a/app/talk/discussion-comment.spec.js
+++ b/app/talk/discussion-comment.spec.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import assert from 'assert';
 import DiscussionComment from './discussion-comment';
-import CommentBox from './comment-box';
 import { shallow } from 'enzyme';
 
 const discussion = {
@@ -24,26 +23,27 @@ describe('DiscussionComment', function() {
         <button
           className="link-style"
           type="button"
-          onClick={wrapper.instance().promptToSignIn} >
-            sign in
+          onClick={wrapper.instance().promptToSignIn}
+        >
+          sign in
         </button>),
         true);
     });
   });
 
   describe('logged in', function() {
-    beforeEach(function(){
+    beforeEach(function() {
       wrapper = shallow(<DiscussionComment discussion={discussion} user={user} />);
     });
 
     it('will show a user avatar', function() {
       assert.equal(wrapper.find('.talk-comment-author').length, 1);
     });
-    it('will show a comment box', function(){
-      assert.equal(wrapper.find(CommentBox).props().user, user);
-    })
+    it('will show a comment box', function() {
+      assert.equal(wrapper.find('Commentbox').props().user, user);
+    });
   });
-  
+
   describe('comment validation', function(){
     it('will not allow empty comments', function(){
       // weirdly, comment validations returns true if validation fails.


### PR DESCRIPTION
This contains work necessary to [get the mocha `--watch` flag working](https://github.com/zooniverse/Panoptes-Front-End/pull/4233).

Describe your changes.
Clean up spies and stubs after the first test run.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
