### PR TITLE
lock react-select to 1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8295,9 +8295,9 @@
       }
     },
     "react-select": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/react-select/-/react-select-1.0.1.tgz",
-      "integrity": "sha512-488j7KOR/48OSfrOuQsGpZldY2Tuv2BIcaJ3uPZ4EgQDZnwyxGl4hCGkhsu8mkEGu38oPEjqoNacG+j/nktfWQ==",
+      "version": "1.0.0-rc.10",
+      "resolved": "https://registry.npmjs.org/react-select/-/react-select-1.0.0-rc.10.tgz",
+      "integrity": "sha1-8Tc0YlD5JVyXn7+iGGCJmSh3I1A=",
       "requires": {
         "classnames": "2.2.5",
         "prop-types": "15.6.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "react-rendered-size": "~1.1.0",
     "react-router": "~2.5.2",
     "react-router-scroll": "~0.3.2",
-    "react-select": "~1.0.0-rc.10",
+    "react-select": "1.0.0-rc.10",
     "react-sizes": "~0.4.3",
     "react-swipe": "~5.0.3",
     "react-translate-component": "~0.13.0",


### PR DESCRIPTION
ensure keyboard navigation works as expected for autocomplete select elements, reported to be broken in NFN https://www.zooniverse.org/talk/17/525366?comment=872032

Staging branch URL:

Fixes # .

Describe your changes.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
