### PR TITLE
Improve workflows page

### DIFF
--- a/app/pages/lab/workflows.jsx
+++ b/app/pages/lab/workflows.jsx
@@ -9,10 +9,11 @@ import Paginator from '../../talk/lib/paginator';
 
 const WorkflowsPage = (props) => {
   const renderWorkflow = ((workflow) => {
+    let progressPercentage = workflow.completeness * 100;
     return (
       <li key={workflow.id}>
         <Link key={workflow.id} to={props.labPath(`/workflows/${workflow.id}`)} className="nav-list-item" activeClassName="active">
-          {workflow.display_name}
+          {workflow.display_name}{' -- '}{`${progressPercentage.toFixed(0)} % Complete`}
           {(props.project.configuration && workflow.id === props.project.configuration.default_workflow) && (
             <span title="Default workflow">{' '}*{' '}</span>
           )}
@@ -33,8 +34,9 @@ const WorkflowsPage = (props) => {
       <p>A workflow is the sequence of tasks that you’re asking volunteers to perform.</p>
       <p>An asterisk (*) denotes a default workflow.</p>
       <p>If you have multiple workflows you can rearrange the order in which they are listed on your project's front page by clicking the reorder view button and then clicking and dragging on the left gray tab next to each workflow title listed below.</p>
+      <p>NOTE: Please leave at least one active workflow; even if all workflows are 100% complete.</p>
       <p>{reorderButton}</p>
-      
+
       {props.reorder &&
         <DragReorderable tag="ul" className="nav-list" items={props.workflows} render={renderWorkflow} onChange={props.handleWorkflowReorder} />}
 

--- a/app/pages/lab/workflows.jsx
+++ b/app/pages/lab/workflows.jsx
@@ -8,7 +8,7 @@ import LoadingIndicator from '../../components/loading-indicator';
 import Paginator from '../../talk/lib/paginator';
 
 const WorkflowsPage = (props) => {
-  const renderWorkflow = ((workflow) => {
+  const renderWorkflowTable = ((workflow) => {
     const progressPercentage = workflow.completeness * 100;
     return (
       <tr key={workflow.id}>
@@ -27,8 +27,21 @@ const WorkflowsPage = (props) => {
     );
   });
 
+  const renderWorkflowList = ((workflow) => {
+    return (
+      <li key={workflow.id}>
+        <Link key={workflow.id} to={props.labPath(`/workflows/${workflow.id}`)} className="nav-list-item" activeClassName="active">
+          {workflow.display_name}
+          {(props.project.configuration && workflow.id === props.project.configuration.default_workflow) && (
+            <span title="Default workflow">{' '}*{' '}</span>
+          )}
+        </Link>
+      </li>
+    );
+  });
+
   const reorderButton = props.reorder ?
-    <button type="button" data-button="reorderWorkflow" onClick={props.toggleReorder}>List view</button> :
+    <button type="button" data-button="reorderWorkflow" onClick={props.toggleReorder}>Table view</button> :
     <button type="button" data-button="reorderWorkflow" onClick={props.toggleReorder}>Reorder view</button>;
   const meta = props.workflows.length ? props.workflows[0].getMeta() : {};
 
@@ -43,7 +56,12 @@ const WorkflowsPage = (props) => {
       <p>{reorderButton}</p>
 
       {props.reorder &&
-        <DragReorderable tag="ul" className="nav-list" items={props.workflows} render={renderWorkflow} onChange={props.handleWorkflowReorder} />}
+        <DragReorderable
+          tag="ul" className="nav-list"
+          items={props.workflows}
+          render={renderWorkflowList}
+          onChange={props.handleWorkflowReorder}
+        />}
 
       {(!props.reorder && props.workflows.length > 0) &&
         <div>
@@ -55,7 +73,7 @@ const WorkflowsPage = (props) => {
               </tr>
             </thead>
             <tbody>
-              {props.workflows.map(workflow => renderWorkflow(workflow))}
+              {props.workflows.map(workflow => renderWorkflowTable(workflow))}
             </tbody>
           </table>
           <hr />

--- a/app/pages/lab/workflows.jsx
+++ b/app/pages/lab/workflows.jsx
@@ -9,16 +9,21 @@ import Paginator from '../../talk/lib/paginator';
 
 const WorkflowsPage = (props) => {
   const renderWorkflow = ((workflow) => {
-    let progressPercentage = workflow.completeness * 100;
+    const progressPercentage = workflow.completeness * 100;
     return (
-      <li key={workflow.id}>
-        <Link key={workflow.id} to={props.labPath(`/workflows/${workflow.id}`)} className="nav-list-item" activeClassName="active">
-          {workflow.display_name}{' -- '}{`${progressPercentage.toFixed(0)} % Complete`}
-          {(props.project.configuration && workflow.id === props.project.configuration.default_workflow) && (
-            <span title="Default workflow">{' '}*{' '}</span>
-          )}
-        </Link>
-      </li>
+      <tr key={workflow.id}>
+        <td>
+          <Link key={workflow.id} to={props.labPath(`/workflows/${workflow.id}`)}  activeClassName="active">
+            {workflow.display_name}
+            {(props.project.configuration && workflow.id === props.project.configuration.default_workflow) && (
+              <span title="Default workflow">{' '}*{' '}</span>
+            )}
+          </Link>
+        </td>
+        <td>
+          {`${progressPercentage.toFixed(0)} % Complete`}
+        </td>
+      </tr>
     );
   });
 
@@ -34,7 +39,7 @@ const WorkflowsPage = (props) => {
       <p>A workflow is the sequence of tasks that you’re asking volunteers to perform.</p>
       <p>An asterisk (*) denotes a default workflow.</p>
       <p>If you have multiple workflows you can rearrange the order in which they are listed on your project's front page by clicking the reorder view button and then clicking and dragging on the left gray tab next to each workflow title listed below.</p>
-      <p>NOTE: Please leave at least one active workflow; even if all workflows are 100% complete.</p>
+      <p><em>Note</em>: Please leave at least one active workflow; even if all workflows are 100% complete.</p>
       <p>{reorderButton}</p>
 
       {props.reorder &&
@@ -42,9 +47,17 @@ const WorkflowsPage = (props) => {
 
       {(!props.reorder && props.workflows.length > 0) &&
         <div>
-          <ul className="nav-list">
-            {props.workflows.map(workflow => renderWorkflow(workflow))}
-          </ul>
+          <table className="standard-table">
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Progress</th>
+              </tr>
+            </thead>
+            <tbody>
+              {props.workflows.map(workflow => renderWorkflow(workflow))}
+            </tbody>
+          </table>
           <hr />
           <Paginator
             page={meta.page}

--- a/app/pages/lab/workflows.spec.js
+++ b/app/pages/lab/workflows.spec.js
@@ -52,7 +52,7 @@ describe('WorkflowsPage', function () {
     sinon.assert.calledOnce(showCreateWorkflowSpy);
   });
 
-  it('should default render the list view', function() {
+  it('should default render the table view', function() {
     assert.equal(wrapper.find('Paginator').length, 1);
     assert.equal(reorderWorkflowButton.text(), 'Reorder view');
   });
@@ -65,10 +65,10 @@ describe('WorkflowsPage', function () {
   it('should render the reorderable view after toggled', function() {
     wrapper.setProps({ reorder: true });
     assert.equal(wrapper.find('DragReorderable').length, 1);
-    assert.equal(wrapper.find('[data-button="reorderWorkflow"]').text(), 'List view');
+    assert.equal(wrapper.find('[data-button="reorderWorkflow"]').text(), 'Table view');
   });
 
-  it('should re-render the list view when list view button is clicked', function() {
+  it('should re-render the table view when table view button is clicked', function() {
     reorderWorkflowButton.simulate('click');
     sinon.assert.calledTwice(toggleReorderSpy);
     wrapper.setProps({ reorder: false });

--- a/app/pages/lab/workflows.spec.js
+++ b/app/pages/lab/workflows.spec.js
@@ -44,7 +44,7 @@ describe('WorkflowsPage', function () {
 
   it('will display the correct amount of workflows', function () {
     wrapper.setProps({ workflows });
-    assert.equal(wrapper.find('.nav-list li').length, 2);
+    assert.equal(wrapper.find('Link').length, 2);
   });
 
   it('should call the workflow create handler', function () {


### PR DESCRIPTION
Staging branch URL: https://fix-4303.pfe-preview.zooniverse.org/

Fixes #4303, counts toward #4221. 

This is the first step to improve the workflow page. Moving the workflow settings from their current place (the visibility page) to the workflows seems a good idea, but I'll do that in a separate PR.
Changes:

1. Display workflow completeness.
2. Add note about making workflows inactive.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
