### PR TITLE
Workflow selection

### DIFF
--- a/app/pages/project/workflow-selection.jsx
+++ b/app/pages/project/workflow-selection.jsx
@@ -142,8 +142,8 @@ class WorkflowSelection extends React.Component {
 
   clearInactiveWorkflow(selectedWorkflowID) {
     const { preferences } = this.props;
-    const selectedWorkflow = preferences.preferences.selected_workflow;
-    const projectSetWorkflow = preferences.settings.workflow_id;
+    const selectedWorkflow = preferences.preferences ? preferences.preferences.selected_workflow : undefined;
+    const projectSetWorkflow = preferences.settings ? preferences.settings.workflow_id : undefined;
 
     if (selectedWorkflowID === selectedWorkflow) {
       preferences.update({ 'preferences.selected_workflow': undefined });

--- a/app/pages/project/workflow-selection.spec.js
+++ b/app/pages/project/workflow-selection.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import assert from 'assert';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import sinon from 'sinon';
 import apiClient from 'panoptes-client/lib/api-client';
 import WorkflowSelection from './workflow-selection';
@@ -14,7 +14,6 @@ const location = {
 };
 
 const context = {
-  initialLoadComplete: true,
   router: {}
 };
 
@@ -92,7 +91,7 @@ describe('WorkflowSelection', function () {
   const translations = {
     locale: 'en'
   };
-  const wrapper = shallow(
+  const wrapper = mount(
     <WorkflowSelection
       actions={actions}
       project={project}

--- a/app/pages/project/workflow-selection.spec.js
+++ b/app/pages/project/workflow-selection.spec.js
@@ -218,4 +218,26 @@ describe('WorkflowSelection', function () {
       sinon.assert.calledWith(workflowSpy, '1', true);
     });
   });
+
+  describe('on project change', function () {
+    it('should load a workflow for the new project', function () {
+      const newProject = mockPanoptesResource('projects',
+        {
+          id: 'b',
+          display_name: 'Another test project',
+          experimental_tools: [],
+          configuration: {
+            default_workflow: '10'
+          },
+          links: {
+            active_workflows: ['10'],
+            owner: { id: '1' }
+          }
+        }
+      );
+      wrapper.setProps({ project: newProject });
+      sinon.assert.calledOnce(workflowSpy);
+      sinon.assert.calledWith(workflowSpy, '10', true);
+    });
+  });
 });


### PR DESCRIPTION
Staging branch URL: https://workflow-selection.pfe-preview.zooniverse.org

Switches the workflow selection tests from shallow to full DOM rendering, which should allow us to test the full component lifecycle. Also fixes a small bug in workflow selection, which wasn't caught by shallow rendering.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
