### PR TITLE
Upgrade Panoptes client to 2.8.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,6 @@
 {
   "name": "panoptes-front-end",
+  "requires": true,
   "lockfileVersion": 1,
   "dependencies": {
     "@types/node": {
@@ -7242,9 +7243,9 @@
       "dev": true
     },
     "panoptes-client": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-2.7.2.tgz",
-      "integrity": "sha1-xYWVYtNgVCaKoxHihVqhZ3EU+oI=",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-2.8.1.tgz",
+      "integrity": "sha1-esqoHnNuiyZdrKmIaYO5EqN8ZzY=",
       "requires": {
         "json-api-client": "3.2.2",
         "local-storage": "1.4.2",
@@ -9638,11 +9639,6 @@
       "resolved": "https://registry.npmjs.org/string/-/string-3.3.3.tgz",
       "integrity": "sha1-XqIRzZLSKOGEKUmQpsyXs2anfLA="
     },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -9653,6 +9649,11 @@
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
       }
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
     "stringstream": {
       "version": "0.0.5",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "markdownz": "~7.4",
     "modal-form": "~2.4",
     "moment": "~2.18.1",
-    "panoptes-client": "~2.7",
+    "panoptes-client": "~2.8.1",
     "papaparse": "mholt/PapaParse#cada171",
     "prop-types": "~15.6.0",
     "pusher-js": "~3.2.1",


### PR DESCRIPTION
Staging branch URL: https://upgrade-api-client.pfe-preview.zooniverse.org

Fixes #4179.

Fixes bearer token expiration problems with the Talk client.
# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
