### PR TITLE
Add details about editted user to admin page

### DIFF
--- a/app/pages/admin/user-settings.jsx
+++ b/app/pages/admin/user-settings.jsx
@@ -5,6 +5,7 @@ import apiClient from 'panoptes-client/lib/api-client';
 import AutoSave from '../../components/auto-save';
 import LoadingIndicator from '../../components/loading-indicator';
 import handleInputChange from '../../lib/handle-input-change';
+import UserDetails from './user-settings/details';
 import UserProperties from './user-settings/properties';
 import UserProjects from './user-settings/projects';
 import UserLimitToggle from './user-settings/limit-toggle';
@@ -53,8 +54,10 @@ class UserSettings extends Component {
     return (
       <div>
         <div className="project-status">
-          <h4>Settings for {this.state.editUser.login}</h4>
+          <h4>Details for {this.state.editUser.login}</h4>
+          <UserDetails user={this.state.editUser} />
 
+          <h4>Settings for {this.state.editUser.login}</h4>
           <UserProperties user={this.state.editUser} />
 
           <ul>

--- a/app/pages/admin/user-settings/details.jsx
+++ b/app/pages/admin/user-settings/details.jsx
@@ -1,0 +1,27 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import AutoSave from '../../../components/auto-save';
+import handleInputChange from '../../../lib/handle-input-change';
+
+const UserDetails = (props) => {
+  const handleChange = handleInputChange.bind(props.user);
+
+  return (
+    <div className="user-details">
+      <ul>
+        <li>ID: {props.user.id}</li>
+        <li>Login: {props.user.login}</li>
+        <li>Display name: {props.user.display_name}</li>
+        <li>Email address: {props.user.email}</li>
+      </ul>
+
+    </div>
+  );
+}
+
+UserDetails.propTypes = {
+  user: PropTypes.object
+}
+
+export default UserDetails;

--- a/app/pages/admin/user-settings/details.spec.js
+++ b/app/pages/admin/user-settings/details.spec.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import assert from 'assert';
+import { shallow } from 'enzyme';
+import UserDetails from './details';
+
+describe('UserDetails', function () {
+    let wrapper;
+    let user = {};
+
+    before(function () {
+        wrapper = shallow(<UserDetails user={user} />);
+    });
+
+    it('renders without crashing', function () {
+        const container = wrapper.find('div.user-details');
+        assert.equal(container.length, 1);
+    });
+});


### PR DESCRIPTION
Staging branch URL: https://user-admin-details.pfe-preview.zooniverse.org/

This displays a few additional details about the user that's being editted. Particularly, we need to verify their email address for delete requests.

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
