### PR TITLE
Modal feedback: keyboard focus management and styling

### DIFF
--- a/app/classifier/classifier.jsx
+++ b/app/classifier/classifier.jsx
@@ -223,16 +223,15 @@ class Classifier extends React.Component {
 
   completeClassification() {
     const currentAnnotation = this.state.annotations[this.state.annotations.length - 1];
-    this.checkForFeedback(currentAnnotation.task)
-      .then(() => {
-        if (this.props.workflow.configuration.hide_classification_summaries && !this.subjectIsGravitySpyGoldStandard()) {
-          this.props.onCompleteAndLoadAnotherSubject();
-        } else {
-          this.props.onComplete()
-            .catch(error => console.error(error));
-        }
-        this.setState({ annotations: [{}] });
-      });
+      if (this.props.workflow.configuration.hide_classification_summaries && !this.subjectIsGravitySpyGoldStandard()) {
+        this.props.onCompleteAndLoadAnotherSubject()
+          .then(() => this.checkForFeedback(currentAnnotation.task));
+      } else {
+        this.props.onComplete()
+          .then(() => this.checkForFeedback(currentAnnotation.task))
+          .catch(error => console.error(error));
+      }
+      this.setState({ annotations: [{}] });
   }
 
   toggleExpertClassification(value) {

--- a/app/classifier/task-nav.jsx
+++ b/app/classifier/task-nav.jsx
@@ -6,7 +6,6 @@ import { getSessionID } from '../lib/session';
 import tasks from './tasks';
 import CacheClassification from '../components/cache-classification';
 import GridTool from './drawing-tools/grid';
-import { isFeedbackActive, isThereFeedback } from './feedback/helpers';
 
 /* eslint-disable multiline-ternary, no-nested-ternary, react/jsx-no-bind */
 
@@ -125,8 +124,7 @@ class TaskNav extends React.Component {
 
     const task = this.props.task ? this.props.task : this.props.workflow.tasks[this.props.workflow.first_task];
 
-    const disableTalk = this.props.classification.metadata.subject_flagged ||
-    (isFeedbackActive(this.props.project) && isThereFeedback(this.props.subject, this.props.workflow));
+    const disableTalk = this.props.classification.metadata.subject_flagged;
     const visibleTasks = Object.keys(this.props.workflow.tasks).filter(key => this.props.workflow.tasks[key].type !== 'shortcut');
     const TaskComponent = tasks[task.type];
 

--- a/app/classifier/task-nav.jsx
+++ b/app/classifier/task-nav.jsx
@@ -215,7 +215,7 @@ class TaskNav extends React.Component {
             </Link>}
           {completed &&
             <button
-              autoFocus={true}
+              autoFocus={this.props.autoFocus}
               className="continue major-button"
               onClick={this.props.nextSubject}
             >
@@ -234,6 +234,7 @@ TaskNav.propTypes = {
     shortcut: PropTypes.object,
     value: PropTypes.any
   }),
+  autoFocus: PropTypes.bool,
   children: PropTypes.node,
   classification: PropTypes.shape({
     annotations: PropTypes.array,
@@ -266,6 +267,7 @@ TaskNav.propTypes = {
 };
 
 TaskNav.defaultProps = {
+  autoFocus: true,
   disabled: false,
   updateAnnotations: () => null
 };

--- a/app/features/feedback/classifier/components/feedback-modal.jsx
+++ b/app/features/feedback/classifier/components/feedback-modal.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import Translate from 'react-translate-component';
 import counterpart from 'counterpart';
 import SubjectViewer from '../../../../components/subject-viewer';
+import ModalFocus from '../../../../components/modal-focus';
 
 /* eslint-disable max-len */
 counterpart.registerTranslations('en', {
@@ -15,7 +16,7 @@ counterpart.registerTranslations('en', {
 
 function FeedbackModal({ messages, subjectViewerProps }) {
   return (
-    <section className="feedbackmodal">
+    <ModalFocus className="feedbackmodal">
       <Translate content="FeedbackModal.title" component="h2" />
       {subjectViewerProps && (<SubjectViewer {...subjectViewerProps} />)}
       <ul>
@@ -26,11 +27,14 @@ function FeedbackModal({ messages, subjectViewerProps }) {
         )}
       </ul>
 
-      <input
+      <button
+        className="standard-button"
         type="submit"
-        value={counterpart('FeedbackModal.ok')}
-      />
-    </section>
+        autoFocus={true}
+      >
+        <Translate content="FeedbackModal.ok" />
+      </button>
+    </ModalFocus>
   );
 }
 

--- a/app/features/feedback/classifier/components/feedback-modal.jsx
+++ b/app/features/feedback/classifier/components/feedback-modal.jsx
@@ -14,28 +14,41 @@ counterpart.registerTranslations('en', {
 });
 /* eslint-enable max-len */
 
-function FeedbackModal({ messages, subjectViewerProps }) {
-  return (
-    <ModalFocus className="feedbackmodal">
-      <Translate content="FeedbackModal.title" component="h2" />
-      {subjectViewerProps && (<SubjectViewer {...subjectViewerProps} />)}
-      <ul>
-        {messages.map(message =>
-          <li key={Math.random()}>
-            {message}
-          </li>
-        )}
-      </ul>
+class FeedbackModal extends React.Component {
+  constructor() {
+    super();
+    this.closeButton = null;
+  }
 
-      <button
-        className="standard-button"
-        type="submit"
-        autoFocus={true}
-      >
-        <Translate content="FeedbackModal.ok" />
-      </button>
-    </ModalFocus>
-  );
+  componentDidMount() {
+    const { closeButton } = this;
+    closeButton.focus && closeButton.focus();
+  }
+
+  render() {
+    const { messages, subjectViewerProps } = this.props;
+    return (
+      <ModalFocus className="feedbackmodal">
+        <Translate content="FeedbackModal.title" component="h2" />
+        {subjectViewerProps && (<SubjectViewer {...subjectViewerProps} />)}
+        <ul>
+          {messages.map(message =>
+            <li key={Math.random()}>
+              {message}
+            </li>
+          )}
+        </ul>
+
+        <button
+          className="standard-button"
+          type="submit"
+          ref={(button) => { this.closeButton = button; }}
+        >
+          <Translate content="FeedbackModal.ok" />
+        </button>
+      </ModalFocus>
+    );
+  }
 }
 
 FeedbackModal.propTypes = {

--- a/css/feedback.styl
+++ b/css/feedback.styl
@@ -6,3 +6,5 @@
 
   .subject
     display: block
+    max-height: 60vh
+    max-width: 100%


### PR DESCRIPTION
Staging branch URL: https://modal-feedback.pfe-preview.zooniverse.org/

Fixes some of the points raised in #4320.

Adds autofocus behaviour to the feedback popup, and traps focus until the modal is closed. Changes the order in which feedback is checked, so that feedback can steal focus from the task navigation buttons when it opens.

Also adds some basic styling to the OK button and restricts the height of large subjects to around 60% of the viewport height.

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [x] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
