### PR TITLE
Modal feedback: only trigger feedback once

### DIFF
--- a/app/classifier/classifier.jsx
+++ b/app/classifier/classifier.jsx
@@ -225,10 +225,9 @@ class Classifier extends React.Component {
     const currentAnnotation = this.state.annotations[this.state.annotations.length - 1];
       if (this.props.workflow.configuration.hide_classification_summaries && !this.subjectIsGravitySpyGoldStandard()) {
         this.props.onCompleteAndLoadAnotherSubject()
-          .then(() => this.checkForFeedback(currentAnnotation.task));
+          .catch(error => console.error(error));
       } else {
         this.props.onComplete()
-          .then(() => this.checkForFeedback(currentAnnotation.task))
           .catch(error => console.error(error));
       }
       this.setState({ annotations: [{}] });

--- a/app/classifier/classifier.jsx
+++ b/app/classifier/classifier.jsx
@@ -167,8 +167,11 @@ class Classifier extends React.Component {
 
     if (currentTask && currentTask.type === 'drawing') {
       isInProgress = annotations.reduce((result, annotation) => {
-        return result ||
-          annotation.value.map(value => value._inProgress).includes(true);
+        if (annotation.value.map) {
+          return annotation.value.map(value => value._inProgress).includes(true);
+        } else {
+          return result;
+        }
       }, false);
     }
 

--- a/app/features/feedback/shared/strategies/radial/reducer.js
+++ b/app/features/feedback/shared/strategies/radial/reducer.js
@@ -22,6 +22,7 @@ function isAnnotationWithinTolerance(rule, annotation) {
 // Determines whether there are any annotations falling within tolerance for a
 // rule, and appends all successful annotations if so.
 function radialReducer(rule, annotations) {
+  annotations = annotations || [];
   const result = annotations.filter(annotation =>
     isAnnotationWithinTolerance(rule, annotation));
 


### PR DESCRIPTION
Staging branch URL: https://modal-feedback.pfe-preview.zooniverse.org/

Fixes #4327 

Fixes a bug noticed by @mcbouslog where feedback shows twice if triggered on the last task of a workflow.

Describe your changes.
Remove the call to `checkForFeedback()` when a classification is submitted.

Catch undefined variables in the radial reducer and `updateFeedback()` and handle them.


# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
