### PR TITLE
add text-align left to survey task button

### DIFF
--- a/css/survey-task.styl
+++ b/css/survey-task.styl
@@ -135,6 +135,7 @@ $survey-task-pill-button
   background: rgba(64, 64, 64, 1)
   color: white
   display: flex
+  text-align: left
 
   &:hover
     background: rgba(102, 102, 102, 1)
@@ -209,7 +210,7 @@ $survey-task-pill-button
   overflow: hidden
   text-indent: 1em
   width: .5em
-  
+
   input[type=radio]
     position: absolute
     opacity: 0.01


### PR DESCRIPTION
Staging branch URL: https://survey-task-button-text-align.pfe-preview.zooniverse.org/
- to project with issue: https://survey-task-button-text-align.pfe-preview.zooniverse.org/projects/amyrobey996/numbat-discovery?env=production

Fixes https://www.zooniverse.org/projects/amyrobey996/numbat-discovery.

Describe your changes.
- add `text-align: left` to `survey-task-chooser-choice-button` class

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [x] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
