### PR TITLE
Allow survey tasks to clear radio button answers

### DIFF
--- a/app/classifier/tasks/survey/choice.jsx
+++ b/app/classifier/tasks/survey/choice.jsx
@@ -177,6 +177,7 @@ class Choice extends React.Component {
                         >
                           <input
                             name={questionId}
+                            value={answerId}
                             type={inputType}
                             autoFocus={!hasFocus && i === 0}
                             checked={isChecked}

--- a/app/classifier/tasks/survey/choice.jsx
+++ b/app/classifier/tasks/survey/choice.jsx
@@ -6,6 +6,9 @@ import Translate from 'react-translate-component';
 import ImageFlipper from './image-flipper';
 import Utility from './utility';
 
+const BACKSPACE = 8;
+const SPACE = 32;
+
 
 class Choice extends React.Component {
   constructor(props) {
@@ -71,6 +74,19 @@ class Choice extends React.Component {
 
   handleIdentification() {
     this.props.onConfirm(this.props.choiceID, this.state.answers);
+  }
+
+  handleRadioKeyDown(questionId, answerId, e) {
+    switch (e.which) {
+      case BACKSPACE:
+      case SPACE:
+        if (e.target.checked) {
+          e.preventDefault();
+          this.handleRadioToggle(questionId, answerId, e);
+        }
+        break;
+      default:
+    }
   }
 
   handleRadioToggle(questionId, answerId, e) {
@@ -172,6 +188,7 @@ class Choice extends React.Component {
                             checked={isChecked}
                             onChange={this.handleAnswer.bind(this, questionId, answerId)}
                             onClick={this.handleRadioToggle.bind(this, questionId, answerId)}
+                            onKeyDown={this.handleRadioKeyDown.bind(this, questionId, answerId)}
                             onFocus={this.handleFocus.bind(this, questionId, answerId)}
                             onBlur={this.handleFocus.bind(this, null, null)}
                           />

--- a/app/classifier/tasks/survey/choice.jsx
+++ b/app/classifier/tasks/survey/choice.jsx
@@ -73,6 +73,15 @@ class Choice extends React.Component {
     this.props.onConfirm(this.props.choiceID, this.state.answers);
   }
 
+  handleRadioToggle(questionId, answerId, e) {
+    const { type } = e.target;
+    const { answers } = this.state;
+    if (type === 'radio' && answers[questionId] === answerId) {
+      delete answers[questionId];
+      this.setState({ answers });
+    }
+  }
+
   render() {
     const { choiceID, task, translation } = this.props;
     const choice = task.choices[this.props.choiceID];
@@ -162,6 +171,7 @@ class Choice extends React.Component {
                             autoFocus={!hasFocus && i === 0}
                             checked={isChecked}
                             onChange={this.handleAnswer.bind(this, questionId, answerId)}
+                            onClick={this.handleRadioToggle.bind(this, questionId, answerId)}
                             onFocus={this.handleFocus.bind(this, questionId, answerId)}
                             onBlur={this.handleFocus.bind(this, null, null)}
                           />

--- a/app/classifier/tasks/survey/choice.jsx
+++ b/app/classifier/tasks/survey/choice.jsx
@@ -77,14 +77,14 @@ class Choice extends React.Component {
       case SPACE:
         if (e.target.checked) {
           e.preventDefault();
-          this.handleRadioToggle(questionId, answerId, e);
+          this.resetSingleAnswerQuestion(questionId, answerId, e);
         }
         break;
       default:
     }
   }
 
-  handleRadioToggle(questionId, answerId, e) {
+  resetSingleAnswerQuestion(questionId, answerId, e) {
     const { type } = e.target;
     const { answers } = this.state;
     if (type === 'radio' && answers[questionId] === answerId) {
@@ -181,7 +181,7 @@ class Choice extends React.Component {
                             autoFocus={!hasFocus && i === 0}
                             checked={isChecked}
                             onChange={this.handleAnswer.bind(this, questionId, answerId)}
-                            onClick={this.handleRadioToggle.bind(this, questionId, answerId)}
+                            onClick={this.resetSingleAnswerQuestion.bind(this, questionId, answerId)}
                             onKeyDown={this.handleRadioKeyDown.bind(this, questionId, answerId)}
                             onFocus={this.handleFocus.bind(this, questionId, answerId)}
                             onBlur={this.handleFocus.bind(this, null, null)}

--- a/app/classifier/tasks/survey/choice.jsx
+++ b/app/classifier/tasks/survey/choice.jsx
@@ -73,10 +73,12 @@ class Choice extends React.Component {
   }
 
   handleRadioKeyDown(e) {
+    const { type, checked } = e.target;
+    const isRadio = type === 'radio';
     switch (e.which) {
       case BACKSPACE:
       case SPACE:
-        if (e.target.checked) {
+        if (isRadio && checked) {
           e.preventDefault();
           this.resetSingleAnswerQuestion(e);
         }

--- a/app/classifier/tasks/survey/choice.jsx
+++ b/app/classifier/tasks/survey/choice.jsx
@@ -44,17 +44,18 @@ class Choice extends React.Component {
     return answerProvided.every(answer => (answer === true));
   }
 
-  handleAnswer(questionId, answerId, e) {
+  handleAnswer(e) {
+    const { name, value } = e.target;
     const { answers } = this.state;
-    answers[questionId] = answers[questionId] ? answers[questionId] : [];
-    if (this.props.task.questions[questionId].multiple) {
+    answers[name] = answers[name] ? answers[name] : [];
+    if (this.props.task.questions[name].multiple) {
       if (e.target.checked) {
-        answers[questionId].push(answerId);
+        answers[name].push(value);
       } else {
-        answers[questionId].splice(answers[questionId].indexOf(answerId), 1);
+        answers[name].splice(answers[name].indexOf(value), 1);
       }
     } else {
-      answers[questionId] = answerId;
+      answers[name] = value;
     }
     this.setState({ answers });
   }
@@ -71,24 +72,24 @@ class Choice extends React.Component {
     this.props.onConfirm(this.props.choiceID, this.state.answers);
   }
 
-  handleRadioKeyDown(questionId, answerId, e) {
+  handleRadioKeyDown(e) {
     switch (e.which) {
       case BACKSPACE:
       case SPACE:
         if (e.target.checked) {
           e.preventDefault();
-          this.resetSingleAnswerQuestion(questionId, answerId, e);
+          this.resetSingleAnswerQuestion(e);
         }
         break;
       default:
     }
   }
 
-  resetSingleAnswerQuestion(questionId, answerId, e) {
-    const { type } = e.target;
+  resetSingleAnswerQuestion(e) {
+    const { type, name, value } = e.target;
     const { answers } = this.state;
-    if (type === 'radio' && answers[questionId] === answerId) {
-      delete answers[questionId];
+    if (type === 'radio' && answers[name] === value) {
+      delete answers[name];
       this.setState({ answers });
     }
   }
@@ -181,9 +182,9 @@ class Choice extends React.Component {
                             type={inputType}
                             autoFocus={!hasFocus && i === 0}
                             checked={isChecked}
-                            onChange={this.handleAnswer.bind(this, questionId, answerId)}
-                            onClick={this.resetSingleAnswerQuestion.bind(this, questionId, answerId)}
-                            onKeyDown={this.handleRadioKeyDown.bind(this, questionId, answerId)}
+                            onChange={this.handleAnswer.bind(this)}
+                            onClick={this.resetSingleAnswerQuestion.bind(this)}
+                            onKeyDown={this.handleRadioKeyDown.bind(this)}
                             onFocus={this.handleFocus.bind(this, questionId, answerId)}
                             onBlur={this.handleFocus.bind(this, null, null)}
                           />

--- a/app/classifier/tasks/survey/choice.jsx
+++ b/app/classifier/tasks/survey/choice.jsx
@@ -54,12 +54,7 @@ class Choice extends React.Component {
         answers[questionId].splice(answers[questionId].indexOf(answerId), 1);
       }
     } else {
-      if (answerId === answers[questionId]) {
-        delete answers[questionId];
-        this.refs[questionId].checked = false;
-      } else {
-        answers[questionId] = answerId;
-      }
+      answers[questionId] = answerId;
     }
     this.setState({ answers });
   }
@@ -181,7 +176,6 @@ class Choice extends React.Component {
                           data-focused={isFocused || null}
                         >
                           <input
-                            ref={questionId}
                             name={questionId}
                             type={inputType}
                             autoFocus={!hasFocus && i === 0}

--- a/app/classifier/tasks/survey/choice.spec.js
+++ b/app/classifier/tasks/survey/choice.spec.js
@@ -1,5 +1,6 @@
 import { shallow } from 'enzyme';
 import assert from 'assert';
+import sinon from 'sinon';
 import React from 'react';
 import Choice from './choice';
 import { workflow } from '../../../pages/dev-classifier/mock-data';
@@ -105,6 +106,21 @@ describe('Choice', function () {
       assert.equal(wrapper.state().answers.ho, 'two');
       answer.simulate('keyDown', fakeEvent);
       assert.equal(wrapper.state().answers.ho, 'two');
+    });
+    it('should not prevent the default keyDown event for checkboxes', function () {
+      const checkbox = wrapper.find('input[name="be"][value="mo"]');
+      const fakeEvent = {
+        which: 32,
+        target: {
+          type: 'checkbox',
+          name: 'be',
+          value: 'mo',
+          checked: true
+        },
+        preventDefault: sinon.spy()
+      };
+      checkbox.simulate('keyDown', fakeEvent);
+      assert.equal(fakeEvent.preventDefault.notCalled, true);
     });
   })
 });

--- a/app/classifier/tasks/survey/choice.spec.js
+++ b/app/classifier/tasks/survey/choice.spec.js
@@ -2,9 +2,30 @@ import { shallow } from 'enzyme';
 import assert from 'assert';
 import React from 'react';
 import Choice from './choice';
+import { workflow } from '../../../pages/dev-classifier/mock-data';
+
+const task = workflow.tasks.survey;
+const annotation = {
+  task: 'survey',
+  value: [{
+    choice: 'ar',
+    answers: {
+      ho: 'two',
+      be: [
+        'mo',
+        'ea'
+      ]
+    },
+    filters: {}
+  }]
+};
 
 describe('Choice', function () {
+  
   describe('with single answer questions', function () {
+    before(function () {
+      let wrapper = shallow(<Choice translation={task} task={task} annotation={annotation} choiceID='ar' />)
+    });
     it('should render radio buttons for answers', function () {
       
     });

--- a/app/classifier/tasks/survey/choice.spec.js
+++ b/app/classifier/tasks/survey/choice.spec.js
@@ -26,6 +26,7 @@ const annotationValue = {
 
 describe('Choice', function () {
   let wrapper;
+  let answer;
 
   describe('with single answer questions', function () {
     beforeEach(function () {
@@ -36,6 +37,7 @@ describe('Choice', function () {
         annotationValue={annotationValue}
         choiceID='ar'
       />);
+      answer = wrapper.find('input[name="ho"][value="two"]');
     });
     it('should render radio buttons for answers', function () {
       const question = task.questions.ho;
@@ -47,7 +49,6 @@ describe('Choice', function () {
       assert.equal(answer.props().checked, true);
     });
     it('should clear the chosen answer on click', function () {
-      const answer = wrapper.find('input[name="ho"][value="two"]');
       const fakeEvent = {
         target: {
           type: 'radio',
@@ -61,7 +62,6 @@ describe('Choice', function () {
       assert.equal(wrapper.state().answers.ho, undefined);
     });
     it('should clear the chosen answer on space', function () {
-      const answer = wrapper.find('input[name="ho"][value="two"]');
       const fakeEvent = {
         which: 32,
         target: {
@@ -77,7 +77,6 @@ describe('Choice', function () {
       assert.equal(wrapper.state().answers.ho, undefined);
     });
     it('should clear the chosen answer on backspace', function () {
-      const answer = wrapper.find('input[name="ho"][value="two"]');
       const fakeEvent = {
         which: 8,
         target: {
@@ -93,7 +92,6 @@ describe('Choice', function () {
       assert.equal(wrapper.state().answers.ho, undefined);
     });
     it('should not clear the chosen answer on any other key press', function () {
-      const answer = wrapper.find('input[name="ho"][value="two"]');
       const fakeEvent = {
         which: 9,
         target: {

--- a/app/classifier/tasks/survey/choice.spec.js
+++ b/app/classifier/tasks/survey/choice.spec.js
@@ -28,7 +28,7 @@ describe('Choice', function () {
   let wrapper;
 
   describe('with single answer questions', function () {
-    before(function () {
+    beforeEach(function () {
       wrapper = shallow(<Choice
         translation={task}
         task={task}
@@ -47,16 +47,66 @@ describe('Choice', function () {
       assert.equal(answer.props().checked, true);
     });
     it('should clear the chosen answer on click', function () {
-      
+      const answer = wrapper.find('input[name="ho"][value="two"]');
+      const fakeEvent = {
+        target: {
+          type: 'radio',
+          name: 'ho',
+          value: 'two',
+          checked: true
+        }
+      }
+      assert.equal(wrapper.state().answers.ho, 'two');
+      answer.simulate('click', fakeEvent);
+      assert.equal(wrapper.state().answers.ho, undefined);
     });
     it('should clear the chosen answer on space', function () {
-      
+      const answer = wrapper.find('input[name="ho"][value="two"]');
+      const fakeEvent = {
+        which: 32,
+        target: {
+          type: 'radio',
+          name: 'ho',
+          value: 'two',
+          checked: true
+        },
+        preventDefault: () => null
+      }
+      assert.equal(wrapper.state().answers.ho, 'two');
+      answer.simulate('keyDown', fakeEvent);
+      assert.equal(wrapper.state().answers.ho, undefined);
     });
     it('should clear the chosen answer on backspace', function () {
-      
+      const answer = wrapper.find('input[name="ho"][value="two"]');
+      const fakeEvent = {
+        which: 8,
+        target: {
+          type: 'radio',
+          name: 'ho',
+          value: 'two',
+          checked: true
+        },
+        preventDefault: () => null
+      }
+      assert.equal(wrapper.state().answers.ho, 'two');
+      answer.simulate('keyDown', fakeEvent);
+      assert.equal(wrapper.state().answers.ho, undefined);
     });
     it('should not clear the chosen answer on any other key press', function () {
-      
+      const answer = wrapper.find('input[name="ho"][value="two"]');
+      const fakeEvent = {
+        which: 9,
+        target: {
+          type: 'radio',
+          name: 'ho',
+          value: 'two',
+          checked: true
+        },
+        preventDefault: () => null
+      }
+      assert.equal(wrapper.state().answers.ho, 'two');
+      answer.simulate('keyDown', fakeEvent);
+      assert.equal(wrapper.state().answers.ho, 'two');
     });
   })
 });

--- a/app/classifier/tasks/survey/choice.spec.js
+++ b/app/classifier/tasks/survey/choice.spec.js
@@ -20,17 +20,31 @@ const annotation = {
   }]
 };
 
+const annotationValue = {
+  answers: Object.assign({}, annotation.value[0].answers)
+};
+
 describe('Choice', function () {
-  
+  let wrapper;
+
   describe('with single answer questions', function () {
     before(function () {
-      let wrapper = shallow(<Choice translation={task} task={task} annotation={annotation} choiceID='ar' />)
+      wrapper = shallow(<Choice
+        translation={task}
+        task={task}
+        annotation={annotation}
+        annotationValue={annotationValue}
+        choiceID='ar'
+      />);
     });
     it('should render radio buttons for answers', function () {
-      
+      const question = task.questions.ho;
+      const answers = wrapper.find('input[name="ho"][type="radio"]');
+      assert.equal(Object.keys(question.answers).length, answers.length);
     });
     it('should render the chosen answer as checked', function () {
-      
+      const answer = wrapper.find('input[name="ho"][value="two"]');
+      assert.equal(answer.props().checked, true);
     });
     it('should clear the chosen answer on click', function () {
       

--- a/app/classifier/tasks/survey/choice.spec.js
+++ b/app/classifier/tasks/survey/choice.spec.js
@@ -1,0 +1,27 @@
+import { shallow } from 'enzyme';
+import assert from 'assert';
+import React from 'react';
+import Choice from './choice';
+
+describe('Choice', function () {
+  describe('with single answer questions', function () {
+    it('should render radio buttons for answers', function () {
+      
+    });
+    it('should render the chosen answer as checked', function () {
+      
+    });
+    it('should clear the chosen answer on click', function () {
+      
+    });
+    it('should clear the chosen answer on space', function () {
+      
+    });
+    it('should clear the chosen answer on backspace', function () {
+      
+    });
+    it('should not clear the chosen answer on any other key press', function () {
+      
+    });
+  })
+});


### PR DESCRIPTION
Staging branch URL: https://survey-radio-toggle.pfe-preview.zooniverse.org

Fixes a bug reported by Snapshot Wisconsin: https://www.zooniverse.org/talk/17/535525

Adds handlers to the survey choice radio buttons so that a selected answer can be cleared on click, space or backspace.

Removes some old code which cleared the current answer but was never actually called.

Removes named refs from the `Choice` component.

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [x] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, ~~Chrome~~, ~~Edge~~, ~~Safari~~?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
