### PR TITLE
Remove React.PropTypes

### DIFF
--- a/app/components/loading-indicator.jsx
+++ b/app/components/loading-indicator.jsx
@@ -5,7 +5,7 @@ const LoadingIndicator = ({ children, off }) => {
   const visibility = off ? 'hidden' : 'visible';
   return (
     <span className="loading-indicator" style={{ visibility }}>
-      <span className="loading-indicator-icon"></span>{' '}
+      <span className="loading-indicator-icon" />{' '}
       {children}
     </span>
   );
@@ -17,6 +17,7 @@ LoadingIndicator.propTypes = {
 };
 
 LoadingIndicator.defaultProps = {
+  children: null,
   off: false
 };
 

--- a/app/components/loading-indicator.jsx
+++ b/app/components/loading-indicator.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 const LoadingIndicator = ({ children, off }) => {
   const visibility = off ? 'hidden' : 'visible';
@@ -11,8 +12,8 @@ const LoadingIndicator = ({ children, off }) => {
 };
 
 LoadingIndicator.propTypes = {
-  children: React.PropTypes.node,
-  off: React.PropTypes.bool
+  children: PropTypes.node,
+  off: PropTypes.bool
 };
 
 LoadingIndicator.defaultProps = {

--- a/app/components/media-card.jsx
+++ b/app/components/media-card.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 const IMAGE_EXTENSIONS = ['gif', 'jpeg', 'jpg', 'png', 'svg'];
 const VIDEO_EXTENSIONS = ['mp4'];
@@ -31,10 +32,10 @@ const MediaCard = ({ children, className, src, style }) => {
 };
 
 MediaCard.propTypes = {
-  children: React.PropTypes.node,
-  className: React.PropTypes.string,
-  src: React.PropTypes.string,
-  style: React.PropTypes.object
+  children: PropTypes.node,
+  className: PropTypes.string,
+  src: PropTypes.string,
+  style: PropTypes.object
 };
 
 MediaCard.defaultProps = {

--- a/app/components/media-card.jsx
+++ b/app/components/media-card.jsx
@@ -39,6 +39,7 @@ MediaCard.propTypes = {
 };
 
 MediaCard.defaultProps = {
+  children: null,
   className: '',
   src: '',
   style: {}


### PR DESCRIPTION
Staging branch URL: https://remove-proptypes.pfe-preview.zooniverse.org

Removes a couple of instances of `React.PropTypes` that had crept back in to the Media Card and Loading Indicator.

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [x] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
