### PR TITLE
Upgrade modal-form to 2.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6739,9 +6739,25 @@
       }
     },
     "modal-form": {
-      "version": "2.4.8",
-      "resolved": "https://registry.npmjs.org/modal-form/-/modal-form-2.4.8.tgz",
-      "integrity": "sha1-L3kPrdD38jASHjYdnvKEjNYVqJ0="
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/modal-form/-/modal-form-2.5.1.tgz",
+      "integrity": "sha512-yVeEfCm040SUZ1cOZUMG+uQ9Z7ppykuR4XG7EViApep/xAa6qdwFdTAVMdbjaSOWnE5lfdoW7agyvGmaVnfe/w==",
+      "requires": {
+        "create-react-class": "15.6.3",
+        "prop-types": "15.6.0"
+      },
+      "dependencies": {
+        "create-react-class": {
+          "version": "15.6.3",
+          "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.3.tgz",
+          "integrity": "sha512-M+/3Q6E6DLO6Yx3OwrWjwHBnvfXXYA7W+dFjt/ZDBemHO1DDZhsalX/NUtnTYclN6GfnBDRh4qRHjcDHmlJBJg==",
+          "requires": {
+            "fbjs": "0.8.12",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1"
+          }
+        }
+      }
     },
     "moment": {
       "version": "2.18.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "json-api-client": "~3.2.2",
     "lodash": "~4.17.4",
     "markdownz": "~7.4",
-    "modal-form": "~2.4",
+    "modal-form": "~2.5.1",
     "moment": "~2.18.1",
     "panoptes-client": "~2.8.1",
     "papaparse": "mholt/PapaParse#cada171",


### PR DESCRIPTION
Staging branch URL: https://modal-form.pfe-preview.zooniverse.org

Upgrades `modal-form` to remove React.PropTypes.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
