### PR TITLE
change org landing default project query to launch approved

### DIFF
--- a/app/pages/organization/organization-container.jsx
+++ b/app/pages/organization/organization-container.jsx
@@ -122,10 +122,10 @@ class OrganizationContainer extends React.Component {
 
   fetchProjects(organization, collaboratorView, locationQuery = this.props.location.query) {
     this.setState({ errorFetchingProjects: null, fetchingProjects: true, fetchingProjectAvatars: true });
-    const query = { beta_approved: true, include: 'avatar' };
+    const query = { launch_approved: true, include: 'avatar' };
 
     if (collaboratorView) {
-      delete query.beta_approved;
+      delete query.launch_approved;
     }
     if (locationQuery && locationQuery.category) {
       query.tags = locationQuery.category;


### PR DESCRIPTION
Staging branch URL: https://org-projects-launch-approved.pfe-preview.zooniverse.org/

Reverts #4227, if reverting that PR would be preferable please do.

The org landing project query was temporarily changed to filter by `beta_approved` to allow Snapshot Safari to beta test with beta_approved (but not launch approved) projects. Snapshot Safari is now ready to launch and those projects are now launch approved, so the org landing should be filtering projects by launch approved as always intended.

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [x] Can you post a talk comment?

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
