### PR TITLE
Hide beta styles for launch approved projects

### DIFF
--- a/app/pages/project/index.cjsx
+++ b/app/pages/project/index.cjsx
@@ -224,10 +224,11 @@ ProjectPageController = createReactClass
   render: ->
     slug = @props.params.owner + '/' + @props.params.name
     betaApproved = @state.project?.beta_approved
+    launchApproved = @state.project?.launch_approved
 
     <div className="project-page-wrapper">
       <Helmet title="#{@state.project?.display_name ? counterpart 'loading'}" />
-      {if betaApproved
+      {if (!launchApproved && betaApproved)
         <div className="beta-border"></div>}
 
       {if @state.project? and @state.owner?

--- a/app/pages/project/project-navbar.jsx
+++ b/app/pages/project/project-navbar.jsx
@@ -27,14 +27,6 @@ function ProjectName({ loading, project, translation }) {
   if (loading) {
     return <span>Loading…</span>;
   }
-  if (project.beta_approved) {
-    return (
-      <div className="project-name">
-        {translation.display_name}
-        <small className="project-name__under-review">Under Review</small>
-      </div>
-    );
-  }
   if (project.launch_approved) {
     return (
       <span>
@@ -44,6 +36,14 @@ function ProjectName({ loading, project, translation }) {
           <i className="fa fa-check fa-stack-1x checkmark-stack__checkmark" />
         </span>
       </span>
+    );
+  }
+  if (project.beta_approved) {
+    return (
+      <div className="project-name">
+        {translation.display_name}
+        <small className="project-name__under-review">Under Review</small>
+      </div>
     );
   }
   return <span>{translation.display_name}</span>;


### PR DESCRIPTION
Staging branch URL: https://beta-approved.pfe-preview.zooniverse.org

Checks `project.launch_approved` before applying beta review styles and wording to a project. Should make launching a project a little easier, as suggested by @mcbouslog.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
