### PR TITLE
Upgrade drag-reorderable to 0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2599,9 +2599,9 @@
       }
     },
     "drag-reorderable": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/drag-reorderable/-/drag-reorderable-0.1.0.tgz",
-      "integrity": "sha1-eL90n/wnErC/0McXKqJic/lm48M="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/drag-reorderable/-/drag-reorderable-0.2.0.tgz",
+      "integrity": "sha1-PBw8PazId/3ji8XRvFwTdiVXtd8="
     },
     "ecc-jsbn": {
       "version": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "counterpart": "~0.17.0",
     "data-uri-to-blob": "0.0.4",
     "debounce": "~1.0.0",
-    "drag-reorderable": "~0.1.0",
+    "drag-reorderable": "~0.2.0",
     "engine.io-client": "~1.8.2",
     "events": "~1.1.1",
     "hash.js": "~1.0.3",


### PR DESCRIPTION
Staging branch URL:https://drag-reorderable.pfe-preview.zooniverse.org

Upgrades drag-reorderable to remove React.PropTypes.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
