### PR TITLE
Add a ready flag to the project container

### DIFF
--- a/app/pages/project/index.cjsx
+++ b/app/pages/project/index.cjsx
@@ -48,6 +48,7 @@ ProjectPageController = createReactClass
     projectAvatar: null
     projectIsComplete: false
     projectRoles: null
+    ready: false
     splits: null
 
   _listenedToPreferences: null
@@ -144,7 +145,8 @@ ProjectPageController = createReactClass
             awaitPreferences,
             this.props.actions.translations.load('project', project.id, this.props.translations.locale)
           ]).then(([background, organization, owner, pages, projectAvatar, projectIsComplete, projectRoles, preferences]) =>
-              @setState({ background, organization, owner, pages, projectAvatar, projectIsComplete, projectRoles, preferences })
+              ready = true
+              @setState({ background, organization, owner, pages, projectAvatar, projectIsComplete, projectRoles, preferences, ready })
               @loadFieldGuide(project.id)
               this.props.actions.translations.loadTranslations('project_page', pages.map((page) => page.id), this.props.translations.locale)
             ).catch((error) => @setState({ error }); console.error(error); );
@@ -231,7 +233,7 @@ ProjectPageController = createReactClass
       {if (!launchApproved && betaApproved)
         <div className="beta-border"></div>}
 
-      {if @state.project? and @state.owner?
+      {if @state.ready
         <ProjectTranslations
           project={@state.project}
         >


### PR DESCRIPTION
Staging branch URL: https://project-loading.pfe-preview.zooniverse.org

Fixes a race condition where workflow selection would fail if the component mounted before project preferences had loaded.

Adds a boolean flag to the project container, to indicate when project resources have loaded and the page is safe to render.

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [x] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
