### PR TITLE
Fix stuck tutorial bug #4343

### DIFF
--- a/app/pages/project/index.spec.js
+++ b/app/pages/project/index.spec.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import assert from 'assert';
+import sinon from 'sinon';
+import ProjectPageController from './';
+
+describe('ProjectPageController', function () {
+  describe('with initial load complete', function () {
+    it('should fetch project data on mount.', function () {
+    
+    });
+    it('should fetch project data again on project change.', function () {
+      
+    });
+    it('should fetch project data again on user change.', function () {
+      
+    });
+    it('should not fetch project data again on any other prop change.', function () {
+      
+    });
+  });
+  describe('without initial load complete', function () {
+    it('should not fetch project data on mount.', function () {
+    
+    });
+    it('should fetch project data again on project change.', function () {
+      
+    });
+    it('should not fetch project data again on user change.', function () {
+      
+    });
+    it('should not fetch project data again on any other prop change.', function () {
+      
+    });
+  })
+});


### PR DESCRIPTION
Staging branch URL:

Fixes #4343.

Fixes a bug in the project page controller where `fetchProjectData` is called twice on component mount, which leads to user preferences being created for a new project, but then overwritten with `undefined`.
- [x] - Set out expectations for the project page controller.
- [ ] - Write actual tests to isolate the bug.
- [ ] - Fix the bug.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
