### PR TITLE
Update project controller test spies

### DIFF
--- a/app/pages/project/index.cjsx
+++ b/app/pages/project/index.cjsx
@@ -19,7 +19,7 @@ counterpart.registerTranslations 'nl', require('../../locales/nl').default
 counterpart.setFallbackLocale 'en'
 
 
-ProjectPageController = createReactClass
+ProjectPageController = 
   displayName: 'ProjectPageController'
 
   contextTypes:
@@ -304,7 +304,8 @@ mapDispatchToProps = (dispatch) -> ({
   }
 });
 
+ControllerComponent = createReactClass ProjectPageController
 module.exports = {
-    default: connect(mapStateToProps, mapDispatchToProps, null, { pure: false })(ProjectPageController)
+    default: connect(mapStateToProps, mapDispatchToProps, null, { pure: false })(ControllerComponent)
     ProjectPageController
   }

--- a/app/pages/project/index.spec.js
+++ b/app/pages/project/index.spec.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import createReactClass from 'create-react-class';
 import { mount } from 'enzyme';
 import assert from 'assert';
 import sinon from 'sinon';
@@ -42,8 +43,9 @@ describe('ProjectPageController', function () {
     
     beforeEach(function () {
       context.initialLoadComplete = true;
+      const ControllerComponent = createReactClass(ProjectPageController);
       wrapper = mount(
-        <ProjectPageController
+        <ControllerComponent
           location={location}
           params={params}
         />,
@@ -115,8 +117,9 @@ describe('ProjectPageController', function () {
     
     beforeEach(function () {
       context.initialLoadComplete = false;
+      const ControllerComponent = createReactClass(ProjectPageController);
       wrapper = mount(
-        <ProjectPageController
+        <ControllerComponent
           location={location}
           params={params}
         />,

--- a/app/pages/project/index.spec.js
+++ b/app/pages/project/index.spec.js
@@ -21,26 +21,27 @@ const context = {
 };
 
 describe('ProjectPageController', function () {
+  let wrapper;
+  let apiRequestStub;
+  let fetchProjectStub;
+
+  before(function () {
+    apiRequestStub = sinon.stub(apiClient, 'request').callsFake(function (method, url, payload) {
+      return Promise.resolve([]);
+    }); 
+    sinon.stub(Split, 'load').callsFake(() => Promise.resolve([]));
+    fetchProjectStub = sinon.stub(ProjectPageController, 'fetchProjectData').callsFake(function () {
+      return Promise.resolve([]);
+    });
+  });
+
+  after(function () {
+    apiRequestStub.restore();
+    Split.load.restore();
+    fetchProjectStub.restore();
+  });
+
   describe('with initial load complete', function () {
-    let wrapper;
-    let apiRequestStub;
-    let fetchProjectStub;
-    
-    before(function () {
-      apiRequestStub = sinon.stub(apiClient, 'request').callsFake(function (method, url, payload) {
-        return Promise.resolve([]);
-      }); 
-      sinon.stub(Split, 'load').callsFake(() => Promise.resolve([]));
-      fetchProjectStub = sinon.stub(ProjectPageController, 'fetchProjectData').callsFake(function () {
-        return Promise.resolve([]);
-      });
-    });
-    
-    after(function () {
-      apiRequestStub.restore();
-      Split.load.restore();
-      fetchProjectStub.restore();
-    });
     
     beforeEach(function () {
       context.initialLoadComplete = true;
@@ -93,25 +94,6 @@ describe('ProjectPageController', function () {
   });
 
   describe('without initial load complete', function () {
-    let wrapper;
-    let apiRequestStub;
-    let fetchProjectStub;
-    
-    before(function () {
-      apiRequestStub = sinon.stub(apiClient, 'request').callsFake(function (method, url, payload) {
-        return Promise.resolve([]);
-      }); 
-      sinon.stub(Split, 'load').callsFake(() => Promise.resolve([]));
-      fetchProjectStub = sinon.stub(ProjectPageController, 'fetchProjectData').callsFake(function () {
-        return Promise.resolve([]);
-      });
-    });
-    
-    after(function () {
-      apiRequestStub.restore();
-      Split.load.restore();
-      fetchProjectStub.restore();
-    });
     
     beforeEach(function () {
       context.initialLoadComplete = false;

--- a/app/pages/project/index.spec.js
+++ b/app/pages/project/index.spec.js
@@ -24,22 +24,23 @@ describe('ProjectPageController', function () {
   describe('with initial load complete', function () {
     let wrapper;
     let apiRequestStub;
-    const payload = {
-      slug: 'owner/test-project',
-      include: 'avatar,background,owners'
-    };
+    let fetchProjectStub;
     
     before(function () {
       apiRequestStub = sinon.stub(apiClient, 'request').callsFake(function (method, url, payload) {
         return Promise.resolve([]);
       }); 
       sinon.stub(Split, 'load').callsFake(() => Promise.resolve([]));
+      fetchProjectStub = sinon.stub(ProjectPageController, 'fetchProjectData').callsFake(function () {
+        return Promise.resolve([]);
+      });
     });
     
     after(function () {
       apiRequestStub.restore();
       Split.load.restore();
-    })
+      fetchProjectStub.restore();
+    });
     
     beforeEach(function () {
       context.initialLoadComplete = true;
@@ -54,12 +55,12 @@ describe('ProjectPageController', function () {
     });
     
     afterEach(function () {
-      apiRequestStub.resetHistory();
-    })
+      fetchProjectStub.resetHistory();
+    });
     
     it('should fetch project data on mount.', function () {
-      sinon.assert.calledOnce(apiRequestStub);
-      sinon.assert.calledWith(apiRequestStub, 'get', '/projects', payload);
+      sinon.assert.calledOnce(fetchProjectStub);
+      sinon.assert.calledWith(fetchProjectStub, params.owner, params.name);
     });
     
     it('should fetch project data again on project change.', function () {
@@ -70,50 +71,47 @@ describe('ProjectPageController', function () {
           name: 'another-project'
         }
       });
-      const newPayload = {
-        slug: 'someone/another-project',
-        include: 'avatar,background,owners'
-      };
-      sinon.assert.calledTwice(apiRequestStub);
-      sinon.assert.calledWith(apiRequestStub, 'get', '/projects', newPayload);
+      sinon.assert.calledTwice(fetchProjectStub);
+      sinon.assert.calledWith(fetchProjectStub, 'someone', 'another-project');
     });
     
     it('should fetch project data again on user change.', function () {
       const user = { id: '1' };
       wrapper.setState({ loading: false });
       wrapper.setProps({ user });
-      sinon.assert.calledTwice(apiRequestStub);
-      sinon.assert.calledWith(apiRequestStub, 'get', '/projects', payload);
+      sinon.assert.calledTwice(fetchProjectStub);
+      sinon.assert.calledWith(fetchProjectStub, params.owner, params.name, user);
     });
     
     it('should not fetch project data again while the first request is still loading.', function () {
       const translations = { locale: 'es' };
       wrapper.setState({ loading: false });
       wrapper.setProps({ translations });
-      sinon.assert.calledOnce(apiRequestStub);
-      sinon.assert.calledWith(apiRequestStub, 'get', '/projects', payload);
+      sinon.assert.calledOnce(fetchProjectStub);
+      sinon.assert.calledWith(fetchProjectStub, params.owner, params.name);
     });
   });
 
   describe('without initial load complete', function () {
     let wrapper;
     let apiRequestStub;
-    const payload = {
-      slug: 'owner/test-project',
-      include: 'avatar,background,owners'
-    };
+    let fetchProjectStub;
     
     before(function () {
       apiRequestStub = sinon.stub(apiClient, 'request').callsFake(function (method, url, payload) {
         return Promise.resolve([]);
       }); 
       sinon.stub(Split, 'load').callsFake(() => Promise.resolve([]));
+      fetchProjectStub = sinon.stub(ProjectPageController, 'fetchProjectData').callsFake(function () {
+        return Promise.resolve([]);
+      });
     });
     
     after(function () {
       apiRequestStub.restore();
       Split.load.restore();
-    })
+      fetchProjectStub.restore();
+    });
     
     beforeEach(function () {
       context.initialLoadComplete = false;
@@ -128,11 +126,11 @@ describe('ProjectPageController', function () {
     });
     
     afterEach(function () {
-      apiRequestStub.resetHistory();
-    })
+      fetchProjectStub.resetHistory();
+    });
     
     it('should not fetch project data on mount.', function () {
-      sinon.assert.notCalled(apiRequestStub);
+      sinon.assert.notCalled(fetchProjectStub);
     });
     
     it('should fetch project data again on project change.', function () {
@@ -143,25 +141,21 @@ describe('ProjectPageController', function () {
           name: 'another-project'
         }
       });
-      const newPayload = {
-        slug: 'someone/another-project',
-        include: 'avatar,background,owners'
-      };
-      sinon.assert.calledOnce(apiRequestStub);
-      sinon.assert.calledWith(apiRequestStub, 'get', '/projects', newPayload);
+      sinon.assert.calledOnce(fetchProjectStub);
+      sinon.assert.calledWith(fetchProjectStub, 'someone', 'another-project');
     });
     
     it('should not fetch project data again on user change.', function () {
       const user = { id: '1' };
       wrapper.setState({ loading: false });
       wrapper.setProps({ user });
-      sinon.assert.notCalled(apiRequestStub);
+      sinon.assert.notCalled(fetchProjectStub);
     });
     
     it('should not fetch project data again on any other prop change.', function () {
       const translations = { locale: 'es' };
       wrapper.setProps({ translations });
-      sinon.assert.notCalled(apiRequestStub);
+      sinon.assert.notCalled(fetchProjectStub);
     });
-  })
+  });
 });


### PR DESCRIPTION
Staging branch URL: https://project-controller-tests.pfe-preview.zooniverse.org

Updates the project page controller tests to spy directly on calls to `fetchProjectData`. For this to work, you have to export the bare component config object, then wrap it in `createReactClass` after you've bound your wrapped stubs and spies to it.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
