### PR TITLE
Use correct color space for image inversion

### DIFF
--- a/app/components/svg-image.jsx
+++ b/app/components/svg-image.jsx
@@ -8,7 +8,7 @@ const FILTERS = {
 const INVERT =
   `<svg style="position: fixed; right: 100%; top: 100%; visibility: hidden;">
     <defs>
-      <filter id="svg-invert-filter">
+      <filter id="svg-invert-filter" color-interpolation-filters="sRGB">
         <feComponentTransfer>
           <feFuncR type="table" tableValues="1 0"/>
           <feFuncG type="table" tableValues="1 0"/>


### PR DESCRIPTION
Staging branch URL: https://fix-color-invert.pfe-preview.zooniverse.org/

Describe your changes.

The previous version of color inversion was done in `linearRGB` space
and produced the incorrect results (inverted image was too white/"blown
out").  This forces the filter to be calculated in the correct `sRGB`
color space.  This change is required for Galaxy Zoo to move overt to
PFE.

Original method:
![screen shot 2018-02-12 at 2 11 11 pm](https://user-images.githubusercontent.com/6557526/36100886-a343c14a-0fff-11e8-9019-6f12b060b2d6.png)

New method:
![screen shot 2018-02-12 at 2 11 02 pm](https://user-images.githubusercontent.com/6557526/36100890-a9506ba6-0fff-11e8-891d-c17293115669.png)


# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [x] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
