### PR TITLE
edit workflow.mobile_friendly with workflow.configuration.swipe_enabled

### DIFF
--- a/app/pages/lab/mobile/mobile-section-container.jsx
+++ b/app/pages/lab/mobile/mobile-section-container.jsx
@@ -85,7 +85,7 @@ class MobileSectionContainer extends Component {
   }
 
   renderMobileSection() {
-    const checked = this.props.workflow.configuration.swipe_enabled || false;
+    const checked = (this.props.workflow.mobile_friendly && this.props.workflow.configuration.swipe_enabled) || false;
     return <MobileSection
       checked={checked}
       enabled={this.state.enabled}
@@ -96,7 +96,7 @@ class MobileSectionContainer extends Component {
 
   toggleChecked() {
     const { project, workflow } = this.props;
-    const currentStatus = workflow.configuration.swipe_enabled || false;
+    const currentStatus = (workflow.mobile_friendly && workflow.configuration.swipe_enabled) || false;
     const updateWorkflow = workflow.update({
       'configuration.swipe_enabled': !currentStatus,
       mobile_friendly: !currentStatus
@@ -108,7 +108,7 @@ class MobileSectionContainer extends Component {
         return allWorkflows.reduce((hasSwipeWorkflow, thisWorkflow) => {
           return (hasSwipeWorkflow)
             ? hasSwipeWorkflow
-            : (thisWorkflow.configuration && thisWorkflow.configuration.swipe_enabled);
+            : (thisWorkflow.mobile_friendly && thisWorkflow.configuration && thisWorkflow.configuration.swipe_enabled);
         }, false);
       })
       .then(mobileFriendly => {
@@ -143,7 +143,7 @@ class MobileSectionContainer extends Component {
       validations
     });
 
-    if (!enabled && this.props.workflow.configuration.swipe_enabled) {
+    if (!enabled && this.props.workflow.mobile_friendly && this.props.workflow.configuration.swipe_enabled) {
       this.toggleChecked();
     }
   }
@@ -159,6 +159,7 @@ MobileSectionContainer.propTypes = {
   }),
   workflow: React.PropTypes.shape({
     configuration: React.PropTypes.object,
+    mobile_friendly: React.PropTypes.bool,
     tasks: React.PropTypes.object,
     update: React.PropTypes.func
   }),

--- a/app/pages/lab/mobile/mobile-section-container.spec.js
+++ b/app/pages/lab/mobile/mobile-section-container.spec.js
@@ -164,9 +164,17 @@ describe('<MobileSectionContainer />', function () {
       assert.ok(isBoolean(component.props().checked));
     });
 
-    it('should equal true if the workflow has swipe enabled', function () {
+    it('should equal true if the workflow has swipe enabled and mobile_friendly true', function () {
       const { checked } = component.props();
       assert.strictEqual(checked, true);
+    });
+
+    it('should equal false if the workflow has mobile_friendly false', function () {
+      const workflow = fixtures.workflow({ mobile_friendly: false });
+      wrapper = shallow(<MobileSectionContainer task={fixtures.task()} workflow={workflow} project={fixtures.project()} />);
+      component = wrapper.find('MobileSection').first();
+      const { checked } = component.props();
+      assert.strictEqual(checked, false);
     });
 
     it('should equal false if the workflow doesn\'t have swipe enabled', function () {
@@ -219,7 +227,7 @@ describe('<MobileSectionContainer />', function () {
   });
 
   describe('resource updating', function () {
-    it('should update the original workflow prop when toggling enabled', function (done) {
+    it('should update the original workflow props when toggling enabled', function (done) {
       let wrapper = mount(<MobileSectionContainer
         project={fixtures.project()}
         task={fixtures.task()}
@@ -232,6 +240,7 @@ describe('<MobileSectionContainer />', function () {
           wrapper.update();
           const workflow = wrapper.props().workflow;
           assert.strictEqual(workflow.configuration.swipe_enabled, false);
+          assert.strictEqual(workflow.mobile_friendly, false);
         })
         .then(function () {
           return component.props().toggleChecked();
@@ -240,6 +249,7 @@ describe('<MobileSectionContainer />', function () {
           wrapper.update();
           const workflow = wrapper.props().workflow;
           assert.strictEqual(workflow.configuration.swipe_enabled, true);
+          assert.strictEqual(workflow.mobile_friendly, true);
           done();
         });
     });


### PR DESCRIPTION
Staging branch URL: https://workflow-mobile-friendly.pfe-preview.zooniverse.org/

Related to https://github.com/zooniverse/mobile/issues/151.

Adds functionality so workflow editor mobile section edits `workflow.mobile_friendly` boolean similarly to `workflow.configuration.swipe_enabled`. This will allow API request in mobile app for projects' workflows to be filtered by `mobile_friendly`.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
