### PR TITLE
Add name to single question's input element

### DIFF
--- a/app/classifier/tasks/single/index.jsx
+++ b/app/classifier/tasks/single/index.jsx
@@ -22,6 +22,9 @@ export default class SingleChoiceTask extends React.Component {
 
   render() {
     const { annotation, task, translation } = this.props;
+    if (!task._key) {
+      task._key = Math.random()
+    }
     const answers = [];
     for (const [i, answer] of task.answers.entries()) {
       if (!answer._key) {
@@ -40,6 +43,7 @@ export default class SingleChoiceTask extends React.Component {
               checked={i === annotation.value}
               value={i}
               onChange={this.handleChange.bind(this, i)}
+              name={`${task._key}`}
             />
           </div>
           <div className="answer-button-label-container">
@@ -50,7 +54,7 @@ export default class SingleChoiceTask extends React.Component {
     }
     return (
       <GenericTask
-        autoFocus = {annotation.value === null}
+        autoFocus={annotation.value === null}
         question={translation.question}
         help={translation.help}
         answers={answers}


### PR DESCRIPTION
Staging branch URL: https://fix-4351.pfe-preview.zooniverse.org/

Fixes #4351 .

Describe your changes.

This PR makes the keyboard work as expected for the radio buttons. A random number is assigned to the task as a `_key` so this still works when multiple questions are in a combo task.

A test workflow with two single question tasks in combo: https://fix-4351.pfe-preview.zooniverse.org/projects/cmk24/test-project-2/classify?reload=0&workflow=3161

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [x] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
