### PR TITLE
Update project email settings correctly

### DIFF
--- a/app/pages/settings/email.jsx
+++ b/app/pages/settings/email.jsx
@@ -60,29 +60,34 @@ TalkPreferences.propTypes = {
 };
 
 function ProjectPreferences({ projects, projectPreferences, onChange }) {
-  const projectNames = {};
-  projects.map(project => projectNames[project.id] = project.display_name);
-  const projectIDs = projects.map(proj => proj.id);
-  function filterPrefs() {
-    return projectPreferences.filter(pref => projectIDs.includes(pref.links.project));
+  let projectsDictionary;
+  if (projects.length > 0) {
+    projectsDictionary = projects.reduce((accum, item) => {
+      const newAccum = accum;
+      newAccum[item.id] = item;
+      return newAccum;
+    }, {});
   }
 
   return (
     <tbody>
-      {filterPrefs().map((projectPreference, i) => {
-        if (projects[i]) {
+      {projectPreferences.map((pref, i) => {
+        if (projectsDictionary[pref.links.project]) {
           return (
-            <tr key={projectPreference.id}>
+            <tr key={pref.id}>
               <td>
                 <input
+                  id={pref.id}
                   type="checkbox"
                   name="email_communication"
-                  checked={projectPreference.email_communication}
+                  checked={pref.email_communication}
                   onChange={e => onChange(i, e)}
                 />
               </td>
               <td>
-                {projectNames[projectPreference.links.project]}
+                <label htmlFor={pref.id}>
+                  {projectsDictionary[pref.links.project].display_name}
+                </label>
               </td>
             </tr>
           );

--- a/app/pages/settings/email.spec.js
+++ b/app/pages/settings/email.spec.js
@@ -72,10 +72,10 @@ const projects = [
 
 const projectPreferences = [
   {
-    id: '1',
-    email_communication: true,
+    id: '3',
+    email_communication: false,
     links: {
-      project: 'a'
+      project: 'c'
     }
   },
   {
@@ -83,6 +83,13 @@ const projectPreferences = [
     email_communication: false,
     links: {
       project: 'b'
+    }
+  },
+  {
+    id: '1',
+    email_communication: true,
+    links: {
+      project: 'a'
     }
   }
 ];

--- a/app/pages/settings/email.spec.js
+++ b/app/pages/settings/email.spec.js
@@ -171,13 +171,16 @@ describe('EmailSettings', function () {
 
     projects.forEach((project, i) => {
       it(`shows project ${i} email input correctly`, function () {
-        const email = projectSettings.at(i).find('input');
-        assert.equal(email.prop('checked'), projectPreferences[i].email_communication);
+        const projectPreference = projectPreferences.filter(pref => pref.links.project === project.id)[0];
+        const email = projectSettings.find(`input[id="${projectPreference.id}"]`);
+        assert.equal(email.prop('checked'), projectPreference.email_communication);
       });
 
       it(`updates project ${i} email settings on change`, function () {
-        const emailPreference = projectPreferences[i].email_communication;
-        const email = projectSettings.at(i).find('input');
+        const projectPreference = projectPreferences.filter(pref => pref.links.project === project.id)[0];
+        const emailPreference = projectPreference.email_communication;
+        const email = projectSettings.find(`input[id="${projectPreference.id}"]`);
+        const index = projectPreferences.indexOf(projectPreference);
         const fakeEvent = {
           target: {
             type: email.prop('type'),
@@ -186,11 +189,12 @@ describe('EmailSettings', function () {
           }
         };
         email.simulate('change', fakeEvent);
-        assert.equal(wrapper.state().projectPreferences[i].email_communication, !emailPreference);
+        assert.equal(wrapper.state().projectPreferences[index].email_communication, !emailPreference);
       });
 
       it(`shows project ${i} name correctly`, function () {
-        const name = projectSettings.at(i).find('td').last();
+        const projectPreference = projectPreferences.filter(pref => pref.links.project === project.id)[0];
+        const name = projectSettings.find(`label[htmlFor="${projectPreference.id}"]`);
         assert.equal(name.text(), project.display_name);
       });
     });


### PR DESCRIPTION
Staging branch URL: https://fix-project-email.pfe-preview.zooniverse.org/

Fixes #4263.

Previous code relied on preferences and projects having the same length and order, which will not be the case for real arrays returned from Panoptes.

Updates the email settings tests to check the case where preferences and projects are of different lengths, and have a different order. Updates the email settings component to pass the tests.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
