### PR TITLE
Use project instead of workflows in Apply For Beta form

### DIFF
--- a/app/pages/lab/apply-for-beta-form.jsx
+++ b/app/pages/lab/apply-for-beta-form.jsx
@@ -9,7 +9,7 @@ const REQUIRED_PAGES = ['Research', 'FAQ'];
 
 // Static functions
 const projectHasActiveWorkflows = (project) => {
-  if (project.links.active_workflows) {
+  if (project.links.active_workflows && project.links.active_workflows.length > 0) {
     return true;
   }
   return false;
@@ -93,6 +93,7 @@ class ApplyForBetaForm extends React.Component {
     this.updateValidationsFromProps = this.updateValidationsFromProps.bind(this);
 
     this.state = {
+      links: {},
       validations: {
         projectIsPublic: projectIsPublic(props.project),
         projectIsLive: projectIsLive(props.project),
@@ -105,6 +106,7 @@ class ApplyForBetaForm extends React.Component {
       doingAsyncValidation: false
     };
   }
+
 
   componentWillUpdate(nextProps) {
     this.updateValidationsFromProps(nextProps);

--- a/app/pages/lab/apply-for-beta-form.jsx
+++ b/app/pages/lab/apply-for-beta-form.jsx
@@ -8,28 +8,17 @@ const MINIMUM_SUBJECT_COUNT = 100;
 const REQUIRED_PAGES = ['Research', 'FAQ'];
 
 // Static functions
-const projectHasActiveWorkflows = (workflows) => {
-  return workflows.some((workflow) => {
-    return workflow.active;
-  });
+const projectHasActiveWorkflows = (project) => {
+  if (project.links.active_workflows) {
+    return true;
+  }
+  return false;
 };
 
-const projectHasMinimumActiveSubjects = (workflows) => {
-  const activeWorkflows = workflows.filter((workflow) => {
-    return workflow.active;
-  });
-  const uniqueSetIDs = activeWorkflows.reduce((sets, workflow) => {
-    return uniq(sets.concat(workflow.links.subject_sets));
-  }, []);
-  // Second parameter is an empty object to prevent request caching.
-  return apiClient.type('subject_sets', {})
-    .get(uniqueSetIDs)
-    .then((sets) => {
-      const subjectCount = sets.reduce((count, set) => {
-        return count + set.set_member_subjects_count;
-      }, 0);
-      return (subjectCount >= MINIMUM_SUBJECT_COUNT) ? true : `The project only has ${subjectCount} of ${MINIMUM_SUBJECT_COUNT} required subjects`;
-    });
+const projectHasMinimumActiveSubjects = (project) => {
+  const subjectCount = project.subjects_count;
+  return (subjectCount >= MINIMUM_SUBJECT_COUNT) ?
+    true : `The project only has ${subjectCount} of ${MINIMUM_SUBJECT_COUNT} required subjects`;
 };
 
 const projectHasRequiredContent = (project) => {
@@ -107,7 +96,7 @@ class ApplyForBetaForm extends React.Component {
       validations: {
         projectIsPublic: projectIsPublic(props.project),
         projectIsLive: projectIsLive(props.project),
-        projectHasActiveWorkflows: projectHasActiveWorkflows(props.workflows),
+        projectHasActiveWorkflows: projectHasActiveWorkflows(props.project),
         labPolicyReviewed: false,
         bestPracticesReviewed: false,
         feedbackReviewed: false
@@ -126,7 +115,7 @@ class ApplyForBetaForm extends React.Component {
     // error messages.
     this.setState({ doingAsyncValidation: true });
     return Promise.all([
-      projectHasMinimumActiveSubjects(this.props.workflows),
+      projectHasMinimumActiveSubjects(this.props.project),
       projectHasRequiredContent(this.props.project)
     ])
     .catch((error) => {
@@ -194,6 +183,7 @@ class ApplyForBetaForm extends React.Component {
   }
 
   updateValidationsFromProps(props) {
+
     // We need to do a props comparison, otherwise we get a loop where props
     // update state -> updates state repeatedly.
     //
@@ -206,7 +196,7 @@ class ApplyForBetaForm extends React.Component {
     const newValues = {
       projectIsPublic: projectIsPublic(props.project),
       projectIsLive: projectIsLive(props.project),
-      projectHasActiveWorkflows: projectHasActiveWorkflows(props.workflows)
+      projectHasActiveWorkflows: projectHasActiveWorkflows(props.project)
     };
 
     Object.keys(newValues).forEach((key) => {
@@ -223,7 +213,6 @@ class ApplyForBetaForm extends React.Component {
   render() {
     const applyButtonDisabled = !this.canApplyForReview() ||
       this.state.doingAsyncValidation;
-
     return (
       <div>
 
@@ -264,7 +253,6 @@ class ApplyForBetaForm extends React.Component {
 
 ApplyForBetaForm.defaultProps = {
   project: {},
-  workflows: [],
   applyFn: Function.prototype
 };
 
@@ -274,12 +262,6 @@ ApplyForBetaForm.propTypes = {
     live: PropTypes.bool.isRequired,
     private: PropTypes.bool.isRequired
   }).isRequired,
-  workflows: PropTypes.arrayOf(PropTypes.shape({
-    active: PropTypes.bool.isRequired,
-    links: PropTypes.shape({
-      subject_sets: PropTypes.arrayOf(PropTypes.string).isRequired
-    })
-  })).isRequired,
   applyFn: PropTypes.func.isRequired
 };
 

--- a/app/pages/lab/apply-for-beta-form.jsx
+++ b/app/pages/lab/apply-for-beta-form.jsx
@@ -93,7 +93,6 @@ class ApplyForBetaForm extends React.Component {
     this.updateValidationsFromProps = this.updateValidationsFromProps.bind(this);
 
     this.state = {
-      links: {},
       validations: {
         projectIsPublic: projectIsPublic(props.project),
         projectIsLive: projectIsLive(props.project),

--- a/app/pages/lab/apply-for-beta-form.jsx
+++ b/app/pages/lab/apply-for-beta-form.jsx
@@ -9,10 +9,7 @@ const REQUIRED_PAGES = ['Research', 'FAQ'];
 
 // Static functions
 const projectHasActiveWorkflows = (project) => {
-  if (project.links.active_workflows && project.links.active_workflows.length > 0) {
-    return true;
-  }
-  return false;
+  return project.links.active_workflows && project.links.active_workflows.length > 0;
 };
 
 const projectHasMinimumActiveSubjects = (project) => {

--- a/app/pages/lab/apply-for-beta-form.spec.js
+++ b/app/pages/lab/apply-for-beta-form.spec.js
@@ -10,6 +10,9 @@ const REQUIRED_PAGES = ['Research', 'FAQ'];
 const createProjectProp = (properties) => {
   return Object.assign({}, {
     id: "1234",
+    links: {
+      active_workflows: [1, 2]
+    },
     private: false,
     live: true,
   }, properties);
@@ -151,7 +154,7 @@ describe('ApplyForBeta component:', function() {
       describe('active workflow checkbox:', function() {
         const setActiveWorkflowStatusWrappers = function() {
           setWrappers('Project has at least one active workflow');
-        }
+        };
 
         beforeEach(testSetup);
 
@@ -166,12 +169,12 @@ describe('ApplyForBeta component:', function() {
         });
 
         it('should be unchecked if the project has no active workflows', function() {
+          project.links.active_workflows = undefined;
           setActiveWorkflowStatusWrappers();
           assertCheckboxChecked(checkbox, false);
         });
 
         it('should be checked if the project has at least one active workflow', function() {
-          workflows[0].active = true;
           setActiveWorkflowStatusWrappers();
           assertCheckboxChecked(checkbox);
         });

--- a/app/pages/lab/visibility.cjsx
+++ b/app/pages/lab/visibility.cjsx
@@ -21,8 +21,6 @@ module.exports = createReactClass
       private: false
       beta_requested: false
       launch_requested: false
-    workflows: []
-    loadingWorkflows: false
 
   mixins: [SetToggle]
 
@@ -94,7 +92,7 @@ module.exports = createReactClass
           </div>
           <span>Review status has been applied for. <button type="button" disabled={@state.setting.beta_requested} onClick={@set.bind this, 'beta_requested', false}>Cancel application</button></span>
         else
-          <ApplyForBetaForm project={@props.project} workflows={@state.workflows} applyFn={@set.bind this, 'beta_requested', true} />
+          <ApplyForBetaForm project={@props.project} applyFn={@set.bind this, 'beta_requested', true} />
         }
 
       </div>

--- a/app/pages/lab/workflows-container.jsx
+++ b/app/pages/lab/workflows-container.jsx
@@ -66,6 +66,7 @@ export default class WorkflowsContainer extends React.Component {
     workflow.update({ active: checked }).save()
       .catch(error => console.log(error))
       .then(() => {
+        this.props.project.uncache();
         if (!workflow.active && workflow.id === defaultWorkflow) {
           this.props.project.update({ 'configuration.default_workflow': null });
           this.props.project.save();


### PR DESCRIPTION
Staging branch URL: https://visibility-page.pfe-preview.zooniverse.org/

Fixes #4360 .

Describe your changes.
Get active workflows and subject count from project instead of workflows, which isn't available anymore.
I'm not sure this is working properly. I'm seeing some strange behaviour when I pass from no active workflows to even just one active. When I check the visibility page the checkbox takes ages to update or doesn't update at all, even if the project does have `active_workflows`. 


# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
