### PR TITLE
Remove unused import and prop

### DIFF
--- a/app/pages/project/finished-banner.jsx
+++ b/app/pages/project/finished-banner.jsx
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Link } from 'react-router';
-import getWorkflowsInOrder from '../../lib/get-workflows-in-order';
 
 const THREE_DAYS = 3 * 24 * 60 * 60 * 1000;
 
@@ -106,6 +105,5 @@ FinishedBanner.propTypes = {
   project: PropTypes.shape({
     id: PropTypes.string,
     slug: PropTypes.string,
-  }),
-  projectIsComplete: PropTypes.bool
+  })
 };


### PR DESCRIPTION
Staging branch URL: https://remove-unused-import.pfe-preview.zooniverse.org/

Describe your changes.
- remove unused getWorkflowsInOrder import
- remove unused projectIsComplete prop

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
