### PR TITLE
Replace uniq with uniqBy for Talk roles

### DIFF
--- a/app/talk/lib/display-roles.cjsx
+++ b/app/talk/lib/display-roles.cjsx
@@ -1,7 +1,7 @@
 React = require 'react'
 PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
-uniq = require 'lodash/uniq'
+uniqBy = require 'lodash/uniqBy'
 
 zooniverseTeamRole = (role) ->
   role.section is 'zooniverse' and [ 'admin', 'team' ].indexOf(role.name) isnt -1
@@ -32,7 +32,7 @@ DisplayRoles = createReactClass
 
   render: ->
     <div className="talk-display-roles">
-      {uniq(@props.roles, roleDisplayName).map(@role)}
+      {uniqBy(@props.roles, roleDisplayName).map(@role)}
     </div>
 
 module.exports = DisplayRoles


### PR DESCRIPTION
Staging branch URL: https://dedupe-talk-roles.pfe-preview.zooniverse.org

Fixes #3898 

Describe your changes.
Dedupes the array of display names, not the original roles array, before listing someone's Talk roles.
https://lodash.com/docs/4.17.5#uniqBy

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
