### PR TITLE
Replace mocha --compilers with --require

### DIFF
--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,1 +1,1 @@
- --compilers js:babel-core/register,coffee:coffee-script/register,cjsx:coffee-react/register
+ --require babel-core/register --require coffee-script/register --require coffee-react/register


### PR DESCRIPTION
See https://github.com/mochajs/mocha/wiki/compilers-deprecation

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
