### PR TITLE
Hide the field guide on the project home page

### DIFF
--- a/app/pages/project/project-page.jsx
+++ b/app/pages/project/project-page.jsx
@@ -5,6 +5,7 @@ import { Markdown } from 'markdownz';
 import { sugarClient } from 'panoptes-client/lib/sugar';
 import ProjectNavbar from './components/ProjectNavbar';
 import PotentialFieldGuide from './potential-field-guide';
+import ProjectHomeContainer from './home/';
 
 export default class ProjectPage extends React.Component {
   getChildContext() {
@@ -84,7 +85,7 @@ export default class ProjectPage extends React.Component {
           user: this.props.user,
           workflow: this.props.workflow
         })}
-        {React.Children.only(this.props.children).type.name !== 'ProjectHomeContainer' &&
+        {React.Children.only(this.props.children).type !== ProjectHomeContainer &&
           <PotentialFieldGuide
             guide={this.props.guide}
             guideIcons={this.props.guideIcons}

--- a/app/pages/project/project-page.spec.js
+++ b/app/pages/project/project-page.spec.js
@@ -6,15 +6,12 @@ import { sugarClient } from 'panoptes-client/lib/sugar';
 import { project } from '../dev-classifier/mock-data';
 import ProjectPage from './project-page';
 import ProjectNavbar from './components/ProjectNavbar';
+import ProjectHomeContainer from './home/';
 
 function Page() {
   return (
     <p>Hello world!</p>
   );
-}
-
-function ProjectHomeContainer() {
-  return (<p>Mocked home page.</p>);
 }
 
 describe('ProjectPage', function () {


### PR DESCRIPTION
Staging branch URL: https://home-field-guide.pfe-preview.zooniverse.org/

Fixes #4372 .

Describe your changes.
Hide the field guide if the project's only child component is ProjectHomeContainer.
Compares the component functions directly, since the production version is an anonymous function and has no name.

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
