### PR TITLE
Fix breakpoint calculation

### DIFF
--- a/app/pages/project/components/ProjectNavbar/ProjectNavbar.jsx
+++ b/app/pages/project/components/ProjectNavbar/ProjectNavbar.jsx
@@ -55,12 +55,11 @@ export class ProjectNavbar extends Component {
     // 1200 is the max-width for the navbar wrapper
     const doesNavFit = this.state.breakpoint < 1200;
     const isWindowWide = this.props.width > this.state.breakpoint;
-    const navbarNarrowProps = { ...this.props, useWideLayoutVariant: !doesNavFit };
-
+    const navbarNarrowProps = { ...this.props, useWideLayoutVariant: !doesNavFit && isWindowWide };
     if ((isWindowWide) && (doesNavFit)) {
       return <ProjectNavbarWide {...this.props} />;
     }
-    
+
     return <ProjectNavbarNarrow {...navbarNarrowProps} />;
   }
 }

--- a/app/pages/project/components/ProjectNavbar/ProjectNavbarContainer.jsx
+++ b/app/pages/project/components/ProjectNavbar/ProjectNavbarContainer.jsx
@@ -86,6 +86,7 @@ class ProjectNavbarContainer extends Component {
     const links = getProjectLinks({ project, projectRoles, workflow, user });
 
     return _.map(links, link => ({
+      disabled: link.disabled || false,
       isExternalLink: link.isExternalLink || false,
       label: counterpart(link.translationPath),
       url: link.url

--- a/app/pages/project/components/ProjectNavbar/components/NavLink/NavLink.jsx
+++ b/app/pages/project/components/ProjectNavbar/components/NavLink/NavLink.jsx
@@ -7,7 +7,6 @@ import { pxToRem } from '../../../../../../theme';
 import socialIcons from '../../socialIcons';
 
 const commonStyles = `
-  color: white;
   display: block;
   font-family: Karla;
   font-size: ${pxToRem(15)};
@@ -22,10 +21,18 @@ const commonStyles = `
 export const StyledInternalLink = styled(Link).attrs({
   activeClassName: 'active'
 })`
+  color: white;
   ${commonStyles}
 `;
 
 export const StyledExternalLink = styled.a`
+  color: white;
+  ${commonStyles}
+`;
+
+export const StyledLinkPlaceholder = styled.span`
+  color: lightgrey;
+  cursor: not-allowed;
   ${commonStyles}
 `;
 
@@ -47,6 +54,14 @@ function NavLink({ isExternalLink, isSocialLink, label, site, url, ...props }) {
     const icon = socialIcons[site].icon;
     linkProps['aria-label'] = socialIcons[site].label;
     iconClasses = `fa ${icon} fa-fw`;
+  }
+
+  if (linkProps.disabled) {
+    return (
+      <StyledLinkPlaceholder {...linkProps}>
+        {label}
+      </StyledLinkPlaceholder>
+    );
   }
 
   return (

--- a/app/pages/project/components/ProjectNavbar/components/NavLink/NavLink.spec.js
+++ b/app/pages/project/components/ProjectNavbar/components/NavLink/NavLink.spec.js
@@ -9,7 +9,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import { expect } from 'chai';
 
-import NavLink, { StyledExternalLink, StyledInternalLink } from './NavLink';
+import NavLink from './NavLink';
 import socialIcons from '../../socialIcons';
 import { getProjectLinks } from '../../helpers';
 import {
@@ -28,6 +28,16 @@ const MOCK_SOCIAL_SITE = 'facebook.com/';
 describe('NavLink', function() {
   it('renders without crashing', function() {
     shallow(<NavLink />);
+  });
+
+  describe('when the link is disabled', function() {
+    it('should be the StyledLinkPlaceholder component ', function() {
+      const navLinks = getProjectLinks({ project: projectWithoutRedirect, projectRoles, workflow: null, user: null });
+      const navLinksWithLabels = buildLinksWithLabels(navLinks);
+      const classifyLink = navLinksWithLabels[1];
+      const wrapper = shallow(<NavLink url={classifyLink.url} label={classifyLink.label} disabled={classifyLink.disabled} />);
+      expect(wrapper.name()).to.equal('styled.span');
+    });
   });
 
   describe('when the link is internal', function() {

--- a/app/pages/project/components/ProjectNavbar/components/ProjectNavbarWide/ProjectNavbarWide.jsx
+++ b/app/pages/project/components/ProjectNavbar/components/ProjectNavbarWide/ProjectNavbarWide.jsx
@@ -27,7 +27,11 @@ export const Nav = styled.nav`
   display: flex;
   flex: 1;
   justify-content: flex-end;
-  margin-left: ${pxToRem(20)}
+  margin-left: ${pxToRem(20)};
+
+  > span {
+    margin-right: ${pxToRem(30)} !important; 
+  }
 `;
 
 export const StyledNavLink = styled(NavLink)`
@@ -40,7 +44,7 @@ export const StyledNavLink = styled(NavLink)`
   }
 
   &:not(:last-of-type) {
-    margin-right: ${pxToRem(30)}
+    margin-right: ${pxToRem(30)};
   }
 `;
 

--- a/app/pages/project/components/ProjectNavbar/helpers/getProjectLinks.js
+++ b/app/pages/project/components/ProjectNavbar/helpers/getProjectLinks.js
@@ -52,8 +52,8 @@ function getProjectLinks({ project, projectRoles, workflow, user }) {
     _.unset(links, 'about');
   }
 
-  if (!redirect && !workflow) {
-    _.unset(links, 'classify');
+  if (!workflow) {
+    links.classify.disabled = true;
   }
 
   if (!user) {

--- a/app/pages/project/components/ProjectNavbar/helpers/getProjectLinks.spec.js
+++ b/app/pages/project/components/ProjectNavbar/helpers/getProjectLinks.spec.js
@@ -14,14 +14,14 @@ import {
 
 
 describe('getProjectLinks', function() {
-  it('uses the project slug in building the navbar links', function() {
+  it('should use the project slug in building the navbar links', function() {
     const navLinks = getProjectLinks({ project: projectWithoutRedirect, projectRoles, workflow, user: projectOwnerUser });
     Object.keys(navLinks).forEach((link) => {
       expect(navLinks[link].url.includes(projectWithoutRedirect.slug));
     });
   });
 
-  it('returns about, classify, talk, and collections set of navbar links', function() {
+  it('should return about, classify, talk, and collections set of navbar links', function() {
     const navLinks = getProjectLinks({ project: projectWithoutRedirect, projectRoles, workflow, user: null });
     expect(Object.keys(navLinks).indexOf('about') > -1).to.be.true;
     expect(Object.keys(navLinks).indexOf('classify') > -1).to.be.true;
@@ -30,45 +30,45 @@ describe('getProjectLinks', function() {
   });
 
   describe('without a user', function() {
-    it('does not return a recents link', function() {
+    it('should not return a recents link', function() {
       const navLinks = getProjectLinks({ project: projectWithoutRedirect, projectRoles, workflow, user: null });
       expect(Object.keys(navLinks).indexOf('recents') > -1).to.be.false;
     });
 
-    it('does not return a lab link', function() {
+    it('should not return a lab link', function() {
       const navLinks = getProjectLinks({ project: projectWithoutRedirect, projectRoles, workflow, user: null });
       expect(Object.keys(navLinks).indexOf('lab') > -1).to.be.false;
     });
 
-    it('does not return an admin link', function() {
+    it('should not return an admin link', function() {
       const navLinks = getProjectLinks({ project: projectWithoutRedirect, projectRoles, workflow, user: null });
       expect(Object.keys(navLinks).indexOf('admin') > -1).to.be.false;
     });
   });
 
   describe('with a user', function() {
-    it('returns a recents link', function() {
+    it('should return a recents link', function() {
       const navLinks = getProjectLinks({ project: projectWithoutRedirect, projectRoles, workflow, user: randomUser });
       expect(Object.keys(navLinks).indexOf('recents') > -1).to.be.true;
     });
 
-    it('does not return a lab link if the user is not the project owner or a collaborator', function() {
+    it('should not return a lab link if the user is not the project owner or a collaborator', function() {
       const navLinks = getProjectLinks({ project: projectWithoutRedirect, projectRoles, workflow, user: randomUser });
       expect(Object.keys(navLinks).indexOf('lab') > -1).to.be.false;
     });
 
-    it('does not return an admin page link if the user is not an admin', function() {
+    it('should not return an admin page link if the user is not an admin', function() {
       const navLinks = getProjectLinks({ project: projectWithoutRedirect, projectRoles, workflow, user: randomUser });
       expect(Object.keys(navLinks).indexOf('admin') > -1).to.be.false;
     });
 
     describe('who have a project role', function() {
-      it('returns the lab link if the user is the project owner', function() {
+      it('should return the lab link if the user is the project owner', function() {
         const navLinks = getProjectLinks({ project: projectWithoutRedirect, projectRoles, workflow, user: projectOwnerUser });
         expect(Object.keys(navLinks).indexOf('lab') > -1).to.be.true;
       });
 
-      it('returns the lab link if the user is a project collaborator', function() {
+      it('should return the lab link if the user is a project collaborator', function() {
         const navLinks = getProjectLinks({ project: projectWithoutRedirect, projectRoles, workflow, user: projectCollabUser });
         expect(Object.keys(navLinks).indexOf('lab') > -1).to.be.true;
       });
@@ -83,7 +83,7 @@ describe('getProjectLinks', function() {
         apiClient.params.admin = false;
       });
 
-      it('returns the admin link if the user is an admin', function() {
+      it('should return the admin link if the user is an admin', function() {
         const navLinks = getProjectLinks({ project: projectWithoutRedirect, projectRoles, workflow, user: adminUser });
         expect(Object.keys(navLinks).indexOf('admin') > -1).to.be.true;
       });
@@ -91,22 +91,22 @@ describe('getProjectLinks', function() {
   });
 
   describe('a project with a redirect', function() {
-    it('resets the classify link to the redirected project\'s classify page', function() {
+    it('should reset the classify link to the redirected project\'s classify page', function() {
       const navLinks = getProjectLinks({ project: projectWithRedirect, projectRoles, workflow, user: randomUser });
       expect(navLinks.classify.url.includes(projectWithRedirect.redirect)).to.be.true;
       expect(navLinks.classify.isExternalLink).to.be.true;
     });
 
-    it('does not return the about link', function() {
+    it('should not return the about link', function() {
       const navLinks = getProjectLinks({ project: projectWithRedirect, projectRoles, workflow, user: randomUser });
       expect(Object.keys(navLinks).indexOf('about') > -1).to.be.false;
     });
   });
 
-  describe('a project without a workflow and without a redirect', function() {
-    it('does not return the classify link', function() {
+  describe('a project without a workflow', function() {
+    it('should return the classify link with disabled: true', function() {
       const navLinks = getProjectLinks({ project: projectWithoutRedirect, projectRoles, workflow: null, user: null });
-      expect(Object.keys(navLinks).indexOf('classify') > -1).to.be.false;
+      expect(navLinks.classify.disabled).to.be.true;
     });
   });
 });

--- a/app/pages/project/components/ProjectNavbar/testHelpers/helperFunctions.js
+++ b/app/pages/project/components/ProjectNavbar/testHelpers/helperFunctions.js
@@ -1,9 +1,10 @@
 export function buildLinksWithLabels(navLinks) {
   return Object.keys(navLinks).map((linkName) => {
     return {
+      disabled: navLinks[linkName].disabled || false,
       isExternalLink: navLinks[linkName].isExternalLink || false,
       label: linkName,
       url: navLinks[linkName].url
     };
-  })
+  });
 }


### PR DESCRIPTION
Staging branch URL: https://fix-breakpoint-calculation.pfe-preview.zooniverse.org/

Fixes projects that are already collapsed into the drop down menu because of number of links to switch to the flex column layout for mobile sized screens. I also changed the classify link to use a disabled placeholder while the workflow is loading rather than appear later. This was causing some odd blips between layout styles.

Project to test this with: https://fix-breakpoint-calculation.pfe-preview.zooniverse.org/projects/meredithspalmer/snapshot-grumeti?env=production

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
