### PR TITLE
upgrade markdownz to 7.4.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6130,7 +6130,7 @@
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.0.3.tgz",
       "integrity": "sha1-2UpGSPmxwXnWT6lykSaL22zpQ08=",
       "requires": {
-        "uc.micro": "1.0.3"
+        "uc.micro": "1.0.5"
       }
     },
     "load-json-file": {
@@ -6197,23 +6197,6 @@
       "requires": {
         "lodash._basecopy": "3.0.1",
         "lodash.keys": "3.1.2"
-      },
-      "dependencies": {
-        "lodash.isarray": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-          "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
-        },
-        "lodash.keys": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-          "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-          "requires": {
-            "lodash._getnative": "3.9.1",
-            "lodash.isarguments": "3.1.0",
-            "lodash.isarray": "3.0.4"
-          }
-        }
       }
     },
     "lodash._basecopy": {
@@ -6376,7 +6359,7 @@
         "entities": "1.1.1",
         "linkify-it": "2.0.3",
         "mdurl": "1.0.1",
-        "uc.micro": "1.0.3"
+        "uc.micro": "1.0.5"
       }
     },
     "markdown-it-anchor": {
@@ -6439,9 +6422,9 @@
       "integrity": "sha1-H1GjRxRWolCaOCDc7ZrRzpYb22Q="
     },
     "markdownz": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/markdownz/-/markdownz-7.4.1.tgz",
-      "integrity": "sha512-ijHPLd09P+3yh/H9xtuox1cDXwHd6nBI3szUfmyJN2nxZVXneJw1JqpYeYUTPlgqeOwcgyEhhrVXI9nbZuqqPA==",
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/markdownz/-/markdownz-7.4.2.tgz",
+      "integrity": "sha512-kIZj3GoEY7vgomzsNS+zdZqQpqKig0tchMbo5X8bjDDeuWnZ3V3xtBeC2xRmJXSAbnFjwKcMFMemWctYlUjl1g==",
       "requires": {
         "markdown-it": "7.0.1",
         "markdown-it-anchor": "2.5.1",
@@ -10028,9 +10011,9 @@
       "integrity": "sha1-BMgamb3V3FImPqKdJMa/jUgYpLs="
     },
     "uc.micro": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.3.tgz",
-      "integrity": "sha1-ftUNXg+an7ClczeSWfKndFjVAZI="
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.5.tgz",
+      "integrity": "sha512-JoLI4g5zv5qNyT09f4YAvEZIIV1oOjqnewYg5D38dkQljIzpPT296dbIGvKro3digYI1bkb7W6EP1y4uDlmzLg=="
     },
     "uglify-js": {
       "version": "3.0.18",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "he": "~1.1.0",
     "json-api-client": "~3.2.2",
     "lodash": "~4.17.4",
-    "markdownz": "~7.4",
+    "markdownz": "~7.4.2",
     "mocha": "~5.0.1",
     "modal-form": "~2.5.1",
     "moment": "~2.18.1",


### PR DESCRIPTION
Staging branch URL: https://upgrade-markdownz.pfe-preview.zooniverse.org

Fixes findDOMNode errors when Markdown is unmounted.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
