### PR TITLE
Remove React.createClass and React.PropTypes

### DIFF
--- a/app/pages/lab/help/example.cjsx
+++ b/app/pages/lab/help/example.cjsx
@@ -1,6 +1,7 @@
 React = require 'react'
 counterpart = require 'counterpart'
 {Markdown} = require 'markdownz'
+createReactClass = require 'create-react-class'
 
 counterpart.registerTranslations 'en',
   example:
@@ -246,7 +247,7 @@ counterpart.registerTranslations 'en',
       *Note:* if you have a large subject set it may be cumbersome to manually create a manifest. We suggest using a command-line or other tool to copy-paste a directory list of files into a spreadsheet to help you get started.
     '''
 
-module.exports = React.createClass
+module.exports = createReactClass
   displayName: 'example'
 
   render: ->

--- a/app/pages/lab/mobile/mobile-section-container.jsx
+++ b/app/pages/lab/mobile/mobile-section-container.jsx
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import filter from 'lodash/filter';
 import every from 'lodash/every';
 import reduce from 'lodash/reduce';
@@ -151,22 +152,22 @@ class MobileSectionContainer extends Component {
 }
 
 MobileSectionContainer.propTypes = {
-  task: React.PropTypes.shape({
-    answers: React.PropTypes.array,
-    feedback: React.PropTypes.object,
-    question: React.PropTypes.string,
-    type: React.PropTypes.string,
-    unlinkedTask: React.PropTypes.string
+  task: PropTypes.shape({
+    answers: PropTypes.array,
+    feedback: PropTypes.object,
+    question: PropTypes.string,
+    type: PropTypes.string,
+    unlinkedTask: PropTypes.string
   }),
-  workflow: React.PropTypes.shape({
-    configuration: React.PropTypes.object,
-    mobile_friendly: React.PropTypes.bool,
-    tasks: React.PropTypes.object,
-    update: React.PropTypes.func
+  workflow: PropTypes.shape({
+    configuration: PropTypes.object,
+    mobile_friendly: PropTypes.bool,
+    tasks: PropTypes.object,
+    update: PropTypes.func
   }),
-  project: React.PropTypes.shape({
-    launch_approved: React.PropTypes.bool,
-    update: React.PropTypes.func
+  project: PropTypes.shape({
+    launch_approved: PropTypes.bool,
+    update: PropTypes.func
   })
 };
 


### PR DESCRIPTION
Staging branch URL: https://remove-proptypes.pfe-preview.zooniverse.org

Removes a couple more instances of `React.createClass` and `React.PropTypes` that have crept back in.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
