### PR TITLE
Show login names next to display names in private messages

### DIFF
--- a/app/talk/inbox-conversation.cjsx
+++ b/app/talk/inbox-conversation.cjsx
@@ -32,7 +32,7 @@ Message = createReactClass
   render: ->
     <div className="conversation-message">
       <span>
-        <strong><Link to="/users/#{@state.commentOwner?.login}">{@state.commentOwner?.display_name}</Link></strong>{' '}
+        <strong><Link to="/users/#{@state.commentOwner?.login}">{@state.commentOwner?.display_name}</Link> (@{@state.commentOwner?.login})</strong>{' '}
         <span>{timestamp(@props.data.updated_at)}</span>
       </span>
       <Markdown>{@props.data.body}</Markdown>


### PR DESCRIPTION
Otherwise all you can see is the display name, making it easy to
impersonate another user.

Staging branch URL: https://talk-pm-login-name.pfe-preview.zooniverse.org

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [x] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?