### PR TITLE
edit project nav org link

### DIFF
--- a/app/pages/project/components/ProjectNavbar/ProjectNavbarContainer.jsx
+++ b/app/pages/project/components/ProjectNavbar/ProjectNavbarContainer.jsx
@@ -74,7 +74,7 @@ class ProjectNavbarContainer extends Component {
       link.push({
         isExternalLink: true,
         label: organization.display_name,
-        to: `/organizations/${organization.slug}`
+        url: `/organizations/${organization.slug}`
       });
     }
 


### PR DESCRIPTION
Staging branch URL: https://fix-org-nav-link.pfe-preview.zooniverse.org/projects/markb-panoptes/calbug

Fixes "Each of the Snapshot Safari projects has a link in the project navigation that says Snapshot Safari but opens the project home in a new tab. https://www.zooniverse.org/projects/shuebner729/snapshot-apnr"

org nav link prop of `to` was set when I think should be `url` similar to other nav links 

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
