### PR TITLE
Fix project name redirect

### DIFF
--- a/app/pages/project/components/ProjectNavbar/ProjectNavbarContainer.jsx
+++ b/app/pages/project/components/ProjectNavbar/ProjectNavbarContainer.jsx
@@ -100,6 +100,7 @@ class ProjectNavbarContainer extends Component {
     const navLinks = this.getNavLinks();
     const projectTitle = _.get(this.props.translation, 'display_name', undefined);
     const projectLink = `/projects/${this.props.project.slug}`;
+    const redirect = this.props.project.redirect ? this.props.project.redirect : '';
     const underReview = this.props.project.beta_approved;
 
     return (
@@ -110,6 +111,7 @@ class ProjectNavbarContainer extends Component {
         navLinks={navLinks}
         projectTitle={projectTitle}
         projectLink={projectLink}
+        redirect={redirect}
         underReview={underReview}
       />
     );
@@ -130,6 +132,7 @@ ProjectNavbarContainer.propTypes = {
   project: PropTypes.shape({
     beta_approved: PropTypes.bool,
     launch_approved: PropTypes.bool,
+    redirect: PropTypes.string,
     slug: PropTypes.string,
     title: PropTypes.string,
     urls: PropTypes.array

--- a/app/pages/project/components/ProjectNavbar/components/ProjectNavbarNarrow/ProjectNavbarNarrow.jsx
+++ b/app/pages/project/components/ProjectNavbar/components/ProjectNavbarNarrow/ProjectNavbarNarrow.jsx
@@ -52,7 +52,8 @@ export class ProjectNavbarNarrow extends Component {
       projectLink,
       projectTitle,
       navLinks,
-      underReview,
+      redirect,
+      underReview
     } = this.props;
 
     return (
@@ -69,6 +70,7 @@ export class ProjectNavbarNarrow extends Component {
             <ProjectTitle
               launched={launched}
               link={projectLink}
+              redirect={redirect}
               title={projectTitle}
               underReview={underReview}
             />
@@ -97,7 +99,7 @@ ProjectNavbarNarrow.defaultProps = {
     { url: '' }
   ],
   projectLink: '',
-  projectTitle: '',
+  projectTitle: ''
 };
 
 ProjectNavbarNarrow.propTypes = {
@@ -110,7 +112,8 @@ ProjectNavbarNarrow.propTypes = {
   })),
   projectLink: PropTypes.string,
   projectTitle: PropTypes.string,
-  underReview: PropTypes.bool,
+  redirect: PropTypes.string,
+  underReview: PropTypes.bool
 };
 
 const mapSizesToProps = ({ height }) => ({

--- a/app/pages/project/components/ProjectNavbar/components/ProjectNavbarWide/ProjectNavbarWide.jsx
+++ b/app/pages/project/components/ProjectNavbar/components/ProjectNavbarWide/ProjectNavbarWide.jsx
@@ -57,6 +57,7 @@ function ProjectNavbarWide(props) {
     navLinks,
     projectTitle,
     projectLink,
+    redirect,
     underReview,
     ...otherProps
   } = props;
@@ -73,6 +74,7 @@ function ProjectNavbarWide(props) {
         <ProjectTitle
           launched={launched}
           link={projectLink}
+          redirect={redirect}
           title={projectTitle}
           underReview={underReview}
         />
@@ -93,6 +95,7 @@ ProjectNavbarWide.propTypes = {
   })),
   projectLink: PropTypes.string,
   projectTitle: PropTypes.string,
+  redirect: PropTypes.string,
   underReview: PropTypes.bool
 };
 

--- a/app/pages/project/components/ProjectNavbar/components/ProjectTitle/ProjectTitle.jsx
+++ b/app/pages/project/components/ProjectNavbar/components/ProjectTitle/ProjectTitle.jsx
@@ -35,6 +35,18 @@ export const StyledLink = styled(IndexLink).attrs({
   }
 `;
 
+export const StyledRedirect = styled.a`
+  border-bottom: ${pxToRem(3)} solid transparent;
+  color: white;
+  text-decoration: none;
+  white-space: nowrap;
+
+  &:hover,
+  &:focus {
+    border-bottom: ${pxToRem(3)} solid white;
+  }
+`;
+
 export const StyledCheckMarkWrapper = styled.span.attrs({
   'aria-label': "Zooniverse Approved",
   role: 'img',
@@ -62,22 +74,25 @@ export const StyledUnderReview = styled.small`
 `;
 
 
-function ProjectTitle({ launched, link, title, underReview }) {
+function ProjectTitle({ launched, link, redirect, title, underReview }) {
+  const TitleComponent = (redirect) ? StyledRedirect : StyledLink;
+
   return (
     <ThemeProvider theme={{ mode: 'light' }}>
       <H1>
         {underReview && !launched &&
           <StyledUnderReview>{counterpart('project.nav.underReview')}</StyledUnderReview>}
-        <StyledLink to={link}>
+        <TitleComponent to={link} href={redirect}>
           <span>
             {title}
+            {redirect && <span>{' '}<i className="fa fa-external-link" /></span>}
             {launched &&
               <StyledCheckMarkWrapper className="fa-stack">
                 <i className="fa fa-circle fa-stack-2x" />
                 <StyledCheckMark className="fa fa-check fa-stack-1x" />
               </StyledCheckMarkWrapper>}
-            </span>
-        </StyledLink>
+          </span>
+        </TitleComponent>
       </H1>
     </ThemeProvider>
   );
@@ -86,6 +101,7 @@ function ProjectTitle({ launched, link, title, underReview }) {
 ProjectTitle.defaultProps = {
   launched: false,
   link: '',
+  redirect: '',
   title: '',
   underReview: false
 };
@@ -93,6 +109,7 @@ ProjectTitle.defaultProps = {
 ProjectTitle.propTypes = {
   launched: PropTypes.bool,
   link: PropTypes.string,
+  redirect: PropTypes.string,
   title: PropTypes.string,
   underReview: PropTypes.bool
 };

--- a/app/pages/project/components/ProjectNavbar/components/ProjectTitle/ProjectTitle.spec.js
+++ b/app/pages/project/components/ProjectNavbar/components/ProjectTitle/ProjectTitle.spec.js
@@ -8,9 +8,9 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { expect } from 'chai';
-import ProjectTitle, { H1, StyledLink, StyledCheckMark, StyledCheckMarkWrapper, StyledUnderReview } from './ProjectTitle';
+import ProjectTitle, { H1, StyledLink, StyledRedirect, StyledCheckMark, StyledCheckMarkWrapper, StyledUnderReview } from './ProjectTitle';
 import {
-  projectWithoutRedirect,
+  projectWithoutRedirect, projectWithRedirect
 } from '../../testHelpers';
 
 describe('ProjectTitle', function() {
@@ -31,7 +31,7 @@ describe('ProjectTitle', function() {
     expect(wrapper.find(H1)).to.have.lengthOf(1);
   });
 
-  it('should render a StyledLink component', function() {
+  it('should render a StyledLink component if project without redirect', function() {
     expect(wrapper.find(StyledLink)).to.have.lengthOf(1);
   });
 
@@ -88,6 +88,20 @@ describe('ProjectTitle', function() {
 
     it('should render a StyledUnderReview component', function() {
       expect(wrapper.find(StyledUnderReview)).to.have.lengthOf(1);
+    });
+  });
+
+  describe('when the project has a redirect', function() {
+    before(function() {
+      wrapper.setProps({ redirect: projectWithRedirect.redirect });
+    });
+
+    it('should use the project redirect in the StyledRedirect href prop', function() {
+      expect(wrapper.find(StyledRedirect).props().href).to.equal(projectWithRedirect.redirect);
+    });
+
+    it('should render the font awesome external link icon', function() {
+      expect(wrapper.find('i.fa-external-link')).to.have.lengthOf(1);
     });
   });
 });


### PR DESCRIPTION
Staging branch URL: https://fix-project-name-redirect.pfe-preview.zooniverse.org/
- relevant staging project: https://fix-project-name-redirect.pfe-preview.zooniverse.org/projects/rafe-dot-lafrance/notes-from-nature-on-staging

Fixes #4387.

Describe your changes.
- passes `redirect` through props to ProjectTitle
- creates StyledRedirect for project title with redirect
- updates tests

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
