### PR TITLE
setup the spies in before functions

### DIFF
--- a/app/pages/project/project-page.spec.js
+++ b/app/pages/project/project-page.spec.js
@@ -80,10 +80,15 @@ describe('ProjectPage', function () {
   });
 
   describe('on component lifecycle', function () {
-    const sugarClientSubscribeSpy = sinon.spy(sugarClient, 'subscribeTo');
-    const sugarClientUnsubscribeSpy = sinon.spy(sugarClient, 'unsubscribeFrom');
+    let sugarClientSubscribeSpy;
+    let sugarClientUnsubscribeSpy;
     const channel = `project-${project.id}`;
     let wrapper;
+
+    before(function () {
+      sugarClientSubscribeSpy = sinon.spy(sugarClient, 'subscribeTo');
+      sugarClientUnsubscribeSpy = sinon.spy(sugarClient, 'unsubscribeFrom');
+    });
 
     afterEach(function () {
       sugarClientSubscribeSpy.resetHistory();


### PR DESCRIPTION
avoid the "Attempted to wrap subscribeTo which is already wrapped" error when running `npm run test-and-watch`

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
