### PR TITLE
add email password reset form errors

### DIFF
--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -168,7 +168,7 @@ export default {
   },
   resetPassword: {
     heading: 'Reset Password',
-    newPasswordFormDialog: 'Go ahead and enter a new password, then you can get back to doing some research.',
+    newPasswordFormDialog: 'Enter matching passwords that are at least 8 characters long so you can get back to doing some research.',
     newPasswordFormLabel: 'New password:',
     newPasswordConfirmationLabel: 'Again, to confirm:',
     enterEmailLabel: 'Please enter your email address here and we’ll send you a link you can follow to reset it.',

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -174,7 +174,7 @@ export default {
     enterEmailLabel: 'Please enter your email address here and we’ll send you a link you can follow to reset it.',
     emailSuccess: 'We’ve just sent you an email with a link to reset your password.',
     emailError: 'There was an error resetting your password.',
-    resetError: 'Something went wrong, please try and reset your password via email again.',
+    passwordsDoNotMatch: 'The passwords do not match, please try again.',
     loggedInDialog: 'You are currently logged in. Please log out if you would like to reset your password.'
   },
   workflowToggle: {

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -168,9 +168,9 @@ export default {
   },
   resetPassword: {
     heading: 'Reset Password',
-    newPasswordFormDialog: 'Enter matching passwords that are at least 8 characters long so you can get back to doing some research.',
+    newPasswordFormDialog: 'Enter the same password twice so you can get back to doing some research. Passwords need to be at least 8 characters long.',
     newPasswordFormLabel: 'New password:',
-    newPasswordConfirmationLabel: 'Again, to confirm:',
+    newPasswordConfirmationLabel: 'Repeat your password to confirm:',
     enterEmailLabel: 'Please enter your email address here and we’ll send you a link you can follow to reset it.',
     emailSuccess: 'We’ve just sent you an email with a link to reset your password.',
     emailError: 'There was an error resetting your password.',

--- a/app/locales/es.js
+++ b/app/locales/es.js
@@ -156,9 +156,9 @@ export default {
   },
   resetPassword: {
     heading: 'Reset Password',
-    newPasswordFormDialog: 'Enter matching passwords that are at least 8 characters long so you can get back to doing some research.',
+    newPasswordFormDialog: 'Enter the same password twice so you can get back to doing some research. Passwords need to be at least 8 characters long.',
     newPasswordFormLabel: 'New password:',
-    newPasswordConfirmationLabel: 'Again, to confirm:',
+    newPasswordConfirmationLabel: 'Repeat your password to confirm:',
     enterEmailLabel: 'Please enter your email address here and we’ll send you a link you can follow to reset it.',
     emailSuccess: 'We’ve just sent you an email with a link to reset your password.',
     emailError: 'There was an error reseting your password.',

--- a/app/locales/es.js
+++ b/app/locales/es.js
@@ -156,7 +156,7 @@ export default {
   },
   resetPassword: {
     heading: 'Reset Password',
-    newPasswordFormDialog: 'Go ahead and enter a new password, then you can get back to doing some research.',
+    newPasswordFormDialog: 'Enter matching passwords that are at least 8 characters long so you can get back to doing some research.',
     newPasswordFormLabel: 'New password:',
     newPasswordConfirmationLabel: 'Again, to confirm:',
     enterEmailLabel: 'Please enter your email address here and we’ll send you a link you can follow to reset it.',

--- a/app/locales/es.js
+++ b/app/locales/es.js
@@ -163,6 +163,7 @@ export default {
     emailSuccess: 'We’ve just sent you an email with a link to reset your password.',
     emailError: 'There was an error reseting your password.',
     resetError: 'Something went wrong, please try and reset your password via email again.',
+    passwordsDoNotMatch: 'The passwords do not match, please try again.',
     loggedInDialog: 'You are currently logged in. Please log out if you would like to reset your password.'
   },
   workflowToggle: {

--- a/app/locales/nl.js
+++ b/app/locales/nl.js
@@ -189,7 +189,7 @@ export default {
   },
   resetPassword: {
     heading: 'Wachtwoord vergeten',
-    newPasswordFormDialog: 'Voer een nieuw wachtwoord in, dan kun je verder met onderzoek doen.',
+    newPasswordFormDialog: 'Voer bijbehorende wachtwoorden in die ten minste 8 tekens lang zijn, zodat u verder kunt gaan met onderzoek.',
     newPasswordFormLabel: 'Nieuw wachtwoord:',
     newPasswordConfirmationLabel: 'Herhaal, ter controle:',
     enterEmailLabel: 'Voer je e-mailadres in en we sturen je een link waarmee je kunt herstellen.',

--- a/app/locales/nl.js
+++ b/app/locales/nl.js
@@ -189,7 +189,7 @@ export default {
   },
   resetPassword: {
     heading: 'Wachtwoord vergeten',
-    newPasswordFormDialog: 'Voer bijbehorende wachtwoorden in die ten minste 8 tekens lang zijn, zodat u verder kunt gaan met onderzoek.',
+    newPasswordFormDialog: 'Voer hetzelfde wachtwoord tweemaal in, zodat je verder kunt met onderzoek doen. Een wachtwoord moet tenminste 8 tekens lang zijn.',
     newPasswordFormLabel: 'Nieuw wachtwoord:',
     newPasswordConfirmationLabel: 'Herhaal, ter controle:',
     enterEmailLabel: 'Voer je e-mailadres in en we sturen je een link waarmee je kunt herstellen.',

--- a/app/locales/nl.js
+++ b/app/locales/nl.js
@@ -195,7 +195,7 @@ export default {
     enterEmailLabel: 'Voer je e-mailadres in en we sturen je een link waarmee je kunt herstellen.',
     emailSuccess: 'We hebben je zojuist een e-mail met een herstellink gezonden.',
     emailError: 'Er ging iets mis bij het herstellen van je wachtwoord.',
-    resetError: 'Er ging iets mis, probeer het nogmaals.',
+    passwordsDoNotMatch: 'De wachtwoorden komen niet overeen, probeer het opnieuw.',
     loggedInDialog: 'Je bent op dit moment ingelogd. Log uit om je wachtwoord te herstellen.'
   },
   workflowToggle: {

--- a/app/pages/reset-password/new-password-form.jsx
+++ b/app/pages/reset-password/new-password-form.jsx
@@ -17,6 +17,9 @@ const NewPasswordForm = ({ onSubmit, disabled, inProgress, resetSuccess, resetEr
         type="password"
         className="standard-input"
         size="20"
+        required
+        pattern={".{"+minLength+",}"}
+        title={minLength+" characters minimum"}
       />
     </label>
     <label>
@@ -28,6 +31,9 @@ const NewPasswordForm = ({ onSubmit, disabled, inProgress, resetSuccess, resetEr
         type="password"
         className="standard-input"
         size="20"
+        required
+        pattern={".{"+minLength+",}"}
+        title={minLength+" characters minimum"}
       />
     </label>
     <p>
@@ -51,7 +57,6 @@ const NewPasswordForm = ({ onSubmit, disabled, inProgress, resetSuccess, resetEr
         </small>}
     </p>
   </form>
-  );
 );
 
 NewPasswordForm.propTypes = {

--- a/app/pages/reset-password/new-password-form.jsx
+++ b/app/pages/reset-password/new-password-form.jsx
@@ -46,14 +46,13 @@ const NewPasswordForm = ({ onSubmit, disabled, inProgress, resetSuccess, resetEr
         <i className="fa fa-check-circle form-help success" />}
 
       {resetError &&
-        <Translate
-          className="form-help error"
-          component="small"
-          content="resetPassword.resetError"
-        />}
+        <small className="form-help error">
+          {resetError}
+        </small>}
     </p>
   </form>
   );
+);
 
 NewPasswordForm.propTypes = {
   disabled: PropTypes.bool,

--- a/app/pages/reset-password/new-password-form.jsx
+++ b/app/pages/reset-password/new-password-form.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import Translate from 'react-translate-component';
 
-const NewPasswordForm = ({ onSubmit, disabled, inProgress, resetSuccess, resetError }) => (
+const NewPasswordForm = ({ onSubmit, disabled, inProgress, resetSuccess, resetError, minLength }) => (
   <form onSubmit={onSubmit}>
     <Translate
       component="p"
@@ -60,7 +60,8 @@ NewPasswordForm.propTypes = {
   inProgress: PropTypes.bool,
   onSubmit: PropTypes.func,
   resetError: PropTypes.string,
-  resetSuccess: PropTypes.bool
+  resetSuccess: PropTypes.bool,
+  minLength: PropTypes.number
 };
 
 NewPasswordForm.defaultProps = {
@@ -68,7 +69,8 @@ NewPasswordForm.defaultProps = {
   inProgress: false,
   onSubmit: () => {},
   resetError: null,
-  resetSuccess: null
+  resetSuccess: null,
+  minLength: 8
 };
 
 export default NewPasswordForm;

--- a/app/pages/reset-password/new-password-form.jsx
+++ b/app/pages/reset-password/new-password-form.jsx
@@ -20,6 +20,7 @@ const NewPasswordForm = ({ onSubmit, disabled, inProgress, resetSuccess, resetEr
         required
         pattern={".{"+minLength+",}"}
         title={minLength+" characters minimum"}
+        autoComplete="new-password"
       />
     </label>
     <label>
@@ -34,6 +35,7 @@ const NewPasswordForm = ({ onSubmit, disabled, inProgress, resetSuccess, resetEr
         required
         pattern={".{"+minLength+",}"}
         title={minLength+" characters minimum"}
+        autoComplete="new-password"
       />
     </label>
     <p>

--- a/app/pages/reset-password/new-password-form.spec.js
+++ b/app/pages/reset-password/new-password-form.spec.js
@@ -8,7 +8,6 @@ describe('NewPasswordForm', function () {
   let wrapper;
   const newPasswordSpy = sinon.spy();
 
-
   before(function () {
     wrapper = shallow(<NewPasswordForm onSubmit={newPasswordSpy} />);
   });
@@ -36,9 +35,11 @@ describe('NewPasswordForm', function () {
     assert.equal(wrapper.find('i.form-help.success').length, 0);
   });
 
-  it('conditionally shows and hides a reset password error message', function () {
-    wrapper.setProps({ resetError: 'test error message' });
-    assert.equal(wrapper.find('Translate').last().prop('content'), 'resetPassword.resetError');
+  it('conditionally shows and hides an error message', function () {
+    let expectedMsg = "Password is too short (minimum is 8 characters)";
+    wrapper.setProps({ resetError: expectedMsg });
+    let renderedText = wrapper.find('small.form-help.error').text()
+    assert.equal(renderedText, expectedMsg);
     wrapper.setProps({ resetError: null });
     assert.equal(wrapper.find('Translate').length, 3);
   });

--- a/app/pages/reset-password/reset-password.jsx
+++ b/app/pages/reset-password/reset-password.jsx
@@ -80,7 +80,6 @@ class ResetPasswordPage extends React.Component {
       .then(() => {
         this.setState({
           resetSuccess: true,
-          inProgress: false
         });
         alert(resolve => <LoginDialog onSuccess={resolve} />);
         this.context.router.push('/projects');
@@ -90,6 +89,10 @@ class ResetPasswordPage extends React.Component {
           resetError: error.message
         });
       })
+      .then(() => {
+        this.setState({
+          inProgress: false
+        });
       });
   }
 

--- a/app/pages/reset-password/reset-password.jsx
+++ b/app/pages/reset-password/reset-password.jsx
@@ -64,6 +64,17 @@ class ResetPasswordPage extends React.Component {
     const token = this.props.location.query.reset_password_token;
     const password = event.target[0].value;
     const confirmation = event.target[1].value;
+    const passwordMatch = password === confirmation
+    if (!passwordMatch) {
+      this.setState({
+        inProgress: false,
+        resetError: <Translate
+          component="p"
+          content="resetPassword.passwordsDoNotMatch"
+        />
+      });
+      return;
+    }
 
     auth.resetPassword({ password, confirmation, token })
       .then(() => {

--- a/app/pages/reset-password/reset-password.jsx
+++ b/app/pages/reset-password/reset-password.jsx
@@ -86,7 +86,10 @@ class ResetPasswordPage extends React.Component {
         this.context.router.push('/projects');
       })
       .catch((error) => {
-        this.setState({ resetError: error });
+        this.setState({
+          resetError: error.message
+        });
+      })
       });
   }
 

--- a/app/pages/reset-password/reset-password.jsx
+++ b/app/pages/reset-password/reset-password.jsx
@@ -118,7 +118,7 @@ class ResetPasswordPage extends React.Component {
         {this.props.location.query && this.props.location.query.reset_password_token && !this.state.resetSuccess &&
           <NewPasswordForm
             onSubmit={this.handlePasswordResetSubmit}
-            disabled={this.state.resetError || this.state.resetSuccess}
+            disabled={this.state.resetSuccess}
             inProgress={this.state.inProgress}
             resetSuccess={this.state.resetSuccess}
             resetError={this.state.resetError}


### PR DESCRIPTION
Staging branch URL:  https://email-reset-errors.pfe-preview.zooniverse.org/reset-password?reset_password_token=H6GtX

Fixes #4390 and lots of email reports of problems with email password resets, specifically no API error reports, no length checking or password match checks. 

This PR adds:
1. the API failure messages to the form
0. HTML5 input password length validation before form submission
0. Checks the passwords match before attempting to contact the API.

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [ ] Can you submit a classification?
- [x] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
