### PR TITLE
Add dropdown task default annotations on update

### DIFF
--- a/app/classifier/tasks/dropdown/index.cjsx
+++ b/app/classifier/tasks/dropdown/index.cjsx
@@ -90,21 +90,22 @@ module.exports = createReactClass
     @menus = []
 
   componentDidMount: ->
-    @setDefaultAnnotations()
+    @setDefaultValues()
 
     if @props.autoFocus is true
       @handleFocus()
 
   componentDidUpdate: (prevProps) ->
     if prevProps.task isnt @props.task
-      @setDefaultAnnotations()
+      @setDefaultValues()
       if @props.autoFocus is true
         @handleFocus()
 
-  setDefaultAnnotations: ->
+  setDefaultValues: ->
     unless @props.annotation.value.length
-      for select, i in @props.task.selects
-        @onChangeSelect(i)
+      value = @props.task.selects.map () -> { option: false, value: null }
+      newAnnotation = Object.assign @props.annotation, {value}
+      @props.onChange newAnnotation
 
   selectedOptions: () ->
     # return annotation values mapped to react-select option objects

--- a/app/classifier/tasks/dropdown/index.cjsx
+++ b/app/classifier/tasks/dropdown/index.cjsx
@@ -90,16 +90,21 @@ module.exports = createReactClass
     @menus = []
 
   componentDidMount: ->
-    annotationValues = @props.annotation.value
-    unless annotationValues.length
-      @props.annotation.value = @props.task.selects.map -> {value: null, option: false}
+    @setDefaultAnnotations()
 
     if @props.autoFocus is true
       @handleFocus()
 
   componentDidUpdate: (prevProps) ->
-    if prevProps.task isnt @props.task and @props.autoFocus is true
-      @handleFocus()
+    if prevProps.task isnt @props.task
+      @setDefaultAnnotations()
+      if @props.autoFocus is true
+        @handleFocus()
+
+  setDefaultAnnotations: ->
+    unless @props.annotation.value.length
+      for select, i in @props.task.selects
+        @onChangeSelect(i)
 
   selectedOptions: () ->
     # return annotation values mapped to react-select option objects

--- a/app/classifier/tasks/dropdown/index.cjsx
+++ b/app/classifier/tasks/dropdown/index.cjsx
@@ -104,7 +104,7 @@ module.exports = createReactClass
   setDefaultValues: ->
     unless @props.annotation.value.length
       value = @props.task.selects.map () -> { option: false, value: null }
-      newAnnotation = Object.assign @props.annotation, {value}
+      newAnnotation = Object.assign {}, @props.annotation, {value}
       @props.onChange newAnnotation
 
   selectedOptions: () ->
@@ -208,5 +208,5 @@ module.exports = createReactClass
 
     @clearRelated(i)
 
-    newAnnotation = Object.assign @props.annotation, {value}
+    newAnnotation = Object.assign {}, @props.annotation, {value}
     @props.onChange newAnnotation

--- a/app/classifier/tasks/dropdown/index.spec.js
+++ b/app/classifier/tasks/dropdown/index.spec.js
@@ -4,6 +4,7 @@
 import React from 'react';
 import assert from 'assert';
 import { mount } from 'enzyme';
+import sinon from 'sinon';
 import Select from 'react-select'; // required to properly simulate change
 import DropdownTask from './';
 import { workflow } from '../../../pages/dev-classifier/mock-data';
@@ -83,11 +84,13 @@ describe('DropdownTask', function () {
     describe('and annotation not provided,', function () {
       let annotation;
       let wrapper;
+      let onChangeSpy;
 
       beforeEach(function () {
         annotation = { value: [] };
+        onChangeSpy = sinon.spy();
 
-        wrapper = mount(<DropdownTask task={multiSelects} annotation={annotation} onChange={function (a) { return a; }} />);
+        wrapper = mount(<DropdownTask task={multiSelects} annotation={annotation} onChange={onChangeSpy} />);
       });
 
       it('should render without crashing', function () {
@@ -103,12 +106,14 @@ describe('DropdownTask', function () {
         assert.equal(renderedSelects.length, multiSelects.selects.length);
       });
 
-      it('should have an annotation with values equal in length to the number of selects', function () {
-        assert.equal(annotation.value.length, multiSelects.selects.length);
+      it('should on mount have an annotation with values equal in length to the number of selects', function () {
+        const newAnnotation = onChangeSpy.firstCall.args[0];
+        assert.equal(newAnnotation.value.length, multiSelects.selects.length);
       });
 
-      it('should have an annotation reflecting nothing selected', function () {
-        annotation.value.forEach((annotationValue) => {
+      it('should on mount have an annotation reflecting nothing selected', function () {
+        const newAnnotation = onChangeSpy.firstCall.args[0];
+        newAnnotation.value.forEach((annotationValue) => {
           const { option, value } = annotationValue;
           assert.equal(value, null);
           assert.equal(option, false);
@@ -153,14 +158,12 @@ describe('DropdownTask', function () {
       it('should not save custom answer if allowCreate false', function () {
         const countrySelect = wrapper.find('#countryID').find(Select);
         const countrySelectInput = countrySelect.find('input');
+        onChangeSpy.resetHistory();
 
         countrySelectInput.simulate('change', { target: { value: 'test Country' }});
         countrySelectInput.simulate('keyDown', { keyCode: 13, which: 13, key: 'Enter' });
 
-        const countryOption = annotation.value[0].option;
-        const countryValue = annotation.value[0].value;
-        assert.equal(countryValue, null);
-        assert.equal(countryOption, false);
+        assert.equal(onChangeSpy.called, false);
       });
     });
 
@@ -277,8 +280,13 @@ describe('DropdownTask', function () {
     describe('and component updated', function () {
       const annotation1 = { value: [] };
       const annotation2 = { value: [] };
-      const wrapper = mount(<DropdownTask task={multiSelects} annotation={annotation1} onChange={function (a) { return a; }} />);
+      const onChangeSpy = sinon.spy();
+
+      const wrapper = mount(<DropdownTask task={multiSelects} annotation={annotation1} onChange={onChangeSpy} />);
       wrapper.setProps({ task: singleSelect, annotation: annotation2 });
+
+      // first call on mount should set first task's default values, second call on update should be to set second task's default values
+      const newAnnotation = onChangeSpy.secondCall.args[0];
 
       it('should render all selects', function () {
         const renderedSelects = wrapper.find(Select);
@@ -286,11 +294,11 @@ describe('DropdownTask', function () {
       });
 
       it('should have an annotation with values equal in length to the number of selects', function () {
-        assert.equal(annotation2.value.length, singleSelect.selects.length);
+        assert.equal(newAnnotation.value.length, singleSelect.selects.length);
       });
 
       it('should have an annotation reflecting nothing selected', function () {
-        annotation2.value.forEach((annotationValue) => {
+        newAnnotation.value.forEach((annotationValue) => {
           const { option, value } = annotationValue;
           assert.equal(value, null);
           assert.equal(option, false);

--- a/app/classifier/tasks/dropdown/index.spec.js
+++ b/app/classifier/tasks/dropdown/index.spec.js
@@ -103,6 +103,10 @@ describe('DropdownTask', function () {
         assert.equal(renderedSelects.length, multiSelects.selects.length);
       });
 
+      it('should have an annotation with values equal in length to the number of selects', function () {
+        assert.equal(annotation.value.length, multiSelects.selects.length);
+      });
+
       it('should have an annotation reflecting nothing selected', function () {
         annotation.value.forEach((annotationValue) => {
           const { option, value } = annotationValue;
@@ -159,6 +163,7 @@ describe('DropdownTask', function () {
         assert.equal(countryOption, false);
       });
     });
+
     describe('and first annotation provided (Country),', function () {
       let annotation;
       let wrapper;
@@ -197,6 +202,7 @@ describe('DropdownTask', function () {
         assert.equal(stateOption, false);
       });
     });
+
     describe('and all annotations provided, no custom answers,', function () {
       let annotation;
       let wrapper;
@@ -232,6 +238,7 @@ describe('DropdownTask', function () {
         assert.deepEqual(annotation, expectedAnnotation);
       });
     });
+
     describe('and all annotations provided, including custom answers,', function () {
       let annotation;
       let wrapper;
@@ -264,6 +271,30 @@ describe('DropdownTask', function () {
           { value: null, option: false }
         ] };
         assert.deepEqual(annotation, expectedAnnotation);
+      });
+    });
+
+    describe('and component updated', function () {
+      const annotation1 = { value: [] };
+      const annotation2 = { value: [] };
+      const wrapper = mount(<DropdownTask task={multiSelects} annotation={annotation1} onChange={function (a) { return a; }} />);
+      wrapper.setProps({ task: singleSelect, annotation: annotation2 });
+
+      it('should render all selects', function () {
+        const renderedSelects = wrapper.find(Select);
+        assert.equal(renderedSelects.length, singleSelect.selects.length);
+      });
+
+      it('should have an annotation with values equal in length to the number of selects', function () {
+        assert.equal(annotation2.value.length, singleSelect.selects.length);
+      });
+
+      it('should have an annotation reflecting nothing selected', function () {
+        annotation2.value.forEach((annotationValue) => {
+          const { option, value } = annotationValue;
+          assert.equal(value, null);
+          assert.equal(option, false);
+        });
       });
     });
   });


### PR DESCRIPTION
Staging branch URL: https://dropdown-default-update-fix.pfe-preview.zooniverse.org/projects/markb-panoptes/test-project-1-mb/classify?reload=1&workflow=3165

Closes #4401. 

Describe your changes.
- check and if annotations not present, set default annotations (`{ option: false, value: null }`) on component update

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
