### PR TITLE
Put Talk discussion and board titles in the page title

### DIFF
--- a/app/talk/board.cjsx
+++ b/app/talk/board.cjsx
@@ -3,6 +3,8 @@ PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 ReactDOM = require 'react-dom'
 {Link} = require 'react-router'
+{ Helmet } = require 'react-helmet'
+counterpart = require 'counterpart'
 DiscussionPreview = require './discussion-preview'
 apiClient = require 'panoptes-client/lib/api-client'
 talkClient = require 'panoptes-client/lib/talk-client'
@@ -203,6 +205,7 @@ module.exports = createReactClass
     {board} = @state
 
     <div className="talk-board">
+      <Helmet title="#{board?.title} » #{counterpart 'projectTalk.title'}" />
       <h1 className="talk-page-header">{board?.title}</h1>
       <p>{board?.description}</p>
       <FollowBoard user={@props.user} board={board} />

--- a/app/talk/discussion.cjsx
+++ b/app/talk/discussion.cjsx
@@ -11,6 +11,8 @@ SingleSubmitButton = require '../components/single-submit-button'
 upvotedByCurrentUser = require './lib/upvoted-by-current-user'
 Moderation = require './lib/moderation'
 {Link} = require 'react-router'
+{ Helmet } = require 'react-helmet'
+counterpart = require 'counterpart'
 talkConfig = require './config'
 SignInPrompt = require '../partials/sign-in-prompt'
 alert = require('../lib/alert').default
@@ -305,6 +307,7 @@ module.exports = createReactClass
     {discussion} = @state
 
     <div className="talk-discussion">
+      <Helmet title="#{discussion?.title} » #{counterpart 'projectTalk.title'}" />
       {if not @state.editingTitle
         <h1 className="talk-page-header">
           {discussion?.title}


### PR DESCRIPTION
Note that this doesn't include the project name in the title for project
Talk pages because otherwise the title will be kind of long.

Staging branch URL: https://talk-title.pfe-preview.zooniverse.org/talk

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [x] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?