### PR TITLE
Update feedback after annotations

### DIFF
--- a/app/classifier/classifier.jsx
+++ b/app/classifier/classifier.jsx
@@ -147,11 +147,8 @@ class Classifier extends React.Component {
 
   updateAnnotations(annotations) {
     annotations = annotations || this.props.classification.annotations.slice();
-    this.setState({ annotations });
     this.props.classification.update({ annotations });
-    if (this.props.feedback.active) {
-      this.updateFeedback();
-    }
+    this.setState({ annotations }, this.updateFeedback);
   }
 
   updateFeedback() {
@@ -175,7 +172,7 @@ class Classifier extends React.Component {
       }, false);
     }
 
-    if (!isInProgress) {
+    if (this.props.feedback.active && !isInProgress) {
       this.props.actions.feedback.update(currentAnnotation);
     }
   }

--- a/app/classifier/classifier.jsx
+++ b/app/classifier/classifier.jsx
@@ -197,6 +197,7 @@ class Classifier extends React.Component {
       if (this.props.subject === subject) { // The subject could have changed while we were loading.
         this.setState({ subjectLoading: false });
         this.props.onLoad();
+        this.updateFeedback();
       }
     });
   }

--- a/app/classifier/classifier.jsx
+++ b/app/classifier/classifier.jsx
@@ -152,6 +152,9 @@ class Classifier extends React.Component {
   }
 
   updateFeedback() {
+    if (!this.props.feedback.active) {
+      return false;
+    }
     // Check to see if we're still drawing, and update feedback if not. We need
     // to check the entire annotation array, as the user may be editing an
     // existing annotation.
@@ -172,7 +175,7 @@ class Classifier extends React.Component {
       }, false);
     }
 
-    if (this.props.feedback.active && !isInProgress) {
+    if (!isInProgress) {
       this.props.actions.feedback.update(currentAnnotation);
     }
   }


### PR DESCRIPTION
Staging branch URL: https://fix-4410.pfe-preview.zooniverse.org

Fixes #4410 .

Describe your changes.
Check the default annotation for feedback after loading a new subject.

Wait for `state.annotations` to change before updating feedback rules.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
