### PR TITLE
Handle Social Sites with Preceding Routes

### DIFF
--- a/app/pages/lab/social-links-editor.jsx
+++ b/app/pages/lab/social-links-editor.jsx
@@ -4,6 +4,8 @@ import DragReorderable from 'drag-reorderable';
 import AutoSave from '../../components/auto-save.coffee';
 import SOCIAL_ICONS from '../../lib/social-icons';
 
+const ROUTE_BEFORE_DOMAIN = ['wordpress'];
+
 export default class SocialLinksEditor extends React.Component {
   constructor(props) {
     super(props);
@@ -37,6 +39,10 @@ export default class SocialLinksEditor extends React.Component {
   handleNewLink(site, e) {
     let index = this.indexFinder(this.props.project.urls, site);
     if (index < 0) { index = this.props.project.urls.length; }
+    let url = `https://${site}${e.target.value}`;
+    if (ROUTE_BEFORE_DOMAIN.some(el => site.indexOf(el) >= 0)) {
+      url = `https://${e.target.value}.${site}`;
+    }
 
     if (e.target.value) {
       const changes = {
@@ -44,7 +50,7 @@ export default class SocialLinksEditor extends React.Component {
           label: '',
           path: e.target.value,
           site,
-          url: `https://${site}${e.target.value}`
+          url
         }
       };
       this.props.project.update(changes);
@@ -86,10 +92,13 @@ export default class SocialLinksEditor extends React.Component {
   renderRow(site, i) {
     const index = this.indexFinder(this.props.project.urls, site);
     const value = index >= 0 ? this.props.project.urls[index].path : '';
+    const precedeSiteName = ROUTE_BEFORE_DOMAIN.some(el => site.indexOf(el) >= 0);
 
     return (
       <tr key={i}>
-        <td>{site}</td>
+        {!precedeSiteName && (
+          <td>{site}</td>
+        )}
         <AutoSave tag="td" resource={this.props.project}>
           <input
             type="text"
@@ -100,6 +109,9 @@ export default class SocialLinksEditor extends React.Component {
             onMouseUp={this.handleEnableDrag}
           />
         </AutoSave>
+        {precedeSiteName && (
+          <td>.{site}</td>
+        )}
         <td>
           <button type="button" onClick={this.handleRemoveLink.bind(this, site)}>
             <i className="fa fa-remove" />


### PR DESCRIPTION
Staging branch URL: https://fix-wordpress.pfe-preview.zooniverse.org/

Fixes #4406 

Describe your changes.
This is a quick fix that accounts for social websites that have the route coming before the site name. I tried to make it as flexible as possible, in case we add more social websites with URL paths similar to Wordpress. 

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [x] Can you post a talk comment?

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
