### PR TITLE
Fix Talk preview images on project home

### DIFF
--- a/app/pages/project/home/project-home.jsx
+++ b/app/pages/project/home/project-home.jsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router';
 import classnames from 'classnames';
 import { Markdown } from 'markdownz';
 import Translate from 'react-translate-component';
-import getSubjectLocation from '../../../lib/get-subject-location.coffee';
+import getSubjectLocations from '../../../lib/get-subject-locations';
 import Thumbnail from '../../../components/thumbnail';
 import FinishedBanner from '../finished-banner';
 import ProjectMetadata from './metadata';
@@ -83,16 +83,23 @@ const ProjectHomePage = (props) => {
       {renderTalkSubjectsPreview && (
         <div className="project-home-page__container">
           {props.talkSubjects.map((subject) => {
-            const location = getSubjectLocation(subject);
+            const locations = getSubjectLocations(subject);
+            let format = '';
+            let src = '';
+            if (locations.image) {
+              [format, src] = locations.image;
+            } else if (locations.video) {
+              [format, src] = locations.video;
+            }
             return (
               <div className="project-home-page__talk-image" key={subject.id}>
                 <Link to={`/projects/${props.project.slug}/talk/subjects/${subject.id}`} >
                   <Thumbnail
                     alt=""
                     controls={false}
-                    format={location.format}
+                    format={format}
                     height={240}
-                    src={location.src}
+                    src={src}
                     width={600}
                   />
                 </Link>


### PR DESCRIPTION
Staging branch URL: https://talk-preview-images.pfe-preview.zooniverse.org

Fixes a problem mentioned on Talk, where previews don't display for audio projects, even if the subjects do have linked images. https://www.zooniverse.org/talk/18/565262

Describe your changes.
Use the first image listed in a subject's locations for the Talk preview thumbnail. Fall back to displaying video, for video subjects, if no image is available.

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [x] Can you post a talk comment?

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
