### PR TITLE
Change z-index to work in Edge

### DIFF
--- a/app/pages/project/components/ProjectNavbar/components/ProjectNavbarNarrow/NarrowMenu.jsx
+++ b/app/pages/project/components/ProjectNavbar/components/ProjectNavbarNarrow/NarrowMenu.jsx
@@ -18,7 +18,7 @@ export const MenuWrapper = styled.div`
 
   &.open {
     max-height: ${props => props.height}px;
-    z-index: 1
+    z-index: 2
   }
 `;
 


### PR DESCRIPTION
Staging branch URL: https://fix-4397.pfe-preview.zooniverse.org/

Fixes #4397

Changes the z-index so the narrow menu used on small resolutions or screen sizes appears correctly in Edge. 

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
