### PR TITLE
Fix classifier exports

### DIFF
--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -200,7 +200,5 @@ mapDispatchToProps = (dispatch) -> ({
   }
 });
 
-module.exports = {
-    default: connect(mapStateToProps, mapDispatchToProps)(ClassifierWrapper)
-    ClassifierWrapper
-  }
+module.exports = connect(mapStateToProps, mapDispatchToProps)(ClassifierWrapper)
+module.exports.ClassifierWrapper = ClassifierWrapper

--- a/app/pages/project/classify.cjsx
+++ b/app/pages/project/classify.cjsx
@@ -7,7 +7,7 @@ ReactDOM = require 'react-dom'
 apiClient = require 'panoptes-client/lib/api-client'
 counterpart = require 'counterpart'
 `import FinishedBanner from './finished-banner';`
-Classifier = require('../../classifier').default
+Classifier = require '../../classifier'
 seenThisSession = require '../../lib/seen-this-session'
 ClassificationQueue = require('../../lib/classification-queue').default
 `import WorkflowAssignmentDialog from '../../components/workflow-assignment-dialog';`


### PR DESCRIPTION
Staging branch URL: https://classifier-export.pfe-preview.zooniverse.org

Fixes my earlier attempt to export the wrapped and unwrapped components together.

Describe your changes.
Export the connected component for the project classify page.
Export the bare component for the dev classifier.


# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
