### PR TITLE
Add more contrast to the project navbar

### DIFF
--- a/app/pages/project/components/ProjectNavbar/components/Background/Background.jsx
+++ b/app/pages/project/components/ProjectNavbar/components/Background/Background.jsx
@@ -22,7 +22,7 @@ export const BackgroundWrapper = styled.div.attrs({
   width: 100%;
 `;
 
-// IE 11 doesn't support filter. Not even their own propriety MS filter. :faceplam:
+// IE 11 doesn't support filter. Not even their own propriety MS filter. :faceplam: IE and Edge do not support background-blend
 export const IEContrastLayer = styled.div`
   background-color: rgba(0,93,105,0.5);
   height: 100%;
@@ -31,6 +31,8 @@ export const IEContrastLayer = styled.div`
 `;
 
 export const ImgBackground = styled.div`
+  background-blend-mode: multiply;
+  background-color: rgba(0,93,105,0.3);
   background-image: url("${props => props.src}");
   background-position: center;
   background-repeat: no-repeat;
@@ -41,17 +43,23 @@ export const ImgBackground = styled.div`
   transform: scale(1.15);
 `;
 
-function isIE11() {
-  return ('ActiveXObject' in window);
+function checkIfMSBrowser() {
+  if ('CSS' in window) {
+    return !CSS.supports('background-blend-mode', 'multiply');
+  }
+
+  return 'ActiveXObject' in window;
 }
 
 function Background({ src, ...otherProps }) {
+  const isMSBrowser = checkIfMSBrowser();
+
   return (
     <ThemeProvider theme={{ mode: 'light' }}>
       <BackgroundWrapper hasBg={!!src} {...otherProps}>
         {src &&
           <ImgBackground src={src}>
-            {isIE11() &&
+            {isMSBrowser &&
               <IEContrastLayer />}
           </ImgBackground>}
       </BackgroundWrapper>


### PR DESCRIPTION
Staging branch URL: https://increase-contrast-project-navbar.pfe-preview.zooniverse.org/

This in response to some volunteers reporting eye strain with the new project navbar that has the project background blurred behind it. @beckyrother and I are looking for a possible remedy. We're hoping an increase in contrast will help. 

IE does not support the blur filter nor background blend modes, so it is just a teal overlay:

<img width="1422" alt="screen shot 2018-03-09 at 1 57 31 pm" src="https://user-images.githubusercontent.com/5016731/37227565-56171acc-23a3-11e8-879f-b598becddf0e.png">

Edge does not support background blend modes, so it's a blurred image background with a teal overlay:

<img width="1415" alt="screen shot 2018-03-09 at 1 57 00 pm" src="https://user-images.githubusercontent.com/5016731/37227573-63628810-23a3-11e8-9bfd-5a826ba4edba.png">

All other browsers blend the blurred image background and a teal color at 30% opacity

Here's how it looks now for comparison: https://master.pfe-preview.zooniverse.org/projects/brooke/i-fancy-cats

@beckyrother this can be tested on production with our users using this url: https://increase-contrast-project-navbar.pfe-preview.zooniverse.org/?env=production

This should not merge unless we have confirmation that it's helping with the eye strain.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
