### PR TITLE
Align feedback OK button to the bottom right of modal

### DIFF
--- a/app/features/feedback/classifier/components/feedback-modal.jsx
+++ b/app/features/feedback/classifier/components/feedback-modal.jsx
@@ -39,13 +39,15 @@ class FeedbackModal extends React.Component {
           )}
         </ul>
 
-        <button
-          className="standard-button"
-          type="submit"
-          ref={(button) => { this.closeButton = button; }}
-        >
-          <Translate content="FeedbackModal.ok" />
-        </button>
+        <div className="buttons">
+          <button
+            className="standard-button"
+            type="submit"
+            ref={(button) => { this.closeButton = button; }}
+          >
+            <Translate content="FeedbackModal.ok" />
+          </button>
+        </div>
       </ModalFocus>
     );
   }

--- a/css/feedback.styl
+++ b/css/feedback.styl
@@ -8,3 +8,6 @@
     display: block
     max-height: 60vh
     max-width: 100%
+
+  .buttons
+    text-align: right


### PR DESCRIPTION
Moves the OK button to the bottom right of the feedback modal, as per #4430.