### PR TITLE
Use task key to update annotations

### DIFF
--- a/app/classifier/classifier.jsx
+++ b/app/classifier/classifier.jsx
@@ -228,15 +228,14 @@ class Classifier extends React.Component {
   }
 
   completeClassification() {
-    const currentAnnotation = this.state.annotations[this.state.annotations.length - 1];
-      if (this.props.workflow.configuration.hide_classification_summaries && !this.subjectIsGravitySpyGoldStandard()) {
-        this.props.onCompleteAndLoadAnotherSubject()
-          .catch(error => console.error(error));
-      } else {
-        this.props.onComplete()
-          .catch(error => console.error(error));
-      }
-      this.setState({ annotations: [{}] });
+    if (this.props.workflow.configuration.hide_classification_summaries && !this.subjectIsGravitySpyGoldStandard()) {
+      this.props.onCompleteAndLoadAnotherSubject()
+        .catch(error => console.error(error));
+    } else {
+      this.props.onComplete()
+        .catch(error => console.error(error));
+    }
+    this.setState({ annotations: [{}] });
   }
 
   toggleExpertClassification(value) {

--- a/app/classifier/classifier.jsx
+++ b/app/classifier/classifier.jsx
@@ -5,6 +5,7 @@ import { VisibilitySplit } from 'seven-ten';
 import Translate from 'react-translate-component';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
+import findIndex from 'lodash/findIndex';
 
 import SubjectViewer from '../components/subject-viewer';
 import ClassificationSummary from './classification-summary';
@@ -221,7 +222,8 @@ class Classifier extends React.Component {
 
   handleAnnotationChange(classification, newAnnotation) {
     const annotations  = classification.annotations.slice();
-    annotations[annotations.length - 1] = newAnnotation;
+    const index = findIndex(annotations, annotation => annotation.task === newAnnotation.task);
+    annotations[index] = newAnnotation;
     this.updateAnnotations(annotations);
   }
 

--- a/app/classifier/task.jsx
+++ b/app/classifier/task.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import findIndex from 'lodash/findIndex';
 import tasks from './tasks';
 import Shortcut from './tasks/shortcut';
 import TaskTranslations from './tasks/translations';
@@ -13,7 +14,8 @@ class Task extends React.Component {
   handleAnnotationChange(newAnnotation) {
     const { classification } = this.props;
     const annotations = classification.annotations.slice();
-    annotations[annotations.length - 1] = newAnnotation;
+    const index = findIndex(annotations, annotation => annotation.task === newAnnotation.task);
+    annotations[index] = newAnnotation;
     this.props.updateAnnotations(annotations);
   }
 


### PR DESCRIPTION
Staging branch URL: https://update-annotations.pfe-preview.zooniverse.org

Use `annotation.task` to determine which annotation to update when changing a classification, rather than automatically using the last annotation in the annotations array.

First step towards allowing the classifier to operate on more than one annotation at a time, when making a classification. That would allow us to deprecate combo task annotations, in favour of each task being responsible for updating its own annotation in the annotations array.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
