### PR TITLE
Add UPP request after every 10 classifications

### DIFF
--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -25,6 +25,8 @@ auth.listen ->
 
 PROMPT_MINI_COURSE_EVERY = 5
 
+RELOAD_UPP_EVERY = 10
+
 ClassifierWrapper = createReactClass
   displayName: 'ClassifierWrapper'
 
@@ -104,12 +106,18 @@ ClassifierWrapper = createReactClass
   onCompleteAndLoadAnotherSubject: ->
     classificationsThisSession += 1
     @maybeLaunchMiniCourse()
+    @maybeRequestUserProjectPreferences()
     @props.onCompleteAndLoadAnotherSubject?()
 
   onComplete: ->
     classificationsThisSession += 1
     @maybeLaunchMiniCourse()
+    @maybeRequestUserProjectPreferences()
     @props.onComplete?()
+
+  maybeRequestUserProjectPreferences: ->  
+    if classificationsThisSession % RELOAD_UPP_EVERY is 0
+      @props.requestUserProjectPreferences(@props.project, @props.user)
 
   maybeLaunchMiniCourse: ->
     shouldPrompt = classificationsThisSession % PROMPT_MINI_COURSE_EVERY is 0

--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -25,7 +25,7 @@ auth.listen ->
 
 PROMPT_MINI_COURSE_EVERY = 5
 
-RELOAD_UPP_EVERY = 10
+RELOAD_UPP_EVERY = 5
 
 ClassifierWrapper = createReactClass
   displayName: 'ClassifierWrapper'

--- a/app/pages/project/classify.cjsx
+++ b/app/pages/project/classify.cjsx
@@ -132,6 +132,7 @@ module.exports = createReactClass
           currentClassifications.forWorkflow[props.workflow.id] = classification
           @setState { classification }
         .catch (error) =>
+          # console.error(error)
           @setState rejected: { classification: error }
 
   createNewClassification: (project, workflow) ->
@@ -186,6 +187,7 @@ module.exports = createReactClass
     if upcomingSubjects.forWorkflow[workflow.id].length is 0
       # console.log 'Fetching subjects', workflow.id
       @maybePromptWorkflowAssignmentDialog(@props)
+      
       subjectQuery =
         workflow_id: workflow.id
       if subjectSet?
@@ -246,6 +248,7 @@ module.exports = createReactClass
           onComplete={@saveClassification}
           onCompleteAndLoadAnotherSubject={@saveClassificationAndLoadAnotherSubject}
           onClickNext={@loadAnotherSubject}
+          requestUserProjectPreferences={@props.requestUserProjectPreferences}
           splits={@props.splits}
         />
       else if @state.rejected?.classification?
@@ -275,6 +278,7 @@ module.exports = createReactClass
 
     {workflow, subjects} = classification.links
     seenThisSession.add workflow, subjects
+
     unless @state.demoMode
       classificationQueue.add(classification)
     Promise.resolve classification
@@ -291,7 +295,7 @@ module.exports = createReactClass
         .then =>
           @setState { promptWorkflowAssignmentDialog: false }
         .then =>
-          if props.preferences.selected_workflow isnt props.preferences.settings.workflow_id
+          if props.preferences.preferences.selected_workflow isnt props.preferences.settings.workflow_id
             props.preferences.update
               'preferences.selected_workflow': props.preferences.settings.workflow_id
             props.preferences.save()

--- a/app/pages/project/index.cjsx
+++ b/app/pages/project/index.cjsx
@@ -198,6 +198,19 @@ ProjectPageController =
       .catch (error) =>
         console.warn error.message
 
+  requestUserProjectPreferences: (project, user) ->
+    @listenToPreferences null
+
+    if user?
+      user.get('project_preferences', project_id: project.id)
+        .then ([preferences]) =>
+          @setState { preferences }
+          @listenToPreferences preferences
+        .catch (error) =>
+          console.warn error.message
+    else
+      Promise.resolve()
+
   listenToPreferences: (preferences) ->
     @_listenedToPreferences?.stopListening 'change', @_boundForceUpdate
     preferences?.listen 'change', @_boundForceUpdate
@@ -263,6 +276,7 @@ ProjectPageController =
               projectAvatar={@state.projectAvatar}
               projectIsComplete={@state.projectIsComplete}
               projectRoles={@state.projectRoles}
+              requestUserProjectPreferences={@requestUserProjectPreferences}
               splits={@state.splits}
             />
           </WorkflowSelection>

--- a/app/pages/project/project-page.jsx
+++ b/app/pages/project/project-page.jsx
@@ -71,6 +71,7 @@ export default class ProjectPage extends React.Component {
           projectAvatar: this.props.projectAvatar,
           projectIsComplete: this.props.projectIsComplete,
           projectRoles: this.props.projectRoles,
+          requestUserProjectPreferences: this.props.requestUserProjectPreferences,
           splits: this.props.splits,
           translation: this.props.translation,
           user: this.props.user,


### PR DESCRIPTION
This is an ugly hack, but I think it'll work for checking if the user has updated project preferences. This is related to #4428, but I won't tag for closing since I don't think this should be the long term solution.

@amyrebecca could you check to see if this works for Snapshot WI's workflow promotion project?

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
