### PR TITLE
Correctly clone sub-tasks when multi_image_clone_markers enabled

### DIFF
--- a/app/classifier/tasks/drawing/markings-renderer.cjsx
+++ b/app/classifier/tasks/drawing/markings-renderer.cjsx
@@ -65,9 +65,9 @@ module.exports = createReactClass
 
               toolDescription = taskDescription.tools[mark.tool]
               if parseInt(mark.frame) is parseInt(@props.frame) or (
-                @props.workflow.configuration.multi_image_clone_markers and not
-                @props.workflow.configuration.enable_switching_flipbook_and_separate and
-                @props.multi_image_mode == 'flipbook'
+                @props.workflow.configuration.multi_image_clone_markers and
+                (not @props.workflow.configuration.enable_switching_flipbook_and_separate) and
+                @props.workflow.configuration.multi_image_mode == 'flipbook'
               )
                 {details} = toolDescription
               else

--- a/app/classifier/tasks/drawing/markings-renderer.cjsx
+++ b/app/classifier/tasks/drawing/markings-renderer.cjsx
@@ -64,8 +64,11 @@ module.exports = createReactClass
                 continue
 
               toolDescription = taskDescription.tools[mark.tool]
-
-              if parseInt(mark.frame) is parseInt(@props.frame)
+              if parseInt(mark.frame) is parseInt(@props.frame) or (
+                @props.workflow.configuration.multi_image_clone_markers and not
+                @props.workflow.configuration.enable_switching_flipbook_and_separate and
+                @props.multi_image_mode == 'flipbook'
+              )
                 {details} = toolDescription
               else
                 details = null

--- a/app/pages/dev-classifier/index.cjsx
+++ b/app/pages/dev-classifier/index.cjsx
@@ -28,6 +28,10 @@ ClassificationViewer = createReactClass
     @props.classification._workflow.configuration.persist_annotations = e.target.checked
     @forceUpdate()
 
+  toggleMultiImageCloneMarkers: (e) ->
+    @props.classification._workflow.configuration.multi_image_clone_markers = e.target.checked
+    @forceUpdate()
+
   render: ->
     showing =  if @state.showOnlyLast
       @props.classification.annotations[@props.classification.annotations.length - 1]
@@ -53,6 +57,11 @@ ClassificationViewer = createReactClass
       <label>
         <input type="checkbox" checked={@props.classification._workflow.configuration.persist_annotations} onChange={@togglePersistAnnotations} />{' '}
         Persist Annotations
+      </label>
+      &ensp;
+      <label>
+        <input type="checkbox" checked={@props.classification._workflow.configuration.multi_image_clone_markers} onChange={@toggleMultiImageCloneMarkers} />{' '}
+        Clone markings between frames
       </label>
       <br />
       <pre>{JSON.stringify showing, replacer, 2}</pre>

--- a/app/pages/dev-classifier/mock-data.coffee
+++ b/app/pages/dev-classifier/mock-data.coffee
@@ -39,6 +39,7 @@ workflow = apiClient.type('workflows').create
   configuration:
     enable_subject_flags: true
     enable_switching_flipbook_and_separate: true
+    multi_image_clone_markers: false
     multi_image_layout: 'grid3'
     invert_subject: true
     persist_annotations: false


### PR DESCRIPTION
Staging branch URL:

Fixes #4094.

Added check so that drawing sub-tasks clone in multiple frames when multi_image_clone_markers enabled and separate frames disabled

There are cases not covered so far which might be useful - i.e. switching between flipbook and separate frames enabled and cloning markers enabled. This would require threading the flag in the state of `SubjectViewer` down to MarkingsRenderer.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
