### PR TITLE
Add default value for hideSubjectViewer

### DIFF
--- a/app/features/feedback/shared/strategies/radial/create-rule.js
+++ b/app/features/feedback/shared/strategies/radial/create-rule.js
@@ -3,7 +3,7 @@ import ruleChecker from '../../helpers/rule-checker';
 function createRule(subjectRule, workflowRule) {
   const rule = {
     failureEnabled: workflowRule.failureEnabled,
-    hideSubjectViewer: workflowRule.hideSubjectViewer,
+    hideSubjectViewer: workflowRule.hideSubjectViewer || false,
     id: subjectRule.id,
     strategy: workflowRule.strategy,
     successEnabled: workflowRule.successEnabled,


### PR DESCRIPTION
Staging branch URL: https://fix-multi-step-workflow.pfe-preview.zooniverse.org/

Staging project: https://fix-multi-step-workflow.pfe-preview.zooniverse.org//projects/rogerhutchings/feedback-test

Adds in a default value for the feedback `hideSubjectViewer` property, since it was breaking when not actively set on the workflow.