### PR TITLE
Classifier: initialise workflow history from annotations

### DIFF
--- a/app/classifier/classifier.jsx
+++ b/app/classifier/classifier.jsx
@@ -56,6 +56,8 @@ class Classifier extends React.Component {
 
   componentWillMount() {
     this.updateAnnotations();
+    const workflowHistory = this.props.classification.annotations.map(annotation => annotation.task);
+    this.setState({ workflowHistory });
   }
 
   componentDidMount() {


### PR DESCRIPTION
Staging branch URL: https://persist-workflow-history.pfe-preview.zooniverse.org/

Fixes #4464.

Describe your changes.
Workflow history (introduced in #4450) tracks which tasks you've done for the current subject, but isn't persisted outside the classifier. This maps annotations to workflow history when the classifier loads, so that the current task persists even if the classifier unmounts. This is a quick patch for #4464 but it should work.

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
