### PR TITLE
Fix recursive workflows

### DIFF
--- a/app/classifier/classifier.jsx
+++ b/app/classifier/classifier.jsx
@@ -5,7 +5,7 @@ import { VisibilitySplit } from 'seven-ten';
 import Translate from 'react-translate-component';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import findIndex from 'lodash/findIndex';
+import findLastIndex from 'lodash/findLastIndex';
 import { browserHistory } from 'react-router';
 
 import { getSessionID } from '../lib/session';
@@ -222,7 +222,7 @@ class Classifier extends React.Component {
 
   handleAnnotationChange(classification, newAnnotation) {
     const annotations  = classification.annotations.slice();
-    const index = findIndex(annotations, annotation => annotation.task === newAnnotation.task);
+    const index = findLastIndex(annotations, annotation => annotation.task === newAnnotation.task);
     annotations[index] = newAnnotation;
     this.updateAnnotations(annotations);
   }
@@ -305,7 +305,7 @@ class Classifier extends React.Component {
         const { workflowHistory } = this.state;
         const taskKey = this.state.workflowHistory.length > 0 ? workflowHistory[workflowHistory.length - 1] : null;
         currentTask = this.props.workflow.tasks[taskKey];
-        const index = findIndex(this.state.annotations, annotation => annotation.task === taskKey);
+        const index = findLastIndex(this.state.annotations, annotation => annotation.task === taskKey);
         currentAnnotation = this.state.annotations[index];
       }
     }

--- a/app/classifier/task.jsx
+++ b/app/classifier/task.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import findIndex from 'lodash/findIndex';
+import findLastIndex from 'lodash/findLastIndex';
 import tasks from './tasks';
 import Shortcut from './tasks/shortcut';
 import TaskTranslations from './tasks/translations';
@@ -14,7 +14,7 @@ class Task extends React.Component {
   handleAnnotationChange(newAnnotation) {
     const { classification } = this.props;
     const annotations = classification.annotations.slice();
-    const index = findIndex(annotations, annotation => annotation.task === newAnnotation.task);
+    const index = findLastIndex(annotations, annotation => annotation.task === newAnnotation.task);
     annotations[index] = newAnnotation;
     this.props.updateAnnotations(annotations);
   }


### PR DESCRIPTION
Staging branch URL: https://fix-4469.pfe-preview.zooniverse.org/
- sane workflow: https://fix-4469.pfe-preview.zooniverse.org/projects/markb-panoptes/test-project-2-mb/classify?workflow=3173
- copy of production workflow: https://fix-4469.pfe-preview.zooniverse.org/projects/markb-panoptes/test-project-2-mb/classify?workflow=3172

Fixes #4469.

Replace lodash's `findIndex` with `findLastIndex` when selecting annotation, fixes recursive workflows.

- [ ] test on workflow with persist annotations

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
