### PR TITLE
Remove unnecessary page_size query params

### DIFF
--- a/app/lib/get-workflows-in-order.js
+++ b/app/lib/get-workflows-in-order.js
@@ -4,9 +4,6 @@ function getWorkflowsInOrder(project, query) {
     project.configuration.workflow_order :
     [];
 
-  // TODO remove default page_size once pagination solution implemented
-  query.page_size = query.page_size || 20;
-
   function getAllWorkflows(query) {
     let allWorkflows = [];
     return getWorkflows(query, 1);

--- a/app/pages/admin/project-status-list.jsx
+++ b/app/pages/admin/project-status-list.jsx
@@ -33,7 +33,6 @@ class ProjectStatusList extends Component {
 
     const projectsQuery = {
       include: 'avatar',
-      page_size: 24,
       sort: '-updated_at'
     };
 

--- a/app/pages/lab/workflows-container.jsx
+++ b/app/pages/lab/workflows-container.jsx
@@ -41,7 +41,7 @@ export default class WorkflowsContainer extends React.Component {
   getWorkflowList(page) {
     if (this.state.reorder) {
       this.context.router.push({ pathname: this.props.location.pathname, query: null });
-      getWorkflowsInOrder(this.props.project, { fields: 'display_name', page_size: this.props.project.links.workflows.length })
+      getWorkflowsInOrder(this.props.project, { fields: 'display_name' })
       .then((workflows) => {
         this.setState({ workflows, loading: false });
       });


### PR DESCRIPTION
Staging branch URL: https://remove-page-sizes.pfe-preview.zooniverse.org/

Describe your changes.
- with the refactor of `getWorkflowsInOrder` to cycle through requests until no `next_page` in meta, I think we can remove the following `page_size` query params 

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
