### PR TITLE
Store text task value in component state

### DIFF
--- a/app/classifier/tasks/text/index.cjsx
+++ b/app/classifier/tasks/text/index.cjsx
@@ -58,7 +58,7 @@ module.exports = createReactClass
   getInitialState: ->
     textareaHeight: undefined
     initOffsetHeight: undefined
-    value: ''
+    value: @props.annotation.value
 
   componentDidMount: ->
     @setState initOffsetHeight: @refs.textInput.offsetHeight
@@ -68,6 +68,8 @@ module.exports = createReactClass
     if nextProps.task isnt @props.task
       @setState { value: '', textareaHeight: @state.initOffsetHeight }, =>
         @updateHeight()
+    if nextProps.annotation.value isnt @props.annotation.value
+      @setState value: nextProps.annotation.value
 
   componentDidUpdate: (prevProps) ->
     if prevProps.task isnt @props.task and @props.autoFocus is true

--- a/app/classifier/tasks/text/index.cjsx
+++ b/app/classifier/tasks/text/index.cjsx
@@ -92,8 +92,7 @@ module.exports = createReactClass
       textInBetween = textAreaValue.substring(selectionStart, selectionEnd)
       textAfter = textAreaValue.substring(selectionEnd, textAreaValue.length)
       value = textBefore + startTag + textInBetween + endTag + textAfter
-    newAnnotation = Object.assign @props.annotation, {value}
-    @props.onChange newAnnotation
+    @setState { value }
 
   updateHeight: ->
     @setState textareaHeight: @refs.textInput.scrollHeight + 2

--- a/app/classifier/tasks/text/index.cjsx
+++ b/app/classifier/tasks/text/index.cjsx
@@ -66,7 +66,7 @@ module.exports = createReactClass
 
   componentWillReceiveProps: (nextProps) ->
     if nextProps.task isnt @props.task
-      @setState textareaHeight: @state.initOffsetHeight, =>
+      @setState { value: '', textareaHeight: @state.initOffsetHeight }, =>
         @updateHeight()
 
   componentDidUpdate: (prevProps) ->

--- a/app/classifier/tasks/text/index.cjsx
+++ b/app/classifier/tasks/text/index.cjsx
@@ -58,6 +58,7 @@ module.exports = createReactClass
   getInitialState: ->
     textareaHeight: undefined
     initOffsetHeight: undefined
+    value: ''
 
   componentDidMount: ->
     @setState initOffsetHeight: @refs.textInput.offsetHeight
@@ -71,6 +72,9 @@ module.exports = createReactClass
   componentDidUpdate: (prevProps) ->
     if prevProps.task isnt @props.task and @props.autoFocus is true
       @refs.textInput.focus()
+
+  componentWillUnMount: ->
+    @updateAnnotation()
 
   setTagSelection: (e) ->
     textTag = e.target.value
@@ -101,8 +105,9 @@ module.exports = createReactClass
           autoFocus={@props.autoFocus}
           className="standard-input full"
           ref="textInput"
-          value={@props.annotation.value}
+          value={@state.value}
           onChange={@handleChange}
+          onBlur={@updateAnnotation}
           rows="1"
           style={height: @state.textareaHeight}
         />
@@ -117,11 +122,16 @@ module.exports = createReactClass
   handleChange: ->
     value = @refs.textInput.value
 
-    if @props.annotation.value?.length > value.length
+    if @state.value?.length > value.length
       @setState textareaHeight: @state.initOffsetHeight, =>
         @updateHeight()
     else
       @updateHeight()
+
+    @setState { value }
+
+  updateAnnotation: ->
+    value = @refs.textInput.value
 
     newAnnotation = Object.assign @props.annotation, {value}
     @props.onChange newAnnotation


### PR DESCRIPTION
https://fix-text-input.pfe-preview.zooniverse.org/

Update text task value in local state while typing. Update the annotation on blur, or when the component unmounts.

This fixes performance problems by updating the classifier less frequently. However, testing on the dev classifier shows that it also breaks the Next button for required tasks.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
