### PR TITLE
Parse translation keys once, on load

### DIFF
--- a/app/classifier/tasks/translations.jsx
+++ b/app/classifier/tasks/translations.jsx
@@ -4,28 +4,9 @@ import merge from 'lodash/merge';
 import { connect } from 'react-redux';
 
 function TaskTranslations(props) {
-  const { task } = props;
-  const taskStrings = props.translations.strings.workflow;
-  let translation = merge({}, task);
-
-  function explodeTranslationKey(translationKey, value) {
-    const translationKeys = translationKey.split('.');
-    const translationObject = {};
-    let temp = translationObject;
-    while (translationKeys.length) {
-      temp[translationKeys[0]] = (translationKeys.length === 1) ? value : {};
-      temp = temp[translationKeys[0]];
-      translationKeys.shift();
-    }
-    return translationObject;
-  }
-
-  Object.keys(taskStrings).map((translationKey) => {
-    const newTranslation = explodeTranslationKey(translationKey, taskStrings[translationKey]);
-    if (newTranslation.tasks && newTranslation.tasks[props.taskKey]) {
-      translation = merge(translation, newTranslation.tasks[props.taskKey]);
-    }
-  });
+  const { task, translations } = props;
+  const taskStrings = translations.strings.workflow.tasks ? translations.strings.workflow.tasks[props.taskKey] : {};
+  const translation = merge({}, task, taskStrings);
 
   return React.cloneElement(props.children, { translation });
 }

--- a/app/classifier/tasks/translations.spec.js
+++ b/app/classifier/tasks/translations.spec.js
@@ -19,8 +19,24 @@ const translations = {
   strings: {
     workflow: {
       display_name: 'A test workflow',
-      'tasks.survey.choices.ar.label': 'Translated Armadillo',
-      'tasks.survey.questions.ho.answers.one.label': 'Translated 1'
+      tasks: {
+        survey: {
+          choices: {
+            ar: {
+              label: 'Translated Armadillo'
+            }
+          },
+          questions: {
+            ho: {
+              answers: {
+                one: {
+                  label: 'Translated 1'
+                }
+              }
+            }
+          }
+        }
+      }
     }
   }
 };

--- a/app/classifier/translations.jsx
+++ b/app/classifier/translations.jsx
@@ -6,24 +6,7 @@ import { connect } from 'react-redux';
 function Translations(props) {
   const { original, translations, type } = props;
   const languageStrings = translations.strings[type];
-  let translation = merge({}, original);
-
-  function explodeTranslationKey(translationKey, value) {
-    const translationKeys = translationKey.split('.');
-    const translationObject = {};
-    let temp = translationObject;
-    while (translationKeys.length) {
-      temp[translationKeys[0]] = (translationKeys.length === 1) ? value : {};
-      temp = temp[translationKeys[0]];
-      translationKeys.shift();
-    }
-    return translationObject;
-  }
-
-  Object.keys(languageStrings).map((translationKey) => {
-    const newTranslation = explodeTranslationKey(translationKey, languageStrings[translationKey]);
-    translation = merge(translation, newTranslation);
-  });
+  const translation = merge({}, original, languageStrings);
 
   return React.cloneElement(props.children, { translation });
 }

--- a/app/redux/ducks/translations.js
+++ b/app/redux/ducks/translations.js
@@ -1,14 +1,31 @@
 import apiClient from 'panoptes-client/lib/api-client';
 import counterpart from 'counterpart';
+import merge from 'lodash/merge';
 
 const DEFAULT_LOCALE = counterpart.getLocale();
 
 counterpart.setFallbackLocale(DEFAULT_LOCALE);
+
+// Helpers
+
+function explodeTranslationKey(translationKey, value) {
+  const translationKeys = translationKey.split('.');
+  const translationObject = {};
+  let temp = translationObject;
+  while (translationKeys.length) {
+    temp[translationKeys[0]] = (translationKeys.length === 1) ? value : {};
+    temp = temp[translationKeys[0]];
+    translationKeys.shift();
+  }
+  return translationObject;
+}
+
 // Actions
 const ERROR = 'pfe/translations/ERROR';
 const LOAD = 'pfe/translations/LOAD';
 const SET_LOCALE = 'pfe/translations/SET_LOCALE';
-const SET_STRINGS = 'pfe/translations/SET_STRINGS';
+const SET_TRANSLATION = 'pfe/translations/SET_TRANSLATION';
+const SET_TRANSLATIONS = 'pfe/translations/SET_TRANSLATIONS';
 
 const initialState = {
   locale: DEFAULT_LOCALE,
@@ -24,13 +41,31 @@ const initialState = {
 
 // Reducer
 export default function reducer(state = initialState, action = {}) {
+  let type, languageStrings, strings, translations;
   switch (action.type) {
     case SET_LOCALE:
       return Object.assign({}, state, { locale: action.payload });
-    case SET_STRINGS:
-      const strings = Object.assign({}, state.strings, action.payload);
+    case SET_TRANSLATION:
+      ({ type, languageStrings } = action.payload);
+      let translation = {};
+      Object.keys(languageStrings).map((translationKey) => {
+        const newTranslation = explodeTranslationKey(translationKey, languageStrings[translationKey]);
+        translation = merge(translation, newTranslation);
+      });
+      strings = Object.assign({}, state.strings, { [type]: translation });
       return Object.assign({}, state, { strings });
-
+    case SET_TRANSLATIONS:
+      ({ type, translations } = action.payload);
+      translations.forEach((translation, i) => {
+        Object.keys(translation.strings).map((translationKey) => {
+          const newTranslation = explodeTranslationKey(translationKey, translation.strings[translationKey]);
+          translation.strings = merge(translation.strings, newTranslation);
+          translations[i] = translation;
+        });
+      });
+      
+      strings = Object.assign({}, state.strings, { [type]: translations });
+      return Object.assign({}, state, { strings });
     default:
       return state;
   }
@@ -48,16 +83,18 @@ export function load(resource_type, translated_id, language) {
       .then(([translation]) => {
         if (translation && translation.strings) {
           dispatch({
-            type: SET_STRINGS,
+            type: SET_TRANSLATION,
             payload: {
-              [resource_type]: translation.strings
+              type: resource_type,
+              languageStrings: translation.strings
             }
           });
         } else {
           dispatch({
-            type: SET_STRINGS,
+            type: SET_TRANSLATION,
             payload: {
-              [resource_type]: {}
+              type: resource_type,
+              languageStrings: {}
             }
           });
         }
@@ -91,9 +128,10 @@ export function loadTranslations(translated_type, translated_id, language) {
       .then((translations) => {
         if (translations) {
           dispatch({
-            type: SET_STRINGS,
+            type: SET_TRANSLATIONS,
             payload: {
-              [translated_type]: translations
+              type: translated_type,
+              translations
             }
           });
         }


### PR DESCRIPTION
https://parse-translations-once.pfe-preview.zooniverse.org

Update the translations actions to explode translation keys to objects once, on load from Panoptes. Remove `explodeTranslationKeys` from the translation components, so that it doesn't run on every render.

Update the task translation tests to reflect that translations are now nested objects, matching the task object structure for convenience.

Fixes a performance problem on AACW. Translations were being parsed into objects and re-rendered each time you typed a new character. Exploding the dropdown task strings into objects, for that workflow, takes ~0.5s, leading to delays of several seconds between typing a letter and seeing the display update.

Some testing URLs:
Wildcam Darien in Spanish: https://parse-translations-once.pfe-preview.zooniverse.org/projects/wildcam/wildcam-darien?language=es&env=production
AACW: https://parse-translations-once.pfe-preview.zooniverse.org/projects/usct/african-american-civil-war-soldiers?env=production


# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
