### PR TITLE
Explain why reset password emails may not be sent on the reset form

### DIFF
--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -182,7 +182,9 @@ export default {
     emailSuccess: 'We’ve just sent you an email with a link to reset your password.',
     emailError: 'There was an error resetting your password.',
     passwordsDoNotMatch: 'The passwords do not match, please try again.',
-    loggedInDialog: 'You are currently logged in. Please log out if you would like to reset your password.'
+    loggedInDialog: 'You are currently logged in. Please log out if you would like to reset your password.',
+    missingEmailsSpamNote: 'Please check your spam folder if you have not received the reset email.',
+    missingEmailsAlternateNote: 'If you have still not received an email, please try any other email address you may have signed up with.'
   },
   workflowToggle: {
     label: 'Active'

--- a/app/locales/es.js
+++ b/app/locales/es.js
@@ -71,7 +71,7 @@ export default {
       getStarted: 'Get started',
       workflowAssignment: 'You\'ve unlocked level %(workflowDisplayName)s',
       visitLink: 'Visit the project',
-      links: 'Links'      
+      links: 'Links'
     }
   },
   organization: {
@@ -177,7 +177,9 @@ export default {
     emailError: 'There was an error reseting your password.',
     resetError: 'Something went wrong, please try and reset your password via email again.',
     passwordsDoNotMatch: 'The passwords do not match, please try again.',
-    loggedInDialog: 'You are currently logged in. Please log out if you would like to reset your password.'
+    loggedInDialog: 'You are currently logged in. Please log out if you would like to reset your password.',
+    missingEmailsSpamNote: 'Please check your spam folder if you have not received the reset email.',
+    missingEmailsAlternateNote: 'If you have still not received an email, please try any other email address you may have signed up with.'
   },
   workflowToggle: {
     label: 'Active'

--- a/app/locales/nl.js
+++ b/app/locales/nl.js
@@ -203,7 +203,9 @@ export default {
     emailSuccess: 'We hebben je zojuist een e-mail met een herstellink gezonden.',
     emailError: 'Er ging iets mis bij het herstellen van je wachtwoord.',
     passwordsDoNotMatch: 'De wachtwoorden komen niet overeen, probeer het opnieuw.',
-    loggedInDialog: 'Je bent op dit moment ingelogd. Log uit om je wachtwoord te herstellen.'
+    loggedInDialog: 'Je bent op dit moment ingelogd. Log uit om je wachtwoord te herstellen.',
+    missingEmailsSpamNote: 'Please check your spam folder if you have not received the reset email.',
+    missingEmailsAlternateNote: 'If you have still not received an email, please try any other email address you may have signed up with.'
   },
   workflowToggle: {
     label: 'Actief'

--- a/app/locales/nl.js
+++ b/app/locales/nl.js
@@ -204,8 +204,8 @@ export default {
     emailError: 'Er ging iets mis bij het herstellen van je wachtwoord.',
     passwordsDoNotMatch: 'De wachtwoorden komen niet overeen, probeer het opnieuw.',
     loggedInDialog: 'Je bent op dit moment ingelogd. Log uit om je wachtwoord te herstellen.',
-    missingEmailsSpamNote: 'Please check your spam folder if you have not received the reset email.',
-    missingEmailsAlternateNote: 'If you have still not received an email, please try any other email address you may have signed up with.'
+    missingEmailsSpamNote: 'Als je geen e-mail ontvangen hebt, controleer dan of het wellicht in je spamfolder terecht is gekomen.',
+    missingEmailsAlternateNote: 'Als je nog steeds geen e-mail ontvangen hebt, controleer of je misschien een ander e-mailadres voor je account hebt gebruikt.'
   },
   workflowToggle: {
     label: 'Actief'

--- a/app/pages/reset-password/submit-email-form.jsx
+++ b/app/pages/reset-password/submit-email-form.jsx
@@ -42,20 +42,18 @@ const SubmitEmailForm = ({ user, onSubmit, onChange, disabled, inProgress, email
           <i className="fa fa-check-circle form-help success" />}
       </p>
 
-      <div id="reset-status">
-        {emailSuccess &&
-          <Translate
-            component="p"
-            content="resetPassword.emailSuccess"
-          />}
+      {emailSuccess &&
+        <Translate
+          component="p"
+          content="resetPassword.emailSuccess"
+        />}
 
-        {emailError &&
-          <Translate
-            className="form-help error"
-            component="small"
-            content="resetPassword.emailError"
-          />}
-      </div>
+      {emailError &&
+        <Translate
+          className="form-help error"
+          component="small"
+          content="resetPassword.emailError"
+        />}
       <p>
         <Translate
           component="small"

--- a/app/pages/reset-password/submit-email-form.jsx
+++ b/app/pages/reset-password/submit-email-form.jsx
@@ -42,30 +42,32 @@ const SubmitEmailForm = ({ user, onSubmit, onChange, disabled, inProgress, email
           <i className="fa fa-check-circle form-help success" />}
       </p>
 
-      {emailSuccess &&
-        <Translate
-          component="p"
-          content="resetPassword.emailSuccess"
-        />}
+      <div id="reset-status">
+        {emailSuccess &&
+          <Translate
+            component="p"
+            content="resetPassword.emailSuccess"
+          />}
 
-      {emailError &&
+        {emailError &&
+          <Translate
+            className="form-help error"
+            component="small"
+            content="resetPassword.emailError"
+          />}
+      </div>
+      <p>
         <Translate
-          className="form-help error"
           component="small"
-          content="resetPassword.emailError"
-        />}
-        <p>
-          <Translate
-            component="small"
-            content="resetPassword.missingEmailsSpamNote"
-          />
-        </p>
-        <p>
-          <Translate
-            component="small"
-            content="resetPassword.missingEmailsAlternateNote"
-          />
-        </p>
+          content="resetPassword.missingEmailsSpamNote"
+        />
+      </p>
+      <p>
+        <Translate
+          component="small"
+          content="resetPassword.missingEmailsAlternateNote"
+        />
+      </p>
     </form>
   );
 };

--- a/app/pages/reset-password/submit-email-form.jsx
+++ b/app/pages/reset-password/submit-email-form.jsx
@@ -54,6 +54,18 @@ const SubmitEmailForm = ({ user, onSubmit, onChange, disabled, inProgress, email
           component="small"
           content="resetPassword.emailError"
         />}
+        <p>
+          <Translate
+            component="small"
+            content="resetPassword.missingEmailsSpamNote"
+          />
+        </p>
+        <p>
+          <Translate
+            component="small"
+            content="resetPassword.missingEmailsAlternateNote"
+          />
+        </p>
     </form>
   );
 };

--- a/app/pages/reset-password/submit-email-form.spec.js
+++ b/app/pages/reset-password/submit-email-form.spec.js
@@ -42,14 +42,14 @@ describe('SubmitEmailForm', function () {
   it('conditionally shows and hides an email success icon and message', function () {
     wrapper.setProps({ emailSuccess: true });
     assert.equal(wrapper.find('i.form-help.success').length, 1);
-    assert.equal(wrapper.find('#reset-status').find('Translate').prop('content'), 'resetPassword.emailSuccess');
+    assert.equal(wrapper.find('Translate[content="resetPassword.emailSuccess"]').length, 1);
     wrapper.setProps({ emailSuccess: false });
     assert.equal(wrapper.find('i.form-help.success').length, 0);
   });
 
   it('conditionally shows and hides an email error message', function () {
     wrapper.setProps({ emailError: 'test error message' });
-    assert.equal(wrapper.find('#reset-status').find('Translate').last().prop('content'), 'resetPassword.emailError');
+    assert.equal(wrapper.find('Translate[content="resetPassword.emailError"]').length, 1);
     wrapper.setProps({ emailError: null });
   });
 });

--- a/app/pages/reset-password/submit-email-form.spec.js
+++ b/app/pages/reset-password/submit-email-form.spec.js
@@ -42,16 +42,14 @@ describe('SubmitEmailForm', function () {
   it('conditionally shows and hides an email success icon and message', function () {
     wrapper.setProps({ emailSuccess: true });
     assert.equal(wrapper.find('i.form-help.success').length, 1);
-    assert.equal(wrapper.find('Translate').last().prop('content'), 'resetPassword.emailSuccess');
+    assert.equal(wrapper.find('#reset-status').find('Translate').prop('content'), 'resetPassword.emailSuccess');
     wrapper.setProps({ emailSuccess: false });
     assert.equal(wrapper.find('i.form-help.success').length, 0);
-    assert.equal(wrapper.find('Translate').length, 1);
   });
 
   it('conditionally shows and hides an email error message', function () {
     wrapper.setProps({ emailError: 'test error message' });
-    assert.equal(wrapper.find('Translate').last().prop('content'), 'resetPassword.emailError');
+    assert.equal(wrapper.find('#reset-status').find('Translate').last().prop('content'), 'resetPassword.emailError');
     wrapper.setProps({ emailError: null });
-    assert.equal(wrapper.find('Translate').length, 1);
   });
 });


### PR DESCRIPTION
lots of users report they can't reset emails via contact@ most of the time it's cause they signed up with a different email address

Staging branch URL: https://unsubscribe-page-text-updates.pfe-preview.zooniverse.org/reset-password

Fixes: reports from contact @ emails, where some users signed up with different email addresses but try to reset their current one. 

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
