### PR TITLE
Make Hide Previous Marks public

### DIFF
--- a/app/classifier/tasks/generic-editor.cjsx
+++ b/app/classifier/tasks/generic-editor.cjsx
@@ -62,13 +62,12 @@ module.exports = createReactClass
         </div>}
       {' '}
 
-      {if @props.project and 'hide previous marks' in @props.project.experimental_tools
-        <label className="pill-button">
-          <AutoSave resource={@props.workflow}>
-            <input type="checkbox" checked={@props.task.enableHidePrevMarks} onChange={@toggleHidePrevMarksEnabled} />{' '}
-            Allow hiding marks
-          </AutoSave>
-        </label>}
+      <label className="pill-button">
+        <AutoSave resource={@props.workflow}>
+          <input type="checkbox" checked={@props.task.enableHidePrevMarks} onChange={@toggleHidePrevMarksEnabled} />{' '}
+          Allow hiding marks
+        </AutoSave>
+      </label>
 
       {if isAQuestion
         multipleHelp = 'Multiple Choice: Check this box if more than one answer can be selected.'

--- a/app/pages/admin/project-status/experimental-features.jsx
+++ b/app/pages/admin/project-status/experimental-features.jsx
@@ -8,7 +8,6 @@ const experimentalFeatures = [
   'dropdown',
   'mini-course',
   'worldwide telescope',
-  'hide previous marks',
   'grid',
   'workflow assignment',
   'Gravity Spy Gold Standard',


### PR DESCRIPTION
https://hide-previous-marks.pfe-preview.zooniverse.org

Remove the experimental flag for the Hide Previous Marks option on drawing tasks.

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
