### PR TITLE
Unsubscribe all the things

### DIFF
--- a/app/pages/settings/email.jsx
+++ b/app/pages/settings/email.jsx
@@ -5,6 +5,7 @@ import apiClient from 'panoptes-client/lib/api-client';
 import talkClient from 'panoptes-client/lib/talk-client';
 import AutoSave from '../../components/auto-save';
 import handleInputChange from '../../lib/handle-input-change';
+import GeneralUnsubscribe from './general-unsubscribe';
 
 function TalkPreferenceOption({ preference, index, digest, onChange }) {
   return (
@@ -282,7 +283,7 @@ class EmailSettingsPage extends React.Component {
             </label>
           </AutoSave>
         </p>
-
+        <GeneralUnsubscribe {...this.props} />
         <p>
           <strong>
             <Translate content="emailSettings.talk.section" />

--- a/app/pages/settings/general-unsubscribe.jsx
+++ b/app/pages/settings/general-unsubscribe.jsx
@@ -1,0 +1,86 @@
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import auth from 'panoptes-client/lib/auth';
+
+class GeneralUnsubscribe extends Component {
+  constructor() {
+    super();
+    this.handleSubmit = this.handleSubmit.bind(this);
+    this.state = {
+      emailSuccess: false,
+      emailError: false,
+      inProgress: false
+    };
+  }
+
+  handleSubmit(event) {
+    event.preventDefault();
+    const email = this.props.user ? this.props.user.email : null;
+    this.setState({
+      inProgress: true,
+      emailSuccess: false,
+      emailError: false
+    });
+    auth.unsubscribeEmail({ email })
+      .then(() => this.setState({ emailSuccess: true }))
+      .catch((error) => {
+        this.setState({ emailError: true });
+        console.log('Email unsubscribe error: ', error.message);
+      })
+      .then(() => this.setState({ inProgress: false }));
+  }
+
+  renderForm(disabledButton) {
+    return (
+      <form onSubmit={this.handleSubmit}>
+        <p>Unsubscribe from all Zooniverse emails, except Talk.</p>
+        <p>
+          <button
+            className="standard-button"
+            disabled={disabledButton}
+            type="submit"
+          >Submit
+          </button>
+          {' '}
+          {this.renderIconFeedback()}
+        </p>
+        {this.renderTextFeedback()}
+      </form>
+    );
+  }
+
+  renderIconFeedback() {
+    if (this.state.inProgress) {
+      return <i className="fa fa-spinner fa-spin form-help" />;
+    } else if (this.state.emailSuccess) {
+      return <i className="fa fa-check-circle form-help success" />;
+    }
+    return null;
+  }
+
+  renderTextFeedback() {
+    if (this.state.emailSuccess) {
+      return <p>You've been unsubscribed!</p>;
+    } else if (this.state.emailError) {
+      return (
+        <p className="form-help error">
+          There was an error unsubscribing your email.
+        </p>
+      );
+    }
+    return null;
+  }
+
+  render() {
+    const disabledButton = this.state.emailSuccess;
+    return this.renderForm(disabledButton);
+  }
+}
+
+GeneralUnsubscribe.propTypes = {
+  user: PropTypes.shape({
+    email: PropTypes.string
+  })
+};
+
+export default GeneralUnsubscribe;

--- a/app/pages/settings/general-unsubscribe.spec.js
+++ b/app/pages/settings/general-unsubscribe.spec.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import GeneralUnsubscribe from './general-unsubscribe';
+
+describe('Unsubscribe from all email lists', function () {
+  const handleSubmitSpy = sinon.spy();
+  let wrapper;
+
+  before(function () {
+    wrapper = shallow(
+      <GeneralUnsubscribe
+        onSubmit={handleSubmitSpy}
+      />
+    );
+  });
+
+  it('renders an unsubscribe from all emails form', function () {
+    wrapper.setProps({ user: null });
+    expect(wrapper.find('form')).to.have.lengthOf(1);
+  });
+
+  it('should call handleSubmit on clicking the button', function () {
+    wrapper.find('form').simulate('submit', { preventDefault() {} });
+    expect(handleSubmitSpy.calledOnce).to.be.true;
+  });
+});

--- a/app/pages/settings/general-unsubscribe.spec.js
+++ b/app/pages/settings/general-unsubscribe.spec.js
@@ -5,24 +5,23 @@ import sinon from 'sinon';
 import GeneralUnsubscribe from './general-unsubscribe';
 
 describe('Unsubscribe from all email lists', function () {
-  const handleSubmitSpy = sinon.spy();
+  const handleSubmitStub = sinon.stub(GeneralUnsubscribe.prototype, 'handleSubmit').callsFake(() => {});
   let wrapper;
 
-  before(function () {
+  beforeEach(function () {
     wrapper = shallow(
       <GeneralUnsubscribe
-        onSubmit={handleSubmitSpy}
+        onSubmit={handleSubmitStub}
       />
     );
   });
 
   it('renders an unsubscribe from all emails form', function () {
-    wrapper.setProps({ user: null });
     expect(wrapper.find('form')).to.have.lengthOf(1);
   });
 
   it('should call handleSubmit on clicking the button', function () {
-    wrapper.find('form').simulate('submit', { preventDefault() {} });
-    expect(handleSubmitSpy.calledOnce).to.be.true;
+    wrapper.find('form').simulate('submit');
+    expect(handleSubmitStub.calledOnce).to.be.true;
   });
 });


### PR DESCRIPTION
Staging branch URL: https://unsubscribe-everything.pfe-preview.zooniverse.org/settings/email

Fixes #4487 .

Describe your changes.
Adds an unsubscribe from everything button to the email settings page.
Uses pretty much the same code as `/unsubscribe`.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
