### PR TITLE
Add onClick prop to NavLink

### DIFF
--- a/app/pages/project/components/ProjectNavbar/components/NavLink/NavLink.jsx
+++ b/app/pages/project/components/ProjectNavbar/components/NavLink/NavLink.jsx
@@ -35,10 +35,11 @@ export const StyledLinkPlaceholder = styled.span`
   ${commonStyles}
 `;
 
-function NavLink({ className, disabled, isExternalLink, label, url }) {
+function NavLink({ className, disabled, isExternalLink, label, onClick, url }) {
   const linkProps = {
     className,
-    disabled
+    disabled,
+    onClick
   };
 
   const LinkComponent = (disabled) ? StyledLinkPlaceholder : StyledInternalLink;
@@ -70,7 +71,7 @@ NavLink.defaultProps = {
   disabled: false,
   isExternalLink: false,
   label: '',
-  site: '',
+  onClick: () => true,
   url: ''
 };
 
@@ -79,7 +80,7 @@ NavLink.propTypes = {
   disabled: PropTypes.bool,
   isExternalLink: PropTypes.bool,
   label: PropTypes.string,
-  site: PropTypes.string,
+  onClick: PropTypes.func,
   url: PropTypes.string
 };
 


### PR DESCRIPTION
https://fix-4491.pfe-preview.zooniverse.org/

Pass the custom click handler down to nav links.
Remove the unused site prop.

Fixes #4491

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
