### PR TITLE
Set a max-width for video

### DIFF
--- a/app/pages/lab/media.jsx
+++ b/app/pages/lab/media.jsx
@@ -36,7 +36,7 @@ export default class EditMediaPage extends React.Component {
 
 EditMediaPage.defaultProps = {
   project: {},
-  validSubjectExtensions: ['.jpg', '.jpeg', '.png', '.gif', '.svg', '.mp3'],
+  validSubjectExtensions: ['.jpg', '.jpeg', '.png', '.gif', '.svg', '.mp3', '.mp4', '.m4v'],
 };
 
 EditMediaPage.propTypes = {

--- a/css/markdown-video.styl
+++ b/css/markdown-video.styl
@@ -5,3 +5,8 @@
     max-height: 390px
     max-width: 600px
     width: 100%
+
+.markdown
+
+  video
+    max-width: 100%


### PR DESCRIPTION
https://video-css.pfe-preview.zooniverse.org

Set a max width for embedded video tags in Markdown sections, so that they don't overflow tutorials and field guides. Requested by cetalingua so that they can upload their own video examples rather than relying on YouTube: https://www.zooniverse.org/projects/cetalingua/manatee-chat/talk/1508/576330

https://video-css.pfe-preview.zooniverse.org/projects/eatyourgreens/-project-testing-ground/classify has a video in the tutorial (fourth slide) and also in the field guide (section one.)

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
