### PR TITLE
Pass annotations to FileViewer

### DIFF
--- a/app/components/file-viewer/index.jsx
+++ b/app/components/file-viewer/index.jsx
@@ -55,7 +55,7 @@ function FileViewer(props) {
       viewerProps,
       {
         annotation: cloneDeep(props.annotation),
-        annotations: props.classification.annotations,
+        annotations: props.annotations,
         subject: props.subject,
         viewBoxDimensions: props.viewBoxDimensions
       }
@@ -69,7 +69,7 @@ function FileViewer(props) {
 FileViewer.propTypes = {
   annotation: PropTypes.object,
   className: PropTypes.string,
-  classification: PropTypes.object,
+  annotations: PropTypes.arrayOf(PropTypes.object),
   format: PropTypes.oneOfType([
     PropTypes.array,
     PropTypes.string
@@ -90,5 +90,9 @@ FileViewer.propTypes = {
   ]),
   viewBoxDimensions: PropTypes.object
 };
+
+FileViewer.defaultProps = {
+  annotations: []
+}
 
 export default FileViewer;

--- a/app/components/frame-viewer.jsx
+++ b/app/components/frame-viewer.jsx
@@ -64,7 +64,7 @@ export default class FrameViewer extends React.Component {
     );
     const modellingProps = type === 'application' ? { // could be a more specific type check here
       annotation: this.props.annotation,
-      classification: this.props.classification,
+      annotations: this.props.annotations,
       subject: this.props.subject,
       workflow: this.props.workflow
     } : {};
@@ -126,9 +126,7 @@ FrameViewer.propTypes = {
   annotation: PropTypes.shape(
     { id: PropTypes.string }
   ),
-  classification: PropTypes.shape(
-    { annotations: PropTypes.array }
-  ),
+  annotations: PropTypes.arrayOf(PropTypes.object),
   frame: PropTypes.number,
   frameWrapper: PropTypes.func,
   modification: PropTypes.object,
@@ -146,9 +144,7 @@ FrameViewer.propTypes = {
 };
 
 FrameViewer.defaultProps = {
-  classification: {
-    annotations: []
-  },
+  annotations: [],
   frame: 0,
   onChange: () => {},
   preferences: { },


### PR DESCRIPTION
https://update-annotations.pfe-preview.zooniverse.org/

Remove classification prop. Pass annotations down to FileViewer from the classifier.

This should fix Galaxy Builder, which renders your annotations to the subject viewer while you are classifying.

Needs checking to make sure the subject viewer hasn't broken anywhere that annotations are not available eg. Talk, collections, recents.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
