### PR TITLE
Add Object.values to polyfill service

### DIFF
--- a/views/index.ejs
+++ b/views/index.ejs
@@ -70,7 +70,7 @@
 
     <div id="panoptes-main-container"></div>
 
-    <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=default,es6,Promise,fetch,Array.prototype.includes,Array.prototype.find&amp;flags=gated"></script>
+    <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=default,es6,Promise,fetch,Array.prototype.includes,Array.prototype.find,Object.values&amp;flags=gated"></script>
     <script>('assign' in Object) || document.write('<script src="/fallback-polyfills.js"></'+'script>');</script>
   </body>
 </html>


### PR DESCRIPTION
Staging branch URL:

Follow up to #4490. Adds Object.values to the polyfill.io service we're using so that we don't forget that this isn't apart of the default set provided.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
