### PR TITLE
Temporary hacky bugfix by type checking for #4502

### DIFF
--- a/app/classifier/frame-annotator.jsx
+++ b/app/classifier/frame-annotator.jsx
@@ -50,6 +50,7 @@ export default class FrameAnnotator extends React.Component {
 
     if (this.props.annotation.task) {
       taskDescription = this.props.workflow.tasks[this.props.annotation.task];
+      
       (({ BeforeSubject, AfterSubject } = tasks[taskDescription.type]));
     }
 
@@ -108,7 +109,8 @@ export default class FrameAnnotator extends React.Component {
             warningBanner
           )}
 
-          {!!AfterSubject && (
+          {/* Gross hacky bugfix :( */}
+          {!!AfterSubject && this.props.annotation && typeof this.props.annotation.value[0] === 'object' && (
             <AfterSubject {...hookProps} />)}
 
         </div>

--- a/app/classifier/frame-annotator.spec.js
+++ b/app/classifier/frame-annotator.spec.js
@@ -13,7 +13,8 @@ import WarningBanner from './warning-banner';
 import { classification, workflow, subject, preferences } from '../pages/dev-classifier/mock-data';
 
 const annotation = {
-  task: 'init'
+  task: 'init',
+  value: [{}]
 };
 
 const viewBoxDimensions = {
@@ -140,7 +141,7 @@ describe('<FrameAnnotator />', function() {
 
     before(function() {
       // combo task has BeforeSubject, InsideSubject, and AfterSubject hooks
-      const comboAnnotation = { task: 'combo' };
+      const comboAnnotation = { task: 'combo', value: [{}] };
       TaskComponent = tasks[comboAnnotation.task];
       wrapper = shallow(
         <FrameAnnotator

--- a/app/classifier/tasks/survey/annotation-view.cjsx
+++ b/app/classifier/tasks/survey/annotation-view.cjsx
@@ -4,9 +4,9 @@ createReactClass = require 'create-react-class'
 module.exports = createReactClass
   displayName: 'SurveyAnnotationView'
 
-  getDefaultProperties: ->
+  getDefaultProps: ->
     task: null
-    classification: null
+    annotations: null
     annotation: null
 
   render: ->

--- a/app/classifier/tasks/survey/index.cjsx
+++ b/app/classifier/tasks/survey/index.cjsx
@@ -47,12 +47,30 @@ module.exports = createReactClass
   render: ->
     <div className="survey-task">
       {if @state.selectedChoiceID is ''
-        <Chooser task={@props.task} filters={@state.filters} onFilter={@handleFilter} onChoose={@handleChoice} onRemove={@handleRemove} annotation={@props.annotation} focusedChoice={@state.focusedChoice} translation={@props.translation} />
+        <Chooser
+          task={@props.task}
+          filters={@state.filters}
+          onFilter={@handleFilter}
+          onChoose={@handleChoice}
+          onRemove={@handleRemove}
+          annotation={@props.annotation}
+          focusedChoice={@state.focusedChoice}
+          translation={@props.translation}
+        />
       else
         # @ is undefined within the scope of find
         currentSelection = @state.selectedChoiceID
         existingAnnotationValue = @props.annotation.value.find (value) -> value.choice is currentSelection
-        <Choice annotation={@props.annotation} annotationValue={existingAnnotationValue} task={@props.task} choiceID={@state.selectedChoiceID} onSwitch={@handleChoice} onCancel={@clearSelection} onConfirm={@handleAnnotation} translation={@props.translation} />
+        <Choice
+          annotation={@props.annotation}
+          annotationValue={existingAnnotationValue}
+          task={@props.task}
+          choiceID={@state.selectedChoiceID}
+          onSwitch={@handleChoice}
+          onCancel={@clearSelection}
+          onConfirm={@handleAnnotation}
+          translation={@props.translation}
+        />
       }
     </div>
 

--- a/app/classifier/tasks/survey/summary.jsx
+++ b/app/classifier/tasks/survey/summary.jsx
@@ -17,12 +17,15 @@ class SurveySummary extends React.Component {
   render() {
     const { task, annotation, translation } = this.props;
     const choiceSummaries = annotation.value.map((identification) => {
-      const allAnswers = Object.keys(identification.answers).map((questionId) => {
-        const answerKeys = [].concat(identification.answers[questionId]);
-        const answers = answerKeys.map(answerId => translation.questions[questionId].answers[answerId].label);
-        return answers.join(', ');
-      });
-      return `${translation.choices[identification.choice].label}: ${allAnswers.join('; ')}`;
+      // Gross hacky bug fix :()
+      if (typeof identification === 'object') {
+        const allAnswers = Object.keys(identification.answers).map((questionId) => {
+          const answerKeys = [].concat(identification.answers[questionId]);
+          const answers = answerKeys.map(answerId => translation.questions[questionId].answers[answerId].label);
+          return answers.join(', ');
+        });
+        return `${translation.choices[identification.choice].label}: ${allAnswers.join('; ')}`;
+      }
     });
     return (
       <div>


### PR DESCRIPTION
Staging branch URL: https://fix-4502.pfe-preview.zooniverse.org/

Fixes #4502. (sort of) 

This is a really hacky fix and should only be temporary until a proper fix is made. I added some type checks because the `AfterSubject` hook component for the survey task and its summary component, was trying to use the shortcut annotation value with projects that are setup to be a survey with a shortcut.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
