### PR TITLE
Use thumbnail service for tutorial and mini course images

### DIFF
--- a/app/components/media-card.jsx
+++ b/app/components/media-card.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import Thumbnail from './thumbnail';
 
 const IMAGE_EXTENSIONS = ['gif', 'jpeg', 'jpg', 'png', 'svg'];
 const VIDEO_EXTENSIONS = ['mp4'];
@@ -9,7 +10,7 @@ const MediaCard = ({ children, className, src, style }) => {
   let renderType;
 
   if (IMAGE_EXTENSIONS.includes(srcExtension)) {
-    renderType = <img alt="" className="media-card-media" src={src} />;
+    renderType = <Thumbnail alt="" className="media-card-media" width={800} src={src} />;
   } else if (VIDEO_EXTENSIONS.includes(srcExtension)) {
     renderType = (
       <video className="media-card-media" src={src}>

--- a/app/components/thumbnail.jsx
+++ b/app/components/thumbnail.jsx
@@ -69,7 +69,9 @@ export default class Thumbnail extends React.Component {
     }
 
     return (
-      <img alt="" {...this.props} src={src} {...dimensions} style={style} onError={this.handleError} />
+      <div  style={style}>
+        <img alt="" {...this.props} src={src} {...dimensions} onError={this.handleError} />
+      </div>
     );
   }
 }

--- a/css/tutorial.styl
+++ b/css/tutorial.styl
@@ -33,6 +33,7 @@
     border-top-right-radius: 8px
     display: block
     margin: auto
+    width: 100%
     max-width: 100%
 
 .step-through-direction


### PR DESCRIPTION
Staging branch URL: https://thumbnail-images.pfe-preview.zooniverse.org/

Passes Media Card images through the thumbnail service, to reduce download size.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
