### PR TITLE
update non-logged-in zoohome classification count

### DIFF
--- a/app/pages/home-not-logged-in.jsx
+++ b/app/pages/home-not-logged-in.jsx
@@ -27,7 +27,7 @@ export default class HomePage extends React.Component {
     super(props);
     this.resizeTimeout = NaN;
     this.state = {
-      count: 55000000,
+      count: 250469827,
       promotedProjects: [],
       screenWidth: 0,
       volunteerCount: 1500000

--- a/app/pages/home-not-logged-in/research.jsx
+++ b/app/pages/home-not-logged-in/research.jsx
@@ -38,10 +38,15 @@ counterpart.registerTranslations('en', {
   }
 });
 
+const GZ123_COUNT = 98989226
+const OUROBOROS_COUNT = 142800311
+const OTHERS_COUNT = 8680290
+
+
 const HomePageResearch = (({ count, screenWidth, showDialog, volunteerCount }) =>
   <section className="home-research">
     <Translate className="tertiary-kicker" component="h2" content="researchHomePage.works" />
-    <span className="class-counter">{count.toLocaleString()}</span>
+    <span className="class-counter">{(count + GZ123_COUNT + OUROBOROS_COUNT + OTHERS_COUNT).toLocaleString()}</span>
     <Translate className="main-kicker" component="h3" content="researchHomePage.classifications" />
     <div className="home-research__classification-count">
       <h3 className="main-kicker">{volunteerCount.toLocaleString()}</h3>{' '}


### PR DESCRIPTION
Staging branch URL:

Fixes #3926  .

Added static classification counts from Ouroboros, Juggernaut, and other very early projects (e.g. GZ1) to not-logged-in zooniverse home page. May not include every project, and there are still a few Ouroboros projects that are active and those changes won't be updated, but this is much closer than before. 

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
