### PR TITLE
Process annotations in the classifier

### DIFF
--- a/app/classifier/task-nav.jsx
+++ b/app/classifier/task-nav.jsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router';
 import Translate from 'react-translate-component';
 import tasks from './tasks';
 import CacheClassification from '../components/cache-classification';
-import GridTool from './drawing-tools/grid';
+
 
 /* eslint-disable multiline-ternary, no-nested-ternary, react/jsx-no-bind */
 
@@ -57,29 +57,9 @@ class TaskNav extends React.Component {
 
   // Done
   completeClassification(e) {
-    const { annotations, workflow } = this.props;
+    const { workflow } = this.props;
     if (workflow.configuration.persist_annotations) {
       CacheClassification.delete();
-    }
-
-    const currentAnnotation = annotations[annotations.length - 1];
-    const currentTask = workflow.tasks[currentAnnotation.task];
-
-    if (currentTask && currentTask.tools) {
-      currentTask.tools.map((tool) => {
-        if (tool.type === 'grid') {
-          GridTool.mapCells(annotations);
-        }
-      });
-    }
-
-    if (currentAnnotation.shortcut) {
-      const unlinkedTask = workflow.tasks[currentTask.unlinkedTask];
-      const unlinkedAnnotation = tasks[unlinkedTask.type].getDefaultAnnotation(unlinkedTask, workflow, tasks);
-      unlinkedAnnotation.task = currentTask.unlinkedTask;
-      unlinkedAnnotation.value = currentAnnotation.shortcut.value.slice();
-      delete currentAnnotation.shortcut;
-      annotations.push(unlinkedAnnotation);
     }
     this.props.completeClassification(e);
   }


### PR DESCRIPTION
Some tasks process the annotations array once classification is complete. This commit moves that code out of the task nav and up into the classifier.

Staging branch URL: https://process-annotations.pfe-preview.zooniverse.org

Follows on from #4504

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
