### PR TITLE
Add ScrollIntoView to Comment component

### DIFF
--- a/app/talk/comment.cjsx
+++ b/app/talk/comment.cjsx
@@ -58,7 +58,7 @@ module.exports = createReactClass
     
 
   componentDidMount: ->
-    if @props.active
+    if @props.scrollIntoView
       ReactDOM.findDOMNode(@).scrollIntoView()
 
   onClickReply: (e) ->

--- a/app/talk/discussion.cjsx
+++ b/app/talk/discussion.cjsx
@@ -227,6 +227,7 @@ module.exports = createReactClass
 
   comment: (data, i) ->
     active = +data.id is +@props.location.query?.comment
+    scrollToLastComment = (i is @state.comments.length - 1) && @state.shouldScrollToBottom
     <Comment
       {...@props}
       project={@props.project}
@@ -244,7 +245,7 @@ module.exports = createReactClass
       onLikeComment={@onLikeComment}
       onUpdateComment={@onUpdateComment}
       onDeleteComment={@onDeleteComment}
-      scrollIntoView = {@state.shouldScrollToBottom || active}
+      scrollIntoView = {scrollToLastComment || active}
     />
 
   onClickDeleteDiscussion: ->

--- a/app/talk/discussion.cjsx
+++ b/app/talk/discussion.cjsx
@@ -43,6 +43,7 @@ module.exports = createReactClass
     authors: {}
     subjects: {}
     author_roles: {}
+    shouldScrollToBottom: false
 
   getDefaultProps: ->
     location: query: page: 1
@@ -70,7 +71,7 @@ module.exports = createReactClass
       @setComments(nextProps.location.query.page)
 
   componentDidMount: ->
-    @shouldScrollToBottom = true if @props.location.query?.scrollToLastComment
+    @setState { shouldScrollToBottom: true } if @props.location.query?.scrollToLastComment
 
   componentWillMount: ->
     @setDiscussion().then (discussion) =>
@@ -149,9 +150,8 @@ module.exports = createReactClass
               @setState {author_roles}
 
           @setState {comments, commentsMeta}, =>
-            if @shouldScrollToBottom
-              @scrollToBottomOfDiscussion()
-              @shouldScrollToBottom = false
+            if @state.shouldScrollToBottom
+              @setState { shouldScrollToBottom: false }
         else
           {board, owner, name} = @props.params
           if (owner and name)
@@ -163,9 +163,6 @@ module.exports = createReactClass
     @commentsRequest(page).then (comments) =>
       commentsMeta = comments[0]?.getMeta() ? {}
       @setState {commentsMeta}
-
-  scrollToBottomOfDiscussion: ->
-    ReactDOM.findDOMNode(@)?.scrollIntoView(false)
 
   discussionsRequest: (discussion = @props.params.discussion) ->
     talkClient.type('discussions').get({id: discussion, sort_linked_comments: 'created_at'})
@@ -229,6 +226,7 @@ module.exports = createReactClass
     ReactDOM.findDOMNode(@).scrollIntoView(false)
 
   comment: (data, i) ->
+    active = +data.id is +@props.location.query?.comment
     <Comment
       {...@props}
       project={@props.project}
@@ -238,14 +236,16 @@ module.exports = createReactClass
       author={@state.authors[data.user_id]}
       subject={@state.subjects[data.focus_id]}
       roles={@state.author_roles[data.user_id]}
-      active={+data.id is +@props.location.query?.comment}
+      active={active}
       user={@props.user}
       locked={@state.discussion?.locked}
       project={@props.project}
       onClickReply={@onClickReply}
       onLikeComment={@onLikeComment}
       onUpdateComment={@onUpdateComment}
-      onDeleteComment={@onDeleteComment}/>
+      onDeleteComment={@onDeleteComment}
+      scrollIntoView = {@state.shouldScrollToBottom || active}
+    />
 
   onClickDeleteDiscussion: ->
     deletePhrase = 'delete'


### PR DESCRIPTION
Scroll the last comment into view when scrollToLastComment is set, rather than scrolling to the bottom of the page.

Staging branch URL: https://scroll-last-comment.pfe-preview.zooniverse.org

Fixes #4515 .

Describe your changes.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
