### PR TITLE
Use frame viewer to display drawing feedback

### DIFF
--- a/app/classifier/classifier.jsx
+++ b/app/classifier/classifier.jsx
@@ -122,15 +122,16 @@ class Classifier extends React.Component {
       return Promise.resolve(false);
     }
 
+    const annotations = this.state.annotations.slice();
+    const annotation = annotations[annotations.length - 1];
     const subjectViewerProps = {
       subject: this.props.subject,
       workflow: this.props.workflow,
       preferences: this.props.preferences,
-      classification: this.props.classification,
-      frameWrapper: FrameAnnotator,
-      allowFlipbook: workflowAllowsFlipbook(this.props.workflow),
-      allowSeparateFrames: workflowAllowsSeparateFrames(this.props.workflow),
-      playIterations: this.props.workflow.configuration.playIterations
+      annotations: annotations,
+      annotation: annotation,
+      frame: 0,
+      frameWrapper: FrameAnnotator
     };
 
     return openFeedbackModal({ feedback: taskFeedback, subjectViewerProps, taskId })

--- a/app/features/feedback/classifier/components/feedback-modal.jsx
+++ b/app/features/feedback/classifier/components/feedback-modal.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import Translate from 'react-translate-component';
 import counterpart from 'counterpart';
-import SubjectViewer from '../../../../components/subject-viewer';
+import FrameViewer from '../../../../components/frame-viewer';
 import ModalFocus from '../../../../components/modal-focus';
 
 /* eslint-disable max-len */
@@ -30,7 +30,7 @@ class FeedbackModal extends React.Component {
     return (
       <ModalFocus className="feedbackmodal">
         <Translate content="FeedbackModal.title" component="h2" />
-        {subjectViewerProps && (<SubjectViewer {...subjectViewerProps} />)}
+        {subjectViewerProps && (<FrameViewer {...subjectViewerProps} />)}
         <ul>
           {messages.map(message =>
             <li key={Math.random()}>

--- a/app/features/feedback/classifier/helpers/open-feedback-modal.jsx
+++ b/app/features/feedback/classifier/helpers/open-feedback-modal.jsx
@@ -49,7 +49,7 @@ function getSubjectViewerProps(feedback, subjectViewerProps, taskId) {
   }
 
   const props = _.cloneDeep(subjectViewerProps);
-  const { annotations } = props.classification;
+  const { annotations } = props;
   const targetAnnotation = _.find(annotations, ['task', taskId]);
   targetAnnotation.feedback = feedbackMarks;
   return props;


### PR DESCRIPTION
Use the frame viewer component to display feedback for drawing tasks. Always use the first subject frame to show feedback.

Staging branch URL: https://feedback-subject-viewer.pfe-preview.zooniverse.org

Fixes #4509

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
