### PR TITLE
Home page: Don't count older classifications twice

### DIFF
--- a/app/pages/home-not-logged-in.jsx
+++ b/app/pages/home-not-logged-in.jsx
@@ -27,7 +27,7 @@ export default class HomePage extends React.Component {
     super(props);
     this.resizeTimeout = NaN;
     this.state = {
-      count: 250469827,
+      count: 0,
       promotedProjects: [],
       screenWidth: 0,
       volunteerCount: 1500000


### PR DESCRIPTION
Set the base classification count to 0, as it's already covered by the constants in the HomePageResearch component. Currently, zooniverse.org shows (2 * 250,469,827) as the initial classification count, instead of 250,469,827. See https://master.pfe-preview.zooniverse.org while not logged in.

Staging branch URL: https://zoohome-classcount.pfe-preview.zooniverse.org/


# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
