### PR TITLE
add default string to src in Thumbnail.getThumbnailSrc

### DIFF
--- a/app/classifier/tasks/survey/chooser.jsx
+++ b/app/classifier/tasks/survey/chooser.jsx
@@ -216,7 +216,7 @@ class Chooser extends React.Component {
             if (choiceId === this.props.focusedChoice) {
               tabIndex = 0;
             }
-            const src = this.props.task.images[choice.images[0]];
+            const src = this.props.task.images[choice.images[0]] || '';
             const srcPath = Thumbnail.getThumbnailSrc({
               origin: 'https://thumbnails.zooniverse.org',
               width: 500,

--- a/app/components/thumbnail.jsx
+++ b/app/components/thumbnail.jsx
@@ -70,7 +70,7 @@ export default class Thumbnail extends React.Component {
   }
 }
 
-Thumbnail.getThumbnailSrc = function getThumbnailSrc({ origin, width, height, src }) {
+Thumbnail.getThumbnailSrc = function getThumbnailSrc({ origin, width, height, src = '' }) {
   let srcPath = src.split('//').pop();
   srcPath = srcPath.replace('static.zooniverse.org/', '');
   return (`${origin}/${width}x${height}/${srcPath}`);


### PR DESCRIPTION
Staging branch URL: https://fix-thumbnail-src-default.pfe-preview.zooniverse.org/projects/markb-panoptes/survey-task-test-project/classify?reload=0&workflow=3114

Fixes https://www.zooniverse.org/talk/17/605346.

Describe your changes.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
