### PR TITLE
Remove launch_approved from mobile validation

### DIFF
--- a/app/pages/lab/mobile/mobile-section-container.jsx
+++ b/app/pages/lab/mobile/mobile-section-container.jsx
@@ -8,10 +8,6 @@ import MobileSection from './mobile-section';
 const VALID_QUESTION_LENGTH = 200;
 const VALID_TASK_TYPES_FOR_MOBILE = ['single', 'multiple'];
 
-function launchApprovedProject({ project }) {
-  return (project.launch_approved) ? project.launch_approved : false;
-}
-
 function taskQuestionNotTooLong({ task }) {
   return task.question ? task.question.length < VALID_QUESTION_LENGTH : false;
 }
@@ -38,7 +34,6 @@ function workflowNotTooManyShortcuts({ task, workflow }) {
 }
 
 const validatorFns = {
-  launchApprovedProject,
   taskQuestionNotTooLong,
   taskFeedbackDisabled,
   taskHasTwoAnswers,
@@ -166,7 +161,6 @@ MobileSectionContainer.propTypes = {
     update: PropTypes.func
   }),
   project: PropTypes.shape({
-    launch_approved: PropTypes.bool,
     update: PropTypes.func
   })
 };

--- a/app/pages/lab/mobile/mobile-section.jsx
+++ b/app/pages/lab/mobile/mobile-section.jsx
@@ -7,6 +7,7 @@ counterpart.registerTranslations('en', {
   mobileSection: {
     title: 'Mobile App',
     download: {
+      disclaimer: 'Please note that projects that are not launch approved will only show in the preview section of the app.',
       help: 'If you haven\'t yet, be sure to download the Zooniverse Mobile App on Android or iPhone!',
       iphone: 'Zooniverse for iPhone',
       android: 'Zooniverse for Android'
@@ -70,6 +71,10 @@ class MobileSection extends Component {
             <ul>
               {map(this.props.validations, this.renderValidation)}
             </ul>
+
+            <p className="form-help">
+              <Translate content="mobileSection.download.disclaimer" component="small" />
+            </p>
 
             <p className="form-help">
               <Translate content="mobileSection.download.help" component="small" />

--- a/app/pages/lab/mobile/mobile-section.jsx
+++ b/app/pages/lab/mobile/mobile-section.jsx
@@ -18,7 +18,6 @@ counterpart.registerTranslations('en', {
       workflowNotTooManyShortcuts: 'Has less than three shortcuts',
       workflowFlipbookDisabled: 'Cannot be a flipbook',
       taskFeedbackDisabled: 'Cannot provide feedback',
-      launchApprovedProject: 'Project must be launch approved',
     },
     projectEligible: 'Check this box if you think your question fits in this way.  If you have a Yes/No question, we recommend Yes is the first option listed so that it appears on the right.',
     projectIneligible: 'Sorry, but the mobile app will not currently work for this workflow. The following are the requirements for the swipe workflow.',


### PR DESCRIPTION
Staging branch URL: https://remove_launch_approved_from_mobile.pfe-preview.zooniverse.org/

### Change.
 I am making this change so the mobile preview feature I'm building can work. 

The way this feature will work is that project builders will be able to preview their projects on mobile is they are mobile enabled and in development. This causes an issue with how we allow project builders to mobile enable a workflow. Currently we are checking if a project is launch approved before we allow users to enable it on mobile. This poses a problem for users who just want to preview their project on mobile.

Besides for this preview mode, we will still check on mobile if a project is launch approved before displaying it to a classifying user.

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [x] Can you post a talk comment?

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
