### PR TITLE
Require img src for getThumbnailSrc

### DIFF
--- a/app/classifier/tasks/survey/chooser.jsx
+++ b/app/classifier/tasks/survey/chooser.jsx
@@ -216,14 +216,14 @@ class Chooser extends React.Component {
             if (choiceId === this.props.focusedChoice) {
               tabIndex = 0;
             }
-            const src = this.props.task.images[choice.images[0]] || '';
+            const src = this.props.task.images[choice.images[0]];
             const srcPath = Thumbnail.getThumbnailSrc({
               origin: 'https://thumbnails.zooniverse.org',
               width: 500,
               height: 500,
               src
             });
-            const thumbnail = src ? srcPath : '';
+            const thumbnail = srcPath || '';
             return (
               <button
                 autoFocus={choiceId === this.props.focusedChoice}

--- a/app/components/cropped-image.jsx
+++ b/app/components/cropped-image.jsx
@@ -29,13 +29,12 @@ class CroppedImage extends React.Component {
       height: 500,
       src
     });
-    const thumbnail = src ? srcPath : '';
     const img = new Image();
     img.onload = () => {
       const { naturalWidth, naturalHeight } = img;
-      this.setState({ naturalWidth, naturalHeight, src: thumbnail });
+      this.setState({ naturalWidth, naturalHeight, src: srcPath });
     };
-    img.src = thumbnail;
+    img.src = srcPath;
   }
 
   render() {

--- a/app/components/thumbnail.jsx
+++ b/app/components/thumbnail.jsx
@@ -70,7 +70,10 @@ export default class Thumbnail extends React.Component {
   }
 }
 
-Thumbnail.getThumbnailSrc = function getThumbnailSrc({ origin, width, height, src = '' }) {
+Thumbnail.getThumbnailSrc = function getThumbnailSrc({ origin, width, height, src }) {
+  if (!src) {
+    return undefined;
+  }
   let srcPath = src.split('//').pop();
   srcPath = srcPath.replace('static.zooniverse.org/', '');
   return (`${origin}/${width}x${height}/${srcPath}`);


### PR DESCRIPTION
Return undefined from Thumbnail.getThumbnailSrc if there's no image src. This avoids returning invalid image URLs when src is an empty string.

Staging branch URL: https://thumbnail-images.pfe-preview.zooniverse.org

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
