### PR TITLE
Don't overwrite file URLs in getSubjectLocations

### DIFF
--- a/app/lib/get-subject-locations.js
+++ b/app/lib/get-subject-locations.js
@@ -13,7 +13,7 @@ const getSubjectLocations = (subjects) => {
     for (const mimeType of Object.keys(locationData)) {
       const src = locationData[mimeType];
       let [type, format] = mimeType.split('/');
-      if (READABLE_FORMATS.hasOwnProperty(type) && READABLE_FORMATS[type].includes(format)) {
+      if (!subjectLocations[type] && READABLE_FORMATS.hasOwnProperty(type) && READABLE_FORMATS[type].includes(format)) {
         subjectLocations[type] = [format, src];
       }
     }


### PR DESCRIPTION
Return the URL of the first file of a given type (image/audio/video/application) from `subject.locations`. Skip a file type if a URL has already been found for that type.

Staging branch URL: https://subject-previews.pfe-preview.zooniverse.org

Fixes #4536 .

Describe your changes.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
