### PR TITLE
Fix query is undefined when calling resource.delete()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5154,15 +5154,6 @@
       "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
       "dev": true
     },
-    "json-api-client": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/json-api-client/-/json-api-client-3.2.2.tgz",
-      "integrity": "sha1-5DNNAvFJJC+fnv48/01DpI4pA6o=",
-      "requires": {
-        "normalizeurl": "0.1.3",
-        "superagent": "1.8.5"
-      }
-    },
     "json-loader": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.4.tgz",
@@ -6463,15 +6454,15 @@
       "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-2.8.1.tgz",
       "integrity": "sha1-esqoHnNuiyZdrKmIaYO5EqN8ZzY=",
       "requires": {
-        "json-api-client": "3.3.0",
+        "json-api-client": "3.3.1",
         "local-storage": "1.4.2",
         "sugar-client": "1.0.1"
       },
       "dependencies": {
         "json-api-client": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/json-api-client/-/json-api-client-3.3.0.tgz",
-          "integrity": "sha1-MkCqXTaMXoZLQlenvRnYQixBVLk=",
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/json-api-client/-/json-api-client-3.3.1.tgz",
+          "integrity": "sha1-s/A5YtU9wXW2FWkp5lZJaxPHe8I=",
           "requires": {
             "normalizeurl": "0.1.3",
             "superagent": "1.8.5"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "events": "~1.1.1",
     "hash.js": "~1.0.3",
     "he": "~1.1.0",
-    "json-api-client": "~3.2.2",
     "lodash": "~4.17.4",
     "markdownz": "~7.5.0",
     "mocha": "~5.0.1",


### PR DESCRIPTION
Upgrade json-api-client to 3.3.1.
Remove unused json-api-client@3.2.2 from package.json.
Fixes a bug where calling `resource.delete()` throws a `query is undefined` error.

Staging branch URL: https://upgrade-json-client.pfe-preview.zooniverse.org/

Fixes #4534 .

Describe your changes.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
