### PR TITLE
remove unneeded org avatar size set

### DIFF
--- a/app/pages/organization/organization-page.jsx
+++ b/app/pages/organization/organization-page.jsx
@@ -11,8 +11,6 @@ import OrganizationMetadata from './organization-metadata';
 import Thumbnail from '../../components/thumbnail';
 import ExternalLinksBlockContainer from '../../components/ExternalLinksBlock';
 
-const AVATAR_SIZE = 100;
-
 class OrganizationPage extends React.Component {
   constructor() {
     super();
@@ -75,8 +73,6 @@ class OrganizationPage extends React.Component {
                 <Thumbnail
                   src={this.props.organizationAvatar.src}
                   className="avatar organization-hero__avatar"
-                  width={AVATAR_SIZE}
-                  height={AVATAR_SIZE}
                 />}
               <div>
                 <h1 className="organization-hero__title">{this.props.organization.display_name}</h1>


### PR DESCRIPTION
Staging branch URL: https://org-avatar-fix.pfe-preview.zooniverse.org/organizations/markb-panoptes/nfnorgtest

Fixes https://www.zooniverse.org/organizations/meredithspalmer/snapshot-safari.

Removes unnecessary org avatar height and width definitions through Thumbnail component, styles org avatar through related CSS.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
