### PR TITLE
Galaxy builder bugfixes

### DIFF
--- a/app/components/file-viewer/canvas-viewer.jsx
+++ b/app/components/file-viewer/canvas-viewer.jsx
@@ -16,9 +16,9 @@ class CanvasViewer extends React.Component {
     this.state = {
       loading: true,
       modelFailedToLoad: false,
-      modelErrorMessage: null,
       hasMessage: false,
       modelErrorMessage: null,
+      message: null,
       canvasSize: {
         width: 512,
         height: 512

--- a/app/features/modelling/baseReglModel.jsx
+++ b/app/features/modelling/baseReglModel.jsx
@@ -1,7 +1,8 @@
 import reglBase from 'regl';
 
 class BaseReglModel {
-  constructor(canvas, { frame, metadata, sizing }) {
+  constructor(canvas, { frame, metadata, src, sizing }, eventHandlers) {
+    this.eventHandlers = eventHandlers;
     this.update = this.update.bind(this); // function to call on new annotation
     this.getModel = this.getModel.bind(this);
     this.calculateModel = this.calculateModel.bind(this);
@@ -19,6 +20,7 @@ class BaseReglModel {
     this.state = {
       comparisonTexture: null,
       dataHasLoaded: false,
+      modelHasErrored: false,
       metadata,
       sizing,
       frame,
@@ -29,6 +31,7 @@ class BaseReglModel {
   update(annotations, newViewBox) {
     // this function parses the new annotation and then triggers a render.
     // update the render funtions
+    if (this.state.modelHasErrored) return;
     this.regl.poll();
     this.regl.clear({
       color: [0, 0, 0, 1]
@@ -50,7 +53,7 @@ class BaseReglModel {
     }
   }
   getTexture() {
-    return {
+    return this.state.modelHasErrored ? {} : {
       data: this.regl.read(),
       width: this.canvas.width,
       height: this.canvas.height

--- a/app/features/modelling/galaxy-builder/galaxyRegls.js
+++ b/app/features/modelling/galaxy-builder/galaxyRegls.js
@@ -110,8 +110,18 @@ export const drawSersic = r => r(Object.assign({}, baseObj, {
   }
 }));
 
-export const drawSpiral = (r) => {
-  const maxPointCount = 240;
+export const drawSpiral = (r, canvas) => {
+  const gl = canvas.getContext('webgl');
+  let maxPointCount = 240;
+  if (gl) {
+    maxPointCount = Math.min(
+      Math.max(
+        100,
+        gl.getParameter(gl.MAX_FRAGMENT_UNIFORM_VECTORS) - 100
+      ),
+      600
+    );
+  }
   const spiralArgs = {
     frag: `
       precision highp float;

--- a/app/features/modelling/galaxy-builder/galaxyRegls.js
+++ b/app/features/modelling/galaxy-builder/galaxyRegls.js
@@ -122,8 +122,6 @@ export const drawSpiral = (r, canvas) => {
       600
     );
   }
-  console.log('max spiral number:', maxPointCount);
-  console.log(gl);
   const spiralArgs = {
     frag: `
       precision highp float;

--- a/app/features/modelling/galaxy-builder/galaxyRegls.js
+++ b/app/features/modelling/galaxy-builder/galaxyRegls.js
@@ -116,12 +116,14 @@ export const drawSpiral = (r, canvas) => {
   if (gl) {
     maxPointCount = Math.min(
       Math.max(
-        100,
+        200,
         gl.getParameter(gl.MAX_FRAGMENT_UNIFORM_VECTORS) - 100
       ),
       600
     );
   }
+  console.log('max spiral number:', maxPointCount);
+  console.log(gl);
   const spiralArgs = {
     frag: `
       precision highp float;

--- a/app/features/modelling/galaxy-builder/galaxyRegls.js
+++ b/app/features/modelling/galaxy-builder/galaxyRegls.js
@@ -111,7 +111,7 @@ export const drawSersic = r => r(Object.assign({}, baseObj, {
 }));
 
 export const drawSpiral = (r) => {
-  const maxPointCount = 300;
+  const maxPointCount = 240;
   const spiralArgs = {
     frag: `
       precision highp float;

--- a/app/features/modelling/galaxy-builder/index.js
+++ b/app/features/modelling/galaxy-builder/index.js
@@ -17,7 +17,15 @@ class GalaxyBuilderModel extends baseModel {
       fetch(`${src}?=`)
         .then(response => response.json())
         .then(data => this.handleDataLoad(data))
-        .catch(e => console.warn(e));
+        .catch((e) => {
+          console.warn(e);
+          this.state.modelHasErrored = true;
+          this.eventHandlers.modelDidError({
+            modelErrorMessage: `
+            We’re afraid your browser doesn’t support the WebGL we need to render galaxies.
+            You can comment on photos (the second image) in Talk, but won’t be able to classify.`
+          });
+        });
     }
   }
   handleDataLoad(data) {
@@ -65,6 +73,7 @@ class GalaxyBuilderModel extends baseModel {
       this.update(this.state.annotations, oldViewBox);
     }
     this.eventHandlers.onLoad(this.state.sizing);
+    return Promise.resolve();
   }
   setModel() {
     // return taskName: render method object


### PR DESCRIPTION
Fixes #4542

Describe your changes.
Added error catching for canvas-viewer where text is displayed rather than any image. Howerver, volunteers could still hypothetically complete a classification.

Added a dynamic scaling to the maximum number of points in a spiral arm. This will not fix mobile classifying, as PSF convolution requires a minimum of 121 uniforms, which significantly eats into the 256 most mobile devices allow.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
