### PR TITLE
Optional feedback fix

### DIFF
--- a/app/features/feedback/shared/strategies/dud/create-rule.js
+++ b/app/features/feedback/shared/strategies/dud/create-rule.js
@@ -2,10 +2,10 @@ import ruleChecker from '../../helpers/rule-checker';
 
 function createRule(subjectRule, workflowRule) {
   const rule = {
-    failureEnabled: workflowRule.failureEnabled,
+    failureEnabled: workflowRule.failureEnabled || false,
     id: subjectRule.id,
     strategy: workflowRule.strategy,
-    successEnabled: workflowRule.successEnabled
+    successEnabled: workflowRule.successEnabled || false
   };
 
   if (rule.failureEnabled) {

--- a/app/features/feedback/shared/strategies/radial/create-rule.js
+++ b/app/features/feedback/shared/strategies/radial/create-rule.js
@@ -2,11 +2,11 @@ import ruleChecker from '../../helpers/rule-checker';
 
 function createRule(subjectRule, workflowRule) {
   const rule = {
-    failureEnabled: workflowRule.failureEnabled,
+    failureEnabled: workflowRule.failureEnabled || false,
     hideSubjectViewer: workflowRule.hideSubjectViewer || false,
     id: subjectRule.id,
     strategy: workflowRule.strategy,
-    successEnabled: workflowRule.successEnabled,
+    successEnabled: workflowRule.successEnabled || false,
     tolerance: subjectRule.tolerance || workflowRule.defaultTolerance,
     x: subjectRule.x,
     y: subjectRule.y


### PR DESCRIPTION
Staging branch URL: https://optional-feedback-fix.pfe-preview.zooniverse.org/

Staging branch project URL: https://optional-feedback-fix.pfe-preview.zooniverse.org/projects/aprajita/space-warps-hsc/classify?reload=0&workflow=6605env=production

Fixes a bug which caused feedback to crash and break the "Done" button. This was caused by an optional property being treated as required, so the `SpaceFriday` workflow (which has a third success-only feedback rule) was breaking 🐼 

cc @aprajita

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
