### PR TITLE
Changed galaxy-builder webgl error message to be more specific and helpful

### DIFF
--- a/app/features/modelling/baseReglModel.jsx
+++ b/app/features/modelling/baseReglModel.jsx
@@ -1,8 +1,9 @@
 import reglBase from 'regl';
 
 class BaseReglModel {
-  constructor(canvas, { frame, metadata, src, sizing }, eventHandlers) {
+  constructor(canvas, { frame, metadata, src, sizing }, eventHandlers, errMessage) {
     this.eventHandlers = eventHandlers;
+    this.modelErrorMessage = errMessage;
     this.update = this.update.bind(this); // function to call on new annotation
     this.getModel = this.getModel.bind(this);
     this.calculateModel = this.calculateModel.bind(this);

--- a/app/features/modelling/galaxy-builder/index.js
+++ b/app/features/modelling/galaxy-builder/index.js
@@ -9,7 +9,7 @@ class GalaxyBuilderModel extends baseModel {
   constructor(canvas, { frame, metadata, src, sizing }, eventHandlers) {
     const modelErrorMessage = `
     Sorry, this project requires features which are not supported by your
-    device. Please try again on a desktop computer, and let us know in talk
+    device. Please try again on a different computer, and let us know in talk
     if you're still having problems. You can comment on photos (the second
     image) in Talk, but please do not classify!`;
     super(canvas, { frame, metadata, src, sizing }, eventHandlers, modelErrorMessage);

--- a/app/features/modelling/galaxy-builder/index.js
+++ b/app/features/modelling/galaxy-builder/index.js
@@ -7,7 +7,12 @@ import { parseDisk, parseBulge, parseBar, parseSpiralArms } from './parseFunctio
 
 class GalaxyBuilderModel extends baseModel {
   constructor(canvas, { frame, metadata, src, sizing }, eventHandlers) {
-    super(canvas, { frame, metadata, src, sizing }, eventHandlers);
+    const modelErrorMessage = `
+    Sorry, this project requires features which are not supported by your
+    device. Please try again on a desktop computer, and let us know in talk
+    if you're still having problems. You can comment on photos (the second
+    image) in Talk, but please do not classify!`;
+    super(canvas, { frame, metadata, src, sizing }, eventHandlers, modelErrorMessage);
     this.panZoom = panZoom(this.regl);
     this.scaleModel = scaleModel(this.regl);
     this.state.shouldCompareToImage = false;
@@ -21,11 +26,7 @@ class GalaxyBuilderModel extends baseModel {
           console.warn(e);
           this.state.modelHasErrored = true;
           this.eventHandlers.modelDidError({
-            modelErrorMessage: `
-            Sorry, this project requires features which are not supported by your
-            device. Please try again on a desktop computer, and let us know in talk
-            if you're still having problems. You can comment on photos (the second
-            image) in Talk, but please do not classify!`
+            modelErrorMessage: this.modelErrorMessage
           });
         });
     }
@@ -106,11 +107,7 @@ class GalaxyBuilderModel extends baseModel {
       this.model = {};
       this.state.modelHasErrored = true;
       this.eventHandlers.modelDidError({
-        modelErrorMessage: `
-        Sorry, this project requires features which are not supported by your
-        device. Please try again on a desktop computer, and let us know in talk
-        if you're still having problems. You can comment on photos (the second
-        image) in Talk, but please do not classify!`
+        modelErrorMessage: this.modelErrorMessage
       });
     }
   }

--- a/app/features/modelling/galaxy-builder/index.js
+++ b/app/features/modelling/galaxy-builder/index.js
@@ -107,8 +107,10 @@ class GalaxyBuilderModel extends baseModel {
       this.state.modelHasErrored = true;
       this.eventHandlers.modelDidError({
         modelErrorMessage: `
-        We’re afraid your browser doesn’t support the WebGL we need to render galaxies.
-        You can comment on photos (the second image) in Talk, but won’t be able to classify.`
+        Sorry, this project requires features which are not supported by your
+        device. Please try again on a desktop computer, and let us know in talk
+        if you're still having problems. You can comment on photos (the second
+        image) in Talk, but please do not classify!`
       });
     }
   }

--- a/app/features/modelling/galaxy-builder/index.js
+++ b/app/features/modelling/galaxy-builder/index.js
@@ -22,8 +22,10 @@ class GalaxyBuilderModel extends baseModel {
           this.state.modelHasErrored = true;
           this.eventHandlers.modelDidError({
             modelErrorMessage: `
-            We’re afraid your browser doesn’t support the WebGL we need to render galaxies.
-            You can comment on photos (the second image) in Talk, but won’t be able to classify.`
+            Sorry, this project requires features which are not supported by your
+            device. Please try again on a desktop computer, and let us know in talk
+            if you're still having problems. You can comment on photos (the second
+            image) in Talk, but please do not classify!`
           });
         });
     }


### PR DESCRIPTION
Addresses concerns raised in  #4550 

Changed error message from 
> We’re afraid your browser doesn’t support the WebGL we need to render galaxies. You can comment on photos (the second image) in Talk, but won’t be able to classify.

To
> Sorry, this project requires features which are not supported by your device. Please try again on a desktop computer, and let us know in talk if you're still having problems. You can comment on photos (the second image) in Talk, but please do not classify!