### PR TITLE
Talk: hide details for deleted authors

### DIFF
--- a/app/talk/comment.cjsx
+++ b/app/talk/comment.cjsx
@@ -166,15 +166,17 @@ module.exports = createReactClass
     feedback = @renderFeedback()
     activeClass = if @props.active then 'active' else ''
     isDeleted = if @props.data.is_deleted then 'deleted' else ''
-    profile_link = "/users/#{@props.data.user_login}"
+    profile_link = if @props.author?.login then <Link to="/users/#{@props.author?.login}">{@props.data.user_display_name}</Link> else @props.data.user_display_name
+    author_login = if @props.author?.login then "@#{@props.author.login}" else ""
+
     if @props.project?
       profile_link = "/projects/#{@props.project.slug}#{profile_link}"
     <div className="talk-comment #{activeClass} #{isDeleted}">
       <div className="talk-comment-author">
         {<Avatar user={@props.author} /> if @props.author?}
         <div>
-          <Link to={profile_link}>{@props.data.user_display_name}</Link>
-          <div className="user-mention-name">@{@props.data.user_login}</div>
+          {profile_link}
+          <div className="user-mention-name">{author_login}</div>
         </div>
         <DisplayRoles roles={@props.roles} section={@props.data.section} />
       </div>


### PR DESCRIPTION
Hide login and display names for deleted comment authors. Don't link through to the deleted profile.

Staging branch URL: https://talk-deleted-author.pfe-preview.zooniverse.org

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
