### PR TITLE
Remove react-rendered-size

### DIFF
--- a/app/pages/project/components/ProjectNavbar/ProjectNavbar.jsx
+++ b/app/pages/project/components/ProjectNavbar/ProjectNavbar.jsx
@@ -4,8 +4,10 @@ import ProjectNavbarNarrow from './components/ProjectNavbarNarrow';
 import ProjectNavbarWide, { SizeAwareProjectNavbarWide } from './components/ProjectNavbarWide';
 
 function haveNavLinksChanged(oldProps, newProps) {
-  const oldLinks = _.map(oldProps.navLinks, 'label');
-  const newLinks = _.map(newProps.navLinks, 'label');
+  const oldLinks = oldProps.navLinks.map(link => link.label);
+  const newLinks = newProps.navLinks.map(link => link.label);
+
+  // returns an array of values not included in the other using SameValueZero for equality comparison
   return _.difference(oldLinks, newLinks).length > 0 ||
     oldLinks.length !== newLinks.length;
 }

--- a/app/pages/project/components/ProjectNavbar/ProjectNavbar.jsx
+++ b/app/pages/project/components/ProjectNavbar/ProjectNavbar.jsx
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import ProjectNavbarNarrow from './components/ProjectNavbarNarrow';
 import ProjectNavbarWide, { SizeAwareProjectNavbarWide } from './components/ProjectNavbarWide';
 
@@ -17,6 +18,7 @@ class ProjectNavbar extends Component {
     super(props);
     this.setBreakpoint = this.setBreakpoint.bind(this);
     this.state = {
+      loading: true,
       useWide: false
     };
   }
@@ -30,9 +32,11 @@ class ProjectNavbar extends Component {
   setBreakpoint(size) {
     // `size` is undefined when the component is first mounted, as there hasn't
     // been time for the callback to fire.
+    
     if (size) {
       const useWide = size.width < document.body.clientWidth;
-      this.setState({ useWide });
+      const newState = (this.state.loading) ? { useWide, loading: false } : { useWide };
+      this.setState(newState);
     }
   }
 
@@ -40,8 +44,9 @@ class ProjectNavbar extends Component {
     const NavBarComponent = (this.state.useWide) ? ProjectNavbarWide : ProjectNavbarNarrow;
 
     return (
-      <div>
-        <NavBarComponent {...this.props} />
+      <React.Fragment>
+        {!this.state.loading &&
+          <NavBarComponent {...this.props} />}
         <SizeAwareProjectNavbarWide
           {...this.props}
           onSize={this.setBreakpoint}
@@ -50,9 +55,31 @@ class ProjectNavbar extends Component {
             position: 'absolute'
           }}
         />
-      </div>
+      </React.Fragment>
     );
   }
 }
+
+ProjectNavbar.defaultProps = {
+  avatarSrc: '',
+  backgroundSrc: '',
+  launched: false,
+  navLinks: [],
+  projectLink: '',
+  projectTitle: '',
+  redirect: '',
+  underReview: false
+};
+
+ProjectNavbar.propTypes = {
+  avatarSrc: PropTypes.string,
+  backgroundSrc: PropTypes.string,
+  launched: PropTypes.bool,
+  navLinks: PropTypes.arrayOf(PropTypes.object),
+  projectTitle: PropTypes.string,
+  projectLink: PropTypes.string,
+  redirect: PropTypes.string,
+  underReview: PropTypes.bool
+};
 
 export default ProjectNavbar;

--- a/app/pages/project/components/ProjectNavbar/ProjectNavbar.jsx
+++ b/app/pages/project/components/ProjectNavbar/ProjectNavbar.jsx
@@ -1,6 +1,5 @@
 import _ from 'lodash';
 import React, { Component } from 'react';
-import sizeMe from 'react-sizeme'
 import ProjectNavbarNarrow from './components/ProjectNavbarNarrow';
 import ProjectNavbarWide, { SizeAwareProjectNavbarWide } from './components/ProjectNavbarWide';
 
@@ -11,7 +10,7 @@ function haveNavLinksChanged(oldProps, newProps) {
     oldLinks.length !== newLinks.length;
 }
 
-export class ProjectNavbar extends Component {
+class ProjectNavbar extends Component {
   constructor(props) {
     super(props);
     this.setBreakpoint = this.setBreakpoint.bind(this);

--- a/app/pages/project/components/ProjectNavbar/ProjectNavbar.spec.js
+++ b/app/pages/project/components/ProjectNavbar/ProjectNavbar.spec.js
@@ -11,7 +11,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import ProjectNavbar from './ProjectNavbar';
 
-describe.only('ProjectNavbar', function () {
+describe('ProjectNavbar', function () {
   before(function() {
     Object.defineProperty(document.body, 'clientWidth', { value: 100 });
   });
@@ -27,20 +27,19 @@ describe.only('ProjectNavbar', function () {
     });
 
     it('should not render either navbar variants if SizeAwareProjectNavbarWide component\'s callback hasn\'t fired yet', function() {
-      expect(wrapper.find('ProjectNavbarNarrow')).to.have.lengthOf(0);
+      expect(wrapper.find('withSizes(ProjectNavbarNarrow)')).to.have.lengthOf(0);
       expect(wrapper.find('ProjectNavbarWide')).to.have.lengthOf(0);
     });
 
     it('should render ProjectNavbarWide if state.useWide is true', function () {
       wrapper.setState({ loading: false, useWide: true });
-      expect(wrapper.find('ProjectNavbarNarrow')).to.have.lengthOf(0);
+      expect(wrapper.find('withSizes(ProjectNavbarNarrow)')).to.have.lengthOf(0);
       expect(wrapper.find('ProjectNavbarWide')).to.have.lengthOf(1);
     });
 
     it('should render ProjectNavbarNarrow if state.useWide is false', function () {
       wrapper.setState({ useWide: false });
-      console.log(wrapper.childAt(0).name());      
-      expect(wrapper.find('ProjectNavbarNarrow')).to.have.lengthOf(1);
+      expect(wrapper.find('withSizes(ProjectNavbarNarrow)')).to.have.lengthOf(1);
       expect(wrapper.find('ProjectNavbarWide')).to.have.lengthOf(0);
     });
   });

--- a/app/pages/project/components/ProjectNavbar/ProjectNavbarContainer.jsx
+++ b/app/pages/project/components/ProjectNavbar/ProjectNavbarContainer.jsx
@@ -14,7 +14,7 @@ class ProjectNavbarContainer extends Component {
 
     this.state = {
       adminEnabled: false
-    }
+    };
   }
 
   componentDidMount() {

--- a/app/pages/project/components/ProjectNavbar/ProjectNavbarContainer.spec.js
+++ b/app/pages/project/components/ProjectNavbar/ProjectNavbarContainer.spec.js
@@ -54,6 +54,6 @@ describe('ProjectNavbarContainer', function() {
   });
 
   it('renders ProjectNavbar', function() {
-    expect(wrapper.dive().find('ProjectNavbar')).to.have.lengthOf(1);
+    expect(wrapper.find('ProjectNavbar')).to.have.lengthOf(1);
   });
 });

--- a/app/pages/project/components/ProjectNavbar/components/ProjectNavbarNarrow/ProjectNavbarNarrow.jsx
+++ b/app/pages/project/components/ProjectNavbar/components/ProjectNavbarNarrow/ProjectNavbarNarrow.jsx
@@ -48,7 +48,8 @@ export class ProjectNavbarNarrow extends Component {
     const {
       avatarSrc,
       backgroundSrc,
-      height, launched,
+      height,
+      launched,
       projectLink,
       projectTitle,
       navLinks,

--- a/app/pages/project/components/ProjectNavbar/components/ProjectNavbarWide/index.js
+++ b/app/pages/project/components/ProjectNavbar/components/ProjectNavbarWide/index.js
@@ -1,4 +1,4 @@
-import sizeMe from 'react-sizeme'
+import sizeMe from 'react-sizeme';
 import ProjectNavbarWide from './ProjectNavbarWide';
 
 export default ProjectNavbarWide;

--- a/app/pages/project/components/ProjectNavbar/components/ProjectNavbarWide/index.js
+++ b/app/pages/project/components/ProjectNavbar/components/ProjectNavbarWide/index.js
@@ -1,3 +1,6 @@
+import sizeMe from 'react-sizeme'
 import ProjectNavbarWide from './ProjectNavbarWide';
 
 export default ProjectNavbarWide;
+
+export const SizeAwareProjectNavbarWide = sizeMe()(ProjectNavbarWide);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1268,6 +1268,11 @@
       "integrity": "sha1-R2iMuZu2gE8OBtPnY7HDLlfY5rY=",
       "dev": true
     },
+    "batch-processor": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/batch-processor/-/batch-processor-1.0.0.tgz",
+      "integrity": "sha1-dclcMrdI4IUNEMKxaPa9vpiRrOg="
+    },
     "bcrypt-pbkdf": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
@@ -2712,7 +2717,7 @@
         "qs": {
           "version": "6.5.1",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+          "integrity": "sha1-NJzfbu+J7EXBLX1es/wMhwNDptg="
         }
       }
     },
@@ -2893,6 +2898,14 @@
       "integrity": "sha1-lcM78B0MxAVVauyJn+Yf1NduoPk=",
       "dev": true
     },
+    "element-resize-detector": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/element-resize-detector/-/element-resize-detector-1.1.14.tgz",
+      "integrity": "sha1-rwZKCmGKggrVcKlcXuxbd74BKME=",
+      "requires": {
+        "batch-processor": "1.0.0"
+      }
+    },
     "elliptic": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
@@ -3006,7 +3019,7 @@
     "enzyme": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.3.0.tgz",
-      "integrity": "sha512-l8csyPyLmtxskTz6pX9W8eDOyH1ckEtDttXk/vlFWCjv00SkjTjtoUrogqp4yEvMyneU9dUJoOLnqFoiHb8IHA==",
+      "integrity": "sha1-CXGr0Wfy1L8/W9UIIp4cS23FBHk=",
       "dev": true,
       "requires": {
         "cheerio": "1.0.0-rc.2",
@@ -3045,7 +3058,7 @@
     "enzyme-adapter-utils": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/enzyme-adapter-utils/-/enzyme-adapter-utils-1.3.0.tgz",
-      "integrity": "sha512-vVXSt6uDv230DIv+ebCG66T1Pm36Kv+m74L1TrF4kaE7e1V7Q/LcxO0QRkajk5cA6R3uu9wJf5h13wOTezTbjA==",
+      "integrity": "sha1-1shXVoJsJXqFRNNizHpn6X6mmMc=",
       "dev": true,
       "requires": {
         "lodash": "4.17.10",
@@ -6397,6 +6410,11 @@
       "integrity": "sha1-9HGh2khr5g9quVXRcRVSPdHSVdU=",
       "dev": true
     },
+    "lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
+    },
     "lodash.flattendeep": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
@@ -6892,7 +6910,7 @@
     "modal-form": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/modal-form/-/modal-form-2.5.1.tgz",
-      "integrity": "sha512-yVeEfCm040SUZ1cOZUMG+uQ9Z7ppykuR4XG7EViApep/xAa6qdwFdTAVMdbjaSOWnE5lfdoW7agyvGmaVnfe/w==",
+      "integrity": "sha1-YDfwWL4FVYgkrtU6azAIGwUcU8M=",
       "requires": {
         "create-react-class": "15.6.3",
         "prop-types": "15.6.1"
@@ -7274,7 +7292,7 @@
     "object-inspect": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.5.0.tgz",
-      "integrity": "sha512-UmOFbHbwvv+XHj7BerrhVq+knjceBdkvU5AriwLMvhv2qi+e7DJzxfBeFpILEjVzCp+xA+W/pIf06RGPWlZNfw==",
+      "integrity": "sha1-nYdsEeQPSFx5IVZwKBt2dIj5v+M=",
       "dev": true
     },
     "object-is": {
@@ -7372,7 +7390,7 @@
     },
     "onetime": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
       "dev": true
     },
@@ -8539,7 +8557,7 @@
     "raf": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.0.tgz",
-      "integrity": "sha512-pDP/NMRAXoTfrhCfyfSEwJAKLaxBU9eApMeBPB1TkDouZmvPerIClV8lTAd+uF8ZiTaVl69e1FCxQrAd/VTjGw==",
+      "integrity": "sha1-ooh2iBtLwsqRF9QTgWPduA94FXU=",
       "dev": true,
       "requires": {
         "performance-now": "2.1.0"
@@ -8554,7 +8572,7 @@
     "randexp": {
       "version": "0.4.6",
       "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
-      "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
+      "integrity": "sha1-6YatXl4x2uE93W97MBmqfIf2DKM=",
       "dev": true,
       "requires": {
         "discontinuous-range": "1.0.0",
@@ -8891,6 +8909,17 @@
       "requires": {
         "exenv": "1.2.2",
         "shallowequal": "1.0.2"
+      }
+    },
+    "react-sizeme": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/react-sizeme/-/react-sizeme-2.4.2.tgz",
+      "integrity": "sha512-MIMsxausKDlDR6cc/ofWzyddFz78UfMtkLGnbiTmWl/ohHLv9Eme52auABG6uNBjM4eJYQUzs+o8OFWtYjlO+g==",
+      "requires": {
+        "element-resize-detector": "1.1.14",
+        "invariant": "2.2.4",
+        "lodash.debounce": "4.0.8",
+        "lodash.throttle": "4.1.1"
       }
     },
     "react-sizes": {
@@ -9406,7 +9435,7 @@
     "ret": {
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "integrity": "sha1-uKSCXVvbH8P29Twrwz+BOIaBx7w=",
       "dev": true
     },
     "right-align": {
@@ -9630,7 +9659,7 @@
     "seven-ten": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/seven-ten/-/seven-ten-3.2.0.tgz",
-      "integrity": "sha512-Em1IQEfWkSsAIdedtCUQqUl7UQfmG5GhsSznVO6v4n9FecrpRzOislr3Jmhb+MfngabUC9Kfxn43izg2q5Twmg==",
+      "integrity": "sha1-3pj/wVKeL1cBPxq9VyicHS8LNcE=",
       "requires": {
         "devour-client": "1.3.9",
         "prop-types": "15.6.1",
@@ -11788,7 +11817,7 @@
     },
     "zooniverse-user-string-getter": {
       "version": "1.1.23",
-      "resolved": "http://registry.npmjs.org/zooniverse-user-string-getter/-/zooniverse-user-string-getter-1.1.23.tgz",
+      "resolved": "https://registry.npmjs.org/zooniverse-user-string-getter/-/zooniverse-user-string-getter-1.1.23.tgz",
       "integrity": "sha1-sjKhrg9wPyb30pxnIguKGC7pKEk=",
       "requires": {
         "es6-promise": "3.3.1"

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "react-router": "~3.2.0",
     "react-router-scroll": "~0.4.4",
     "react-select": "1.0.0-rc.10",
+    "react-sizeme": "~2.4.2",
     "react-sizes": "~0.4.3",
     "react-swipe": "~5.1.1",
     "react-translate-component": "~0.14.0",
@@ -131,7 +132,7 @@
     "_deploy": "export PATH_ROOT=www.zooniverse.org; npm run _build && npm run _publish",
     "deploy": "export NODE_ENV=production; npm run _deploy",
     "test-and-watch": "NODE_ENV=development BABEL_ENV=test mocha --watch --watch-extensions js,jsx,coffee,cjsx test/setup.js test/enzyme-configuration.js $(find app -name *.spec.js*) --reporter nyan || true",
-    "test": "NODE_ENV=development BABEL_ENV=test mocha test/setup.js test/enzyme-configuration.js $(find app -name *.spec.js*) --reporter nyan || true",
+    "test": "NODE_ENV=development BABEL_ENV=test mocha test/setup.js test/enzyme-configuration.js $(find app -name ProjectNavbar.spec.js) --reporter nyan || true",
     "test-travis": "NODE_ENV=development BABEL_ENV=test mocha test/setup.js test/enzyme-configuration.js $(find app -name *.spec.js*)",
     "lint": "eslint ./app --ext .jsx,.js",
     "lint:watch": "esw --watch --color ./app --ext .jsx,.js"

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "_deploy": "export PATH_ROOT=www.zooniverse.org; npm run _build && npm run _publish",
     "deploy": "export NODE_ENV=production; npm run _deploy",
     "test-and-watch": "NODE_ENV=development BABEL_ENV=test mocha --watch --watch-extensions js,jsx,coffee,cjsx test/setup.js test/enzyme-configuration.js $(find app -name *.spec.js*) --reporter nyan || true",
-    "test": "NODE_ENV=development BABEL_ENV=test mocha test/setup.js test/enzyme-configuration.js $(find app -name ProjectNavbar.spec.js) --reporter nyan || true",
+    "test": "NODE_ENV=development BABEL_ENV=test mocha test/setup.js test/enzyme-configuration.js $(find app -name *.spec.js*) --reporter nyan || true",
     "test-travis": "NODE_ENV=development BABEL_ENV=test mocha test/setup.js test/enzyme-configuration.js $(find app -name *.spec.js*)",
     "lint": "eslint ./app --ext .jsx,.js",
     "lint:watch": "esw --watch --color ./app --ext .jsx,.js"


### PR DESCRIPTION
Staging branch URL: https://react-measure.pfe-preview.zooniverse.org/

Uses `react-sizeme` instead of `react-rendered-size` to determine which nav bar to show on the project home page.

The current design specifies that the contents of the nav bar change, which necessitates a dynamic breakpoint - let's get that working for React 16 (#4543 ), and move the discussion of whether that's actually a good idea to a separate issue.

This still needs the tests finishing, but is enough to test in browser.

Still to do:

- [ ] Finish tests

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
