### PR TITLE
Filter out seen subjects from the subject queue

### DIFF
--- a/app/pages/project/classify.jsx
+++ b/app/pages/project/classify.jsx
@@ -248,7 +248,12 @@ export class ProjectClassifyPage extends React.Component {
         }
       }).then((subjects) => {
         const nonLoadedSubjects = subjects.filter(newSubject => newSubject !== subjectToLoad);
-        const filteredSubjects = nonLoadedSubjects.filter(nonLoadedSubject => !nonLoadedSubject.already_seen && !nonLoadedSubject.retired);
+        const filteredSubjects = nonLoadedSubjects.filter((nonLoadedSubject) => {
+          const notSeen = !nonLoadedSubject.already_seen &&
+            !nonLoadedSubject.retired &&
+            !seenThisSession.check(workflow, nonLoadedSubject);
+          return notSeen;
+        });
         const subjectsToLoad = (filteredSubjects.length > 0) ? filteredSubjects : nonLoadedSubjects;
 
         upcomingSubjects.forWorkflow[workflow.id].push(...subjectsToLoad);

--- a/app/pages/project/classify.jsx
+++ b/app/pages/project/classify.jsx
@@ -8,7 +8,6 @@ import { Helmet } from 'react-helmet';
 import { connect } from 'react-redux';
 
 import counterpart from 'counterpart';
-import Translate from 'react-translate-component';
 import { Split } from 'seven-ten';
 
 import seenThisSession from '../../lib/seen-this-session';
@@ -64,7 +63,7 @@ export class ProjectClassifyPage extends React.Component {
     this.loadingSelectedWorkflow = false;
     this.project = null;
     this.workflow = null;
-
+    
     this.state = {
       subject: null,
       classification: null,
@@ -72,7 +71,7 @@ export class ProjectClassifyPage extends React.Component {
       demoMode: sessionDemoMode,
       promptWorkflowAssignmentDialog: false,
       rejected: null,
-      validUserGroup: false,
+      validUserGroup: false
     };
   }
 
@@ -85,7 +84,7 @@ export class ProjectClassifyPage extends React.Component {
     this.validateUserGroup(this.props, this.context);
   }
 
-  componentWillUpdate(nextProps, nextState) {
+  componentWillUpdate(nextProps) {
     const nextWorkflowID = (isPresent(nextProps) && isPresent(nextProps.workflow)) ? nextProps.workflow : null;
     this.context.geordi.remember({ workflowID: nextWorkflowID });
   }
@@ -129,7 +128,7 @@ export class ProjectClassifyPage extends React.Component {
     }
   }
 
-  shouldWorkflowAssignmentPrompt = (nextProps) => {
+  shouldWorkflowAssignmentPrompt(nextProps) {
     // Only for Gravity Spy which is assigning workflows to logged in users
     if (nextProps.project.experimental_tools.indexOf('workflow assignment') > -1) {
       const assignedWorkflowID = nextProps.preferences && nextProps.preferences.settings && nextProps.preferences.settings.workflow_id;
@@ -140,9 +139,9 @@ export class ProjectClassifyPage extends React.Component {
         }
       }
     }
-  };
+  }
 
-  loadAppropriateClassification = (props) => {
+  loadAppropriateClassification(props) {
     // Create a classification if it doesn't exist for the chosen workflow, then resolve our state with it.
     if (this.state.rejected && this.state.rejected.classification) {
       this.setState({ rejected: null });
@@ -158,9 +157,9 @@ export class ProjectClassifyPage extends React.Component {
         this.setState({ rejected: { classification: error } });
       });
     }
-  };
+  }
 
-  getSubjectSet = (workflow) => {
+  getSubjectSet(workflow) {
     if (workflow.grouped) {
       return workflow.get('subject_sets').then((subjectSets) => {
         const randomIndex = Math.floor(Math.random() * subjectSets.length);
@@ -169,9 +168,9 @@ export class ProjectClassifyPage extends React.Component {
     } else {
       return Promise.resolve();
     }
-  };
+  }
 
-  createNewClassification = (project, workflow) => {
+  createNewClassification(project, workflow) {
     // A subject set is only specified if the workflow is grouped.
     const subjectSetPromise = this.getSubjectSet(workflow);
 
@@ -209,9 +208,9 @@ export class ProjectClassifyPage extends React.Component {
 
       return classification;
     });
-  };
+  }
 
-  getNextSubject = (project, workflow, subjectSet) => {
+  getNextSubject(project, workflow, subjectSet) {
     let subject;
     let subjectToLoad;
 
@@ -277,7 +276,7 @@ export class ProjectClassifyPage extends React.Component {
 
     // console.log 'Chose a subject'
     return subject;
-  };
+  }
 
   render() {
     return (
@@ -296,17 +295,17 @@ export class ProjectClassifyPage extends React.Component {
     );
   }
 
-  renderClassifier = () => {
+  renderClassifier() {
     if (this.state.classification) {
       return (
         <Classifier
           {...this.props}
           classification={this.state.classification}
           demoMode={this.state.demoMode}
-          onChangeDemoMode={this.handleDemoModeChange}
-          onComplete={this.saveClassification}
-          onCompleteAndLoadAnotherSubject={this.saveClassificationAndLoadAnotherSubject}
-          onClickNext={this.loadAnotherSubject}
+          onChangeDemoMode={this.handleDemoModeChange.bind(this)}
+          onComplete={this.saveClassification.bind(this)}
+          onCompleteAndLoadAnotherSubject={this.saveClassificationAndLoadAnotherSubject.bind(this)}
+          onClickNext={this.loadAnotherSubject.bind(this)}
           requestUserProjectPreferences={this.props.requestUserProjectPreferences}
           splits={this.props.splits}
         />
@@ -320,19 +319,19 @@ export class ProjectClassifyPage extends React.Component {
         <span>Loading classification</span>
       );
     }
-  };
+  }
 
-  handleDemoModeChange = (newDemoMode) => {
+  handleDemoModeChange(newDemoMode) {
     sessionDemoMode = newDemoMode;
     this.setState({ demoMode: sessionDemoMode });
-  };
+  }
 
-  saveClassificationAndLoadAnotherSubject = () => {
+  saveClassificationAndLoadAnotherSubject() {
     this.saveClassification();
     this.loadAnotherSubject();
-  };
+  }
 
-  saveClassification = () => {
+  saveClassification() {
     if (this.context.geordi) {
       this.context.geordi.logEvent({ type: 'classify' });
     }
@@ -348,18 +347,18 @@ export class ProjectClassifyPage extends React.Component {
       classificationQueue.add(classification);
     }
     return Promise.resolve(classification);
-  };
+  }
 
-  loadAnotherSubject = () => {
+  loadAnotherSubject() {
     // Forget the old classification so a new one will load.
     currentClassifications.forWorkflow[this.props.workflow.id] = null;
 
     if (this.props.workflow) {
       this.loadAppropriateClassification(this.props);
     }
-  };
+  }
 
-  maybePromptWorkflowAssignmentDialog = (props) => {
+  maybePromptWorkflowAssignmentDialog(props) {
     if (this.state.promptWorkflowAssignmentDialog) {
       WorkflowAssignmentDialog.start({ splits: props.splits, project: props.project }).then(() =>
         this.setState({ promptWorkflowAssignmentDialog: false })
@@ -370,9 +369,9 @@ export class ProjectClassifyPage extends React.Component {
         }
       });
     }
-  };
+  }
 
-  validateUserGroup = (props, context) => {
+  validateUserGroup(props, context) {
     if (props.location.query && props.location.query.group && props.user) {
       apiClient.type('user_groups').get(props.location.query.group).then((group) => {
         const isUserMemberOfGroup = group.links && group.links.users && group.links.users.includes(props.user.id);
@@ -387,9 +386,9 @@ export class ProjectClassifyPage extends React.Component {
         }
       });
     }
-  };
+  }
 
-  clearUserGroupForClassification = (props, context) => {
+  clearUserGroupForClassification(props, context) {
     if (props.location.query && props.location.query.group) {
       const query = props.location.query;
       this.setState({ validUserGroup: false });
@@ -402,7 +401,7 @@ export class ProjectClassifyPage extends React.Component {
       newLocation.search = '';
       context.router.push(newLocation);
     }
-  };
+  }
 }
 
 ProjectClassifyPage.contextTypes = {
@@ -415,7 +414,7 @@ ProjectClassifyPage.propTypes = {
   loadingSelectedWorkflow: PropTypes.bool,
   project: PropTypes.object,
   storage: PropTypes.object,
-  workflow: PropTypes.object,
+  workflow: PropTypes.object
 };
 
 


### PR DESCRIPTION
Staging branch URL: https://seen-subjects.pfe-preview.zooniverse.org

Filters the incoming subject queue for any subjects that have been seen this session, but not yet marked as seen by Panoptes.

Also fixes some linter warnings for the classifier page:
- uses named class methods instead of anonymous functions.
- removes the unused `Translate` component.
- removes some semicolons and commas.

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
