### PR TITLE
Disable next button for required tasks

### DIFF
--- a/app/classifier/components/TaskNavButtons/TaskNavButtons.jsx
+++ b/app/classifier/components/TaskNavButtons/TaskNavButtons.jsx
@@ -27,7 +27,7 @@ export default function TaskNavButtons(props) {
         <NextButton
           autoFocus={false}
           onClick={props.addAnnotationForTask}
-          waitingForAnswer={props.waitingForAnswer}
+          disabled={props.waitingForAnswer}
         />
       </ButtonsWrapper>
     );

--- a/app/classifier/components/TaskNavButtons/TaskNavButtons.spec.jsx
+++ b/app/classifier/components/TaskNavButtons/TaskNavButtons.spec.jsx
@@ -62,6 +62,11 @@ describe('TaskNavButtons', function() {
       wrapper.setProps({ showBackButton: true });
       expect(wrapper.find('BackButton')).to.have.lengthOf(1);
     });
+
+    it('should disable the Next button when waiting for a required answer.', function () {
+      wrapper.setProps({ waitingForAnswer: true });
+      expect(wrapper.find('NextButton').prop('disabled')).to.be.true;
+    });
   });
 
   describe('when props.completed is true and props.showNextButton is false', function() {
@@ -109,6 +114,11 @@ describe('TaskNavButtons', function() {
     it('should render a TalkLink component if props.showDoneAndTalkLink is true', function () {
       wrapper.setProps({ showDoneAndTalkLink: true });
       expect(wrapper.find('TalkLink')).to.have.lengthOf(1);
+    });
+
+    it('should disable the Done button when waiting for a required answer.', function () {
+      wrapper.setProps({ waitingForAnswer: true });
+      expect(wrapper.find('DoneButton').prop('disabled')).to.be.true;
     });
   });
 });


### PR DESCRIPTION
Staging branch URL: https://disable-next-button.pfe-preview.zooniverse.org

Fixes #4575 .

Adds Task Nav tests for the case where the task is required but the task has not been answered yet.
Fixes a typo in the props for the Next button.

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
