### PR TITLE
Use subject images or videos to preview recent subjects

### DIFF
--- a/app/pages/profile/recents.jsx
+++ b/app/pages/profile/recents.jsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router';
 import Translate from 'react-translate-component';
 import SubjectViewer from '../../components/subject-viewer';
 import Thumbnail from '../../components/thumbnail';
-import getSubjectLocation from '../../lib/get-subject-location';
+import getSubjectLocations from '../../lib/get-subject-locations';
 
 class Recents extends React.Component {
   constructor() {
@@ -33,7 +33,17 @@ class Recents extends React.Component {
           <div className="content-container collection-page-with-project-context">
             <ul className="collections-show">
               {this.state.recents.map((recent) => {
-                const { type, format, src } = getSubjectLocation(recent);
+                const locations = getSubjectLocations(recent);
+                let type = '';
+                let format = '';
+                let src = '';
+                if (locations.image) {
+                  type = 'image';
+                  [format, src] = locations.image;
+                } else if (locations.video) {
+                  type = 'video';
+                  [format, src] = locations.video;
+                }
                 const fakeSubject = {
                   id: recent.links.subject,
                   locations: [{ [`${type}/${format}`]: src }]

--- a/app/pages/profile/recents.jsx
+++ b/app/pages/profile/recents.jsx
@@ -16,8 +16,10 @@ class Recents extends React.Component {
 
   componentDidMount() {
     const { user } = this.props;
-    !!user && user.get('recents', { project_id: this.props.project.id, sort: '-created_at' })
-    .then(recents => this.setState({ recents }));
+    if (user && user.get) {
+      user.get('recents', { project_id: this.props.project.id, sort: '-created_at' })
+        .then(recents => this.setState({ recents }));
+    }
   }
 
   render() {


### PR DESCRIPTION
Staging branch URL: https://recents-previews.pfre-preview.zooniverse.org

Fixes #4577 .

Describe your changes.
Update the Recents page to use the same code as the project home page for displaying subject previews.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
