### PR TITLE
Fix wrapping and warning on back button. Fix Talk link styles

### DIFF
--- a/app/classifier/components/TaskNavButtons/components/BackButton/BackButton.jsx
+++ b/app/classifier/components/TaskNavButtons/components/BackButton/BackButton.jsx
@@ -10,7 +10,7 @@ import { zooTheme } from '../../../../../theme';
 
 function checkIfMSBrowser() {
   if ('CSS' in window) {
-    return !CSS.supports('width', 'max-content');
+    return !CSS.supports('width', 'max-content') && !CSS.supports('width', '-moz-max-content');
   }
 
   return 'ActiveXObject' in window;
@@ -58,6 +58,9 @@ export const StyledBackButton = styled.button.attrs({
   }
 `;
 
+// Firefox returns CSS.supports('width', 'max-content') as false
+// even though CanIUse reports it is supported by Firefox
+// Only the vendor prefixed -moz-max-content returns true
 export const StyledBackButtonToolTip = styled.span`
   bottom: ${(checkIfMSBrowser()) ? '-130%' : '-100%'};
   box-sizing: border-box;
@@ -70,6 +73,7 @@ export const StyledBackButtonToolTip = styled.span`
   padding: 1em 0;
   position: absolute;
   width: ${(checkIfMSBrowser()) ? '400%' : 'max-content'};
+  width: -moz-max-content;
 `;
 
 export class BackButton extends React.Component {

--- a/app/classifier/components/TaskNavButtons/components/NextButton/NextButton.jsx
+++ b/app/classifier/components/TaskNavButtons/components/NextButton/NextButton.jsx
@@ -12,7 +12,7 @@ export const StyledNextButton = styled.button.attrs({
   disabled: props => props.disabled,
   type: 'button'
 })`
-  background-color: ${theme('mode', { 
+  background: ${theme('mode', { 
     dark: zooTheme.colors.darkTheme.background.default,
     light: zooTheme.colors.highlight.default
   })};

--- a/app/classifier/components/TaskNavButtons/components/TalkLink/TalkLink.jsx
+++ b/app/classifier/components/TaskNavButtons/components/TalkLink/TalkLink.jsx
@@ -8,10 +8,12 @@ import { darken, lighten } from 'polished';
 import Translate from 'react-translate-component';
 import { pxToRem, zooTheme } from '../../../../../theme';
 
+// These hasn't been moved into the zoo theme because the button might go away
+const TALK_LINK_BLUE = '#43bbfd';
+const TALK_LINK_BLUE_HOVER = '#69c9fd';
+
 const commonStyles = `
-  background: #43bbfd;
-  border: 0;
-  color: #fff;
+  box-sizing: border-box;
   cursor: pointer;
   display: inline-block;
   flex: 2 0;
@@ -21,39 +23,78 @@ const commonStyles = `
   position: relative;
   text-align: center;
   text-decoration: none;
+  white-space: nowrap;
 `;
 
 export const StyledTalkLink = styled(Link)`
   ${commonStyles}
+  background: ${theme('mode', {
+    dark: zooTheme.colors.darkTheme.background.default,
+    light: TALK_LINK_BLUE
+  })};
+  border: ${theme('mode', {
+    dark: `thin solid ${TALK_LINK_BLUE}`,
+    light: 'thin solid transparent'
+  })};
+  color: ${theme('mode', {
+    dark: zooTheme.colors.darkTheme.font,
+    light: 'white'
+  })};
 
   &:hover, &:focus {
-    background: #69c9fd;
+    background: ${theme('mode', {
+      dark: TALK_LINK_BLUE_HOVER,
+      light: TALK_LINK_BLUE_HOVER
+    })};
+    border: ${theme('mode', {
+      dark: `thin solid ${TALK_LINK_BLUE}`,
+      light: `thin solid ${TALK_LINK_BLUE_HOVER}`
+    })};
   }
 `;
 
-export const StyledDisabledTalkPlaceholder = styled.span`
+// can't style the cursor and pointer-events: none simulatenously
+export const StyledDisabledTalkPlaceholder = styled.span.attrs({
+  tabIndex: -1
+})`
   ${commonStyles}
+  background: ${theme('mode', {
+    dark: zooTheme.colors.darkTheme.background.default,
+    light: TALK_LINK_BLUE
+  })};
+  border: ${theme('mode', {
+    dark: `thin solid ${TALK_LINK_BLUE}`,
+    light: 'thin solid transparent'
+  })};
+  color: ${theme('mode', {
+    dark: zooTheme.colors.darkTheme.font,
+    light: 'white'
+  })};
   opacity: 0.5;
   pointer-events: none;
 `;
 
 // TODO: Add Seven-Ten visibility split wrapper
 // because we want to test removing the talk links from the classifier task area
-export default function TalkLink({ disabled, onClick, projectSlug, subjectId, translateContent }) {
+export function TalkLink({ disabled, onClick, projectSlug, subjectId, theme, translateContent }) {
   if (disabled) {
     return (
-      <StyledDisabledTalkPlaceholder>
-        <Translate content={translateContent} />
-      </StyledDisabledTalkPlaceholder>
+      <ThemeProvider theme={{ mode: theme }}>
+        <StyledDisabledTalkPlaceholder>
+          <Translate content={translateContent} />
+        </StyledDisabledTalkPlaceholder>
+      </ThemeProvider>
     );
   }
   return (
-    <StyledTalkLink
-      onClick={onClick}
-      to={`/projects/${projectSlug}/talk/subjects/${subjectId}`}
-    >
-      <Translate content={translateContent} />
-    </StyledTalkLink>
+    <ThemeProvider theme={{ mode: theme }}>
+      <StyledTalkLink
+        onClick={onClick}
+        to={`/projects/${projectSlug}/talk/subjects/${subjectId}`}
+      >
+        <Translate content={translateContent} />
+      </StyledTalkLink>
+    </ThemeProvider>
   );
 }
 
@@ -72,3 +113,9 @@ TalkLink.propTypes = {
   subjectId: PropTypes.string.isRequired,
   translateContent: PropTypes.string
 };
+
+const mapStateToProps = state => ({
+  theme: state.userInterface.theme
+});
+
+export default connect(mapStateToProps)(TalkLink);

--- a/app/classifier/components/TaskNavButtons/components/TalkLink/TalkLink.jsx
+++ b/app/classifier/components/TaskNavButtons/components/TalkLink/TalkLink.jsx
@@ -11,10 +11,10 @@ import { pxToRem, zooTheme } from '../../../../../theme';
 // These hasn't been moved into the zoo theme because the button might go away
 const TALK_LINK_BLUE = '#43bbfd';
 const TALK_LINK_BLUE_HOVER = '#69c9fd';
+const TALK_LINK_BLUE_HOVER_DARK = '#104A79';
 
 const commonStyles = `
   box-sizing: border-box;
-  cursor: pointer;
   display: inline-block;
   flex: 2 0;
   line-height: 2em;
@@ -28,6 +28,8 @@ const commonStyles = `
 
 export const StyledTalkLink = styled(Link)`
   ${commonStyles}
+  cursor: pointer;    
+  
   background: ${theme('mode', {
     dark: zooTheme.colors.darkTheme.background.default,
     light: TALK_LINK_BLUE
@@ -43,7 +45,7 @@ export const StyledTalkLink = styled(Link)`
 
   &:hover, &:focus {
     background: ${theme('mode', {
-      dark: TALK_LINK_BLUE_HOVER,
+      dark: TALK_LINK_BLUE_HOVER_DARK,
       light: TALK_LINK_BLUE_HOVER
     })};
     border: ${theme('mode', {
@@ -54,9 +56,7 @@ export const StyledTalkLink = styled(Link)`
 `;
 
 // can't style the cursor and pointer-events: none simulatenously
-export const StyledDisabledTalkPlaceholder = styled.span.attrs({
-  tabIndex: -1
-})`
+export const StyledDisabledTalkPlaceholder = styled.span`
   ${commonStyles}
   background: ${theme('mode', {
     dark: zooTheme.colors.darkTheme.background.default,
@@ -70,8 +70,8 @@ export const StyledDisabledTalkPlaceholder = styled.span.attrs({
     dark: zooTheme.colors.darkTheme.font,
     light: 'white'
   })};
+  cursor: not-allowed;
   opacity: 0.5;
-  pointer-events: none;
 `;
 
 // TODO: Add Seven-Ten visibility split wrapper
@@ -86,6 +86,7 @@ export function TalkLink({ disabled, onClick, projectSlug, subjectId, theme, tra
       </ThemeProvider>
     );
   }
+
   return (
     <ThemeProvider theme={{ mode: theme }}>
       <StyledTalkLink

--- a/app/classifier/components/TaskNavButtons/components/TalkLink/TalkLink.spec.jsx
+++ b/app/classifier/components/TaskNavButtons/components/TalkLink/TalkLink.spec.jsx
@@ -9,7 +9,7 @@ import React from 'react';
 import { mount } from 'enzyme';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import TalkLink, { StyledTalkLink, StyledDisabledTalkPlaceholder } from './TalkLink';
+import { TalkLink, StyledTalkLink, StyledDisabledTalkPlaceholder } from './TalkLink';
 
 describe('TalkLink', function() {
   describe('rendering', function() {


### PR DESCRIPTION
Staging branch URL: https://more-button-style-fixes.pfe-preview.zooniverse.org/

Fixes more from #4570:

- Back button smaller on second step (Penguin Watch, Manatee Chat, Galaxy Zoo), intended?
  - Adds `white-space: nowrap` to the styles for the TalkLink component
- dark theme - Done & Talk filled with blue, Back and Done transparent (Penguin Watch), should all these buttons be transparent, then fill on hover?
  - Added Redux connect and ThemeProvider as well as variant styles for the TalkLink component for light and dark themes.
- Back Button: the warning message extends below the box making it harder to read (tested in Firefox 59.0.2).
  - Added a specific vendor prefixed style for Firefox to get the width correct. Firefox will now use `width: -moz-max-content` and IE and Edge continue to fall back to percentages since they do not support this property yet.
- TalkLink: Does it disable them from the keyboard too? If not, consider adding tabindex="-1" when the link is disabled.
  - Added tabindex="-1"
- TalkLink: when Done & Talk is disabled, and rendered as a span, it still has cursor: pointer as a style.
  - I don't have a solution for this. Using `pointer-events: none` means I cannot style the cursor. It's an either/or styling. I decided that disabling pointer events was more important. I'm open to changing this, though.

@beckyrother I need some design input about the updating Talk link button for the dark theme. The theme PR review had comments that the button seemed out of place with the solid blue styling in the dark theme. I took cues from how the other buttons are styled in the dark theme and made it use a border styling that fills on hover or focus instead. Would you like the blue fill color to be different? Here's an example using Galaxy Zoo (select the star or artifact option): https://more-button-style-fixes.pfe-preview.zooniverse.org/projects/zookeeper/galaxy-zoo/classify?env=production 

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
