### PR TITLE
Turn pan/zoom controls off in the feedback subject viewer

### DIFF
--- a/app/classifier/classifier.jsx
+++ b/app/classifier/classifier.jsx
@@ -137,7 +137,8 @@ class Classifier extends React.Component {
       annotations: annotations,
       annotation: annotation,
       frame: 0,
-      frameWrapper: FrameAnnotator
+      frameWrapper: FrameAnnotator,
+      zoomControls: false
     };
 
     return openFeedbackModal({ feedback: taskFeedback, subjectViewerProps, taskId })

--- a/app/components/frame-viewer.jsx
+++ b/app/components/frame-viewer.jsx
@@ -74,7 +74,7 @@ export default class FrameViewer extends React.Component {
       return (
         <PanZoom
           ref={(c) => { this.panZoom = c; }}
-          enabled={zoomEnabled}
+          enabled={this.props.zoomControls && zoomEnabled}
           frameDimensions={this.state.frameDimensions}
           subject={this.props.subject}
         >
@@ -140,7 +140,8 @@ FrameViewer.propTypes = {
   ),
   workflow: PropTypes.shape(
     { configuration: PropTypes.object }
-  )
+  ),
+  zoomControls: PropTypes.bool
 };
 
 FrameViewer.defaultProps = {
@@ -153,5 +154,6 @@ FrameViewer.defaultProps = {
   },
   workflow: {
     configuration: {}
-  }
+  },
+  zoomControls: true
 };

--- a/app/components/frame-viewer.jsx
+++ b/app/components/frame-viewer.jsx
@@ -69,7 +69,6 @@ export default class FrameViewer extends React.Component {
       workflow: this.props.workflow
     } : {};
 
-    const ProgressMarker = this.props.progressMarker;
     if (FrameWrapper) {
       return (
         <PanZoom


### PR DESCRIPTION
Staging branch URL: https://feedback-subject-viewer.pfe-preview.zooniverse.org

Fixes #4509 .

Adds a `zoomControls` boolean prop to the frame viewer, which allows display of the pan/zoom buttons to be turned on or off.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
