### PR TITLE
A temporary fix for the overflowing survey task choice

### DIFF
--- a/css/survey-task.styl
+++ b/css/survey-task.styl
@@ -117,7 +117,8 @@ $survey-task-pill-button
   flex-wrap: wrap
 
   &[data-columns="3"] > *
-    flex-basis: calc(33.33% - 2px)
+    flex-basis: calc(33.33% - 1px)
+    max-width: calc(33.33% - 1px) // temporary fix for an overflowing button text
 
   &[data-columns="2"] > *
     flex-basis: calc(50% - 2px)


### PR DESCRIPTION
Staging branch URL: https://fix-4596.pfe-preview.zooniverse.org/projects/coloradocorridorsproject/colorado-corridors-project/classify?env=production

Fixes #4596. The survey task redesign is up next, so we shouldn't spend too much time trying to come up with a prettier fix. 

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
