### PR TITLE
Set a max-width for tutorial and mini-course

### DIFF
--- a/css/mini-course-dialog.styl
+++ b/css/mini-course-dialog.styl
@@ -36,6 +36,10 @@
           background-color: MINI_COURSE_BLUE
 
   .media-card.steps__step
+    > .media-card-header 
+      div
+        max-width: 100% !important
+
     > .media-card-content
       margin: 1em 3vw
 

--- a/css/tutorial.styl
+++ b/css/tutorial.styl
@@ -22,6 +22,8 @@
     text-align: center
 
   .media-card.tutorial-step
+    max-width: 400px
+
     > .media-card-content
       @extends .content-container
 

--- a/css/tutorial.styl
+++ b/css/tutorial.styl
@@ -22,7 +22,7 @@
     text-align: center
 
   .media-card.tutorial-step
-    max-width: 400px
+    max-width: 450px
 
     > .media-card-content
       @extends .content-container

--- a/css/tutorial.styl
+++ b/css/tutorial.styl
@@ -12,7 +12,7 @@
   flex-direction: column
   max-height: 85vh
   max-width: 95vw
-  width: 50ch
+  // width: 50ch
 
   > .step-through-content
     // TODO: I'd rather the header media not scroll.
@@ -22,7 +22,10 @@
     text-align: center
 
   .media-card.tutorial-step
-    max-width: 450px
+    z-index: 1
+
+    > .media-card-header
+      max-width: 400px
 
     > .media-card-content
       @extends .content-container


### PR DESCRIPTION
Staging branch URL: https://fix-4585.pfe-preview.zooniverse.org/projects/zooniverse/gravity-spy/classify?env=production

Fixes #4585. Sets a max-width for the tutorial on the step container. Sets a max-width for the mini-course.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
