### PR TITLE
Workflow Selection: parse IDs as numbers

### DIFF
--- a/app/pages/project/workflow-selection.jsx
+++ b/app/pages/project/workflow-selection.jsx
@@ -23,8 +23,9 @@ class WorkflowSelection extends React.Component {
       nextProps.preferences.preferences.selected_workflow &&
       this.state.workflow
     ) {
+      const userWorkflowID = parseInt(nextProps.preferences.preferences.selected_workflow);
       if (!nextState.loadingSelectedWorkflow &&
-        nextProps.preferences.preferences.selected_workflow !== this.state.workflow.id
+        userWorkflowID !== parseInt(this.state.workflow.id)
       ) {
         this.getSelectedWorkflow(nextProps);
       }
@@ -47,7 +48,7 @@ class WorkflowSelection extends React.Component {
       this.props.location.query.workflow &&
       this.checkUserRoles(project, user)
     ) {
-      selectedWorkflowID = this.props.location.query.workflow;
+      selectedWorkflowID = parseInt(this.props.location.query.workflow);
       activeFilter = false;
       if (preferences && preferences.preferences.selected_workflow !== selectedWorkflowID) {
         this.handlePreferencesChange('preferences.selected_workflow', selectedWorkflowID);
@@ -57,7 +58,7 @@ class WorkflowSelection extends React.Component {
       project.experimental_tools &&
       project.experimental_tools.indexOf('allow workflow query') > -1
     ) {
-      selectedWorkflowID = this.props.location.query.workflow;
+      selectedWorkflowID = parseInt(this.props.location.query.workflow);
       if (preferences && preferences.preferences.selected_workflow !== selectedWorkflowID) {
         this.handlePreferencesChange('preferences.selected_workflow', selectedWorkflowID);
       }
@@ -71,6 +72,7 @@ class WorkflowSelection extends React.Component {
       selectedWorkflowID = this.selectRandomWorkflow(project);
     }
 
+    selectedWorkflowID = parseInt(selectedWorkflowID);
     this.getWorkflow(selectedWorkflowID, activeFilter);
   }
 

--- a/app/pages/project/workflow-selection.spec.js
+++ b/app/pages/project/workflow-selection.spec.js
@@ -142,7 +142,7 @@ describe('WorkflowSelection', function () {
     controller.getSelectedWorkflow({ project });
     const selectedWorkflowID = workflowStub.getCall(0).args[0];
     sinon.assert.calledOnce(workflowStub);
-    assert.notEqual(project.links.active_workflows.indexOf(selectedWorkflowID), -1);
+    assert.notEqual(project.links.active_workflows.indexOf(selectedWorkflowID.toString()), -1);
   });
 
   it('should respect the workflow query param if "allow workflow query" is set', function () {
@@ -150,7 +150,7 @@ describe('WorkflowSelection', function () {
     project.experimental_tools = ['allow workflow query'];
     controller.getSelectedWorkflow({ project });
     sinon.assert.calledOnce(workflowStub);
-    sinon.assert.calledWith(workflowStub, '6', true);
+    sinon.assert.calledWith(workflowStub, 6, true);
   });
 
   describe('with a logged-in user', function () {
@@ -163,21 +163,21 @@ describe('WorkflowSelection', function () {
       const user = owner;
       controller.getSelectedWorkflow({ project, preferences, user });
       sinon.assert.calledOnce(workflowStub);
-      sinon.assert.calledWith(workflowStub, '6', false);
+      sinon.assert.calledWith(workflowStub, 6, false);
     });
 
     it('should load the specified workflow for a collaborator', function () {
       const user = apiClient.type('users').create({ id: '2' });
       controller.getSelectedWorkflow({ project, preferences, user });
       sinon.assert.calledOnce(workflowStub);
-      sinon.assert.calledWith(workflowStub, '6', false);
+      sinon.assert.calledWith(workflowStub, 6, false);
     });
 
     it('should load the specified workflow for a tester', function () {
       const user = apiClient.type('users').create({ id: '3' });
       controller.getSelectedWorkflow({ project, preferences, user });
       sinon.assert.calledOnce(workflowStub);
-      sinon.assert.calledWith(workflowStub, '6', false);
+      sinon.assert.calledWith(workflowStub, 6, false);
     });
   });
 
@@ -193,14 +193,14 @@ describe('WorkflowSelection', function () {
       preferences.update({ 'preferences.selected_workflow': '4' });
       controller.getSelectedWorkflow({ project, preferences });
       sinon.assert.calledOnce(workflowStub);
-      sinon.assert.calledWith(workflowStub, '4', true);
+      sinon.assert.calledWith(workflowStub, 4, true);
     });
 
     it('should try to load a stored project workflow', function () {
       preferences.update({ 'settings.workflow_id': '2' });
       controller.getSelectedWorkflow({ project, preferences });
       sinon.assert.calledOnce(workflowStub);
-      sinon.assert.calledWith(workflowStub, '2', true);
+      sinon.assert.calledWith(workflowStub, 2, true);
     });
   });
 
@@ -215,7 +215,7 @@ describe('WorkflowSelection', function () {
       const user = apiClient.type('users').create({ id: '4' });
       controller.getSelectedWorkflow({ project, preferences, user });
       sinon.assert.calledOnce(workflowStub);
-      sinon.assert.calledWith(workflowStub, '1', true);
+      sinon.assert.calledWith(workflowStub, 1, true);
     });
   });
 
@@ -237,7 +237,7 @@ describe('WorkflowSelection', function () {
       );
       wrapper.setProps({ project: newProject });
       sinon.assert.calledOnce(workflowStub);
-      sinon.assert.calledWith(workflowStub, '10', true);
+      sinon.assert.calledWith(workflowStub, 10, true);
     });
   });
 });

--- a/app/pages/project/workflow-selection.spec.js
+++ b/app/pages/project/workflow-selection.spec.js
@@ -196,8 +196,22 @@ describe('WorkflowSelection', function () {
       sinon.assert.calledWith(workflowStub, 4, true);
     });
 
+    it('should parse the stored user workflow as an int', function () {
+      preferences.update({ 'preferences.selected_workflow': '4random' });
+      controller.getSelectedWorkflow({ project, preferences });
+      sinon.assert.calledOnce(workflowStub);
+      sinon.assert.calledWith(workflowStub, 4, true);
+    });
+
     it('should try to load a stored project workflow', function () {
       preferences.update({ 'settings.workflow_id': '2' });
+      controller.getSelectedWorkflow({ project, preferences });
+      sinon.assert.calledOnce(workflowStub);
+      sinon.assert.calledWith(workflowStub, 2, true);
+    });
+
+    it('parse the stored project workflow as an int', function () {
+      preferences.update({ 'settings.workflow_id': '2random' });
       controller.getSelectedWorkflow({ project, preferences });
       sinon.assert.calledOnce(workflowStub);
       sinon.assert.calledWith(workflowStub, 2, true);


### PR DESCRIPTION
Parse `workflow_id` as an integer before using it in comparisons, or storing it in user preferences. Fixes a bug where a malformed ID could cause an infinite loop of requests to `/api/workflows`.

Staging branch URL: https://workflow-selection.pfe-preview.zooniverse.org/

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
