### PR TITLE
Split up the survey task chooser

### DIFF
--- a/app/classifier/tasks/survey/chooser/CharacteristicsFilter.jsx
+++ b/app/classifier/tasks/survey/chooser/CharacteristicsFilter.jsx
@@ -1,0 +1,125 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import TriggeredModalForm from 'modal-form/triggered';
+import Translate from 'react-translate-component';
+import counterpart from 'counterpart';
+
+class CharacteristicsFilter extends React.Component {
+  handleFilter(characteristicId, valueId) {
+    this.props.onFilter(characteristicId, valueId);
+  }
+
+  render() {
+    const { task, translation, filters } = this.props;
+    return (
+      <div className="survey-task-chooser-characteristics">
+        {task.characteristicsOrder.map((characteristicId, i) => {
+          const characteristic = task.characteristics[characteristicId];
+          const selectedValue = characteristic.values[filters[characteristicId]];
+          const characteristicStrings = translation.characteristics[characteristicId];
+          const selectedValueStrings = characteristicStrings.values[filters[characteristicId]];
+          let hasBeenAutoFocused = false;
+          return (
+            <TriggeredModalForm
+              key={characteristicId}
+              ref={`${characteristicId}-dropdown`}
+              className="survey-task-chooser-characteristic-menu"
+              triggerProps={{ autoFocus: i === 0 && !this.props.focusedChoice }}
+              trigger={
+                <span className="survey-task-chooser-characteristic" data-is-active={!!selectedValue}>
+                  <span className="survey-task-chooser-characteristic-label">
+                    {selectedValue ? selectedValueStrings.label : characteristicStrings.label}
+                  </span>
+                </span>
+                }
+            >
+              <div className="survey-task-chooser-characteristic-menu-container">
+                {characteristic.valuesOrder.map((valueId) => {
+                  const value = characteristic.values[valueId];
+                  const valueStrings = characteristicStrings.values[valueId];
+                  const disabled = (valueId === filters[characteristicId]);
+                  const autoFocus = (!disabled && !hasBeenAutoFocused);
+                  const selected = (valueId === filters[characteristicId]);
+
+                  if (autoFocus) {
+                    hasBeenAutoFocused = true;
+                  }
+
+                  return (
+                    <button
+                      key={valueId}
+                      type="submit"
+                      title={valueStrings.label}
+                      className="survey-task-chooser-characteristic-value"
+                      disabled={disabled}
+                      data-selected={selected}
+                      autoFocus={autoFocus}
+                      onClick={this.handleFilter.bind(this, characteristicId, valueId)}
+                    >
+                      {value.image ?
+                        <img
+                          src={task.images[value.image]}
+                          alt={valueStrings.label}
+                          className="survey-task-chooser-characteristic-value-icon"
+                        /> :
+                        valueStrings.label
+                      }
+                    </button>
+                  );
+                })}
+
+                <button
+                  type="submit"
+                  className="survey-task-chooser-characteristic-clear-button"
+                  disabled={Object.keys(filters).indexOf(characteristicId) === -1}
+                  autoFocus={!hasBeenAutoFocused}
+                  onClick={this.handleFilter.bind(this, characteristicId, undefined)}
+                >
+                  <Translate content="tasks.survey.clear" />
+                </button>
+              </div>
+              <div className="survey-task-chooser-characteristic-value-label">
+                {characteristic.valuesOrder.reduce((label, valueId) => {
+                  const valueStrings = characteristicStrings.values[valueId];
+                  if (valueId === filters[characteristicId]) {
+                    return valueStrings.label;
+                  }
+                  return label;
+                }, counterpart('tasks.survey.makeSelection'))}
+              </div>
+            </TriggeredModalForm>
+          );
+        })}
+      </div>
+    );
+  }
+}
+
+CharacteristicsFilter.propTypes = {
+  filters: PropTypes.object,
+  focusedChoice: PropTypes.string,
+  onFilter: PropTypes.func,
+  task: PropTypes.shape({
+    alwaysShowThumbnails: PropTypes.bool,
+    characteristics: PropTypes.object,
+    characteristicsOrder: PropTypes.array,
+    choices: PropTypes.object,
+    choicesOrder: PropTypes.array,
+    images: PropTypes.object,
+    questions: PropTypes.object
+  }),
+  translation: PropTypes.shape({
+    characteristics: PropTypes.object,
+    choices: PropTypes.object,
+    questions: PropTypes.object
+  }).isRequired
+};
+
+CharacteristicsFilter.defaultProps = {
+  filters: {},
+  focusedChoice: '',
+  onFilter: Function.prototype,
+  task: null
+};
+
+export default CharacteristicsFilter;

--- a/app/classifier/tasks/survey/chooser/Choices.jsx
+++ b/app/classifier/tasks/survey/chooser/Choices.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import sortIntoColumns from 'sort-into-columns';
 import Thumbnail from '../../../../components/thumbnail';
 
 const BACKSPACE = 8;
@@ -31,6 +32,16 @@ class Choices extends React.Component {
         newChoiceButtons[index] = button;
       });
     this.choiceButtons = newChoiceButtons.filter(Boolean);
+  }
+
+  howManyColumns({ length }) {
+    if (length <= 5) {
+      return 1;
+    } else if (length <= 20) {
+      return 2;
+    } else {
+      return 3;
+    }
   }
 
   whatSizeThumbnails({ length }) {
@@ -73,10 +84,12 @@ class Choices extends React.Component {
   }
 
   render() {
-    const { columnsCount, filteredChoices, sortedFilteredChoices, task, translation } = this.props;
+    const { filteredChoices, task, translation } = this.props;
     this.choiceButtons = [];
-    const thumbnailSize = this.whatSizeThumbnails(filteredChoices);
     const selectedChoices = this.props.annotation.value.map(item => item.choice);
+    const columnsCount = this.howManyColumns(filteredChoices);
+    const sortedFilteredChoices = sortIntoColumns(filteredChoices, columnsCount);
+    const thumbnailSize = this.whatSizeThumbnails(sortedFilteredChoices);
     return (
       <div className="survey-task-chooser-choices" data-thumbnail-size={thumbnailSize} data-columns={columnsCount}>
         {sortedFilteredChoices.length === 0 && <div><em>No matches.</em></div>}
@@ -133,12 +146,10 @@ Choices.propTypes = {
     task: PropTypes.string,
     value: PropTypes.array
   }),
-  columnsCount: PropTypes.number,
   filteredChoices: PropTypes.array,
   focusedChoice: PropTypes.string,
   onChoose: PropTypes.func,
   onRemove: PropTypes.func,
-  sortedFilteredChoices: PropTypes.array,
   task: PropTypes.shape({
     alwaysShowThumbnails: PropTypes.bool,
     characteristics: PropTypes.object,
@@ -160,10 +171,8 @@ Choices.defaultProps = {
     task: '',
     value: []
   },
-  columnsCount: 3,
   filteredChoices: [],
   focusedChoice: '',
-  sortedFilteredChoices: [],
   onChoose: Function.prototype,
   onRemove: Function.prototype,
   task: null

--- a/app/classifier/tasks/survey/chooser/Choices.jsx
+++ b/app/classifier/tasks/survey/chooser/Choices.jsx
@@ -1,0 +1,172 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import Thumbnail from '../../../../components/thumbnail';
+
+const BACKSPACE = 8;
+const UP = 38;
+const DOWN = 40;
+
+class Choices extends React.Component {
+  constructor() {
+    super();
+    this.choiceButtons = [];
+  }
+
+  componentDidMount() {
+    this.sortChoiceButtons();
+  }
+
+  componentDidUpdate() {
+    this.sortChoiceButtons();
+  }
+
+  sortChoiceButtons() {
+    // overrides default DOM focus order by sorting the buttons according to task.choicesOrder
+    const newChoiceButtons = [];
+    this.choiceButtons
+      .filter(Boolean)
+      .map((button) => {
+        const choiceID = button.getAttribute('data-choiceID');
+        const index = this.props.task.choicesOrder.indexOf(choiceID);
+        newChoiceButtons[index] = button;
+      });
+    this.choiceButtons = newChoiceButtons.filter(Boolean);
+  }
+
+  whatSizeThumbnails({ length }) {
+    if (length <= 5) {
+      return 'large';
+    } else if (length <= 10) {
+      return 'medium';
+    } else if (length <= 20) {
+      return 'small';
+    } else if (this.props.task.alwaysShowThumbnails) {
+      return 'small';
+    } else {
+      return 'none';
+    }
+  }
+
+  handleKeyDown(choiceId, e) {
+    const index = this.choiceButtons.indexOf(document.activeElement);
+    let newIndex;
+    switch (e.which) {
+      case BACKSPACE:
+        this.props.onRemove(choiceId);
+        e.preventDefault();
+        break;
+      case UP:
+        newIndex = index - 1;
+        if (newIndex === -1) {
+          newIndex = this.choiceButtons.length - 1;
+        }
+        this.choiceButtons[newIndex].focus();
+        e.preventDefault();
+        break;
+      case DOWN:
+        newIndex = (index + 1) % this.choiceButtons.length;
+        this.choiceButtons[newIndex].focus();
+        e.preventDefault();
+        break;
+      default:
+    }
+  }
+
+  render() {
+    const { columnsCount, filteredChoices, sortedFilteredChoices, task, translation } = this.props;
+    this.choiceButtons = [];
+    const thumbnailSize = this.whatSizeThumbnails(filteredChoices);
+    const selectedChoices = this.props.annotation.value.map(item => item.choice);
+    return (
+      <div className="survey-task-chooser-choices" data-thumbnail-size={thumbnailSize} data-columns={columnsCount}>
+        {sortedFilteredChoices.length === 0 && <div><em>No matches.</em></div>}
+        {sortedFilteredChoices.map((choiceId, i) => {
+          const choice = task.choices[choiceId];
+          const chosenAlready = selectedChoices.indexOf(choiceId) > -1;
+          let tabIndex = -1;
+          if (i === 0 && this.props.focusedChoice.length === 0) {
+            tabIndex = 0;
+          }
+          if (choiceId === this.props.focusedChoice) {
+            tabIndex = 0;
+          }
+          const src = this.props.task.images[choice.images[0]];
+          const srcPath = Thumbnail.getThumbnailSrc({
+            origin: 'https://thumbnails.zooniverse.org',
+            width: 500,
+            height: 500,
+            src
+          });
+          const thumbnail = srcPath || '';
+          return (
+            <button
+              autoFocus={choiceId === this.props.focusedChoice}
+              key={choiceId}
+              data-choiceID={choiceId}
+              ref={button => this.choiceButtons.push(button)}
+              tabIndex={tabIndex}
+              type="button"
+              className={`survey-task-chooser-choice-button ${chosenAlready ? 'survey-task-chooser-choice-button-chosen' : ''}`}
+              onClick={this.props.onChoose.bind(null, choiceId)}
+              onKeyDown={this.handleKeyDown.bind(this, choiceId)}
+            >
+              <span className="survey-task-chooser-choice">
+                {choice.images.length > 0 &&
+                  <span
+                    className="survey-task-chooser-choice-thumbnail"
+                    role="presentation"
+                    style={{ backgroundImage: `url('${thumbnail}')` }}
+                  />
+                }
+                <span className="survey-task-chooser-choice-label">{translation.choices[choiceId].label}</span>
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    );
+  }
+}
+
+Choices.propTypes = {
+  annotation: PropTypes.shape({
+    task: PropTypes.string,
+    value: PropTypes.array
+  }),
+  columnsCount: PropTypes.number,
+  filteredChoices: PropTypes.array,
+  focusedChoice: PropTypes.string,
+  onChoose: PropTypes.func,
+  onRemove: PropTypes.func,
+  sortedFilteredChoices: PropTypes.array,
+  task: PropTypes.shape({
+    alwaysShowThumbnails: PropTypes.bool,
+    characteristics: PropTypes.object,
+    characteristicsOrder: PropTypes.array,
+    choices: PropTypes.object,
+    choicesOrder: PropTypes.array,
+    images: PropTypes.object,
+    questions: PropTypes.object
+  }),
+  translation: PropTypes.shape({
+    characteristics: PropTypes.object,
+    choices: PropTypes.object,
+    questions: PropTypes.object
+  }).isRequired
+};
+
+Choices.defaultProps = {
+  annotation: {
+    task: '',
+    value: []
+  },
+  columnsCount: 3,
+  filteredChoices: [],
+  focusedChoice: '',
+  sortedFilteredChoices: [],
+  onChoose: Function.prototype,
+  onRemove: Function.prototype,
+  task: null
+};
+
+export default Choices;

--- a/app/classifier/tasks/survey/chooser/Choices.jsx
+++ b/app/classifier/tasks/survey/chooser/Choices.jsx
@@ -90,6 +90,8 @@ class Choices extends React.Component {
     const columnsCount = this.howManyColumns(filteredChoices);
     const sortedFilteredChoices = sortIntoColumns(filteredChoices, columnsCount);
     const thumbnailSize = this.whatSizeThumbnails(sortedFilteredChoices);
+    const choiceNotPresent = this.props.focusedChoice.length === 0 || 
+      filteredChoices.indexOf(this.props.focusedChoice) === -1;
     return (
       <div className="survey-task-chooser-choices" data-thumbnail-size={thumbnailSize} data-columns={columnsCount}>
         {sortedFilteredChoices.length === 0 && <div><em>No matches.</em></div>}
@@ -97,7 +99,7 @@ class Choices extends React.Component {
           const choice = task.choices[choiceId];
           const chosenAlready = selectedChoices.indexOf(choiceId) > -1;
           let tabIndex = -1;
-          if (i === 0 && this.props.focusedChoice.length === 0) {
+          if (i === 0 && choiceNotPresent) {
             tabIndex = 0;
           }
           if (choiceId === this.props.focusedChoice) {

--- a/app/classifier/tasks/survey/chooser/Chooser.jsx
+++ b/app/classifier/tasks/survey/chooser/Chooser.jsx
@@ -24,6 +24,10 @@ class Chooser extends React.Component {
     }).filter(Boolean);
   }
 
+  handleClearFilters() {
+    this.props.task.characteristicsOrder.map(characteristicId => this.props.onFilter(characteristicId, undefined));
+  }
+
   render() {
     const { annotation, task, translation, filters, focusedChoice, onChoose, onFilter, onRemove } = this.props;
     const filteredChoices = this.getFilteredChoices();
@@ -57,7 +61,7 @@ class Chooser extends React.Component {
             type="button"
             className="survey-task-chooser-characteristic-clear-button"
             disabled={Object.keys(filters).length === 0}
-            onClick={this.handleClearFilters}
+            onClick={this.handleClearFilters.bind(this)}
           >
             <i className="fa fa-ban" /> <Translate content="tasks.survey.clearFilters" />
           </button>

--- a/app/classifier/tasks/survey/chooser/Chooser.jsx
+++ b/app/classifier/tasks/survey/chooser/Chooser.jsx
@@ -2,28 +2,10 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import sortIntoColumns from 'sort-into-columns';
 import Translate from 'react-translate-component';
-import Thumbnail from '../../../../components/thumbnail';
 import CharacteristicsFilter from './CharacteristicsFilter';
-
-// key codes
-const BACKSPACE = 8;
-const UP = 38;
-const DOWN = 40;
+import Choices from './Choices';
 
 class Chooser extends React.Component {
-  constructor() {
-    super();
-    this.choiceButtons = [];
-    this.handleClearFilters = this.handleClearFilters.bind(this);
-  }
-
-  componentDidMount() {
-    this.sortChoiceButtons();
-  }
-
-  componentDidUpdate() {
-    this.sortChoiceButtons();
-  }
 
   getFilteredChoices() {
     return this.props.task.choicesOrder.map((choiceId) => {
@@ -53,70 +35,11 @@ class Chooser extends React.Component {
     }
   }
 
-  sortChoiceButtons() {
-    // overrides default DOM focus order by sorting the buttons according to task.choicesOrder
-    const newChoiceButtons = [];
-    this.choiceButtons
-      .filter(Boolean)
-      .map((button) => {
-        const choiceID = button.getAttribute('data-choiceID');
-        const index = this.props.task.choicesOrder.indexOf(choiceID);
-        newChoiceButtons[index] = button;
-      });
-    this.choiceButtons = newChoiceButtons.filter(Boolean);
-  }
-
-  whatSizeThumbnails({ length }) {
-    if (length <= 5) {
-      return 'large';
-    } else if (length <= 10) {
-      return 'medium';
-    } else if (length <= 20) {
-      return 'small';
-    } else if (this.props.task.alwaysShowThumbnails) {
-      return 'small';
-    } else {
-      return 'none';
-    }
-  }
-
-  handleClearFilters() {
-    this.props.task.characteristicsOrder.map(characteristicId => this.props.onFilter(characteristicId, undefined));
-  }
-
-  handleKeyDown(choiceId, e) {
-    const index = this.choiceButtons.indexOf(document.activeElement);
-    let newIndex;
-    switch (e.which) {
-      case BACKSPACE:
-        this.props.onRemove(choiceId);
-        e.preventDefault();
-        break;
-      case UP:
-        newIndex = index - 1;
-        if (newIndex === -1) {
-          newIndex = this.choiceButtons.length - 1;
-        }
-        this.choiceButtons[newIndex].focus();
-        e.preventDefault();
-        break;
-      case DOWN:
-        newIndex = (index + 1) % this.choiceButtons.length;
-        this.choiceButtons[newIndex].focus();
-        e.preventDefault();
-        break;
-      default:
-    }
-  }
-
   render() {
-    const { task, translation, filters, onFilter } = this.props;
-    this.choiceButtons = [];
+    const { annotation, task, translation, filters, focusedChoice, onChoose, onFilter, onRemove } = this.props;
     const filteredChoices = this.getFilteredChoices();
-    const thumbnailSize = this.whatSizeThumbnails(filteredChoices);
     const columnsCount = this.howManyColumns(filteredChoices);
     const sortedFilteredChoices = sortIntoColumns(filteredChoices, columnsCount);
-    const selectedChoices = this.props.annotation.value.map(item => item.choice);
     return (
       <div className="survey-task-chooser">
         <CharacteristicsFilter
@@ -127,52 +50,18 @@ class Chooser extends React.Component {
           onFilter={onFilter}
         />
         <hr className="survey-task-chooser__divider" />
-        <div className="survey-task-chooser-choices" data-thumbnail-size={thumbnailSize} data-columns={columnsCount}>
-          {sortedFilteredChoices.length === 0 && <div><em>No matches.</em></div>}
-          {sortedFilteredChoices.map((choiceId, i) => {
-            const choice = task.choices[choiceId];
-            const chosenAlready = selectedChoices.indexOf(choiceId) > -1;
-            let tabIndex = -1;
-            if (i === 0 && this.props.focusedChoice.length === 0) {
-              tabIndex = 0;
-            }
-            if (choiceId === this.props.focusedChoice) {
-              tabIndex = 0;
-            }
-            const src = this.props.task.images[choice.images[0]];
-            const srcPath = Thumbnail.getThumbnailSrc({
-              origin: 'https://thumbnails.zooniverse.org',
-              width: 500,
-              height: 500,
-              src
-            });
-            const thumbnail = srcPath || '';
-            return (
-              <button
-                autoFocus={choiceId === this.props.focusedChoice}
-                key={choiceId}
-                data-choiceID={choiceId}
-                ref={button => this.choiceButtons.push(button)}
-                tabIndex={tabIndex}
-                type="button"
-                className={`survey-task-chooser-choice-button ${chosenAlready ? 'survey-task-chooser-choice-button-chosen' : ''}`}
-                onClick={this.props.onChoose.bind(null, choiceId)}
-                onKeyDown={this.handleKeyDown.bind(this, choiceId)}
-              >
-                <span className="survey-task-chooser-choice">
-                  {choice.images.length > 0 &&
-                    <span
-                      className="survey-task-chooser-choice-thumbnail"
-                      role="presentation"
-                      style={{ backgroundImage: `url('${thumbnail}')` }}
-                    />
-                  }
-                  <span className="survey-task-chooser-choice-label">{translation.choices[choiceId].label}</span>
-                </span>
-              </button>
-            );
-          })}
-        </div>
+        <Choices
+          annotation={annotation}
+          columnsCount={columnsCount}
+          filters={filters}
+          filteredChoices={filteredChoices}
+          focusedChoice={focusedChoice}
+          sortedFilteredChoices={sortedFilteredChoices}
+          task={task}
+          translation={translation}
+          onChoose={onChoose}
+          onRemove={onRemove}
+        />
         <div style={{ textAlign: 'center' }}>
           <Translate
             content="tasks.survey.showing"

--- a/app/classifier/tasks/survey/chooser/Chooser.jsx
+++ b/app/classifier/tasks/survey/chooser/Chooser.jsx
@@ -2,9 +2,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import sortIntoColumns from 'sort-into-columns';
 import Translate from 'react-translate-component';
-import TriggeredModalForm from 'modal-form/triggered';
-import counterpart from 'counterpart';
-import Thumbnail from '../../../components/thumbnail';
+import Thumbnail from '../../../../components/thumbnail';
+import CharacteristicsFilter from './CharacteristicsFilter';
 
 // key codes
 const BACKSPACE = 8;
@@ -81,10 +80,6 @@ class Chooser extends React.Component {
     }
   }
 
-  handleFilter(characteristicId, valueId) {
-    this.props.onFilter(characteristicId, valueId);
-  }
-
   handleClearFilters() {
     this.props.task.characteristicsOrder.map(characteristicId => this.props.onFilter(characteristicId, undefined));
   }
@@ -115,7 +110,7 @@ class Chooser extends React.Component {
   }
 
   render() {
-    const { task, translation, filters } = this.props;
+    const { task, translation, filters, onFilter } = this.props;
     this.choiceButtons = [];
     const filteredChoices = this.getFilteredChoices();
     const thumbnailSize = this.whatSizeThumbnails(filteredChoices);
@@ -124,85 +119,13 @@ class Chooser extends React.Component {
     const selectedChoices = this.props.annotation.value.map(item => item.choice);
     return (
       <div className="survey-task-chooser">
-        <div className="survey-task-chooser-characteristics">
-          {task.characteristicsOrder.map((characteristicId, i) => {
-            const characteristic = task.characteristics[characteristicId];
-            const selectedValue = characteristic.values[filters[characteristicId]];
-            const characteristicStrings = translation.characteristics[characteristicId];
-            const selectedValueStrings = characteristicStrings.values[filters[characteristicId]];
-            let hasBeenAutoFocused = false;
-            return (
-              <TriggeredModalForm
-                key={characteristicId}
-                ref={`${characteristicId}-dropdown`}
-                className="survey-task-chooser-characteristic-menu"
-                triggerProps={{ autoFocus: i === 0 && !this.props.focusedChoice }}
-                trigger={
-                  <span className="survey-task-chooser-characteristic" data-is-active={!!selectedValue}>
-                    <span className="survey-task-chooser-characteristic-label">
-                      {selectedValue ? selectedValueStrings.label : characteristicStrings.label}
-                    </span>
-                  </span>
-                  }
-              >
-                <div className="survey-task-chooser-characteristic-menu-container">
-                  {characteristic.valuesOrder.map((valueId) => {
-                    const value = characteristic.values[valueId];
-                    const valueStrings = characteristicStrings.values[valueId];
-                    const disabled = (valueId === filters[characteristicId]);
-                    const autoFocus = (!disabled && !hasBeenAutoFocused);
-                    const selected = (valueId === filters[characteristicId]);
-
-                    if (autoFocus) {
-                      hasBeenAutoFocused = true;
-                    }
-
-                    return (
-                      <button
-                        key={valueId}
-                        type="submit"
-                        title={valueStrings.label}
-                        className="survey-task-chooser-characteristic-value"
-                        disabled={disabled}
-                        data-selected={selected}
-                        autoFocus={autoFocus}
-                        onClick={this.handleFilter.bind(this, characteristicId, valueId)}
-                      >
-                        {value.image ?
-                          <img
-                            src={task.images[value.image]}
-                            alt={valueStrings.label}
-                            className="survey-task-chooser-characteristic-value-icon"
-                          /> :
-                          valueStrings.label
-                        }
-                      </button>
-                    );
-                  })}
-
-                  <button
-                    type="submit"
-                    className="survey-task-chooser-characteristic-clear-button"
-                    disabled={Object.keys(filters).indexOf(characteristicId) === -1}
-                    autoFocus={!hasBeenAutoFocused}
-                    onClick={this.handleFilter.bind(this, characteristicId, undefined)}
-                  >
-                    <Translate content="tasks.survey.clear" />
-                  </button>
-                </div>
-                <div className="survey-task-chooser-characteristic-value-label">
-                  {characteristic.valuesOrder.reduce((label, valueId) => {
-                    const valueStrings = characteristicStrings.values[valueId];
-                    if (valueId === filters[characteristicId]) {
-                      return valueStrings.label;
-                    }
-                    return label;
-                  }, counterpart('tasks.survey.makeSelection'))}
-                </div>
-              </TriggeredModalForm>
-            );
-          })}
-        </div>
+        <CharacteristicsFilter
+          filters={filters}
+          focusedChoice={focusedChoice}
+          task={task}
+          translation={translation}
+          onFilter={onFilter}
+        />
         <hr className="survey-task-chooser__divider" />
         <div className="survey-task-chooser-choices" data-thumbnail-size={thumbnailSize} data-columns={columnsCount}>
           {sortedFilteredChoices.length === 0 && <div><em>No matches.</em></div>}

--- a/app/classifier/tasks/survey/chooser/Chooser.jsx
+++ b/app/classifier/tasks/survey/chooser/Chooser.jsx
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import sortIntoColumns from 'sort-into-columns';
 import Translate from 'react-translate-component';
 import CharacteristicsFilter from './CharacteristicsFilter';
 import Choices from './Choices';
@@ -25,21 +24,9 @@ class Chooser extends React.Component {
     }).filter(Boolean);
   }
 
-  howManyColumns({ length }) {
-    if (length <= 5) {
-      return 1;
-    } else if (length <= 20) {
-      return 2;
-    } else {
-      return 3;
-    }
-  }
-
   render() {
     const { annotation, task, translation, filters, focusedChoice, onChoose, onFilter, onRemove } = this.props;
     const filteredChoices = this.getFilteredChoices();
-    const columnsCount = this.howManyColumns(filteredChoices);
-    const sortedFilteredChoices = sortIntoColumns(filteredChoices, columnsCount);
     return (
       <div className="survey-task-chooser">
         <CharacteristicsFilter
@@ -52,11 +39,9 @@ class Chooser extends React.Component {
         <hr className="survey-task-chooser__divider" />
         <Choices
           annotation={annotation}
-          columnsCount={columnsCount}
           filters={filters}
           filteredChoices={filteredChoices}
           focusedChoice={focusedChoice}
-          sortedFilteredChoices={sortedFilteredChoices}
           task={task}
           translation={translation}
           onChoose={onChoose}
@@ -65,7 +50,7 @@ class Chooser extends React.Component {
         <div style={{ textAlign: 'center' }}>
           <Translate
             content="tasks.survey.showing"
-            with={{ count: sortedFilteredChoices.length, max: task.choicesOrder.length }}
+            with={{ count: filteredChoices.length, max: task.choicesOrder.length }}
           />
           &ensp;
           <button

--- a/app/classifier/tasks/survey/chooser/index.jsx
+++ b/app/classifier/tasks/survey/chooser/index.jsx
@@ -1,0 +1,1 @@
+export { default } from './Chooser';


### PR DESCRIPTION
Staging branch URL: https://survey-task.pfe-preview.zooniverse.org/

Splits the survey task chooser up into a CharacteristicsFilter and Choices component.

This also fixes a bug where you can't tab into the filtered choice list if your currently selected choice isn't present in the filtered list (every item is set to tabindex -1.)

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
