### PR TITLE
Revert "Add deleteIfOutOfBounds to drawing tool root"

### DIFF
--- a/app/classifier/tasks/drawing/markings-renderer.cjsx
+++ b/app/classifier/tasks/drawing/markings-renderer.cjsx
@@ -1,13 +1,10 @@
 React = require 'react'
 createReactClass = require 'create-react-class'
 drawingTools = require '../../drawing-tools'
-deleteIfOutOfBounds = require '../../drawing-tools/delete-if-out-of-bounds'
 strategies = require('../../../features/feedback/shared/strategies').default
 
 module.exports = createReactClass
   displayName: 'MarkingsRenderer'
-
-  tools: []
 
   getDefaultProps: ->
     annotations: []
@@ -38,13 +35,8 @@ module.exports = createReactClass
     @setState oldSetOfMarks: newSetOfMarks
     # console.log 'Marks are now', newSetOfMarks
 
-  componentDidUpdate: () ->
-    for tool in this.tools
-      deleteIfOutOfBounds(tool)
-
   render: ->
     skippedMarks = 0
-    this.tools = []
     <g>
       {for annotation in @props.annotations
         annotation._key ?= Math.random()
@@ -120,13 +112,7 @@ module.exports = createReactClass
                 getScreenCurrentTransformationMatrix: @props.getScreenCurrentTransformationMatrix
 
               ToolComponent = drawingTools[toolDescription.type]
-              <ToolComponent
-                ref={(tool) => this.tools.push(tool) if tool}
-                key={mark._key}
-                {...toolProps}
-                {...toolEnv}
-                {...toolMethods}
-              />}
+              <ToolComponent key={mark._key} {...toolProps} {...toolEnv} {...toolMethods} />}
           </g>}
     </g>
 
@@ -148,9 +134,8 @@ module.exports = createReactClass
     if mark is @state.selection
       @setState selection: null
     markIndex = annotation.value.indexOf mark
-    if markIndex > -1
-      annotation.value.splice markIndex, 1
-      @props.onChange annotation
+    annotation.value.splice markIndex, 1
+    @props.onChange annotation
     if mark.templateID
       index = []
       for cell in annotation.value


### PR DESCRIPTION
## PR Overview
Reverts zooniverse/Panoptes-Front-End#4580

This reversion removes the `deleteIfOutOfBounds` logic in the `markings-renderer.cjsx` component, which was introduced to fix Issue #4579. (i.e. users could place markings outside of the Subject bounds, noted on Space Warps.)

Unfortunately, the introduction of `deleteIfOutOfBounds` introduced a _new, more serious issue,_ where if a user zoomed into Subject image, any markings that _are outside the field of view_ start to disappear. (i.e. the problem is that `deleteIfOutOfBounds` checks for the bounds of the _subject viewer/viewport,_ not the _subject image itself._ )

This newly introduced issue has significant impact on projects like Penguin Watch (see issue #4607), so we need to undo these changes.

### Dev Notes
- This should fix #4607 
- This should re-open #4579 
- A proper solution would be to,
  1. fix the deleteIfOutOfBounds logic (after confirming that it's not doing what it's _supposed to do._ )
  2. reapply the code from PR #4580 to re-fix #4579.
- ...but that would require mucking about in old undocumented PFE logic, so let's do that later.
- For now, REVERT!

There is a separate, though more minor, issue where if a user zooms into a Subject image, then clicks on Reset Zoom Levels, the markings _appear_ to disappear, but are actually shrunk to something like 5% size. This is mostly a presentational/UI issue, and isn't as severe as what we're trying to solve right now.

### Status
@eatyourgreens @srallen please give this a check.