### PR TITLE
Improved classifier button styles

### DIFF
--- a/app/classifier/components/TaskNavButtons/components/BackButton/BackButton.jsx
+++ b/app/classifier/components/TaskNavButtons/components/BackButton/BackButton.jsx
@@ -45,15 +45,18 @@ export const StyledBackButton = styled.button.attrs({
   &:focus, &:hover {
     background: ${theme('mode', {
       dark: zooTheme.colors.darkTheme.background.default,
-      light: zooTheme.colors.teal.gradient
+      light: `linear-gradient(
+        ${zooTheme.colors.lightTheme.button.answer.gradient.top},
+        ${zooTheme.colors.lightTheme.button.answer.gradient.bottom}
+      )`
     })};
     border: ${theme('mode', {
-      dark: `thin solid ${zooTheme.colors.darkTheme.button.answer}`,
+      dark: `thin solid ${zooTheme.colors.darkTheme.button.answer.default}`,
       light: 'thin solid transparent'
     })};
     color: ${theme('mode', {
       dark: zooTheme.colors.darkTheme.font,
-      light: 'white'
+      light: 'black'
     })};
   }
 `;

--- a/app/classifier/components/TaskNavButtons/components/DoneButton/DoneButton.jsx
+++ b/app/classifier/components/TaskNavButtons/components/DoneButton/DoneButton.jsx
@@ -34,7 +34,11 @@ export const StyledDoneButton = styled.button.attrs({
   &:hover, &:focus {
     background: ${theme('mode', {
       dark: zooTheme.colors.darkTheme.button.done.hover,
-      light: darken(0.05, zooTheme.colors.lightTheme.button.done)
+      light: darken(0.15, zooTheme.colors.lightTheme.button.done)
+    })};
+    border: ${theme('mode', {
+      dark: `solid thin ${zooTheme.colors.darkTheme.button.done.default}`,
+      light: `solid thin ${darken(0.15, zooTheme.colors.lightTheme.button.done)}`
     })};
     color: 'white';
   }
@@ -46,14 +50,15 @@ export const StyledDoneButton = styled.button.attrs({
     })};
 
     border: ${theme('mode', {
-      dark: `solid thin ${lighten(0.05, zooTheme.colors.darkTheme.background.default)}`,
+      dark: `solid thin ${zooTheme.colors.darkTheme.button.done.default}`,
       light: `solid thin ${lighten(0.05, zooTheme.colors.lightTheme.button.done)}`
     })};
     color: ${theme('mode', {
-      dark: 'white',
+      dark: zooTheme.colors.darkTheme.font,
       light: '#EEF1F4'
     })};
     cursor: not-allowed;
+    opacity: 0.5;
   }
 `;
 

--- a/app/classifier/components/TaskNavButtons/components/NextButton/NextButton.jsx
+++ b/app/classifier/components/TaskNavButtons/components/NextButton/NextButton.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import styled, { ThemeProvider } from 'styled-components';
 import theme from 'styled-theming';
-import { adjustHue, darken } from 'polished';
 import Translate from 'react-translate-component';
 import { pxToRem, zooTheme } from '../../../../../theme';
 
@@ -23,7 +22,7 @@ export const StyledNextButton = styled.button.attrs({
   border-radius: 0;
   color: ${theme('mode', {
     dark: zooTheme.colors.highlight.default,
-    light: 'white'
+    light: 'black'
   })};
   cursor: pointer;
   flex: 3 0;
@@ -35,27 +34,32 @@ export const StyledNextButton = styled.button.attrs({
     margin-left: 1ch;
   }
 
-  &:hover, &:focus {
+  &:hover:not(:disabled), &:focus:not(:disabled) {
     background: ${theme('mode', {
       dark: zooTheme.colors.highlight.default,
       light: zooTheme.colors.lightTheme.button.nextHover
     })};
     color: ${theme('mode', {
-      dark: 'white',
-      light: 'white'
+      dark: 'black',
+      light: 'black'
     })};;
   }
 
   &:disabled {
     background: ${theme('mode', {
-      dark: 'grey',
+      dark: zooTheme.colors.darkTheme.background.default,
       light: zooTheme.colors.highlight.light
     })};
+    border: ${theme('mode', {
+      dark: `solid thin ${zooTheme.colors.highlight.default}`,
+      light: `solid thin ${zooTheme.colors.highlight.default}`
+    })};
     color: ${theme('mode', {
-      dark: 'white',
-      light: '#EEF1F4'
+      dark: zooTheme.colors.highlight.defaults,
+      light: 'black'
     })};
     cursor: not-allowed;
+    opacity: 0.5;
   }
 `;
 

--- a/app/classifier/components/TaskNavButtons/components/NextButton/NextButton.jsx
+++ b/app/classifier/components/TaskNavButtons/components/NextButton/NextButton.jsx
@@ -55,7 +55,7 @@ export const StyledNextButton = styled.button.attrs({
       light: `solid thin ${zooTheme.colors.highlight.default}`
     })};
     color: ${theme('mode', {
-      dark: zooTheme.colors.highlight.defaults,
+      dark: zooTheme.colors.highlight.default,
       light: 'black'
     })};
     cursor: not-allowed;

--- a/app/classifier/components/TaskNavButtons/components/TalkLink/TalkLink.jsx
+++ b/app/classifier/components/TaskNavButtons/components/TalkLink/TalkLink.jsx
@@ -46,11 +46,11 @@ export const StyledTalkLink = styled(Link)`
   &:hover, &:focus {
     background: ${theme('mode', {
       dark: TALK_LINK_BLUE_HOVER_DARK,
-      light: TALK_LINK_BLUE_HOVER
+      light: darken(0.25, TALK_LINK_BLUE_HOVER)
     })};
     border: ${theme('mode', {
       dark: `thin solid ${TALK_LINK_BLUE}`,
-      light: `thin solid ${TALK_LINK_BLUE_HOVER}`
+      light: `thin solid ${darken(0.25, TALK_LINK_BLUE_HOVER)}`
     })};
   }
 `;

--- a/app/classifier/components/TaskTabs/components/TutorialTab/TutorialTab.jsx
+++ b/app/classifier/components/TaskTabs/components/TutorialTab/TutorialTab.jsx
@@ -32,8 +32,25 @@ export const StyledTutorialButton = styled.button.attrs({
   padding: ${pxToRem(16)};
   text-transform: uppercase;
 
+  &:focus, &:hover {
+    background: ${theme('mode', {
+      dark: `linear-gradient(
+        ${zooTheme.colors.darkTheme.button.answer.gradient.top},
+        ${zooTheme.colors.darkTheme.button.answer.gradient.bottom}
+      )`,
+      light: `linear-gradient(
+        ${zooTheme.colors.lightTheme.button.answer.gradient.top},
+        ${zooTheme.colors.lightTheme.button.answer.gradient.bottom}
+      )`
+    })};
+    color: ${theme('mode', {
+      dark: zooTheme.colors.darkTheme.font,
+      light: 'black'
+    })};
+  }
+
   &:disabled {
-    background-color: ${theme('mode', {
+    background: ${theme('mode', {
       dark: darken(0.04, zooTheme.colors.darkTheme.background.default),
       light: zooTheme.colors.lightTheme.background.default
     })};
@@ -43,20 +60,9 @@ export const StyledTutorialButton = styled.button.attrs({
     })};
     color: ${theme('mode', {
       dark: lighten(0.10, zooTheme.colors.darkTheme.background.default),
-      light: zooTheme.colors.lightTheme.button.answerDisabled
+      light: zooTheme.colors.lightTheme.button.answer.disabled
     })};
     cursor: not-allowed;
-  }
-
-  &:focus:not(&:disabled), &:hover:not(&:disabled) {
-    background: ${theme('mode', {
-      dark: zooTheme.colors.darkTheme.button,
-      light: zooTheme.colors.teal.gradient
-    })};
-    color: ${theme('mode', {
-      dark: zooTheme.colors.darkTheme.font,
-      light: 'white'
-    })};
   }
 `;
 

--- a/app/classifier/tasks/components/TaskInputField/TaskInputField.jsx
+++ b/app/classifier/tasks/components/TaskInputField/TaskInputField.jsx
@@ -16,8 +16,8 @@ export const StyledTaskInputField = styled.label`
     light: zooTheme.colors.lightTheme.background.default
   })};
   border: ${theme('mode', {
-    dark: `thin solid ${zooTheme.colors.darkTheme.font}`,
-    light: 'thin solid transparent'
+    dark: `2px solid ${zooTheme.colors.darkTheme.font}`,
+    light: '2px solid transparent'
   })};
   box-shadow: 1px 1px 2px 0 rgba(0,0,0,0.5);
   color: ${theme('mode', {
@@ -33,31 +33,53 @@ export const StyledTaskInputField = styled.label`
 
   &:hover, &:focus, &[data-focus=true] {
     background: ${theme('mode', {
-      dark: zooTheme.colors.darkTheme.background.default,
-      light: zooTheme.colors.teal.gradient
+      dark: `linear-gradient(
+        ${zooTheme.colors.darkTheme.button.answer.gradient.top},
+        ${zooTheme.colors.darkTheme.button.answer.gradient.bottom}
+      )`,
+      light: `linear-gradient(
+        ${zooTheme.colors.lightTheme.button.answer.gradient.top},
+        ${zooTheme.colors.lightTheme.button.answer.gradient.bottom}
+      )`
     })};
-    border: ${theme('mode', {
-      dark: `thin solid ${zooTheme.colors.darkTheme.button.answer}`,
-      light: `thin solid ${zooTheme.colors.teal.gradient}`
+    border-width: 2px;
+    border-style: solid;
+    border-left-color: transparent;
+    border-right-color: transparent;
+    border-top-color: ${theme('mode', {
+      dark: zooTheme.colors.darkTheme.button.answer.gradient.top,
+      light: zooTheme.colors.lightTheme.button.answer.gradient.top
+    })};
+    border-bottom-color: ${theme('mode', {
+      dark: zooTheme.colors.darkTheme.button.answer.gradient.bottom,
+      light: zooTheme.colors.lightTheme.button.answer.gradient.bottom
     })};
     color: ${theme('mode', {
       dark: zooTheme.colors.darkTheme.font,
-      light: 'white'
+      light: 'black'
     })};
   }
 
   &:active {
     background: ${theme('mode', {
-      dark: zooTheme.colors.teal.dark,
-      light: zooTheme.colors.teal.gradient
+      dark: `linear-gradient(
+        ${zooTheme.colors.darkTheme.button.answer.gradient.top},
+        ${zooTheme.colors.darkTheme.button.answer.gradient.bottom}
+      )`,
+      light: `linear-gradient(
+        ${zooTheme.colors.lightTheme.button.answer.gradient.top},
+        ${zooTheme.colors.lightTheme.button.answer.gradient.bottom}
+      )`
     })};
-    border: ${theme('mode', {
-      dark: `thin solid ${zooTheme.colors.teal.dark}`,
-      light: `thin solid ${zooTheme.colors.teal.mid}`
+    border-width: 2px;
+    border-style: solid;
+    border-color: ${theme('mode', {
+      dark: zooTheme.colors.teal.dark,
+      light: zooTheme.colors.teal.mid
     })};
     color: ${theme('mode', {
       dark: zooTheme.colors.darkTheme.font,
-      light: 'white'
+      light: 'black'
     })};
   }
 
@@ -67,8 +89,8 @@ export const StyledTaskInputField = styled.label`
       light: zooTheme.colors.teal.mid
     })};
     border: ${theme('mode', {
-      dark: `thin solid ${zooTheme.colors.teal.mid}`,
-      light: `thin solid transparent`
+      dark: `2px solid ${zooTheme.colors.teal.mid}`,
+      light: `2px solid transparent`
     })};
     color: ${theme('mode', {
       dark: zooTheme.colors.darkTheme.font,

--- a/app/theme/colors.js
+++ b/app/theme/colors.js
@@ -5,8 +5,14 @@ export default {
       default: '#333333'
     },
     button: {
-      answer: '#5C5C5C',
-      done: { 
+      answer: {
+        default: '#5C5C5C',
+        gradient: {
+          top: '#004954',
+          bottom: '#002C31'
+        }
+      },
+      done: {
         default: '#B8E986',
         hover: '#345446'
       }
@@ -19,7 +25,13 @@ export default {
       default: '#EEF2F5'
     },
     button: {
-      answerDisabled: '#A6A7A9',
+      answer: {
+        disabled: '#A6A7A9',
+        gradient: {
+          top: '#C0E3E5',
+          bottom: '#8BCED2'
+        }
+      },
       done: '#078F52',
       nextHover: '#ea9300'
     },
@@ -54,7 +66,6 @@ export default {
   },
   teal: {
     dark: '#005D69',
-    gradient: 'linear-gradient(#C0E3E5, #8BCED2)',
     light: '#ADDDE0',
     mid: '#00979D'
   }


### PR DESCRIPTION
Staging branch URL: https://classifier-button-styles.pfe-preview.zooniverse.org/dev/classifier

Fixes #4590 and fixes #4600.

This updates the classifier task buttons to have improved contrast for readability, makes the Talk button styles more consistent with the others, adds a gradient to the task buttons in the dark theme. Also fixes the broken hover and focus styles for the tutorial button.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
