### PR TITLE
Edit analytics data from object to string, add discussion log events

### DIFF
--- a/app/talk/board.cjsx
+++ b/app/talk/board.cjsx
@@ -121,7 +121,7 @@ module.exports = createReactClass
         @setState {board}
         @context?.geordi?.logEvent
           type: "talk-view"
-          data: {board: board?.title}
+          data: board?.title
 
   onCreateDiscussion: ->
     @setState newDiscussionOpen: false

--- a/app/talk/board.cjsx
+++ b/app/talk/board.cjsx
@@ -120,7 +120,7 @@ module.exports = createReactClass
       .then (board) =>
         @setState {board}
         @context?.geordi?.logEvent
-          type: "talk-view"
+          type: "view-board"
           data: board?.title
 
   onCreateDiscussion: ->

--- a/app/talk/comment-box.cjsx
+++ b/app/talk/comment-box.cjsx
@@ -47,7 +47,7 @@ module.exports = createReactClass
   logPageClick: (clicked, button) ->
     @context?.geordi?.logEvent
       type: clicked
-      data: {button: button}
+      data: button
 
   componentWillReceiveProps: (nextProps) ->
     if nextProps.reply isnt @props.reply

--- a/app/talk/discussion-new-form.cjsx
+++ b/app/talk/discussion-new-form.cjsx
@@ -78,7 +78,7 @@ module.exports = createReactClass
         titleInput.value = ''
         @context?.geordi?.logEvent
           type: 'add-discussion'
-          data: {discussion: discussion.title}
+          data: discussion.title
         @props.onCreateDiscussion?(discussion)
 
   boardRadio: (board, i) ->

--- a/app/talk/discussion-new-form.cjsx
+++ b/app/talk/discussion-new-form.cjsx
@@ -13,6 +13,9 @@ projectSection = require '../talk/lib/project-section'
 module.exports = createReactClass
   displayName: 'DiscussionNewForm'
 
+  contextTypes:
+    geordi: PropTypes.object
+
   propTypes:
     boardId: PropTypes.number
     onCreateDiscussion: PropTypes.func
@@ -73,6 +76,9 @@ module.exports = createReactClass
       .then (discussion) =>
         @setState loading: false
         titleInput.value = ''
+        @context?.geordi?.logEvent
+          type: 'add-discussion'
+          data: {discussion: discussion.title}
         @props.onCreateDiscussion?(discussion)
 
   boardRadio: (board, i) ->

--- a/app/talk/discussion-preview.cjsx
+++ b/app/talk/discussion-preview.cjsx
@@ -15,15 +15,8 @@ module.exports = createReactClass
   propTypes:
     discussion: PropTypes.object
 
-  contextTypes:
-    geordi: PropTypes.object
-  
   getDefaultProps: ->
     project: {}
-
-  logDiscussionClick: ->
-    @context.geordi?.logEvent
-      type: "view-discussion"
 
   discussionLink: ->
     {discussion} = @props
@@ -49,7 +42,7 @@ module.exports = createReactClass
         {if @props.subject?
           subject = getSubjectLocation(@props.subject)
           <div className="subject-preview">
-            <Link to={@discussionLink()} onClick={@logDiscussionClick.bind null, this}>
+            <Link to={@discussionLink()}>
               <Thumbnail src={subject.src} format={subject.format} width={100} height={150} controls={false} />
             </Link>
           </div>
@@ -57,7 +50,7 @@ module.exports = createReactClass
 
         <h1>
           {<i className="fa fa-thumb-tack talk-sticky-pin"></i> if discussion.sticky}
-          <Link to={@discussionLink()} onClick={@logDiscussionClick.bind null, this}>
+          <Link to={@discussionLink()}>
             {discussion.title}
           </Link>
         </h1>

--- a/app/talk/discussion.cjsx
+++ b/app/talk/discussion.cjsx
@@ -174,7 +174,7 @@ module.exports = createReactClass
         @setState {discussion: discussion[0]}
         @context?.geordi?.logEvent
           type: "talk-view"
-          data: {discussion: discussion?[0]?.title}
+          data: discussion?[0]?.title
 
         talkClient
           .type 'boards'

--- a/app/talk/discussion.cjsx
+++ b/app/talk/discussion.cjsx
@@ -173,7 +173,7 @@ module.exports = createReactClass
       .then (discussion) =>
         @setState {discussion: discussion[0]}
         @context?.geordi?.logEvent
-          type: "talk-view"
+          type: "view-discussion"
           data: discussion?[0]?.title
 
         talkClient

--- a/app/talk/discussion.cjsx
+++ b/app/talk/discussion.cjsx
@@ -29,6 +29,7 @@ module.exports = createReactClass
   displayName: 'TalkDiscussion'
 
   contextTypes:
+    geordi: PropTypes.object
     router: PropTypes.object.isRequired
 
   getInitialState: ->
@@ -171,6 +172,9 @@ module.exports = createReactClass
     @discussionsRequest(discussion)
       .then (discussion) =>
         @setState {discussion: discussion[0]}
+        @context?.geordi?.logEvent
+          type: "talk-view"
+          data: {discussion: discussion?[0]?.title}
 
         talkClient
           .type 'boards'

--- a/app/talk/popular-tags.jsx
+++ b/app/talk/popular-tags.jsx
@@ -69,7 +69,7 @@ export default class PopularTags extends React.Component {
     const logClick = this.context.geordi && this.context.geordi.makeHandler ? this.context.geordi.makeHandler('hashtag-sidebar') : null;
 
     if (this.props.project) {
-      tagType = tag => <ProjectTag key={tag.id} project={this.props.project} tag={tag} onClick={logClick ? logClick.bind(this, tag) : null} />;
+      tagType = tag => <ProjectTag key={tag.id} project={this.props.project} tag={tag} onClick={logClick ? logClick.bind(this, tag.name) : null} />;
     } else {
       tagType = tag => <TalkTag key={tag.id} tag={tag} onClick={logClick ? logClick.bind(this, tag) : null} />;
     }

--- a/app/talk/quick-subject-comment-form.cjsx
+++ b/app/talk/quick-subject-comment-form.cjsx
@@ -109,5 +109,6 @@ module.exports = createReactClass
         placeholder={"Add a note about this subject, or mark with a #hashtag"}
         onSubmitComment={@onSubmitComment}
         subject={@props.subject}
-        submit="Add Your comment"/>
+        submit="Add Your comment"
+        logSubmit={true}/>
     </div>

--- a/app/talk/search-input.cjsx
+++ b/app/talk/search-input.cjsx
@@ -17,7 +17,7 @@ module.exports = createReactClass
   logSearch: (value) ->
     @context?.geordi?.logEvent
       type: 'search'
-      data: {searchTerm: value}
+      data: value
 
   onSearchSubmit: (e) ->
     e.preventDefault()


### PR DESCRIPTION
Staging branch URL: https://add-easy-sw-analytics.pfe-preview.zooniverse.org/

Towards requested Snapshot Wisconsin analytics requests.

- add log for viewing Discussion
- add log for new Discussion title
- add log boolean in TalkQuickSubjectCommentForm's CommentBox component, to enable logging 
- edit SW requested log events data from objects to strings

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [x] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
