### PR TITLE
Fix dev classifier annotation preview

### DIFF
--- a/app/pages/dev-classifier/ClassificationViewer.jsx
+++ b/app/pages/dev-classifier/ClassificationViewer.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import mockData from './mock-data';
 import { ClassifierWrapper } from '../../classifier';
 import tasks from '../../classifier/tasks';
+import ProjectThemeButton from '../project/components/ProjectThemeButton';
 
 export default class ClassificationViewer extends React.Component {
   constructor() {
@@ -67,7 +68,9 @@ export default class ClassificationViewer extends React.Component {
       this.ignoreUnderscoredProperties
 
     return (
-      <div>
+      <div className="classifier--dev__tools">
+        <ProjectThemeButton />
+        <hr />
         <label>
           <input
             type="checkbox"

--- a/app/pages/dev-classifier/index.jsx
+++ b/app/pages/dev-classifier/index.jsx
@@ -8,7 +8,6 @@ import tasks from '../../classifier/tasks';
 import ClassificationViewer from './ClassificationViewer';
 import * as userInterfaceActions from '../../redux/ducks/userInterface';
 import { zooTheme } from '../../theme';
-import ProjectThemeButton from '../project/components/ProjectThemeButton';
 
 export class DevClassifierPage extends React.Component {
   static defaultProps = {
@@ -44,11 +43,7 @@ export class DevClassifierPage extends React.Component {
           classification={this.props.classification}
           onClickNext={this.reload}
         >
-          <div className="classifier--dev__tools">
-            <ProjectThemeButton />
-            <hr />
-            <ClassificationViewer classification={this.props.classification} />
-          </div>
+          <ClassificationViewer classification={this.props.classification} />
         </ClassifierWrapper>
       </div>
     );

--- a/app/pages/dev-classifier/index.jsx
+++ b/app/pages/dev-classifier/index.jsx
@@ -54,10 +54,4 @@ const mapStateToProps = state => ({
   theme: state.userInterface.theme
 });
 
-const mapDispatchToProps = dispatch => ({
-  actions: {
-    theme: bindActionCreators(userInterfaceActions, dispatch)
-  }
-});
-
-export default connect(mapStateToProps, mapDispatchToProps)(DevClassifierPage);
+export default connect(mapStateToProps)(DevClassifierPage);

--- a/css/classify.styl
+++ b/css/classify.styl
@@ -88,7 +88,10 @@
   &--dev
     flex-wrap: wrap;
 
-    .classifier--dev__tools
+    > .subject-viewer
+      flex-basis: 50%;
+
+    > .classifier--dev__tools
       width: 100%
 
   .subject-container


### PR DESCRIPTION
Staging branch URL: https://fix-dev-classifier-annotation-preview.pfe-preview.zooniverse.org/dev/classifier

This fixes the dev classifier layout and the annotation preview that I broke in a previous theme update.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
