### PR TITLE
Add text highlighter to dev classifier

### DIFF
--- a/app/classifier/tasks/highlighter/index.jsx
+++ b/app/classifier/tasks/highlighter/index.jsx
@@ -135,28 +135,26 @@ Highlighter.getTaskText = task => task.instruction;
 Highlighter.getDefaultAnnotation = () => ({ _toolIndex: 0, value: [] });
 
 Highlighter.defaultProps = {
+  onChange: () => null,
+  showRequiredNotice: false,
   task: {
     help: '',
     highlighterLabels: [],
     type: 'highlighter',
     instruction: 'Highlight the text'
+  },
+  workflow: {
+    tasks: []
   }
 };
 
 Highlighter.propTypes = {
   annotation: PropTypes.shape({
     _toolIndex: PropTypes.number,
-    task: PropTypes.shape({
-      help: PropTypes.string,
-      highlighterLabels: PropTypes.array,
-      instruction: PropTypes.string,
-      required: PropTypes.bool,
-      tools: PropTypes.array,
-      type: PropTypes.string
-    }),
-    tools: PropTypes.array
-  }),
+    task: PropTypes.string
+  }).isRequired,
   onChange: PropTypes.func,
+  showRequiredNotice: PropTypes.bool,
   task: PropTypes.shape({
     help: PropTypes.string,
     highlighterLabels: PropTypes.array,
@@ -169,3 +167,4 @@ Highlighter.propTypes = {
     tasks: PropTypes.object
   })
 };
+

--- a/app/classifier/tasks/highlighter/label-renderer.jsx
+++ b/app/classifier/tasks/highlighter/label-renderer.jsx
@@ -54,7 +54,7 @@ export default class LabelRenderer extends React.Component {
     );
     return (
       <div className="label-renderer" >
-        <div >
+        <div className="text-viewer" >
           {labeledContent}
         </div>
         {children}

--- a/app/pages/dev-classifier/mock-data.coffee
+++ b/app/pages/dev-classifier/mock-data.coffee
@@ -528,7 +528,7 @@ subject = apiClient.type('subjects').create
       {'image/jpeg': "#{window.location.origin}/assets/dev-classifier/very-wide.jpeg"} # //lorempixel.com/1900/1000/animals/3
       {'image/jpeg': "#{window.location.origin}/assets/dev-classifier/very-tall.jpeg"} # //lorempixel.com/1000/1900/animals/4
       {'image/jpeg': "#{window.location.origin}/assets/dev-classifier/small.jpeg"} # //lorempixel.com/400/300/animals/4
-      {'text/plain': "#{window.location.origin}/assets/dev-classifier/algernon.txt"}
+      {'text/plain': "https://static.zooniverse.org/preview.zooniverse.org/panoptes-front-end/highlighter-task/assets/dev-classifier/algernon.txt"}
     ]
   else
     [

--- a/app/pages/dev-classifier/mock-data.coffee
+++ b/app/pages/dev-classifier/mock-data.coffee
@@ -74,6 +74,7 @@ workflow = apiClient.type('workflows').create
         {label: 'Survey the image', next: 'survey'}
         {label: 'Maybe select something', next: 'dropdown'}
         {label: 'Slide a slider', next: 'slider'}
+        {label: 'Annotate text', next:'highlight'}
         {label: 'We’re done here.', next: null}
       ]
       unlinkedTask: 'shortcut'
@@ -484,6 +485,20 @@ workflow = apiClient.type('workflows').create
       step: '0.5'
       defaultValue: '3'
 
+    highlight:
+      type: 'highlighter'
+      instruction: 'Highlight words and phrases with the mouse, then select categories.'
+      highlighterLabels: [
+        {
+          label: 'Name',
+          color: '#ff6639'
+        },
+        {
+          label: 'Place',
+          color: '#57c4f7'
+        }
+      ]
+
 # Bulk up the survey task a bit:
 'abcdefghijlkmnopqrstuvwxyz1234'.split('').forEach (x, i) ->
   xi = x + i
@@ -513,6 +528,7 @@ subject = apiClient.type('subjects').create
       {'image/jpeg': "#{window.location.origin}/assets/dev-classifier/very-wide.jpeg"} # //lorempixel.com/1900/1000/animals/3
       {'image/jpeg': "#{window.location.origin}/assets/dev-classifier/very-tall.jpeg"} # //lorempixel.com/1000/1900/animals/4
       {'image/jpeg': "#{window.location.origin}/assets/dev-classifier/small.jpeg"} # //lorempixel.com/400/300/animals/4
+      {'text/plain': "#{window.location.origin}/assets/dev-classifier/algernon.txt"}
     ]
   else
     [

--- a/public/assets/dev-classifier/algernon.txt
+++ b/public/assets/dev-classifier/algernon.txt
@@ -1,0 +1,15 @@
+Progris riport 1 martch 3.
+
+Dr Strauss says I shoud rite down what I think and remembir and evrey thing
+that happins to me from now on. I dont no why but he says its importint so
+they will see if they can use me. I hope they use me becaus Miss Kinnian says
+mabye they can make me smart. I want to be smart. My name is Charlie Gordon
+I werk in Donners bakery where Mr Donner gives me 11 dollers a week and bred
+or cake if I want. I am 32 yeres old and next munth is my brithday. I tolld
+dr Strauss and perfesser Nemur I cant rite good but he says it dont matter he
+says I shud rite just like I talk and like I rite compushishens in Miss Kinnians
+class at the beekmin collidge center for retarted adults where I go to
+lern 3 times a week on my time off. Dr Strauss says to rite a lot evrything
+I think and evrything that happins to me but I cant think anymor because I
+have nothing to rite so I will close for today... yrs truly Charlie
+Gordon.


### PR DESCRIPTION
Add the highlighter task to the dev classifier.
Add a text file to the mock subject locations.

Staging branch URL: https://highlighter-task.pfe-preview.zooniverse.org

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
