### PR TITLE
handle a deactivated workflow being found in user project preferences

### DIFF
--- a/app/pages/project/workflow-selection.jsx
+++ b/app/pages/project/workflow-selection.jsx
@@ -99,16 +99,11 @@ class WorkflowSelection extends React.Component {
       }
     })
     .then((workflow) => {
-      let activeWorkflow;
-      if (activeFilter && workflow && workflow.active) {
-        activeWorkflow = workflow;
-      } else {
-        activeWorkflow = null;
-      }
-
-      if (activeWorkflow) {
-        this.setState({ loadingSelectedWorkflow: false, activeWorkflow });
-        actions.translations.load('workflow', activeWorkflow.id, translations.locale);
+      const allowedActiveWorkflow = activeFilter && workflow && workflow.active
+      const ignoreActiveFilter = !activeFilter && workflow
+      if (allowedActiveWorkflow || ignoreActiveFilter) {
+        this.setState({ loadingSelectedWorkflow: false, workflow });
+        actions.translations.load('workflow', workflow.id, translations.locale);
       } else {
         console.log(`No workflow ${selectedWorkflowID} for project ${this.props.project.id}`);
         if (this.props.project.configuration &&

--- a/app/pages/project/workflow-selection.jsx
+++ b/app/pages/project/workflow-selection.jsx
@@ -13,8 +13,8 @@ class WorkflowSelection extends React.Component {
     };
   }
 
-  workflowsMatch(selectedWorkflowID, testWorkflowID) {
-    return parseInt(selectedWorkflowID) === parseInt(testWorkflowID)
+  idsMatch(selectedID, testID) {
+    return parseInt(selectedID) === parseInt(testID)
   }
 
   componentDidMount() {
@@ -29,7 +29,7 @@ class WorkflowSelection extends React.Component {
     ) {
       const userWorkflowID = parseInt(nextProps.preferences.preferences.selected_workflow);
       if (!nextState.loadingSelectedWorkflow &&
-        !this.workflowsMatch(userWorkflowID, this.state.workflow.id)
+        !this.idsMatch(userWorkflowID, this.state.workflow.id)
       ) {
         this.getSelectedWorkflow(nextProps);
       }
@@ -55,7 +55,7 @@ class WorkflowSelection extends React.Component {
       selectedWorkflowID = this.props.location.query.workflow;
       activeFilter = false;
       if (preferences &&
-        !this.workflowsMatch(preferences.preferences.selected_workflow, selectedWorkflowID)
+        !this.idsMatch(preferences.preferences.selected_workflow, selectedWorkflowID)
       ) {
         this.handlePreferencesChange('preferences.selected_workflow', selectedWorkflowID);
       }
@@ -66,7 +66,7 @@ class WorkflowSelection extends React.Component {
     ) {
       selectedWorkflowID = this.props.location.query.workflow;
       if (preferences &&
-        !this.workflowsMatch(preferences.preferences.selected_workflow, selectedWorkflowID)
+        !this.idsMatch(preferences.preferences.selected_workflow, selectedWorkflowID)
       ) {
         this.handlePreferencesChange('preferences.selected_workflow', selectedWorkflowID);
       }
@@ -107,7 +107,7 @@ class WorkflowSelection extends React.Component {
       } else {
         console.log(`No workflow ${selectedWorkflowID} for project ${this.props.project.id}`);
         if (this.props.project.configuration &&
-          this.workflowsMatch(selectedWorkflowID, this.props.project.configuration.default_workflow)
+          this.idsMatch(selectedWorkflowID, this.props.project.configuration.default_workflow)
         ) {
           // If a project still has an inactive workflow set as a default workflow prior to this being fix in the lab.
           // Don't try again and get caught in a loop
@@ -150,10 +150,10 @@ class WorkflowSelection extends React.Component {
     const selectedWorkflow = preferences.preferences ? preferences.preferences.selected_workflow : undefined;
     const projectSetWorkflow = preferences.settings ? preferences.settings.workflow_id : undefined;
 
-    if (this.workflowsMatch(selectedWorkflowID, selectedWorkflow)) {
+    if (this.idsMatch(selectedWorkflowID, selectedWorkflow)) {
       preferences.update({ 'preferences.selected_workflow': undefined });
       return preferences.save().catch(error => console.warn(error.message));
-    } else if (this.workflowsMatch(selectedWorkflowID, projectSetWorkflow)) {
+    } else if (this.idsMatch(selectedWorkflowID, projectSetWorkflow)) {
       preferences.update({ 'settings.workflow_id': undefined });
       return preferences.save().catch(error => console.warn(error.message));
     } else {

--- a/app/pages/project/workflow-selection.jsx
+++ b/app/pages/project/workflow-selection.jsx
@@ -86,16 +86,9 @@ class WorkflowSelection extends React.Component {
 
   getWorkflow(selectedWorkflowID, activeFilter = true) {
     const { actions, translations } = this.props;
-    const query = {
-      id: `${selectedWorkflowID}`,
-      project_id: this.props.project.id
-    };
-    if (activeFilter) {
-      query.active = true;
-    }
     apiClient
     .type('workflows')
-    .get(query)
+    .get(`${selectedWorkflowID}`)
     .catch((error) => {
       if (error.status === 404) {
         this.clearInactiveWorkflow(selectedWorkflowID)
@@ -105,10 +98,17 @@ class WorkflowSelection extends React.Component {
         this.setState({ error, loadingSelectedWorkflow: false });
       }
     })
-    .then(([workflow]) => {
-      if (workflow) {
-        this.setState({ loadingSelectedWorkflow: false, workflow });
-        actions.translations.load('workflow', workflow.id, translations.locale);
+    .then((workflow) => {
+      let activeWorkflow;
+      if (activeFilter && workflow && workflow.active) {
+        activeWorkflow = workflow;
+      } else {
+        activeWorkflow = null;
+      }
+
+      if (activeWorkflow) {
+        this.setState({ loadingSelectedWorkflow: false, activeWorkflow });
+        actions.translations.load('workflow', activeWorkflow.id, translations.locale);
       } else {
         console.log(`No workflow ${selectedWorkflowID} for project ${this.props.project.id}`);
         if (this.props.project.configuration &&

--- a/app/pages/project/workflow-selection.jsx
+++ b/app/pages/project/workflow-selection.jsx
@@ -13,6 +13,10 @@ class WorkflowSelection extends React.Component {
     };
   }
 
+  workflowsMatch(selectedWorkflowID, testWorkflowID) {
+    return parseInt(selectedWorkflowID) === parseInt(testWorkflowID)
+  }
+
   componentDidMount() {
     this.getSelectedWorkflow(this.props);
   }
@@ -25,7 +29,7 @@ class WorkflowSelection extends React.Component {
     ) {
       const userWorkflowID = parseInt(nextProps.preferences.preferences.selected_workflow);
       if (!nextState.loadingSelectedWorkflow &&
-        userWorkflowID !== parseInt(this.state.workflow.id)
+        !this.workflowsMatch(userWorkflowID, this.state.workflow.id)
       ) {
         this.getSelectedWorkflow(nextProps);
       }
@@ -48,9 +52,11 @@ class WorkflowSelection extends React.Component {
       this.props.location.query.workflow &&
       this.checkUserRoles(project, user)
     ) {
-      selectedWorkflowID = parseInt(this.props.location.query.workflow);
+      selectedWorkflowID = this.props.location.query.workflow;
       activeFilter = false;
-      if (preferences && preferences.preferences.selected_workflow !== selectedWorkflowID) {
+      if (preferences &&
+        !this.workflowsMatch(preferences.preferences.selected_workflow, selectedWorkflowID)
+      ) {
         this.handlePreferencesChange('preferences.selected_workflow', selectedWorkflowID);
       }
     } else if (this.props.location.query &&
@@ -58,8 +64,10 @@ class WorkflowSelection extends React.Component {
       project.experimental_tools &&
       project.experimental_tools.indexOf('allow workflow query') > -1
     ) {
-      selectedWorkflowID = parseInt(this.props.location.query.workflow);
-      if (preferences && preferences.preferences.selected_workflow !== selectedWorkflowID) {
+      selectedWorkflowID = this.props.location.query.workflow;
+      if (preferences &&
+        !this.workflowsMatch(preferences.preferences.selected_workflow, selectedWorkflowID)
+      ) {
         this.handlePreferencesChange('preferences.selected_workflow', selectedWorkflowID);
       }
     } else if (preferences && preferences.preferences.selected_workflow) {
@@ -104,7 +112,7 @@ class WorkflowSelection extends React.Component {
       } else {
         console.log(`No workflow ${selectedWorkflowID} for project ${this.props.project.id}`);
         if (this.props.project.configuration &&
-          selectedWorkflowID === this.props.project.configuration.default_workflow
+          this.workflowsMatch(selectedWorkflowID, this.props.project.configuration.default_workflow)
         ) {
           // If a project still has an inactive workflow set as a default workflow prior to this being fix in the lab.
           // Don't try again and get caught in a loop
@@ -147,10 +155,10 @@ class WorkflowSelection extends React.Component {
     const selectedWorkflow = preferences.preferences ? preferences.preferences.selected_workflow : undefined;
     const projectSetWorkflow = preferences.settings ? preferences.settings.workflow_id : undefined;
 
-    if (selectedWorkflowID === selectedWorkflow) {
+    if (this.workflowsMatch(selectedWorkflowID, selectedWorkflow)) {
       preferences.update({ 'preferences.selected_workflow': undefined });
       return preferences.save().catch(error => console.warn(error.message));
-    } else if (selectedWorkflowID === projectSetWorkflow) {
+    } else if (this.workflowsMatch(selectedWorkflowID, projectSetWorkflow)) {
       preferences.update({ 'settings.workflow_id': undefined });
       return preferences.save().catch(error => console.warn(error.message));
     } else {

--- a/app/pages/project/workflow-selection.jsx
+++ b/app/pages/project/workflow-selection.jsx
@@ -99,9 +99,12 @@ class WorkflowSelection extends React.Component {
       }
     })
     .then((workflow) => {
+      const workflowMatchesProjectID = this.idsMatch(workflow.links.project, this.props.project.id)
       const allowedActiveWorkflow = activeFilter && workflow && workflow.active
       const ignoreActiveFilter = !activeFilter && workflow
-      if (allowedActiveWorkflow || ignoreActiveFilter) {
+      const loadableWorkflow = allowedActiveWorkflow || ignoreActiveFilter
+
+      if (workflowMatchesProjectID && loadableWorkflow) {
         this.setState({ loadingSelectedWorkflow: false, workflow });
         actions.translations.load('workflow', workflow.id, translations.locale);
       } else {


### PR DESCRIPTION
Updates to the workflow selection code to avoid continuous looping and data requests on the API,  specifically:
 + When attempting to select a workflow ensure we test the IDs using the same type by using a function.
 + Instead of using a search query to find the workflow resource, get the resource via the ID and manually test the active state on the returned resource if it exists.

Staging branch URL: https://get-workflow-resource-not-search.pfe-preview.zooniverse.org/

##### Steps to reproduce:
+ visit https://www.zooniverse.org/projects/tkotwim/the-american-soldier
+ update your user project preferences to have an inactive selected_workflow
```
const upp = zooAPI.type('project_preferences').get({ user_id: '1', project_id: '5551'})
upp.update({ 'preferences.selected_workflow': '6627' }).save();
```
+ reload the project page to see the workflow query loop https://www.zooniverse.org/projects/tkotwim/the-american-soldier

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
