### PR TITLE
Re-add recent projects to non-logged in home page

### DIFF
--- a/app/lib/get-social-data.js
+++ b/app/lib/get-social-data.js
@@ -20,7 +20,7 @@ function getBlogPosts(returnPosts) {
 }
 
 function getRecentProjects() {
-  const query = { launch_approved: true, page_size: 3, sort: '-updated_at' };
+  const query = { launch_approved: true, page_size: 3, sort: '-updated_at', cards: true };
   return apiClient.type('projects').get(query)
   .then(recentProjects => recentProjects);
 }

--- a/app/pages/home-common/social.jsx
+++ b/app/pages/home-common/social.jsx
@@ -40,6 +40,9 @@ export default class HomePageSocial extends React.Component {
         newestProject
       });
     });
+    getRecentProjects().then((recentProjects) => {
+      this.setState({ recentProjects });
+    });
     getBlogPosts((blogPosts) => {
       this.setState({ blogPosts });
     });
@@ -119,6 +122,10 @@ export default class HomePageSocial extends React.Component {
               project={newestProject}
             />
             <hr />
+
+            <Translate className="tertiary-kicker" component="h3" content="socialHomePage.recentProjects" />
+
+            {recentProjects.map(project => this.renderUpdatedProject(project))}
 
             <Translate className="tertiary-kicker" component="h3" content="socialHomePage.recentPublications" />
             <span className="timestamp-label">{newestPublication.date}</span>


### PR DESCRIPTION
Staging branch URL: https://readd-non-logged-in-recent-project.pfe-preview.zooniverse.org/

Reinstates recent projects to non-logged in home page, this time with just the cards api data instead of the full resource response (no workflow links, etc).

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
