### PR TITLE
Add RTL language display to projects

### DIFF
--- a/app/classifier/components/TaskNavButtons/components/BackButton/BackButton.jsx
+++ b/app/classifier/components/TaskNavButtons/components/BackButton/BackButton.jsx
@@ -78,7 +78,7 @@ export const StyledBackButtonToolTip = styled.span`
   width: ${(checkIfMSBrowser()) ? '400%' : 'max-content'};
   width: -moz-max-content;
 
-  [lang=he] &, [lang=ar] & {
+  .rtl & {
     left: auto;
     right: 0;
   }
@@ -93,7 +93,7 @@ export class BackButton extends React.Component {
     };
 
     this.showWarning = this.showWarning.bind(this);
-    this.hideWarning = this.hideWarning.bind(this);    
+    this.hideWarning = this.hideWarning.bind(this);
   }
 
   showWarning() {

--- a/app/classifier/components/TaskNavButtons/components/BackButton/BackButton.jsx
+++ b/app/classifier/components/TaskNavButtons/components/BackButton/BackButton.jsx
@@ -77,6 +77,11 @@ export const StyledBackButtonToolTip = styled.span`
   position: absolute;
   width: ${(checkIfMSBrowser()) ? '400%' : 'max-content'};
   width: -moz-max-content;
+
+  [lang=he] &, [lang=ar] & {
+    left: auto;
+    right: 0;
+  }
 `;
 
 export class BackButton extends React.Component {

--- a/app/classifier/tasks/components/TaskInputField/TaskInputField.jsx
+++ b/app/classifier/tasks/components/TaskInputField/TaskInputField.jsx
@@ -29,7 +29,6 @@ export const StyledTaskInputField = styled.label`
   margin: ${pxToRem(10)} 0;
   padding: ${(props) => { return doesTheLabelHaveAnImage(props.label) ? '0' : '1ch 2ch'; }};
   position: relative;
-  text-align: left;
 
   &:hover, &:focus, &[data-focus=true] {
     background: ${theme('mode', {

--- a/app/classifier/tasks/drawing/components/DrawingToolInputIcon/DrawingToolInputIcon.jsx
+++ b/app/classifier/tasks/drawing/components/DrawingToolInputIcon/DrawingToolInputIcon.jsx
@@ -6,7 +6,12 @@ import icons from '../../icons';
 
 export const StyledDrawingToolInputIcon = styled.span`
   color: ${props => props.color};
-  margin-right: 1ch;
+
+  &::after {
+    content: " ";
+    margin-right: 1ch;
+    white-space: pre;
+  }
 
   > svg {
     fill-opacity: 0.1;

--- a/app/classifier/tasks/generic.jsx
+++ b/app/classifier/tasks/generic.jsx
@@ -1,10 +1,12 @@
 import { Markdown } from 'markdownz';
 import PropTypes from 'prop-types';
 import React from 'react';
+import { connect } from 'react-redux';
+import classNames from 'classnames';
 import alert from '../../lib/alert';
 import TaskHelpButton from './components/TaskHelpButton';
 
-export default class GenericTask extends React.Component {
+class GenericTask extends React.Component {
   constructor(props) {
     super(props);
     this.container = null;
@@ -28,10 +30,18 @@ export default class GenericTask extends React.Component {
   }
 
   showHelp() {
+    const { translations } = this.props;
+    const className = classNames({
+      'content-container': true,
+      rtl: translations.rtl
+    });
     alert(
       (resolve, reject) =>
         (
-          <div className="content-container">
+          <div
+            className={className}
+            lang={translations.locale}
+          >
             <Markdown className="classification-task-help">
               {this.props.help}
             </Markdown>
@@ -84,7 +94,11 @@ GenericTask.propTypes = {
     PropTypes.bool
   ]),
   answers: PropTypes.arrayOf(PropTypes.node),
-  showRequiredNotice: PropTypes.bool
+  showRequiredNotice: PropTypes.bool,
+  translations: PropTypes.shape({
+    locale: PropTypes.string,
+    rtl: PropTypes.bool
+  })
 };
 
 GenericTask.defaultProps = {
@@ -94,5 +108,16 @@ GenericTask.defaultProps = {
   help: '',
   required: false,
   answers: [],
-  showRequiredNotice: false
+  showRequiredNotice: false,
+  translations: {
+    locale: 'en',
+    rtl: false
+  }
 };
+
+const mapStateToProps = state => ({
+  translations: state.translations
+});
+
+export default connect(mapStateToProps)(GenericTask);
+export { GenericTask };

--- a/app/classifier/tasks/generic.spec.js
+++ b/app/classifier/tasks/generic.spec.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import assert from 'assert';
 import { mount } from 'enzyme';
-import GenericTask from './generic';
+import { GenericTask } from './generic';
 import { mockReduxStore } from './testHelpers';
 
 const task = {

--- a/app/classifier/tasks/slider/slider.spec.js
+++ b/app/classifier/tasks/slider/slider.spec.js
@@ -5,6 +5,7 @@ import sinon from 'sinon';
 import React from 'react';
 import assert from 'assert';
 import SliderTask from './index';
+import { mockReduxStore } from '../testHelpers';
 
 const task = {
   instruction: 'A slider',
@@ -22,7 +23,7 @@ describe('SliderTask', function () {
   beforeEach(function () {
     onChangeSpy = sinon.spy();
 
-    wrapper = mount(<SliderTask task={task} onChange={onChangeSpy} />);
+    wrapper = mount(<SliderTask task={task} onChange={onChangeSpy} />, mockReduxStore);
   });
 
   it('should render without crashing', function () {
@@ -158,7 +159,7 @@ describe('SliderSummary', function () {
   let summary;
 
   beforeEach(function () {
-    summary = mount(<SliderTask.Summary task={task} annotation={{ value: '0.7' }} />);
+    summary = mount(<SliderTask.Summary task={task} annotation={{ value: '0.7' }} />, mockReduxStore);
   });
 
   it('should render without crashing', function () {
@@ -175,7 +176,7 @@ describe('SliderSummary', function () {
   });
 
   it('should have the correct answer label when the value is falsy (i.e. 0)', function () {
-    summary = mount(<SliderTask.Summary task={task} annotation={{ value: '0' }} />);
+    summary = mount(<SliderTask.Summary task={task} annotation={{ value: '0' }} />, mockReduxStore);
     const answers = summary.find('.answer');
     assert.notEqual(answers.text(), 'No answer');
   });

--- a/app/classifier/translations.jsx
+++ b/app/classifier/translations.jsx
@@ -5,10 +5,11 @@ import { connect } from 'react-redux';
 
 function Translations(props) {
   const { original, translations, type } = props;
+  const { locale, rtl } = translations;
   const languageStrings = translations.strings[type];
   const translation = merge({}, original, languageStrings);
 
-  return React.cloneElement(props.children, { translation });
+  return React.cloneElement(props.children, { locale, rtl, translation });
 }
 
 Translations.propTypes = {

--- a/app/classifier/tutorial.jsx
+++ b/app/classifier/tutorial.jsx
@@ -7,6 +7,7 @@ import Translate from 'react-translate-component';
 import { Markdown } from 'markdownz';
 import { Provider } from 'react-redux';
 import animatedScrollTo from 'animated-scrollto';
+import classnames from 'classnames';
 import MediaCard from '../components/media-card';
 
 import Translations from './translations';
@@ -221,13 +222,22 @@ export default class Tutorial extends React.Component {
     if (isIE) {
       tutorialStyle = { height: '85vh' };
     }
+    const className = classnames({
+      'tutorial-steps': true,
+      rtl: this.props.rtl
+    })
     const totalSteps = this.props.tutorial.steps.length;
     const allSteps = Array.from(Array(totalSteps).keys());
     const currentStep = this.props.tutorial.steps[this.state.stepIndex];
     const mediaCardSrc = this.props.media[currentStep.media] ? this.props.media[currentStep.media].src : '';
 
     return (
-      <div ref={(component) => { this.div = component; }} className="tutorial-steps" style={tutorialStyle}>
+      <div
+        ref={(component) => { this.div = component; }}
+        className={className}
+        lang={this.props.locale}
+        style={tutorialStyle}
+      >
         <MediaCard className="tutorial-step" src={mediaCardSrc}>
           <Markdown>{this.props.translation.steps[this.state.stepIndex].content}</Markdown>
           <hr />          

--- a/app/locales/ar.js
+++ b/app/locales/ar.js
@@ -1,0 +1,598 @@
+export default {
+  loading: '(Loading)',
+  classifier: {
+    back: 'Back',
+    backButtonWarning: 'Going back will clear your work for the current task.',
+    close: 'Close',
+    continue: 'Continue',
+    done: 'Done',
+    doneAndTalk: 'Done & Talk',
+    dontShowMinicourse: 'Do not show mini-course in the future',
+    letsGo: 'Let’s go!',
+    next: 'Next',
+    optOut: 'Opt out',
+    taskTabs: {
+      taskTab: 'Task',
+      tutorialTab: 'Tutorial'
+    },
+    recents: 'Your recent classifications',
+    talk: 'Talk',
+    taskHelpButton: 'Need some help with this task?',
+    miniCourseButton: 'Restart the project mini-course',
+    workflowAssignmentDialog: {
+      promotionMessage: "Congratulations! You've unlocked the next workflow. If you prefer to stay on this workflow, you can choose to stay.",
+      acceptButton: 'Try the new workflow',
+      declineButton: 'No, thanks'
+    }
+  },
+  project: {
+    loading: 'Loading project',
+    disclaimer: 'This project has been built using the Zooniverse Project Builder but is not yet an official Zooniverse project. Queries and issues relating to this project directed at the Zooniverse Team may not receive any response.',
+    about: {
+      header: 'About',
+      nav: {
+        research: 'Research',
+        results: 'Results',
+        faq: 'FAQ',
+        education: 'Education',
+        team: 'The Team',
+      }
+    },
+    nav: {
+      about: 'About',
+      adminPage: 'Admin page',
+      classify: 'Classify',
+      collections: 'Collect',
+      exploreProject: 'Explore Project',
+      lab: 'Lab',
+      recents: 'Recents',
+      talk: 'Talk',
+      underReview: 'Under Review',
+      zooniverseApproved: 'Zooniverse Approved'
+    },
+    classifyPage: {
+      dark: 'dark',
+      light: 'light',
+      title: 'Classify',
+      themeToggle: 'Switch to %(theme)s theme'
+    },
+    home: {
+      organization: 'Organization',
+      researcher: 'Words from the researcher',
+      about: 'About %(title)s',
+      metadata: {
+        statistics: '%(title)s Statistics',
+        classifications: 'Classifications',
+        volunteers: 'Volunteers',
+        completedSubjects: 'Completed Subjects',
+        subjects: 'Subjects'
+      },
+      talk: {
+        zero: 'No one is talking about <strong>%(title)s</strong> right now.',
+        one: '<strong>1</strong> person is talking about <strong>%(title)s</strong> right now.',
+        other: '<strong>%(count)s</strong> people are talking about <strong>%(title)s</strong> right now.'
+      },
+      joinIn: 'Join in',
+      learnMore: 'Learn more',
+      getStarted: 'Get started',
+      workflowAssignment: 'You\'ve unlocked level %(workflowDisplayName)s',
+      visitLink: 'Visit the project',
+      links: 'External Project Links'
+    }
+  },
+  organization: {
+    error: 'There was an error retrieving organization',
+    home: {
+      introduction: 'Introduction',
+      links: 'Links',
+      metadata: {
+        projects: 'Projects'
+      },
+      projects: {
+        error: 'There was an error loading organization projects.',
+        loading: 'Loading organization projects...',
+        none: 'There are no projects associated with this organization.'
+      },
+      readLess: 'Read Less',
+      readMore: 'Read More',
+      researcher: 'Words from a researcher',
+      viewToggle: 'View As Volunteer'
+    },
+    loading: 'Loading organization',
+    notFound: 'organization not found.',
+    notPermission: 'If you\'re sure the URL is correct, you might not have permission to view this organization.',
+    pleaseWait: 'Please wait...'
+  },
+  tasks: {
+    less: 'Less',
+    more: 'More',
+    shortcut: {
+      noAnswer: 'No answer'
+    },
+    survey: {
+      clear: 'Clear',
+      clearFilters: 'Clear filters',
+      makeSelection: 'Make a selection',
+      showing: 'Showing %(count)s of %(max)s',
+      confused: 'Often confused with',
+      dismiss: 'Dismiss',
+      itsThis: 'I think it’s this',
+      cancel: 'Cancel',
+      identify: 'Identify',
+      surveyOf: 'Survey of %(count)s',
+      identifications: {
+        zero: 'No identifications',
+        one: '1 identification',
+        other: '%(count)s identifications'
+      }
+    }
+  },
+  privacy: {
+    title: 'Zooniverse User Agreement and Privacy Policy',
+    userAgreement: {
+      summary: '## User Agreement\n**Summary**\n\nThe Zooniverse is a suite of citizen science projects operated by the Citizen Science Alliance (CSA), which support scientific research by involving members of the public - you - in the processes of analyzing and discussing data. Data from these projects is used to study online community design and theory, interface design, and other topics. This document describes what will happen to your contributions if you choose to contribute and what data we collect, how we use it and how we protect it.',
+      contribution: '**What you agree to if you contribute to the Zooniverse**\n\nProjects involving the public are needed to enable researchers to cope with the otherwise unmanageable flood of data. The web provides a means of reaching a large audience willing to devote their free time to projects that can add to our knowledge of the world and the Universe.\n\nThe major goal for this project is for the analyzed data to be available to the researchers for use, modification and redistribution in order to further scientific research. Therefore, if you contribute to the Zooniverse, you grant the CSA and its collaborators, permission to use your contributions however we like to further this goal, trusting us to do the right thing with your data. However, you give us this permission non-exclusively, meaning that you yourself still own your contribution.\n\nWe ask you to grant us these broad permissions, because they allow us to change the legal details by which we keep the data available; this is important because the legal environment can change and we need to be able to respond without obtaining permission from every single contributor.\n\nFinally, you must not contribute data to the Zooniverse that you do not own. For example, do not copy information from published journal articles. If people do this, it can cause major legal headaches for us.',
+      data: '**What you may do with Zooniverse data**\n\nYou retain ownership of any contribution you make to the Zooniverse, and any recorded interaction with the dataset associated with the Zooniverse. You may use, distribute or modify your individual contribution in any way you like. However, you do not possess ownership of the dataset itself. This license does not apply to data about you, covered in the Privacy Policy.',
+      legal: '**Legal details**\n\nBy submitting your contribution to the Zooniverse, you agree to grant the CSA a perpetual, royalty-free, non-exclusive, sub-licensable license to: use, reproduce, modify, adapt, publish, translate, create derivative works from, distribute, and exercise all copyright and publicity rights with respect to your contribution worldwide and/or to incorporate your contribution in other works in any media now known or later developed for the full term of any rights that may exist in your contribution.\n\nIf you do not want to grant to the CSA the rights set out above, you cannot interact with the Zooniverse.\n\nBy interacting with the Zooniverse, you:\n\n* Warrant that your contribution contains only data that you have the right to make available to the CSA for all the purposes specified above, is not defamatory, and does not infringe any law; and\n\n* Indemnify the CSA against all legal fees, damages and other expenses that may be incurred by the CSA as a result of your breach of the above warranty; and\n\n* Waive any moral rights in your contribution for the purposes specified above.\n\nThis license does not apply to data about you, covered in the Privacy Policy.'
+    },
+    privacyPolicy: {
+      intro: '## Privacy Policy\n\nIn addition to the contributions you make towards the scientific goals of the Zooniverse, we collect additional data about you to support and improve the operation of the project. We also conduct experiments on the design of the website that we evaluate based on your reactions and behavior. This Privacy Policy describes what data we collect, how we use it and how we protect it.\n\nWe respect the privacy of every individual who participates in the Zooniverse. We operate in accordance with the United Kingdom Data Protection Act 1998 and the Freedom of Information Act 2000, as well as with United States regulations regarding protection of human subjects in research.',
+      data: '**Data we collect**\n\n_Identifying information_: If you register with the Zooniverse, we ask you to create a username and supply your e-mail address. Your e-mail address is not visible to other users, but others will see your username in various contexts. Notably, your username is associated with any classifications or other contributions you make, e.g., on Talk pages. You may optionally provide your real name to be included when we publically thank participants, e.g., in presentations, publications or discoveries.\n\n_Usage information_: We also monitor how people use our website, and aggregate general statistics about users and traffic patterns as well as data about how users respond to various site features. This includes, among other things, recording:\n\n* When you log in.\n\n* Pages you request.\n\n* Classifications you make.\n\n* Other contributions, such as posts on Talk pages.\n\nIf you register and log in, the logs associate these activities with your username. Otherwise, they are associated with your IP address. In order to collect this data, we may use software that collects statistics from IP data. This software can determine what times of day people access our site, which country they access the websites from, how long they visit for, what browser they are using, etc.',
+      info: '**What we do with the information we gather**\n\nUsage information is collected to help us improve our website in particular for the following reasons:\n\n* Internal record keeping.\n\n* We may periodically send email promoting new research-related projects or other information relating to our research. Information about these contacts is given below. We will not use your contact information for commercial purposes.\n\n* We may use the information to customize the website.\n\n* We may use the information to conduct experiments regarding the use of various site features.',
+      thirdParties: '**What is shared with third parties**\n\nWe will never release e-mail addresses to third parties without your express permission. We will also never share data we collect about you unless (a) it cannot be associated with you or your username, and (b) it is necessary to accomplish our research goals. Specifically, we may share your anonymized data with research study participants, other researchers, or in scholarly work describing our research. For example, we might use one of your classifications as an illustration in a paper, show some of your classifications to another user to see if they agree or disagree, or publish statistics about user interaction.\n\nContributions you make to the Talk pages are widely available to others. Aside from the above, information is held as confidentially as is practical within our secured database.',
+      cookies: '**How we use cookies**\n\nIn some areas of our site, a cookie may be placed on your computer. A cookie is a small file that resides on your computer\'s hard drive that allows us to improve the quality of your visit to our websites by responding to you as an individual.\n\nWe use traffic log cookies to identify which pages are being used and improve our website. We only use this information for statistical analysis purposes, they are not shared with other sites and are not used for advertisements.\n\nYou can choose to accept or decline cookies. Most web browsers automatically accept cookies, but you can usually modify your browser setting to decline cookies if you prefer. However, if you choose to decline cookies from the Zooniverse then functionality, including your ability to log-in and participate, will be impaired.\n\nAcceptance of cookies is implied if you continue to access our website without adjusting your browser settings.',
+      dataStorage: '**Where we store your data**\n\nWe use Amazon Web Services so we can quickly and reliably serve our website to an unpredictable number of people. This means that your data will be stored in multiple locations, including the United States of America (USA). Amazon is a participant in the Safe Harbor program developed by the USA Department of Commerce and the European Union (EU). Amazon has certified that it adheres to the Safe Harbor Privacy Principles agreed upon by the USA and the EU.\n\nOur mailing list server, which contains a copy of subscribed email addresses and no other personal data, is hosted on a virtual private server with Linode in the UK.',
+      security: '**Security measures**\n\nMembers of the research teams are made aware of our privacy policy and practices by reviewing this statement upon joining the team. We follow industry best practices to secure user data, and access to the database and logs are limited to members of the research group and system administrative staff.',
+      dataRemoval: '**Removing your data**\n\nDue to the way in which we archive data, it is generally not possible to completely remove your personal data from our systems. However, if you have specific concerns, please contact us and we will see what we can do.',
+      contactUser: '**When we will contact you**\n\nIf you do not register, we will never contact you. If you do register, we will contact you by e-mail in the following circumstances:\n\n* Occasionally, we will send e-mail messages to you highlighting a particular aspect of our research, announcing new features, explaining changes to the system, or inviting you to special events.\n\n* We may also use your information to contact you for the purpose of research into our site\'s operation. We may contact you by email. We may ask for additional information at that time. Providing additional information is entirely optional and will in no way affect your service in the site.\n\n* We may contact you with a newsletter about the progress of the project.\n\nYou are unlikely to receive more than two messages per month.\n\nYou can \'opt out\' of the newsletter at any time by visiting the Zooniverse [unsubscribe](https://www.zooniverse.org/unsubscribe) page.',
+      furtherInfo: '**Further information and requests**\n\nThe Data Controller is the Department of Physics, University of Oxford. For a copy of the information we hold on you please contact the project team at the address below:\n\nProfessor Chris Lintott\nOxford Astrophysics\nDenys Wilkinson Building\nKeble Road\nOxford, OX1 3RH\nUnited Kingdom'
+    }
+  },
+  security: {
+    title: 'Zooniverse Security',
+    intro: 'The Zooniverse takes very seriously the security of our websites and systems, and protecting our users and their personal information is our highest priority. We take every precaution to ensure that the information you give us stays secure, but it is also important that you take steps to secure your own account, including:\n\n* Do not use the same password on different websites. The password you use for your Zooniverse account should be unique to us.\n* Never give your password to anyone. We will never ask you to send us your password, and you should never enter your Zooniverse password into any website other than ours. Always check your browser\'s address bar to make sure you have a secure connection to _www.zooniverse.org_.\n\nFor general advice and information about staying safe online, please visit:\n\n* [Get Safe Online](https://www.getsafeonline.org)\n* [Stay Safe Online](https://www.staysafeonline.org)\n* [US-CERT - Tips](https://www.us-cert.gov/ncas/tips)',
+    details: '## Reporting Security Issues\n\nThe Zooniverse supports [responsible disclosure](https://en.wikipedia.org/wiki/Responsible_disclosure) of vulnerabilities. If you believe you have discovered a security vulnerability in any Zooniverse software, we ask that this first be reported to [security@zooniverse.org](mailto:security@zooniverse.org) to allow time for vulnerabilities to be fixed before details are published.\n\n## Known Vulnerabilities and Incidents\n\nWe believe it is important to be completely transparent about security issues. A complete list of fixed vulnerabilities and past security incidents is given below:\n\n* _(No entries at this time)_\n\nNew vulnerabilities and incidents will be announced via the [Zooniverse blog in the "technical" category](http://blog.zooniverse.org/category/technical/).'
+  },
+  userAdminPage: {
+    header: 'Admin',
+    nav: {
+      createAdmin: 'Manage Users',
+      projectStatus: 'Set Project Status',
+      grantbot: 'Grantbot',
+      organizationStatus: 'Set Organization Status'
+    },
+    notAdminMessage: 'You are not an administrator',
+    notSignedInMessage: 'You are not signed in'
+  },
+  signIn: {
+    title: 'Sign in/register',
+    withZooniverse: 'Sign in with your Zooniverse account',
+    whyHaveAccount: 'Signed-in volunteers can keep track of their work and will be credited in any resulting publications.',
+    signIn: 'Sign in',
+    register: 'Register',
+    orThirdParty: 'Or sign in with another service',
+    withFacebook: 'Sign in with Facebook',
+    withGoogle: 'Sign in with Google'
+  },
+  notFoundPage: {
+    message: 'Not found'
+  },
+  resetPassword: {
+    heading: 'Reset Password',
+    newPasswordFormDialog: 'Enter the same password twice so you can get back to doing some research. Passwords need to be at least 8 characters long.',
+    newPasswordFormLabel: 'New password:',
+    newPasswordConfirmationLabel: 'Repeat your password to confirm:',
+    enterEmailLabel: 'Please enter your email address here and we’ll send you a link you can follow to reset it.',
+    emailSuccess: 'We’ve just sent you an email with a link to reset your password.',
+    emailError: 'There was an error resetting your password.',
+    passwordsDoNotMatch: 'The passwords do not match, please try again.',
+    loggedInDialog: 'You are currently logged in. Please log out if you would like to reset your password.',
+    missingEmailsSpamNote: 'Please check your spam folder if you have not received the reset email.',
+    missingEmailsAlternateNote: 'If you have still not received an email, please try any other email address you may have signed up with.'
+  },
+  workflowToggle: {
+    label: 'Active'
+  },
+  collections: {
+    createForm: {
+      private: 'Private',
+      submit: 'Add Collection'
+    }
+  },
+  emailSettings: {
+    email: 'Email address',
+    general: {
+      section: 'Zooniverse email preferences',
+      updates: 'Get general Zooniverse email updates',
+      classify: 'Get email updates when you first classify on a project',
+      note: 'Note: Unticking the box will not unsubscribe you from any of the projects',
+      manual: 'Manage projects individually',
+      beta: 'Get beta project email updates and become a beta tester'
+    },
+    talk: {
+      section: 'Talk email preferences',
+      header: 'Send me an email',
+      frequency: {
+        immediate: 'Immediately',
+        day: 'Daily',
+        week: 'Weekly',
+        never: 'Never'
+      },
+      options: {
+        participating_discussions: 'When discussions I\'m participating in are updated',
+        followed_discussions: 'When discussions I\'m following are updated',
+        mentions: 'When I\'m mentioned',
+        group_mentions: 'When I\'m mentioned by group (@admins, @team, etc.)',
+        messages: 'When I receive a private message',
+        started_discussions: 'When a discussion is started in a board I\'m following'
+      }
+    },
+    project: {
+      section: 'Project email preferences',
+      header: 'Project',
+    }
+  },
+  about: {
+    index: {
+      header: 'About',
+      title: 'About',
+      nav: {
+        about: 'About',
+        publications: 'Publications',
+        ourTeam: 'Our Team',
+        acknowledgements: 'Acknowledgements',
+        contact: 'Contact Us',
+        faq: 'FAQ',
+        resources: 'Resources'
+      }
+    },
+    home: {
+      title: '## What is the Zooniverse?',
+      whatIsZooniverse: 'The Zooniverse is the world’s largest and most popular platform for people-powered research. This research is made possible by volunteers — hundreds of thousands of people around the world who come together to assist professional researchers. Our goal is to enable research that would not be possible, or practical, otherwise. Zooniverse research results in new discoveries, datasets useful to the wider research community, and [many publications](/about/publications).',
+      anyoneCanResearch: '### At the Zooniverse, anyone can be a researcher\n\nYou don’t need any specialised background, training, or expertise to participate in any Zooniverse projects. We make it easy for anyone to contribute to real academic research, on their own computer, at their own convenience.\n\nYou’ll be able to study authentic objects of interest gathered by researchers, like images of faraway galaxies, historical records and diaries, or videos of animals in their natural habitats. By answering simple questions about them, you’ll help contribute to our understanding of our world, our history, our Universe, and more.\n\nWith our wide-ranging and ever-expanding suite of projects, covering many disciplines and topics across the sciences and humanities, there\'s a place for anyone and everyone to explore, learn and have fun in the Zooniverse. To volunteer with us, just go to the [Projects](/projects) page, choose one you like the look of, and get started.',
+      accelerateResearch: '### We accelerate important research by working together\n\nThe major challenge of 21st century research is dealing with the flood of information we can now collect about the world around us. Computers can help, but in many fields the human ability for pattern recognition — and our ability to be surprised — makes us superior. With the help of Zooniverse volunteers, researchers can analyze their information more quickly and accurately than would otherwise be possible, saving time and resources, advancing the ability of computers to do the same tasks, and leading to faster progress and understanding of the world, getting to exciting results more quickly.\n\nOur projects combine contributions from many individual volunteers, relying on a version of the ‘wisdom of crowds’ to produce reliable and accurate data. By having many people look at the data we often can also estimate how likely we are to make an error. The product of a Zooniverse projects is often exactly what’s needed to make progress in many fields of research.',
+      discoveries: '### Volunteers and professionals make real discoveries together\n\nZooniverse projects are constructed with the aim of converting volunteers\' efforts into measurable results. These projects have produced a large number of [published research papers](/about/publications), as well as several open-source sets of analyzed data. In some cases, Zooniverse volunteers have even made completely unexpected and scientifically significant discoveries.\n\nA significant amount of this research takes place on the Zooniverse discussion boards, where volunteers can work together with each other and with the research teams. These boards are integrated with each project to allow for everything from quick hashtagging to in-depth collaborative analysis. There is also a central Zooniverse board for general chat and discussion about Zooniverse-wide matters.\n\nMany of the most interesting discoveries from Zooniverse projects have come from discussion between volunteers and researchers. We encourage all users to join the conversation on the discussion boards for more in-depth participation.'
+    },
+    acknowledgements: {
+      title: '## Acknowledging the Zooniverse',
+      citation: '### Academic Citation',
+      instructions: 'Per the [Zooniverse Project Builder Policies](/lab-policies), all research publications using any data derived from Zooniverse approved projects (those listed on the [Zooniverse Projects page](/projects)) are required to acknowledge the Zooniverse and the Project Builder platform. To do so, please use the following text:',
+      supportText: '*This publication uses data generated via the [Zooniverse.org](https://www.zooniverse.org/) platform, development of which is funded by generous support, including a Global Impact Award from Google, and by a grant from the Alfred P. Sloan Foundation.*',
+      publicationRequest: 'We ask that all researchers making use of the Zooniverse Project Builder platform in any way also consider including the above acknowledgement in their publications.',
+      publicationShareForm: 'We strongly encourage project owners to report published accepted research publications using Zooniverse-produced data to us via [this form](https://docs.google.com/forms/d/e/1FAIpQLSdbAKVT2tGs1WfBqWNrMekFE5lL4ZuMnWlwJuCuNM33QO2ZYg/viewform). You can find a list of publications written using the Zooniverse on our [Publications page](publications).',
+      questions: 'If you have any questions about how to acknowledge the Zooniverse, such as referencing a particular individual or custom code, please [get in touch](contact).',
+      press: '### Writing About Zooniverse in the Press',
+      projectURLs: 'When writing about specific Zooniverse projects in the press, please include the project URL (in print as well as digital editions).',
+      ZooURL: 'When writing about the Zooniverse in general, please include the [Zooniverse.org](https://www.zooniverse.org/) URL somewhere in your article.',
+      enquiries: 'If you are interested in interviewing a member of the team, please [get in touch](contact).'
+    },
+    contact: {
+      title: '## Contact & Social Media',
+      discussionBoards: 'Most of the time, the best way to reach the Zooniverse team, or any project teams, especially about any project-specific issues, is through the discussion boards.',
+      email: 'If you need to contact the Zooniverse team about a general matter, you can also send an email to the team at [contact@zooniverse.org](mailto:contact@zooniverse.org). Please understand that the Zooniverse team is relatively small and very busy, so unfortunately we cannot reply to all of the emails we receive.',
+      collaborating: 'If you are interested in collaborating with the Zooniverse, for instance on a custom-built project, please email [collab@zooniverse.org](mailto:collab@zooniverse.org). (Note that our [Project Builder](/lab) offers an effective way to set up a new project without needing to contact the team!)',
+      pressInquiries: 'For press inquires, please contact the Zooniverse directors Chris Lintott at [chris@zooniverse.org](mailto:chris@zooniverse.org) or +44 (0) 7808 167288 or Laura Trouille at [trouille@zooniverse.org](mailto:trouille@zooniverse.org) or +1 312 322 0820.',
+      dailyZoo: 'If you want to keep up to date with what\'s going on across the Zooniverse and our latest results, check out the [Daily Zooniverse](http://daily.zooniverse.org/) or the main [Zooniverse blog](http://blog.zooniverse.org/). You can also follow the Zooniverse on [Twitter](http://twitter.com/the_zooniverse), [Facebook](http://facebook.com/therealzooniverse), and [Google+](https://plus.google.com/+ZooniverseOrgReal).'
+    },
+    faq: {
+      title: '## Frequently Asked Questions',
+      whyNeedHelp: '- **Why do researchers need your help? Why can\'t computers do these tasks?**\nHumans are better than computers at many tasks. For most Zooniverse projects, computers just aren’t good enough to do the required task, or they may miss interesting features that a human would spot - this is why we need your help. Some Zooniverse projects are also using human classifications to help train computers to do better at these research tasks in the future. When you participate in a Zooniverse project, you are contributing to real research.',
+      amIDoingThisRight: '- **How do I know if I\'m doing this right?**\nFor most of the subjects shown in Zooniverse projects, the researchers don\'t know the correct answer and that\'s why they need your help. Human beings are really good at pattern recognition tasks, so generally your first guess is likely the right one. Don’t worry too much about making an occasional mistake - more than one person will review each image, video or graph in a project. Most Zooniverse projects have a Help button, a Frequently Asked Questions (FAQ) page, and a Field Guide with more information to guide you when classifying.',
+      whatHappensToClassifications: '- **What happens to my classification after I submit it?**\nYour classifications are stored in the Zooniverse\'s secure online database. Later on a project\'s research team accesses and combines the multiple volunteer assessments stored for each subject, including your classifications, together. Once you have submitted your response for a given subject image, graph, or video, you can\'t go back and edit it. Further information can be found on the [Zooniverse User Agreement and Privacy Policy page](/privacy).',
+      accountInformation: '- **What does the Zooniverse do with my account information?**\nThe Zooniverse takes very seriously the task of protecting our volunteer\'s personal information and classification data. Details about these efforts can be found on the [Zooniverse User Agreement and Privacy Policy page](/privacy) and the [Zooniverse Security page](/security).',
+      featureRequest: '- **I have a feature request or found a bug; who should I talk to/how do I report it?**\nYou can post your suggestions for new features and report bugs via the [Zooniverse Talk](/talk) or through the [Zooniverse Software repository](https://github.com/zooniverse/Panoptes-Front-End/issues).',
+      hiring: '- **Is the Zooniverse hiring?**\nThe Zooniverse is a collaboration between institutions from the United Kingdom and the United States; all of our team are employed by one or the other of these partner institutions. Check out the [Zoonvierse jobs page](https://jobs.zooniverse.org/) to find out more about employment opportunities within the Zooniverse.',
+      howToAcknowledge: '- **I\'m a project owner/research team member, how do I acknowledge the Zooniverse and the Project Builder Platform in my paper, talk abstract, etc.?**\nYou can find more details on how to cite the Zooniverse in research publications using data derived from use of the Zooniverse Project Builder on our [Acknowledgements page](/about/acknowledgements).',
+      browserSupport: '- **What browser version does Zooniverse support?**\nWe support major browsers up to the second to last version.',
+      furtherHelp: 'Didn\'t find the answer to your question? Ask on [Zooniverse Talk](/talk) or [get in touch](/about/contact).'
+    },
+    resources: {
+      title: '## Resources',
+      filler: 'Useful downloads and guidelines for talking about the Zooniverse.',
+      introduction: '### Brand Materials',
+      officialMaterials: '[Download official Zooniverse logos](https://github.com/zooniverse/Brand/tree/master/style%%20guide/logos). Our official color is teal hex `#00979D` or `RGBA(65, 149, 155, 1.00)`.',
+      printables: '[Download printable handouts, posters, and other ephemera](https://github.com/zooniverse/Brand/tree/master/style%%20guide/downloads). If you have specific needs not addressed here, please [let us know](/about/contact).',
+      press: '### Press Information',
+      tips: 'Tips for writing about the Zooniverse in the press',
+      listOne: '- Please always include URLs when writing about specific projects. If writing generally about the Zooniverse, please include www.zooniverse.org somewhere in your article. Check out the [Acknowledgements page](/about/acknowledgements) for more details about how to correctly acknowledge the Zooniverse.',
+      listTwo: '- Please note: we are a platform for people-powered research, not a company or non-profit.',
+      listThree: '- If you have questions about the Zooniverse and would like to speak to a member of our team, please [contact us](/about/contact).'
+    }
+  },
+  getInvolved: {
+    index: {
+      title: 'Get Involved',
+      nav: {
+        volunteering: 'Volunteering',
+        education: 'Education',
+        callForProjects: 'Call for Projects',
+        collections: 'Collections',
+        favorites: 'Favorites'
+      }
+    },
+    callForProjects: {
+      audio: {
+        header: '## Call for Zooniverse Audio Transcription Project Proposals',
+        intro: 'Would your research benefit from the involvement of hundreds or even thousands of volunteers? Zooniverse.org is the world’s largest and most successful online platform for crowdsourced research. We currently have over 1.6 million registered volunteers working in collaboration with professional researchers on more than 70 research projects across a range of disciplines, from astronomy to biology, climatology to humanities subjects.',
+        seekingProposals: 'Thanks to a generous grant from the Institute of Museum and Library Services, we are currently seeking proposals for two new custom audio transcription projects in the humanities or from GLAM institutions (Galleries, Libraries, Archives and Museums), to be developed as part of the Zooniverse platform.',
+        projectSelection: '### Project Selection',
+        requirements: 'This call will be limited to research teams with audio recordings of spoken language (not limited to English) which would benefit from transcription into digital text formats and/or classification tasks like metadata tagging. We are particularly keen to work on projects where the resulting data can be incorporated into an existing content management system (CMS) and used for research purposes.',
+        audioCompatibility: 'Audio compatibility is currently not available on our free [Project Builder](https://www.zooniverse.org/lab) tool. One aim of this effort will be to use these projects to help test and expand the functionality of our audio tools.',
+        selectionCriteriaTitle: '### Selection Criteria',
+        selectionCriteriaOne: '1. We are looking for projects that harness crowdsourced audio transcription for the purposes of unlocking data currently trapped in sources that cannot be transcribed through automation, and for which human effort is truly necessary. Therefore, proposals should address any previously-attempted methods of automated speech to text transcription.',
+        selectionCriteriaTwo: '2. The data extracted must have an audience or usefulness, be this to academic researchers, members of the public or both.',
+        selectionCriteriaThree: '3. Audio clips for transcription should feature one speaker at a time (per audio clip), as our current research effort does not include speaker diarization.',
+        selectionCriteriaFour: '4. Project teams need clear plans for how to make the crowdsourced data openly and publicly available, ideally through a CMS or site hosted and maintained by your institution.',
+        selectionCriteriaFive: '5. Audio material must be digitized; we do not have funds to support digitization of audio material.',
+        selectionCriteriaSix: '6. We will not accept projects if the material for transcription has previously been edited or published as text.',
+        furtherNotes: '### Further Notes',
+        imlsGrantInfo: 'The two selected audio transcription projects will be part of an ongoing Zooniverse effort, [Transforming Libraries and Archives through Crowdsourcing](https://www.imls.gov/grants/awarded/lg-71-16-0028-16). We particularly welcome applications from marginalized or underrepresented groups, or which utilize content about or generated by underrepresented groups.',
+        deadline: '### Deadline for Audio Project Proposals:',
+        contact: 'Project proposals are due by 28 February 2018. If you have questions or require any further guidance, please contact Samantha Blickhan, IMLS Postdoctoral Fellow: samantha@zooniverse.org.',
+        submissionLink: '[SUBMIT AN AUDIO TRANSCRIPTION PROPOSAL](https://goo.gl/forms/ALbUaRN17Rlq7AkD3)',
+        break: '***'
+      },
+      bio: {
+        header: '## Call for Biomedical Project Proposals',
+        wouldResearchBenefit: 'Would your research benefit from the involvement of thousands of volunteers? We are currently seeking proposals for biomedical projects to be developed as part of the Zooniverse platform. The Zooniverse is the world’s largest and most successful online platform for crowd-sourced research; we currently have over 1.5 million registered volunteers working in collaboration with professional researchers on more than 50 research projects across a range of disciplines, from physics to biology.',
+        projectBuilder: 'Using our unique [Project Builder](/lab) you can create your own Zooniverse project for free with a set of tried and tested tools, including multiple-choice questions and region marking or drawing tools. If we don’t yet offer the tools you need, please propose your project below; we are particularly interested in developing novel projects that extend the functionality of our platform.',
+        projectSelection: '### Project Selection',
+        expandFunctionality: 'We are looking for biomedical projects that will help us expand the functionality of the Zooniverse and build on the selection of tools available to researchers via our platform. Projects may involve a processing task applied to images, graphs, videos or another data format, data collection, or a combination of the two. Successful projects will be developed and hosted by the Zooniverse team, in close collaboration with the applicants.',
+        examples: 'Examples of our current biomedical projects include [Microscopy Masters](https://www.zooniverse.org/projects/jbrugg/microscopy-masters), where volunteers classify cryo-electron microscopy images to advance understanding of protein and virus structure, and [Worm Watch Lab](https://www.wormwatchlab.org/), which aims to improve understanding of the relationship between genes and behaviour.',
+        selectionCriteriaTitle: '### Selection Criteria:',
+        selectionCriteriaOne: '1. Projects extending the capability of the Zooniverse platform or serving as case studies for crowdsourcing in new areas are encouraged.',
+        selectionCriteriaTwo: '2. Alignment with biomedical research (long-term aim of research is to improve human health outcomes).',
+        selectionCriteriaThree: '3. Merit and usefulness of the data expected to result from the project.',
+        deadline: '### Deadline\nProject proposals are accepted on a rolling basis. Applications will be reviewed at the beginning of each month.',
+        submissionLink: '[SUBMIT A BIOMEDICAL PROPOSAL](https://goo.gl/forms/uUGdO5CpWDNFE5Uz2)'
+      }
+    },
+    education: {
+      title: '## Education in the Zooniverse',
+      becomeCitizenScientist: 'As a volunteer on these websites, both you and your students can become citizen scientists and citizen researchers, participating in real science and other research. If you or your students think you have make a mistake, don’t worry; even the researchers make mistakes. These projects are set up to have more than one volunteer analyzing each piece of data, thereby eliminating the vast majority of human error. Mistakes are a part of the process, and can even help us evaluate the difficulty of the data. As long as everyone does their best, they are helping!',
+      resources: '### Resources for educators using Zooniverse',
+      zooTeach: '- [ZooTeach](http://www.zooteach.org/) is a repository of lessons and resources for teachers. At ZooTeach, you will find a variety of resources for education, including: guides to projects for students and teachers, teacher-created presentations designed to introduce students to a particular project, and lessons developed to connect your students to projects and research within the context of things they already know.',
+      educationPages: '- Many Zooniverse projects have their own education pages with additional resources for teachers. Resources may include a video tutorial of how to use the project, other helpful documents and videos about the classification process, and education resources related to the research behind the project.',
+      joinConversationTitle: '### Take part in the conversation',
+      joinConversationBody: 'Keep up with the latest Zooniverse educational efforts on the [Zooniverse Blog](http://blog.zooniverse.org/) or by following [&#64;zooteach](https://twitter.com/ZooTeach) on Twitter. You can also talk with other Zooniverse educators and peers interested in using people-powered research in all sorts of learning environments on the [Zooniverse Education Talk board](http://zooniverse.org/talk/16).',
+      howEducatorsUseZooniverse: '### How are educators using Zooniverse?',
+      inspiration: 'Looking for a little inspiration? Here are some ways educators have used Zooniverse projects and educational resources:',
+      floatingForests: '- [Floating Forests: Teaching Young Children About Kelp](http://blog.zooniverse.org/2015/04/29/floating-forests-teaching-young-children-about-kelp/)',
+      cosmicCurves: '- [Cosmic Curves: Investigating Gravitational Lensing at the Adler Planetarium](http://blog.zooniverse.org/2014/03/18/cosmic-curves-investigating-gravitational-lensing-at-the-adler-planetarium/)',
+      snapshotSerengeti: '- [Snapshot Serengeti Brings Authentic Research Into Undergraduate Courses](http://blog.zooniverse.org/2014/02/19/snapshot-serengeti-brings-authentic-research-into-undergraduate-courses/)',
+      contactUs: 'We’d love to hear about how you’ve used Zooniverse with youth or adult learners! Please contact [education@zooniverse.org](mailto:education@zooniverse.org) if you have any interesting stories to share.'
+    },
+    volunteering: {
+      title: '## How to Volunteer',
+      introduction: 'First of all, everyone who contributes to a Zooniverse project is a volunteer! We have a wonderful, global community who help us do what we do. The main ways of volunteering with us are helping us with classifications on data, being a beta tester on projects we\'ve yet to launch, and being a moderator for a project. For more information about any of these roles, just read below.',
+      projectVolunteeringTitle: '### Volunteer on a Project',
+      projectVolunteeringDescription: 'Volunteering on a project is the easiest and most common way of volunteering. We always need volunteers to go onto our projects and classify the data contained in them. You can read more about what happens with the classifications and how it helps the scientific community and the progress of science on the [About](/about) page.',
+      projectLink: 'There is no minimum time requirement needed; do as much or as little as you\'d like. To get started as a classifications volunteer, just to go to the [Projects](/projects) page, have a look through, find one you like the look of, and get stuck in!',
+      betaTesterTitle: '### Volunteer as a Beta Tester',
+      betaTesterDescription: 'Volunteers also help us test projects before they are launched to check that they work properly. This involves working through some classifications on the beta project to check that it works, looking for any bugs, and filling out a questionnaire at the end. This helps us find any issues in the project that need resolving and also assess how suitable the project is for the Zooniverse. You can read some guidelines on what makes a project suitable on the [Policies](/lab-policies) page, under \'Rules and Regulations\'.',
+      betaTesterSignUp: 'To sign up as a beta tester, go to [www.zooniverse.org/settings/email](/settings/email) and tick the box relating to beta testing. We\'ll then send you emails when a project is ready to be tested. You can change your email settings any time you want using the [same email page](/settings/email) and unticking the box.',
+      projectModeratorTitle: '### Volunteer as a Project Moderator',
+      projectModeratorBody: 'Volunteer moderators have extra permissions in the Talk discussion tool for a particular project. They help moderate discussions and act as a point of contact for the project. Moderators are selected by the project owner. If you\'re interested in becoming a moderator on a project you\'re taking part in, go to the project\'s About page and get in touch with the researcher.',
+      furtherInformationTitle: '### Further Information',
+      contactUs: 'If you\'d like any more information on any of these different roles, contact us via the [Contact Us](/about/contact) page.'
+    }
+  },
+  lab: {
+    help: {
+      howToBuildProject: {
+        title: '## How to create a project with our Project Builder',
+        overview: {
+          quickGuide: '* [A quick guide to building a project](#a-quick-guide-to-building-a-project)',
+          navigating: '* [Navigating the project builder](#navigating-the-project-builder)\n  * [Project](#project)\n  * [Workflows](#workflows)\n  * [Subjects](#subjects)',
+          inDetail: {
+            title: '* [Project building in detail](#project-building-in-detail)',
+            projectDetails: '* [Project Details](#project-details)',
+            about: '  * [About](#about)',
+            collaborators: '* [Collaborators](#collaborators)',
+            fieldGuide: '* [Field Guide](#field-guide)',
+            tutorial: '* [Tutorial](#tutorial)',
+            media: '* [Media](#media)',
+            visibility: '* [Visibility](#visibility)',
+            workflows: '* [Workflows](#workflow-details)',
+            createTasks: '* [Create Tasks](#create-tasks)',
+            taskContent: '* [Task Content](#task-content)',
+            questions: '* [Questions](#questions)',
+            drawing: '* [Drawing](#drawing)',
+            transcription: '* [Transcription](#transcription)',
+            linking: '* [Linking the Workflow Together](#linking-the-workflow-together)',
+            subjectSets: '* [Subject Sets](#subject-sets)',
+            furtherHelp: '* [Further Help](#further-help)'
+          }
+        },
+        sectionOverview: {
+          title: 'There are three sections in this guide:',
+          quickGuide: '1.  [A quick guide to building a project](#a-quick-guide-to-building-a-project) provides an overview of all the steps you need to complete to set up your project.',
+          navigating: '2.  [Navigating the Project Builder](#navigating-the-project-builder) introduces the navigation bar (nav-bar) used in the project builder.',
+          inDetail: '3.  [Project building in detail](#project-building-in-detail) provides a more detailed description of how to set up a project.'
+        },
+        quickGuide: {
+          title: '## A quick guide to building a project',
+          intro: 'A brief overview of all the steps you need to complete to set up your project.',
+          step1: '1. Log in to your Zooniverse account.',
+          step2: '2. Click on "Build a Project" (www.zooniverse.org/lab) and click "Create a New Project".',
+          step3: '3. Enter your project details in the pop-up that appears. You’ll then be taken to a “Project Details” page where you can add further basic information.',
+          step4: '4. Add more information about your project via the blue tabs on the left-hand side of the project builder page. Guidance for each of these sections is provided on the page itself.',
+          step5: '5.  If you have data to upload, add your subjects via the “Subject Sets” tab of the Project Builder (detailed instructions are provided [here](#subjects)).',
+          step6: '6. Next, create your workflow. Click on the “Workflow” tab in the navigation bar on the left-hand side of the page. Use the “New workflow” button to create a workflow. Multiple workflows can be created.',
+          step7: '7. Once you’ve created a workflow, the "Associated Subject Sets" section allows you to link your workflow to your subject sets. If you have no subjects, go to the “Subject Sets” tab and upload your data (see step 5 above).',
+          step8: '8. Hit the "Test this workflow" button to see how your project looks.',
+          step9: '9. Explore your project to figure out what works and what doesn\'t. Make changes, then refresh your project page to test these out.',
+          step10: '10. Guidelines on how to design your project to maximize engagement and data quality are provided on the [Policies page](/help/lab-policies).',
+          step11: '11. When you are happy with your project, set it to “Public” on the “Visibility” tab. Use the “Apply for review” button to submit it to the Zooniverse team for review.',
+          backToTop: '[Back to top](#how-to-create-a-project-with-our-project-builder)'
+        },
+        navigatingTheProjectBuilder: {
+          title: '## Navigating the Project Builder',
+          intro: 'On the left-hand side of the project builder you will see a number of tabs which can be divided into three key sections; “Project”, “Workflows” and “Subject Sets”. These are terms you\'ll see a lot, and they have specific meanings in the Zooniverse.',
+          project: '**Project** is pretty self-explanatory; Galaxy Zoo and Penguin Watch are examples of Zooniverse projects that could be built using the project builder.',
+          workflows: '**Workflows** are sequences of tasks that volunteers are asked to do.',
+          subjectSets: '**Subject sets** are collections of data (typically images) that volunteers are asked to perform tasks on.',
+          glossaryPage: 'For more Zooniverse definitions, check out the [Glossary page](/help/glossary).'
+        },
+        project: {
+          title: '### Project',
+          intro: 'The tabs listed below are where you enter descriptive information for your project.',
+          details: '- **Project Details:** Here you can add information that generates a home page for your project. Start by naming and describing your project, add a logo and background image.',
+          about: '- **About:** Here you can add all sorts of additional pages, including *Research, Team, Results, Education,* and *FAQ*',
+          collaborators: '- **Collaborators:** Add people to your team. You can specify their roles so that they have access to the tools they need (such as access to the project before it\'s public).',
+          fieldGuide: '- **Field Guide:** A field guide is a place to store general project-specific information that volunteers will need to understand in order to complete classifications and talk about what they\'re seeing.',
+          tutorial: '- **Tutorial:** This is where you create tutorials to show your users how to contribute to your project.',
+          media: '- **Media:** Add images you need for your project pages (not the images you want people to classify!)',
+          visibility: '- **Visibility:** Set your project\'s "state" - private or public, live or in development, and apply for review by the Zooniverse. You can also activate or deactivate specific workflows on this page.',
+          talk: '- **Talk:** Create and manage discussion boards for your project.',
+          dataExports: '- **Data Exports:** Access your raw and aggregated classification data, subject data, and comments from Talk.'
+        },
+        workflow: {
+          title: '### Workflows',
+          body: 'A workflow is the sequence of tasks volunteers are asked to perform. For example, you might want to ask volunteers to answer questions about your images, or to mark features in your data, or both. The workflow tab is where you define those tasks and set the order in which volunteers are asked to do them. Your project might have multiple workflows (if you want to set different tasks for different image sets). See the detailed [Workflow](#workflow-details) section for more information.'
+        },
+        subjects: {
+          title: '### Subjects',
+          body: 'A subject is a unit of data to be analyzed. A single subject can include more than one image. A “subject set” consists of both the "manifest" (a list of the subjects and their properties), and the images themselves. Subjects can be grouped into different sets if useful for your research. See the [Subject Details](#subject-sets) section for more on subjects.',
+          backToTop: '[Back to top](#how-to-create-a-project-with-our-project-builder)'
+        },
+        projectDetails: {
+          title: '## Project building in detail',
+          intro: 'Detailed instructions on how to use the pages described above.',
+          subtitle: '### Project details',
+          name: '* **Name**: The project name is the first thing people will see and it will show up in the project URL. Try to keep it short and sweet.',
+          avatar: '* **Avatar**: Pick an avatar image for your project. This will represent your project on the Zooniverse home page. It can also be used as your project\'s brand. It\'s best if it\'s recognizable even as a small icon. To add an image, either drag and drop or click to open your file viewer. For best results, use a square image of not more than 50KB, but at minimum 100x100 pixels.',
+          background: '* **Background**: This image will be the background for all of your project pages, including your project\'s front page. It should be relatively high resolution and you should be able to read text written across it. To add an image, either drag and drop or click to open your file viewer. For best results, use images of at least 1 megapixel, no larger than 256 KB. Most people\'s screens are not much bigger than 1300 pixels across and 750 pixels high, so if your image is a lot bigger than this you may find it doesn\'t look the way you expect. Feel free to experiment with different sizes on a "typical" desktop, laptop or mobile screen.',
+          description: '* **Description**: This should be a one-line call to action for your project. This will display on your landing page and, if approved, on the Zooniverse home page. Some volunteers will decide whether to try your project based on reading this, so try to write short text that will make people actively want to join your project.',
+          introduction: '* **Introduction**: Add a brief introduction to get people interested in your project. This will display on your project\'s front page. Note this field [renders markdown](http://markdownlivepreview.com/), so you can format the text. You can make this longer than the Description, but it\'s still probably best to save much longer text for areas like the About, Research Case or FAQ tabs.',
+          workflowDescription: '* **Workflow Description:** A workflow is a set of tasks a volunteer completes to create a classification. Your project might have multiple workflows (if you want to set different tasks for different subject image sets). Add text here when you have multiple workflows and want to help your volunteers decide which one they should do.',
+          checkboxVolunteers: '* **Checkbox: Volunteers choose workflow:**  If you have multiple workflows, check this to let volunteers select which workflow they want to work on; otherwise, they\'ll be served randomly.',
+          researcherQuote: '* **Researcher Quote:** This text will appear on the project landing page alongside an avatar of the selected researcher. It’s a way of communicating information to your volunteers, highlighting specific team members, and getting volunteers enthusiastic about participating.',
+          announcementBanner: '* **Announcement Banner:** This text will appear as a banner at the top of all your project’s pages. Only use this when you’ve got a big important announcement to make! Many projects use this to signal the end of a beta review, or other major events in a project’s life cycle.',
+          disciplineTag: '* **Discipline Tag:** Enter or select one or more discipline tags to identify which field(s) of research your project belongs to. These tags will determine the categories your project will appear under on the main Zooniverse projects page, if your project becomes a full Zooniverse project.',
+          otherTags: '* **Other Tags:** Enter a list of additional tags to describe your project separated by commas to help users find your project.',
+          externalLinks: '* **External links:** Adding an external link will make it appear as a new tab alongside the About, Classify, Talk, and Collect tabs. You can rearrange the displayed order by clicking and dragging on the left gray tab next to each link.',
+          socialLinks: '* **Social links:** Adding a social link will append a media icon at the end of your project menu bar. You can rearrange the displayed order by clicking and dragging on the left gray tab next to each link.',
+          checkboxPrivate: '* **Checkbox: Private project:** On "private" projects, only users with specified project roles can see or classify on the project. We strongly recommend you keep your project private while you\'re still editing it. Share it with your team to get feedback by adding them in the Collaborators area (linked at the left-hand side of the Project Builder). Team members you add can see your project even if it\'s private. Once your project is public, anyone with the link can view and classify on it.',
+          backToTop: '[Back to top](#how-to-create-a-project-with-our-project-builder)'
+        },
+        about: {
+          title: '### About',
+          intro: 'This section contains pages where you can enter further information for Research, Team, Results, Education and FAQ. All of these pages use [Markdown](http://markdownlivepreview.com/) to format text and display images.',
+          research: '* **Research:** Use this section to explain your research to your audience in as much detail as you\'d like. Explaining your motivation to volunteers is critical for the success of your project – please fill in this page (it will display even if you don’t)!',
+          team: '* **Team:** Introduce the members of your team, and the roles they play in your project.',
+          results: '* **Results:** Share results from your project with volunteers and the public here. This page will only display if you add content to it.',
+          education: '* **Education:** On this page, you can provide resources for educators and students to use alongside your project, such as course syllabi, pedagogical tools, further reading, and instructions on how the project might be used in an educational context. This page will only display if you add content to it.',
+          faq: '* **FAQ:** Add details here about your research, how to classify, and what you plan to do with the classifications. This page can evolve as your project does so that your active community members have a resource to point new users to. This page will only display if you add content to it.'
+        },
+        collaborators: {
+          title: '### Collaborators',
+          intro: 'Here you can add people to your team. You can specify their roles so that they have access to the tools they need (such as access to the project before it\'s public).',
+          owner: '* **Owner:** The owner is the original project creator. There can be only one.',
+          collaborator: '* **Collaborator:** Collaborators have full access to edit workflows and project content, including deleting some or all of the project.',
+          expert: '* **Expert:** Experts can enter “gold mode” to make authoritative gold standard classifications that will be used to validate data quality.',
+          researcher: '* **Researcher:** Members of the research team will be marked as researchers on “Talk".',
+          moderator: '* **Moderator:** Moderators have extra privileges in the community discussion area to moderate discussions. They will also be marked as moderators on “Talk".',
+          tester: '* **Tester:** Testers can view and classify on your project to give feedback while it’s still private. They cannot access the project builder.',
+          translator: '* **Translator:** Translators will have access to the project builder as well as the translation site, so they can translate all of your project text into a different language.',
+          backToTop: '[Back to top](#how-to-create-a-project-with-our-project-builder)'
+        },
+        fieldGuide: {
+          title: '### Field Guide',
+          intro: 'A field guide is a place to store general project-specific information that volunteers will need to understand in order to complete classifications and talk about what they\'re seeing. It\'s available anywhere in your project, accessible via a tab on the right-hand side of the screen.',
+          details: 'Information can be grouped into different sections, and each section should have a title and an icon. Content for each section is rendered with [Markdown](http://markdownlivepreview.com/), so you can include any media you\'ve uploaded for your project there.'
+        },
+        tutorial: {
+          title: '### Tutorial',
+          intro: 'In this section, you can create a step-by-step tutorial to show your users how to use your project. You can upload images and enter text to create each step of the tutorial. You can add as many steps as you want, but keep your tutorial as short as possible so volunteers can start classifying as soon as possible.',
+          details: 'In some cases, you might have several different workflows, and will therefore need several different tutorials. In the Workflows tab, you can specify which tutorial shows for the workflow a volunteer is on.'
+        },
+        media: {
+          title: '### Media',
+          intro: 'You can upload your own media to your project (such as example images for your Help pages or Tutorial) so you can link to it without an external host. To start uploading, drop an image into the grey box (or click “Select files” to bring up your file browser and select a file). Once the image has uploaded, it will appear above the "Add an image" box. You can then copy the Markdown text beneath the image into your project, or add another image.'
+        },
+        visibility: {
+          title: '### Visibility',
+          intro: 'This page is where you decide whether your project is public and whether it\'s ready to go live.',
+          projectState: '* **Project State and Visibility:** Set your project to “Private” or “Public”. Only the assigned collaborators can view a private project. Anyone with the URL can access a public project. Here, you can also choose whether your project is in “Development”, or “Live”. Note: in a live project, active workflows are locked and can no longer be edited.',
+          betaStatus: '* **Beta Status:** Here, you will find a checklist of tasks that must be complete for your project to undergo beta review. Projects must complete review in order to launch as full Zooniverse projects and be promoted as such. Once these tasks are complete, click “Apply for review”.',
+          workflowSettings: '* **Workflow Settings:** You will see a list of all workflows created for the project. You can set the workflows to “Active”, choose what metric to measure for completeness statistics, and whether those statistics should be shown on your project’s Stats Page.For more information on the different project stages, see our [Project Builder policies](/help/lab-policies).',
+          backToTop: '[Back to top](#how-to-create-a-project-with-our-project-builder)'
+        },
+        talk: {
+          title: '### Talk',
+          intro: '“Talk” is the name for the discussion boards attached to your project. On your Talk, volunteers will be able to discuss your project and subjects with each other, as well as with you and your project’s researchers. **Maintaining a vibrant and active Talk is important for keeping your volunteers engaged with your project.** Conversations on Talk also can lead to additional research discoveries.',
+          details: 'You can use this page to set up the initial Talk boards for your project. We highly recommend first activating the default subject-discussion board, which hosts a single dedicated conversation for each subject. After that, you can add additional boards, where each board will host conversation about a general topic. Example boards might include: “Announcements,” “Project Discussion,” “Questions for the Research Team,” or “Technical Support.”'
+        },
+        dataExports: {
+          title: '### Data Exports',
+          intro: 'In this section you can request data exports for your Project Data (CSV format) and Talk Data (JSON format). Note that the Zooniverse will process at most 1 of each export within a 24-hour period and some exports may take a long time to process. We will email you when they are ready. For examples of how to work with the data exports see our [Data Digging code repository](https://github.com/zooniverse/Data-digging).'
+        },
+        workflowDetails: {
+          title: '### Workflow Details',
+          introduction: 'Note that a workflow with fewer tasks is easier for volunteers to complete. We know from surveys of our volunteers that many people classify in their limited spare time, and sometimes they only have a few minutes. Longer, more complex workflows mean each classification takes longer, so if your workflow is very long you may lose volunteers.',
+          workflowTitle: '* **Workflow title:** Give your workflow a short, but descriptive name. If you have multiple workflows and give volunteers the option of choosing which they want to work on, this Workflow title will appear on a button instead of "Get started!"',
+          version: '* **Version:** Version indicates which version of the workflow you are on. Every time you save changes to a workflow, you create a new version. Big changes, like adding or deleting questions, will change the version by a whole number: 1.0 to 2.0, etc. Smaller changes, like modifying the help text, will change the version by a decimal, e.g. 2.0 to 2.1. The version is tracked with each classification in case you need it when analyzing your data.',
+          tasks: '* **Tasks:** There are two main types of tasks: questions and drawing. For question tasks, the volunteer chooses from a list of answers but does not mark or draw on the image. In drawing tasks, the volunteer marks or draws directly on the image using tools that you specify. They can also give sub-classifications for each mark. Note that you can set the first task from the drop-down menu.',
+          mainText: '* **Main Text:** Describe the task, or ask the question, in a way that is clear to a non-expert. The wording here is very important, because you will in general get what you ask for. Solicit opinions from team members and testers before you make the project public: it often takes a few tries to reach the combination of simplicity and clarity that will guide your volunteers to give you the inputs you need. You can use markdown in the main text.',
+          helpText: '* **Help Text:** Add text and images for a pop-up help window. This is shown next to the main text of the task in the main classification interface, when the volunteer clicks a button asking for help. You can use markdown in this text, and link to other images to help illustrate your description. The help text can be as long as you need, but you should try to keep it simple and avoid jargon. One thing that is useful in the help text is a concise description of why you are asking for this information.',
+          backToTop: '[Back to top](#how-to-create-a-project-with-our-project-builder)'
+        },
+        createTasks: {
+          title: '### Create Tasks',
+          body: 'Create tasks with the "Add a task" button. Delete tasks with the "Delete this task" button under the “Choices” box.'
+        },
+        taskContent: {
+          title: '### Task Content',
+          body: 'Tasks can be Questions, Drawings or Transcription. All types have "Main Text" boxes where you can ask your questions or tell users what to draw, as well as provide additional support for completing the task in the "Help Text" box.'
+        },
+        questions: {
+          title: '#### Questions',
+          intro: 'Choices: This section contains all your answers. The key features of this section are:',
+          required: '- **Required:** if you select this, the user has to answer the question before moving on.',
+          multiple: '- **Multiple:** if you select this, the user can select more than one answer - use this for "select all that apply" type questions.',
+          nextTask: '- **Next Task:** The “Next task” selection (which appears below the text box for each answer) describes what task you want the volunteer to perform next after they give a particular answer. You can choose from among the tasks you’ve already defined. If you want to link a task to another you haven’t built yet, you can come back and do it later (don’t forget to save your changes).'
+        },
+        drawing: {
+          title: '#### Drawing',
+          intro: 'This section contains all the different things people can mark. We call each separate option a "Tool" and you can specify a label, colour, and tool type for each option. Check out the [Aggregation documents](https://aggregation-caesar.zooniverse.org/docs) to understand how multiple volunteer answers are turned into final shapes for your data analysis. The tool types are:',
+          bezier: '- **bezier:** an arbitrary shape made of point-to-point curves. The midpoint of each segment drawn can be dragged to adjust the curvature.',
+          circle: '- **circle:** a point and a radius.',
+          column: '- **column:** a box with full height but variable width; this tool *cannot* be rotated.',
+          ellipse: '- **ellipse:** an oval of any size and axis ratio; this tool *can* be rotated.',
+          line: '- **line:** a straight line at any angle.',
+          point: '- **point:** X marks the spot.',
+          polygon: '- **polygon:** an arbitrary shape made of point-to-point lines.',
+          rectangle: '- **rectangle:** a box of any size and length-width ratio; this tool *cannot* be rotated.',
+          triangle: '- **triangle:** an equilateral triangle of any size and vertex distance from the center; this tool *can* be rotated.',
+          gridTable: '- **grid table:** cells which can be made into a table for consecutive annotations.',
+          backToTop: '[Back to top](#how-to-create-a-project-with-our-project-builder)'
+        },
+        transcription: {
+          title: '#### Transcription',
+          intro: 'This section deals with projects which require user-generated text. Tasks can range from adding keywords or extracting metadata to full text transcriptions.',
+          keywordTagging: '- **Keyword tagging** is helpful when teams want to create a list of all of the things volunteers see in a given image, to make that object more discoverable in a database or online collection. In these cases diversity of opinion is helpful. Setting a retirement rate of 5 to 10 people will help capture diverse opinions.',
+          fullTextTranscription: '- **Full text transcription** is more cumbersome and diversity of opinion is less helpful. Teams are usually trying to capture exactly what is on a page, so it will help to set a relatively low retirement rate for each image (i.e. 3 or 5) and be very clear in the tutorial how you would like volunteers to transcribe. Should they preserve spelling and punctuation or modernize it?',
+          aggregatedClassifications: '- Zooniverse does not currently offer aggregated classifications for text subjects. We can only report what each user transcribed for each subject. Before embarking on a transcription project be sure you have in-house expertise or access to expertise for combining multiple independent transcriptions into a single reading that you could use for research or to upload into a library or museum catalogue or content management system. For more information on Project Builder Data, please visit our [Data Digging code repository](https://github.com/zooniverse/Data-digging) as well as our [Data processing Talk board](https://www.zooniverse.org/talk/1322).'
+        },
+        linking: {
+          title: '#### Linking the workflow together',
+          intro: 'Now that all the tasks have been created, we\'ve got to string them together by specifying what happens *next*. Set your first task using the "First Task" drop-down menu below the "Add Task" button. Then, using the “Next task” drop-down under the “Choices” box, specify *what comes next*. In question tasks, you can specify different "Next Tasks" for each available answer (provided users can only select one answer).',
+          multiImageOptions: '**Multi-Image options:** If your tasks require users to see multiple subjects per task (like on [Snapshot Serengeti](https://www.snapshotserengeti.org)), decide how users will see them. The Flipbook option means users have to press a button to switch between subjects, while separate frames mean that each subject will be visible for the duration of the classification task.',
+          subjectRetirement: '**Subject retirement:** Decide how many people you want to complete each task. You can change this number at any point (particularly after beta review). We suggest starting out high, between 10 and 20.'
+        },
+        subjectSets: {
+          title: '### Subject Sets',
+          intro: 'On this page, you can add groups of data to be classified.',
+          summary: 'To do so, drag and drop items onto the drop zone in the browser and then upload. You can give each set a name so that you can easily distinguish between them.',
+          details: 'Subject sets can be pretty powerful, and sometimes complex. You can have a single subject set that you add to over time, or have multiple subject sets, say, from different years or places. You can have different subject sets for different workflows, but you don\'t have to. You can even have multiple images in a given subject. For more details and advice on creating and structuring subject sets and associated manifests, check out https://www.zooniverse.org/help/example and scroll down to DETAILS - Subject sets and manifest details, a.k.a. “What is a manifest?”'
+        },
+        furtherHelp: {
+          title: '## Further Help',
+          body: 'If you\'d like some further information, check out the [documentation behind building Kitteh Zoo](/help/example), that talks you through building this project in the Project Builder.\n\nIf this doesn\'t help, get in contact with the Zooniverse team via the [contact page](/about/contact).',
+          backToTop: '[Back to top](#how-to-create-a-project-with-our-project-builder)'
+        }
+      }
+    }
+  }
+};

--- a/app/locales/he.js
+++ b/app/locales/he.js
@@ -1,0 +1,598 @@
+export default {
+  loading: '(Loading)',
+  classifier: {
+    back: 'Back',
+    backButtonWarning: 'Going back will clear your work for the current task.',
+    close: 'Close',
+    continue: 'Continue',
+    done: 'Done',
+    doneAndTalk: 'Done & Talk',
+    dontShowMinicourse: 'Do not show mini-course in the future',
+    letsGo: 'Let’s go!',
+    next: 'Next',
+    optOut: 'Opt out',
+    taskTabs: {
+      taskTab: 'Task',
+      tutorialTab: 'Tutorial'
+    },
+    recents: 'Your recent classifications',
+    talk: 'Talk',
+    taskHelpButton: 'Need some help with this task?',
+    miniCourseButton: 'Restart the project mini-course',
+    workflowAssignmentDialog: {
+      promotionMessage: "Congratulations! You've unlocked the next workflow. If you prefer to stay on this workflow, you can choose to stay.",
+      acceptButton: 'Try the new workflow',
+      declineButton: 'No, thanks'
+    }
+  },
+  project: {
+    loading: 'Loading project',
+    disclaimer: 'This project has been built using the Zooniverse Project Builder but is not yet an official Zooniverse project. Queries and issues relating to this project directed at the Zooniverse Team may not receive any response.',
+    about: {
+      header: 'About',
+      nav: {
+        research: 'Research',
+        results: 'Results',
+        faq: 'FAQ',
+        education: 'Education',
+        team: 'The Team',
+      }
+    },
+    nav: {
+      about: 'About',
+      adminPage: 'Admin page',
+      classify: 'Classify',
+      collections: 'Collect',
+      exploreProject: 'Explore Project',
+      lab: 'Lab',
+      recents: 'Recents',
+      talk: 'Talk',
+      underReview: 'Under Review',
+      zooniverseApproved: 'Zooniverse Approved'
+    },
+    classifyPage: {
+      dark: 'dark',
+      light: 'light',
+      title: 'Classify',
+      themeToggle: 'Switch to %(theme)s theme'
+    },
+    home: {
+      organization: 'Organization',
+      researcher: 'Words from the researcher',
+      about: 'About %(title)s',
+      metadata: {
+        statistics: '%(title)s Statistics',
+        classifications: 'Classifications',
+        volunteers: 'Volunteers',
+        completedSubjects: 'Completed Subjects',
+        subjects: 'Subjects'
+      },
+      talk: {
+        zero: 'No one is talking about <strong>%(title)s</strong> right now.',
+        one: '<strong>1</strong> person is talking about <strong>%(title)s</strong> right now.',
+        other: '<strong>%(count)s</strong> people are talking about <strong>%(title)s</strong> right now.'
+      },
+      joinIn: 'Join in',
+      learnMore: 'Learn more',
+      getStarted: 'Get started',
+      workflowAssignment: 'You\'ve unlocked level %(workflowDisplayName)s',
+      visitLink: 'Visit the project',
+      links: 'External Project Links'
+    }
+  },
+  organization: {
+    error: 'There was an error retrieving organization',
+    home: {
+      introduction: 'Introduction',
+      links: 'Links',
+      metadata: {
+        projects: 'Projects'
+      },
+      projects: {
+        error: 'There was an error loading organization projects.',
+        loading: 'Loading organization projects...',
+        none: 'There are no projects associated with this organization.'
+      },
+      readLess: 'Read Less',
+      readMore: 'Read More',
+      researcher: 'Words from a researcher',
+      viewToggle: 'View As Volunteer'
+    },
+    loading: 'Loading organization',
+    notFound: 'organization not found.',
+    notPermission: 'If you\'re sure the URL is correct, you might not have permission to view this organization.',
+    pleaseWait: 'Please wait...'
+  },
+  tasks: {
+    less: 'Less',
+    more: 'More',
+    shortcut: {
+      noAnswer: 'No answer'
+    },
+    survey: {
+      clear: 'Clear',
+      clearFilters: 'Clear filters',
+      makeSelection: 'Make a selection',
+      showing: 'Showing %(count)s of %(max)s',
+      confused: 'Often confused with',
+      dismiss: 'Dismiss',
+      itsThis: 'I think it’s this',
+      cancel: 'Cancel',
+      identify: 'Identify',
+      surveyOf: 'Survey of %(count)s',
+      identifications: {
+        zero: 'No identifications',
+        one: '1 identification',
+        other: '%(count)s identifications'
+      }
+    }
+  },
+  privacy: {
+    title: 'Zooniverse User Agreement and Privacy Policy',
+    userAgreement: {
+      summary: '## User Agreement\n**Summary**\n\nThe Zooniverse is a suite of citizen science projects operated by the Citizen Science Alliance (CSA), which support scientific research by involving members of the public - you - in the processes of analyzing and discussing data. Data from these projects is used to study online community design and theory, interface design, and other topics. This document describes what will happen to your contributions if you choose to contribute and what data we collect, how we use it and how we protect it.',
+      contribution: '**What you agree to if you contribute to the Zooniverse**\n\nProjects involving the public are needed to enable researchers to cope with the otherwise unmanageable flood of data. The web provides a means of reaching a large audience willing to devote their free time to projects that can add to our knowledge of the world and the Universe.\n\nThe major goal for this project is for the analyzed data to be available to the researchers for use, modification and redistribution in order to further scientific research. Therefore, if you contribute to the Zooniverse, you grant the CSA and its collaborators, permission to use your contributions however we like to further this goal, trusting us to do the right thing with your data. However, you give us this permission non-exclusively, meaning that you yourself still own your contribution.\n\nWe ask you to grant us these broad permissions, because they allow us to change the legal details by which we keep the data available; this is important because the legal environment can change and we need to be able to respond without obtaining permission from every single contributor.\n\nFinally, you must not contribute data to the Zooniverse that you do not own. For example, do not copy information from published journal articles. If people do this, it can cause major legal headaches for us.',
+      data: '**What you may do with Zooniverse data**\n\nYou retain ownership of any contribution you make to the Zooniverse, and any recorded interaction with the dataset associated with the Zooniverse. You may use, distribute or modify your individual contribution in any way you like. However, you do not possess ownership of the dataset itself. This license does not apply to data about you, covered in the Privacy Policy.',
+      legal: '**Legal details**\n\nBy submitting your contribution to the Zooniverse, you agree to grant the CSA a perpetual, royalty-free, non-exclusive, sub-licensable license to: use, reproduce, modify, adapt, publish, translate, create derivative works from, distribute, and exercise all copyright and publicity rights with respect to your contribution worldwide and/or to incorporate your contribution in other works in any media now known or later developed for the full term of any rights that may exist in your contribution.\n\nIf you do not want to grant to the CSA the rights set out above, you cannot interact with the Zooniverse.\n\nBy interacting with the Zooniverse, you:\n\n* Warrant that your contribution contains only data that you have the right to make available to the CSA for all the purposes specified above, is not defamatory, and does not infringe any law; and\n\n* Indemnify the CSA against all legal fees, damages and other expenses that may be incurred by the CSA as a result of your breach of the above warranty; and\n\n* Waive any moral rights in your contribution for the purposes specified above.\n\nThis license does not apply to data about you, covered in the Privacy Policy.'
+    },
+    privacyPolicy: {
+      intro: '## Privacy Policy\n\nIn addition to the contributions you make towards the scientific goals of the Zooniverse, we collect additional data about you to support and improve the operation of the project. We also conduct experiments on the design of the website that we evaluate based on your reactions and behavior. This Privacy Policy describes what data we collect, how we use it and how we protect it.\n\nWe respect the privacy of every individual who participates in the Zooniverse. We operate in accordance with the United Kingdom Data Protection Act 1998 and the Freedom of Information Act 2000, as well as with United States regulations regarding protection of human subjects in research.',
+      data: '**Data we collect**\n\n_Identifying information_: If you register with the Zooniverse, we ask you to create a username and supply your e-mail address. Your e-mail address is not visible to other users, but others will see your username in various contexts. Notably, your username is associated with any classifications or other contributions you make, e.g., on Talk pages. You may optionally provide your real name to be included when we publically thank participants, e.g., in presentations, publications or discoveries.\n\n_Usage information_: We also monitor how people use our website, and aggregate general statistics about users and traffic patterns as well as data about how users respond to various site features. This includes, among other things, recording:\n\n* When you log in.\n\n* Pages you request.\n\n* Classifications you make.\n\n* Other contributions, such as posts on Talk pages.\n\nIf you register and log in, the logs associate these activities with your username. Otherwise, they are associated with your IP address. In order to collect this data, we may use software that collects statistics from IP data. This software can determine what times of day people access our site, which country they access the websites from, how long they visit for, what browser they are using, etc.',
+      info: '**What we do with the information we gather**\n\nUsage information is collected to help us improve our website in particular for the following reasons:\n\n* Internal record keeping.\n\n* We may periodically send email promoting new research-related projects or other information relating to our research. Information about these contacts is given below. We will not use your contact information for commercial purposes.\n\n* We may use the information to customize the website.\n\n* We may use the information to conduct experiments regarding the use of various site features.',
+      thirdParties: '**What is shared with third parties**\n\nWe will never release e-mail addresses to third parties without your express permission. We will also never share data we collect about you unless (a) it cannot be associated with you or your username, and (b) it is necessary to accomplish our research goals. Specifically, we may share your anonymized data with research study participants, other researchers, or in scholarly work describing our research. For example, we might use one of your classifications as an illustration in a paper, show some of your classifications to another user to see if they agree or disagree, or publish statistics about user interaction.\n\nContributions you make to the Talk pages are widely available to others. Aside from the above, information is held as confidentially as is practical within our secured database.',
+      cookies: '**How we use cookies**\n\nIn some areas of our site, a cookie may be placed on your computer. A cookie is a small file that resides on your computer\'s hard drive that allows us to improve the quality of your visit to our websites by responding to you as an individual.\n\nWe use traffic log cookies to identify which pages are being used and improve our website. We only use this information for statistical analysis purposes, they are not shared with other sites and are not used for advertisements.\n\nYou can choose to accept or decline cookies. Most web browsers automatically accept cookies, but you can usually modify your browser setting to decline cookies if you prefer. However, if you choose to decline cookies from the Zooniverse then functionality, including your ability to log-in and participate, will be impaired.\n\nAcceptance of cookies is implied if you continue to access our website without adjusting your browser settings.',
+      dataStorage: '**Where we store your data**\n\nWe use Amazon Web Services so we can quickly and reliably serve our website to an unpredictable number of people. This means that your data will be stored in multiple locations, including the United States of America (USA). Amazon is a participant in the Safe Harbor program developed by the USA Department of Commerce and the European Union (EU). Amazon has certified that it adheres to the Safe Harbor Privacy Principles agreed upon by the USA and the EU.\n\nOur mailing list server, which contains a copy of subscribed email addresses and no other personal data, is hosted on a virtual private server with Linode in the UK.',
+      security: '**Security measures**\n\nMembers of the research teams are made aware of our privacy policy and practices by reviewing this statement upon joining the team. We follow industry best practices to secure user data, and access to the database and logs are limited to members of the research group and system administrative staff.',
+      dataRemoval: '**Removing your data**\n\nDue to the way in which we archive data, it is generally not possible to completely remove your personal data from our systems. However, if you have specific concerns, please contact us and we will see what we can do.',
+      contactUser: '**When we will contact you**\n\nIf you do not register, we will never contact you. If you do register, we will contact you by e-mail in the following circumstances:\n\n* Occasionally, we will send e-mail messages to you highlighting a particular aspect of our research, announcing new features, explaining changes to the system, or inviting you to special events.\n\n* We may also use your information to contact you for the purpose of research into our site\'s operation. We may contact you by email. We may ask for additional information at that time. Providing additional information is entirely optional and will in no way affect your service in the site.\n\n* We may contact you with a newsletter about the progress of the project.\n\nYou are unlikely to receive more than two messages per month.\n\nYou can \'opt out\' of the newsletter at any time by visiting the Zooniverse [unsubscribe](https://www.zooniverse.org/unsubscribe) page.',
+      furtherInfo: '**Further information and requests**\n\nThe Data Controller is the Department of Physics, University of Oxford. For a copy of the information we hold on you please contact the project team at the address below:\n\nProfessor Chris Lintott\nOxford Astrophysics\nDenys Wilkinson Building\nKeble Road\nOxford, OX1 3RH\nUnited Kingdom'
+    }
+  },
+  security: {
+    title: 'Zooniverse Security',
+    intro: 'The Zooniverse takes very seriously the security of our websites and systems, and protecting our users and their personal information is our highest priority. We take every precaution to ensure that the information you give us stays secure, but it is also important that you take steps to secure your own account, including:\n\n* Do not use the same password on different websites. The password you use for your Zooniverse account should be unique to us.\n* Never give your password to anyone. We will never ask you to send us your password, and you should never enter your Zooniverse password into any website other than ours. Always check your browser\'s address bar to make sure you have a secure connection to _www.zooniverse.org_.\n\nFor general advice and information about staying safe online, please visit:\n\n* [Get Safe Online](https://www.getsafeonline.org)\n* [Stay Safe Online](https://www.staysafeonline.org)\n* [US-CERT - Tips](https://www.us-cert.gov/ncas/tips)',
+    details: '## Reporting Security Issues\n\nThe Zooniverse supports [responsible disclosure](https://en.wikipedia.org/wiki/Responsible_disclosure) of vulnerabilities. If you believe you have discovered a security vulnerability in any Zooniverse software, we ask that this first be reported to [security@zooniverse.org](mailto:security@zooniverse.org) to allow time for vulnerabilities to be fixed before details are published.\n\n## Known Vulnerabilities and Incidents\n\nWe believe it is important to be completely transparent about security issues. A complete list of fixed vulnerabilities and past security incidents is given below:\n\n* _(No entries at this time)_\n\nNew vulnerabilities and incidents will be announced via the [Zooniverse blog in the "technical" category](http://blog.zooniverse.org/category/technical/).'
+  },
+  userAdminPage: {
+    header: 'Admin',
+    nav: {
+      createAdmin: 'Manage Users',
+      projectStatus: 'Set Project Status',
+      grantbot: 'Grantbot',
+      organizationStatus: 'Set Organization Status'
+    },
+    notAdminMessage: 'You are not an administrator',
+    notSignedInMessage: 'You are not signed in'
+  },
+  signIn: {
+    title: 'Sign in/register',
+    withZooniverse: 'Sign in with your Zooniverse account',
+    whyHaveAccount: 'Signed-in volunteers can keep track of their work and will be credited in any resulting publications.',
+    signIn: 'Sign in',
+    register: 'Register',
+    orThirdParty: 'Or sign in with another service',
+    withFacebook: 'Sign in with Facebook',
+    withGoogle: 'Sign in with Google'
+  },
+  notFoundPage: {
+    message: 'Not found'
+  },
+  resetPassword: {
+    heading: 'Reset Password',
+    newPasswordFormDialog: 'Enter the same password twice so you can get back to doing some research. Passwords need to be at least 8 characters long.',
+    newPasswordFormLabel: 'New password:',
+    newPasswordConfirmationLabel: 'Repeat your password to confirm:',
+    enterEmailLabel: 'Please enter your email address here and we’ll send you a link you can follow to reset it.',
+    emailSuccess: 'We’ve just sent you an email with a link to reset your password.',
+    emailError: 'There was an error resetting your password.',
+    passwordsDoNotMatch: 'The passwords do not match, please try again.',
+    loggedInDialog: 'You are currently logged in. Please log out if you would like to reset your password.',
+    missingEmailsSpamNote: 'Please check your spam folder if you have not received the reset email.',
+    missingEmailsAlternateNote: 'If you have still not received an email, please try any other email address you may have signed up with.'
+  },
+  workflowToggle: {
+    label: 'Active'
+  },
+  collections: {
+    createForm: {
+      private: 'Private',
+      submit: 'Add Collection'
+    }
+  },
+  emailSettings: {
+    email: 'Email address',
+    general: {
+      section: 'Zooniverse email preferences',
+      updates: 'Get general Zooniverse email updates',
+      classify: 'Get email updates when you first classify on a project',
+      note: 'Note: Unticking the box will not unsubscribe you from any of the projects',
+      manual: 'Manage projects individually',
+      beta: 'Get beta project email updates and become a beta tester'
+    },
+    talk: {
+      section: 'Talk email preferences',
+      header: 'Send me an email',
+      frequency: {
+        immediate: 'Immediately',
+        day: 'Daily',
+        week: 'Weekly',
+        never: 'Never'
+      },
+      options: {
+        participating_discussions: 'When discussions I\'m participating in are updated',
+        followed_discussions: 'When discussions I\'m following are updated',
+        mentions: 'When I\'m mentioned',
+        group_mentions: 'When I\'m mentioned by group (@admins, @team, etc.)',
+        messages: 'When I receive a private message',
+        started_discussions: 'When a discussion is started in a board I\'m following'
+      }
+    },
+    project: {
+      section: 'Project email preferences',
+      header: 'Project',
+    }
+  },
+  about: {
+    index: {
+      header: 'About',
+      title: 'About',
+      nav: {
+        about: 'About',
+        publications: 'Publications',
+        ourTeam: 'Our Team',
+        acknowledgements: 'Acknowledgements',
+        contact: 'Contact Us',
+        faq: 'FAQ',
+        resources: 'Resources'
+      }
+    },
+    home: {
+      title: '## What is the Zooniverse?',
+      whatIsZooniverse: 'The Zooniverse is the world’s largest and most popular platform for people-powered research. This research is made possible by volunteers — hundreds of thousands of people around the world who come together to assist professional researchers. Our goal is to enable research that would not be possible, or practical, otherwise. Zooniverse research results in new discoveries, datasets useful to the wider research community, and [many publications](/about/publications).',
+      anyoneCanResearch: '### At the Zooniverse, anyone can be a researcher\n\nYou don’t need any specialised background, training, or expertise to participate in any Zooniverse projects. We make it easy for anyone to contribute to real academic research, on their own computer, at their own convenience.\n\nYou’ll be able to study authentic objects of interest gathered by researchers, like images of faraway galaxies, historical records and diaries, or videos of animals in their natural habitats. By answering simple questions about them, you’ll help contribute to our understanding of our world, our history, our Universe, and more.\n\nWith our wide-ranging and ever-expanding suite of projects, covering many disciplines and topics across the sciences and humanities, there\'s a place for anyone and everyone to explore, learn and have fun in the Zooniverse. To volunteer with us, just go to the [Projects](/projects) page, choose one you like the look of, and get started.',
+      accelerateResearch: '### We accelerate important research by working together\n\nThe major challenge of 21st century research is dealing with the flood of information we can now collect about the world around us. Computers can help, but in many fields the human ability for pattern recognition — and our ability to be surprised — makes us superior. With the help of Zooniverse volunteers, researchers can analyze their information more quickly and accurately than would otherwise be possible, saving time and resources, advancing the ability of computers to do the same tasks, and leading to faster progress and understanding of the world, getting to exciting results more quickly.\n\nOur projects combine contributions from many individual volunteers, relying on a version of the ‘wisdom of crowds’ to produce reliable and accurate data. By having many people look at the data we often can also estimate how likely we are to make an error. The product of a Zooniverse projects is often exactly what’s needed to make progress in many fields of research.',
+      discoveries: '### Volunteers and professionals make real discoveries together\n\nZooniverse projects are constructed with the aim of converting volunteers\' efforts into measurable results. These projects have produced a large number of [published research papers](/about/publications), as well as several open-source sets of analyzed data. In some cases, Zooniverse volunteers have even made completely unexpected and scientifically significant discoveries.\n\nA significant amount of this research takes place on the Zooniverse discussion boards, where volunteers can work together with each other and with the research teams. These boards are integrated with each project to allow for everything from quick hashtagging to in-depth collaborative analysis. There is also a central Zooniverse board for general chat and discussion about Zooniverse-wide matters.\n\nMany of the most interesting discoveries from Zooniverse projects have come from discussion between volunteers and researchers. We encourage all users to join the conversation on the discussion boards for more in-depth participation.'
+    },
+    acknowledgements: {
+      title: '## Acknowledging the Zooniverse',
+      citation: '### Academic Citation',
+      instructions: 'Per the [Zooniverse Project Builder Policies](/lab-policies), all research publications using any data derived from Zooniverse approved projects (those listed on the [Zooniverse Projects page](/projects)) are required to acknowledge the Zooniverse and the Project Builder platform. To do so, please use the following text:',
+      supportText: '*This publication uses data generated via the [Zooniverse.org](https://www.zooniverse.org/) platform, development of which is funded by generous support, including a Global Impact Award from Google, and by a grant from the Alfred P. Sloan Foundation.*',
+      publicationRequest: 'We ask that all researchers making use of the Zooniverse Project Builder platform in any way also consider including the above acknowledgement in their publications.',
+      publicationShareForm: 'We strongly encourage project owners to report published accepted research publications using Zooniverse-produced data to us via [this form](https://docs.google.com/forms/d/e/1FAIpQLSdbAKVT2tGs1WfBqWNrMekFE5lL4ZuMnWlwJuCuNM33QO2ZYg/viewform). You can find a list of publications written using the Zooniverse on our [Publications page](publications).',
+      questions: 'If you have any questions about how to acknowledge the Zooniverse, such as referencing a particular individual or custom code, please [get in touch](contact).',
+      press: '### Writing About Zooniverse in the Press',
+      projectURLs: 'When writing about specific Zooniverse projects in the press, please include the project URL (in print as well as digital editions).',
+      ZooURL: 'When writing about the Zooniverse in general, please include the [Zooniverse.org](https://www.zooniverse.org/) URL somewhere in your article.',
+      enquiries: 'If you are interested in interviewing a member of the team, please [get in touch](contact).'
+    },
+    contact: {
+      title: '## Contact & Social Media',
+      discussionBoards: 'Most of the time, the best way to reach the Zooniverse team, or any project teams, especially about any project-specific issues, is through the discussion boards.',
+      email: 'If you need to contact the Zooniverse team about a general matter, you can also send an email to the team at [contact@zooniverse.org](mailto:contact@zooniverse.org). Please understand that the Zooniverse team is relatively small and very busy, so unfortunately we cannot reply to all of the emails we receive.',
+      collaborating: 'If you are interested in collaborating with the Zooniverse, for instance on a custom-built project, please email [collab@zooniverse.org](mailto:collab@zooniverse.org). (Note that our [Project Builder](/lab) offers an effective way to set up a new project without needing to contact the team!)',
+      pressInquiries: 'For press inquires, please contact the Zooniverse directors Chris Lintott at [chris@zooniverse.org](mailto:chris@zooniverse.org) or +44 (0) 7808 167288 or Laura Trouille at [trouille@zooniverse.org](mailto:trouille@zooniverse.org) or +1 312 322 0820.',
+      dailyZoo: 'If you want to keep up to date with what\'s going on across the Zooniverse and our latest results, check out the [Daily Zooniverse](http://daily.zooniverse.org/) or the main [Zooniverse blog](http://blog.zooniverse.org/). You can also follow the Zooniverse on [Twitter](http://twitter.com/the_zooniverse), [Facebook](http://facebook.com/therealzooniverse), and [Google+](https://plus.google.com/+ZooniverseOrgReal).'
+    },
+    faq: {
+      title: '## Frequently Asked Questions',
+      whyNeedHelp: '- **Why do researchers need your help? Why can\'t computers do these tasks?**\nHumans are better than computers at many tasks. For most Zooniverse projects, computers just aren’t good enough to do the required task, or they may miss interesting features that a human would spot - this is why we need your help. Some Zooniverse projects are also using human classifications to help train computers to do better at these research tasks in the future. When you participate in a Zooniverse project, you are contributing to real research.',
+      amIDoingThisRight: '- **How do I know if I\'m doing this right?**\nFor most of the subjects shown in Zooniverse projects, the researchers don\'t know the correct answer and that\'s why they need your help. Human beings are really good at pattern recognition tasks, so generally your first guess is likely the right one. Don’t worry too much about making an occasional mistake - more than one person will review each image, video or graph in a project. Most Zooniverse projects have a Help button, a Frequently Asked Questions (FAQ) page, and a Field Guide with more information to guide you when classifying.',
+      whatHappensToClassifications: '- **What happens to my classification after I submit it?**\nYour classifications are stored in the Zooniverse\'s secure online database. Later on a project\'s research team accesses and combines the multiple volunteer assessments stored for each subject, including your classifications, together. Once you have submitted your response for a given subject image, graph, or video, you can\'t go back and edit it. Further information can be found on the [Zooniverse User Agreement and Privacy Policy page](/privacy).',
+      accountInformation: '- **What does the Zooniverse do with my account information?**\nThe Zooniverse takes very seriously the task of protecting our volunteer\'s personal information and classification data. Details about these efforts can be found on the [Zooniverse User Agreement and Privacy Policy page](/privacy) and the [Zooniverse Security page](/security).',
+      featureRequest: '- **I have a feature request or found a bug; who should I talk to/how do I report it?**\nYou can post your suggestions for new features and report bugs via the [Zooniverse Talk](/talk) or through the [Zooniverse Software repository](https://github.com/zooniverse/Panoptes-Front-End/issues).',
+      hiring: '- **Is the Zooniverse hiring?**\nThe Zooniverse is a collaboration between institutions from the United Kingdom and the United States; all of our team are employed by one or the other of these partner institutions. Check out the [Zoonvierse jobs page](https://jobs.zooniverse.org/) to find out more about employment opportunities within the Zooniverse.',
+      howToAcknowledge: '- **I\'m a project owner/research team member, how do I acknowledge the Zooniverse and the Project Builder Platform in my paper, talk abstract, etc.?**\nYou can find more details on how to cite the Zooniverse in research publications using data derived from use of the Zooniverse Project Builder on our [Acknowledgements page](/about/acknowledgements).',
+      browserSupport: '- **What browser version does Zooniverse support?**\nWe support major browsers up to the second to last version.',
+      furtherHelp: 'Didn\'t find the answer to your question? Ask on [Zooniverse Talk](/talk) or [get in touch](/about/contact).'
+    },
+    resources: {
+      title: '## Resources',
+      filler: 'Useful downloads and guidelines for talking about the Zooniverse.',
+      introduction: '### Brand Materials',
+      officialMaterials: '[Download official Zooniverse logos](https://github.com/zooniverse/Brand/tree/master/style%%20guide/logos). Our official color is teal hex `#00979D` or `RGBA(65, 149, 155, 1.00)`.',
+      printables: '[Download printable handouts, posters, and other ephemera](https://github.com/zooniverse/Brand/tree/master/style%%20guide/downloads). If you have specific needs not addressed here, please [let us know](/about/contact).',
+      press: '### Press Information',
+      tips: 'Tips for writing about the Zooniverse in the press',
+      listOne: '- Please always include URLs when writing about specific projects. If writing generally about the Zooniverse, please include www.zooniverse.org somewhere in your article. Check out the [Acknowledgements page](/about/acknowledgements) for more details about how to correctly acknowledge the Zooniverse.',
+      listTwo: '- Please note: we are a platform for people-powered research, not a company or non-profit.',
+      listThree: '- If you have questions about the Zooniverse and would like to speak to a member of our team, please [contact us](/about/contact).'
+    }
+  },
+  getInvolved: {
+    index: {
+      title: 'Get Involved',
+      nav: {
+        volunteering: 'Volunteering',
+        education: 'Education',
+        callForProjects: 'Call for Projects',
+        collections: 'Collections',
+        favorites: 'Favorites'
+      }
+    },
+    callForProjects: {
+      audio: {
+        header: '## Call for Zooniverse Audio Transcription Project Proposals',
+        intro: 'Would your research benefit from the involvement of hundreds or even thousands of volunteers? Zooniverse.org is the world’s largest and most successful online platform for crowdsourced research. We currently have over 1.6 million registered volunteers working in collaboration with professional researchers on more than 70 research projects across a range of disciplines, from astronomy to biology, climatology to humanities subjects.',
+        seekingProposals: 'Thanks to a generous grant from the Institute of Museum and Library Services, we are currently seeking proposals for two new custom audio transcription projects in the humanities or from GLAM institutions (Galleries, Libraries, Archives and Museums), to be developed as part of the Zooniverse platform.',
+        projectSelection: '### Project Selection',
+        requirements: 'This call will be limited to research teams with audio recordings of spoken language (not limited to English) which would benefit from transcription into digital text formats and/or classification tasks like metadata tagging. We are particularly keen to work on projects where the resulting data can be incorporated into an existing content management system (CMS) and used for research purposes.',
+        audioCompatibility: 'Audio compatibility is currently not available on our free [Project Builder](https://www.zooniverse.org/lab) tool. One aim of this effort will be to use these projects to help test and expand the functionality of our audio tools.',
+        selectionCriteriaTitle: '### Selection Criteria',
+        selectionCriteriaOne: '1. We are looking for projects that harness crowdsourced audio transcription for the purposes of unlocking data currently trapped in sources that cannot be transcribed through automation, and for which human effort is truly necessary. Therefore, proposals should address any previously-attempted methods of automated speech to text transcription.',
+        selectionCriteriaTwo: '2. The data extracted must have an audience or usefulness, be this to academic researchers, members of the public or both.',
+        selectionCriteriaThree: '3. Audio clips for transcription should feature one speaker at a time (per audio clip), as our current research effort does not include speaker diarization.',
+        selectionCriteriaFour: '4. Project teams need clear plans for how to make the crowdsourced data openly and publicly available, ideally through a CMS or site hosted and maintained by your institution.',
+        selectionCriteriaFive: '5. Audio material must be digitized; we do not have funds to support digitization of audio material.',
+        selectionCriteriaSix: '6. We will not accept projects if the material for transcription has previously been edited or published as text.',
+        furtherNotes: '### Further Notes',
+        imlsGrantInfo: 'The two selected audio transcription projects will be part of an ongoing Zooniverse effort, [Transforming Libraries and Archives through Crowdsourcing](https://www.imls.gov/grants/awarded/lg-71-16-0028-16). We particularly welcome applications from marginalized or underrepresented groups, or which utilize content about or generated by underrepresented groups.',
+        deadline: '### Deadline for Audio Project Proposals:',
+        contact: 'Project proposals are due by 28 February 2018. If you have questions or require any further guidance, please contact Samantha Blickhan, IMLS Postdoctoral Fellow: samantha@zooniverse.org.',
+        submissionLink: '[SUBMIT AN AUDIO TRANSCRIPTION PROPOSAL](https://goo.gl/forms/ALbUaRN17Rlq7AkD3)',
+        break: '***'
+      },
+      bio: {
+        header: '## Call for Biomedical Project Proposals',
+        wouldResearchBenefit: 'Would your research benefit from the involvement of thousands of volunteers? We are currently seeking proposals for biomedical projects to be developed as part of the Zooniverse platform. The Zooniverse is the world’s largest and most successful online platform for crowd-sourced research; we currently have over 1.5 million registered volunteers working in collaboration with professional researchers on more than 50 research projects across a range of disciplines, from physics to biology.',
+        projectBuilder: 'Using our unique [Project Builder](/lab) you can create your own Zooniverse project for free with a set of tried and tested tools, including multiple-choice questions and region marking or drawing tools. If we don’t yet offer the tools you need, please propose your project below; we are particularly interested in developing novel projects that extend the functionality of our platform.',
+        projectSelection: '### Project Selection',
+        expandFunctionality: 'We are looking for biomedical projects that will help us expand the functionality of the Zooniverse and build on the selection of tools available to researchers via our platform. Projects may involve a processing task applied to images, graphs, videos or another data format, data collection, or a combination of the two. Successful projects will be developed and hosted by the Zooniverse team, in close collaboration with the applicants.',
+        examples: 'Examples of our current biomedical projects include [Microscopy Masters](https://www.zooniverse.org/projects/jbrugg/microscopy-masters), where volunteers classify cryo-electron microscopy images to advance understanding of protein and virus structure, and [Worm Watch Lab](https://www.wormwatchlab.org/), which aims to improve understanding of the relationship between genes and behaviour.',
+        selectionCriteriaTitle: '### Selection Criteria:',
+        selectionCriteriaOne: '1. Projects extending the capability of the Zooniverse platform or serving as case studies for crowdsourcing in new areas are encouraged.',
+        selectionCriteriaTwo: '2. Alignment with biomedical research (long-term aim of research is to improve human health outcomes).',
+        selectionCriteriaThree: '3. Merit and usefulness of the data expected to result from the project.',
+        deadline: '### Deadline\nProject proposals are accepted on a rolling basis. Applications will be reviewed at the beginning of each month.',
+        submissionLink: '[SUBMIT A BIOMEDICAL PROPOSAL](https://goo.gl/forms/uUGdO5CpWDNFE5Uz2)'
+      }
+    },
+    education: {
+      title: '## Education in the Zooniverse',
+      becomeCitizenScientist: 'As a volunteer on these websites, both you and your students can become citizen scientists and citizen researchers, participating in real science and other research. If you or your students think you have make a mistake, don’t worry; even the researchers make mistakes. These projects are set up to have more than one volunteer analyzing each piece of data, thereby eliminating the vast majority of human error. Mistakes are a part of the process, and can even help us evaluate the difficulty of the data. As long as everyone does their best, they are helping!',
+      resources: '### Resources for educators using Zooniverse',
+      zooTeach: '- [ZooTeach](http://www.zooteach.org/) is a repository of lessons and resources for teachers. At ZooTeach, you will find a variety of resources for education, including: guides to projects for students and teachers, teacher-created presentations designed to introduce students to a particular project, and lessons developed to connect your students to projects and research within the context of things they already know.',
+      educationPages: '- Many Zooniverse projects have their own education pages with additional resources for teachers. Resources may include a video tutorial of how to use the project, other helpful documents and videos about the classification process, and education resources related to the research behind the project.',
+      joinConversationTitle: '### Take part in the conversation',
+      joinConversationBody: 'Keep up with the latest Zooniverse educational efforts on the [Zooniverse Blog](http://blog.zooniverse.org/) or by following [&#64;zooteach](https://twitter.com/ZooTeach) on Twitter. You can also talk with other Zooniverse educators and peers interested in using people-powered research in all sorts of learning environments on the [Zooniverse Education Talk board](http://zooniverse.org/talk/16).',
+      howEducatorsUseZooniverse: '### How are educators using Zooniverse?',
+      inspiration: 'Looking for a little inspiration? Here are some ways educators have used Zooniverse projects and educational resources:',
+      floatingForests: '- [Floating Forests: Teaching Young Children About Kelp](http://blog.zooniverse.org/2015/04/29/floating-forests-teaching-young-children-about-kelp/)',
+      cosmicCurves: '- [Cosmic Curves: Investigating Gravitational Lensing at the Adler Planetarium](http://blog.zooniverse.org/2014/03/18/cosmic-curves-investigating-gravitational-lensing-at-the-adler-planetarium/)',
+      snapshotSerengeti: '- [Snapshot Serengeti Brings Authentic Research Into Undergraduate Courses](http://blog.zooniverse.org/2014/02/19/snapshot-serengeti-brings-authentic-research-into-undergraduate-courses/)',
+      contactUs: 'We’d love to hear about how you’ve used Zooniverse with youth or adult learners! Please contact [education@zooniverse.org](mailto:education@zooniverse.org) if you have any interesting stories to share.'
+    },
+    volunteering: {
+      title: '## How to Volunteer',
+      introduction: 'First of all, everyone who contributes to a Zooniverse project is a volunteer! We have a wonderful, global community who help us do what we do. The main ways of volunteering with us are helping us with classifications on data, being a beta tester on projects we\'ve yet to launch, and being a moderator for a project. For more information about any of these roles, just read below.',
+      projectVolunteeringTitle: '### Volunteer on a Project',
+      projectVolunteeringDescription: 'Volunteering on a project is the easiest and most common way of volunteering. We always need volunteers to go onto our projects and classify the data contained in them. You can read more about what happens with the classifications and how it helps the scientific community and the progress of science on the [About](/about) page.',
+      projectLink: 'There is no minimum time requirement needed; do as much or as little as you\'d like. To get started as a classifications volunteer, just to go to the [Projects](/projects) page, have a look through, find one you like the look of, and get stuck in!',
+      betaTesterTitle: '### Volunteer as a Beta Tester',
+      betaTesterDescription: 'Volunteers also help us test projects before they are launched to check that they work properly. This involves working through some classifications on the beta project to check that it works, looking for any bugs, and filling out a questionnaire at the end. This helps us find any issues in the project that need resolving and also assess how suitable the project is for the Zooniverse. You can read some guidelines on what makes a project suitable on the [Policies](/lab-policies) page, under \'Rules and Regulations\'.',
+      betaTesterSignUp: 'To sign up as a beta tester, go to [www.zooniverse.org/settings/email](/settings/email) and tick the box relating to beta testing. We\'ll then send you emails when a project is ready to be tested. You can change your email settings any time you want using the [same email page](/settings/email) and unticking the box.',
+      projectModeratorTitle: '### Volunteer as a Project Moderator',
+      projectModeratorBody: 'Volunteer moderators have extra permissions in the Talk discussion tool for a particular project. They help moderate discussions and act as a point of contact for the project. Moderators are selected by the project owner. If you\'re interested in becoming a moderator on a project you\'re taking part in, go to the project\'s About page and get in touch with the researcher.',
+      furtherInformationTitle: '### Further Information',
+      contactUs: 'If you\'d like any more information on any of these different roles, contact us via the [Contact Us](/about/contact) page.'
+    }
+  },
+  lab: {
+    help: {
+      howToBuildProject: {
+        title: '## How to create a project with our Project Builder',
+        overview: {
+          quickGuide: '* [A quick guide to building a project](#a-quick-guide-to-building-a-project)',
+          navigating: '* [Navigating the project builder](#navigating-the-project-builder)\n  * [Project](#project)\n  * [Workflows](#workflows)\n  * [Subjects](#subjects)',
+          inDetail: {
+            title: '* [Project building in detail](#project-building-in-detail)',
+            projectDetails: '* [Project Details](#project-details)',
+            about: '  * [About](#about)',
+            collaborators: '* [Collaborators](#collaborators)',
+            fieldGuide: '* [Field Guide](#field-guide)',
+            tutorial: '* [Tutorial](#tutorial)',
+            media: '* [Media](#media)',
+            visibility: '* [Visibility](#visibility)',
+            workflows: '* [Workflows](#workflow-details)',
+            createTasks: '* [Create Tasks](#create-tasks)',
+            taskContent: '* [Task Content](#task-content)',
+            questions: '* [Questions](#questions)',
+            drawing: '* [Drawing](#drawing)',
+            transcription: '* [Transcription](#transcription)',
+            linking: '* [Linking the Workflow Together](#linking-the-workflow-together)',
+            subjectSets: '* [Subject Sets](#subject-sets)',
+            furtherHelp: '* [Further Help](#further-help)'
+          }
+        },
+        sectionOverview: {
+          title: 'There are three sections in this guide:',
+          quickGuide: '1.  [A quick guide to building a project](#a-quick-guide-to-building-a-project) provides an overview of all the steps you need to complete to set up your project.',
+          navigating: '2.  [Navigating the Project Builder](#navigating-the-project-builder) introduces the navigation bar (nav-bar) used in the project builder.',
+          inDetail: '3.  [Project building in detail](#project-building-in-detail) provides a more detailed description of how to set up a project.'
+        },
+        quickGuide: {
+          title: '## A quick guide to building a project',
+          intro: 'A brief overview of all the steps you need to complete to set up your project.',
+          step1: '1. Log in to your Zooniverse account.',
+          step2: '2. Click on "Build a Project" (www.zooniverse.org/lab) and click "Create a New Project".',
+          step3: '3. Enter your project details in the pop-up that appears. You’ll then be taken to a “Project Details” page where you can add further basic information.',
+          step4: '4. Add more information about your project via the blue tabs on the left-hand side of the project builder page. Guidance for each of these sections is provided on the page itself.',
+          step5: '5.  If you have data to upload, add your subjects via the “Subject Sets” tab of the Project Builder (detailed instructions are provided [here](#subjects)).',
+          step6: '6. Next, create your workflow. Click on the “Workflow” tab in the navigation bar on the left-hand side of the page. Use the “New workflow” button to create a workflow. Multiple workflows can be created.',
+          step7: '7. Once you’ve created a workflow, the "Associated Subject Sets" section allows you to link your workflow to your subject sets. If you have no subjects, go to the “Subject Sets” tab and upload your data (see step 5 above).',
+          step8: '8. Hit the "Test this workflow" button to see how your project looks.',
+          step9: '9. Explore your project to figure out what works and what doesn\'t. Make changes, then refresh your project page to test these out.',
+          step10: '10. Guidelines on how to design your project to maximize engagement and data quality are provided on the [Policies page](/help/lab-policies).',
+          step11: '11. When you are happy with your project, set it to “Public” on the “Visibility” tab. Use the “Apply for review” button to submit it to the Zooniverse team for review.',
+          backToTop: '[Back to top](#how-to-create-a-project-with-our-project-builder)'
+        },
+        navigatingTheProjectBuilder: {
+          title: '## Navigating the Project Builder',
+          intro: 'On the left-hand side of the project builder you will see a number of tabs which can be divided into three key sections; “Project”, “Workflows” and “Subject Sets”. These are terms you\'ll see a lot, and they have specific meanings in the Zooniverse.',
+          project: '**Project** is pretty self-explanatory; Galaxy Zoo and Penguin Watch are examples of Zooniverse projects that could be built using the project builder.',
+          workflows: '**Workflows** are sequences of tasks that volunteers are asked to do.',
+          subjectSets: '**Subject sets** are collections of data (typically images) that volunteers are asked to perform tasks on.',
+          glossaryPage: 'For more Zooniverse definitions, check out the [Glossary page](/help/glossary).'
+        },
+        project: {
+          title: '### Project',
+          intro: 'The tabs listed below are where you enter descriptive information for your project.',
+          details: '- **Project Details:** Here you can add information that generates a home page for your project. Start by naming and describing your project, add a logo and background image.',
+          about: '- **About:** Here you can add all sorts of additional pages, including *Research, Team, Results, Education,* and *FAQ*',
+          collaborators: '- **Collaborators:** Add people to your team. You can specify their roles so that they have access to the tools they need (such as access to the project before it\'s public).',
+          fieldGuide: '- **Field Guide:** A field guide is a place to store general project-specific information that volunteers will need to understand in order to complete classifications and talk about what they\'re seeing.',
+          tutorial: '- **Tutorial:** This is where you create tutorials to show your users how to contribute to your project.',
+          media: '- **Media:** Add images you need for your project pages (not the images you want people to classify!)',
+          visibility: '- **Visibility:** Set your project\'s "state" - private or public, live or in development, and apply for review by the Zooniverse. You can also activate or deactivate specific workflows on this page.',
+          talk: '- **Talk:** Create and manage discussion boards for your project.',
+          dataExports: '- **Data Exports:** Access your raw and aggregated classification data, subject data, and comments from Talk.'
+        },
+        workflow: {
+          title: '### Workflows',
+          body: 'A workflow is the sequence of tasks volunteers are asked to perform. For example, you might want to ask volunteers to answer questions about your images, or to mark features in your data, or both. The workflow tab is where you define those tasks and set the order in which volunteers are asked to do them. Your project might have multiple workflows (if you want to set different tasks for different image sets). See the detailed [Workflow](#workflow-details) section for more information.'
+        },
+        subjects: {
+          title: '### Subjects',
+          body: 'A subject is a unit of data to be analyzed. A single subject can include more than one image. A “subject set” consists of both the "manifest" (a list of the subjects and their properties), and the images themselves. Subjects can be grouped into different sets if useful for your research. See the [Subject Details](#subject-sets) section for more on subjects.',
+          backToTop: '[Back to top](#how-to-create-a-project-with-our-project-builder)'
+        },
+        projectDetails: {
+          title: '## Project building in detail',
+          intro: 'Detailed instructions on how to use the pages described above.',
+          subtitle: '### Project details',
+          name: '* **Name**: The project name is the first thing people will see and it will show up in the project URL. Try to keep it short and sweet.',
+          avatar: '* **Avatar**: Pick an avatar image for your project. This will represent your project on the Zooniverse home page. It can also be used as your project\'s brand. It\'s best if it\'s recognizable even as a small icon. To add an image, either drag and drop or click to open your file viewer. For best results, use a square image of not more than 50KB, but at minimum 100x100 pixels.',
+          background: '* **Background**: This image will be the background for all of your project pages, including your project\'s front page. It should be relatively high resolution and you should be able to read text written across it. To add an image, either drag and drop or click to open your file viewer. For best results, use images of at least 1 megapixel, no larger than 256 KB. Most people\'s screens are not much bigger than 1300 pixels across and 750 pixels high, so if your image is a lot bigger than this you may find it doesn\'t look the way you expect. Feel free to experiment with different sizes on a "typical" desktop, laptop or mobile screen.',
+          description: '* **Description**: This should be a one-line call to action for your project. This will display on your landing page and, if approved, on the Zooniverse home page. Some volunteers will decide whether to try your project based on reading this, so try to write short text that will make people actively want to join your project.',
+          introduction: '* **Introduction**: Add a brief introduction to get people interested in your project. This will display on your project\'s front page. Note this field [renders markdown](http://markdownlivepreview.com/), so you can format the text. You can make this longer than the Description, but it\'s still probably best to save much longer text for areas like the About, Research Case or FAQ tabs.',
+          workflowDescription: '* **Workflow Description:** A workflow is a set of tasks a volunteer completes to create a classification. Your project might have multiple workflows (if you want to set different tasks for different subject image sets). Add text here when you have multiple workflows and want to help your volunteers decide which one they should do.',
+          checkboxVolunteers: '* **Checkbox: Volunteers choose workflow:**  If you have multiple workflows, check this to let volunteers select which workflow they want to work on; otherwise, they\'ll be served randomly.',
+          researcherQuote: '* **Researcher Quote:** This text will appear on the project landing page alongside an avatar of the selected researcher. It’s a way of communicating information to your volunteers, highlighting specific team members, and getting volunteers enthusiastic about participating.',
+          announcementBanner: '* **Announcement Banner:** This text will appear as a banner at the top of all your project’s pages. Only use this when you’ve got a big important announcement to make! Many projects use this to signal the end of a beta review, or other major events in a project’s life cycle.',
+          disciplineTag: '* **Discipline Tag:** Enter or select one or more discipline tags to identify which field(s) of research your project belongs to. These tags will determine the categories your project will appear under on the main Zooniverse projects page, if your project becomes a full Zooniverse project.',
+          otherTags: '* **Other Tags:** Enter a list of additional tags to describe your project separated by commas to help users find your project.',
+          externalLinks: '* **External links:** Adding an external link will make it appear as a new tab alongside the About, Classify, Talk, and Collect tabs. You can rearrange the displayed order by clicking and dragging on the left gray tab next to each link.',
+          socialLinks: '* **Social links:** Adding a social link will append a media icon at the end of your project menu bar. You can rearrange the displayed order by clicking and dragging on the left gray tab next to each link.',
+          checkboxPrivate: '* **Checkbox: Private project:** On "private" projects, only users with specified project roles can see or classify on the project. We strongly recommend you keep your project private while you\'re still editing it. Share it with your team to get feedback by adding them in the Collaborators area (linked at the left-hand side of the Project Builder). Team members you add can see your project even if it\'s private. Once your project is public, anyone with the link can view and classify on it.',
+          backToTop: '[Back to top](#how-to-create-a-project-with-our-project-builder)'
+        },
+        about: {
+          title: '### About',
+          intro: 'This section contains pages where you can enter further information for Research, Team, Results, Education and FAQ. All of these pages use [Markdown](http://markdownlivepreview.com/) to format text and display images.',
+          research: '* **Research:** Use this section to explain your research to your audience in as much detail as you\'d like. Explaining your motivation to volunteers is critical for the success of your project – please fill in this page (it will display even if you don’t)!',
+          team: '* **Team:** Introduce the members of your team, and the roles they play in your project.',
+          results: '* **Results:** Share results from your project with volunteers and the public here. This page will only display if you add content to it.',
+          education: '* **Education:** On this page, you can provide resources for educators and students to use alongside your project, such as course syllabi, pedagogical tools, further reading, and instructions on how the project might be used in an educational context. This page will only display if you add content to it.',
+          faq: '* **FAQ:** Add details here about your research, how to classify, and what you plan to do with the classifications. This page can evolve as your project does so that your active community members have a resource to point new users to. This page will only display if you add content to it.'
+        },
+        collaborators: {
+          title: '### Collaborators',
+          intro: 'Here you can add people to your team. You can specify their roles so that they have access to the tools they need (such as access to the project before it\'s public).',
+          owner: '* **Owner:** The owner is the original project creator. There can be only one.',
+          collaborator: '* **Collaborator:** Collaborators have full access to edit workflows and project content, including deleting some or all of the project.',
+          expert: '* **Expert:** Experts can enter “gold mode” to make authoritative gold standard classifications that will be used to validate data quality.',
+          researcher: '* **Researcher:** Members of the research team will be marked as researchers on “Talk".',
+          moderator: '* **Moderator:** Moderators have extra privileges in the community discussion area to moderate discussions. They will also be marked as moderators on “Talk".',
+          tester: '* **Tester:** Testers can view and classify on your project to give feedback while it’s still private. They cannot access the project builder.',
+          translator: '* **Translator:** Translators will have access to the project builder as well as the translation site, so they can translate all of your project text into a different language.',
+          backToTop: '[Back to top](#how-to-create-a-project-with-our-project-builder)'
+        },
+        fieldGuide: {
+          title: '### Field Guide',
+          intro: 'A field guide is a place to store general project-specific information that volunteers will need to understand in order to complete classifications and talk about what they\'re seeing. It\'s available anywhere in your project, accessible via a tab on the right-hand side of the screen.',
+          details: 'Information can be grouped into different sections, and each section should have a title and an icon. Content for each section is rendered with [Markdown](http://markdownlivepreview.com/), so you can include any media you\'ve uploaded for your project there.'
+        },
+        tutorial: {
+          title: '### Tutorial',
+          intro: 'In this section, you can create a step-by-step tutorial to show your users how to use your project. You can upload images and enter text to create each step of the tutorial. You can add as many steps as you want, but keep your tutorial as short as possible so volunteers can start classifying as soon as possible.',
+          details: 'In some cases, you might have several different workflows, and will therefore need several different tutorials. In the Workflows tab, you can specify which tutorial shows for the workflow a volunteer is on.'
+        },
+        media: {
+          title: '### Media',
+          intro: 'You can upload your own media to your project (such as example images for your Help pages or Tutorial) so you can link to it without an external host. To start uploading, drop an image into the grey box (or click “Select files” to bring up your file browser and select a file). Once the image has uploaded, it will appear above the "Add an image" box. You can then copy the Markdown text beneath the image into your project, or add another image.'
+        },
+        visibility: {
+          title: '### Visibility',
+          intro: 'This page is where you decide whether your project is public and whether it\'s ready to go live.',
+          projectState: '* **Project State and Visibility:** Set your project to “Private” or “Public”. Only the assigned collaborators can view a private project. Anyone with the URL can access a public project. Here, you can also choose whether your project is in “Development”, or “Live”. Note: in a live project, active workflows are locked and can no longer be edited.',
+          betaStatus: '* **Beta Status:** Here, you will find a checklist of tasks that must be complete for your project to undergo beta review. Projects must complete review in order to launch as full Zooniverse projects and be promoted as such. Once these tasks are complete, click “Apply for review”.',
+          workflowSettings: '* **Workflow Settings:** You will see a list of all workflows created for the project. You can set the workflows to “Active”, choose what metric to measure for completeness statistics, and whether those statistics should be shown on your project’s Stats Page.For more information on the different project stages, see our [Project Builder policies](/help/lab-policies).',
+          backToTop: '[Back to top](#how-to-create-a-project-with-our-project-builder)'
+        },
+        talk: {
+          title: '### Talk',
+          intro: '“Talk” is the name for the discussion boards attached to your project. On your Talk, volunteers will be able to discuss your project and subjects with each other, as well as with you and your project’s researchers. **Maintaining a vibrant and active Talk is important for keeping your volunteers engaged with your project.** Conversations on Talk also can lead to additional research discoveries.',
+          details: 'You can use this page to set up the initial Talk boards for your project. We highly recommend first activating the default subject-discussion board, which hosts a single dedicated conversation for each subject. After that, you can add additional boards, where each board will host conversation about a general topic. Example boards might include: “Announcements,” “Project Discussion,” “Questions for the Research Team,” or “Technical Support.”'
+        },
+        dataExports: {
+          title: '### Data Exports',
+          intro: 'In this section you can request data exports for your Project Data (CSV format) and Talk Data (JSON format). Note that the Zooniverse will process at most 1 of each export within a 24-hour period and some exports may take a long time to process. We will email you when they are ready. For examples of how to work with the data exports see our [Data Digging code repository](https://github.com/zooniverse/Data-digging).'
+        },
+        workflowDetails: {
+          title: '### Workflow Details',
+          introduction: 'Note that a workflow with fewer tasks is easier for volunteers to complete. We know from surveys of our volunteers that many people classify in their limited spare time, and sometimes they only have a few minutes. Longer, more complex workflows mean each classification takes longer, so if your workflow is very long you may lose volunteers.',
+          workflowTitle: '* **Workflow title:** Give your workflow a short, but descriptive name. If you have multiple workflows and give volunteers the option of choosing which they want to work on, this Workflow title will appear on a button instead of "Get started!"',
+          version: '* **Version:** Version indicates which version of the workflow you are on. Every time you save changes to a workflow, you create a new version. Big changes, like adding or deleting questions, will change the version by a whole number: 1.0 to 2.0, etc. Smaller changes, like modifying the help text, will change the version by a decimal, e.g. 2.0 to 2.1. The version is tracked with each classification in case you need it when analyzing your data.',
+          tasks: '* **Tasks:** There are two main types of tasks: questions and drawing. For question tasks, the volunteer chooses from a list of answers but does not mark or draw on the image. In drawing tasks, the volunteer marks or draws directly on the image using tools that you specify. They can also give sub-classifications for each mark. Note that you can set the first task from the drop-down menu.',
+          mainText: '* **Main Text:** Describe the task, or ask the question, in a way that is clear to a non-expert. The wording here is very important, because you will in general get what you ask for. Solicit opinions from team members and testers before you make the project public: it often takes a few tries to reach the combination of simplicity and clarity that will guide your volunteers to give you the inputs you need. You can use markdown in the main text.',
+          helpText: '* **Help Text:** Add text and images for a pop-up help window. This is shown next to the main text of the task in the main classification interface, when the volunteer clicks a button asking for help. You can use markdown in this text, and link to other images to help illustrate your description. The help text can be as long as you need, but you should try to keep it simple and avoid jargon. One thing that is useful in the help text is a concise description of why you are asking for this information.',
+          backToTop: '[Back to top](#how-to-create-a-project-with-our-project-builder)'
+        },
+        createTasks: {
+          title: '### Create Tasks',
+          body: 'Create tasks with the "Add a task" button. Delete tasks with the "Delete this task" button under the “Choices” box.'
+        },
+        taskContent: {
+          title: '### Task Content',
+          body: 'Tasks can be Questions, Drawings or Transcription. All types have "Main Text" boxes where you can ask your questions or tell users what to draw, as well as provide additional support for completing the task in the "Help Text" box.'
+        },
+        questions: {
+          title: '#### Questions',
+          intro: 'Choices: This section contains all your answers. The key features of this section are:',
+          required: '- **Required:** if you select this, the user has to answer the question before moving on.',
+          multiple: '- **Multiple:** if you select this, the user can select more than one answer - use this for "select all that apply" type questions.',
+          nextTask: '- **Next Task:** The “Next task” selection (which appears below the text box for each answer) describes what task you want the volunteer to perform next after they give a particular answer. You can choose from among the tasks you’ve already defined. If you want to link a task to another you haven’t built yet, you can come back and do it later (don’t forget to save your changes).'
+        },
+        drawing: {
+          title: '#### Drawing',
+          intro: 'This section contains all the different things people can mark. We call each separate option a "Tool" and you can specify a label, colour, and tool type for each option. Check out the [Aggregation documents](https://aggregation-caesar.zooniverse.org/docs) to understand how multiple volunteer answers are turned into final shapes for your data analysis. The tool types are:',
+          bezier: '- **bezier:** an arbitrary shape made of point-to-point curves. The midpoint of each segment drawn can be dragged to adjust the curvature.',
+          circle: '- **circle:** a point and a radius.',
+          column: '- **column:** a box with full height but variable width; this tool *cannot* be rotated.',
+          ellipse: '- **ellipse:** an oval of any size and axis ratio; this tool *can* be rotated.',
+          line: '- **line:** a straight line at any angle.',
+          point: '- **point:** X marks the spot.',
+          polygon: '- **polygon:** an arbitrary shape made of point-to-point lines.',
+          rectangle: '- **rectangle:** a box of any size and length-width ratio; this tool *cannot* be rotated.',
+          triangle: '- **triangle:** an equilateral triangle of any size and vertex distance from the center; this tool *can* be rotated.',
+          gridTable: '- **grid table:** cells which can be made into a table for consecutive annotations.',
+          backToTop: '[Back to top](#how-to-create-a-project-with-our-project-builder)'
+        },
+        transcription: {
+          title: '#### Transcription',
+          intro: 'This section deals with projects which require user-generated text. Tasks can range from adding keywords or extracting metadata to full text transcriptions.',
+          keywordTagging: '- **Keyword tagging** is helpful when teams want to create a list of all of the things volunteers see in a given image, to make that object more discoverable in a database or online collection. In these cases diversity of opinion is helpful. Setting a retirement rate of 5 to 10 people will help capture diverse opinions.',
+          fullTextTranscription: '- **Full text transcription** is more cumbersome and diversity of opinion is less helpful. Teams are usually trying to capture exactly what is on a page, so it will help to set a relatively low retirement rate for each image (i.e. 3 or 5) and be very clear in the tutorial how you would like volunteers to transcribe. Should they preserve spelling and punctuation or modernize it?',
+          aggregatedClassifications: '- Zooniverse does not currently offer aggregated classifications for text subjects. We can only report what each user transcribed for each subject. Before embarking on a transcription project be sure you have in-house expertise or access to expertise for combining multiple independent transcriptions into a single reading that you could use for research or to upload into a library or museum catalogue or content management system. For more information on Project Builder Data, please visit our [Data Digging code repository](https://github.com/zooniverse/Data-digging) as well as our [Data processing Talk board](https://www.zooniverse.org/talk/1322).'
+        },
+        linking: {
+          title: '#### Linking the workflow together',
+          intro: 'Now that all the tasks have been created, we\'ve got to string them together by specifying what happens *next*. Set your first task using the "First Task" drop-down menu below the "Add Task" button. Then, using the “Next task” drop-down under the “Choices” box, specify *what comes next*. In question tasks, you can specify different "Next Tasks" for each available answer (provided users can only select one answer).',
+          multiImageOptions: '**Multi-Image options:** If your tasks require users to see multiple subjects per task (like on [Snapshot Serengeti](https://www.snapshotserengeti.org)), decide how users will see them. The Flipbook option means users have to press a button to switch between subjects, while separate frames mean that each subject will be visible for the duration of the classification task.',
+          subjectRetirement: '**Subject retirement:** Decide how many people you want to complete each task. You can change this number at any point (particularly after beta review). We suggest starting out high, between 10 and 20.'
+        },
+        subjectSets: {
+          title: '### Subject Sets',
+          intro: 'On this page, you can add groups of data to be classified.',
+          summary: 'To do so, drag and drop items onto the drop zone in the browser and then upload. You can give each set a name so that you can easily distinguish between them.',
+          details: 'Subject sets can be pretty powerful, and sometimes complex. You can have a single subject set that you add to over time, or have multiple subject sets, say, from different years or places. You can have different subject sets for different workflows, but you don\'t have to. You can even have multiple images in a given subject. For more details and advice on creating and structuring subject sets and associated manifests, check out https://www.zooniverse.org/help/example and scroll down to DETAILS - Subject sets and manifest details, a.k.a. “What is a manifest?”'
+        },
+        furtherHelp: {
+          title: '## Further Help',
+          body: 'If you\'d like some further information, check out the [documentation behind building Kitteh Zoo](/help/example), that talks you through building this project in the Project Builder.\n\nIf this doesn\'t help, get in contact with the Zooniverse team via the [contact page](/about/contact).',
+          backToTop: '[Back to top](#how-to-create-a-project-with-our-project-builder)'
+        }
+      }
+    }
+  }
+};

--- a/app/pages/project/components/ProjectNavbar/components/ProjectNavbarWide/ProjectNavbarWide.jsx
+++ b/app/pages/project/components/ProjectNavbar/components/ProjectNavbarWide/ProjectNavbarWide.jsx
@@ -48,15 +48,21 @@ export const List = styled.ul`
 `;
 
 export const ListItem = styled.li`
+  display: inline;
   list-style: none;
 
-  &:not(:last-of-type) {
+  &:not(:last-of-type)::after {
+    content: " ";
+    font-size: 0;
+    line-height: 0;
     margin-right: ${pxToRem(30)};
+    white-space: pre;
   }
 `;
 
 export const StyledNavLink = styled(NavLink)`
   border-bottom: ${pxToRem(3)} solid transparent;
+  display: inline-block;
   margin-top: ${pxToRem(2)};
 
   &:hover,

--- a/app/pages/project/components/ProjectNavbar/components/ProjectNavbarWide/ProjectNavbarWide.jsx
+++ b/app/pages/project/components/ProjectNavbar/components/ProjectNavbarWide/ProjectNavbarWide.jsx
@@ -26,7 +26,13 @@ export const StyledOuterWrapper = styled.div`
 `;
 
 export const StyledAvatar = styled(Avatar)`
-  margin-right: ${pxToRem(20)};
+  [lang] & {
+    margin: 0 ${pxToRem(20)} 0 0;
+  }
+  
+  [lang=he] &, [lang=ar] & {
+    margin: 0 0 0 ${pxToRem(20)};
+  }
 `;
 
 export const StyledWrapper = styled(Wrapper)`

--- a/app/pages/project/components/ProjectNavbar/components/ProjectNavbarWide/ProjectNavbarWide.jsx
+++ b/app/pages/project/components/ProjectNavbar/components/ProjectNavbarWide/ProjectNavbarWide.jsx
@@ -26,11 +26,9 @@ export const StyledOuterWrapper = styled.div`
 `;
 
 export const StyledAvatar = styled(Avatar)`
-  [lang] & {
-    margin: 0 ${pxToRem(20)} 0 0;
-  }
+  margin: 0 ${pxToRem(20)} 0 0;
   
-  [lang=he] &, [lang=ar] & {
+  .rtl & {
     margin: 0 0 0 ${pxToRem(20)};
   }
 `;

--- a/app/pages/project/components/ProjectNavbar/components/ProjectTitle/ProjectTitle.jsx
+++ b/app/pages/project/components/ProjectNavbar/components/ProjectTitle/ProjectTitle.jsx
@@ -6,8 +6,6 @@ import { IndexLink } from 'react-router';
 import counterpart from 'counterpart';
 import { pxToRem, zooTheme } from '../../../../../../theme';
 
-// TODO why does this come back as a missing translation?
-const zooniverseApprovedTranslation = counterpart('project.nav.zooniverseApproved');
 
 export const H1 = styled.h1`
   color: white;
@@ -48,12 +46,17 @@ export const StyledRedirect = styled.a`
 `;
 
 export const StyledCheckMarkWrapper = styled.span.attrs({
-  'aria-label': "Zooniverse Approved",
-  role: 'img',
-  title: "Zooniverse Approved"
+  role: 'img'
 })`
   font-size: 0.75rem;
-  margin-left: 1rem;
+
+  [lang] & {
+    margin: 0 0 0 1rem;
+  }
+
+  [lang=he] &, [lang=ar] & {
+    margin: 0 1rem 0 0;
+  }
 `;
 
 export const StyledCheckMark = styled.i`
@@ -76,6 +79,7 @@ export const StyledUnderReview = styled.small`
 
 function ProjectTitle({ launched, link, redirect, title, underReview }) {
   const TitleComponent = (redirect) ? StyledRedirect : StyledLink;
+  const zooniverseApprovedTranslation = counterpart('project.nav.zooniverseApproved');
 
   return (
     <ThemeProvider theme={{ mode: 'light' }}>
@@ -87,7 +91,11 @@ function ProjectTitle({ launched, link, redirect, title, underReview }) {
             {title}
             {redirect && <span>{' '}<i className="fa fa-external-link" /></span>}
             {launched &&
-              <StyledCheckMarkWrapper className="fa-stack">
+              <StyledCheckMarkWrapper
+                className="fa-stack"
+                aria-label={zooniverseApprovedTranslation}
+                title={zooniverseApprovedTranslation}
+              >
                 <i className="fa fa-circle fa-stack-2x" />
                 <StyledCheckMark className="fa fa-check fa-stack-1x" />
               </StyledCheckMarkWrapper>}

--- a/app/pages/project/components/ProjectNavbar/components/ProjectTitle/ProjectTitle.jsx
+++ b/app/pages/project/components/ProjectNavbar/components/ProjectTitle/ProjectTitle.jsx
@@ -49,12 +49,9 @@ export const StyledCheckMarkWrapper = styled.span.attrs({
   role: 'img'
 })`
   font-size: 0.75rem;
+  margin: 0 0 0 1rem;
 
-  [lang] & {
-    margin: 0 0 0 1rem;
-  }
-
-  [lang=he] &, [lang=ar] & {
+  .rtl & {
     margin: 0 1rem 0 0;
   }
 `;

--- a/app/pages/project/field-guide.cjsx
+++ b/app/pages/project/field-guide.cjsx
@@ -1,5 +1,6 @@
 React = require 'react'
 createReactClass = require 'create-react-class'
+classnames = require 'classnames'
 {Markdown} = require 'markdownz'
 CroppedImage = require('../../components/cropped-image').default
 
@@ -83,8 +84,15 @@ module.exports = createReactClass
 
     levelUp = @cutSelection.bind this, selectionTrail.length - 1
     atRoot = @state.selection.length is 0
+    className = classnames({
+        "field-guide": true,
+        rtl: this.props.rtl
+      })
 
-    <div className="field-guide">
+    <div
+      className={className}
+      lang={this.props.locale}
+    >
       <header>
         <button type="button" className="field-guide-header-button" disabled={atRoot} onClick={levelUp}>
           <i className="fa fa-chevron-left fa-fw"></i>

--- a/app/pages/project/project-page.jsx
+++ b/app/pages/project/project-page.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import classNames from 'classnames';
 import { Markdown } from 'markdownz';
 import { sugarClient } from 'panoptes-client/lib/sugar';
 import ProjectNavbar from './components/ProjectNavbar';
@@ -34,10 +35,15 @@ export default class ProjectPage extends React.Component {
   }
 
   render() {
+    const containerClassNames = classNames({
+      'project-page': true,
+      'rtl': this.props.translations.rtl
+    });
+
     return (
       <div
         lang={this.props.translations.locale}
-        className="project-page"
+        className={containerClassNames}
       >
         <ProjectNavbar
           background={this.props.background}
@@ -107,7 +113,8 @@ ProjectPage.defaultProps = {
     display_name: ''
   },
   translations: {
-    locale: 'en'
+    locale: 'en',
+    rtl: false
   },
   user: null,
   workflow: null
@@ -144,7 +151,8 @@ ProjectPage.propTypes = {
     display_name: PropTypes.string
   }),
   translations: PropTypes.shape({
-    locale: PropTypes.string
+    locale: PropTypes.string,
+    rtl: PropTypes.bool
   }),
   workflow: PropTypes.shape({
     id: PropTypes.string

--- a/app/pages/project/project-page.jsx
+++ b/app/pages/project/project-page.jsx
@@ -35,7 +35,10 @@ export default class ProjectPage extends React.Component {
 
   render() {
     return (
-      <div className="project-page">
+      <div
+        lang={this.props.translations.locale}
+        className="project-page"
+      >
         <ProjectNavbar
           background={this.props.background}
           loading={this.props.loading}
@@ -103,6 +106,9 @@ ProjectPage.defaultProps = {
     id: '',
     display_name: ''
   },
+  translations: {
+    locale: 'en'
+  },
   user: null,
   workflow: null
 };
@@ -136,6 +142,9 @@ ProjectPage.propTypes = {
   routes: PropTypes.array,
   translation: PropTypes.shape({
     display_name: PropTypes.string
+  }),
+  translations: PropTypes.shape({
+    locale: PropTypes.string
   }),
   workflow: PropTypes.shape({
     id: PropTypes.string

--- a/app/redux/ducks/translations.js
+++ b/app/redux/ducks/translations.js
@@ -3,6 +3,10 @@ import counterpart from 'counterpart';
 import merge from 'lodash/merge';
 
 const DEFAULT_LOCALE = counterpart.getLocale();
+const RTL_LANGUAGES = [
+  'ar',
+  'he'
+];
 
 counterpart.setFallbackLocale(DEFAULT_LOCALE);
 
@@ -33,6 +37,7 @@ const initialState = {
   languages: {
     project: []
   },
+  rtl: false,
   strings: {
     project: {},
     workflow: {},
@@ -51,7 +56,9 @@ export default function reducer(state = initialState, action = {}) {
       const languages = Object.assign({}, state.languages, { [action.payload.type]: action.payload.languages });
       return Object.assign({}, state, { languages });
     case SET_LOCALE:
-      return Object.assign({}, state, { locale: action.payload });
+      const locale = action.payload;
+      const rtl = RTL_LANGUAGES.indexOf(locale) > -1;
+      return Object.assign({}, state, { locale, rtl });
     case SET_TRANSLATION:
       ({ type, languageStrings } = action.payload);
       let translation = {};

--- a/app/talk/index.cjsx
+++ b/app/talk/index.cjsx
@@ -36,7 +36,7 @@ module.exports = createReactClass
 
   render: ->
     logClick = @context.geordi?.makeHandler? 'breadcrumb'
-    <div className="talk content-container">
+    <div className="talk content-container" lang="en">
       <Helmet title={counterpart 'talkPage.title'} />
       <h1 className="talk-main-link">
         <Link to="/talk" onClick={logClick?.bind(this, '')}>Zooniverse Talk</Link>

--- a/css/app.styl
+++ b/css/app.styl
@@ -1,3 +1,7 @@
+[lang=he]
+[lang=ar]
+  direction: rtl
+
 body
   margin: 0
 

--- a/css/app.styl
+++ b/css/app.styl
@@ -1,5 +1,4 @@
-[lang=he]
-[lang=ar]
+.rtl
   direction: rtl
 
 body

--- a/css/talk.styl
+++ b/css/talk.styl
@@ -1,3 +1,6 @@
+.talk
+  direction: ltr
+
 .talk-module // shared styles among talk box shaped things
   background: TALK_BACKGROUND
   border-radius: TALK_BORDER_RADIUS


### PR DESCRIPTION
Add lang attribute to project page container.
Add RTL styles for Hebrew and Arabic.
Add language files for Hebrew and Arabic

Staging branch URL: https://project-language.pfe-preview.zooniverse.org/projects/judaicadh/scribes-of-the-cairo-geniza?env=production&language=he

Fixes #4621.

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [x] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
