### PR TITLE
Strip HTML from blog excerpts

### DIFF
--- a/app/pages/home-common/social.jsx
+++ b/app/pages/home-common/social.jsx
@@ -79,7 +79,7 @@ export default class HomePageSocial extends React.Component {
         <div className="home-social__blog-post">
           <div style={background}></div>
           <div>
-            <span className="regular-body">{post.excerpt}</span>
+            <span className="regular-body">{post.excerpt.replace(/<.+?>/g, '')}</span>
             <br />
             <div>
               <a className="home-social__italic-link" href={post.link}> Read More... </a>

--- a/app/pages/home-common/social.jsx
+++ b/app/pages/home-common/social.jsx
@@ -6,6 +6,7 @@ import counterpart from 'counterpart';
 import moment from 'moment';
 import ProjectCard from '../../partials/project-card';
 import { getPublication, getRecentProjects, getBlogPosts, getNewestProject } from '../../lib/get-social-data';
+import striptags from 'striptags';
 
 counterpart.registerTranslations('en', {
   socialHomePage: {
@@ -79,7 +80,7 @@ export default class HomePageSocial extends React.Component {
         <div className="home-social__blog-post">
           <div style={background}></div>
           <div>
-            <span className="regular-body">{post.excerpt.replace(/<.+?>/g, '')}</span>
+            <span className="regular-body">{striptags(post.excerpt)}</span>
             <br />
             <div>
               <a className="home-social__italic-link" href={post.link}> Read More... </a>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8980,6 +8980,11 @@
       "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
       "dev": true
     },
+    "striptags": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/striptags/-/striptags-2.2.1.tgz",
+      "integrity": "sha1-TEULcI1BuL85zyTEn/I0/Gqr/TI="
+    },
     "style-loader": {
       "version": "0.16.1",
       "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-0.16.1.tgz",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "shortid": "~2.2.8",
     "sinon": "~4.1.5",
     "sort-into-columns": "~1.0.0",
+    "striptags": "~2.2.1",
     "styled-components": "~2.2.4",
     "styled-theming": "~2.2.0",
     "sugar-client": "~1.0.1",


### PR DESCRIPTION
Staging branch URL: https://remove-blog-tags.pfe-preview.zooniverse.org/

Fixes https://www.zooniverse.org/talk/17/638676


# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?