### PR TITLE
Fix projectToken remember for projects

### DIFF
--- a/app/classifier/restart-button.jsx
+++ b/app/classifier/restart-button.jsx
@@ -13,10 +13,6 @@ const RestartButton = ({ children, className, start, shouldRender, style }) => {
   }
 };
 
-RestartButton.contextTypes = {
-  geordi: PropTypes.object
-};
-
 RestartButton.defaultProps = {
   className: null,
   shouldRender: true,

--- a/app/pages/project/project-page.jsx
+++ b/app/pages/project/project-page.jsx
@@ -7,10 +7,6 @@ import FieldGuideContainer from './field-guide-container';
 import ProjectHomeContainer from './home/';
 
 export default class ProjectPage extends React.Component {
-  getChildContext() {
-    return this.context.geordi;
-  }
-
   componentDidMount() {
     this.updateSugarSubscription(this.props.project);
     this.context.geordi && this.context.geordi.remember({ projectToken: this.props.project.slug });
@@ -111,7 +107,7 @@ ProjectPage.defaultProps = {
   workflow: null
 };
 
-ProjectPage.childContextTypes = {
+ProjectPage.contextTypes = {
   geordi: PropTypes.object
 };
 


### PR DESCRIPTION
Staging branch URL: https://fix-project-token-logging.pfe-preview.zooniverse.org/

Related to #4637. Fixes geordi key `projectToken` so it's set dynamically based on project, as opposed to currently where `projectToken` remains as `'zooHome'` within all projects. 

This will prevent logging within projects that are not [specified in `enabledTokens`](https://github.com/zooniverse/Panoptes-Front-End/blob/fix-project-token-logging/app/lib/zooniverse-logging.js#L1).

To test I added a console.log before and within [this conditional](https://github.com/zooniverse/Panoptes-Front-End/blob/fix-project-token-logging/app/lib/zooniverse-logging.js#L30), logging the `projectToken`, and added a test project within [`enabledTokens`](https://github.com/zooniverse/Panoptes-Front-End/blob/fix-project-token-logging/app/lib/zooniverse-logging.js#L1). I made a classification and clicked Done and Talk within the test project added, and a test project excluded from `enabledTokens` and confirmed within the test project added the classify and jump to talk events were logged, and confirmed within the excluded test project the classify and jump to talk events were not logged.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
