### PR TITLE
Fix tutorial rendering bug

### DIFF
--- a/app/components/step-through.jsx
+++ b/app/components/step-through.jsx
@@ -21,7 +21,10 @@ class StepThrough extends Component {
 
   componentDidMount() {
     addEventListener('keydown', this.handleKeyDown);
-    setTimeout(this.swiper.swipe.setup);
+    setTimeout(() => {
+      this.swiper.swipe.setup();
+      this.swiper.swipe.setup();
+    });
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
The tutorial renders much too narrow, unless you call swipe.setup() twice.

Staging branch URL: https://fix-tutorial-width.pfe-preview.zooniverse.org

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
