### PR TITLE
Fix Add To Collections close button

### DIFF
--- a/app/collections/manager-icon.jsx
+++ b/app/collections/manager-icon.jsx
@@ -55,11 +55,15 @@ CollectionsManagerIcon.defaultProps = {
 
 CollectionsManagerIcon.propTypes = {
   className: PropTypes.string,
-  project: PropTypes.object,
+  project: PropTypes.shape({
+    id: PropTypes.string
+  }).isRequired,
   subject: PropTypes.shape({
     id: PropTypes.string
-  }),
-  user: PropTypes.object
+  }).isRequired,
+  user: PropTypes.shape({
+    id: PropTypes.string
+  }).isRequired
 };
 
 export default CollectionsManagerIcon;

--- a/app/collections/manager-icon.jsx
+++ b/app/collections/manager-icon.jsx
@@ -19,8 +19,9 @@ class CollectionsManagerIcon extends React.Component {
     this.setState({ open: true });
   }
 
-  close() {
+  close(e) {
     this.setState({ open: false });
+    e.stopPropagation();
   }
 
   render() {


### PR DESCRIPTION
Staging branch URL: https://fix-collections-dialog.pfe-preview.zooniverse.org

Fixes #4665.

Describe your changes.
Prevent click events propagating up from the close button to the parent button in the React tree. Also fixes linter warnings for the manager icon component.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
