### PR TITLE
Reset classifier annotation state when new classifications load

### DIFF
--- a/app/classifier/classifier.jsx
+++ b/app/classifier/classifier.jsx
@@ -180,15 +180,15 @@ class Classifier extends React.Component {
 
   loadSubject(subject) {
     const { actions, project, workflow } = this.props;
-    actions.feedback.init(project, subject, workflow);
+    if (actions.feedback) {
+      actions.feedback.init(project, subject, workflow);
+    }
 
     this.setState({
-      annotations: [],
       expertClassification: null,
       selectedExpertAnnotation: -1,
       showingExpertClassification: false,
-      subjectLoading: true,
-      workflowHistory: []
+      subjectLoading: true
     });
 
     if (project.experimental_tools && project.experimental_tools.indexOf('expert comparison summary') > -1) {
@@ -539,9 +539,13 @@ Classifier.propTypes = {
 };
 
 Classifier.defaultProps = {
+  actions: {},
   classification: {},
   classificationCount: 0,
   demoMode: false,
+  feedback: {
+    active: false
+  },
   minicourse: null,
   onComplete: () => Promise.resolve(),
   onCompleteAndLoadAnotherSubject: () => Promise.resolve(),

--- a/app/classifier/classifier.jsx
+++ b/app/classifier/classifier.jsx
@@ -185,10 +185,12 @@ class Classifier extends React.Component {
     actions.feedback.init(project, subject, workflow);
 
     this.setState({
+      annotations: [],
       expertClassification: null,
       selectedExpertAnnotation: -1,
       showingExpertClassification: false,
-      subjectLoading: true
+      subjectLoading: true,
+      workflowHistory: []
     });
 
     if (project.experimental_tools && project.experimental_tools.indexOf('expert comparison summary') > -1) {

--- a/app/classifier/classifier.jsx
+++ b/app/classifier/classifier.jsx
@@ -285,8 +285,6 @@ class Classifier extends React.Component {
     let onComplete = this.props.onComplete;
     if (this.props.workflow.configuration.hide_classification_summaries && !this.subjectIsGravitySpyGoldStandard()) {
       onComplete = this.props.onCompleteAndLoadAnotherSubject;
-      annotations = [];
-      workflowHistory = [];
     } else {
       workflowHistory.push('summary');
     }

--- a/app/classifier/classifier.jsx
+++ b/app/classifier/classifier.jsx
@@ -539,7 +539,7 @@ Classifier.propTypes = {
 };
 
 Classifier.defaultProps = {
-  classification: null,
+  classification: {},
   classificationCount: 0,
   demoMode: false,
   minicourse: null,
@@ -548,10 +548,13 @@ Classifier.defaultProps = {
   onLoad: Function.prototype,
   onChangeDemoMode: Function.prototype,
   splits: null,
-  subject: null,
+  subject: {},
   tutorial: null,
   user: null,
-  workflow: null
+  workflow: {
+    configuration: {},
+    tasks: {}
+  }
 };
 
 const mapStateToProps = state => ({
@@ -567,3 +570,4 @@ const mapDispatchToProps = dispatch => ({
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(Classifier);
+export { Classifier };

--- a/app/classifier/classifier.jsx
+++ b/app/classifier/classifier.jsx
@@ -87,7 +87,8 @@ class Classifier extends React.Component {
 
     if (nextProps.classification !== this.props.classification) {
       const annotations = nextProps.classification.annotations.slice();
-      this.setState({ annotations });
+      const workflowHistory = annotations.map(annotation => annotation.task);
+      this.setState({ annotations, workflowHistory });
     }
   }
 

--- a/app/classifier/classifier.jsx
+++ b/app/classifier/classifier.jsx
@@ -78,7 +78,7 @@ class Classifier extends React.Component {
       this.loadSubject(nextProps.subject);
     }
 
-    if (this.props.subject !== nextProps.subject || (this.context.geordi && !this.context.geordi.keys.subjectID)) {
+    if (this.context.geordi && ((this.props.subject !== nextProps.subject) ||  !this.context.geordi.keys.subjectID)) {
       this.context.geordi.remember({ subjectID: nextProps.subject.id });
     }
 

--- a/app/classifier/classifier.jsx
+++ b/app/classifier/classifier.jsx
@@ -291,7 +291,7 @@ class Classifier extends React.Component {
       workflowHistory.push('summary');
     }
 
-    this.checkForFeedback(taskKey)
+    return this.checkForFeedback(taskKey)
       .then(() => {
         this.props.classification.update({ completed: true });
         if (!isCmdClick && originalElement.href) {
@@ -543,8 +543,10 @@ Classifier.defaultProps = {
   classificationCount: 0,
   demoMode: false,
   minicourse: null,
+  onComplete: () => Promise.resolve(),
+  onCompleteAndLoadAnotherSubject: () => Promise.resolve(),
   preferences: null,
-  project: null,
+  project: {},
   onLoad: Function.prototype,
   onChangeDemoMode: Function.prototype,
   splits: null,

--- a/app/classifier/classifier.jsx
+++ b/app/classifier/classifier.jsx
@@ -78,7 +78,7 @@ class Classifier extends React.Component {
       this.loadSubject(nextProps.subject);
     }
 
-    if (this.props.subject !== nextProps.subject || (!this.context.geordi && !this.context.geordi.keys.subjectID)) {
+    if (this.props.subject !== nextProps.subject || (this.context.geordi && !this.context.geordi.keys.subjectID)) {
       this.context.geordi.remember({ subjectID: nextProps.subject.id });
     }
 

--- a/app/classifier/classifier.jsx
+++ b/app/classifier/classifier.jsx
@@ -57,13 +57,10 @@ class Classifier extends React.Component {
     };
   }
 
-  componentWillMount() {
+  componentDidMount() {
     const annotations = this.props.classification.annotations.slice();
     const workflowHistory = annotations.map(annotation => annotation.task);
     this.setState({ annotations, workflowHistory });
-  }
-
-  componentDidMount() {
     this.loadSubject(this.props.subject);
   }
 

--- a/app/classifier/classifier.spec.js
+++ b/app/classifier/classifier.spec.js
@@ -1,12 +1,41 @@
 import React from 'react';
-import assert from 'assert';
+import PropTypes from 'prop-types';
+import { expect } from 'chai';
 import sinon from 'sinon';
-import { shallow, mount } from 'enzyme';
+import { shallow } from 'enzyme';
+import { Classifier } from './classifier';
+
+const store = {
+  subscribe: () => { },
+  dispatch: () => { },
+  getState: () => ({
+    userInterface: { theme: 'light' }
+  })
+};
+
+const mockReduxStore = {
+  context: { store },
+  childContextTypes: { store: PropTypes.object.isRequired }
+};
+
+let wrapper;
+before(function () {
+  wrapper = shallow(<Classifier />, mockReduxStore);
+});
 
 describe('Classifier', function () {
+  it('should render with only default props', function () {
+    const instance = wrapper.instance();
+    expect(instance).to.be.instanceOf(Classifier);
+  });
   describe('on mount', function () {
-    it('should initialise annotations and workflow history', function () {
-      
+    it('should initialise annotations', function () {
+      const state = wrapper.state();
+      expect(state.annotations).to.have.lengthOf(0);
+    });
+    it('should initialise workflow history', function () {
+      const state = wrapper.state();
+      expect(state.workflowHistory).to.have.lengthOf(0);
     });
     it('should preserve annotations from an incomplete classification', function () {
       

--- a/app/classifier/classifier.spec.js
+++ b/app/classifier/classifier.spec.js
@@ -99,8 +99,24 @@ describe('Classifier', function () {
     });
   });
   describe('on receiving a new subject', function () {
+    let loadSubject;
+    before(function () {
+      loadSubject = sinon.stub(Classifier.prototype, 'loadSubject').callsFake(() => null);
+      wrapper = shallow(<Classifier />, mockReduxStore);
+    });
+    after(function () {
+      loadSubject.restore();
+    });
     it('should reset annotations and workflow history', function () {
-      
+      const newProps = {
+        subject: {
+          locations: []
+        }
+      };
+      wrapper.setProps(newProps);
+      const state = wrapper.state();
+      expect(state.annotations).to.have.lengthOf(0);
+      expect(state.workflowHistory).to.have.lengthOf(0);
     });
   });
   describe('on completing a classification', function () {

--- a/app/classifier/classifier.spec.js
+++ b/app/classifier/classifier.spec.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import assert from 'assert';
+import sinon from 'sinon';
+import { shallow, mount } from 'enzyme';
+
+describe('Classifier', function () {
+  describe('on mount', function () {
+    it('should initialise annotations and workflow history', function () {
+      
+    });
+    it('should preserve annotations from an incomplete classification', function () {
+      
+    });
+  });
+  describe('on receiving a new classification', function () {
+    it('should reset annotations and workflow history', function () {
+      
+    });
+    it('should preserve annotations from an incomplete classification', function () {
+      
+    });
+  });
+  describe('on receiving a new subject', function () {
+    it('should reset annotations and workflow history', function () {
+      
+    });
+  });
+  describe('on completing a classification', function () {
+    describe('with summaries enabled', function () {
+      it('should display a classification summary', function () {
+        
+      });
+    });
+    describe('with summaries disabled', function () {
+      it('should reset annotations and workflow history', function () {
+        
+      });
+    })
+  })
+});

--- a/app/classifier/classifier.spec.js
+++ b/app/classifier/classifier.spec.js
@@ -131,11 +131,7 @@ describe('Classifier', function () {
   describe('on receiving a new subject', function () {
     let loadSubject;
     before(function () {
-      loadSubject = sinon.stub(Classifier.prototype, 'loadSubject').callsFake(() => null);
       wrapper = shallow(<Classifier />, mockReduxStore);
-    });
-    after(function () {
-      loadSubject.restore();
     });
     it('should reset annotations and workflow history', function () {
       const newProps = {
@@ -147,6 +143,18 @@ describe('Classifier', function () {
       const state = wrapper.state();
       expect(state.annotations).to.have.lengthOf(0);
       expect(state.workflowHistory).to.have.lengthOf(0);
+    });
+    it('should preserve any existing annotations', function () {
+      const newProps = {
+        classification: classification,
+        subject: {
+          locations: []
+        }
+      };
+      wrapper.setProps(newProps);
+      const state = wrapper.state();
+      expect(state.annotations).to.deep.equal(classification.annotations);
+      expect(state.workflowHistory).to.deep.equal(['T0', 'T1']);
     });
   });
 

--- a/app/classifier/classifier.spec.js
+++ b/app/classifier/classifier.spec.js
@@ -18,6 +18,19 @@ const mockReduxStore = {
   childContextTypes: { store: PropTypes.object.isRequired }
 };
 
+const classification = {
+  annotations: [
+    {
+      task: 'T0',
+      value: 'something'
+    },
+    {
+      task: 'T1',
+      value: 1
+    }
+  ]
+};
+
 let wrapper;
 before(function () {
   wrapper = shallow(<Classifier />, mockReduxStore);
@@ -37,9 +50,25 @@ describe('Classifier', function () {
       const state = wrapper.state();
       expect(state.workflowHistory).to.have.lengthOf(0);
     });
-    it('should preserve annotations from an incomplete classification', function () {
-      
-    });
+    describe('with an incomplete classification', function () {
+      let loadSubject;
+      before(function () {
+        loadSubject = sinon.stub(Classifier.prototype, 'loadSubject').callsFake(() => null);
+        wrapper = shallow(<Classifier classification={classification} />, mockReduxStore);
+        wrapper.instance().componentDidMount();
+      });
+      after(function () {
+        loadSubject.restore();
+      });
+      it('should preserve annotations from an incomplete classification', function () {
+        const state = wrapper.state();
+        expect(state.annotations).to.deep.equal(classification.annotations);
+      });
+      it('should rebuild workflow history from an incomplete classification', function () {
+        const state = wrapper.update().state();
+        expect(state.workflowHistory).to.deep.equal(['T0', 'T1']);
+      });
+    })
   });
   describe('on receiving a new classification', function () {
     it('should reset annotations and workflow history', function () {

--- a/app/classifier/classifier.spec.js
+++ b/app/classifier/classifier.spec.js
@@ -67,6 +67,7 @@ describe('Classifier', function () {
     const instance = wrapper.instance();
     expect(instance).to.be.instanceOf(Classifier);
   });
+
   describe('on mount', function () {
     it('should initialise annotations', function () {
       const state = wrapper.state();
@@ -76,6 +77,7 @@ describe('Classifier', function () {
       const state = wrapper.state();
       expect(state.workflowHistory).to.have.lengthOf(0);
     });
+
     describe('with an incomplete classification', function () {
       let loadSubject;
       before(function () {
@@ -96,6 +98,7 @@ describe('Classifier', function () {
       });
     })
   });
+
   describe('on receiving a new classification', function () {
     let loadSubject;
     before(function () {
@@ -124,6 +127,7 @@ describe('Classifier', function () {
       expect(state.workflowHistory).to.have.lengthOf(0);
     });
   });
+
   describe('on receiving a new subject', function () {
     let loadSubject;
     before(function () {
@@ -145,6 +149,7 @@ describe('Classifier', function () {
       expect(state.workflowHistory).to.have.lengthOf(0);
     });
   });
+
   describe('on completing a classification', function () {
     let checkForFeedback;
     let fakeEvent;
@@ -170,6 +175,7 @@ describe('Classifier', function () {
       checkForFeedback.restore();
       loadSubject.restore();
     });
+
     describe('with summaries enabled', function () {
       it('should display a classification summary', function (done) {
         wrapper.setProps({ workflow });
@@ -182,6 +188,7 @@ describe('Classifier', function () {
         });
       });
     });
+
     describe('with summaries disabled', function () {
       it('should reset annotations and workflow history', function (done) {
         workflow.configuration.hide_classification_summaries = true;

--- a/app/classifier/classifier.spec.js
+++ b/app/classifier/classifier.spec.js
@@ -71,11 +71,31 @@ describe('Classifier', function () {
     })
   });
   describe('on receiving a new classification', function () {
-    it('should reset annotations and workflow history', function () {
-      
+    let loadSubject;
+    before(function () {
+      loadSubject = sinon.stub(Classifier.prototype, 'loadSubject').callsFake(() => null);
+      wrapper = shallow(<Classifier />, mockReduxStore);
+    });
+    after(function () {
+      loadSubject.restore();
     });
     it('should preserve annotations from an incomplete classification', function () {
-      
+      const newProps = { classification };
+      wrapper.setProps(newProps);
+      const state = wrapper.state();
+      expect(state.annotations).to.deep.equal(classification.annotations);
+      expect(state.workflowHistory).to.deep.equal(['T0', 'T1']);
+    });
+    it('should reset annotations and workflow history', function () {
+      const newProps = {
+        classification: {
+          annotations: []
+        }
+      }
+      wrapper.setProps(newProps);
+      const state = wrapper.state();
+      expect(state.annotations).to.have.lengthOf(0);
+      expect(state.workflowHistory).to.have.lengthOf(0);
     });
   });
   describe('on receiving a new subject', function () {

--- a/app/classifier/classifier.spec.js
+++ b/app/classifier/classifier.spec.js
@@ -3,7 +3,23 @@ import PropTypes from 'prop-types';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { shallow } from 'enzyme';
+import apiClient from 'panoptes-client/lib/api-client';
 import { Classifier } from './classifier';
+import FakeLocalStorage from '../../test/fake-local-storage';
+
+global.innerWidth = 1000;
+global.innerHeight = 1000;
+global.sessionStorage = new FakeLocalStorage();
+sessionStorage.setItem('session_id', JSON.stringify({ id: 0, ttl: 0 }));
+
+function mockPanoptesResource(type, options) {
+  const resource = apiClient.type(type).create(options);
+  apiClient._typesCache = {};
+  sinon.stub(resource, 'save').callsFake(() => Promise.resolve(resource));
+  sinon.stub(resource, 'get');
+  sinon.stub(resource, 'delete');
+  return resource;
+}
 
 const store = {
   subscribe: () => { },
@@ -18,7 +34,7 @@ const mockReduxStore = {
   childContextTypes: { store: PropTypes.object.isRequired }
 };
 
-const classification = {
+const classification = mockPanoptesResource('classification', {
   annotations: [
     {
       task: 'T0',
@@ -29,7 +45,17 @@ const classification = {
       value: 1
     }
   ]
-};
+});
+
+const workflow = mockPanoptesResource('workflow', {
+  configuration: {
+    hide_classification_summaries: false
+  },
+  tasks: {
+    T0: {},
+    T1: {}
+  }
+});
 
 let wrapper;
 before(function () {
@@ -120,15 +146,56 @@ describe('Classifier', function () {
     });
   });
   describe('on completing a classification', function () {
+    let checkForFeedback;
+    let fakeEvent;
+    let loadSubject;
+    beforeEach(function () {
+      loadSubject = sinon.stub(Classifier.prototype, 'loadSubject').callsFake(() => null);
+      checkForFeedback = sinon.stub(Classifier.prototype, 'checkForFeedback').callsFake(() => Promise.resolve());
+      wrapper = shallow(
+        <Classifier
+          classification={classification}
+          onComplete={classification.save}
+          onCompleteAndLoadAnotherSubject={classification.save}
+        />,
+        mockReduxStore
+      );
+      wrapper.instance().componentDidMount();
+      fakeEvent = {
+        currentTarget: {},
+        preventDefault: () => null
+      }
+    });
+    afterEach(function () {
+      checkForFeedback.restore();
+      loadSubject.restore();
+    });
     describe('with summaries enabled', function () {
-      it('should display a classification summary', function () {
-        
+      it('should display a classification summary', function (done) {
+        wrapper.setProps({ workflow });
+        wrapper.instance().completeClassification(fakeEvent)
+        .then(function () {
+          wrapper.update();
+          expect(classification.completed).to.equal(true);
+          expect(wrapper.find('ClassificationSummary')).to.have.lengthOf(1);
+          done();
+        });
       });
     });
     describe('with summaries disabled', function () {
-      it('should reset annotations and workflow history', function () {
-        
+      it('should reset annotations and workflow history', function (done) {
+        workflow.configuration.hide_classification_summaries = true;
+        wrapper.setProps({ workflow });
+        wrapper.instance().completeClassification(fakeEvent)
+        .then(function () {
+          wrapper.update();
+          const state = wrapper.state();
+          expect(state.annotations).to.have.lengthOf(0);
+          expect(state.workflowHistory).to.have.lengthOf(0);
+          expect(classification.completed).to.equal(true);
+          done();
+        });
       });
-    })
-  })
+    });
+  });
 });

--- a/app/classifier/classifier.spec.js
+++ b/app/classifier/classifier.spec.js
@@ -190,26 +190,28 @@ describe('Classifier', function () {
         wrapper.instance().completeClassification(fakeEvent)
         .then(function () {
           wrapper.update();
+          const state = wrapper.state();
           expect(classification.completed).to.equal(true);
+          expect(state.annotations).to.deep.equal(classification.annotations);
           expect(wrapper.find('ClassificationSummary')).to.have.lengthOf(1);
-          done();
-        });
+        })
+        .then(done, done);
       });
     });
 
     describe('with summaries disabled', function () {
-      it('should reset annotations and workflow history', function (done) {
+      it('should not show a summary', function (done) {
         workflow.configuration.hide_classification_summaries = true;
         wrapper.setProps({ workflow });
         wrapper.instance().completeClassification(fakeEvent)
         .then(function () {
           wrapper.update();
           const state = wrapper.state();
-          expect(state.annotations).to.have.lengthOf(0);
-          expect(state.workflowHistory).to.have.lengthOf(0);
+          expect(state.annotations).to.deep.equal(classification.annotations);
           expect(classification.completed).to.equal(true);
-          done();
-        });
+          expect(wrapper.find('ClassificationSummary')).to.have.lengthOf(0);
+        })
+        .then(done, done);
       });
     });
   });

--- a/app/classifier/task-nav.jsx
+++ b/app/classifier/task-nav.jsx
@@ -64,7 +64,7 @@ class TaskNav extends React.Component {
   }
 
   render() {
-    const completed = !!this.props.classification.completed;
+    const { completed } = this.props;
 
     const task = this.props.task ? this.props.task : this.props.workflow.tasks[this.props.workflow.first_task];
 
@@ -140,6 +140,7 @@ TaskNav.propTypes = {
     metadata: PropTypes.object
   }),
   completeClassification: PropTypes.func,
+  completed: PropTypes.bool,
   disabled: PropTypes.bool,
   nextSubject: PropTypes.func,
   demoMode: PropTypes.bool,
@@ -165,6 +166,7 @@ TaskNav.propTypes = {
 TaskNav.defaultProps = {
   annotations: [],
   autoFocus: true,
+  completed: false,
   disabled: false,
   updateAnnotations: () => null
 };


### PR DESCRIPTION
Sync classifier annotation state when a classification loads.
Hide summaries if classification summaries are disabled.
Add tests for annotation state when the classifier mounts, when classifications are received, when subjects load and when a classification completes.

Staging branch URL: https://classifier-state.pfe-preview.zooniverse.org

Fixes #4668.
Fixes #4634.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
