### PR TITLE
Improve lab wording for workflow task editing on workflows

### DIFF
--- a/app/pages/lab/visibility.cjsx
+++ b/app/pages/lab/visibility.cjsx
@@ -69,7 +69,11 @@ module.exports = createReactClass
       <p className="form-help">
         All workflows can be edited during development, and subjects will never retire.<br />
         In a live project, active workflows are locked and can no longer be edited.<br />
-        <strong>Take care changing a project's live setting to development as classification will not count towards your project.</strong>
+        <small>
+          <strong>
+            Take care changing a project to development as classifications will not count towards your project.
+          </strong>
+        </small>
       </p>
 
       <div>

--- a/app/pages/lab/visibility.cjsx
+++ b/app/pages/lab/visibility.cjsx
@@ -66,7 +66,11 @@ module.exports = createReactClass
         Live
       </label>
 
-      <p className="form-help">All workflows can be edited during development, and subjects will never retire. In a live project, active workflows are locked and can no longer be edited, and classifications count toward subject retirement.</p>
+      <p className="form-help">
+        All workflows can be edited during development, and subjects will never retire.<br />
+        In a live project, active workflows are locked and can no longer be edited.<br />
+        <strong>Take care changing a project's live setting to development as classification will not count towards your project.</strong>
+      </p>
 
       <div>
         <hr />

--- a/app/pages/lab/workflow.cjsx
+++ b/app/pages/lab/workflow.cjsx
@@ -99,7 +99,7 @@ EditWorkflowPage = createReactClass
           <strong>
             You cannot edit tasks for an active workflow on a live project, all the task fields below will be inactive.
             <br />
-            To make changes to workflow tasks, you can deactivate the workflow on the <Link to="/lab/#{@props.project.id}/visibility">visibility page</Link>.
+            To edit these fields, deactivate your workflow on the <Link to="/lab/#{@props.project.id}/workflows">worfklows page</Link> - do not change your project to development.
           </strong>
         </p>}
       <div className="columns-container">

--- a/app/pages/lab/workflow.cjsx
+++ b/app/pages/lab/workflow.cjsx
@@ -95,7 +95,13 @@ EditWorkflowPage = createReactClass
         </ModalFormDialog>}
       <p className="form-help">A workflow is the sequence of tasks that you’re asking volunteers to perform. For example, you might want to ask volunteers to answer questions about your images, or to mark features in your images, or both.</p>
       {if @props.project.live and @props.workflow.active
-        <p className="form-help warning"><strong>If the project is live, you cannot edit tasks in an active workflow, but other workflow settings (such as linking subject sets) can be changed.</strong></p>}
+        <p className="form-help warning">
+          <strong>
+            You cannot edit tasks for an active workflow on a live project, all the task fields below will be inactive.
+            <br />
+            To make changes to workflow tasks, you can deactivate the workflow on the <Link to="/lab/#{@props.project.id}/visibility">visibility page</Link>.
+          </strong>
+        </p>}
       <div className="columns-container">
         <div className="column">
           <div>


### PR DESCRIPTION
Staging branch URL: https://improve-wording-on-lab-workflow.pfe-preview.zooniverse.org/

Add better messaging around how to edit workflow tasks for a live project. Summary is tell the user to deactivate the workflow but leave the project live.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
