### PR TITLE
Log rather than throw error. Fix infinite loop bug

### DIFF
--- a/app/pages/project/workflow-selection.spec.js
+++ b/app/pages/project/workflow-selection.spec.js
@@ -60,7 +60,8 @@ const project = mockPanoptesResource('projects',
     experimental_tools: [],
     links: {
       active_workflows: ['1', '2', '3', '4', '5'],
-      owner: { id: '1' }
+      owner: { id: '1' },
+      workflows: ['1', '2', '3', '4', '5']
     }
   }
 );
@@ -287,13 +288,46 @@ describe('WorkflowSelection', function () {
           },
           links: {
             active_workflows: ['10'],
-            owner: { id: '1' }
+            owner: { id: '1' },
+            workflows: ['10']
           }
         }
       );
       wrapper.setProps({ project: newProject });
       sinon.assert.calledOnce(workflowStub);
       sinon.assert.calledWith(workflowStub, '10', true);
+    });
+  });
+
+  describe('when loading a project without workflows', function() {
+    let getSelectedWorkflowSpy;
+
+    before(function() {
+      getSelectedWorkflowSpy = sinon.spy(controller, 'getSelectedWorkflow');
+
+      const projectWithoutWorkflows = mockPanoptesResource('projects', {
+        id: 'z',
+        display_name: 'A test project',
+        configuration: {},
+        experimental_tools: [],
+        links: {
+          owner: { id: '1' }
+        }
+      });
+
+      wrapper.setProps({ project: projectWithoutWorkflows });
+    });
+
+    beforeEach(function() {
+      getSelectedWorkflowSpy.resetHistory(); 
+    })
+
+    after(function() {
+      getSelectedWorkflowSpy.restore();
+    });
+
+    it('should not attempt to select another workflow', function() {
+      sinon.assert.notCalled(getSelectedWorkflowSpy);
     });
   });
 });


### PR DESCRIPTION
Staging branch URL: https://log-selection-errors.pfe-preview.zooniverse.org/projects/srallen086/untitled-project-5-10-2018-11-53-20-am

Instead of throwing an `Error` object, just log to the console instead when there are no active workflows. I also discovered another way an infinite loop could be caused, which are projects without any workflows at all. So I fixed this and wrote a test for it.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
