### PR TITLE
Language picker

### DIFF
--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -75,6 +75,12 @@ ClassifierWrapper = createReactClass
       @setState {minicourse}
       this.props.actions.translations.load('minicourse', minicourse.id, this.props.translations.locale) if minicourse?
 
+  componentDidUpdate: (prevProps) ->
+    { tutorial, minicourse } = @state
+    if prevProps.translations.locale isnt this.props.translations.locale
+      this.props.actions.translations.load('tutorial', tutorial.id, this.props.translations.locale) if tutorial?
+      this.props.actions.translations.load('minicourse', minicourse.id, this.props.translations.locale) if minicourse?
+
   componentWillReceiveProps: (nextProps) ->
     if nextProps.workflow isnt @props.workflow
       Tutorial.find nextProps.workflow

--- a/app/constants/languageMenu.js
+++ b/app/constants/languageMenu.js
@@ -1,0 +1,17 @@
+export default {
+  en: 'English',
+  cs: 'Čeština',
+  de: 'Deutsch',
+  es: 'Español',
+  el: 'Ελληνικά',
+  fr: 'Francais',
+  he: 'עברית',
+  it: 'Italiano',
+  nl: 'Nederlands',
+  pl: 'Polski',
+  po: 'Português',
+  ru: 'русский',
+  uk: 'українська мова',
+  'zh-cn': '简体中文',
+  'zh-tw': '繁體中文'
+};

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -27,6 +27,7 @@ export default {
     }
   },
   project: {
+    language: 'Language',
     loading: 'Loading project',
     disclaimer: 'This project has been built using the Zooniverse Project Builder but is not yet an official Zooniverse project. Queries and issues relating to this project directed at the Zooniverse Team may not receive any response.',
     about: {

--- a/app/locales/es.js
+++ b/app/locales/es.js
@@ -27,6 +27,7 @@ export default {
     }
   },
   project: {
+    language: 'Idioma',
     loading: 'Loading project',
     disclaimer: 'This project has been built using the Zooniverse Project Builder but is not yet an official Zooniverse project. Queries and issues relating to this project directed at the Zooniverse Team may not receive any response.',
     about: {

--- a/app/locales/it.js
+++ b/app/locales/it.js
@@ -27,6 +27,7 @@ export default {
     }
   },
   project: {
+    language: 'Language',
     disclaimer: "Questo progetto è stato creato con il Project Builder di Zooniverse, ma non è ancora un progetto ufficiale. Per questo motivo è possibile che domande su questo progetto dirette al Team Zooniverse non ricevano una risposta.",
     loading: 'Caricamento progetto',
     about: {

--- a/app/locales/nl.js
+++ b/app/locales/nl.js
@@ -54,6 +54,7 @@ export default {
     miniCourseButton: 'Herstart de minitour'
   },
   project: {
+    language: 'Taal',
     loading: 'Project wordt geladen',
     disclaimer: 'Dit project is gemaakt met de Zooniverse projectbouwer maar is not niet een officieel Zooniverseproject. Vragen en problemen met betrekking tot dit project die gestuurd worden aan het Zooniverseteam krijgen mogelijk geen reactie.',
     about: {

--- a/app/pages/lab/translations/index.jsx
+++ b/app/pages/lab/translations/index.jsx
@@ -4,21 +4,76 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import TranslationTools from './translation-tools';
 import * as translationsActions from '../../../redux/ducks/translations';
+import languageMenu from '../../../constants/languageMenu';
 
 class TranslationsManager extends React.Component {
+  constructor(props) {
+    super(props);
+    const { project } = props;
+    const languages = project.configuration.languages || [project.primary_language];
+    this.state = {
+      languages
+    };
+  }
+
   componentDidMount() {
     const { translations } = this.props.actions;
     translations.listLanguages('project', this.props.project.id);
   }
 
+  handleMenuChange(e) {
+    const { project } = this.props;
+    const { languages } = this.state;
+    const language = e.target.value;
+    const index = languages.indexOf(language);
+    if (index > -1) {
+      languages.splice(index, 1);
+    }
+    if (e.target.checked) {
+      languages.push(language);
+    }
+    project.update({ 'configuration.languages': languages }).save();
+    this.setState({ languages });
+  }
+
   render() {
     const { languages } = this.props.translations;
     const { project } = this.props;
+    const projectLanguages = this.state.languages;
     const languageCodes = languages.project
       .filter(languageCode => languageCode !== project.primary_language);
+    const languageMenuCodes = Object.keys(languageMenu)
+      .filter(language => languageCodes.indexOf(language) > -1);
     return (
       <div>
-        <p>Manage your project translations here.</p>
+        <h1>Translations</h1>
+        <h2>Project language menu</h2>
+        <p>
+          Tick languages here to add a language menu to your project,
+          and make those translations available to your volunteers.
+        </p>
+        <table>
+          <tr>
+            <th>Language</th>
+            <th>Code</th>
+            <th>Live?</th>
+          </tr>
+          {languageMenuCodes.map(language => (
+            <tr key={language}>
+              <td>{languageMenu[language]}</td>
+              <td>{language}</td>
+              <td>
+                <input
+                  type="checkbox"
+                  value={language}
+                  checked={projectLanguages.indexOf(language) > -1}
+                  onChange={this.handleMenuChange.bind(this)}
+                />
+              </td>
+            </tr>
+          ))}
+        </table>
+        <h2>Project translations</h2>
         <ul className="translations">
           {languageCodes.map(languageCode => (
             <li key={languageCode}>

--- a/app/pages/project/components/LanguagePicker/LanguagePicker.jsx
+++ b/app/pages/project/components/LanguagePicker/LanguagePicker.jsx
@@ -15,6 +15,7 @@ function LanguagePicker(props) {
   return (
     <label>
       Language
+      {' '}
       <select
         defaultValue={locale}
         onChange={onChange}

--- a/app/pages/project/components/LanguagePicker/LanguagePicker.jsx
+++ b/app/pages/project/components/LanguagePicker/LanguagePicker.jsx
@@ -2,21 +2,32 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import * as actions from '../../../../redux/ducks/translations';
+import * as translationsActions from '../../../../redux/ducks/translations';
 
 function LanguagePicker(props) {
+  const { actions, options, translations } = props;
+  const { locale } = translations;
+
   function onChange(e) {
-    props.actions.translations.setLocale(e.target.value);
+    actions.translations.setLocale(e.target.value);
   }
 
   return (
     <label>
       Language
       <select
+        defaultValue={locale}
         onChange={onChange}
       >
-        <option value="en">English</option>
-        <option value="nl">Nederlands</option>
+        {options.map(option => (
+          <option
+            key={option.value}
+            value={option.value}
+          >
+            {option.label}
+          </option>
+          )
+        )}
       </select>
     </label>
   );
@@ -27,6 +38,13 @@ LanguagePicker.propTypes = {
     translations: PropTypes.shape({
       setLocale: PropTypes.func
     })
+  }),
+  options: PropTypes.arrayOf(PropTypes.shape({
+    label: PropTypes.string,
+    value: PropTypes.string
+  })).isRequired,
+  translations: PropTypes.shape({
+    locale: PropTypes.string
   })
 };
 
@@ -35,6 +53,9 @@ LanguagePicker.defaultProps = {
     translations: {
       setLocale: () => null
     }
+  },
+  translations: {
+    locale: 'en'
   }
 };
 
@@ -44,7 +65,7 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = dispatch => ({
   actions: {
-    translations: bindActionCreators(actions, dispatch)
+    translations: bindActionCreators(translationsActions, dispatch)
   }
 });
 

--- a/app/pages/project/components/LanguagePicker/LanguagePicker.jsx
+++ b/app/pages/project/components/LanguagePicker/LanguagePicker.jsx
@@ -1,10 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import styled from 'styled-components';
 import Translate from 'react-translate-component';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import * as translationsActions from '../../../../redux/ducks/translations';
 import languageMenu from '../../../../constants/languageMenu';
+
+const StyledLabel = styled.label`
+  word-spacing: 1em;
+`;
 
 function LanguagePicker(props) {
   const { actions, project, translations } = props;
@@ -21,7 +26,7 @@ function LanguagePicker(props) {
   }
 
   return (
-    <label>
+    <StyledLabel>
       <Translate content="project.language" />
       {' '}
       <select
@@ -38,7 +43,7 @@ function LanguagePicker(props) {
           )
         )}
       </select>
-    </label>
+    </StyledLabel>
   );
 }
 

--- a/app/pages/project/components/LanguagePicker/LanguagePicker.jsx
+++ b/app/pages/project/components/LanguagePicker/LanguagePicker.jsx
@@ -9,9 +9,11 @@ function LanguagePicker(props) {
   const { actions, project, translations } = props;
   const { locale } = translations;
 
-  const languages = project.configuration.languages ?
-    project.configuration.languages :
-    Object.keys(languageMenu);
+  const languages = project.configuration.languages ? project.configuration.languages : [];
+
+  if (languages.length < 2) {
+    return null;
+  }
 
   function onChange(e) {
     actions.translations.setLocale(e.target.value);

--- a/app/pages/project/components/LanguagePicker/LanguagePicker.jsx
+++ b/app/pages/project/components/LanguagePicker/LanguagePicker.jsx
@@ -70,3 +70,4 @@ const mapDispatchToProps = dispatch => ({
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(LanguagePicker);
+export { LanguagePicker };

--- a/app/pages/project/components/LanguagePicker/LanguagePicker.jsx
+++ b/app/pages/project/components/LanguagePicker/LanguagePicker.jsx
@@ -3,10 +3,15 @@ import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import * as translationsActions from '../../../../redux/ducks/translations';
+import languageMenu from '../../../../constants/languageMenu';
 
 function LanguagePicker(props) {
-  const { actions, options, translations } = props;
+  const { actions, project, translations } = props;
   const { locale } = translations;
+
+  const languages = project.configuration.languages ?
+    project.configuration.languages :
+    Object.keys(languageMenu);
 
   function onChange(e) {
     actions.translations.setLocale(e.target.value);
@@ -20,12 +25,12 @@ function LanguagePicker(props) {
         defaultValue={locale}
         onChange={onChange}
       >
-        {options.map(option => (
+        {languages.map(language => (
           <option
-            key={option.value}
-            value={option.value}
+            key={language}
+            value={language}
           >
-            {option.label}
+            {languageMenu[language]}
           </option>
           )
         )}
@@ -40,10 +45,11 @@ LanguagePicker.propTypes = {
       setLocale: PropTypes.func
     })
   }),
-  options: PropTypes.arrayOf(PropTypes.shape({
-    label: PropTypes.string,
-    value: PropTypes.string
-  })).isRequired,
+  project: PropTypes.shape({
+    configuration: PropTypes.shape({
+      languages: PropTypes.arrayOf(PropTypes.string)
+    })
+  }).isRequired,
   translations: PropTypes.shape({
     locale: PropTypes.string
   })

--- a/app/pages/project/components/LanguagePicker/LanguagePicker.jsx
+++ b/app/pages/project/components/LanguagePicker/LanguagePicker.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import Translate from 'react-translate-component';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import * as translationsActions from '../../../../redux/ducks/translations';
@@ -21,7 +22,7 @@ function LanguagePicker(props) {
 
   return (
     <label>
-      Language
+      <Translate content="project.language" />
       {' '}
       <select
         defaultValue={locale}

--- a/app/pages/project/components/LanguagePicker/LanguagePicker.jsx
+++ b/app/pages/project/components/LanguagePicker/LanguagePicker.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import * as actions from '../../../../redux/ducks/translations';
+
+function LanguagePicker(props) {
+  function onChange(e) {
+    props.actions.translations.setLocale(e.target.value);
+  }
+
+  return (
+    <label>
+      Language
+      <select
+        onChange={onChange}
+      >
+        <option value="en">English</option>
+        <option value="nl">Nederlands</option>
+      </select>
+    </label>
+  );
+}
+
+LanguagePicker.propTypes = {
+  actions: PropTypes.shape({
+    translations: PropTypes.shape({
+      setLocale: PropTypes.func
+    })
+  })
+};
+
+LanguagePicker.defaultProps = {
+  actions: {
+    translations: {
+      setLocale: () => null
+    }
+  }
+};
+
+const mapStateToProps = state => ({
+  translations: state.translations
+});
+
+const mapDispatchToProps = dispatch => ({
+  actions: {
+    translations: bindActionCreators(actions, dispatch)
+  }
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(LanguagePicker);

--- a/app/pages/project/components/LanguagePicker/LanguagePicker.spec.js
+++ b/app/pages/project/components/LanguagePicker/LanguagePicker.spec.js
@@ -1,0 +1,56 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { LanguagePicker } from './LanguagePicker';
+
+const options=[
+  {
+    label: 'English',
+    value: 'en'
+  },
+  {
+    label: 'Nederlands',
+    value: 'nl'
+  }
+];
+
+describe('LanguagePicker', function () {
+  let wrapper;
+  let changeSpy;
+  beforeEach(function () {
+    changeSpy = sinon.spy()
+    const actions = {
+      translations: {
+        setLocale: changeSpy
+      }
+    }
+    wrapper = shallow(<LanguagePicker actions={actions} options={options} />);
+  });
+
+  it('should render with the default props', function () {
+    expect(wrapper).to.be.ok;
+  });
+
+  describe('onChange', function () {
+    beforeEach(function () {
+      const fakeEvent = {
+        target: {
+          value: 'nl'
+        }
+      };
+      wrapper.find('select').simulate('change', fakeEvent);
+    });
+    afterEach(function () {
+      changeSpy.resetHistory();
+    });
+
+    it('should call setLocale on change', function () {
+      expect(changeSpy.callCount).to.equal(1);
+    });
+
+    it('should pass the new language to setLocale', function () {
+      expect(changeSpy.calledWith('nl')).to.be.true;
+    });
+  });
+});

--- a/app/pages/project/components/LanguagePicker/LanguagePicker.spec.js
+++ b/app/pages/project/components/LanguagePicker/LanguagePicker.spec.js
@@ -4,16 +4,11 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { LanguagePicker } from './LanguagePicker';
 
-const options=[
-  {
-    label: 'English',
-    value: 'en'
-  },
-  {
-    label: 'Nederlands',
-    value: 'nl'
+const project = {
+  configuration: {
+    languages: ['en', 'nl']
   }
-];
+};
 
 describe('LanguagePicker', function () {
   let wrapper;
@@ -25,7 +20,7 @@ describe('LanguagePicker', function () {
         setLocale: changeSpy
       }
     }
-    wrapper = shallow(<LanguagePicker actions={actions} options={options} />);
+    wrapper = shallow(<LanguagePicker actions={actions} project={project} />);
   });
 
   it('should render with the default props', function () {

--- a/app/pages/project/components/LanguagePicker/index.js
+++ b/app/pages/project/components/LanguagePicker/index.js
@@ -1,0 +1,3 @@
+import LanguagePicker from './LanguagePicker';
+
+export default LanguagePicker;

--- a/app/pages/project/components/ProjectNavbar/ProjectNavbar.jsx
+++ b/app/pages/project/components/ProjectNavbar/ProjectNavbar.jsx
@@ -46,7 +46,18 @@ class ProjectNavbar extends Component {
 
     return (
       <React.Fragment>
-        <LanguagePicker />
+        <LanguagePicker
+          options={[
+            {
+              label: 'English',
+              value: 'en'
+            },
+            {
+              label: 'Nederlands',
+              value: 'nl'
+            }
+          ]}
+        />
         {!this.state.loading &&
           <NavBarComponent {...this.props} />}
         <SizeAwareProjectNavbarWide

--- a/app/pages/project/components/ProjectNavbar/ProjectNavbar.jsx
+++ b/app/pages/project/components/ProjectNavbar/ProjectNavbar.jsx
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import LanguagePicker from '../LanguagePicker';
 import ProjectNavbarNarrow from './components/ProjectNavbarNarrow';
 import ProjectNavbarWide, { SizeAwareProjectNavbarWide } from './components/ProjectNavbarWide';
 
@@ -45,6 +46,7 @@ class ProjectNavbar extends Component {
 
     return (
       <React.Fragment>
+        <LanguagePicker />
         {!this.state.loading &&
           <NavBarComponent {...this.props} />}
         <SizeAwareProjectNavbarWide

--- a/app/pages/project/components/ProjectNavbar/ProjectNavbar.jsx
+++ b/app/pages/project/components/ProjectNavbar/ProjectNavbar.jsx
@@ -1,9 +1,14 @@
 import _ from 'lodash';
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import styled from 'styled-components';
 import LanguagePicker from '../LanguagePicker';
 import ProjectNavbarNarrow from './components/ProjectNavbarNarrow';
 import ProjectNavbarWide, { SizeAwareProjectNavbarWide } from './components/ProjectNavbarWide';
+
+export const SettingsMenu = styled.div`
+  text-align: right;
+`;
 
 function haveNavLinksChanged(oldProps, newProps) {
   const oldLinks = oldProps.navLinks.map(link => link.label);
@@ -48,9 +53,11 @@ class ProjectNavbar extends Component {
       <React.Fragment>
         {!this.state.loading &&
           <NavBarComponent {...this.props}>
-            <LanguagePicker
-              project={this.props.project}
-            />
+            <SettingsMenu>
+              <LanguagePicker
+                project={this.props.project}
+              />
+            </SettingsMenu>
           </NavBarComponent>
         }
         <SizeAwareProjectNavbarWide

--- a/app/pages/project/components/ProjectNavbar/ProjectNavbar.jsx
+++ b/app/pages/project/components/ProjectNavbar/ProjectNavbar.jsx
@@ -49,16 +49,7 @@ class ProjectNavbar extends Component {
         {!this.state.loading &&
           <NavBarComponent {...this.props}>
             <LanguagePicker
-              options={[
-                {
-                  label: 'English',
-                  value: 'en'
-                },
-                {
-                  label: 'Nederlands',
-                  value: 'nl'
-                }
-              ]}
+              project={this.props.project}
             />
           </NavBarComponent>
         }

--- a/app/pages/project/components/ProjectNavbar/ProjectNavbar.jsx
+++ b/app/pages/project/components/ProjectNavbar/ProjectNavbar.jsx
@@ -46,20 +46,22 @@ class ProjectNavbar extends Component {
 
     return (
       <React.Fragment>
-        <LanguagePicker
-          options={[
-            {
-              label: 'English',
-              value: 'en'
-            },
-            {
-              label: 'Nederlands',
-              value: 'nl'
-            }
-          ]}
-        />
         {!this.state.loading &&
-          <NavBarComponent {...this.props} />}
+          <NavBarComponent {...this.props}>
+            <LanguagePicker
+              options={[
+                {
+                  label: 'English',
+                  value: 'en'
+                },
+                {
+                  label: 'Nederlands',
+                  value: 'nl'
+                }
+              ]}
+            />
+          </NavBarComponent>
+        }
         <SizeAwareProjectNavbarWide
           {...this.props}
           onSize={this.setBreakpoint}

--- a/app/pages/project/components/ProjectNavbar/ProjectNavbarContainer.jsx
+++ b/app/pages/project/components/ProjectNavbar/ProjectNavbarContainer.jsx
@@ -82,6 +82,7 @@ class ProjectNavbarContainer extends Component {
         backgroundSrc={backgroundSrc}
         launched={launched}
         navLinks={navLinks}
+        project={this.props.project}
         projectTitle={projectTitle}
         projectLink={projectLink}
         redirect={redirect}

--- a/app/pages/project/components/ProjectNavbar/components/ProjectNavbarNarrow/ProjectNavbarNarrow.jsx
+++ b/app/pages/project/components/ProjectNavbar/components/ProjectNavbarNarrow/ProjectNavbarNarrow.jsx
@@ -18,9 +18,12 @@ export const StyledBackground = styled(Background)`
 export const StyledOuterWrapper = styled.div`
   display: flex;
   flex: 1;
-  flex-direction: row;
+  flex-direction: column;
   justify-content: center;
   position: relative;
+`;
+export const SettingsMenu = styled.div`
+  text-align: right;
 `;
 
 export const StyledInnerWrapper = Wrapper.extend`
@@ -48,6 +51,7 @@ export class ProjectNavbarNarrow extends Component {
     const {
       avatarSrc,
       backgroundSrc,
+      children,
       height,
       launched,
       projectLink,
@@ -62,6 +66,9 @@ export class ProjectNavbarNarrow extends Component {
         <StyledBackground src={backgroundSrc} />
 
         <StyledOuterWrapper>
+          <SettingsMenu>
+            {children}
+          </SettingsMenu>
           <StyledInnerWrapper>
             <Avatar
               src={avatarSrc}
@@ -96,6 +103,7 @@ export class ProjectNavbarNarrow extends Component {
 ProjectNavbarNarrow.defaultProps = {
   avatarSrc: '',
   backgroundSrc: '',
+  children: null,
   navLinks: [
     { url: '' }
   ],
@@ -106,6 +114,7 @@ ProjectNavbarNarrow.defaultProps = {
 ProjectNavbarNarrow.propTypes = {
   avatarSrc: PropTypes.string,
   backgroundSrc: PropTypes.string,
+  children: PropTypes.node,
   height: PropTypes.number,
   launched: PropTypes.bool,
   navLinks: PropTypes.arrayOf(PropTypes.shape({

--- a/app/pages/project/components/ProjectNavbar/components/ProjectNavbarNarrow/ProjectNavbarNarrow.jsx
+++ b/app/pages/project/components/ProjectNavbar/components/ProjectNavbarNarrow/ProjectNavbarNarrow.jsx
@@ -22,9 +22,6 @@ export const StyledOuterWrapper = styled.div`
   justify-content: center;
   position: relative;
 `;
-export const SettingsMenu = styled.div`
-  text-align: right;
-`;
 
 export const StyledInnerWrapper = Wrapper.extend`
   flex-direction: column;
@@ -66,9 +63,7 @@ export class ProjectNavbarNarrow extends Component {
         <StyledBackground src={backgroundSrc} />
 
         <StyledOuterWrapper>
-          <SettingsMenu>
             {children}
-          </SettingsMenu>
           <StyledInnerWrapper>
             <Avatar
               src={avatarSrc}

--- a/app/pages/project/components/ProjectNavbar/components/ProjectNavbarWide/ProjectNavbarWide.jsx
+++ b/app/pages/project/components/ProjectNavbar/components/ProjectNavbarWide/ProjectNavbarWide.jsx
@@ -13,15 +13,29 @@ export const StyledHeaderWide = StyledHeader.extend`
   box-shadow: 0 ${pxToRem(2)} ${pxToRem(4)} 0 rgba(0,0,0,0.5);
 `;
 
+export const StyledOuterWrapper = styled.div`
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  justify-content: center;
+  height: 20vh;
+  max-height: ${pxToRem(150)};
+  min-height: ${pxToRem(120)};
+  margin: 0 3vw;
+  z-index: 2;
+`;
+
+export const SettingsMenu = styled.div`
+  text-align: right;
+`;
+
 export const StyledAvatar = styled(Avatar)`
   margin-right: ${pxToRem(20)};
 `;
 
 export const StyledWrapper = styled(Wrapper)`
   box-sizing: border-box;
-  height: 20vh;
-  max-height: ${pxToRem(150)};
-  min-height: ${pxToRem(120)};
+  margin: 0;
   padding: 0 ${pxToRem(10)};
 `;
 
@@ -60,6 +74,7 @@ function ProjectNavbarWide(props) {
   const {
     avatarSrc,
     backgroundSrc,
+    children,
     launched,
     navLinks,
     projectTitle,
@@ -72,28 +87,33 @@ function ProjectNavbarWide(props) {
   return (
     <StyledHeaderWide {...otherProps}>
       <Background src={backgroundSrc} />
-      <StyledWrapper>
-        <StyledAvatar
-          src={avatarSrc}
-          projectTitle={projectTitle}
-          size={80}
-        />
-        <ProjectTitle
-          launched={launched}
-          link={projectLink}
-          redirect={redirect}
-          title={projectTitle}
-          underReview={underReview}
-        />
-        <Nav>
-          <List>
-            {navLinks.map(link => (
-              <ListItem key={link.url || link.to}>
-                <StyledNavLink {...link} />
-              </ListItem>))}
-          </List>
-        </Nav>
-      </StyledWrapper>
+      <StyledOuterWrapper>
+        <SettingsMenu>
+          {children}
+        </SettingsMenu>
+        <StyledWrapper>
+          <StyledAvatar
+            src={avatarSrc}
+            projectTitle={projectTitle}
+            size={80}
+          />
+          <ProjectTitle
+            launched={launched}
+            link={projectLink}
+            redirect={redirect}
+            title={projectTitle}
+            underReview={underReview}
+          />
+          <Nav>
+            <List>
+              {navLinks.map(link => (
+                <ListItem key={link.url || link.to}>
+                  <StyledNavLink {...link} />
+                </ListItem>))}
+            </List>
+          </Nav>
+        </StyledWrapper>
+      </StyledOuterWrapper>
     </StyledHeaderWide>
   );
 }
@@ -101,6 +121,7 @@ function ProjectNavbarWide(props) {
 ProjectNavbarWide.propTypes = {
   avatarSrc: PropTypes.string,
   backgroundSrc: PropTypes.string,
+  children: PropTypes.node,
   launched: PropTypes.bool,
   navLinks: PropTypes.arrayOf(PropTypes.shape({
     url: PropTypes.string

--- a/app/pages/project/components/ProjectNavbar/components/ProjectNavbarWide/ProjectNavbarWide.jsx
+++ b/app/pages/project/components/ProjectNavbar/components/ProjectNavbarWide/ProjectNavbarWide.jsx
@@ -25,10 +25,6 @@ export const StyledOuterWrapper = styled.div`
   z-index: 2;
 `;
 
-export const SettingsMenu = styled.div`
-  text-align: right;
-`;
-
 export const StyledAvatar = styled(Avatar)`
   margin-right: ${pxToRem(20)};
 `;
@@ -88,9 +84,7 @@ function ProjectNavbarWide(props) {
     <StyledHeaderWide {...otherProps}>
       <Background src={backgroundSrc} />
       <StyledOuterWrapper>
-        <SettingsMenu>
           {children}
-        </SettingsMenu>
         <StyledWrapper>
           <StyledAvatar
             src={avatarSrc}

--- a/app/pages/project/components/ProjectNavbar/components/StyledHeader/Header.jsx
+++ b/app/pages/project/components/ProjectNavbar/components/StyledHeader/Header.jsx
@@ -1,6 +1,8 @@
 import styled from 'styled-components';
 
 const Header = styled.header`
+  background: black;
+  color: white;
   display: flex;
   flex-direction: row;
   justify-content: center;

--- a/app/pages/project/components/ProjectNavbar/components/Wrapper/Wrapper.jsx
+++ b/app/pages/project/components/ProjectNavbar/components/Wrapper/Wrapper.jsx
@@ -4,7 +4,6 @@ const Wrapper = styled.div`
   align-items: center;
   display: flex;
   margin: 0 3vw;
-  width: 100%;
   z-index: 2;
 `;
 

--- a/app/pages/project/index.jsx
+++ b/app/pages/project/index.jsx
@@ -74,6 +74,18 @@ class ProjectPageController extends React.Component {
     }
   }
 
+  componentDidUpdate(prevProps) {
+    const { actions, translations } = this.props;
+    const { project, guide, pages } = this.state;
+    const { locale } = translations;
+    if (project && (locale !== prevProps.translations.locale)) {
+      actions.translations.load('project', project.id, locale);
+      actions.translations.loadTranslations('project_page', pages.map(page => page.id), locale);
+      if (guide) {
+        actions.translations.load('field_guide', guide.id, locale);
+      }
+    }
+  }
   componentWillUnmount() {
     Split.clear();
   }
@@ -410,6 +422,12 @@ ProjectPageController.propTypes = {
 };
 
 ProjectPageController.defaultProps = {
+  actions: {
+    translations: {
+      load: () => null,
+      loadTranslations: () => null
+    }
+  },
   location: {
     query: {}
   },

--- a/app/pages/project/project-page.spec.js
+++ b/app/pages/project/project-page.spec.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { shallow, mount } from 'enzyme';
 import { expect } from 'chai';
 import sinon from 'sinon';
@@ -8,6 +9,12 @@ import { project } from '../dev-classifier/mock-data';
 import ProjectPage from './project-page';
 import ProjectNavbar from './components/ProjectNavbar';
 import ProjectHomeContainer from './home/';
+
+const store = {
+  subscribe: () => { },
+  dispatch: () => { },
+  getState: () => ({ userInterface: { theme: 'light' } })
+};
 
 function Page() {
   return (
@@ -118,7 +125,10 @@ describe('ProjectPage', function () {
           <ProjectPage project={project}>
             <Page />
           </ProjectPage>,
-          { context: { geordi }}
+          { 
+            context: { geordi, store },
+            childContextTypes: { store: PropTypes.object.isRequired }
+          }
         );
       });
 

--- a/app/pages/project/workflow-selection.jsx
+++ b/app/pages/project/workflow-selection.jsx
@@ -35,6 +35,9 @@ class WorkflowSelection extends React.Component {
     if (prevProps.project.id !== this.props.project.id) {
       this.getSelectedWorkflow(this.props);
     }
+    if (prevProps.translations.locale !== this.props.translations.locale) {
+      this.props.actions.translations.load('workflow', this.state.workflow.id, this.props.translations.locale);
+    }
   }
 
   getSelectedWorkflow({ project, preferences, user }) {


### PR DESCRIPTION
Staging branch URL: https://language-picker.pfe-preview.zooniverse.org

https://language-picker.pfe-preview.zooniverse.org/projects/y-dot-liefting/snapshot-hoge-veluwe?env=production is available in English and Dutch

- [x] Add a simple language picker to projects.
- [x] Style the language picker.
- [x] Reload translations when language changes.
- [x] Let project owners add and remove languages from their projects.
- [x] Add tests.

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [x] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
