### PR TITLE
Fix type error on collections page

### DIFF
--- a/app/collections/show.jsx
+++ b/app/collections/show.jsx
@@ -52,22 +52,21 @@ class CollectionPage extends React.Component {
     }
   }
 
-  canCollaborate = () => {
-    let canCollaborate;
-    if (!this.props.user) {
-      canCollaborate = false;
-    } else {
-      canCollaborate = this.props.roles.some((role) => {
-        const idMatch = (role.links.owner.id === this.props.user.id);
+  canCollaborate() {
+    const { owner, roles, user } = this.props;
+    let canCollaborate = false;
+    let isOwner = false;
+    if (user && user.id) {
+      canCollaborate = roles.some((role) => {
+        const idMatch = (role.links.owner.id === user.id);
         const isCollaborator = role.roles.includes('collaborator');
-
         return isCollaborator && idMatch;
       });
+      isOwner = user.id === owner.id;
     }
-    const isOwner = this.props.user.id === this.props.owner.id;
 
     this.setState({ canCollaborate: canCollaborate || isOwner });
-  };
+  }
 
   render() {
     const title = `${this.props.collection.display_name} (${this.props.collection.links.subjects ? this.props.collection.links.subjects.length : 0})`;


### PR DESCRIPTION
Fix an error where the collections page crashed if `props.user` is null. Only checks `user.id` if user is defined.

Staging branch URL: https://collections.pfe-preview.zooniverse.org

Fixes #4682.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
