### PR TITLE
Use summariesHook to show a workflow-defined custom summary

### DIFF
--- a/app/classifier/classification-summary.jsx
+++ b/app/classifier/classification-summary.jsx
@@ -73,6 +73,15 @@ class ClassificationSummary extends React.Component {
       );
     }
 
+    if (this.props.workflow.configuration &&
+        this.props.workflow.configuration.custom_summary) {
+      summariesHook.push(
+        <Markdown className='classification-summary'>
+          {this.props.workflow.configuration.custom_summary}
+        </Markdown>
+      );
+    }
+
     if (this.showExoplanetSimFeedback()) {
       return (
         <p style={{ fontWeight: 'bold' }}>Well done! You've found a simulated planet. We include these to help calibrate the project. Keep going to discover a real planet!</p>
@@ -81,7 +90,6 @@ class ClassificationSummary extends React.Component {
 
     return (
       <div>
-        { summariesHook.length ? summariesHook : null }
         { this.hasExpert ?
           <div className="has-expert-classification">
             Expert classification available.&nbsp;
@@ -91,6 +99,7 @@ class ClassificationSummary extends React.Component {
           </div> : '' }
 
         <div>
+          { summariesHook.length ? summariesHook.map(item => item) : null }
           <strong className="classification-summary__title">
             { this.state.showExpert ? 'Expert Classification:' : 'Your classification:' }
           </strong>


### PR DESCRIPTION
Staging branch URL: https://enable-custom-summary-hook.pfe-preview.zooniverse.org/

Looks for the `configuration.custom_summary` property on the workflow resource, and renders it as Markdown on the classification summary if present.

cc @hrspiers 

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
