### PR TITLE
Only call getWorkflows if selectedWorkflowID is defined and truthy

### DIFF
--- a/app/pages/project/workflow-selection.jsx
+++ b/app/pages/project/workflow-selection.jsx
@@ -104,7 +104,7 @@ class WorkflowSelection extends React.Component {
       awaitWorkflow = Promise.resolve(null);
     }
 
-    awaitWorkflow
+    return awaitWorkflow
     .then((workflow) => {
       if (workflow) {
         this.setState({ loadingSelectedWorkflow: false, workflow });

--- a/app/pages/project/workflow-selection.jsx
+++ b/app/pages/project/workflow-selection.jsx
@@ -69,10 +69,11 @@ class WorkflowSelection extends React.Component {
     } else if (project.configuration && project.configuration.default_workflow) {
       selectedWorkflowID = project.configuration.default_workflow;
     } else {
-      selectedWorkflowID = this.selectRandomWorkflow(project);
+      selectedWorkflowID = this.selectRandomActiveWorkflow(project);
     }
 
-    this.getWorkflow(selectedWorkflowID, activeFilter);
+    if (selectedWorkflowID) return this.getWorkflow(selectedWorkflowID, activeFilter);
+    if (process.env.BABEL_ENV !== 'test') console.warn('Cannot select a workflow.')
   }
 
   getWorkflow(selectedWorkflowID, activeFilter = true) {
@@ -123,7 +124,7 @@ class WorkflowSelection extends React.Component {
 
           this.clearInactiveWorkflow(selectedWorkflowID)
             .then(() => {
-              if (project.links.workflows) this.getSelectedWorkflow(this.props);
+              this.getSelectedWorkflow(this.props);
             });
         }
       }
@@ -133,7 +134,7 @@ class WorkflowSelection extends React.Component {
     });
   }
 
-  selectRandomWorkflow(project) {
+  selectRandomActiveWorkflow(project) {
     const linkedActiveWorkflows = project.links.active_workflows;
     if (linkedActiveWorkflows && linkedActiveWorkflows.length > 0) {
       const randomIndex = Math.floor(Math.random() * linkedActiveWorkflows.length);

--- a/app/pages/project/workflow-selection.spec.js
+++ b/app/pages/project/workflow-selection.spec.js
@@ -299,15 +299,30 @@ describe('WorkflowSelection', function () {
     });
   });
 
-  describe('when loading a project without workflows', function() {
-    let getSelectedWorkflowSpy;
+  describe('when loading a project without linked active workflows', function() {
+    it('should not attempt to call getWorkflow', function() {
+      const projectWithoutActiveWorkflows = mockPanoptesResource('projects', {
+        id: 'y',
+        display_name: 'A test project',
+        configuration: {},
+        experimental_tools: [],
+        links: {
+          owner: { id: '1' },
+          workflows: ['20']
+        }
+      });
 
-    before(function() {
-      getSelectedWorkflowSpy = sinon.spy(controller, 'getSelectedWorkflow');
+      wrapper.setProps({ project: projectWithoutActiveWorkflows });
 
+      sinon.assert.notCalled(workflowStub)
+    });
+  });
+
+  describe('when loading a project without any linked workflows', function () {
+    it('should not attempt to call getWorkflow', function () {
       const projectWithoutWorkflows = mockPanoptesResource('projects', {
         id: 'z',
-        display_name: 'A test project',
+        display_name: 'I have no workflows project',
         configuration: {},
         experimental_tools: [],
         links: {
@@ -316,18 +331,8 @@ describe('WorkflowSelection', function () {
       });
 
       wrapper.setProps({ project: projectWithoutWorkflows });
-    });
 
-    beforeEach(function() {
-      getSelectedWorkflowSpy.resetHistory(); 
-    })
-
-    after(function() {
-      getSelectedWorkflowSpy.restore();
-    });
-
-    it('should not attempt to select another workflow', function() {
-      sinon.assert.notCalled(getSelectedWorkflowSpy);
+      sinon.assert.notCalled(workflowStub)
     });
   });
 });


### PR DESCRIPTION
Staging branch URL: https://fix-infinite-loop-bug.pfe-preview.zooniverse.org/

Fixes regression introduced in #4672. #4672 attempted to fix a workflow selection infinite loop by checking first if a project had a linked workflows array before calling `getSelectedWorkflow`. This stopped the workflow selection loop in a scenario when a project has no workflows, but it has a few issue:

- Empty arrays in javascript evaluate true, so you have to check that the array exists and the length of it (oops). So the previous conditional always evaluated true.

- Even if you check the length for `project.links.workflows`, it introduced a new infinite loop with projects that have a linked workflow that is not active like http://zooniverse.org/projects/rolando-dot-tokez/canna-if-i-juanna

- What the actual issue is that sometimes we're calling `getWorkflow` when `selectedWorkflowID` is undefined or falsey. This can be undefined or falsey in a couple of scenarios: 
  - A project that has no linked workflows
  - A project with an inactive workflow linked, but there is no workflow query param, and/or there's no logged in user (like an admin, owner, etc), so the `selectedWorkflowID` from 'selectRandomWorkflow` returns an empty string

This fixes both scenarios by removing the conditional check from the then block after calling `clearInactiveWorkflow` and instead only calls `getWorkflow` if `selectedWorkflowID` is defined and truthy.

I've renamed `selectRandomWorkflow` to `selectRandomActiveWorkflow` to make it clear what it is doing. There's a follow up to this, though: should this method be changed to allow admins, owners, collaborators, and testers to select a random workflow out of the inactive workflow links? That's out of scope of this PR, so I didn't add that.

Projects to test with:
A project with only inactive workflows linked: https://fix-infinite-loop-bug.pfe-preview.zooniverse.org/projects/rolando-dot-tokez/canna-if-i-juanna?env=production
A project with no workflows linked: https://fix-infinite-loop-bug.pfe-preview.zooniverse.org/projects/srallen086/untitled-project-5-10-2018-11-53-20-am

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
