### PR TITLE
Add alumni

### DIFF
--- a/app/pages/about/team-page.cjsx
+++ b/app/pages/about/team-page.cjsx
@@ -257,9 +257,9 @@ counterpart.registerTranslations 'en',
         his PC playing games or reading comics, he's at his PC studying web design and
         coding experimental apps.'''
       simoneDuca:
-        title: 'Web Developer'
-        bio: '''Simone is a front end web developer at the Zooniverse. He has a Phd in logic and philosophy
-        from Bristol and loves cooking.'''
+        title: 'Developer'
+        bio: '''Simone joined the Zooniverse in 2015 as frontend developer. In a previous life, he received a Phd in logic and philosophy
+        from Bristol. After moving "Up North", he joined another worthy cause in 2018.'''
       stuartLynn:
         title: 'Developer'
         bio: '''Stuart arrived at the Adler as a developer in July 2011, having been one of the founding
@@ -647,7 +647,7 @@ teamMembers =
     title: counterpart "team.content.simoneDuca.title"
     bio: counterpart "team.content.simoneDuca.bio"
     image: "/assets/team/simone.jpg"
-    location: "oxford"
+    location: "alumni"
   stuartLynn:
     name: "Stuart Lynn"
     title: counterpart "team.content.stuartLynn.title"

--- a/app/pages/about/team-page.cjsx
+++ b/app/pages/about/team-page.cjsx
@@ -258,7 +258,7 @@ counterpart.registerTranslations 'en',
         coding experimental apps.'''
       simoneDuca:
         title: 'Developer'
-        bio: '''Simone joined the Zooniverse in 2015 as frontend developer. In a previous life, he received a Phd in logic and philosophy
+        bio: '''Simone joined the Zooniverse in 2015 as a frontend developer. In a previous life, he received a Phd in logic and philosophy
         from Bristol. After moving "Up North", he joined another worthy cause in 2018.'''
       stuartLynn:
         title: 'Developer'


### PR DESCRIPTION
Hey, I had some free time, so...

Staging branch URL: Tests are passing, but I'm getting an error when running stage command. It seems a problem with `publisssh`. Has anyone seen this before?

```
Local: ./dist
Bucket: zooniverse-static
Prefix: preview.zooniverse.org/panoptes-front-end/add-alumni
/Users/simone.duca/Documents/Projects/Panoptes-Front-End/node_modules/aws-sdk/lib/request.js:30
            throw err;
            ^

TypeError: Cannot read property 'Contents' of null
  at Response.<anonymous> (/Users/simone.duca/Documents/Projects/Panoptes-Front-End/node_modules/publisssh/lib/publish.iced:126:16)
  at Request.<anonymous> (/Users/simone.duca/Documents/Projects/Panoptes-Front-End/node_modules/aws-sdk/lib/request.js:353:18)
```

Describe your changes.

Adds Simone to the Alumni section.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?
