### PR TITLE
Use workflowHistory to update feedback

### DIFF
--- a/app/classifier/classifier.jsx
+++ b/app/classifier/classifier.jsx
@@ -127,7 +127,6 @@ class Classifier extends React.Component {
     }
 
     const annotations = this.state.annotations.slice();
-    const annotation = annotations[annotations.length - 1];
     const subjectViewerProps = {
       subject: this.props.subject,
       workflow: this.props.workflow,
@@ -157,11 +156,12 @@ class Classifier extends React.Component {
     // to check the entire annotation array, as the user may be editing an
     // existing annotation.
     let isInProgress = false;
-    const { annotations } = this.state;
+    const { annotations, workflowHistory } = this.state;
     const { workflow } = this.props;
-    const currentAnnotation = annotations[annotations.length - 1] || {};
-
-    const currentTask = workflow.tasks[currentAnnotation.task] || null;
+    const currentTaskKey = workflowHistory[workflowHistory.length - 1];
+    const index = findLastIndex(annotations, annotation => annotation.task === currentTaskKey);
+    const currentAnnotation = index > -1 ? annotations[index] : {};
+    const currentTask = workflow.tasks[currentTaskKey] || null;
 
     if (currentTask && currentTask.type === 'drawing') {
       isInProgress = annotations.reduce((result, annotation) => {


### PR DESCRIPTION
Use the last task key stored in workflow history to look up the current annotation.

Staging branch URL: https://update-feedback.pfe-preview.zooniverse.org

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
