### PR TITLE
Add feedback tests to the classifier

### DIFF
--- a/app/classifier/classifier.jsx
+++ b/app/classifier/classifier.jsx
@@ -208,8 +208,12 @@ class Classifier extends React.Component {
     const workflowHistory  = this.state.workflowHistory.slice();
     const prevTaskKey = workflowHistory[workflowHistory.length - 1];
     workflowHistory.push(taskKey);
-    this.checkForFeedback(prevTaskKey)
-      .then(() => this.setState({ workflowHistory }));
+    if (prevTaskKey) {
+      this.checkForFeedback(prevTaskKey)
+        .then(() => this.setState({ workflowHistory }));
+    } else {
+      this.setState({ workflowHistory });
+    }
   }
 
   onPrevTask() {

--- a/app/classifier/classifier.spec.js
+++ b/app/classifier/classifier.spec.js
@@ -257,5 +257,24 @@ describe('Classifier', function () {
       wrapper.instance().onNextTask(newAnnotation.task);
       expect(feedbackUpdateSpy.calledWith(prevAnnotation)).to.equal(true);
     });
+
+    it('should update feedback for the last annotation when a classification is completed', function (done) {
+      const newAnnotation = {task: 'T3', value: 'new task'};
+      const fakeEvent = {
+        currentTarget: {},
+        preventDefault: () => null
+      }
+      const annotations = classification.annotations.slice();
+      annotations.push(newAnnotation);
+      const workflowHistory = wrapper.state().workflowHistory;
+      workflowHistory.push(newAnnotation.task);
+      wrapper.setState({ annotations, workflowHistory });
+      wrapper.instance().completeClassification(fakeEvent)
+      .then(function () {
+        expect(feedbackUpdateSpy.calledWith(newAnnotation)).to.equal(true);
+      })
+      .then(done, done);
+      
+    });
   });
 });

--- a/app/classifier/classifier.spec.js
+++ b/app/classifier/classifier.spec.js
@@ -57,6 +57,12 @@ const workflow = mockPanoptesResource('workflow', {
   }
 });
 
+const subject = mockPanoptesResource('subject', {
+  locations: [
+    { 'text/plain': 'a fake URL'}
+  ]
+});
+
 let wrapper;
 before(function () {
   wrapper = shallow(<Classifier />, mockReduxStore);
@@ -79,14 +85,9 @@ describe('Classifier', function () {
     });
 
     describe('with an incomplete classification', function () {
-      let loadSubject;
       before(function () {
-        loadSubject = sinon.stub(Classifier.prototype, 'loadSubject').callsFake(() => null);
-        wrapper = shallow(<Classifier classification={classification} />, mockReduxStore);
+        wrapper = shallow(<Classifier classification={classification} subject={subject} />, mockReduxStore);
         wrapper.instance().componentDidMount();
-      });
-      after(function () {
-        loadSubject.restore();
       });
       it('should preserve annotations from an incomplete classification', function () {
         const state = wrapper.state();
@@ -100,16 +101,11 @@ describe('Classifier', function () {
   });
 
   describe('on receiving a new classification', function () {
-    let loadSubject;
     before(function () {
-      loadSubject = sinon.stub(Classifier.prototype, 'loadSubject').callsFake(() => null);
       wrapper = shallow(<Classifier />, mockReduxStore);
     });
-    after(function () {
-      loadSubject.restore();
-    });
     it('should preserve annotations from an incomplete classification', function () {
-      const newProps = { classification };
+      const newProps = { classification, subject };
       wrapper.setProps(newProps);
       const state = wrapper.state();
       expect(state.annotations).to.deep.equal(classification.annotations);
@@ -129,7 +125,6 @@ describe('Classifier', function () {
   });
 
   describe('on receiving a new subject', function () {
-    let loadSubject;
     before(function () {
       wrapper = shallow(<Classifier />, mockReduxStore);
     });
@@ -145,12 +140,7 @@ describe('Classifier', function () {
       expect(state.workflowHistory).to.have.lengthOf(0);
     });
     it('should preserve any existing annotations', function () {
-      const newProps = {
-        classification: classification,
-        subject: {
-          locations: []
-        }
-      };
+      const newProps = { classification, subject };
       wrapper.setProps(newProps);
       const state = wrapper.state();
       expect(state.annotations).to.deep.equal(classification.annotations);
@@ -161,13 +151,12 @@ describe('Classifier', function () {
   describe('on completing a classification', function () {
     let checkForFeedback;
     let fakeEvent;
-    let loadSubject;
     beforeEach(function () {
-      loadSubject = sinon.stub(Classifier.prototype, 'loadSubject').callsFake(() => null);
       checkForFeedback = sinon.stub(Classifier.prototype, 'checkForFeedback').callsFake(() => Promise.resolve());
       wrapper = shallow(
         <Classifier
           classification={classification}
+          subject={subject}
           onComplete={classification.save}
           onCompleteAndLoadAnotherSubject={classification.save}
         />,
@@ -181,7 +170,6 @@ describe('Classifier', function () {
     });
     afterEach(function () {
       checkForFeedback.restore();
-      loadSubject.restore();
     });
 
     describe('with summaries enabled', function () {
@@ -219,12 +207,10 @@ describe('Classifier', function () {
   describe('with feedback enabled', function () {
     let feedbackInitSpy;
     let feedbackUpdateSpy;
-    let loadSubject;
 
     before(function () {
       feedbackInitSpy = sinon.spy();
       feedbackUpdateSpy = sinon.spy();
-      loadSubject = sinon.stub(Classifier.prototype, 'loadSubject').callsFake(() => null);
     });
 
     beforeEach(function () {
@@ -240,6 +226,7 @@ describe('Classifier', function () {
       wrapper = shallow(
         <Classifier
           classification={classification}
+          subject={subject}
           feedback={feedback}
           actions={actions}
         />

--- a/app/classifier/classifier.spec.js
+++ b/app/classifier/classifier.spec.js
@@ -215,4 +215,60 @@ describe('Classifier', function () {
       });
     });
   });
+
+  describe('with feedback enabled', function () {
+    let feedbackInitSpy;
+    let feedbackUpdateSpy;
+    let loadSubject;
+
+    before(function () {
+      feedbackInitSpy = sinon.spy();
+      feedbackUpdateSpy = sinon.spy();
+      loadSubject = sinon.stub(Classifier.prototype, 'loadSubject').callsFake(() => null);
+    });
+
+    beforeEach(function () {
+      const feedback = {
+        active: true
+      };
+      const actions = {
+        feedback: {
+          init: feedbackInitSpy,
+          update: feedbackUpdateSpy
+        }
+      };
+      wrapper = shallow(
+        <Classifier
+          classification={classification}
+          feedback={feedback}
+          actions={actions}
+        />
+      );
+      wrapper.instance().componentDidMount();
+    });
+
+    afterEach(function () {
+      feedbackUpdateSpy.resetHistory();
+    });
+
+    it('should update feedback when an annotation is created', function () {
+      const newAnnotation = {task: 'T3', value: 'new task'};
+      const annotations = classification.annotations.slice();
+      annotations.push(newAnnotation);
+      wrapper.instance().updateAnnotations(annotations);
+      wrapper.instance().onNextTask(newAnnotation.task);
+      expect(feedbackUpdateSpy.callCount).to.equal(1);
+      
+    });
+
+    it('should update feedback for the previous annotation when an annotation is created', function () {
+      const newAnnotation = {task: 'T3', value: 'new task'};
+      const annotations = classification.annotations.slice();
+      const prevAnnotation = annotations[annotations.length - 1];
+      annotations.push(newAnnotation);
+      wrapper.instance().updateAnnotations(annotations);
+      wrapper.instance().onNextTask(newAnnotation.task);
+      expect(feedbackUpdateSpy.calledWith(prevAnnotation)).to.equal(true);
+    });
+  });
 });


### PR DESCRIPTION
Adds tests to check that feedback is updated when feedback is checked, and that the correct annotation is used.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
