### PR TITLE
Replace lab index use of history with browserHistory

### DIFF
--- a/app/pages/lab/index.cjsx
+++ b/app/pages/lab/index.cjsx
@@ -1,6 +1,6 @@
 React = require 'react'
 createReactClass = require 'create-react-class'
-{Link} = require 'react-router'
+{browserHistory, Link} = require 'react-router'
 apiClient = require 'panoptes-client/lib/api-client'
 ModalFormDialog = require 'modal-form/dialog'
 { Helmet } = require 'react-helmet'
@@ -225,7 +225,7 @@ module.exports = createReactClass
     queryUpdate[which] = page
     newQuery = Object.assign {}, @props.location.query, queryUpdate
     newLocation = Object.assign {}, @props.location, query: newQuery
-    @props.history.replace newLocation
+    browserHistory.push newLocation
 
   showProjectCreator: ->
     @setState creationInProgress: true
@@ -236,7 +236,7 @@ module.exports = createReactClass
   handleProjectCreation: (project) ->
     @hideProjectCreator()
     newLocation = Object.assign {}, @props.location, pathname: "/lab/#{project.id}"
-    @props.history.push newLocation
+    browserHistory.push newLocation
 
   render: ->
     if @props.user?


### PR DESCRIPTION
Staging branch URL: https://lab-page-fix.pfe-preview.zooniverse.org/

Fixes lab issues with pagination for owned or collaborator projects lists, as well as redirect after creating new project.

Replaces use of `@props.history` with react-router's `browserHistory`.

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [x] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
