### PR TITLE
Move feedback update out of subject load

### DIFF
--- a/app/classifier/classifier.jsx
+++ b/app/classifier/classifier.jsx
@@ -119,7 +119,7 @@ class Classifier extends React.Component {
   }
 
   checkForFeedback(taskId) {
-    this.updateFeedback()
+    this.updateFeedback(taskId)
 
     const { feedback } = this.props;
     const taskFeedback = (feedback.rules && feedback.rules[taskId]) ? feedback.rules[taskId] : [];
@@ -147,37 +147,18 @@ class Classifier extends React.Component {
   }
 
   updateAnnotations(annotations) {
-    this.setState({ annotations }, this.updateFeedback);
+    this.setState({ annotations });
   }
 
-  updateFeedback() {
+  updateFeedback(taskId) {
     if (!this.props.feedback.active) {
       return false;
     }
-    // Check to see if we're still drawing, and update feedback if not. We need
-    // to check the entire annotation array, as the user may be editing an
-    // existing annotation.
-    let isInProgress = false;
-    const { annotations, workflowHistory } = this.state;
-    const { workflow } = this.props;
-    const currentTaskKey = workflowHistory[workflowHistory.length - 1];
-    const index = findLastIndex(annotations, annotation => annotation.task === currentTaskKey);
+
+    const { annotations } = this.state;
+    const index = findLastIndex(annotations, annotation => annotation.task === taskId);
     const currentAnnotation = index > -1 ? annotations[index] : {};
-    const currentTask = workflow.tasks[currentTaskKey] || null;
-
-    if (currentTask && currentTask.type === 'drawing') {
-      isInProgress = annotations.reduce((result, annotation) => {
-        if (annotation.value.map) {
-          return annotation.value.map(value => value._inProgress).includes(true);
-        } else {
-          return result;
-        }
-      }, false);
-    }
-
-    if (!isInProgress) {
-      this.props.actions.feedback.update(currentAnnotation);
-    }
+    this.props.actions.feedback.update(currentAnnotation);
   }
 
   loadSubject(subject) {

--- a/app/classifier/classifier.jsx
+++ b/app/classifier/classifier.jsx
@@ -119,6 +119,8 @@ class Classifier extends React.Component {
   }
 
   checkForFeedback(taskId) {
+    this.updateFeedback()
+
     const { feedback } = this.props;
     const taskFeedback = (feedback.rules && feedback.rules[taskId]) ? feedback.rules[taskId] : [];
 
@@ -200,7 +202,6 @@ class Classifier extends React.Component {
       if (this.props.subject === subject) { // The subject could have changed while we were loading.
         this.setState({ subjectLoading: false });
         this.props.onLoad();
-        this.updateFeedback();
       }
     });
   }


### PR DESCRIPTION
Staging branch URL: https://feedback-classifier-state.pfe-preview.zooniverse.org/

Fixes #4668. (Hopefully)

This should have been obvious, but this removes the call to update feedback from subject load, and instead updates just before we check whether to show the feedback modal or not.

I'll add tests once #4699 is in

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
