### PR TITLE
Change data-choiceID to data-choiceid

### DIFF
--- a/app/classifier/tasks/survey/chooser/Choices.jsx
+++ b/app/classifier/tasks/survey/chooser/Choices.jsx
@@ -27,7 +27,7 @@ class Choices extends React.Component {
     this.choiceButtons
       .filter(Boolean)
       .map((button) => {
-        const choiceID = button.getAttribute('data-choiceID');
+        const choiceID = button.getAttribute('data-choiceid');
         const index = this.props.task.choicesOrder.indexOf(choiceID);
         newChoiceButtons[index] = button;
       });
@@ -117,7 +117,7 @@ class Choices extends React.Component {
             <button
               autoFocus={choiceId === this.props.focusedChoice}
               key={choiceId}
-              data-choiceID={choiceId}
+              data-choiceid={choiceId}
               ref={button => this.choiceButtons.push(button)}
               tabIndex={tabIndex}
               type="button"

--- a/app/classifier/tasks/survey/index.spec.js
+++ b/app/classifier/tasks/survey/index.spec.js
@@ -45,7 +45,7 @@ describe('Survey Task', function () {
     });
 
     it('should render a valid annotation as a selected choice', function () {
-      const selectedChoice = wrapper.find('[data-choiceID="ar"]');
+      const selectedChoice = wrapper.find('[data-choiceid="ar"]');
       assert.equal(selectedChoice.prop('className'), 'survey-task-chooser-choice-button survey-task-chooser-choice-button-chosen');
     });
 


### PR DESCRIPTION
Fixes a React warning about an invalid data attribute in the survey task choices.

Staging branch URL: https://data-attributes.pfe-preview.zooniverse.org/

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
