### PR TITLE
Dev classifier bugfixes

### DIFF
--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -40,6 +40,9 @@ ClassifierWrapper = createReactClass
     onComplete: PropTypes.func
     onCompleteAndLoadAnotherSubject: PropTypes.func
     onClickNext: PropTypes.func
+    translations: PropTypes.shape({
+        locale: PropTypes.string
+      })
     workflow: PropTypes.object
     user: PropTypes.object
 
@@ -49,6 +52,9 @@ ClassifierWrapper = createReactClass
     onComplete: Function.prototype
     onCompleteAndLoadAnotherSubject: Function.prototype
     onClickNext: Function.prototype
+    translations: {
+      locale: 'en'
+    }
     workflow: null
     user: null
 

--- a/app/pages/dev-classifier/mock-data.coffee
+++ b/app/pages/dev-classifier/mock-data.coffee
@@ -154,7 +154,7 @@ workflow = apiClient.type('workflows').create
         {type: 'rotateRectangle', label: 'Rotate Rectangle', color: 'red'}
         {type: 'polygon', label: 'Polygon', color: 'cyan', details: MISC_DRAWING_DETAILS}
         {type: 'circle', label: 'Circle', color: 'blue', details: DRAWING_DETAILS_REQUIRED}
-        {type: 'ellipse', label: 'Ellipse'.repeat(25), color: 'magenta', details: MISC_DRAWING_DETAILS}
+        {type: 'ellipse', label: 'Ellipse '.repeat(25), color: 'magenta', details: MISC_DRAWING_DETAILS}
         {type: 'anchoredEllipse', label: 'Anchored Ellipse', color: 'darkmagenta'}
         {type: 'triangle', label: 'Triangle', color: 'salmon'}
         {type: 'bezier', label: 'Bezier', color: 'orange', details: MISC_DRAWING_DETAILS}


### PR DESCRIPTION
Staging branch URL: https://dev-classifier.pfe-preview.zooniverse.org/dev/classifier

Fixes a couple of small bugs, one of which crashes the entire React app if you visit the dev classifier.

Adds a default locale to the classifier (this one crashes PFE.)
Adds spacing to the test for long drawing tool labels (the ellipse tool.)

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
