### PR TITLE
Fix page title of profile pages

### DIFF
--- a/app/pages/profile/user.jsx
+++ b/app/pages/profile/user.jsx
@@ -139,7 +139,7 @@ class ProfileUser extends Component {
 
     return (
       <div className={pageClasses}>
-        <Helmet title={this.props.user ? `${counterpart("profile.title")} » ${this.props.user.display_name}` : counterpart('loading')} />
+        <Helmet title={this.props.profileUser ? `${counterpart("profile.title")} » ${this.props.profileUser.display_name}` : counterpart('loading')} />
         <section className="hero user-profile-hero" style={headerStyle}>
           <div className="overlay" />
           <div className="hero-container">


### PR DESCRIPTION
Display the profileUser's name, not the logged in user's name.

Staging branch URL: https://profile-titles.pfe-preview.zooniverse.org/

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?