### PR TITLE
Remove opengraph image

### DIFF
--- a/views/index.ejs
+++ b/views/index.ejs
@@ -15,7 +15,6 @@
     <meta property="og:type" content="website" />
     <meta property="og:title" content="Zooniverse" />
     <meta property="og:description" content="The Zooniverse is the world’s largest and most popular platform for people-powered research." />
-    <meta property="og:image" content="https://zooniverse-static.s3.amazonaws.com/assets/opengraph.jpg" />
   </head>
 
   <body>


### PR DESCRIPTION
Staging branch URL: https://remove-opengraph.pfe-preview.zooniverse.org/

Having this outdated image of the home page, which loads as the preview for every page, is worse than having no image at all. One day we should set up some server-side rendering to generate proper previews dynamically, but right now we should just remove this.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?