### PR TITLE
panoptes-client 2.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9371,10 +9371,11 @@
       "dev": true
     },
     "panoptes-client": {
-      "version": "github:zooniverse/panoptes-javascript-client#4699fba91e7d4938a33a963492dd500242dd042c",
-      "from": "github:zooniverse/panoptes-javascript-client#audit",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-2.10.0.tgz",
+      "integrity": "sha512-uqBVRVd+DM9WAvdWGo53jadLhoOzGBJ/Spo46sX7ZMk1F3+ViFaddeZZKJNVuWK/MRbNm/oKXie67VUmdr/R6g==",
       "requires": {
-        "json-api-client": "^4.0.0-0",
+        "json-api-client": "^4.0.0",
         "local-storage": "^1.4.2",
         "sugar-client": "^1.0.1"
       }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "mocha": "~5.2.0",
     "modal-form": "~2.6.0",
     "moment": "~2.21.0",
-    "panoptes-client": "github:zooniverse/panoptes-javascript-client#audit",
+    "panoptes-client": "~2.10.0",
     "papaparse": "github:mholt/PapaParse#cada171",
     "polished": "~1.9.2",
     "prop-types": "~15.6.0",


### PR DESCRIPTION
Staging branch URL: https://upgrade-client.pfe-preview.zooniverse.org

Bump the Panoptes client to 2.10.
Otherwise, identical to #4713 for testing.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
