### PR TITLE
Fix production build

### DIFF
--- a/webpack.build.js
+++ b/webpack.build.js
@@ -52,7 +52,7 @@ module.exports = {
   module: {
     rules: [{
       test: /\.jsx?$/,
-      exclude: /node_modules/,
+      exclude: /node_modules\/(?!(markdown-it-anchor)\/).*/,
       use: 'babel-loader',
     }, {
       test: /\.cjsx$/,

--- a/webpack.build.js
+++ b/webpack.build.js
@@ -52,7 +52,7 @@ module.exports = {
   module: {
     rules: [{
       test: /\.jsx?$/,
-      exclude: /node_modules\/(?!(markdown-it-anchor)\/).*/,
+      exclude: /node_modules\/(?!(markdown-it-anchor)\/).*/, // markdown-it-anchor is written in ES6 and isn't properly compiled
       use: 'babel-loader',
     }, {
       test: /\.cjsx$/,


### PR DESCRIPTION
Staging branch URL: https://fix-build.pfe-preview.zooniverse.org/

Fixes the broken build from the updated markdownz #4712. The latest version of markdown-it-anchor includes a security fix so I don't think we should revert it, however, markdown-it-anchor has to be included in the babel compiling now. 

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
