### PR TITLE
Set tutorial preferences if undefined

### DIFF
--- a/app/classifier/tutorial.jsx
+++ b/app/classifier/tutorial.jsx
@@ -192,10 +192,10 @@ export default class Tutorial extends React.Component {
     if (this.props.user) {
       const { projectPreferences } = this.props;
       // Build this manually. Having an index (even as a strings) keys creates an array.
-      if (projectPreferences.preferences === null) {
+      if (!projectPreferences.preferences) {
         projectPreferences.preferences = {};
       }
-      if (projectPreferences.preferences.tutorials_completed_at === null) {
+      if (!projectPreferences.preferences.tutorials_completed_at) {
         projectPreferences.preferences.tutorials_completed_at = {};
       }
       projectPreferences.update({ [`preferences.tutorials_completed_at.${this.props.tutorial.id}`]: now });


### PR DESCRIPTION
Tutorial preferences might be undefined, rather than null, so set default values if `preferences.tutorials_completed_at` is falsy.

Staging branch URL: https://fix-4721.pfe-preview.zooniverse.org

Fixes #4721.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
