### PR TITLE
Make sure tutorials_completed_at is an object

### DIFF
--- a/app/classifier/tutorial.jsx
+++ b/app/classifier/tutorial.jsx
@@ -198,10 +198,22 @@ export default class Tutorial extends React.Component {
       if (!projectPreferences.preferences.tutorials_completed_at) {
         projectPreferences.preferences.tutorials_completed_at = {};
       }
-      projectPreferences.update({ [`preferences.tutorials_completed_at.${this.props.tutorial.id}`]: now });
-      projectPreferences.save();
-
-      this.logToGeordi(now)
+      let { tutorials_completed_at } = projectPreferences.preferences;
+      if (Array.isArray(tutorials_completed_at)) {
+        const new_completed_at = tutorials_completed_at.reduce((accumulator, currentValue, index) => {
+          if (currentValue) {
+            const tutorial_id = index.toString();
+            accumulator[tutorial_id] = currentValue;
+          }
+          return accumulator;
+        }, {});
+        tutorials_completed_at = new_completed_at;
+      }
+      tutorials_completed_at[this.props.tutorial.id] = now;
+      projectPreferences
+        .update({'preferences.tutorials_completed_at': tutorials_completed_at})
+        .save();
+      this.logToGeordi(now);
     }
   }
 

--- a/app/classifier/tutorial.jsx
+++ b/app/classifier/tutorial.jsx
@@ -14,6 +14,19 @@ import Translations from './translations';
 const completedThisSession = {};
 if (window) window.tutorialsCompletedThisSession = completedThisSession;
 
+function generateObject(accumulator, currentValue, index) {
+  if (currentValue) {
+    const key = index.toString();
+    accumulator[key] = currentValue;
+  }
+  return accumulator;
+}
+
+function arrayToObject(array) {
+  // Reduce a sparse array to a object.
+  return array.reduce(generateObject, {});
+}
+
 export default class Tutorial extends React.Component {
   constructor(props) {
     super(props);
@@ -199,15 +212,15 @@ export default class Tutorial extends React.Component {
         projectPreferences.preferences.tutorials_completed_at = {};
       }
       let { tutorials_completed_at } = projectPreferences.preferences;
+/*
+      PR #4680 introduced a subtle bug where the API incorrectly created  new values of
+      tutorials_completed_at as sparse arrays (see https://github.com/zooniverse/Panoptes-Front-End/issues/4721).
+      Here we convert tutorials_completed_at to an object, if it is an array.
+      We also explicitly pass the whole tutorials_completed_at object back to the API, so that the API client doesn't 
+      try to infer the variable type from the update key.
+*/
       if (Array.isArray(tutorials_completed_at)) {
-        const new_completed_at = tutorials_completed_at.reduce((accumulator, currentValue, index) => {
-          if (currentValue) {
-            const tutorial_id = index.toString();
-            accumulator[tutorial_id] = currentValue;
-          }
-          return accumulator;
-        }, {});
-        tutorials_completed_at = new_completed_at;
+        tutorials_completed_at = arrayToObject(tutorials_completed_at);
       }
       tutorials_completed_at[this.props.tutorial.id] = now;
       projectPreferences

--- a/app/classifier/tutorial.spec.jsx
+++ b/app/classifier/tutorial.spec.jsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import apiClient from 'panoptes-client/lib/api-client';
+import sinon from 'sinon';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import Tutorial from './tutorial';
+
+function mockPanoptesResource(type, options) {
+  const resource = apiClient.type(type).create(options);
+  apiClient._typesCache = {};
+  sinon.stub(resource, 'save').callsFake(() => Promise.resolve(resource));
+  sinon.stub(resource, 'get');
+  sinon.stub(resource, 'delete');
+  return resource;
+}
+
+describe('Tutorial', function () {
+  describe('on unmount', function () {
+    let wrapper;
+
+    before(function () {
+      const tutorial = {
+        id: 'a',
+        steps: [{}]
+      };
+      const projectPreferences = mockPanoptesResource('project_preferences', {
+        preferences: {
+          tutorials_completed_at: []
+        }
+      });
+      projectPreferences.preferences.tutorials_completed_at[100] = 'Hello';
+      const user = {};
+      wrapper = shallow(<Tutorial
+        projectPreferences={projectPreferences}
+        tutorial={tutorial}
+        translation={tutorial}
+        user={user}
+      />);
+      wrapper.instance().logToGeordi = sinon.stub();
+      wrapper.instance().handleUnmount();
+    });
+
+    it('should convert preferences.tutorials_completed_at from array to object', function () {
+      const { tutorials_completed_at } = wrapper.instance().props.projectPreferences.preferences;
+      expect(tutorials_completed_at).to.not.be.an.instanceof(Array);
+      expect(tutorials_completed_at['100']).to.equal('Hello');
+    });
+
+    it('should add the current tutorial to tutorials_completed_at', function () {
+      const { tutorials_completed_at } = wrapper.instance().props.projectPreferences.preferences;
+      const { tutorial } = wrapper.instance().props;
+      expect(tutorials_completed_at[tutorial.id]).to.exist;
+    });
+  });
+});


### PR DESCRIPTION
Follow-up to #4722.
Check if tutorials_completed_at is an array, and convert arrays to an object.
Update project preferences with the entire object.
Add tests for a case where tutorials_completed_at was created as an array.

Staging branch URL: https://tutorial_preferences.pfe-preview.zooniverse.org

Describe your changes.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
