### PR TITLE
Allow home page project card list to scroll if necessary

### DIFF
--- a/css/home-page-for-user.styl
+++ b/css/home-page-for-user.styl
@@ -126,14 +126,15 @@ GRAY = #EFF2F5
     padding: 1em 2em
 
     .project-card-list
-      overflow: hidden
+      overflow: auto
 
       .closed
+        overflow: hidden
         max-height: 0
 
       .open
-        max-height: 10000px
-        transition: max-height 1s ease-in
+        max-height: 1000px
+        transition: max-height .5s ease-out
 
 .home-page-project-stats
   flex-grow: 1


### PR DESCRIPTION
Set a max height of 1000px for the home page recent projects list. Allow the container to scroll if the height of the project card list is larger than that.

Staging branch URL: https://home-projects.pfe-preview.zooniverse.org

Fixes an issue where you can't scroll down to your oldest projects, if you have contributed to a larger number of projects than is allowed by the current max-height.

Describe your changes.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
