### PR TITLE
User account menu: Remove redundant keydown handler

### DIFF
--- a/app/layout/expandable-menu.jsx
+++ b/app/layout/expandable-menu.jsx
@@ -45,6 +45,7 @@ class ExpandableMenu extends React.Component {
       >
         <div
           ref={(menu) => { this.menu = menu; }}
+          onClick={e => e.stopPropagation()}
         >
           {this.props.children}
         </div>

--- a/app/layout/expandable-menu.jsx
+++ b/app/layout/expandable-menu.jsx
@@ -45,7 +45,6 @@ class ExpandableMenu extends React.Component {
       >
         <div
           ref={(menu) => { this.menu = menu; }}
-          onKeyDown={this.navigateMenu}
         >
           {this.props.children}
         </div>


### PR DESCRIPTION
React Portals bubble events up through the React tree, so we don't need two keydown handlers on the user menu any more.

Staging branch URL: https://user-menu.pfe-preview.zooniverse.org

Fixes #4730.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
