### PR TITLE
Make 'persist annotations' public

### DIFF
--- a/app/pages/admin/project-status/experimental-features.jsx
+++ b/app/pages/admin/project-status/experimental-features.jsx
@@ -13,7 +13,6 @@ const experimentalFeatures = [
   'Gravity Spy Gold Standard',
   'allow workflow query',
   'expert comparison summary',
-  'persist annotations',
   'shortcut',
   'freehandLine',
   'freehandShape',

--- a/app/pages/lab/workflow.cjsx
+++ b/app/pages/lab/workflow.cjsx
@@ -263,19 +263,18 @@ EditWorkflowPage = createReactClass
 
           <hr />
 
-          {if 'persist annotations' in @props.project.experimental_tools
-            <div>
-              <AutoSave resource={@props.workflow}>
-              <span className="form-label">Set annotation persistence</span><br />
-              <small className="form-help">Save the annotation of the task you are on when the back button is clicked.</small>
-              <br />
-              <label>
-                <input ref="persistAnnotation" type="checkbox" checked={@props.workflow.configuration.persist_annotations} onChange={@handlePersistAnnotationsToggle} />
-                Persist annotations
-              </label>
-              </AutoSave>
-              <hr />
-            </div>}
+          <div>
+            <AutoSave resource={@props.workflow}>
+            <span className="form-label">Set annotation persistence</span><br />
+            <small className="form-help">Save the annotation of the task you are on when the back button is clicked.</small>
+            <br />
+            <label>
+              <input ref="persistAnnotation" type="checkbox" checked={@props.workflow.configuration.persist_annotations} onChange={@handlePersistAnnotationsToggle} />
+              Persist annotations
+            </label>
+            </AutoSave>
+            <hr />
+          </div>
 
           <div className={disabledIfWorkflowInactive}>
             <AutoSave resource={@props.project}>


### PR DESCRIPTION
Remove it from experimental tools, and remove the experimental flag on it in the workflows lab page.

Staging branch URL: https://persist-annotations.pfe-preview.zooniverse.org

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
