### PR TITLE
Fix comment link import

### DIFF
--- a/app/talk/moderation/comment.cjsx
+++ b/app/talk/moderation/comment.cjsx
@@ -4,7 +4,7 @@ createReactClass = require 'create-react-class'
 {Link} = require 'react-router'
 talkClient = require 'panoptes-client/lib/talk-client'
 Loading = require('../../components/loading-indicator').default
-CommentLink = require '../../pages/profile/comment-link'
+CommentLink = require('../../pages/profile/comment-link').default
 ModerationReports = require './reports'
 ModerationActions = require './actions'
 


### PR DESCRIPTION
Moderation comments require in the CommentLink component from the user profile, which is now ES6.

Staging branch URL: https://moderation-comments.pfe-preview.zooniverse.org

Fixes #4741.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
