### PR TITLE
Restore the drawing summary More/Less button

### DIFF
--- a/app/classifier/tasks/drawing/summary-answer.jsx
+++ b/app/classifier/tasks/drawing/summary-answer.jsx
@@ -45,7 +45,7 @@ MarkProperty.propTypes = {
   }).isRequired
 };
 
-export default function SummaryAnswer({ tool, marks }) {
+export default function SummaryAnswer({ expanded, tool, marks }) {
   return (
     <div className="answer">
       <p>
@@ -53,25 +53,29 @@ export default function SummaryAnswer({ tool, marks }) {
         {' '}
         ({marks.length} {getCorrectSingularOrPluralOfDrawingType(tool.type, marks.length)} marked)
       </p>
-      <ol>
-        {marks.map(mark => (
-          <li key={mark._key}>
-            {Object.keys(mark)
-              .filter(property => property[0] !== '_')
-              .map(property => <MarkProperty key={property} tool={tool} mark={mark} property={property} />)}
-          </li>
-        ))}
-      </ol>
+      {expanded &&
+        <ol>
+          {marks.map(mark => (
+            <li key={mark._key}>
+              {Object.keys(mark)
+                .filter(property => property[0] !== '_')
+                .map(property => <MarkProperty key={property} tool={tool} mark={mark} property={property} />)}
+            </li>
+          ))}
+        </ol>
+      }
     </div>
   );
 }
 
 SummaryAnswer.propTypes = {
+  expanded: PropTypes.bool,
   marks: PropTypes.arrayOf(PropTypes.shape({})),
   tool: PropTypes.shape({})
 };
 
 SummaryAnswer.defaultProps = {
+  expanded: false,
   marks: [],
   tool: {}
 };

--- a/app/classifier/tasks/drawing/summary.jsx
+++ b/app/classifier/tasks/drawing/summary.jsx
@@ -3,6 +3,28 @@ import PropTypes from 'prop-types';
 import { Markdown } from 'markdownz';
 import SummaryAnswer from './summary-answer';
 
+function ToggleButton({ expanded, onClick }) {
+  return (
+    <button
+      type="button"
+      className="toggle-more"
+      onClick={onClick}
+    >
+      {expanded ? 'Less' : 'More'}
+    </button>
+  );
+}
+
+ToggleButton.propTypes = {
+  expanded: PropTypes.bool,
+  onClick: PropTypes.func
+};
+
+ToggleButton.defaultProps = {
+  expanded: false,
+  onClick: () => true
+};
+
 class DrawingSummary extends React.Component {
   static propTypes = {
     annotation: PropTypes.shape({
@@ -19,7 +41,16 @@ class DrawingSummary extends React.Component {
     translation: {}
   }
 
+  state = {
+    expanded: false
+  }
+
+  toggleExpanded() {
+    this.setState(prevState => ({ expanded: !prevState.expanded }));
+  }
+
   render() {
+    const { expanded } = this.state;
     const { value } = this.props.annotation;
     const { instruction, tools } = this.props.translation;
     const marksByTool = tools.map((tool, i) => value.filter(mark => mark.tool === i));
@@ -29,8 +60,19 @@ class DrawingSummary extends React.Component {
           <Markdown>
             {instruction}
           </Markdown>
+          <ToggleButton
+            expanded={expanded}
+            onClick={this.toggleExpanded.bind(this)}
+          />
         </div>
-        {marksByTool.map((toolMarks, i) => <SummaryAnswer key={tools[i]._key} tool={tools[i]} marks={toolMarks} />)}
+        {marksByTool.map((toolMarks, i) => (
+          <SummaryAnswer
+            key={tools[i]._key}
+            expanded={expanded}
+            tool={tools[i]}
+            marks={toolMarks}
+          />
+        ))}
       </React.Fragment>
     );
   }


### PR DESCRIPTION
Add the toggle button back to the drawing task summary.
Hide the full mark details for each mark type unless the summary is expanded by clicking More.

Staging branch URL: https://drawing-summary.pfe-preview.zooniverse.org

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
