### PR TITLE
Text task: flush annotation updates on unmount

### DIFF
--- a/app/classifier/tasks/text/index.jsx
+++ b/app/classifier/tasks/text/index.jsx
@@ -70,7 +70,7 @@ export default class TextTask extends React.Component {
       }
     });
 
-    this.updateAnnotation();
+    this.updateAnnotation(value);
   }
 
   handleChange() {
@@ -81,7 +81,7 @@ export default class TextTask extends React.Component {
       this.setState({ value }, () => { this.handleResize(); });
     }
 
-    this.debouncedUpdateAnnotation();
+    this.debouncedUpdateAnnotation(value);
   }
 
   handleResize() {
@@ -93,12 +93,9 @@ export default class TextTask extends React.Component {
     }
   }
 
-  updateAnnotation() {
-    if (this.textInput.current) {
-      const value = this.textInput.current.value;
-      const newAnnotation = Object.assign(this.props.annotation, { value });
-      this.props.onChange(newAnnotation);
-    }
+  updateAnnotation(value) {
+    const newAnnotation = Object.assign(this.props.annotation, { value });
+    this.props.onChange(newAnnotation);
   }
 
   render() {
@@ -111,7 +108,7 @@ export default class TextTask extends React.Component {
         <label className="answer" htmlFor="textInput">
           <textarea
             className="standard-input full"
-            onBlur={this.updateAnnotation}
+            onBlur={this.handleChange}
             onChange={this.handleChange}
             ref={this.textInput}
             rows={this.state.rows}

--- a/app/classifier/tasks/text/index.jsx
+++ b/app/classifier/tasks/text/index.jsx
@@ -15,11 +15,9 @@ export default class TextTask extends React.Component {
 
     this.textInput = React.createRef();
 
-    this.debouncedUpdateAnnotation = _.debounce(this.updateAnnotation, 500).bind(this);
+    this.debouncedUpdateAnnotation = _.debounce(this.updateAnnotation, 500);
     this.handleChange = this.handleChange.bind(this);
-    this.handleResize = this.handleResize.bind(this);
     this.setTagSelection = this.setTagSelection.bind(this);
-    this.updateAnnotation = this.updateAnnotation.bind(this);
   }
 
   state = {

--- a/app/classifier/tasks/text/index.jsx
+++ b/app/classifier/tasks/text/index.jsx
@@ -116,11 +116,11 @@ export default class TextTask extends React.Component {
         </label>
         {this.props.task.text_tags && this.props.task.text_tags.length > 0 &&
           <div className="transcription-metadata-tags">
-            {this.props.task.text_tags.map((tag, i) => (
+            {this.props.task.text_tags.map(tag => (
               <input
                 type="button"
                 className="standard-button text-tag"
-                key={i}
+                key={tag}
                 value={tag}
                 onClick={this.setTagSelection}
               />
@@ -170,6 +170,7 @@ TextTask.defaultProps = {
   annotation: {
     value: ''
   },
+  autoFocus: false,
   onChange: NOOP,
   task: {
     help: '',

--- a/app/classifier/tasks/text/index.jsx
+++ b/app/classifier/tasks/text/index.jsx
@@ -39,7 +39,7 @@ export default class TextTask extends React.Component {
   }
 
   componentWillUnmount() {
-    this.updateAnnotation();
+    this.debouncedUpdateAnnotation.flush();
   }
 
   setTagSelection(e) {

--- a/app/classifier/tasks/text/index.jsx
+++ b/app/classifier/tasks/text/index.jsx
@@ -106,7 +106,7 @@ export default class TextTask extends React.Component {
         <label className="answer" htmlFor="textInput">
           <textarea
             className="standard-input full"
-            onBlur={this.handleChange}
+            onBlur={this.debouncedUpdateAnnotation.flush}
             onChange={this.handleChange}
             ref={this.textInput}
             rows={this.state.rows}


### PR DESCRIPTION
Staging branch URL: https://text-task-es6-refactor.pfe-preview.zooniverse.org/

Tries to avoid any timing bugs (eg. the task annotation being updated after the task has unmounted) by flushing updates on unmount, and explicitly passing the current text value to `updateAnnotation` rather than getting it from the DOM. Removes some function binding that broke `_.debounce`.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
