### PR TITLE
Add Jenkinsfile to automatically stage branches

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,11 @@
 FROM node:8.12-alpine
 
 WORKDIR /src
+RUN chown -R node:node /src
 
 RUN apk add --no-cache git
+
+USER node
 
 ADD package.json /src/
 ADD package-lock.json /src/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,28 @@
+#!groovy
+
+node {
+  checkout scm
+
+  def dockerRepoName = 'zooniverse/panoptes-front-end'
+  def dockerImageName = "${dockerRepoName}:${BRANCH_NAME}"
+  def newImage = null
+
+  stage('Build Docker image') {
+    newImage = docker.build(dockerImageName)
+
+    if (BRANCH_NAME == 'master') {
+      stage('Update latest tag') {
+        newImage.push('latest')
+      }
+    }
+  }
+
+  stage('Deploy current branch') {
+    newImage.inside {
+      sh """
+        cd /src
+        npm run --silent stage-with-jenkins
+      """
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
     "_publish": "publisssh ./dist \"zooniverse-static/$PATH_ROOT/$SUBDIR\"",
     "_log-staging-url": "echo \"Staged at https://$SUBDIR.pfe-preview.zooniverse.org/\"",
     "_stage": "export PATH_ROOT=preview.zooniverse.org/panoptes-front-end; npm run _build && npm run _publish && npm run _log-staging-url",
+    "stage-with-jenkins": "export NODE_ENV=staging; export SUBDIR=$(echo $BRANCH_NAME | awk '{print tolower($0)}'); npm run _stage",
     "stage": "export NODE_ENV=staging; export SUBDIR=$(git symbolic-ref --short HEAD | awk '{print tolower($0)}'); npm run _stage",
     "stage-with-docker": "./bin/run-through-docker.sh 'npm run stage'",
     "_deploy": "export PATH_ROOT=www.zooniverse.org; npm run _build && npm run _publish",


### PR DESCRIPTION
Adds a Jenkinsfile to stage branches at {BRANCH_NAME}.pfe-preview.zooniverse.org.

NB. `BRANCH_NAME` will be something like `PR-4753` for a PR branch.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
