### PR TITLE
Fix text task row issues in Windows/Firefox

### DIFF
--- a/app/classifier/tasks/text/index.jsx
+++ b/app/classifier/tasks/text/index.jsx
@@ -75,9 +75,9 @@ export default class TextTask extends React.Component {
   handleChange() {
     const value = this.textInput.current.value;
     if (value.length < this.state.value.length) {
-      this.setState({ rows: 1, value }, () => { this.handleResize(); });
+      this.setState({ rows: 1, value }, this.handleResize);
     } else {
-      this.setState({ value }, () => { this.handleResize(); });
+      this.setState({ value }, this.handleResize);
     }
 
     this.debouncedUpdateAnnotation(value);
@@ -85,7 +85,8 @@ export default class TextTask extends React.Component {
 
   handleResize() {
     const oldRows = this.textInput.current.rows;
-    const newRows = Math.max(Math.min(Math.floor(this.textInput.current.scrollHeight / LINEHEIGHT), MAX_ROWS), 1);
+    let newRows = Math.min(Math.floor(this.textInput.current.scrollHeight / LINEHEIGHT), MAX_ROWS);
+    newRows = Math.max(newRows, 1);
 
     if (newRows && (newRows !== oldRows)) {
       this.setState({ rows: newRows });

--- a/app/classifier/tasks/text/index.jsx
+++ b/app/classifier/tasks/text/index.jsx
@@ -7,6 +7,7 @@ import TextTaskEditor from './editor';
 import TextTaskSummary from './summary';
 
 const LINEHEIGHT = 22.5;
+const MAX_ROWS = 10;
 const NOOP = Function.prototype;
 
 export default class TextTask extends React.Component {
@@ -73,7 +74,7 @@ export default class TextTask extends React.Component {
 
   handleChange() {
     const value = this.textInput.current.value;
-    if (value < this.state.value) {
+    if (value.length < this.state.value.length) {
       this.setState({ rows: 1, value }, () => { this.handleResize(); });
     } else {
       this.setState({ value }, () => { this.handleResize(); });
@@ -84,7 +85,7 @@ export default class TextTask extends React.Component {
 
   handleResize() {
     const oldRows = this.textInput.current.rows;
-    const newRows = Math.floor(this.textInput.current.scrollHeight / LINEHEIGHT);
+    const newRows = Math.max(Math.min(Math.floor(this.textInput.current.scrollHeight / LINEHEIGHT), MAX_ROWS), 1);
 
     if (newRows && (newRows !== oldRows)) {
       this.setState({ rows: newRows });
@@ -110,7 +111,7 @@ export default class TextTask extends React.Component {
             onChange={this.handleChange}
             ref={this.textInput}
             rows={this.state.rows}
-            style={{ lineHeight: `${LINEHEIGHT}px` }}
+            style={{ lineHeight: `${LINEHEIGHT}px`, overflow: 'hidden' }}
             value={this.state.value}
           />
         </label>


### PR DESCRIPTION
Staging branch URL: https://fix-text-rows.pfe-preview.zooniverse.org/

Fixes https://www.zooniverse.org/talk/17/692672

Describe your changes.
- add `.length` to comparison of `value` strings before reseting rows to 1
- add Math.min and Math.max so rows never below 1 or above 10 (per `MAX_ROWS` constant)
- add `overflow: hidden` to fix issue on Windows 7, Firefox 61 where scrollHeight included scrollbar, creating row resizing loop and inconsistency with other browsers

Used BrowswerStack to test, see Passbolt for login info.

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [x] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
