### PR TITLE
Prevent field guide related requests if no field guide

### DIFF
--- a/app/pages/project/index.jsx
+++ b/app/pages/project/index.jsx
@@ -289,11 +289,10 @@ class ProjectPageController extends React.Component {
   loadFieldGuide(projectId) {
     return apiClient.type('field_guides').get({ project_id: projectId })
     .then(([guide]) => {
-      const { actions, translations } = this.props;
       this.setState({ guide });
-      const guideId = guide ? guide.id : undefined;
-      actions.translations.load('field_guide', guideId, translations.locale);
-      if (guide) {
+      if (guide && guide.id) {
+        const { actions, translations } = this.props;
+        actions.translations.load('field_guide', guide.id, translations.locale);
         getAllLinked(guide, 'attached_images')
         .then((images) => {
           const guideIcons = {};

--- a/app/pages/project/index.jsx
+++ b/app/pages/project/index.jsx
@@ -293,12 +293,14 @@ class ProjectPageController extends React.Component {
       this.setState({ guide });
       const guideId = guide ? guide.id : undefined;
       actions.translations.load('field_guide', guideId, translations.locale);
-      getAllLinked(guide, 'attached_images')
-      .then((images) => {
-        const guideIcons = {};
-        images.map(image => guideIcons[image.id] = image);
-        this.setState({ guideIcons });
-      });
+      if (guide) {
+        getAllLinked(guide, 'attached_images')
+        .then((images) => {
+          const guideIcons = {};
+          images.map(image => guideIcons[image.id] = image);
+          this.setState({ guideIcons });
+        });
+      }
     });
   }
 


### PR DESCRIPTION
Staging branch URL: https://fix-get-all-linked.pfe-preview.zooniverse.org/
- staged branch, project no Field Guide: https://fix-get-all-linked.pfe-preview.zooniverse.org/projects/markb-panoptes/calbug
- same project no Field Guide: https://master.pfe-preview.zooniverse.org/projects/markb-panoptes/calbug

Fixes annoying console error `Uncaught (in promise) Error: getAllLinked: resource and link not specified` in any project without a Field Guide.

Check if `guide` is defined before requesting all linked `attached_images`.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
