### PR TITLE
Remove text task max rows

### DIFF
--- a/app/classifier/tasks/text/index.jsx
+++ b/app/classifier/tasks/text/index.jsx
@@ -7,7 +7,6 @@ import TextTaskEditor from './editor';
 import TextTaskSummary from './summary';
 
 const LINEHEIGHT = 22.5;
-const MAX_ROWS = 10;
 const NOOP = Function.prototype;
 
 export default class TextTask extends React.Component {
@@ -85,8 +84,7 @@ export default class TextTask extends React.Component {
 
   handleResize() {
     const oldRows = this.textInput.current.rows;
-    let newRows = Math.min(Math.floor(this.textInput.current.scrollHeight / LINEHEIGHT), MAX_ROWS);
-    newRows = Math.max(newRows, 1);
+    const newRows = Math.max(Math.floor(this.textInput.current.scrollHeight / LINEHEIGHT), 1);
 
     if (newRows && (newRows !== oldRows)) {
       this.setState({ rows: newRows });


### PR DESCRIPTION
Staging branch URL: https://fix-text-task-rows-2.pfe-preview.zooniverse.org/
- test project: https://fix-text-task-rows-2.pfe-preview.zooniverse.org/projects/markb-panoptes/focus-testing-project/classify?reload=0&workflow=2955 

Iteration on #4754, which added a max textarea rows restriction of 10 and hid scroll bars, however, a classifier reported an issue with longer (over 10 rows) transcriptions [in Talk here](https://www.zooniverse.org/talk/17/692672?comment=1155851), so this PR removes the max row restriction.

Although it's unclear and unfortunate why `overflow: hidden` fixes the Windows/Firefox issue detailed in #4754, since it does address the large textarea (and related classifier freeze from infinite loop resizing) I think the max restriction can be safely removed.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
