### PR TITLE
Drawing subtasks

### DIFF
--- a/app/classifier/drawing-tools/root.jsx
+++ b/app/classifier/drawing-tools/root.jsx
@@ -87,7 +87,7 @@ export default class DrawingToolRoot extends React.Component {
 
         {openDetails &&
           <DetailsSubTaskForm
-            onDetailsFormClose={this.focusDrawingTool}
+            onFormClose={this.focusDrawingTool}
             tasks={tasks}
             toolProps={toolProps}
             {...this.props}

--- a/app/classifier/tasks/generic.jsx
+++ b/app/classifier/tasks/generic.jsx
@@ -18,7 +18,7 @@ class GenericTask extends React.Component {
 
   componentDidMount() {
     if (this.props.autoFocus && this.container.focus) {
-      this.container.focus();
+      this.handleMount = setTimeout(() => this.container.focus());
     }
   }
 
@@ -27,6 +27,10 @@ class GenericTask extends React.Component {
     if (this.props.autoFocus && this.props.question !== prevProps.question && this.container.focus) {
       this.container.focus();
     }
+  }
+
+  componentWillUnmount() {
+    clearTimeout(this.handleMount);
   }
 
   showHelp() {

--- a/app/classifier/tasks/text/index.jsx
+++ b/app/classifier/tasks/text/index.jsx
@@ -86,10 +86,11 @@ export default class TextTask extends React.Component {
   }
 
   handleResize() {
-    const oldRows = this.textInput.current.rows;
-    const newRows = Math.max(Math.floor(this.textInput.current.scrollHeight / LINEHEIGHT), 1);
+    const oldRows = this.state.rows;
+    let newRows = Math.floor(this.textInput.current.scrollHeight / LINEHEIGHT);
+    newRows = Math.max(newRows, 1);
 
-    if (newRows && (newRows !== oldRows)) {
+    if (newRows !== oldRows) {
       this.setState({ rows: newRows });
     }
   }

--- a/app/classifier/tasks/text/index.jsx
+++ b/app/classifier/tasks/text/index.jsx
@@ -26,10 +26,12 @@ export default class TextTask extends React.Component {
   }
 
   componentDidMount() {
-    if (this.props.autoFocus) {
-      this.textInput.current.focus();
-    }
-    this.handleResize();
+    this.handleMount = setTimeout(() => {
+      if (this.props.autoFocus) {
+        this.textInput.current.focus();
+      }
+      this.handleResize();
+    });
   }
 
   componentDidUpdate() {
@@ -38,6 +40,7 @@ export default class TextTask extends React.Component {
 
   componentWillUnmount() {
     this.debouncedUpdateAnnotation.flush();
+    clearTimeout(this.handleMount);
   }
 
   setTagSelection(e) {

--- a/app/classifier/tasks/text/index.spec.js
+++ b/app/classifier/tasks/text/index.spec.js
@@ -77,6 +77,7 @@ describe('TextTask', function () {
     it('should wrap text with tags when text highlighted and tag clicked', function () {
       wrapper.instance().textInput.current = {
         value: 'testing the text task tag selection',
+        scrollHeight: 50,
         selectionStart: 12,
         selectionEnd: 21
       };


### PR DESCRIPTION
Staging branch URL: https://drawing-subtasks.pfe-preview.zooniverse.org

Fixes #4095 
Fixes #4666

Fixes a typo in a prop name for drawing subtasks.
The `ModalForm` components mount their children before adding them to the DOM, firing `componentDidMount` in the children before the DOM is ready. This PR adds a timer to `componentDidMount` for text tasks and the generic task to give a delay before trying to access their DOM nodes in order to handle focus etc.

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [x] Can you post a talk comment?

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
