### PR TITLE
Update modal form to 2.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8691,9 +8691,9 @@
       }
     },
     "modal-form": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/modal-form/-/modal-form-2.6.0.tgz",
-      "integrity": "sha1-4/y5xWZML5BJvxZCl2823RgLmKc=",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/modal-form/-/modal-form-2.6.1.tgz",
+      "integrity": "sha512-8oUicQ9BF7jz/dbX+3kXfu3EAMLTD05x4k+WLhsDNyHogQ5sHKgCGQu9686+cQp7b8y2tgVPqDPq2bBgq1cVhA==",
       "requires": {
         "create-react-class": "^15.6.2",
         "prop-types": "^15.6.0"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lodash": "~4.17.10",
     "markdownz": "~7.6.2",
     "mocha": "~5.2.0",
-    "modal-form": "~2.6.0",
+    "modal-form": "~2.6.1",
     "moment": "~2.21.0",
     "panoptes-client": "~2.10.0",
     "papaparse": "github:mholt/PapaParse#cada171",


### PR DESCRIPTION
Updates modal-form to fix issues where the autofocus attribute was ignored in modal form content.

Staging branch URL: https://modal-autofocus.pfe-preview.zooniverse.org

Depends on zooniverse/modal-form#39

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
