### PR TITLE
Update markdownz to 7.6.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8058,11 +8058,6 @@
       "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
       "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
     },
-    "lodash.assign": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
-    },
     "lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
@@ -8287,9 +8282,9 @@
       }
     },
     "markdown-it": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-8.4.1.tgz",
-      "integrity": "sha512-CzzqSSNkFRUf9vlWvhK1awpJreMRqdCrBvZ8DIoDWTOkESMIF741UPAhuAmbyWmdiFPA6WARNhnu2M6Nrhwa+A==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-8.4.2.tgz",
+      "integrity": "sha512-GcRz3AWTqSUphY3vsUqQSFMbgR38a4Lh3GWlHRh/7MRwz8mcu9n2IO7HOh+bXHrR9kOPDl5RNCaEsrneb+xhHQ==",
       "requires": {
         "argparse": "^1.0.7",
         "entities": "~1.1.1",
@@ -8343,13 +8338,9 @@
       "integrity": "sha1-y5yf+RpSVawI8/09YyhuFd8KH8M="
     },
     "markdown-it-table-of-contents": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/markdown-it-table-of-contents/-/markdown-it-table-of-contents-0.3.6.tgz",
-      "integrity": "sha512-zeG6PxwQ4iPx3ujpZck3lVwzqvm1+b45RQW4gawHXR6T9kTUF3zT16IoBvMAdpiReZpg5tbNkhMxU841ocbfgg==",
-      "requires": {
-        "lodash.assign": "~4.2.0",
-        "string": "~3.3.3"
-      }
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-table-of-contents/-/markdown-it-table-of-contents-0.4.0.tgz",
+      "integrity": "sha512-LNLrEO0WfpQ3Kbmqh9FqcnEzEbGl11lH48lpRtWn2vkSkDjDLCSVvklIuib2oj580O7jdRq0ISQr2636LaEfPw=="
     },
     "markdown-it-video": {
       "version": "0.4.0",
@@ -8357,9 +8348,9 @@
       "integrity": "sha1-H1GjRxRWolCaOCDc7ZrRzpYb22Q="
     },
     "markdownz": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/markdownz/-/markdownz-7.6.2.tgz",
-      "integrity": "sha512-//iypNMGKI1t+EUOV+1XGH8w667K/P3osBPxqEQmSMSnWY5W+vzdG7DJjY/5dfHuwsCkb8N3g3MYU+H94cBmrQ==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/markdownz/-/markdownz-7.6.3.tgz",
+      "integrity": "sha512-rra0c8SV/RppWMZj9qbVUKUpz3XoG4VTEkV04uOyMs5NHqyuBEJ2cpkdLZ7COfp0tgeu8HEdetBO4GhagG05dQ==",
       "requires": {
         "markdown-it": "~8.4.1",
         "markdown-it-anchor": "~5.0.2",
@@ -8370,7 +8361,7 @@
         "markdown-it-imsize": "~2.0.1",
         "markdown-it-sub": "~1.0.0",
         "markdown-it-sup": "~1.0.0",
-        "markdown-it-table-of-contents": "~0.3.6",
+        "markdown-it-table-of-contents": "~0.4.0",
         "markdown-it-video": "~0.4.0",
         "twemoji": "~1.4.1"
       }
@@ -8530,9 +8521,9 @@
       "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
     },
     "mime-db": {
-      "version": "1.34.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.34.0.tgz",
-      "integrity": "sha1-RS0Oz/XDA0am3B5kseruDTcZ/5o="
+      "version": "1.35.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.35.0.tgz",
+      "integrity": "sha512-JWT/IcCTsB0Io3AhWUMjRqucrHSPsSf2xKLaRldJVULioggvkJvggZ3VXNNSRkCddE6D+BUI4HEIZIA2OjwIvg=="
     },
     "mime-types": {
       "version": "2.1.18",
@@ -12186,11 +12177,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
-    },
-    "string": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/string/-/string-3.3.3.tgz",
-      "integrity": "sha1-XqIRzZLSKOGEKUmQpsyXs2anfLA="
     },
     "string-width": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "history": "~3.0.0",
     "json-api-client": "~4.0.0",
     "lodash": "~4.17.10",
-    "markdownz": "~7.6.2",
+    "markdownz": "~7.6.3",
     "mocha": "~5.2.0",
     "modal-form": "~2.6.0",
     "moment": "~2.21.0",

--- a/webpack.build.js
+++ b/webpack.build.js
@@ -52,7 +52,8 @@ module.exports = {
   module: {
     rules: [{
       test: /\.jsx?$/,
-      exclude: /node_modules\/(?!(markdown-it-anchor)\/).*/, // markdown-it-anchor is written in ES6 and isn't properly compiled
+      exclude: /node_modules\/(?!(markdown-it-anchor|markdown-it-table-of-contents)\/).*/,
+      // markdown-it-anchor and markdown-it-table-of-contents are written in ES6 and aren't properly compiled
       use: 'babel-loader',
     }, {
       test: /\.cjsx$/,


### PR DESCRIPTION
Updates markdownz to  fix a security warning.
markdown-it-table-of-contents is now written in ES6, so update webpack to pass it through babel.

Staging branch URL: https://markdownz.pfe-preview.zooniverse.org

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [x] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
