### PR TITLE
Fix inbox conversation participants

### DIFF
--- a/app/talk/inbox.cjsx
+++ b/app/talk/inbox.cjsx
@@ -36,7 +36,7 @@ ConversationLink = createReactClass
   componentWillMount: ->
     apiClient
       .type 'users'
-      .get @props.conversation.links.users.filter (userId) => userId isnt @props.user.id
+      .get @props.conversation.participant_ids.filter (userId) => userId isnt +@props.user.id
       .then (users) =>
         @setState {users}
 

--- a/app/talk/inbox.cjsx
+++ b/app/talk/inbox.cjsx
@@ -36,7 +36,7 @@ ConversationLink = createReactClass
   componentWillMount: ->
     apiClient
       .type 'users'
-      .get @props.conversation.participant_ids.filter (userId) => userId isnt +@props.user.id
+      .get @props.conversation.participant_ids.filter (userId) => userId isnt parseInt(@props.user.id)
       .then (users) =>
         @setState {users}
 


### PR DESCRIPTION
Check user ID against conversation.participant_ids when rendering the link to the sender.

Staging branch URL: https://inbox-conversation.pfe-preview.zooniverse.org

Fixes #4762.
Fixes #3934.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
