### PR TITLE
Rewrite URLs in subject metadata as links

### DIFF
--- a/app/components/subject-viewer.cjsx
+++ b/app/components/subject-viewer.cjsx
@@ -295,6 +295,8 @@ module.exports = createReactClass
       <table className="standard-table">
         <tbody>
           {for key, value of @props.subject?.metadata when key.charAt(0) not in @props.metadataFilters and key[...2] isnt '//'
+            if (value.startsWith('http'))
+              value = "[#{value}](+tab+#{value})"
             <tr key={key}>
               <th>{key.replace(///^(#{@props.metadataPrefixes.join('|')})///, '')}</th>
               <Markdown tag="td" content={value} inline />


### PR DESCRIPTION
Rewrite any value in subject metadata that begins with 'http' as a markdown link that opens in a new tab.

Staging branch URL: https://subject-metadata-links.pfe-preview.zooniverse.org

Fixes #3555.
Fixes #2962.

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [x] Can you post a talk comment?

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
