### PR TITLE
Allow concave freehand drawing shapes

### DIFF
--- a/app/classifier/drawing-tools/freehand-segment-line.cjsx
+++ b/app/classifier/drawing-tools/freehand-segment-line.cjsx
@@ -97,8 +97,12 @@ module.exports = createReactClass
     { _inProgress, _currentlyDrawing, points } = @props.mark
     path = createPathFromCoords points
     lineClass = if _inProgress then 'drawing' else 'clickable clickable-line'
+    pointerEvents = if @props.disabled then 'none' else 'painted'
 
-    <DrawingToolRoot tool={this}>
+    <DrawingToolRoot
+      tool={this}
+      pointerEvents={pointerEvents}
+    >
       <path d={path}
         fill="none"
         strokeWidth={GRAB_STROKE_WIDTH / ((@props.scale.horizontal + @props.scale.vertical) / 2)}

--- a/app/classifier/drawing-tools/freehand-segment-shape.cjsx
+++ b/app/classifier/drawing-tools/freehand-segment-shape.cjsx
@@ -97,8 +97,12 @@ module.exports = createReactClass
     path = createPathFromCoords points
     fill = if _inProgress then 'none' else @props.color
     lineClass = if _inProgress then 'drawing' else 'clickable'
+    pointerEvents = if @props.disabled then 'none' else 'painted'
 
-    <DrawingToolRoot tool={this}>
+    <DrawingToolRoot
+      tool={this}
+      pointerEvents={pointerEvents}
+    >
       <path d={path}
         fill={fill}
         fillOpacity="0.2"


### PR DESCRIPTION
Allow drawing inside freehand segment lines and freehand segment shapes by ignoring pointer events completely when the tool is disabled, and ignoring pointer events on transparent areas when drawing.

Staging branch URL: https://concave-freehand-shapes.pfe-preview.zooniverse.org

Fixes #4770 .

Describe your changes.

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [x] Can you post a talk comment?

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
