### PR TITLE
Fix subject metadata popup when metadata contains numbers

### DIFF
--- a/app/components/subject-viewer.cjsx
+++ b/app/components/subject-viewer.cjsx
@@ -295,7 +295,7 @@ module.exports = createReactClass
       <table className="standard-table">
         <tbody>
           {for key, value of @props.subject?.metadata when key.charAt(0) not in @props.metadataFilters and key[...2] isnt '//'
-            if (value.startsWith('http'))
+            if (value.startsWith and value.startsWith('http'))
               value = "[#{value}](+tab+#{value})"
             <tr key={key}>
               <th>{key.replace(///^(#{@props.metadataPrefixes.join('|')})///, '')}</th>


### PR DESCRIPTION
Check that value.startsWith exists before calling it.

Followup to #4769, which breaks the subject metadata popup if any of the metadata values are numbers.
Reported in Talk here: https://www.zooniverse.org/talk/17/698605?comment=1165455

Staging branch URL: https://subject-metadata-links.pfe-preview.zooniverse.org/

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
