### PR TITLE
Bypass API client cache in the field guide editor

### DIFF
--- a/app/pages/lab/field-guide/actions.js
+++ b/app/pages/lab/field-guide/actions.js
@@ -15,13 +15,13 @@ var actions = {
   },
 
   deleteGuide: function(guideID) {
-    return guides.get(guideID).then(function(guide) {
+    return guides.get(guideID, {}).then(function(guide) {
       return guide.delete();
     });
   },
 
   replaceItems: function(guideID, items) {
-    return guides.get(guideID).then(function(guide) {
+    return guides.get(guideID, {}).then(function(guide) {
       guide.update({
         _busy: true,
         items: items
@@ -35,7 +35,7 @@ var actions = {
   },
 
   updateItem: function(guideID, itemIndex, changes) {
-    return guides.get(guideID).then(function(guide) {
+    return guides.get(guideID, {}).then(function(guide) {
       Object.assign(guide.items[itemIndex], changes);
       guide.update({
         _busy: true,
@@ -51,7 +51,7 @@ var actions = {
   },
 
   removeItemIcon: function(guideID, itemIndex) {
-    return guides.get(guideID).then(function(guide) {
+    return guides.get(guideID, {}).then(function(guide) {
       guide.update({
         _busy: true
       });
@@ -78,7 +78,7 @@ var actions = {
   },
 
   setItemIcon: function(guideID, itemIndex, iconFile) {
-    return guides.get(guideID).then(function(guide) {
+    return guides.get(guideID, {}).then(function(guide) {
       guide.update({
         _busy: true
       });
@@ -123,7 +123,7 @@ var actions = {
 
   appendItem: function(guideID) {
     var newItem = {};
-    return guides.get(guideID).then(function(guide) {
+    return guides.get(guideID, {}).then(function(guide) {
       guide.items.push(newItem);
       guide.update({
         _busy: true,
@@ -139,7 +139,7 @@ var actions = {
   },
 
   removeItem: function(guideID, itemIndex) {
-    return guides.get(guideID).then(function(guide) {
+    return guides.get(guideID, {}).then(function(guide) {
       guide.items.splice(itemIndex, 1);
       guide.update({
         _busy: true,


### PR DESCRIPTION
Add a query argument to all resource.get() calls in the field guide editor actions. This forces the API client to bypass its internal cache and request the latest version of the field guide from Panoptes.

Staging branch URL: https://field-guide-editor.pfe-preview.zooniverse.org/

Fixes #4772

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [x] Can you post a talk comment?

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
