### PR TITLE
Add missing task translations

### DIFF
--- a/app/classifier/drawing-tools/components/DetailsSubTaskForm/DetailsSubTaskForm.jsx
+++ b/app/classifier/drawing-tools/components/DetailsSubTaskForm/DetailsSubTaskForm.jsx
@@ -115,7 +115,7 @@ export class DetailsSubTaskForm extends React.Component {
   }
   
   render() {
-    const { theme, tasks, toolProps } = this.props;
+    const { theme, tasks, toolProps, translations } = this.props;
 
     const detailsAreComplete = this.areDetailsComplete(tasks, toolProps);
 
@@ -131,22 +131,19 @@ export class DetailsSubTaskForm extends React.Component {
               {toolProps.details.map((detailTask, i) => {
                 if (!detailTask._key) detailTask._key = Math.random();
                 const TaskComponent = tasks[detailTask.type];
-                const taskKey = `${toolProps.taskKey}.tools.${toolProps.mark.tool}.details.${i}`;
+                const detailTranslation = translations.strings.workflow.tasks ?
+                  translations.strings.workflow.tasks[toolProps.taskKey].tools[toolProps.mark.tool].details[i] :
+                  detailTask;
                 
                 return (
-                  <TaskTranslations
-                    key={detailTask._key}
-                    taskKey={taskKey}
+                  <TaskComponent
+                    autoFocus={i === 0}
                     task={detailTask}
-                  >
-                    <TaskComponent
-                      autoFocus={i === 0}
-                      task={detailTask}
-                      annotation={toolProps.mark.details[i]}
-                      onChange={this.handleDetailsChange.bind(this, i)}
-                      showRequiredNotice={true}
-                    />
-                  </TaskTranslations>
+                    translation={detailTranslation}
+                    annotation={toolProps.mark.details[i]}
+                    onChange={this.handleDetailsChange.bind(this, i)}
+                    showRequiredNotice={true}
+                  />
                 )
               })}
               <hr />
@@ -168,7 +165,8 @@ export class DetailsSubTaskForm extends React.Component {
 }
 
 const mapStateToProps = state => ({
-  theme: state.userInterface.theme
+  theme: state.userInterface.theme,
+  translations: state.translations
 });
 
 export default connect(mapStateToProps)(DetailsSubTaskForm);

--- a/app/classifier/drawing-tools/components/DetailsSubTaskForm/DetailsSubTaskForm.spec.js
+++ b/app/classifier/drawing-tools/components/DetailsSubTaskForm/DetailsSubTaskForm.spec.js
@@ -60,11 +60,17 @@ const toolProps = {
   taskKey: "T0"
 };
 
+const translations = {
+  languages: {},
+  locale: 'en',
+  strings: { workflow: {}}
+}
+
 describe('DetailsSubTaskForm', function() {
   describe('render', function() {
     let wrapper;
     before(function () {
-      wrapper = shallow(<DetailsSubTaskForm tasks={tasks} toolProps={toolProps} />, mockReduxStore);
+      wrapper = shallow(<DetailsSubTaskForm tasks={tasks} translations={translations} toolProps={toolProps} />, mockReduxStore);
     });
 
     it('should render without crashing', function () {

--- a/app/classifier/tasks/crop/index.cjsx
+++ b/app/classifier/tasks/crop/index.cjsx
@@ -57,7 +57,12 @@ module.exports = createReactClass
 
   render: ->
     # The actual value is updated in the Initializer.
-    <GenericTask question={@props.task.instruction} help={@props.task.help} required={@props.task.required} showRequiredNotice={@props.showRequiredNotice}>
+    <GenericTask
+      question={@props.translation.instruction}
+      help={@props.translation.help}
+      required={@props.task.required}
+      showRequiredNotice={@props.showRequiredNotice}
+    >
       <p>
         <button type="button" className="minor-button" disabled={not @props.annotation.value?} onClick={@handleClear}>Clear current crop</button>
       </p>

--- a/app/classifier/tasks/drawing/index.cjsx
+++ b/app/classifier/tasks/drawing/index.cjsx
@@ -113,7 +113,12 @@ module.exports = createReactClass
           <GridButtons {...@props} />}
       </div>
 
-    <GenericTask question={@props.task.instruction} help={@props.task.help} answers={tools} required={@props.task.required} />
+    <GenericTask
+      question={@props.translation.instruction}
+      help={@props.translation.help}
+      answers={tools}
+      required={@props.task.required}
+    />
 
   handleChange: (toolIndex, e) ->
     # This handles changing tools, not any actually drawing.

--- a/app/classifier/tasks/drawing/index.cjsx
+++ b/app/classifier/tasks/drawing/index.cjsx
@@ -96,13 +96,14 @@ module.exports = createReactClass
     tools = for tool, i in @props.task.tools
       tool._key ?= Math.random()
       count = (true for mark in @props.annotation.value when mark.tool is i).length
+      translation = @props.translation.tools[i]
       <div>
         <TaskInputField
           annotation={@props.annotation}
           className={if i is (@props.annotation._toolIndex ? 0) then 'active' else ''}
           index={i}
           key={tool._key}
-          label={tool.label}
+          label={translation.label}
           labelIcon={<DrawingToolInputIcon tool={tool} />}
           labelStatus={<DrawingToolInputStatus count={count} tool={tool} />}
           name="drawing-tool"

--- a/app/classifier/tasks/dropdown/index.jsx
+++ b/app/classifier/tasks/dropdown/index.jsx
@@ -202,8 +202,8 @@ export default class DropdownTask extends React.Component {
 
     return (
       <GenericTask
-        question={this.props.task.instruction}
-        help={this.props.task.help}
+        question={this.props.translation.instruction}
+        help={this.props.translation.help}
         required={this.props.task.required}
         showRequiredNotice={this.props.showRequiredNotice}
       >

--- a/app/classifier/tasks/dropdown/index.jsx
+++ b/app/classifier/tasks/dropdown/index.jsx
@@ -225,7 +225,7 @@ export default class DropdownTask extends React.Component {
 
             return (
               <div id={select.id} key={select.id}>
-                {(select.title !== this.props.task.instruction) &&
+                {(select.title !== this.props.translation.instruction) &&
                   <div>{select.title}</div>}
                 <SelectComponent
                   options={options}
@@ -291,10 +291,12 @@ DropdownTask.propTypes = {
   autoFocus: PropTypes.bool,
   onChange: PropTypes.func,
   task: PropTypes.shape({
-    help: PropTypes.string,
-    instruction: PropTypes.string,
     required: PropTypes.bool,
     selects: PropTypes.array
+  }),
+  translation: PropTypes.shape({
+    help: PropTypes.string,
+    instruction: PropTypes.string
   })
 };
 

--- a/app/classifier/tasks/dropdown/index.spec.js
+++ b/app/classifier/tasks/dropdown/index.spec.js
@@ -91,7 +91,7 @@ describe('DropdownTask', function () {
         annotation = { value: [] };
         onChangeSpy = sinon.spy();
 
-        wrapper = mount(<DropdownTask task={multiSelects} annotation={annotation} onChange={onChangeSpy} />, mockReduxStore);
+        wrapper = mount(<DropdownTask task={multiSelects} translation={multiSelects} annotation={annotation} onChange={onChangeSpy} />, mockReduxStore);
       });
 
       it('should render without crashing', function () {
@@ -181,7 +181,7 @@ describe('DropdownTask', function () {
           { value: null, option: false }
         ] };
 
-        wrapper = mount(<DropdownTask task={multiSelects} annotation={annotation} onChange={function (a) { return a; }} />, mockReduxStore);
+        wrapper = mount(<DropdownTask task={multiSelects} translation={multiSelects} annotation={annotation} onChange={function (a) { return a; }} />, mockReduxStore);
       });
 
       it('should make selects conditional on first annotation and allowCreate false now enabled (State now enabled, City still disabled)', function () {
@@ -220,7 +220,7 @@ describe('DropdownTask', function () {
           { value: 'Isotopes-value', option: true }
         ] };
 
-        wrapper = mount(<DropdownTask task={multiSelects} annotation={annotation} onChange={function (a) { return a; }} />, mockReduxStore);
+        wrapper = mount(<DropdownTask task={multiSelects} translation={multiSelects} annotation={annotation} onChange={function (a) { return a; }} />, mockReduxStore);
       });
 
       it('should have the supplied annotations selected', function () {
@@ -256,7 +256,7 @@ describe('DropdownTask', function () {
           { value: 'Rocket', option: false }
         ] };
 
-        wrapper = mount(<DropdownTask task={multiSelects} annotation={annotation} onChange={function (a) { return a; }} />, mockReduxStore);
+        wrapper = mount(<DropdownTask task={multiSelects} translation={multiSelects} annotation={annotation} onChange={function (a) { return a; }} />, mockReduxStore);
       });
 
       it('should have the supplied annotations selected', function () {
@@ -283,7 +283,7 @@ describe('DropdownTask', function () {
       const annotation2 = { value: [] };
       const onChangeSpy = sinon.spy();
 
-      const wrapper = mount(<DropdownTask task={multiSelects} annotation={annotation1} onChange={onChangeSpy} />, mockReduxStore);
+      const wrapper = mount(<DropdownTask task={multiSelects} translation={multiSelects} annotation={annotation1} onChange={onChangeSpy} />, mockReduxStore);
       wrapper.setProps({ task: singleSelect, annotation: annotation2 });
 
       // first call on mount should set first task's default values, second call on update should be to set second task's default values

--- a/app/classifier/tasks/highlighter/index.jsx
+++ b/app/classifier/tasks/highlighter/index.jsx
@@ -95,8 +95,8 @@ export default class Highlighter extends React.Component {
       return (
         <div>
           <GenericTask
-            question={this.props.task.instruction}
-            help={this.props.task.help}
+            question={this.props.translation.instruction}
+            help={this.props.translation.help}
             answers={labels}
             required={this.props.task.required}
             showRequiredNotice={this.props.showRequiredNotice}

--- a/app/classifier/tasks/slider/index.jsx
+++ b/app/classifier/tasks/slider/index.jsx
@@ -134,18 +134,21 @@ SliderTask.propTypes = {
   task: PropTypes.shape({
     answers: PropTypes.array,
     defaultValue: PropTypes.string,
-    help: PropTypes.string,
-    instruction: PropTypes.string,
     max: PropTypes.string,
     min: PropTypes.string,
     step: PropTypes.string
+  }),
+  translation: PropTypes.shape({
+    help: PropTypes.string,
+    instruction: PropTypes.string
   })
 };
 
 SliderTask.defaultProps = {
   annotation: { value: null },
   onChange: NOOP,
-  task: SLIDERTASKDEFAULT
+  task: SLIDERTASKDEFAULT,
+  translation: SLIDERTASKDEFAULT
 };
 
 export default SliderTask;

--- a/app/classifier/tasks/slider/index.jsx
+++ b/app/classifier/tasks/slider/index.jsx
@@ -51,7 +51,7 @@ SliderSummary.propTypes = {
   ).isRequired
 };
 
-const SliderTask = ({ task, annotation, onChange, autoFocus }) => {
+const SliderTask = ({ task, translation, annotation, onChange, autoFocus }) => {
   function handleChange(e) {
     let value = e.target.value;
     value = Math.min(parseFloat(value, 10), parseFloat(task.max, 10));
@@ -63,8 +63,8 @@ const SliderTask = ({ task, annotation, onChange, autoFocus }) => {
   return (
     <div>
       <GenericTask
-        question={task.instruction}
-        help={task.help}
+        question={translation.instruction}
+        help={translation.help}
         required={false}
       >
         <div className="slider-task-container full ">

--- a/app/classifier/tasks/slider/slider.spec.js
+++ b/app/classifier/tasks/slider/slider.spec.js
@@ -23,7 +23,7 @@ describe('SliderTask', function () {
   beforeEach(function () {
     onChangeSpy = sinon.spy();
 
-    wrapper = mount(<SliderTask task={task} onChange={onChangeSpy} />, mockReduxStore);
+    wrapper = mount(<SliderTask task={task} translation={task} onChange={onChangeSpy} />, mockReduxStore);
   });
 
   it('should render without crashing', function () {
@@ -159,7 +159,7 @@ describe('SliderSummary', function () {
   let summary;
 
   beforeEach(function () {
-    summary = mount(<SliderTask.Summary task={task} annotation={{ value: '0.7' }} />, mockReduxStore);
+    summary = mount(<SliderTask.Summary task={task} translation={task} annotation={{ value: '0.7' }} />, mockReduxStore);
   });
 
   it('should render without crashing', function () {
@@ -176,7 +176,7 @@ describe('SliderSummary', function () {
   });
 
   it('should have the correct answer label when the value is falsy (i.e. 0)', function () {
-    summary = mount(<SliderTask.Summary task={task} annotation={{ value: '0' }} />, mockReduxStore);
+    summary = mount(<SliderTask.Summary task={task} translation={task} annotation={{ value: '0' }} />, mockReduxStore);
     const answers = summary.find('.answer');
     assert.notEqual(answers.text(), 'No answer');
   });

--- a/app/classifier/tasks/text/index.jsx
+++ b/app/classifier/tasks/text/index.jsx
@@ -103,8 +103,8 @@ export default class TextTask extends React.Component {
   render() {
     return (
       <GenericTask
-        question={this.props.task.instruction}
-        help={this.props.task.help}
+        question={this.props.translation.instruction}
+        help={this.props.translation.help}
         required={this.props.task.required}
       >
         <label className="answer" htmlFor="textInput">

--- a/app/classifier/tasks/translations.jsx
+++ b/app/classifier/tasks/translations.jsx
@@ -4,8 +4,8 @@ import merge from 'lodash/merge';
 import { connect } from 'react-redux';
 
 function TaskTranslations(props) {
-  const { task, translations } = props;
-  const taskStrings = translations.strings.workflow.tasks ? translations.strings.workflow.tasks[props.taskKey] : {};
+  const { task, taskKey, translations } = props;
+  const taskStrings = translations.strings.workflow.tasks ? translations.strings.workflow.tasks[taskKey] : {};
   const translation = merge({}, task, taskStrings);
 
   return React.cloneElement(props.children, { translation });


### PR DESCRIPTION
Updates all workflow tasks so that we use `props.translation` for task instructions and task help.
Updates drawing tasks to get labels from translations too.

Staging branch URL: https://task-translations.pfe-preview.zooniverse.org

TODO: 

- [x] figure out how to pass translations to drawing task details forms.
- [ ] add translations for dropdown task options?
- [x] fix the tests.

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [x] Can you post a talk comment?

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
