### PR TITLE
Add Text to WWT Button

### DIFF
--- a/app/classifier/classification-summary.jsx
+++ b/app/classifier/classification-summary.jsx
@@ -67,6 +67,7 @@ class ClassificationSummary extends React.Component {
         <strong>
           <WorldWideTelescope
             annotations={this.props.classification.annotations}
+            project={this.props.project}
             subject={this.props.subject}
             workflow={this.props.workflow}
           />

--- a/app/classifier/world-wide-telescope.jsx
+++ b/app/classifier/world-wide-telescope.jsx
@@ -490,7 +490,7 @@ export default class WorldWideTelescope extends React.Component {
               </div>
               <div className="worldwide-telescope__content">
                 <a target="_blank" rel="noopener noreferrer" href={plate.getWwtUrl()} className="standard-button">World Wide Telescope</a>
-                <p>If the image appears misaligned within World Wide Telescope, please click on Talk and label the subject with <a target="_blank" rel="noopener noreferrer" href="https://zooniverse.org/talk/search/?query=misaligned">#misaligned</a>.</p>
+                <p>If the image appears misaligned within World Wide Telescope, please click on Talk and label the subject with <a target="_blank" rel="noopener noreferrer" href={`https://zooniverse.org/projects/${this.props.project.slug}/talk/tags/misaligned`}>#misaligned</a>.</p>
               </div>
             </div>
           );
@@ -502,6 +502,9 @@ export default class WorldWideTelescope extends React.Component {
 
 WorldWideTelescope.propTypes = {
   annotations: PropTypes.arrayOf(PropTypes.object),
+  project: PropTypes.shape({
+    slug: PropTypes.string
+  }),
   subject: PropTypes.shape({
     locations: PropTypes.array,
     metadata: PropTypes.object

--- a/app/classifier/world-wide-telescope.jsx
+++ b/app/classifier/world-wide-telescope.jsx
@@ -480,15 +480,18 @@ export default class WorldWideTelescope extends React.Component {
     }
 
     return (
-      <div>
+      <div className="worldwide-telescope">
         {!!plates.length && (<p>View Your Classification!</p>)}
         {plates.map((plate, idx) => {
           return (
-            <div className="worldwide-telescope" key={idx}>
+            <div className="worldwide-telescope__container" key={idx}>
               <div>
                 <img role="presentation" className="worldwide-telescope__chart-image" src={`${plate.getCropUrl()}`} />
               </div>
-              <a target="_blank" rel="noopener noreferrer" href={plate.getWwtUrl()} className="standard-button">World Wide Telescope</a>
+              <div className="worldwide-telescope__content">
+                <a target="_blank" rel="noopener noreferrer" href={plate.getWwtUrl()} className="standard-button">World Wide Telescope</a>
+                <p>If the image appears misaligned within World Wide Telescope’, please click on Talk and label the subject with <a target="_blank" rel="noopener noreferrer" href="https://zooniverse.org/talk/search/?query=misaligned">#misaligned</a>.</p>
+              </div>
             </div>
           );
         })}

--- a/app/classifier/world-wide-telescope.jsx
+++ b/app/classifier/world-wide-telescope.jsx
@@ -490,7 +490,7 @@ export default class WorldWideTelescope extends React.Component {
               </div>
               <div className="worldwide-telescope__content">
                 <a target="_blank" rel="noopener noreferrer" href={plate.getWwtUrl()} className="standard-button">World Wide Telescope</a>
-                <p>If the image appears misaligned within World Wide Telescope’, please click on Talk and label the subject with <a target="_blank" rel="noopener noreferrer" href="https://zooniverse.org/talk/search/?query=misaligned">#misaligned</a>.</p>
+                <p>If the image appears misaligned within World Wide Telescope, please click on Talk and label the subject with <a target="_blank" rel="noopener noreferrer" href="https://zooniverse.org/talk/search/?query=misaligned">#misaligned</a>.</p>
               </div>
             </div>
           );

--- a/app/classifier/world-wide-telescope.spec.js
+++ b/app/classifier/world-wide-telescope.spec.js
@@ -8,6 +8,10 @@ const testSubject = {
   metadata: {}
 };
 
+const testProject = {
+  slug: "zooniverse/test-project"
+};
+
 const incompleteAnnotations = [
   { task: 'T0',
     type: 'drawing',
@@ -129,7 +133,7 @@ describe('WorldWideTelescope render without incomplete annotations', function ()
   });
 
   it('will render an empty div with incomplete annotations', function() {
-    const page = shallow(<WorldWideTelescope subject={testSubject} workflow={testWorkflow} annotations={incompleteAnnotations} />);
+    const page = shallow(<WorldWideTelescope subject={testSubject} workflow={testWorkflow} project={testProject} annotations={incompleteAnnotations} />);
     assert.equal(page.find('div').children().length, 0)
   });
 });
@@ -138,7 +142,7 @@ describe('WorldWideTelescope with classification', function() {
   let wrapper;
 
   before(function () {
-    wrapper = shallow(<WorldWideTelescope subject={testSubject} annotations={testAnnotations} workflow={testWorkflow} />);
+    wrapper = shallow(<WorldWideTelescope subject={testSubject} annotations={testAnnotations} workflow={testWorkflow} project={testProject} />);
   });
 
   it('will render a WWT link for each full classification', function() {

--- a/app/classifier/world-wide-telescope.spec.js
+++ b/app/classifier/world-wide-telescope.spec.js
@@ -142,12 +142,19 @@ describe('WorldWideTelescope with classification', function() {
   });
 
   it('will render a WWT link for each full classification', function() {
-    const link = wrapper.find('a');
-    assert.equal(link.length, 2);
+    const linkInstances = wrapper.find('.standard-button');
+    assert.equal(linkInstances.length, 2);
   });
 
   it('will render a cropped image for each fully classified chart', function() {
     const image = wrapper.find('img');
     assert.equal(image.length, 2);
+  });
+
+  it('will render text about misaligned images', function() {
+    const content = wrapper.find('.worldwide-telescope__content');
+    content.forEach((node) => {
+      assert.equal(node.childAt(1).type(), 'p');
+    })
   });
 });

--- a/css/world-wide-telescope.styl
+++ b/css/world-wide-telescope.styl
@@ -1,10 +1,21 @@
 .worldwide-telescope
-  align-items: center
-  display: flex
+  margin: 0 1em
 
-  > div
-    text-align: center
-    width: 5em
+  &__container
+    display: flex
+
+    div:first-child
+      text-align: center
+      width: 5em
+
+  &__content
+    display: flex
+    flex-direction: column
+    margin: 0 1em
+
+    p
+      font-size: 0.75em
+      font-weight: 300
 
   &__chart-image
     border-radius: .25em


### PR DESCRIPTION
Staging branch URL: https://wwt-button-text.pfe-preview.zooniverse.org/

Fixes # .

Describe your changes.
This PR adds additional text beneath the WWT button containing instructions for misaligned images.

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [x] Can you post a talk comment?

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?

<img width="375" alt="screen shot 2018-08-03 at 11 10 22 am" src="https://user-images.githubusercontent.com/14099077/43655826-c3f6abc6-9715-11e8-8e03-242cf6189e95.png">
