### PR TITLE
Snapshot WI split setup

### DIFF
--- a/app/components/workflow-assignment-dialog.jsx
+++ b/app/components/workflow-assignment-dialog.jsx
@@ -16,14 +16,14 @@ class WorkflowAssignmentDialog extends React.Component {
   getPromotionMessage = (props) => {
     // The API needs to add the promotion message as a field in project contents...
     const gravitySpy = '1104';
-    const snapshotWiChallenge = '5371';
+    const snapshotWi = ['5371', '2439'];
     let promotionMessage = <Translate content="classifier.workflowAssignmentDialog.promotionMessage" />;
     const gravitySpyMessage = "Congratulations! Because you're doing so well, you can level up and access more types of glitches, have more options for classifying them, and see glitches that our computer algorithms are even less confident in. If you prefer to stay at this level, you can choose to stay.";
-    const snapshotWiMessage = "Congratulations! You’ve unlocked the next level and can now access a new challenge about the habitat you see in the trail camera images. If you prefer, you can choose to stay.";
+    const snapshotWiMessage = "Congratulations! You’ve unlocked the next level and can now access a new challenge about the environment you see in the trail camera images. If you prefer, you can choose to stay.";
 
     if (props.project && props.project.id === gravitySpy) {
       promotionMessage = gravitySpyMessage;
-    } else if (props.project && props.project.id === snapshotWiChallenge) {
+    } else if (props.project && snapshotWi.includes(props.project.id)) {
       promotionMessage = snapshotWiMessage;
     }
 

--- a/app/locales/ar.js
+++ b/app/locales/ar.js
@@ -21,7 +21,7 @@ export default {
     miniCourseButton: 'Restart the project mini-course',
     workflowAssignmentDialog: {
       promotionMessage: "Congratulations! You've unlocked the next workflow. If you prefer to stay on this workflow, you can choose to stay.",
-      acceptButton: 'Try the new workflow',
+      acceptButton: 'Take me to the next level!',
       declineButton: 'No, thanks'
     }
   },

--- a/app/locales/de.js
+++ b/app/locales/de.js
@@ -22,7 +22,7 @@ export default {
     miniCourseButton: 'Restart the project mini-course',
     workflowAssignmentDialog: {
       promotionMessage: "Congratulations! You've unlocked the next workflow. If you prefer to stay on this workflow, you can choose to stay.",
-      acceptButton: 'Try the new workflow',
+      acceptButton: 'Take me to the next level!',
       declineButton: 'No, thanks'
     }
   },

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -22,7 +22,7 @@ export default {
     miniCourseButton: 'Restart the project mini-course',
     workflowAssignmentDialog: {
       promotionMessage: "Congratulations! You've unlocked the next workflow. If you prefer to stay on this workflow, you can choose to stay.",
-      acceptButton: 'Try the new workflow',
+      acceptButton: 'Take me to the next level!',
       declineButton: 'No, thanks'
     }
   },

--- a/app/locales/es.js
+++ b/app/locales/es.js
@@ -22,7 +22,7 @@ export default {
     miniCourseButton: 'Reiniciar el mini-curso del proyecto',
     workflowAssignmentDialog: {
       promotionMessage: "¡Felicitaciones! Has desbloqueado la próxima secuencia de trabajo. Si prefieres seguir en la secuencia actual, puedes escoger permanecer.",
-      acceptButton: 'Intenta la nueva secuencia de trabajo',
+      acceptButton: 'Take me to the next level!',
       declineButton: 'No, gracias'
     }
   },

--- a/app/locales/fr.js
+++ b/app/locales/fr.js
@@ -22,7 +22,7 @@ export default {
     miniCourseButton: 'Restart the project mini-course',
     workflowAssignmentDialog: {
       promotionMessage: "Congratulations! You've unlocked the next workflow. If you prefer to stay on this workflow, you can choose to stay.",
-      acceptButton: 'Try the new workflow',
+      acceptButton: 'Take me to the next level!',
       declineButton: 'No, thanks'
     }
   },

--- a/app/locales/he.js
+++ b/app/locales/he.js
@@ -21,7 +21,7 @@ export default {
     miniCourseButton: 'Restart the project mini-course',
     workflowAssignmentDialog: {
       promotionMessage: "Congratulations! You've unlocked the next workflow. If you prefer to stay on this workflow, you can choose to stay.",
-      acceptButton: 'Try the new workflow',
+      acceptButton: 'Take me to the next level!',
       declineButton: 'No, thanks'
     }
   },

--- a/app/locales/it.js
+++ b/app/locales/it.js
@@ -22,7 +22,7 @@ export default {
     miniCourseButton: 'Restart the project mini-course',
     workflowAssignmentDialog: {
       promotionMessage: "Congratulations! You've unlocked the next workflow. If you prefer to stay on this workflow, you can choose to stay.",
-      acceptButton: 'Try the new workflow',
+      acceptButton: 'Take me to the next level!',
       declineButton: 'No, grazie'
     }
   },

--- a/app/locales/nl.js
+++ b/app/locales/nl.js
@@ -51,7 +51,12 @@ export default {
     recents: 'Je recente waarnemingen',
     talk: 'Overleg',
     taskHelpButton: 'Hulp nodig met deze taak?',
-    miniCourseButton: 'Herhaal de uitleg'
+    miniCourseButton: 'Herhaal de uitleg',
+    workflowAssignmentDialog: {
+      promotionMessage: "Congratulations! You've unlocked the next workflow. If you prefer to stay on this workflow, you can choose to stay.",
+      acceptButton: 'Take me to the next level!',
+      declineButton: 'No, thanks'
+    }
   },
   project: {
     language: 'Taal',

--- a/app/pages/project/home/home-workflow-buttons.jsx
+++ b/app/pages/project/home/home-workflow-buttons.jsx
@@ -1,13 +1,13 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Link } from 'react-router';
 import Translate from 'react-translate-component';
+import { VisibilitySplit } from 'seven-ten';
 import ProjectHomeWorkflowButton from './home-workflow-button';
 import LoadingIndicator from '../../../components/loading-indicator';
 
 export default class ProjectHomeWorkflowButtons extends React.Component {
-  constructor(props) {
-    super(props);
+  constructor() {
+    super();
 
     this.shouldWorkflowBeDisabled = this.shouldWorkflowBeDisabled.bind(this);
   }
@@ -31,34 +31,36 @@ export default class ProjectHomeWorkflowButtons extends React.Component {
     }
 
     return (
-      <div className="project-home-workflow-buttons">
-        {this.props.showWorkflowButtons && this.props.activeWorkflows.length > 0 && this.props.preferences &&
-          (<div className="project-home-page__container project-home-workflow-buttons__workflow-choice-container">
-            <div className="project-home-page__content">
-              <h3 className="workflow-choice-container__call-to-action">
-                <Translate content="project.home.getStarted" />{' '}
-                <i className="fa fa-arrow-down" aria-hidden="true" />
-              </h3>
-              {this.props.project.workflow_description && (
-                <p className="workflow-choice-container__description">{this.props.project.workflow_description}</p>
-              )}
-              {this.props.activeWorkflows.map((workflow) => {
-                return (
-                  <ProjectHomeWorkflowButton
-                    key={workflow.id}
-                    disabled={this.shouldWorkflowBeDisabled(workflow)}
-                    onChangePreferences={this.props.onChangePreferences}
-                    project={this.props.project}
-                    workflow={workflow}
-                    workflowAssignment={this.props.workflowAssignment}
-                  />);
-              })
-            }</div>
-          </div>)}
+      <VisibilitySplit splits={props.splits} splitKey='workflow.assignment' elementKey='div'>
+        <div className="project-home-workflow-buttons">
+          {this.props.showWorkflowButtons && this.props.activeWorkflows.length > 0 && this.props.preferences &&
+            (<div className="project-home-page__container project-home-workflow-buttons__workflow-choice-container">
+              <div className="project-home-page__content">
+                <h3 className="workflow-choice-container__call-to-action">
+                  <Translate content="project.home.getStarted" />{' '}
+                  <i className="fa fa-arrow-down" aria-hidden="true" />
+                </h3>
+                {this.props.project.workflow_description && (
+                  <p className="workflow-choice-container__description">{this.props.project.workflow_description}</p>
+                )}
+                {this.props.activeWorkflows.map((workflow) => {
+                  return (
+                    <ProjectHomeWorkflowButton
+                      key={workflow.id}
+                      disabled={this.shouldWorkflowBeDisabled(workflow)}
+                      onChangePreferences={this.props.onChangePreferences}
+                      project={this.props.project}
+                      workflow={workflow}
+                      workflowAssignment={this.props.workflowAssignment}
+                    />);
+                })
+              }</div>
+            </div>)}
 
-        {this.props.showWorkflowButtons && this.props.activeWorkflows.length === 0 &&
-          <div className="project-home-page__container workflow-choice"><LoadingIndicator /></div>}
-      </div>
+          {this.props.showWorkflowButtons && this.props.activeWorkflows.length === 0 &&
+            <div className="project-home-page__container workflow-choice"><LoadingIndicator /></div>}
+        </div>
+      </VisibilitySplit>
     );
   }
 }

--- a/app/pages/project/home/home-workflow-buttons.jsx
+++ b/app/pages/project/home/home-workflow-buttons.jsx
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import Translate from 'react-translate-component';
-import { VisibilitySplit } from 'seven-ten';
 import ProjectHomeWorkflowButton from './home-workflow-button';
 import LoadingIndicator from '../../../components/loading-indicator';
 
@@ -31,36 +30,34 @@ export default class ProjectHomeWorkflowButtons extends React.Component {
     }
 
     return (
-      <VisibilitySplit splits={props.splits} splitKey='workflow.assignment' elementKey='div'>
-        <div className="project-home-workflow-buttons">
-          {this.props.showWorkflowButtons && this.props.activeWorkflows.length > 0 && this.props.preferences &&
-            (<div className="project-home-page__container project-home-workflow-buttons__workflow-choice-container">
-              <div className="project-home-page__content">
-                <h3 className="workflow-choice-container__call-to-action">
-                  <Translate content="project.home.getStarted" />{' '}
-                  <i className="fa fa-arrow-down" aria-hidden="true" />
-                </h3>
-                {this.props.project.workflow_description && (
-                  <p className="workflow-choice-container__description">{this.props.project.workflow_description}</p>
-                )}
-                {this.props.activeWorkflows.map((workflow) => {
-                  return (
-                    <ProjectHomeWorkflowButton
-                      key={workflow.id}
-                      disabled={this.shouldWorkflowBeDisabled(workflow)}
-                      onChangePreferences={this.props.onChangePreferences}
-                      project={this.props.project}
-                      workflow={workflow}
-                      workflowAssignment={this.props.workflowAssignment}
-                    />);
-                })
-              }</div>
-            </div>)}
+      <div className="project-home-workflow-buttons">
+        {this.props.showWorkflowButtons && this.props.activeWorkflows.length > 0 && this.props.preferences &&
+          (<div className="project-home-page__container project-home-workflow-buttons__workflow-choice-container">
+            <div className="project-home-page__content">
+              <h3 className="workflow-choice-container__call-to-action">
+                <Translate content="project.home.getStarted" />{' '}
+                <i className="fa fa-arrow-down" aria-hidden="true" />
+              </h3>
+              {this.props.project.workflow_description && (
+                <p className="workflow-choice-container__description">{this.props.project.workflow_description}</p>
+              )}
+              {this.props.activeWorkflows.map((workflow) => {
+                return (
+                  <ProjectHomeWorkflowButton
+                    key={workflow.id}
+                    disabled={this.shouldWorkflowBeDisabled(workflow)}
+                    onChangePreferences={this.props.onChangePreferences}
+                    project={this.props.project}
+                    workflow={workflow}
+                    workflowAssignment={this.props.workflowAssignment}
+                  />);
+              })
+            }</div>
+          </div>)}
 
-          {this.props.showWorkflowButtons && this.props.activeWorkflows.length === 0 &&
-            <div className="project-home-page__container workflow-choice"><LoadingIndicator /></div>}
-        </div>
-      </VisibilitySplit>
+        {this.props.showWorkflowButtons && this.props.activeWorkflows.length === 0 &&
+          <div className="project-home-page__container workflow-choice"><LoadingIndicator /></div>}
+      </div>
     );
   }
 }

--- a/app/pages/project/home/home-workflow-buttons.spec.js
+++ b/app/pages/project/home/home-workflow-buttons.spec.js
@@ -34,7 +34,7 @@ describe('ProjectHomeWorkflowButtons', function() {
           preferences={testUserPreferences}
           showWorkflowButtons={true}
           workflowAssignment={true}
-          splits={null}
+          splits={{}}
           user={{ user: { id: 1 }}}
         />,
       );

--- a/app/pages/project/home/project-home.jsx
+++ b/app/pages/project/home/project-home.jsx
@@ -32,12 +32,7 @@ const ProjectHomePage = (props) => {
     };
   }
 
-  // variant div: true shows the workflow buttons below
-  // and is for users in a split variant group that allows workflow promotion
-  // so here, we show the get started link if div: false
-  // since users who are not being promoted will work on only one workflow.
-  const showGetStartedLink = (!props.showWorkflowButtons && projectIsNotRedirected) ||
-    (projectIsNotRedirected && props.splits && props.splits['workflow.assignment'] && !props.splits['workflow.assignment'].variant.value.div)
+  const showGetStartedLink = (!props.showWorkflowButtons && projectIsNotRedirected) || props.splits['workflow.assignment']
 
   return (
     <div className="project-home-page">
@@ -61,17 +56,19 @@ const ProjectHomePage = (props) => {
         </div>
 
         <div className="project-home-page__call-to-action">
-          {props.project && !props.project.redirect &&
+          {projectIsNotRedirected &&
             <Link to={`/projects/${props.project.slug}/about`} className="project-home-page__button call-to-action__button call-to-action__button--learn-more">
               <Translate content="project.home.learnMore" />
             </Link>}
           {showGetStartedLink &&
-            <Link
-              to={`/projects/${props.project.slug}/classify`}
-              className="project-home-page__button call-to-action__button call-to-action__button--get-started"
-            >
-              <Translate content="project.home.getStarted" />
-            </Link>}
+            <VisibilitySplit splits={props.splits} splitKey='workflow.assignment' elementKey='link'>
+              <Link
+                to={`/projects/${props.project.slug}/classify`}
+                className="project-home-page__button call-to-action__button call-to-action__button--get-started"
+              >
+                <Translate content="project.home.getStarted" />
+              </Link>
+            </VisibilitySplit>}
           {props.project && props.project.redirect &&
             <a href={props.project.redirect} className="project-home-page__button">
               <strong><Translate content="project.home.visitLink" /></strong>

--- a/app/pages/project/home/project-home.jsx
+++ b/app/pages/project/home/project-home.jsx
@@ -4,6 +4,8 @@ import { Link } from 'react-router';
 import classnames from 'classnames';
 import { Markdown } from 'markdownz';
 import Translate from 'react-translate-component';
+import { VisibilitySplit } from 'seven-ten';
+
 import getSubjectLocations from '../../../lib/get-subject-locations';
 import Thumbnail from '../../../components/thumbnail';
 import FinishedBanner from '../finished-banner';
@@ -13,6 +15,7 @@ import TalkStatus from './talk-status';
 import ExternalLinksBlock from '../../../components/ExternalLinksBlock';
 
 const ProjectHomePage = (props) => {
+  const projectIsNotRedirected = props.project && !props.project.redirect;
   const avatarSrc = props.researcherAvatar || '/assets/simple-avatar.png';
 
   const descriptionClass = classnames(
@@ -28,6 +31,13 @@ const ProjectHomePage = (props) => {
       backgroundImage: `radial-gradient(rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0.8)), url('${props.background.src}')`
     };
   }
+
+  // variant div: true shows the workflow buttons below
+  // and is for users in a split variant group that allows workflow promotion
+  // so here, we show the get started link if div: false
+  // since users who are not being promoted will work on only one workflow.
+  const showGetStartedLink = (!props.showWorkflowButtons && projectIsNotRedirected) ||
+    (projectIsNotRedirected && props.splits && props.splits['workflow.assignment'] && !props.splits['workflow.assignment'].variant.value.div)
 
   return (
     <div className="project-home-page">
@@ -55,7 +65,7 @@ const ProjectHomePage = (props) => {
             <Link to={`/projects/${props.project.slug}/about`} className="project-home-page__button call-to-action__button call-to-action__button--learn-more">
               <Translate content="project.home.learnMore" />
             </Link>}
-          {!props.showWorkflowButtons && props.project && !props.project.redirect &&
+          {showGetStartedLink &&
             <Link
               to={`/projects/${props.project.slug}/classify`}
               className="project-home-page__button call-to-action__button call-to-action__button--get-started"
@@ -74,17 +84,19 @@ const ProjectHomePage = (props) => {
             className="project-disclaimer"
             content="project.disclaimer"
           />}
-        <ProjectHomeWorkflowButtons
-          activeWorkflows={props.activeWorkflows}
-          onChangePreferences={props.onChangePreferences}
-          preferences={props.preferences}
-          project={props.project}
-          projectIsComplete={props.projectIsComplete}
-          showWorkflowButtons={props.showWorkflowButtons}
-          workflowAssignment={props.project.experimental_tools.includes('workflow assignment')}
-          splits={props.splits}
-          user={props.user}
-        />
+        <VisibilitySplit splits={props.splits} splitKey='workflow.assignment' elementKey='div'>
+          <ProjectHomeWorkflowButtons
+            activeWorkflows={props.activeWorkflows}
+            onChangePreferences={props.onChangePreferences}
+            preferences={props.preferences}
+            project={props.project}
+            projectIsComplete={props.projectIsComplete}
+            showWorkflowButtons={props.showWorkflowButtons}
+            workflowAssignment={props.project.experimental_tools.includes('workflow assignment')}
+            splits={props.splits}
+            user={props.user}
+          />
+        </VisibilitySplit>
       </div>
 
       {renderTalkSubjectsPreview && (

--- a/app/pages/project/home/project-home.spec.js
+++ b/app/pages/project/home/project-home.spec.js
@@ -344,11 +344,11 @@ describe('ProjectHome', function() {
         );
       });
 
-      it('should render the ProjectHomeWorkflowButtons', function () {
+      it('should not render the ProjectHomeWorkflowButtons', function () {
         expect(wrapper.find('ProjectHomeWorkflowButtons')).to.have.lengthOf(0);
       });
 
-      it("should not render a 'Get Started' link to the classify page", function () {
+      it("should render a 'Get Started' link to the classify page", function () {
         expect(wrapper.find({ to: `/projects/${project.slug}/classify` })).to.have.lengthOf(1);
       });
     });

--- a/app/pages/project/home/project-home.spec.js
+++ b/app/pages/project/home/project-home.spec.js
@@ -262,4 +262,93 @@ describe('ProjectHome', function() {
       expect(wrapper.find('.project-home-page__about-text').find('Markdown')).to.have.lengthOf(1);
     });
   });
+
+  describe('when there is a workflow.assignment split test', function() {
+    const splitsMock = { doPromote: {}, doNotPromote: {} }
+    splitsMock.doPromote['workflow.assignment'] = {
+      key: 'workflow.assignment',
+      name: 'Workflow Promotion',
+      state: 'active',
+      type: 'splits',
+      variant: {
+        name: 'Promote',
+        type: 'variants',
+        value: {
+          div: true,
+          only_new_users: false,
+          workflow_id: '2333'
+        }
+      }
+    };
+
+    splitsMock.doNotPromote['workflow.assignment'] = {
+      key: 'workflow.assignment',
+      name: 'Workflow Promotion',
+      state: 'active',
+      type: 'splits',
+      variant: {
+        name: 'Do Not Promote',
+        type: 'variants',
+        value: {
+          div: false,
+          only_new_users: false,
+          workflow_id: '2758'
+        }
+      }
+    }
+
+    const projectWithWorkflowAssignment = Object.assign({}, project, {
+      classifiers_count: 1,
+      classifications_count: 1,
+      completeness: 0.10,
+      experimental_tools: ['workflow assignment'],
+      subjects_count: 1,
+      retired_subjects_count: 0
+    })
+
+    describe('when the split is to promote', function() {
+      before(function () {
+        // Using mount so the VisibilitySplit code will actually run
+        wrapper = mount(
+          <ProjectHome
+            project={projectWithWorkflowAssignment}
+            background={background}
+            splits={splitsMock.doPromote}
+            showWorkflowButtons={true}
+            translation={translation}
+          />
+        );
+      });
+
+      it('should render the ProjectHomeWorkflowButtons', function() {
+        expect(wrapper.find('ProjectHomeWorkflowButtons')).to.have.lengthOf(1);
+      });
+
+      it("should not render a 'Get Started' link to the classify page", function() {
+        expect(wrapper.find({ to: `/projects/${project.slug}/classify` })).to.have.lengthOf(0);
+      });
+    });
+
+    describe('when the split is to not promote', function () {
+      before(function () {
+        wrapper = mount(
+          <ProjectHome
+            project={projectWithWorkflowAssignment}
+            background={background}
+            splits={splitsMock.doNotPromote}
+            showWorkflowButtons={true}
+            translation={translation}
+          />
+        );
+      });
+
+      it('should render the ProjectHomeWorkflowButtons', function () {
+        expect(wrapper.find('ProjectHomeWorkflowButtons')).to.have.lengthOf(0);
+      });
+
+      it("should not render a 'Get Started' link to the classify page", function () {
+        expect(wrapper.find({ to: `/projects/${project.slug}/classify` })).to.have.lengthOf(1);
+      });
+    });
+  });
 });

--- a/app/pages/project/home/project-home.spec.js
+++ b/app/pages/project/home/project-home.spec.js
@@ -275,6 +275,7 @@ describe('ProjectHome', function() {
         type: 'variants',
         value: {
           div: true,
+          link: false,
           only_new_users: false,
           workflow_id: '2333'
         }
@@ -291,6 +292,7 @@ describe('ProjectHome', function() {
         type: 'variants',
         value: {
           div: false,
+          link: true,
           only_new_users: false,
           workflow_id: '2758'
         }


### PR DESCRIPTION
Staging branch URL: https://sw-split-setup.pfe-preview.zooniverse.org/

For an upcoming split for Snapshot Wisconsin at the start of their new season. This is similar to a previous split run by Gravity Spy (#3254 and #3286) where depending on the split cohort, users will be assigned a workflow.

For SW's experiment, I tried to generalize this process a bit more than the GS experiment. The client is still calling the update to the UPP to set the workflow id, but the ids aren't hardcoded in PFE, but instead stored in the Seven-Ten split variants. 

This experiment also implies a visibility split for the home page workflow buttons. Users who will not be promoted should not see the workflow buttons and see instead the 'Get Started' link to the classify page. Users who will promote should see the workflow buttons and not the 'Get Started' link.

The ProjectPageController is refactored to include the request for the splits in the `Promise.all` that is written to wait for all the project associated async requests. Then, `ready: true` is not set until we know whether or not there are splits, and if there is this specific kind of split running, also wait for the workflow assignment to happen. 

This still might not be where it should be for generalized cases, so this should be reevaluated again once we have another project that wants to run an experiment like this. I do not think Seven-Ten should be making any calls to Panoptes to update UPPs, however.

This can be tested with this project: https://sw-split-setup.pfe-preview.zooniverse.org/projects/srallen086/workflow-assignment-testing

If you are in the group that will not promote, you will see the UPP `settings.workflow_id` be set to workflow id `2758`. If you are in the group that will promote, `settings.workflow_id` is set to workflow id `2333` which is also the project default. Logged out users should see project default workflow. 

Note: This project isn't configured to _actually_ promote you. You can mimic it by updating your own UPP if you wish, but you shouldn't need to test that part since it's out of scope of this PR.

If you wish to use them, the zootester1 account has been assigned to the split group that does promote. The account zootester5 is assigned to the group that doesn't promote. (these accounts are in passbolt now)

As an aside, I renamed `preferences` and the associated class methods to update UPP to `projectPreferences` in the ProjectPageController, because `preferences.preferences` is hard to read.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
