### PR TITLE
Disable mark selection for drawing in progress

### DIFF
--- a/app/classifier/tasks/drawing/markings-renderer.cjsx
+++ b/app/classifier/tasks/drawing/markings-renderer.cjsx
@@ -37,6 +37,7 @@ module.exports = createReactClass
 
   render: ->
     skippedMarks = 0
+    drawingInProgress = false
     <g>
       {for annotation in @props.annotations
         annotation._key ?= Math.random()
@@ -55,6 +56,7 @@ module.exports = createReactClass
 
               mark._key ?= Math.random()
               currentAnnotation = @props.annotations[@props.annotations.length - 1]
+              drawingInProgress = @state.selection?._inProgress and mark isnt @state.selection
 
               if skippedMarks < currentAnnotation._hideMarksBefore
                 skippedMarks += 1
@@ -82,7 +84,7 @@ module.exports = createReactClass
               toolEnv =
                 containerRect: @props.containerRect
                 scale: scale
-                disabled: isPriorAnnotation
+                disabled: isPriorAnnotation || drawingInProgress
                 selected: mark is @state.selection and not isPriorAnnotation
                 getEventOffset: @props.getEventOffset
                 preferences: @props.preferences


### PR DESCRIPTION
Disable drawing mark selection, except for the selected tool, when the selected tool is in progress.

Staging branch URL: https://overlap-drawings.pfe-preview.zooniverse.org/

Fixes #4786.

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [x] Can you post a talk comment?

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
