### PR TITLE
Interventions: listen for experiment messages

### DIFF
--- a/app/main.cjsx
+++ b/app/main.cjsx
@@ -12,7 +12,7 @@ style = require '../css/main.styl'
 `import { notify, injectSubjects } from './redux/ducks/interventions';`
 store = configureStore()
 
-sugarClient.on('notification', (message) => store.dispatch(notify(message)));
+sugarClient.on('experiment', (message) => store.dispatch(notify(message)));
 sugarClient.on('subject-queue', (message) => store.dispatch(injectSubjects(message)));
 
 # Redirect any old `/#/foo`-style URLs to `/foo`.


### PR DESCRIPTION
Turns out notification is used by Talk for new message notifications, so listen for experiment messages instead.
https://www.zooniverse.org/talk/17/712137?comment=1186616&page=1

Staging branch URL: https://interventions.pfe-preview.zooniverse.org/

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
