### PR TITLE
Store a single subject queue and classification

### DIFF
--- a/app/classifier/classifier.jsx
+++ b/app/classifier/classifier.jsx
@@ -298,9 +298,11 @@ class Classifier extends React.Component {
       .then(() => {
         workflowHistory = [];
         this.setState({ annotations, showIntervention, showSummary, workflowHistory });
-        return showLastStep ? null : this.onNextSubject();
       })
       .then(onComplete)
+      .then(() => {
+        return showLastStep ? null : this.onNextSubject();
+      })
       .catch(error => console.error(error));
   }
 

--- a/app/pages/project/classify.jsx
+++ b/app/pages/project/classify.jsx
@@ -309,7 +309,15 @@ ProjectClassifyPage.contextTypes = {
 };
 
 ProjectClassifyPage.propTypes = {
-  actions: PropTypes.shape({}),
+  actions: PropTypes.shape({
+    classifier: PropTypes.shape({
+      createClassification: PropTypes.func,
+      emptySubjectQueue: PropTypes.func,
+      fetchSubjects: PropTypes.func,
+      nextSubject: PropTypes.func,
+      refillSubjectQueue: PropTypes.func
+    })
+  }),
   classification: PropTypes.shape({}),
   loadingSelectedWorkflow: PropTypes.bool,
   location: PropTypes.shape({
@@ -331,6 +339,9 @@ ProjectClassifyPage.propTypes = {
 
 ProjectClassifyPage.defaultProps = {
   classification: null,
+  location: {
+    query: {}
+  },
   upcomingSubjects: []
 };
 

--- a/app/pages/project/classify.jsx
+++ b/app/pages/project/classify.jsx
@@ -95,10 +95,6 @@ export class ProjectClassifyPage extends React.Component {
       if (classification && classification.links.workflow !== workflow.id) {
         // The current workflow has changed, so reset the subject queue
         actions.classifier.emptySubjectQueue();
-      } else {
-        // initial workflow load is complete so check if we need to
-        // resume a session or create a new classification.
-        this.loadAppropriateClassification();
       }
     }
 
@@ -349,7 +345,8 @@ window.classificationQueue = classificationQueue;
 const mapStateToProps = state => ({
   classification: state.classify.classification,
   upcomingSubjects: state.classify.upcomingSubjects,
-  theme: state.userInterface.theme
+  theme: state.userInterface.theme,
+  workflow: state.classify.workflow
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/app/pages/project/classify.jsx
+++ b/app/pages/project/classify.jsx
@@ -21,10 +21,6 @@ import WorkflowAssignmentDialog from '../../components/workflow-assignment-dialo
 import ProjectThemeButton from './components/ProjectThemeButton';
 import { zooTheme } from '../../theme';
 
-// Map each project ID to a promise of its last randomly-selected workflow ID.
-// This is to maintain the same random workflow for each project when none is specified by the user.
-const currentWorkflowForProject = {};
-
 function onClassificationSaved(actualClassification) {
   Split.classificationCreated(actualClassification); // Metric log needs classification id
 }
@@ -338,8 +334,6 @@ ProjectClassifyPage.defaultProps = {
   upcomingSubjects: []
 };
 
-// For debugging:
-window.currentWorkflowForProject = currentWorkflowForProject;
 window.classificationQueue = classificationQueue;
 
 const mapStateToProps = state => ({

--- a/app/pages/project/classify.jsx
+++ b/app/pages/project/classify.jsx
@@ -107,7 +107,7 @@ export class ProjectClassifyPage extends React.Component {
     }
 
     if (upcomingSubjects.length !== prevProps.upcomingSubjects.length) {
-      if (upcomingSubjects.length === 0) {
+      if (upcomingSubjects.length < 2) {
         this.refillSubjectQueue();
       }
     }

--- a/app/pages/project/classify.jsx
+++ b/app/pages/project/classify.jsx
@@ -41,7 +41,6 @@ let sessionDemoMode = false;
 export class ProjectClassifyPage extends React.Component {
   constructor(props) {
     super(props);
-    this.loadingSelectedWorkflow = false;
     this.project = null;
     this.workflow = null;
 
@@ -56,7 +55,7 @@ export class ProjectClassifyPage extends React.Component {
 
   componentDidMount() {
     Split.classifierVisited();
-    if (this.props.workflow && !this.props.loadingSelectedWorkflow) {
+    if (this.props.workflow) {
       this.loadAppropriateClassification();
     }
 
@@ -64,7 +63,7 @@ export class ProjectClassifyPage extends React.Component {
   }
 
   componentWillReceiveProps(nextProps, nextContext) {
-    if (nextProps.loadingSelectedWorkflow === false && nextProps.user !== null) {
+    if (nextProps.user !== null) {
       this.shouldWorkflowAssignmentPrompt(nextProps, nextContext);
     }
 
@@ -92,16 +91,14 @@ export class ProjectClassifyPage extends React.Component {
       this.loadAppropriateClassification();
     }
 
-    if (!this.props.loadingSelectedWorkflow) {
-      if (workflow !== prevProps.workflow) {
-        if (classification && classification.links.workflow !== workflow.id) {
-          // The current workflow has changed, so reset the subject queue
-          actions.classifier.emptySubjectQueue();
-        } else {
-          // initial workflow load is complete so check if we need to
-          // resume a session or create a new classification.
-          this.loadAppropriateClassification();
-        }
+    if (workflow !== prevProps.workflow) {
+      if (classification && classification.links.workflow !== workflow.id) {
+        // The current workflow has changed, so reset the subject queue
+        actions.classifier.emptySubjectQueue();
+      } else {
+        // initial workflow load is complete so check if we need to
+        // resume a session or create a new classification.
+        this.loadAppropriateClassification();
       }
     }
 

--- a/app/pages/project/classify.jsx
+++ b/app/pages/project/classify.jsx
@@ -94,7 +94,7 @@ export class ProjectClassifyPage extends React.Component {
 
     if (!this.props.loadingSelectedWorkflow) {
       if (workflow !== prevProps.workflow) {
-        if (prevProps.workflow) {
+        if (classification && classification.links.workflow !== workflow.id) {
           // The current workflow has changed, so reset the subject queue
           actions.classifier.emptySubjectQueue();
         } else {
@@ -103,11 +103,6 @@ export class ProjectClassifyPage extends React.Component {
           this.loadAppropriateClassification();
         }
       }
-    }
-
-    if (classification && classification.links.workflow !== workflow.id) {
-      // the current classification is invalid so reset the subject queue (and classification.)
-      actions.classifier.emptySubjectQueue();
     }
 
     if (upcomingSubjects.length !== prevProps.upcomingSubjects.length) {
@@ -135,23 +130,11 @@ export class ProjectClassifyPage extends React.Component {
     }
   }
 
-  getSubjectSet(workflow) {
-    if (workflow.grouped) {
-      return workflow.get('subject_sets').then((subjectSets) => {
-        const randomIndex = Math.floor(Math.random() * subjectSets.length);
-        return subjectSets[randomIndex];
-      });
-    } else {
-      return Promise.resolve();
-    }
-  }
-
   refillSubjectQueue() {
     const { actions, project, workflow } = this.props;
 
     this.maybePromptWorkflowAssignmentDialog(this.props);
-    this.getSubjectSet(workflow)
-    .then(subjectSet => actions.classifier.fetchSubjects(subjectSet, workflow))
+    actions.classifier.fetchSubjects(workflow)
     .then(() => actions.classifier.createClassification(project, workflow))
     .catch((error) => {
       this.setState({ rejected: { classification: error }});

--- a/app/pages/project/classify.jsx
+++ b/app/pages/project/classify.jsx
@@ -131,15 +131,19 @@ export class ProjectClassifyPage extends React.Component {
     }
   }
 
-  createNewClassification(subjectSet) {
+  createNewClassification() {
     const { actions, project, workflow, upcomingSubjects } = this.props;
 
     if (upcomingSubjects.length > 0) {
       actions.classifier.createClassification(project, workflow);
     } else {
       this.maybePromptWorkflowAssignmentDialog(this.props);
-      actions.classifier.fetchSubjects(subjectSet, workflow)
-      .then(() => actions.classifier.createClassification(project, workflow));
+      this.getSubjectSet(workflow)
+      .then(subjectSet => actions.classifier.fetchSubjects(subjectSet, workflow))
+      .then(() => actions.classifier.createClassification(project, workflow))
+      .catch((error) => {
+        this.setState({ rejected: { classification: error }});
+      });
     }
   }
 
@@ -154,22 +158,9 @@ export class ProjectClassifyPage extends React.Component {
       actions.classifier.resumeClassification(classification);
     } else if (classification) {
       actions.classifier.emptySubjectQueue();
-      this.getSubjectSet(workflow)
-      .then(subjectSet => {
-        this.createNewClassification(subjectSet);
-      })
-      .catch((error) => {
-        this.setState({ rejected: { classification: error }});
-      });
+      this.createNewClassification();
     } else {
-      // A subject set is only specified if the workflow is grouped.
-      this.getSubjectSet(workflow)
-      .then(subjectSet => {
-        this.createNewClassification(subjectSet);
-      })
-      .catch((error) => {
-        this.setState({ rejected: { classification: error }});
-      });
+      this.createNewClassification();
     }
   }
 

--- a/app/pages/project/classify.spec.js
+++ b/app/pages/project/classify.spec.js
@@ -1,24 +1,193 @@
 import React from 'react';
-import assert from 'assert';
+import { expect } from 'chai';
 import { shallow } from 'enzyme';
+import sinon from 'sinon';
 
 import { ProjectClassifyPage } from './classify';
 import FinishedBanner from './finished-banner';
 
+const actions = {
+  classifier: {
+    createClassification: sinon.spy(),
+    emptySubjectQueue: sinon.spy(),
+    fetchSubjects: sinon.stub().callsFake(() => Promise.resolve()),
+    resumeClassification: sinon.spy()
+  }
+};
+
+const workflow = {
+  id: '1'
+};
+
 describe('ProjectClassifyPage', function () {
   let wrapper;
-  let project = {};
-  let apiUser = {id: 123};
+  const project = {
+    experimental_tools: []
+  };
 
   before(function () {
-    wrapper = shallow(<ProjectClassifyPage project={project} />);
+    wrapper = shallow(
+      <ProjectClassifyPage
+        actions={actions}
+        classification={null}
+        loadingSelectedWorkflow={false}
+        project={project}
+        upcomingSubjects={[]}
+        workflow={workflow}
+      />,
+      {
+        context: {
+          geordi: {
+            forget: sinon.spy(),
+            remember: sinon.spy()
+          }
+        },
+        disableLifecycleMethods: false
+      }
+    );
   });
 
   it('renders when not logged in', function () {
-    assert.equal(wrapper.find('.classify-page').length, 1);
+    expect(wrapper.find('.classify-page')).to.have.lengthOf(1);
   });
 
   it('never tells you when the project is finished', () => {
-    assert.equal(wrapper.find(FinishedBanner).length, 0);
+    expect(wrapper.find(FinishedBanner)).to.have.lengthOf(0);
+  });
+
+  describe('on first load', function () {
+    after(function () {
+      actions.classifier.createClassification.resetHistory();
+      actions.classifier.fetchSubjects.resetHistory();
+      actions.classifier.emptySubjectQueue.resetHistory();
+    });
+
+    it('should fetch new subjects', function () {
+      expect(actions.classifier.fetchSubjects.callCount).to.equal(1);
+    });
+    it('should create a new classification', function () {
+      expect(actions.classifier.createClassification.callCount).to.equal(1);
+    });
+  });
+
+  describe('on loading a classification', function () {
+    let classification;
+    let upcomingSubjects;
+
+    beforeEach(function () {
+      classification = {
+        annotations: [],
+        links: {
+          workflow: '1'
+        }
+      };
+    });
+
+    describe('with only one subject in the queue', function () {
+      after(function () {
+        actions.classifier.createClassification.resetHistory();
+        actions.classifier.fetchSubjects.resetHistory();
+        actions.classifier.emptySubjectQueue.resetHistory();
+      });
+
+      beforeEach(function () {
+        upcomingSubjects = [{}];
+        wrapper.setProps({ classification, upcomingSubjects });
+      });
+
+      it('should fetch new subjects', function () {
+        expect(actions.classifier.fetchSubjects.callCount).to.equal(1);
+      });
+
+      it('should create a new classification', function () {
+        expect(actions.classifier.createClassification.callCount).to.equal(1);
+      });
+    });
+
+    describe('when the workflow changes', function () {
+      beforeEach(function () {
+        const newWorkflow = {
+          id: '2'
+        };
+        wrapper.setProps({ workflow: newWorkflow });
+      });
+
+      it('should empty the subject queue', function () {
+        expect(actions.classifier.emptySubjectQueue.callCount).to.equal(1);
+        actions.classifier.emptySubjectQueue.resetHistory();
+      });
+    });
+  });
+
+  describe('with an invalid classification for the workflow', function () {
+    beforeEach(function () {
+      const newWorkflow = {
+        id: '2'
+      };
+      const classification = {
+        annotations: [],
+        links: {
+          workflow: '1'
+        }
+      };
+      wrapper = shallow(
+        <ProjectClassifyPage
+          actions={actions}
+          classification={classification}
+          loadingSelectedWorkflow={false}
+          project={project}
+          upcomingSubjects={[]}
+          workflow={newWorkflow}
+        />,
+        {
+          context: {
+            geordi: {
+              forget: sinon.spy(),
+              remember: sinon.spy()
+            }
+          },
+          disableLifecycleMethods: false
+        }
+      );
+    });
+
+    it('should empty the subject queue', function () {
+      expect(actions.classifier.emptySubjectQueue.callCount).to.equal(1);
+      actions.classifier.emptySubjectQueue.resetHistory();
+    });
+  });
+
+  describe('with a valid classification for the workflow', function () {
+    beforeEach(function () {
+      const classification = {
+        annotations: [],
+        links: {
+          workflow: '1'
+        }
+      };
+      wrapper = shallow(
+        <ProjectClassifyPage
+          actions={actions}
+          classification={classification}
+          loadingSelectedWorkflow={false}
+          project={project}
+          upcomingSubjects={[]}
+          workflow={workflow}
+        />,
+        {
+          context: {
+            geordi: {
+              forget: sinon.spy(),
+              remember: sinon.spy()
+            }
+          },
+          disableLifecycleMethods: false
+        }
+      );
+    });
+
+    it('should resume the classification', function () {
+      expect(actions.classifier.resumeClassification.callCount).to.equal(1);
+    });
   });
 });

--- a/app/pages/project/workflow-selection.jsx
+++ b/app/pages/project/workflow-selection.jsx
@@ -113,9 +113,9 @@ class WorkflowSelection extends React.Component {
     return awaitWorkflow
     .then((workflow) => {
       if (workflow) {
-        this.setState({ loadingSelectedWorkflow: false });
         actions.translations.load('workflow', workflow.id, translations.locale);
         actions.classifier.setWorkflow(workflow);
+        this.setState({ loadingSelectedWorkflow: false });
       } else {
         if (process.env.BABEL_ENV !== 'test') console.log(`No workflow ${selectedWorkflowID} for project ${this.props.project.id}`);
         if (this.props.project.configuration &&
@@ -193,10 +193,10 @@ class WorkflowSelection extends React.Component {
   render() {
     const { translation, workflow } = this.props;
     const { loadingSelectedWorkflow } = this.state;
-    if (loadingSelectedWorkflow) {
-      return <p>Loading workflow.</p>
-    } else {
+    if (workflow && !loadingSelectedWorkflow) {
       return React.cloneElement(this.props.children, { translation, loadingSelectedWorkflow, workflow });
+    } else {
+      return <p>Loading workflow.</p>
     }
   }
 }

--- a/app/pages/project/workflow-selection.jsx
+++ b/app/pages/project/workflow-selection.jsx
@@ -189,7 +189,11 @@ class WorkflowSelection extends React.Component {
   render() {
     const { translation } = this.props;
     const { loadingSelectedWorkflow, workflow } = this.state;
-    return React.cloneElement(this.props.children, { translation, loadingSelectedWorkflow, workflow });
+    if (loadingSelectedWorkflow) {
+      return <p>Loading workflow.</p>
+    } else {
+      return React.cloneElement(this.props.children, { translation, loadingSelectedWorkflow, workflow });
+    }
   }
 }
 

--- a/app/pages/project/workflow-selection.spec.js
+++ b/app/pages/project/workflow-selection.spec.js
@@ -3,7 +3,7 @@ import assert from 'assert';
 import { mount } from 'enzyme';
 import sinon from 'sinon';
 import apiClient from 'panoptes-client/lib/api-client';
-import WorkflowSelection from './workflow-selection';
+import { WorkflowSelection } from './workflow-selection';
 
 function StubPage() {
   return <p>Hello</p>;

--- a/app/redux/ducks/classify.js
+++ b/app/redux/ducks/classify.js
@@ -54,7 +54,7 @@ export default function reducer(state = initialState, action = {}) {
     }
     case NEXT_SUBJECT: {
       const { project, workflow } = action.payload;
-      let classification = null;
+      let { classification } = state;
       const upcomingSubjects = state.upcomingSubjects.slice();
       upcomingSubjects.shift();
       const subject = upcomingSubjects[0];

--- a/app/redux/ducks/classify.js
+++ b/app/redux/ducks/classify.js
@@ -52,7 +52,8 @@ function createNewClassification(project, workflow, subject) {
 
 const initialState = {
   classification: null,
-  upcomingSubjects: []
+  upcomingSubjects: [],
+  workflow: null
 };
 
 const ADD_SUBJECTS = 'pfe/classify/ADD_SUBJECTS';
@@ -61,6 +62,7 @@ const CREATE_CLASSIFICATION = 'pfe/classify/CREATE_CLASSIFICATION';
 const NEXT_SUBJECT = 'pfe/classify/NEXT_SUBJECT';
 const RESUME_CLASSIFICATION = 'pfe/classify/RESUME_CLASSIFICATION';
 const RESET_SUBJECTS = 'pfe/classify/RESET_SUBJECTS';
+const SET_WORKFLOW = 'pfe/classify/SET_WORKFLOW';
 
 export default function reducer(state = initialState, action = {}) {
   switch (action.type) {
@@ -71,7 +73,8 @@ export default function reducer(state = initialState, action = {}) {
       return Object.assign({}, state, { upcomingSubjects });
     }
     case CREATE_CLASSIFICATION: {
-      const { project, workflow } = action.payload;
+      const { project } = action.payload;
+      const { workflow } = state;
       if (state.upcomingSubjects.length > 0) {
         const subject = state.upcomingSubjects[0];
         const classification = createNewClassification(project, workflow, subject);
@@ -80,15 +83,16 @@ export default function reducer(state = initialState, action = {}) {
       return state;
     }
     case NEXT_SUBJECT: {
-      const { project, workflow } = action.payload;
-      let { classification } = state;
+      const { project } = action.payload;
+      const { workflow } = state;
       const upcomingSubjects = state.upcomingSubjects.slice();
       upcomingSubjects.shift();
       const subject = upcomingSubjects[0];
       if (subject) {
-        classification = createNewClassification(project, workflow, subject);
+        const classification = createNewClassification(project, workflow, subject);
+        return Object.assign({}, state, { classification, upcomingSubjects });
       }
-      return Object.assign({}, state, { classification, upcomingSubjects });
+      return Object.assign({}, state, { upcomingSubjects });
     }
     case RESUME_CLASSIFICATION: {
       const { subject } = action.payload;
@@ -102,10 +106,15 @@ export default function reducer(state = initialState, action = {}) {
       return state;
     }
     case RESET_SUBJECTS: {
+      const classification = null;
       const upcomingSubjects = state.upcomingSubjects.slice();
       upcomingSubjects.forEach(subject => subject.destroy());
       upcomingSubjects.splice(0);
-      return Object.assign({}, initialState);
+      return Object.assign({}, state, { classification, upcomingSubjects });
+    }
+    case SET_WORKFLOW: {
+      const { workflow } = action.payload;
+      return Object.assign({}, state, { workflow });
     }
     default:
       return state;
@@ -149,17 +158,17 @@ export function fetchSubjects(workflow) {
     }));
 }
 
-export function createClassification(project, workflow) {
+export function createClassification(project) {
   return {
     type: CREATE_CLASSIFICATION,
-    payload: { project, workflow }
+    payload: { project }
   };
 }
 
-export function nextSubject(project, workflow) {
+export function nextSubject(project) {
   return {
     type: NEXT_SUBJECT,
-    payload: { project, workflow }
+    payload: { project }
   };
 }
 
@@ -177,6 +186,13 @@ export function resumeClassification(classification) {
         payload: { subject }
       });
     });
+  };
+}
+
+export function setWorkflow(workflow) {
+  return {
+    type: SET_WORKFLOW,
+    payload: { workflow }
   };
 }
 

--- a/app/redux/ducks/classify.js
+++ b/app/redux/ducks/classify.js
@@ -31,7 +31,7 @@ const initialState = {
 const ADD_SUBJECTS = 'pfe/classify/ADD_SUBJECTS';
 const FETCH_SUBJECTS = 'pfe/classify/FETCH_SUBJECTS';
 const CREATE_CLASSIFICATION = 'pfe/classify/CREATE_CLASSIFICATION';
-const RESET_CLASSIFICATION = 'pfe/classify/RESET_CLASSIFICATION';
+const NEXT_SUBJECT = 'pfe/classify/NEXT_SUBJECT';
 const RESUME_CLASSIFICATION = 'pfe/classify/RESUME_CLASSIFICATION';
 const RESET_SUBJECTS = 'pfe/classify/RESET_SUBJECTS';
 
@@ -52,10 +52,15 @@ export default function reducer(state = initialState, action = {}) {
       }
       return state;
     }
-    case RESET_CLASSIFICATION: {
-      const classification = null;
+    case NEXT_SUBJECT: {
+      const { project, workflow } = action.payload;
+      let classification = null;
       const upcomingSubjects = state.upcomingSubjects.slice();
       upcomingSubjects.shift();
+      const subject = upcomingSubjects[0];
+      if (subject) {
+        classification = createNewClassification(project, workflow, subject);
+      }
       return Object.assign({}, state, { classification, upcomingSubjects });
     }
     case RESUME_CLASSIFICATION: {
@@ -73,7 +78,7 @@ export default function reducer(state = initialState, action = {}) {
       const upcomingSubjects = state.upcomingSubjects.slice();
       upcomingSubjects.forEach(subject => subject.destroy());
       upcomingSubjects.splice(0);
-      return Object.assign({}, state, { upcomingSubjects });
+      return Object.assign({}, initialState);
     }
     default:
       return state;
@@ -137,9 +142,10 @@ export function createClassification(project, workflow) {
   };
 }
 
-export function resetClassification() {
+export function nextSubject(project, workflow) {
   return {
-    type: RESET_CLASSIFICATION
+    type: NEXT_SUBJECT,
+    payload: { project, workflow }
   };
 }
 


### PR DESCRIPTION
Builds on #4781.
Remove upcomingSubjects.forWorkflow and currentClassifications.forWorkflow.
Simplify redux actions to work with a single classification and queue.
Update ProjectClassifyPage to use props.classification and props.upcomingSubjects.
Modify WorkflowSelection so that its children don't render unless there is a workflow loaded.

Staging branch URL: https://subject-queue-workflow.pfe-preview.zooniverse.org

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
