### PR TITLE
Only set the workflow if the settings.workflow_id is falsey.

### DIFF
--- a/app/pages/project/index.jsx
+++ b/app/pages/project/index.jsx
@@ -342,11 +342,13 @@ class ProjectPageController extends React.Component {
 
   handleSplitWorkflowAssignment(projectPreferences, splits) {
     if (splits['workflow.assignment']) {
-      const projectSetWorkflow = (splits['workflow.assignment'].variant
+      const projectWorkflowToSet = (splits['workflow.assignment'].variant
         && splits['workflow.assignment'].variant.value
         && splits['workflow.assignment'].variant.value.workflow_id)
           ? splits['workflow.assignment'].variant.value.workflow_id
           : '';
+
+      const doesNotHaveProjectSetWorkflow = !(projectPreferences.settings && projectPreferences.settings.workflow_id);
 
       const userSelectedWorkflow = (projectPreferences.preferences && projectPreferences.preferences.selected_workflow)
         ? projectPreferences.preferences.selected_workflow
@@ -354,15 +356,17 @@ class ProjectPageController extends React.Component {
 
       if (splits['workflow.assignment'].variant.value.only_new_users) {
         const newToProject = Object.keys(projectPreferences.preferences).length === 0;
-        if (newToProject) this.handleProjectPreferencesChange('settings.workflow_id', projectSetWorkflow);
+        if (newToProject) this.handleProjectPreferencesChange('settings.workflow_id', projectWorkflowToSet);
       } else {
-        this.handleProjectPreferencesChange('settings.workflow_id', projectSetWorkflow);
+        if (doesNotHaveProjectSetWorkflow) {
+          this.handleProjectPreferencesChange('settings.workflow_id', projectWorkflowToSet);
 
-        if (userSelectedWorkflow && projectSetWorkflow &&
-          userSelectedWorkflow !== projectSetWorkflow) {
-            // if split is not only for new users
-            // clear the user selected workflow if defined
-            this.handleProjectPreferencesChange('preferences.selected_workflow', undefined)
+          if (userSelectedWorkflow && projectWorkflowToSet &&
+            userSelectedWorkflow !== projectWorkflowToSet) {
+              // if split is not only for new users
+              // clear the user selected workflow if defined
+              this.handleProjectPreferencesChange('preferences.selected_workflow', undefined)
+          }
         }
       }
     }


### PR DESCRIPTION
Staging branch URL: https://sw-split-setup.pfe-preview.zooniverse.org/projects/srallen086/workflow-assignment-testing

Follow up from #4784. I realized that the code as is could demote someone who had been promoted when they revisit the project later. This adds in a check to make sure that the `settings.workflow_id` hasn't already been set. 

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
