### PR TITLE
Enable lifecycle method testing in enzyme

### DIFF
--- a/app/classifier/classifier.jsx
+++ b/app/classifier/classifier.jsx
@@ -554,7 +554,9 @@ Classifier.defaultProps = {
       dismiss: () => true
     }
   },
-  classification: {},
+  classification: {
+    annotations: []
+  },
   classificationCount: 0,
   demoMode: false,
   feedback: {
@@ -564,13 +566,16 @@ Classifier.defaultProps = {
     notifications: []
   },
   minicourse: null,
+  onClickNext: () => null,
   onComplete: () => Promise.resolve(),
   preferences: null,
   project: {},
   onLoad: Function.prototype,
   onChangeDemoMode: Function.prototype,
   splits: null,
-  subject: {},
+  subject: {
+    locations: []
+  },
   tutorial: null,
   user: null,
   workflow: {

--- a/app/classifier/drawing-tools/components/DetailsSubTaskForm/DetailsSubTaskForm.jsx
+++ b/app/classifier/drawing-tools/components/DetailsSubTaskForm/DetailsSubTaskForm.jsx
@@ -137,6 +137,7 @@ export class DetailsSubTaskForm extends React.Component {
                 
                 return (
                   <TaskComponent
+                    key={detailTask._key}
                     autoFocus={i === 0}
                     task={detailTask}
                     translation={detailTranslation}

--- a/app/classifier/tasks/dropdown/index.jsx
+++ b/app/classifier/tasks/dropdown/index.jsx
@@ -301,5 +301,9 @@ DropdownTask.propTypes = {
 };
 
 DropdownTask.defaultProps = {
+  annotation: {
+    value: []
+  },
+  onChange: () => true,
   task: { selects: [] }
 };

--- a/app/classifier/tasks/highlighter/index.jsx
+++ b/app/classifier/tasks/highlighter/index.jsx
@@ -151,7 +151,7 @@ Highlighter.propTypes = {
   annotation: PropTypes.shape({
     _toolIndex: PropTypes.number,
     task: PropTypes.string
-  }).isRequired,
+  }),
   onChange: PropTypes.func,
   showRequiredNotice: PropTypes.bool,
   task: PropTypes.shape({
@@ -167,3 +167,14 @@ Highlighter.propTypes = {
   })
 };
 
+Highlighter.defaultProps = {
+  annotation: {
+    value: []
+  },
+  task: {
+    help: '',
+    highlighterLabels: [],
+    instruction: 'Highlight the text',
+    type: 'highlighter'
+  }
+}

--- a/app/classifier/tasks/text/index.jsx
+++ b/app/classifier/tasks/text/index.jsx
@@ -87,7 +87,7 @@ export default class TextTask extends React.Component {
 
   handleResize() {
     const oldRows = this.state.rows;
-    let newRows = Math.floor(this.textInput.current.scrollHeight / LINEHEIGHT);
+    let newRows = this.textInput.current ? Math.floor(this.textInput.current.scrollHeight / LINEHEIGHT) : oldRows;
     newRows = Math.max(newRows, 1);
 
     if (newRows !== oldRows) {

--- a/app/collections/manager-icon.spec.js
+++ b/app/collections/manager-icon.spec.js
@@ -11,10 +11,20 @@ const subject = {
   id: '3632'
 };
 
+const user = {
+  id: '1'
+}
+
 describe('<CollectionsManagerIcon />', function() {
   let wrapper;
   before(function() {
-    wrapper = shallow(<CollectionsManagerIcon className="icon" project={project} subject={subject} />);
+    wrapper = shallow(
+      <CollectionsManagerIcon
+        className="icon"
+        project={project}
+        subject={subject}
+        user={user}
+      />);
   });
 
   it('renders without crashing', function() {

--- a/app/collections/settings.spec.js
+++ b/app/collections/settings.spec.js
@@ -13,14 +13,16 @@ const collectionWithDefaultSubject = {
   default_subject_src: 'subject.png',
   display_name: 'A collection',
   private: false,
-  slug: 'username/a-collection'
+  slug: 'username/a-collection',
+  listen: sinon.spy()
 };
 
 const collectionWithoutDefaultSubject = {
   id: '1',
   display_name: 'A collection',
   private: false,
-  slug: 'username/a-collection'
+  slug: 'username/a-collection',
+  listen: sinon.spy()
 };
 
 describe('<CollectionSettings />', function () {

--- a/app/components/svg-image.jsx
+++ b/app/components/svg-image.jsx
@@ -37,11 +37,11 @@ class SVGImage extends React.Component {
   fixWeirdSize() {
     const image = this.refs.image;
 
-    if (this.props.width && image.width === this.props.width) {
+    if (this.props.width && image && image.width === this.props.width) {
       image.setAttribute('width', this.props.width);
     }
 
-    if (this.props.height && image.height === this.props.height) {
+    if (this.props.height && image && image.height === this.props.height) {
       image.setAttribute('height', this.props.height);
     }
   }

--- a/app/lib/classification-queue.js
+++ b/app/lib/classification-queue.js
@@ -61,7 +61,7 @@ class ClassificationQueue {
           }
         })
         .catch((error) => {
-          console.error('Failed to save a queued classification:', error);
+          if (process.env.BABEL_ENV !== 'test') console.error('Failed to save a queued classification:', error);
 
           if (error.status === 422) {
             console.error('Dropping malformed classification permanently', classificationData);

--- a/app/lib/preload-subject.coffee
+++ b/app/lib/preload-subject.coffee
@@ -10,4 +10,4 @@ module.exports = (subject) ->
           .catch (error) ->
             console.error error
       else
-        console.warn "Not sure how to load subject #{subject.id}'s location of type #{type} (#{src})"
+        console.warn "Not sure how to load subject #{subject.id}'s location of type #{type} (#{src})" unless process.env.BABEL_ENV is 'test' 

--- a/app/pages/admin/project-status.jsx
+++ b/app/pages/admin/project-status.jsx
@@ -312,4 +312,8 @@ ProjectStatus.propTypes = {
   })
 };
 
+ProjectStatus.defaultProps = {
+  params: {}
+};
+
 export default ProjectStatus;

--- a/app/pages/admin/project-status.spec.js
+++ b/app/pages/admin/project-status.spec.js
@@ -53,6 +53,8 @@ describe('ProjectStatus', function () {
     onChangeWorkflowLevelStub.restore();
     handleDialogCancelStub.restore();
     handleDialogSuccessStub.restore();
+    ProjectStatus.prototype.getProject.restore();
+    ProjectStatus.prototype.getWorkflows.restore();
   });
 
   it('renders without crashing', function () {

--- a/app/pages/admin/project-status.spec.js
+++ b/app/pages/admin/project-status.spec.js
@@ -40,6 +40,8 @@ describe('ProjectStatus', function () {
   let wrapper;
 
   before(function () {
+    sinon.stub(ProjectStatus.prototype, 'getProject').callsFake(() => Promise.resolve(project));
+    sinon.stub(ProjectStatus.prototype, 'getWorkflows').callsFake(() => Promise.resolve(workflows));
     onChangeWorkflowLevelStub = sinon.stub(ProjectStatus.prototype, 'onChangeWorkflowLevel');
     handleDialogCancelStub = sinon.stub(ProjectStatus.prototype, 'handleDialogCancel');
     handleDialogSuccessStub = sinon.stub(ProjectStatus.prototype, 'handleDialogSuccess');

--- a/app/pages/admin/user-settings.jsx
+++ b/app/pages/admin/user-settings.jsx
@@ -79,7 +79,9 @@ UserSettings.propTypes = {
 };
 
 UserSettings.defaultProps = {
-  editUser: null
+  editUser: null,
+  params: {},
+  user: null
 };
 
 export default UserSettings;

--- a/app/pages/admin/user-settings.jsx
+++ b/app/pages/admin/user-settings.jsx
@@ -79,7 +79,6 @@ UserSettings.propTypes = {
 };
 
 UserSettings.defaultProps = {
-  editUser: null,
   params: {},
   user: null
 };

--- a/app/pages/admin/user-settings.spec.js
+++ b/app/pages/admin/user-settings.spec.js
@@ -8,7 +8,14 @@ describe('UserSettings', function () {
   let wrapper;
   let user = {id: '1', login: "tester"};
   let editUser = {id: '2', login: 'volunteer'};
-  sinon.stub(UserSettings.prototype, 'getUser').callsFake(() => null);
+
+  before(function () {
+    sinon.stub(UserSettings.prototype, 'getUser').callsFake(() => null);
+  });
+
+  after(function () {
+    UserSettings.prototype.getUser.restore();
+  });
 
   it('errors when no user found', function () {
     wrapper = shallow(<UserSettings user={user} />);

--- a/app/pages/admin/user-settings.spec.js
+++ b/app/pages/admin/user-settings.spec.js
@@ -1,12 +1,14 @@
 import React from 'react';
 import assert from 'assert';
+import sinon from 'sinon';
 import { shallow } from 'enzyme';
 import UserSettings from './user-settings';
 
 describe('UserSettings', function () {
   let wrapper;
-  let user = {id: 1, login: "tester"};
-  let editUser = {id: 2, login: 'volunteer'};
+  let user = {id: '1', login: "tester"};
+  let editUser = {id: '2', login: 'volunteer'};
+  sinon.stub(UserSettings.prototype, 'getUser').callsFake(() => null);
 
   it('errors when no user found', function () {
     wrapper = shallow(<UserSettings user={user} />);

--- a/app/pages/notifications/notification-section.spec.js
+++ b/app/pages/notifications/notification-section.spec.js
@@ -30,7 +30,11 @@ describe('Notification Section', function() {
 
   before(function () {
     sinon.stub(NotificationSection.prototype, 'getUnreadCount').callsFake(() => null);
-  })
+  });
+
+  after(function () {
+    NotificationSection.prototype.getUnreadCount.restore();
+  });
 
   describe('it can display a Zooniverse section', function () {
     beforeEach(function () {

--- a/app/pages/notifications/notification-section.spec.js
+++ b/app/pages/notifications/notification-section.spec.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import assert from 'assert';
+import sinon from 'sinon';
 import { shallow } from 'enzyme';
 import NotificationSection from './notification-section';
 
@@ -26,6 +27,10 @@ const notifications = [
 
 describe('Notification Section', function() {
   let wrapper;
+
+  before(function () {
+    sinon.stub(NotificationSection.prototype, 'getUnreadCount').callsFake(() => null);
+  })
 
   describe('it can display a Zooniverse section', function () {
     beforeEach(function () {

--- a/app/pages/notifications/notification-section.spec.js
+++ b/app/pages/notifications/notification-section.spec.js
@@ -57,9 +57,14 @@ describe('Notification Section', function() {
   });
 
   describe('it correctly displays a project', function () {
-    beforeEach(function () {
+    before(function () {
+      sinon.stub(NotificationSection.prototype, 'componentWillMount').callsFake(() => null);
       wrapper = shallow(<NotificationSection />);
       wrapper.setState({ name: 'Testing' });
+    });
+
+    after(function () {
+      NotificationSection.prototype.componentWillMount.restore();
     });
 
     it('should display the correct title', function () {

--- a/app/pages/project/about/index.jsx
+++ b/app/pages/project/about/index.jsx
@@ -93,7 +93,7 @@ class AboutProject extends Component {
       <div className="project-about-page">
         <Helmet title={`${this.props.translation.display_name} » ${counterpart('project.about.header')}`} />
         <AboutNav pages={pages} projectPath={`/projects/${project.slug}`} />
-        {React.cloneElement(children, { project, pages, team })}
+        {children ? React.cloneElement(children, { project, pages, team }) : null}
       </div>
     );
   }

--- a/app/pages/project/classify.jsx
+++ b/app/pages/project/classify.jsx
@@ -416,6 +416,12 @@ ProjectClassifyPage.propTypes = {
   workflow: PropTypes.object
 };
 
+ProjectClassifyPage.defaultProps = {
+  location: {
+    query: {}
+  }
+};
+
 
 // For debugging:
 window.currentWorkflowForProject = currentWorkflowForProject;

--- a/app/pages/project/project-page.spec.js
+++ b/app/pages/project/project-page.spec.js
@@ -144,6 +144,7 @@ describe('ProjectPage', function () {
           </ProjectPage>,
           { context: { geordi }}
         );
+        geordiRememberSpy.resetHistory();
         wrapper.setProps({ project: newProject });
       });
 

--- a/app/talk/active-users.spec.js
+++ b/app/talk/active-users.spec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import assert from 'assert';
+import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import sinon from 'sinon';
 import ActiveUsers from './active-users';
@@ -11,19 +11,40 @@ const users = [
 ];
 
 describe('ActiveUsers', function () {
-  const getActiveIdsStub = sinon.stub(ActiveUsers.prototype, 'getActiveUserIds').callsFake(() => Promise.resolve(activeIds));
-  const fetchUsersSpy = sinon.spy(ActiveUsers.prototype, 'fetchUncachedUsers');
-  const pageCountSpy = sinon.spy(ActiveUsers.prototype, 'pageCount');
-  const boundedPageSpy = sinon.spy(ActiveUsers.prototype, 'boundedPage');
-  const userIdSpy = sinon.spy(ActiveUsers.prototype, 'userIdsOnPage');
-  const wrapper = shallow(<ActiveUsers />);
-  wrapper.setState({ users });
+  let getActiveIdsStub;
+  let fetchUsersSpy;
+  let pageCountSpy;
+  let boundedPageSpy;
+  let userIdSpy;
+  let wrapper;
+
+  before(function () {
+    getActiveIdsStub = sinon.stub(ActiveUsers.prototype, 'getActiveUserIds').callsFake(() => Promise.resolve(activeIds));
+    fetchUsersSpy = sinon.spy(ActiveUsers.prototype, 'fetchUncachedUsers');
+    pageCountSpy = sinon.spy(ActiveUsers.prototype, 'pageCount');
+    boundedPageSpy = sinon.spy(ActiveUsers.prototype, 'boundedPage');
+    userIdSpy = sinon.spy(ActiveUsers.prototype, 'userIdsOnPage');
+    wrapper = shallow(<ActiveUsers />);
+    wrapper.setState({ users });
+  });
+
+  after(function () {
+    const spies = [
+      getActiveIdsStub,
+      fetchUsersSpy,
+      pageCountSpy,
+      boundedPageSpy,
+      userIdSpy
+    ];
+    spies.forEach(spy => spy.restore());
+  });
 
   it('should render without crashing', function() {
+    expect(wrapper.instance()).to.be.instanceOf(ActiveUsers);
   });
 
   it('should render the correct number of users', function() {
-    assert.equal(wrapper.find('li').length, 2);
+    expect(wrapper.find('li')).to.have.lengthOf(2);
   });
 
   it('should call all expected functions on mount', function() {

--- a/app/talk/active-users.spec.js
+++ b/app/talk/active-users.spec.js
@@ -11,13 +11,12 @@ const users = [
 ];
 
 describe('ActiveUsers', function () {
+  const getActiveIdsStub = sinon.stub(ActiveUsers.prototype, 'getActiveUserIds').callsFake(() => Promise.resolve(activeIds));
+  const fetchUsersSpy = sinon.spy(ActiveUsers.prototype, 'fetchUncachedUsers');
+  const pageCountSpy = sinon.spy(ActiveUsers.prototype, 'pageCount');
+  const boundedPageSpy = sinon.spy(ActiveUsers.prototype, 'boundedPage');
+  const userIdSpy = sinon.spy(ActiveUsers.prototype, 'userIdsOnPage');
   const wrapper = shallow(<ActiveUsers />);
-  const controller = wrapper.instance();
-  const getActiveIdsStub = sinon.stub(controller, 'getActiveUserIds').callsFake(() => Promise.resolve(activeIds));
-  const fetchUsersSpy = sinon.spy(controller, 'fetchUncachedUsers');
-  const pageCountSpy = sinon.spy(controller, 'pageCount');
-  const boundedPageSpy = sinon.spy(controller, 'boundedPage');
-  const userIdSpy = sinon.spy(controller, 'userIdsOnPage');
   wrapper.setState({ users });
 
   it('should render without crashing', function() {
@@ -27,11 +26,7 @@ describe('ActiveUsers', function () {
     assert.equal(wrapper.find('li').length, 2);
   });
 
-  before(function () {
-    controller.update();
-  });
-
-  it('should call all expected functions with update()', function() {
+  it('should call all expected functions on mount', function() {
     sinon.assert.calledOnce(getActiveIdsStub);
     sinon.assert.calledOnce(boundedPageSpy);
     sinon.assert.calledOnce(userIdSpy);

--- a/test/enzyme-configuration.js
+++ b/test/enzyme-configuration.js
@@ -2,6 +2,5 @@ import Enzyme from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 
 Enzyme.configure({
-  adapter: new Adapter(),
-  disableLifecycleMethods: true
+  adapter: new Adapter()
 });

--- a/test/fake-api-client.js
+++ b/test/fake-api-client.js
@@ -11,7 +11,7 @@ export class FakeResource {
       return Promise.resolve(this);
     }
     else {
-      return new Promise((resolve, reject) => { reject(new Error("Save failed!")); });
+      return Promise.reject(new Error("Save failed!"));
     }
   }
 }


### PR DESCRIPTION
Staging branch URL: https://enzyme-lifecycle-tests.pfe-preview.zooniverse.org

Fixes #4794 

Turns on lifecycle method testing and fixes broken tests.

With this PR, `shallow()` in Enzyme 3 runs `componentDidMount`. This broke some tests that ran `componentDidMount()` manually. It also means any spies that spy on method calls during mount must be defined before running `shallow()`, not after. There were also some components where `componentDidMount` broke if called with the default component props.

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [x] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
