### PR TITLE
Add workflow ID to lists and data export

### DIFF
--- a/app/pages/lab/export-workflows-dialog.jsx
+++ b/app/pages/lab/export-workflows-dialog.jsx
@@ -141,6 +141,7 @@ const ExportWorkflowListItem = ({ workflow, media, onChange, workflowError }) =>
           onChange={onChange}
         />
         {workflow.display_name}
+        {' '}(#{workflow.id})
         <small>
           {myMedia &&
             <a

--- a/app/pages/lab/workflows-table.jsx
+++ b/app/pages/lab/workflows-table.jsx
@@ -36,6 +36,7 @@ const WorkflowsTable = ({
               <td>
                 <Link key={workflow.id} to={labPath(`/workflows/${workflow.id}`)} activeClassName="active">
                   {workflow.display_name}
+                  {' '}(#{workflow.id})
                   {(project.configuration && workflow.id === project.configuration.default_workflow) && (
                     <span title="Default workflow">{' '}*{' '}</span>
                   )}

--- a/app/pages/lab/workflows.jsx
+++ b/app/pages/lab/workflows.jsx
@@ -20,6 +20,7 @@ const WorkflowsPage = (props) => {
       <li key={workflow.id}>
         <Link key={workflow.id} to={props.labPath(`/workflows/${workflow.id}`)} className="nav-list-item" activeClassName="active">
           {workflow.display_name}
+          {' '}(#{workflow.id})
           {(props.project.configuration && workflow.id === props.project.configuration.default_workflow) && (
             <span title="Default workflow">{' '}*{' '}</span>
           )}


### PR DESCRIPTION
Staging branch URL: https://add-workflow-id-lab.pfe-preview.zooniverse.org/

Fixes #4785.

Adds workflow ID to list item already displaying workflow display name, in similar way to how subject sets are listed within workflow editor.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
