### PR TITLE
Actually remove workflow default setting if active status is toggled to inactive

### DIFF
--- a/app/pages/lab/workflows-container.jsx
+++ b/app/pages/lab/workflows-container.jsx
@@ -60,7 +60,7 @@ export default class WorkflowsContainer extends React.Component {
   }
 
   handleWorkflowStatusChange(e, page, workflow) {
-    const defaultWorkflow = (this.props.project && this.props.project.configuration.default_workflow) ?
+    const defaultWorkflow = (this.props.project && this.props.project.configuration && this.props.project.configuration.default_workflow) ?
       this.props.project.configuration.default_workflow : null;
     const checked = e.target.checked;
     workflow.update({ active: checked }).save()

--- a/app/pages/lab/workflows-container.jsx
+++ b/app/pages/lab/workflows-container.jsx
@@ -3,8 +3,8 @@ import React from 'react';
 import getWorkflowsInOrder from '../../lib/get-workflows-in-order';
 
 export default class WorkflowsContainer extends React.Component {
-  constructor(props) {
-    super(props);
+  constructor() {
+    super();
     this.state = {
       loading: true,
       reorder: false,
@@ -60,19 +60,18 @@ export default class WorkflowsContainer extends React.Component {
   }
 
   handleWorkflowStatusChange(e, page, workflow) {
-    const defaultWorkflow = (this.props.projectConfiguration && this.props.projectConfiguration.default_workflow) ?
-      this.props.projectConfiguration.default_workflow : null;
+    const defaultWorkflow = (this.props.project && this.props.project.configuration.default_workflow) ?
+      this.props.project.configuration.default_workflow : null;
     const checked = e.target.checked;
     workflow.update({ active: checked }).save()
-      .catch(error => console.log(error))
-      .then(() => {
+      .then((workflow) => {
         this.props.project.uncache();
         if (!workflow.active && workflow.id === defaultWorkflow) {
-          this.props.project.update({ 'configuration.default_workflow': null });
-          this.props.project.save();
+          this.props.project.update({ 'configuration.default_workflow': null }).save();
         }
       })
-      .then(() => this.getWorkflowList(page));
+      .then(() => this.getWorkflowList(page))
+      .catch (error => console.log(error));
   }
 
   handleWorkflowStatsVisibility(e, page, workflow) {
@@ -148,17 +147,8 @@ WorkflowsContainer.contextTypes = {
   router: PropTypes.object.isRequired
 };
 
-WorkflowsContainer.defaultProps = {
-  project: {
-    configuration: {}
-  }
-};
-
 WorkflowsContainer.propTypes = {
   children: PropTypes.node,
-  projectConfiguration: PropTypes.shape({
-    default_workflow: PropTypes.string
-  }),
   location: PropTypes.shape({
     pathname: PropTypes.string,
     query: PropTypes.object

--- a/app/pages/lab/workflows-container.jsx
+++ b/app/pages/lab/workflows-container.jsx
@@ -71,7 +71,7 @@ export default class WorkflowsContainer extends React.Component {
         }
       })
       .then(() => this.getWorkflowList(page))
-      .catch (error => console.log(error));
+      .catch(error => console.log(error));
   }
 
   handleWorkflowStatsVisibility(e, page, workflow) {


### PR DESCRIPTION
Staging branch URL: https://fix-4789.pfe-preview.zooniverse.org/

Fixes #4789 and #4431.

I was wrong about what was going wrong here. I thought the lab code was still written to only remove a workflow from being default if the project was live. That got changed a while ago. The issue was in the checkbox click event handler. `defaultWorkflow` was always null because `props.projectConfiguration` isn't a prop that is being passed down, but there was a ternary conditional checking for it being defined, so it never threw since the variable was just always set as null. Not sure how that got through PR review 🤦‍♀️. Anyway, the conditional to check to see whether or not the default workflow should be unset was always false until now. 

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
