### PR TITLE
Autoplay tutorial videos

### DIFF
--- a/app/components/media-card.jsx
+++ b/app/components/media-card.jsx
@@ -13,7 +13,13 @@ const MediaCard = ({ children, className, src, style }) => {
     renderType = <Thumbnail alt="" className="media-card-media" width={800} src={src} />;
   } else if (VIDEO_EXTENSIONS.includes(srcExtension)) {
     renderType = (
-      <video className="media-card-media" src={src}>
+      <video
+        className="media-card-media"
+        autoPlay
+        loop
+        controls
+        src={src}
+      >
         <p>Your browser does not support this video format.</p>
       </video>
     );


### PR DESCRIPTION
Tutorials support mp4 video as attached media via the MediaCard component, but don't show any play controls. This adds autoplay, controls and loop to media card videos.

Staging branch URL: https://tutorial-videos.pfe-preview.zooniverse.org/

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
