### PR TITLE
Add single question feedback types

### DIFF
--- a/app/features/feedback/shared/strategies/index.js
+++ b/app/features/feedback/shared/strategies/index.js
@@ -1,7 +1,9 @@
-import radial from './radial';
 import dud from './dud';
+import singleAnswerQuestion from './single-answer-question';
+import radial from './radial';
 
 export default {
   dud,
+  singleAnswerQuestion,
   radial
 };

--- a/app/features/feedback/shared/strategies/single-answer-question/README.md
+++ b/app/features/feedback/shared/strategies/single-answer-question/README.md
@@ -1,0 +1,10 @@
+# Feedback Strategy: Single Answer Question
+
+Determines whether the user has correctly answered a question with a single answer, or no answer.
+
+## Subject metadata fields
+
+- `#feedback_N_id` (**required**) - ID of the corresponding workflow task rule.
+- `#feedback_N_answer` (**required**) - index of the correct answer for the corresponding workflow task. Like the answers, this should be zero-indexed, so if the first answer is the correct one, this value should be `0`; if the second answer, `1`, and so on. Setting this to `-1` means there should be no answer, if an answer isn't required.
+- `#feedback_N_successMessage` (optional) - message to show when the target is correctly annotated. Overrides the default success message set on the workflow task rule.
+- `#feedback_N_failureMessage` (optional) - message to show when the target is incorrectly annotated. Overrides the default failure message set on the workflow task rule.

--- a/app/features/feedback/shared/strategies/single-answer-question/create-rule.js
+++ b/app/features/feedback/shared/strategies/single-answer-question/create-rule.js
@@ -1,0 +1,25 @@
+import ruleChecker from '../../helpers/rule-checker';
+
+function createRule(subjectRule, workflowRule) {
+  const rule = {
+    answer: subjectRule.answer,
+    failureEnabled: workflowRule.failureEnabled || false,
+    id: subjectRule.id,
+    strategy: workflowRule.strategy,
+    successEnabled: workflowRule.successEnabled || false
+  };
+
+  if (rule.failureEnabled) {
+    rule.failureMessage = subjectRule.failureMessage ||
+      workflowRule.defaultFailureMessage;
+  }
+
+  if (rule.successEnabled) {
+    rule.successMessage = subjectRule.successMessage ||
+      workflowRule.defaultSuccessMessage;
+  }
+
+  return ruleChecker(rule);
+}
+
+export default createRule;

--- a/app/features/feedback/shared/strategies/single-answer-question/create-rule.spec.js
+++ b/app/features/feedback/shared/strategies/single-answer-question/create-rule.spec.js
@@ -1,0 +1,111 @@
+import chai from 'chai'
+
+import createRule from './create-rule'
+
+const expect = chai.expect
+
+describe('Feedback > Single Answer Question > Rule Creator', function () {
+  it('should create a rule with `failureEnabled` and `successEnabled` defaulting to false', function () {
+    const subjectRule = { answer: '1', id: '2' }
+    const workflowRule = { strategy: '3' }
+    const rule = createRule(subjectRule, workflowRule)
+    expect(rule.failureEnabled).to.be.false
+    expect(rule.successEnabled).to.be.false
+  })
+
+  it('should create a rule with the right properties derived from the workflow', function () {
+    const subjectRule = { answer: '1', id: '2' }
+    const workflowRule = {
+      failureEnabled: true,
+      defaultFailureMessage: 'failure',
+      defaultSuccessMessage: 'success',
+      strategy: '3',
+      successEnabled: true,
+    }
+    const rule = createRule(subjectRule, workflowRule)
+    expect(rule.failureEnabled).to.equal(workflowRule.failureEnabled)
+    expect(rule.failureMessage).to.equal(workflowRule.defaultFailureMessage)
+    expect(rule.strategy).to.equal(workflowRule.strategy)
+    expect(rule.successEnabled).to.equal(workflowRule.successEnabled)
+    expect(rule.successMessage).to.equal(workflowRule.defaultSuccessMessage)
+  })
+
+  it('should create a rule with the right properties derived from the subject metadata', function () {
+    const subjectRule = { answer: '1', id: '2' }
+    const workflowRule = { strategy: '3' }
+    const rule = createRule(subjectRule, workflowRule)
+    expect(rule.answer).to.equal(subjectRule.answer)
+    expect(rule.id).to.equal(subjectRule.id)
+  })
+
+  it('should use the success and failure messages from the subject if available', function () {
+    const subjectRule = {
+      answer: '1',
+      failureMessage: 'failure on subject',
+      id: '2',
+      successMessage: 'success on subject',
+    }
+
+    const workflowRule = {
+      failureEnabled: true,
+      defaultFailureMessage: 'failure',
+      defaultSuccessMessage: 'success',
+      strategy: '3',
+      successEnabled: true,
+    }
+    const rule = createRule(subjectRule, workflowRule)
+    expect(rule.failureMessage).to.equal(subjectRule.failureMessage)
+    expect(rule.successMessage).to.equal(subjectRule.successMessage)
+  })
+
+  describe('behaviour when a required property is missing', function () {
+    const BASE_SUBJECT_RULE = { answer: '1', id: '2' }
+    const BASE_WORKFLOW_RULE = {
+      failureEnabled: true,
+      defaultFailureMessage: 'failure',
+      defaultSuccessMessage: 'success',
+      strategy: '3',
+      successEnabled: true,
+    }
+
+    it('should return an empty object if `answer` is missing', function () {
+      const subjectRule = Object.assign({}, BASE_SUBJECT_RULE)
+      const workflowRule = Object.assign({}, BASE_WORKFLOW_RULE)
+      delete subjectRule.answer
+      const rule = createRule(subjectRule, workflowRule)
+      expect(rule).to.deep.equal({})
+    })
+
+    it('should return an empty object if `id` is missing', function () {
+      const subjectRule = Object.assign({}, BASE_SUBJECT_RULE)
+      const workflowRule = Object.assign({}, BASE_WORKFLOW_RULE)
+      delete subjectRule.id
+      const rule = createRule(subjectRule, workflowRule)
+      expect(rule).to.deep.equal({})
+    })
+
+    it('should return an empty object if `strategy` is missing', function () {
+      const subjectRule = Object.assign({}, BASE_SUBJECT_RULE)
+      const workflowRule = Object.assign({}, BASE_WORKFLOW_RULE)
+      delete workflowRule.strategy
+      const rule = createRule(subjectRule, workflowRule)
+      expect(rule).to.deep.equal({})
+    })
+
+    it('should return an empty object if failure is enabled and `failureMessage` is missing', function () {
+      const subjectRule = Object.assign({}, BASE_SUBJECT_RULE)
+      const workflowRule = Object.assign({}, BASE_WORKFLOW_RULE)
+      delete workflowRule.defaultFailureMessage
+      const rule = createRule(subjectRule, workflowRule)
+      expect(rule).to.deep.equal({})
+    })
+
+    it('should return an empty object if success is enabled and `successMessage` is missing', function () {
+      const subjectRule = Object.assign({}, BASE_SUBJECT_RULE)
+      const workflowRule = Object.assign({}, BASE_WORKFLOW_RULE)
+      delete workflowRule.defaultSuccessMessage
+      const rule = createRule(subjectRule, workflowRule)
+      expect(rule).to.deep.equal({})
+    })
+  })
+})

--- a/app/features/feedback/shared/strategies/single-answer-question/index.js
+++ b/app/features/feedback/shared/strategies/single-answer-question/index.js
@@ -1,0 +1,11 @@
+import reducer from './reducer';
+import createRule from './create-rule';
+
+export default {
+  createRule,
+  id: 'singleAnswerQuestion',
+  title: 'Single Answer Question',
+  labComponent: null,
+  validations: null,
+  reducer
+};

--- a/app/features/feedback/shared/strategies/single-answer-question/index.spec.js
+++ b/app/features/feedback/shared/strategies/single-answer-question/index.spec.js
@@ -1,0 +1,31 @@
+import chai from 'chai'
+
+import index from './index'
+
+const expect = chai.expect
+
+describe('Feedback > Single Answer Question > Index', function () {
+  it('should have a `createRule` property', function () {
+    expect(index.createRule).to.be.a('function')
+  })
+
+  it('should have a `id` property', function () {
+    expect(index.id).to.equal('singleAnswerQuestion')
+  })
+
+  it('should have a `title` property', function () {
+    expect(index.title).to.equal('Single Answer Question')
+  })
+
+  it('should have a `labComponent` property', function () {
+    expect(index.labComponent).to.equal(null)
+  })
+
+  it('should have a `validations` property', function () {
+    expect(index.validations).to.equal(null)
+  })
+
+  it('should have a `reducer` property', function () {
+    expect(index.reducer).to.be.a('function')
+  })
+})

--- a/app/features/feedback/shared/strategies/single-answer-question/reducer.js
+++ b/app/features/feedback/shared/strategies/single-answer-question/reducer.js
@@ -1,0 +1,11 @@
+import _ from 'lodash';
+
+function singleAnswerQuestionReducer(rule, annotations) {
+  const answerId = annotations || -1
+  const result = rule.answer === answerId.toString()
+  return _.assign({}, rule, {
+    success: result
+  });
+}
+
+export default singleAnswerQuestionReducer;

--- a/app/features/feedback/shared/strategies/single-answer-question/reducer.spec.js
+++ b/app/features/feedback/shared/strategies/single-answer-question/reducer.spec.js
@@ -1,0 +1,37 @@
+import chai from 'chai'
+
+import reducer from './reducer'
+
+const expect = chai.expect
+
+describe('Feedback > Single Answer Question > Reducer', function () {
+  it('should not mutate the original object', function () {
+    const original = { answer: '0' }
+    const reduced = reducer(original)
+    expect(reduced).to.not.equal(original)
+  })
+
+  it('should handle a correct answer', function () {
+    const rule = { answer: '1' }
+    const result = reducer(rule, 1)
+    expect(result.success).to.be.true
+  })
+
+  it('should handle an incorrect answer', function () {
+    const rule = { answer: '0' }
+    const result = reducer(rule, 1)
+    expect(result.success).to.be.false
+  })
+
+  it('should handle a correct empty answer', function () {
+    const rule = { answer: '-1' }
+    const result = reducer(rule, undefined)
+    expect(result.success).to.be.true
+  })
+
+  it('should handle an incorrect empty answer', function () {
+    const rule = { answer: '0' }
+    const result = reducer(rule, undefined)
+    expect(result.success).to.be.false
+  })
+})


### PR DESCRIPTION
Staging branch URL: https://question-feedback.pfe-preview.zooniverse.org/projects/rogerhutchings/feedback-test/ and choose the `Single Question Answer` workflow

Adds a feedback strategy for single question answers, including duds. Instructions are all in the README. It was actually all pretty straightforward - I can see potential issues with using the answer ID rather than the actual answer value, since the workflow can change; but that would be true of using the actual answer string as well, so I think it's legit.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
