### PR TITLE
Link survey thumbnail size to number of choice columns

### DIFF
--- a/app/classifier/tasks/survey/chooser/Choices.jsx
+++ b/app/classifier/tasks/survey/chooser/Choices.jsx
@@ -45,16 +45,21 @@ class Choices extends React.Component {
   }
 
   whatSizeThumbnails({ length }) {
-    if (length <= 5) {
-      return 'large';
-    } else if (length <= 10) {
-      return 'medium';
-    } else if (length <= 20) {
+    if (this.props.task.alwaysShowThumbnails) {
       return 'small';
-    } else if (this.props.task.alwaysShowThumbnails) {
-      return 'small';
-    } else {
+    }
+    if (length > 30) {
       return 'none';
+    }
+    switch (this.howManyColumns({ length })) {
+      case 1:
+        return 'large';
+      case 2:
+        return 'medium';
+      case 3:
+        return 'small';
+      default:
+        return 'none';
     }
   }
 


### PR DESCRIPTION
Link thumbnail size to number of columns: 1 = large, 2 = medium, 3 = small.
Don't show thumbnails for more than 30 choices.
Always show small thumbnails if task.alwaysShowThumbnails is set.

Staging branch URL: https://survey-thumbnails.pfe-preview.zooniverse.org/projects/meredithspalmer/snapshot-grumeti/classify?env=production

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
