### PR TITLE
Update to latest Seven-Ten-Client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -424,11 +424,12 @@
       "dev": true
     },
     "axios": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.11.1.tgz",
-      "integrity": "sha1-Oc22WBPixUnRwunDiffjOqZcyiI=",
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.16.2.tgz",
+      "integrity": "sha1-uk+S8XFn37q0CYN4VFS5rBScPG0=",
       "requires": {
-        "follow-redirects": "0.0.7"
+        "follow-redirects": "^1.2.3",
+        "is-buffer": "^1.1.5"
       }
     },
     "babel-cli": {
@@ -3150,6 +3151,7 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
       "requires": {
         "ms": "2.0.0"
       },
@@ -3157,7 +3159,8 @@
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         }
       }
     },
@@ -3323,11 +3326,11 @@
       }
     },
     "devour-client": {
-      "version": "1.3.9",
-      "resolved": "https://registry.npmjs.org/devour-client/-/devour-client-1.3.9.tgz",
-      "integrity": "sha1-ikVplngjs3zahCbSqQGqEc74wY0=",
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/devour-client/-/devour-client-2.0.13.tgz",
+      "integrity": "sha512-2gUSerNm5NqeV/nfarrxI+Cla/C8V9ZB5ebQo9Japa5e4WAJE/Rdoi6cd/L63szgs/BIl9B6PQBSfQjS8p0Lyg==",
       "requires": {
-        "axios": "^0.11.0",
+        "axios": "^0.16.2",
         "es6-promise": "^3.1.2",
         "lodash": "^4.11.2",
         "minilog": "^3.0.0",
@@ -5791,12 +5794,21 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-0.0.7.tgz",
-      "integrity": "sha1-NLkLqyqRGqNHVx2pDyK9NuzYqRk=",
+      "version": "1.5.7",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.7.tgz",
+      "integrity": "sha512-NONJVIFiX7Z8k2WxfqBjtwqMifx7X42ORLFrOZ2LTKGj71G3C0kfdyTqGqr8fx5zSX6Foo/D95dgGWbPUiwnew==",
       "requires": {
-        "debug": "^2.2.0",
-        "stream-consume": "^0.1.0"
+        "debug": "^3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "for-in": {
@@ -7409,8 +7421,7 @@
     "is-buffer": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-      "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
-      "dev": true
+      "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw="
     },
     "is-builtin-module": {
       "version": "1.0.0",
@@ -11539,11 +11550,11 @@
       "dev": true
     },
     "seven-ten": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/seven-ten/-/seven-ten-3.3.0.tgz",
-      "integrity": "sha512-6FpL2GC0O3FrGzu5x+BLMtHl8ryJGgPTvcvp4BSjwTWrY6fkpydOLF6jVosGeLxWG9K6JRuZpD2S6gisEQMcAA==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/seven-ten/-/seven-ten-3.3.1.tgz",
+      "integrity": "sha512-Fl4phB4t9ePmG2bVh4AwxVaLZ57+B3+ttemNQLjiQFv/BA1QTOao+5lLeuIzFTi89wIkkF2AJGCYjbdJsWNDVA==",
       "requires": {
-        "devour-client": "~1.3.9"
+        "devour-client": "~2.0.13"
       }
     },
     "sha.js": {
@@ -12110,11 +12121,6 @@
           }
         }
       }
-    },
-    "stream-consume": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.1.tgz",
-      "integrity": "sha512-tNa3hzgkjEP7XbCkbRXe1jpg+ievoa0O4SCFlMOYEscGSS4JJsckGL8swUyAa/ApGU3Ae4t6Honor4HhL+tRyg=="
     },
     "stream-http": {
       "version": "2.8.3",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "redux": "~3.6.0",
     "redux-thunk": "~2.2.0",
     "regl": "~1.3.0",
-    "seven-ten": "~3.3.0",
+    "seven-ten": "~3.3.1",
     "shortid": "~2.2.8",
     "sinon": "~4.1.5",
     "sort-into-columns": "~1.0.0",


### PR DESCRIPTION
Staging branch URL: https://update-seven-ten-client.pfe-preview.zooniverse.org/

Updates to the latest version of the seven-ten client which includes updated dependencies to resolve a TypeError being thrown by the client. 

This project had a TypeError thrown, but is now resolved: 
https://update-seven-ten-client.pfe-preview.zooniverse.org/projects/srallen086/srallen-testing

compared to master:
https://master.pfe-preview.zooniverse.org/projects/srallen086/srallen-testing


# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
