### PR TITLE
Allow volunteers to turn off intervention messages

### DIFF
--- a/app/classifier/classifier.jsx
+++ b/app/classifier/classifier.jsx
@@ -252,18 +252,16 @@ class Classifier extends React.Component {
     if (!isCmdClick) {
       e.preventDefault();
     }
-    classification.update({
-      'metadata.viewport': {
+    actions.classify.updateClassification({
+      viewport: {
         width: innerWidth,
         height: innerHeight
       },
-      'metadata.interventions': {
+      interventions: {
         message: showIntervention,
         opt_in: user && user.intervention_notifications
       }
     });
-
-
     return this.checkForFeedback(taskKey)
       .then(() => {
         actions.classify.completeClassification(annotations);

--- a/app/classifier/classifier.jsx
+++ b/app/classifier/classifier.jsx
@@ -262,13 +262,14 @@ class Classifier extends React.Component {
   }
 
   completeClassification(e) {
+    const { classification, onComplete, interventions, project, subject, user, workflow } = this.props;
     const originalElement = e.currentTarget;
     const isCmdClick = e.metaKey;
     // don't swallow cmd-click on links
     if (!isCmdClick) {
       e.preventDefault();
     }
-    this.props.classification.update({
+    classification.update({
       annotations: this.processAnnotations(this.state.annotations.slice()),
       'metadata.session': getSessionID(),
       'metadata.finished_at': (new Date()).toISOString(),
@@ -282,15 +283,16 @@ class Classifier extends React.Component {
     let workflowHistory = this.state.workflowHistory.slice();
     const taskKey = workflowHistory[workflowHistory.length - 1];
 
-    const showIntervention = (this.props.interventions.notifications.length > 0);
-    const showSummary = !this.props.workflow.configuration.hide_classification_summaries ||
+    const showIntervention = user &&
+      user.intervention_notifications &&
+      (interventions.notifications.length > 0);
+    const showSummary = !workflow.configuration.hide_classification_summaries ||
       this.subjectIsGravitySpyGoldStandard();
     const showLastStep = showIntervention || showSummary;
 
-    const { onComplete, project, subject } = this.props;
     return this.checkForFeedback(taskKey)
       .then(() => {
-        this.props.classification.update({ completed: true });
+        classification.update({ completed: true });
         if (!showIntervention && !isCmdClick && originalElement.href) {
           const subjectTalkPath = `/projects/${project.slug}/talk/subjects/${subject.id}`;
           browserHistory.push(subjectTalkPath);
@@ -320,7 +322,7 @@ class Classifier extends React.Component {
   }
 
   render() {
-    const { interventions } = this.props;
+    const { interventions, user } = this.props;
     const { showIntervention, showSummary, workflowHistory } = this.state;
     const currentTaskKey = workflowHistory.length > 0 ? workflowHistory[workflowHistory.length - 1] : null;
     const largeFormatImage = this.props.workflow.configuration.image_layout && this.props.workflow.configuration.image_layout.includes('no-max-height');

--- a/app/classifier/classifier.jsx
+++ b/app/classifier/classifier.jsx
@@ -381,6 +381,7 @@ class Classifier extends React.Component {
             {showIntervention &&
               <Intervention
                 notifications={interventions.notifications}
+                user={user}
               />
             }
             {currentTaskKey &&

--- a/app/classifier/classifier.jsx
+++ b/app/classifier/classifier.jsx
@@ -258,8 +258,8 @@ class Classifier extends React.Component {
         height: innerHeight
       },
       interventions: {
-        message: showIntervention,
-        opt_in: user && user.intervention_notifications
+        message: !!showIntervention,
+        opt_in: !!user && user.intervention_notifications
       }
     });
     return this.checkForFeedback(taskKey)

--- a/app/classifier/classifier.jsx
+++ b/app/classifier/classifier.jsx
@@ -265,6 +265,17 @@ class Classifier extends React.Component {
     const { classification, onComplete, interventions, project, subject, user, workflow } = this.props;
     const originalElement = e.currentTarget;
     const isCmdClick = e.metaKey;
+    const annotations = this.state.annotations.slice();
+    let workflowHistory = this.state.workflowHistory.slice();
+    const taskKey = workflowHistory[workflowHistory.length - 1];
+
+    const showIntervention = user &&
+      user.intervention_notifications &&
+      (interventions.notifications.length > 0);
+    const showSummary = !workflow.configuration.hide_classification_summaries ||
+      this.subjectIsGravitySpyGoldStandard();
+    const showLastStep = showIntervention || showSummary;
+
     // don't swallow cmd-click on links
     if (!isCmdClick) {
       e.preventDefault();
@@ -276,19 +287,13 @@ class Classifier extends React.Component {
       'metadata.viewport': {
         width: innerWidth,
         height: innerHeight
+      },
+      'metadata.interventions': {
+        message: showIntervention,
+        opt_in: user && user.intervention_notifications
       }
     });
 
-    const annotations = this.state.annotations.slice();
-    let workflowHistory = this.state.workflowHistory.slice();
-    const taskKey = workflowHistory[workflowHistory.length - 1];
-
-    const showIntervention = user &&
-      user.intervention_notifications &&
-      (interventions.notifications.length > 0);
-    const showSummary = !workflow.configuration.hide_classification_summaries ||
-      this.subjectIsGravitySpyGoldStandard();
-    const showLastStep = showIntervention || showSummary;
 
     return this.checkForFeedback(taskKey)
       .then(() => {

--- a/app/classifier/classifier.spec.js
+++ b/app/classifier/classifier.spec.js
@@ -3,23 +3,14 @@ import PropTypes from 'prop-types';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { shallow } from 'enzyme';
-import apiClient from 'panoptes-client/lib/api-client';
 import { Classifier } from './classifier';
 import FakeLocalStorage from '../../test/fake-local-storage';
+import mockPanoptesResource from '../../test/mock-panoptes-resource';
 
 global.innerWidth = 1000;
 global.innerHeight = 1000;
 global.sessionStorage = new FakeLocalStorage();
 sessionStorage.setItem('session_id', JSON.stringify({ id: 0, ttl: 0 }));
-
-function mockPanoptesResource(type, options) {
-  const resource = apiClient.type(type).create(options);
-  apiClient._typesCache = {};
-  sinon.stub(resource, 'save').callsFake(() => Promise.resolve(resource));
-  sinon.stub(resource, 'get');
-  sinon.stub(resource, 'delete');
-  return resource;
-}
 
 const store = {
   subscribe: () => { },

--- a/app/classifier/classifier.spec.js
+++ b/app/classifier/classifier.spec.js
@@ -158,10 +158,19 @@ describe('Classifier', function () {
   describe('on completing a classification', function () {
     let checkForFeedback;
     let fakeEvent;
+    const actions = {
+      classify: {
+        completeClassification: sinon.stub()
+      },
+      interventions: {
+        dismiss: sinon.stub()
+      }
+    };
     beforeEach(function () {
       checkForFeedback = sinon.stub(Classifier.prototype, 'checkForFeedback').callsFake(() => Promise.resolve());
       wrapper = shallow(
         <Classifier
+          actions={actions}
           classification={classification}
           subject={subject}
           onComplete={classification.save}
@@ -178,6 +187,14 @@ describe('Classifier', function () {
       checkForFeedback.restore();
     });
 
+    it('should complete the classification', function (done) {
+      wrapper.setProps({ workflow });
+      wrapper.instance().completeClassification(fakeEvent).then(function () {
+        const { annotations } = wrapper.state();
+        expect(actions.classify.completeClassification.calledWith(annotations)).to.be.true;
+        done();
+      });
+    });
     describe('with summaries enabled', function () {
       it('should display a classification summary', function (done) {
         wrapper.setProps({ workflow });
@@ -185,8 +202,6 @@ describe('Classifier', function () {
         .then(function () {
           wrapper.update();
           const state = wrapper.state();
-          expect(classification.completed).to.equal(true);
-          expect(state.annotations).to.deep.equal(classification.annotations);
           expect(wrapper.find('ClassificationSummary')).to.have.lengthOf(1);
         })
         .then(done, done);
@@ -201,8 +216,6 @@ describe('Classifier', function () {
         .then(function () {
           wrapper.update();
           const state = wrapper.state();
-          expect(state.annotations).to.deep.equal(classification.annotations);
-          expect(classification.completed).to.equal(true);
           expect(wrapper.find('ClassificationSummary')).to.have.lengthOf(0);
         })
         .then(done, done);
@@ -226,6 +239,9 @@ describe('Classifier', function () {
         active: true
       };
       const actions = {
+        classify: {
+          completeClassification: sinon.stub()
+        },
         feedback: {
           init: feedbackInitSpy,
           update: feedbackUpdateSpy

--- a/app/classifier/components/Intervention/Intervention.jsx
+++ b/app/classifier/components/Intervention/Intervention.jsx
@@ -1,12 +1,22 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-function Intervention({ notifications }) {
+function Intervention({ notifications, user }) {
   const notification = notifications[notifications.length - 1];
   const { message } = notification.data;
+  function optOut() {
+    user
+      .update({ intervention_notifications: false })
+      .save();
+  }
   return (
     <div>
       <p>{message}</p>
+      <button
+        onClick={optOut}
+      >
+        Don&apos;t show me these messages again
+      </button>
     </div>
   );
 }
@@ -16,7 +26,10 @@ Intervention.propTypes = {
     data: PropTypes.shape({
       message: PropTypes.string
     })
-  })).isRequired
+  })).isRequired,
+  user: PropTypes.shape({
+    intervention_notifications: PropTypes.bool
+  }).isRequired
 };
 
 export default Intervention;

--- a/app/classifier/components/Intervention/Intervention.jsx
+++ b/app/classifier/components/Intervention/Intervention.jsx
@@ -1,6 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import counterpart from 'counterpart';
+import styled from 'styled-components';
+
+const StyledInterventionMessage = styled.div`
+  padding: 0 2em;
+`;
 
 function Intervention({ notifications, user }) {
   const notification = notifications[notifications.length - 1];
@@ -14,17 +19,18 @@ function Intervention({ notifications, user }) {
       .save();
   }
   return (
-    <div>
+    <StyledInterventionMessage>
       <p>{message}</p>
       <label>
         <input
           ref={checkbox}
+          autoFocus={true}
           type="checkbox"
           onChange={onChange}
         />
         {counterpart('classifier.interventions.optOut')}
       </label>
-    </div>
+    </StyledInterventionMessage>
   );
 }
 

--- a/app/classifier/components/Intervention/Intervention.jsx
+++ b/app/classifier/components/Intervention/Intervention.jsx
@@ -1,22 +1,29 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import counterpart from 'counterpart';
 
 function Intervention({ notifications, user }) {
   const notification = notifications[notifications.length - 1];
   const { message } = notification.data;
-  function optOut() {
+  const checkbox = React.createRef();
+
+  function onChange() {
+    // Invert the checked value because true means do not send me messages.
     user
-      .update({ intervention_notifications: false })
+      .update({ intervention_notifications: !checkbox.current.checked })
       .save();
   }
   return (
     <div>
       <p>{message}</p>
-      <button
-        onClick={optOut}
-      >
-        Don&apos;t show me these messages again
-      </button>
+      <label>
+        <input
+          ref={checkbox}
+          type="checkbox"
+          onChange={onChange}
+        />
+        {counterpart('classifier.interventions.optOut')}
+      </label>
     </div>
   );
 }

--- a/app/classifier/components/Intervention/Intervention.jsx
+++ b/app/classifier/components/Intervention/Intervention.jsx
@@ -4,7 +4,13 @@ import counterpart from 'counterpart';
 import styled from 'styled-components';
 
 const StyledInterventionMessage = styled.div`
-  padding: 0 2em;
+  border-bottom: solid 1px;
+  margin: 0 2em 1em;
+  padding: 0 0 .7em;
+  
+  label: {
+    font-size: 0.7em;
+  }
 `;
 
 function Intervention({ notifications, user }) {

--- a/app/classifier/components/Intervention/Intervention.spec.js
+++ b/app/classifier/components/Intervention/Intervention.spec.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import Intervention from './Intervention';
+
+describe('Intervention', function () {
+  let wrapper;
+  const notifications = [{
+    data: {
+      message: 'Hello!'
+    }
+  }];
+  const { message } = notifications[0].data;
+  const user = {
+    id: 'a',
+    update: sinon.stub().callsFake(() => {
+      return { save: () => true };
+    })
+  };
+  before(function () {
+    wrapper = mount(
+      <Intervention
+        notifications={notifications}
+        user={user}
+      />);
+  });
+  it('should render', function () {
+    expect(wrapper).to.be.ok;
+  });
+  it('should show a notification message', function () {
+    expect(wrapper.contains(<p>{message}</p>)).to.be.true;
+  });
+  describe('opt-out checkbox', function () {
+    let optOut;
+    before(function () {
+      optOut = wrapper.find('input[type="checkbox"]');
+      optOut.simulate('change');
+    });
+    after(function () {
+      user.update.resetHistory();
+    });
+    it('should update the user when checked/unchecked', function () {
+      expect(user.update.callCount).to.equal(1);
+    });
+    it('should set the user opt-out preference', function () {
+      const changes = { intervention_notifications: true }
+      expect(user.update.calledWith(changes)).to.be.true;
+    })
+  });
+});

--- a/app/classifier/tasks/dropdown/editor.spec.js
+++ b/app/classifier/tasks/dropdown/editor.spec.js
@@ -1,25 +1,15 @@
 /* eslint prefer-arrow-callback: 0, func-names: 0, 'react/jsx-boolean-value': ['error', 'always'], 'react/jsx-filename-extension': 0 */
 /* global describe, it, beforeEach */
 
-import { mount, shallow } from 'enzyme';
+import { shallow } from 'enzyme';
 import React from 'react';
 import assert from 'assert';
 import sinon from 'sinon';
-import apiClient from 'panoptes-client/lib/api-client';
 import DropdownEditor from './editor';
 import DropdownDialog from './dropdown-dialog';
 import DropdownList from './dropdown-list';
 import { workflow } from '../../../pages/dev-classifier/mock-data';
-
-function mockPanoptesResource(type, options) {
-  const resource = apiClient.type(type).create(options);
-  apiClient._typesCache = {};
-  sinon.stub(resource, 'save').callsFake(() => Promise.resolve(resource));
-  sinon.stub(resource, 'get');
-  sinon.stub(resource, 'delete');
-  sinon.stub(resource, 'update');
-  return resource;
-}
+import mockPanoptesResource from '../../../../test/mock-panoptes-resource';
 
 const defaultDropdownTask = {
   type: 'dropdown',
@@ -95,8 +85,8 @@ describe('DropdownEditor: methods', function () {
   beforeEach(function () {
     mockWorkflow = mockPanoptesResource('workflows', {});
     multiSelectsTask = JSON.parse(JSON.stringify(workflow.tasks.dropdown));
-    wrapper = mount(<DropdownEditor task={multiSelectsTask} workflow={mockWorkflow} />);
-    updateSelectsStub = sinon.stub(wrapper.instance(), 'updateSelects');
+    wrapper = shallow(<DropdownEditor task={multiSelectsTask} workflow={mockWorkflow} />);
+    updateSelectsStub = sinon.stub(wrapper.instance(), 'updateSelects').callsFake(() => null);
   });
 
   afterEach(function () {
@@ -140,6 +130,8 @@ describe('DropdownEditor: methods', function () {
 
   it('should create a new select', function () {
     const createDropdownSpy = sinon.spy(wrapper.instance(), 'createDropdown');
+    // fake a condition ref
+    wrapper.instance().condition = { value: 4 };
     wrapper.instance().createDropdown();
 
     sinon.assert.calledOnce(createDropdownSpy);

--- a/app/classifier/tasks/shortcut/editor.spec.js
+++ b/app/classifier/tasks/shortcut/editor.spec.js
@@ -4,18 +4,8 @@ import { shallow, mount } from 'enzyme';
 import React from 'react';
 import assert from 'assert';
 import sinon from 'sinon';
-import apiClient from 'panoptes-client/lib/api-client';
 import ShortcutEditor from './editor';
-
-function mockPanoptesResource(type, options) {
-  const resource = apiClient.type(type).create(options);
-  apiClient._typesCache = {};
-  sinon.stub(resource, 'save').callsFake(() => Promise.resolve(resource));
-  sinon.stub(resource, 'get');
-  sinon.stub(resource, 'delete');
-  sinon.stub(resource, 'update');
-  return resource;
-}
+import mockPanoptesResource from '../../../../test/mock-panoptes-resource';
 
 const task = {
   question: 'What is it',

--- a/app/classifier/tutorial.spec.jsx
+++ b/app/classifier/tutorial.spec.jsx
@@ -1,18 +1,9 @@
 import React from 'react';
-import apiClient from 'panoptes-client/lib/api-client';
 import sinon from 'sinon';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import Tutorial from './tutorial';
-
-function mockPanoptesResource(type, options) {
-  const resource = apiClient.type(type).create(options);
-  apiClient._typesCache = {};
-  sinon.stub(resource, 'save').callsFake(() => Promise.resolve(resource));
-  sinon.stub(resource, 'get');
-  sinon.stub(resource, 'delete');
-  return resource;
-}
+import mockPanoptesResource from '../../test/mock-panoptes-resource';
 
 describe('Tutorial', function () {
   describe('on unmount', function () {

--- a/app/lib/session.coffee
+++ b/app/lib/session.coffee
@@ -1,4 +1,5 @@
-stored = sessionStorage?.getItem('session_id')
+storage = window.sessionStorage ? window.localStorage
+stored = JSON.parse storage?.getItem('session_id')
 
 generateSessionID = () ->
   hash = require('hash.js')
@@ -7,17 +8,17 @@ generateSessionID = () ->
   ttl = fiveMinutesFromNow()
   stored = {id, ttl}
   try
-    sessionStorage.setItem('session_id', JSON.stringify(stored))
+    storage.setItem('session_id', JSON.stringify(stored))
   stored
 
 getSessionID = () ->
-  {id, ttl} = JSON.parse(sessionStorage.getItem('session_id')) ? stored
+  {id, ttl} = JSON.parse(storage.getItem('session_id')) ? generateSessionID()
   if ttl < Date.now()
     {id} = generateSessionID()
   else
     ttl = fiveMinutesFromNow()
     try
-      sessionStorage.setItem('session_id', JSON.stringify({id, ttl}))
+      storage.setItem('session_id', JSON.stringify({id, ttl}))
   id
 
 fiveMinutesFromNow = () ->

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -24,6 +24,9 @@ export default {
       promotionMessage: "Congratulations! You've unlocked the next workflow. If you prefer to stay on this workflow, you can choose to stay.",
       acceptButton: 'Take me to the next level!',
       declineButton: 'No, thanks'
+    },
+    interventions: {
+      optOut: "Don't show me these messages again."
     }
   },
   project: {

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -975,6 +975,8 @@ export default {
       displayNameHelp: 'How your name will appear to other users in Talk and on your Profile Page',
       realName: 'Real name (optional)',
       realNameHelp: 'Public; we’ll use this to give acknowledgement in papers, on posters, etc.',
+      interventions: 'Show project intervention notifications.',
+      interventionsHelp: 'Allow projects to display messages while you are classifying.',
       changePassword: {
         heading: 'Change your password',
         currentPassword: 'Current password (required)',

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -980,6 +980,7 @@ export default {
       realNameHelp: 'Public; we’ll use this to give acknowledgement in papers, on posters, etc.',
       interventions: 'Show project intervention notifications.',
       interventionsHelp: 'Allow projects to display messages while you are classifying.',
+      interventionsPreferences: 'Notification preferences',
       changePassword: {
         heading: 'Change your password',
         currentPassword: 'Current password (required)',

--- a/app/pages/lab/social-links-editor.spec.js
+++ b/app/pages/lab/social-links-editor.spec.js
@@ -2,17 +2,8 @@ import React from 'react';
 import assert from 'assert';
 import { shallow, mount } from 'enzyme';
 import sinon from 'sinon';
-import apiClient from 'panoptes-client/lib/api-client';
 import SocialLinksEditor from './social-links-editor';
-
-function mockPanoptesResource(type, options) {
-  const resource = apiClient.type(type).create(options);
-  apiClient._typesCache = {};
-  sinon.stub(resource, 'save').callsFake(() => Promise.resolve(resource));
-  sinon.stub(resource, 'get');
-  sinon.stub(resource, 'delete');
-  return resource;
-}
+import mockPanoptesResource from '../../../test/mock-panoptes-resource';
 
 const testProject = {
   urls: [

--- a/app/pages/organization/organization-container.spec.js
+++ b/app/pages/organization/organization-container.spec.js
@@ -8,18 +8,12 @@ import sinon from 'sinon';
 import apiClient from 'panoptes-client/lib/api-client';
 import Translate from 'react-translate-component';
 import OrganizationContainer from './organization-container';
+import mockPanoptesResource from '../../../test/mock-panoptes-resource';
 
 const params = {
   name: 'org-name',
   owner: 'org-owner'
 };
-
-function mockPanoptesResource(type, options) {
-  const resource = apiClient.type(type).create(options);
-  apiClient._typesCache = {};
-  sinon.stub(resource, 'get');
-  return resource;
-}
 
 export const organization = mockPanoptesResource('organizations', {
   categories: ['Plants', 'Bugs', 'Butterflies'],

--- a/app/pages/project/workflow-selection.spec.js
+++ b/app/pages/project/workflow-selection.spec.js
@@ -4,6 +4,7 @@ import { mount } from 'enzyme';
 import sinon from 'sinon';
 import apiClient from 'panoptes-client/lib/api-client';
 import { WorkflowSelection } from './workflow-selection';
+import mockPanoptesResource from '../../../test/mock-panoptes-resource';
 
 function StubPage() {
   return <p>Hello</p>;
@@ -43,15 +44,6 @@ const projectRoles = [
     }
   }
 ];
-
-function mockPanoptesResource(type, options) {
-  const resource = apiClient.type(type).create(options);
-  apiClient._typesCache = {};
-  sinon.stub(resource, 'save').callsFake(() => Promise.resolve(resource));
-  sinon.stub(resource, 'get');
-  sinon.stub(resource, 'delete');
-  return resource;
-}
 
 const project = mockPanoptesResource('projects',
   {

--- a/app/pages/settings/AccountInformationPage.jsx
+++ b/app/pages/settings/AccountInformationPage.jsx
@@ -41,6 +41,21 @@ export default function AccountInformationPage(props) {
               />
             </AutoSave>
             <span className="form-help">{counterpart('userSettings.account.realNameHelp')}</span>
+            <br />
+            <AutoSave resource={props.user}>
+              <label className="form-label">
+                <input
+                  type="checkbox"
+                  className="standard-input"
+                  name="intervention_notifications"
+                  checked={props.user.intervention_notifications}
+                  onChange={handleInputChange.bind(props.user)}
+                />
+                {counterpart('userSettings.account.interventions')}
+              </label>
+            </AutoSave>
+            <br />
+            <span className="form-help">{counterpart('userSettings.account.interventionsHelp')}</span>
           </p>
         </div>
       </div>

--- a/app/pages/settings/AccountInformationPage.jsx
+++ b/app/pages/settings/AccountInformationPage.jsx
@@ -41,7 +41,9 @@ export default function AccountInformationPage(props) {
               />
             </AutoSave>
             <span className="form-help">{counterpart('userSettings.account.realNameHelp')}</span>
-            <br />
+          </p>
+          <fieldset>
+            <legend>{counterpart('userSettings.account.interventionsPreferences')}</legend>
             <AutoSave resource={props.user}>
               <label className="form-label">
                 <input
@@ -56,7 +58,7 @@ export default function AccountInformationPage(props) {
             </AutoSave>
             <br />
             <span className="form-help">{counterpart('userSettings.account.interventionsHelp')}</span>
-          </p>
+          </fieldset>
         </div>
       </div>
       <hr />

--- a/app/pages/settings/email.spec.js
+++ b/app/pages/settings/email.spec.js
@@ -5,19 +5,11 @@ import sinon from 'sinon';
 import apiClient from 'panoptes-client/lib/api-client';
 import talkClient from 'panoptes-client/lib/talk-client';
 import EmailSettings from './email';
+import mockPanoptesResource from '../../../test/mock-panoptes-resource';
 
 function mockTalkResource(type, options) {
   const resource = talkClient.type(type).create(options);
   talkClient._typesCache = {};
-  sinon.stub(resource, 'save').callsFake(() => Promise.resolve(resource));
-  sinon.stub(resource, 'get');
-  sinon.stub(resource, 'delete');
-  return resource;
-}
-
-function mockPanoptesResource(type, options) {
-  const resource = apiClient.type(type).create(options);
-  apiClient._typesCache = {};
   sinon.stub(resource, 'save').callsFake(() => Promise.resolve(resource));
   sinon.stub(resource, 'get');
   sinon.stub(resource, 'delete');

--- a/app/redux/ducks/classify.js
+++ b/app/redux/ducks/classify.js
@@ -99,6 +99,7 @@ const FETCH_SUBJECTS = 'pfe/classify/FETCH_SUBJECTS';
 const PREPEND_SUBJECTS = 'pfe/classify/PREPEND_SUBJECTS';
 const COMPLETE_CLASSIFICATION = 'pfe/classify/COMPLETE_CLASSIFICATION';
 const CREATE_CLASSIFICATION = 'pfe/classify/CREATE_CLASSIFICATION';
+const UPDATE_CLASSIFICATION = 'pfe/classify/UPDATE_CLASSIFICATION';
 const NEXT_SUBJECT = 'pfe/classify/NEXT_SUBJECT';
 const RESUME_CLASSIFICATION = 'pfe/classify/RESUME_CLASSIFICATION';
 const RESET_SUBJECTS = 'pfe/classify/RESET_SUBJECTS';
@@ -131,6 +132,11 @@ export default function reducer(state = initialState, action = {}) {
         return Object.assign({}, state, { classification });
       }
       return state;
+    }
+    case UPDATE_CLASSIFICATION: {
+      const metadata = Object.assign({}, state.classification.metadata, action.payload.metadata);
+      const classification = state.classification.update({ metadata });
+      return Object.assign({}, state, { classification });
     }
     case NEXT_SUBJECT: {
       const { project } = action.payload;
@@ -260,6 +266,13 @@ export function completeClassification(annotations) {
   return {
     type: COMPLETE_CLASSIFICATION,
     payload: { annotations }
+  };
+}
+
+export function updateClassification(metadata) {
+  return {
+    type: UPDATE_CLASSIFICATION,
+    payload: { metadata }
   };
 }
 

--- a/app/redux/ducks/classify.js
+++ b/app/redux/ducks/classify.js
@@ -1,6 +1,9 @@
 import apiClient from 'panoptes-client/lib/api-client';
 import counterpart from 'counterpart';
+import GridTool from '../../classifier/drawing-tools/grid';
+import { getSessionID } from '../../lib/session';
 import seenThisSession from '../../lib/seen-this-session';
+import tasks from '../../classifier/tasks';
 
 function awaitSubjects(subjectQuery) {
   return apiClient.get('/subjects/queued', subjectQuery)
@@ -52,6 +55,39 @@ function createNewClassification(project, workflow, subject) {
   return classification;
 }
 
+function completeAnnotations(workflow, annotations) {
+  // take care of any task-specific processing of the annotations array before submitting a classification
+  const currentAnnotation = annotations[annotations.length - 1];
+  const currentTask = workflow.tasks[currentAnnotation.task];
+
+  if (currentTask && currentTask.tools) {
+    currentTask.tools.map((tool) => {
+      if (tool.type === 'grid') {
+        GridTool.mapCells(annotations);
+      }
+    });
+  }
+
+  if (currentAnnotation.shortcut) {
+    const unlinkedTask = workflow.tasks[currentTask.unlinkedTask];
+    const unlinkedAnnotation = tasks[unlinkedTask.type].getDefaultAnnotation(unlinkedTask, workflow, tasks);
+    unlinkedAnnotation.task = currentTask.unlinkedTask;
+    unlinkedAnnotation.value = currentAnnotation.shortcut.value.slice();
+    delete currentAnnotation.shortcut;
+    annotations.push(unlinkedAnnotation);
+  }
+  return annotations;
+}
+
+function finishClassification(workflow, classification, annotations) {
+  return classification.update({
+    annotations: completeAnnotations(workflow, annotations),
+    'metadata.session': getSessionID(),
+    'metadata.finished_at': (new Date()).toISOString(),
+    completed: true
+  });
+}
+
 const initialState = {
   classification: null,
   upcomingSubjects: [],
@@ -61,6 +97,7 @@ const initialState = {
 const APPEND_SUBJECTS = 'pfe/classify/APPEND_SUBJECTS';
 const FETCH_SUBJECTS = 'pfe/classify/FETCH_SUBJECTS';
 const PREPEND_SUBJECTS = 'pfe/classify/PREPEND_SUBJECTS';
+const COMPLETE_CLASSIFICATION = 'pfe/classify/COMPLETE_CLASSIFICATION';
 const CREATE_CLASSIFICATION = 'pfe/classify/CREATE_CLASSIFICATION';
 const NEXT_SUBJECT = 'pfe/classify/NEXT_SUBJECT';
 const RESUME_CLASSIFICATION = 'pfe/classify/RESUME_CLASSIFICATION';
@@ -79,6 +116,11 @@ export default function reducer(state = initialState, action = {}) {
         return Object.assign({}, state, { upcomingSubjects });
       }
       return state;
+    }
+    case COMPLETE_CLASSIFICATION: {
+      const { annotations } = action.payload;
+      const classification = finishClassification(state.workflow, state.classification, annotations);
+      return Object.assign({}, state, { classification });
     }
     case CREATE_CLASSIFICATION: {
       const { project } = action.payload;
@@ -211,6 +253,13 @@ export function createClassification(project) {
   return {
     type: CREATE_CLASSIFICATION,
     payload: { project }
+  };
+}
+
+export function completeClassification(annotations) {
+  return {
+    type: COMPLETE_CLASSIFICATION,
+    payload: { annotations }
   };
 }
 

--- a/app/redux/ducks/classify.spec.js
+++ b/app/redux/ducks/classify.spec.js
@@ -1,16 +1,6 @@
 import reducer from './classify';
-import apiClient from 'panoptes-client/lib/api-client';
 import { expect } from 'chai';
-import sinon from 'sinon';
-
-function mockPanoptesResource(type, options) {
-  const resource = apiClient.type(type).create(options);
-  apiClient._typesCache = {};
-  sinon.stub(resource, 'save').resolves(resource);
-  sinon.stub(resource, 'get');
-  sinon.stub(resource, 'delete');
-  return resource;
-}
+import mockPanoptesResource from '../../../test/mock-panoptes-resource';
 
 describe('Classifier actions', function () {
   describe('append subjects', function () {
@@ -343,7 +333,7 @@ describe('Classifier actions', function () {
       }
     };
     const state = {
-      classification: apiClient.type('classifications').create({}),
+      classification: mockPanoptesResource('classifications', {}),
       workflow: { id: '1' },
       upcomingSubjects: [1, 2]
     };

--- a/app/redux/ducks/classify.spec.js
+++ b/app/redux/ducks/classify.spec.js
@@ -279,6 +279,45 @@ describe('Classifier actions', function () {
       expect(newState.classification.annotations).to.deep.equal(action.payload.annotations);
     });
   });
+  describe('update classification', function () {
+    const action = {
+      type: 'pfe/classify/UPDATE_CLASSIFICATION',
+      payload: {
+        metadata: {
+          a: 1,
+          b: 2
+        }
+      }
+    };
+    const state = {
+      classification: mockPanoptesResource('classifications', { 
+        id: '1',
+        metadata: {
+          b: 3,
+          c: 4
+        }
+      }),
+      workflow: {
+        id: '1',
+        tasks: {
+          a: {}
+        }
+      },
+      upcomingSubjects: [1, 2]
+    };
+    it('should add new keys to classification metadata', function () {
+      const newState = reducer(state, action);
+      expect(newState.classification.metadata.a).to.equal(1);
+    });
+    it('should overwrite classification metadata with changes', function () {
+      const newState = reducer(state, action);
+      expect(newState.classification.metadata.b).to.equal(2);
+    });
+    it('should preserve unchanged classification metadata', function () {
+      const newState = reducer(state, action);
+      expect(newState.classification.metadata.c).to.equal(4);
+    });
+  });
   describe('set workflow', function () {
     const action = {
       type: 'pfe/classify/SET_WORKFLOW',

--- a/app/redux/ducks/interventions.spec.js
+++ b/app/redux/ducks/interventions.spec.js
@@ -3,15 +3,7 @@ import sinon from 'sinon';
 import apiClient from 'panoptes-client/lib/api-client';
 import { sugarClient } from 'panoptes-client/lib/sugar';
 import reducer, { notify, subscribe, unsubscribe, dismiss } from './interventions';
-
-function mockPanoptesResource(type, options) {
-  const resource = apiClient.type(type).create(options);
-  apiClient._typesCache = {};
-  sinon.stub(resource, 'save').resolves(resource);
-  sinon.stub(resource, 'get');
-  sinon.stub(resource, 'delete');
-  return resource;
-}
+import mockPanoptesResource from '../../../test/mock-panoptes-resource';
 
 describe('Intervention actions', function () {
   let subscribeSpy;

--- a/app/redux/ducks/interventions.spec.js
+++ b/app/redux/ducks/interventions.spec.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import apiClient from 'panoptes-client/lib/api-client';
 import { sugarClient } from 'panoptes-client/lib/sugar';
-import reducer, { notify } from './interventions';
+import reducer, { notify, subscribe, unsubscribe, dismiss } from './interventions';
 
 function mockPanoptesResource(type, options) {
   const resource = apiClient.type(type).create(options);
@@ -161,6 +161,32 @@ describe('Intervention actions', function () {
           expect(action).to.deep.equal(expectedAction);
         });
       })
+    });
+    describe('subscribe', function () {
+      it('should create a subscribe action', function () {
+        const expectedAction = {
+          type: 'pfe/interventions/SUBSCRIBE',
+          payload: 'A channel'
+        };
+        expect(subscribe('A channel')).to.deep.equal(expectedAction);
+      });
+    });
+    describe('unsubscribe', function () {
+      it('should create an unsubscribe action', function () {
+        const expectedAction = {
+          type: 'pfe/interventions/UNSUBSCRIBE',
+          payload: 'A channel'
+        };
+        expect(unsubscribe('A channel')).to.deep.equal(expectedAction);
+      });
+    });
+    describe('dismiss', function () {
+      it('should create a dismiss action', function () {
+        const expectedAction = {
+          type: 'pfe/interventions/DISMISS_NOTIFICATION'
+        };
+        expect(dismiss()).to.deep.equal(expectedAction);
+      });
     });
   });
 });

--- a/app/redux/ducks/interventions.spec.js
+++ b/app/redux/ducks/interventions.spec.js
@@ -1,0 +1,96 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { sugarClient } from 'panoptes-client/lib/sugar';
+import reducer from './interventions';
+
+describe('Intervention actions', function () {
+  let subscribeSpy;
+  let unsubscribeSpy;
+  before(function () {
+    subscribeSpy = sinon.stub(sugarClient, 'subscribeTo').callsFake(() => true);
+    unsubscribeSpy = sinon.stub(sugarClient, 'unsubscribeFrom').callsFake(() => true);
+  });
+  after(function () {
+    subscribeSpy.restore();
+    unsubscribeSpy.restore();
+  });
+  describe('add notification', function () {
+    const state = {
+      error: null,
+      notifications: []
+    };
+    const action = {
+      type: 'pfe/interventions/ADD_NOTIFICATION',
+      payload: 'Hello'
+    };
+    it('should store a notification', function () {
+      const newState = reducer(state, action);
+      expect(newState.notifications).to.deep.equal(['Hello']);
+    });
+  });
+  describe('dismiss notification', function () {
+    const state = {
+      error: null,
+      notifications: ['Goodbye','Hello']
+    };
+    const action = {
+      type: 'pfe/interventions/DISMISS_NOTIFICATION'
+    };
+    it('should remove the most recent notification', function () {
+      const newState = reducer(state, action);
+      expect(newState.notifications).to.deep.equal(['Goodbye']);
+    });
+  });
+  describe('subscribe', function () {
+    const state = {
+      error: null,
+      notifications: []
+    };
+    const action = {
+      type: 'pfe/interventions/SUBSCRIBE',
+      payload: 'A channel'
+    };
+    before(function () {
+      const newState = reducer(state, action);
+    });
+    it('should subscribe to Sugar', function () {
+      expect(subscribeSpy.callCount).to.equal(1);
+    });
+    it('should subscribe to the specified channel', function () {
+      expect(subscribeSpy.calledWith(action.payload)).to.be.true;
+    });
+  });
+  describe('unsubscribe', function () {
+    const state = {
+      error: null,
+      notifications: []
+    };
+    const action = {
+      type: 'pfe/interventions/UNSUBSCRIBE',
+      payload: 'A channel'
+    };
+    before(function () {
+      const newState = reducer(state, action);
+    });
+    it('should unsubscribe from Sugar', function () {
+      expect(unsubscribeSpy.callCount).to.equal(1);
+    });
+    it('should unsubscribe from the specified channel', function () {
+      expect(unsubscribeSpy.calledWith(action.payload)).to.be.true;
+    });
+  });
+  describe('on error', function () {
+    const state = {
+      error: null,
+      notifications: ['Goodbye','Hello']
+    };
+    const action = {
+      type: 'pfe/interventions/ERROR',
+      payload: 'Oh no!'
+    };
+    it('should store the error', function () {
+      const newState = reducer(state, action);
+      expect(newState.error).to.equal(action.payload);
+    });
+  });
+});

--- a/app/redux/ducks/interventions.spec.js
+++ b/app/redux/ducks/interventions.spec.js
@@ -7,7 +7,7 @@ import reducer, { notify, subscribe, unsubscribe, dismiss } from './intervention
 function mockPanoptesResource(type, options) {
   const resource = apiClient.type(type).create(options);
   apiClient._typesCache = {};
-  sinon.stub(resource, 'save').callsFake(() => Promise.resolve(resource));
+  sinon.stub(resource, 'save').resolves(resource);
   sinon.stub(resource, 'get');
   sinon.stub(resource, 'delete');
   return resource;

--- a/test/mock-panoptes-resource.js
+++ b/test/mock-panoptes-resource.js
@@ -1,0 +1,12 @@
+import apiClient from 'panoptes-client/lib/api-client';
+import sinon from 'sinon';
+
+export default function mockPanoptesResource(type, options) {
+  const resource = apiClient.type(type).create(options);
+  apiClient._typesCache = {};
+  sinon.stub(resource, 'save').resolves(resource);
+  sinon.stub(resource, 'get');
+  sinon.stub(resource, 'delete');
+  sinon.spy(resource, 'update');
+  return resource;
+}


### PR DESCRIPTION
Staging branch URL: https://interventions.pfe-preview.zooniverse.org/

Fixes #4810.

Allow users to set `user.intervention_notifications` from their account settings page.
Add an opt-out checkbox to the Interventions component.
Track intervention messages and opt in as `classification.metadata.interventions.message` and `classification.metadata.interventions.opt_in`.
Adds tests for the Intervention component and intervention actions.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
