### PR TITLE
Fix required survey task answers

### DIFF
--- a/app/classifier/tasks/survey/index.cjsx
+++ b/app/classifier/tasks/survey/index.cjsx
@@ -31,8 +31,8 @@ module.exports = createReactClass
       value: []
 
     isAnnotationComplete: (task, annotation) ->
-      # Booleans compare to numbers as expected: true = 1, false = 0.
-      annotation.value.length >= (task.required ? 0) and not annotation._choiceInProgress
+      minRequiredAnswers = if task.required then 1 else 0
+      annotation.value.length >= minRequiredAnswers and not annotation._choiceInProgress
 
   getDefaultProps: ->
     task: null


### PR DESCRIPTION
Compare the length of annotation.value with the minimum number of required answers.

Staging branch URL: https://survey-required.pfe-preview.zooniverse.org/projects/thegalaxyonorionsbelt/are-we-alone-in-the-zooniverse/classify?env=production&reload=0&workflow=75

Fixes #4822.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
