### PR TITLE
Add a saveAnnotations action to the classifier

### DIFF
--- a/app/classifier/classifier.jsx
+++ b/app/classifier/classifier.jsx
@@ -12,6 +12,7 @@ import { getSessionID } from '../lib/session';
 import preloadSubject from '../lib/preload-subject';
 import workflowAllowsFlipbook from '../lib/workflow-allows-flipbook';
 import workflowAllowsSeparateFrames from '../lib/workflow-allows-separate-frames';
+import * as classifierActions from '../redux/ducks/classify';
 import * as feedbackActions from '../redux/ducks/feedback';
 import * as interventionActions from '../redux/ducks/interventions';
 import * as userInterfaceActions from '../redux/ducks/userInterface';
@@ -96,7 +97,7 @@ class Classifier extends React.Component {
 
   componentWillUnmount() {
     const annotations = this.state.annotations.slice();
-    this.props.classification.update({ annotations });
+    this.props.actions.classify.saveAnnotations(annotations);
     try {
       !!this.context.geordi && this.context.geordi.forget(['subjectID']);
     } catch (err) {
@@ -596,6 +597,7 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = dispatch => ({
   actions: {
+    classify: bindActionCreators(classifierActions, dispatch),
     feedback: bindActionCreators(feedbackActions, dispatch),
     interventions: bindActionCreators(interventionActions, dispatch),
     theme: bindActionCreators(userInterfaceActions, dispatch)

--- a/app/classifier/classifier.spec.js
+++ b/app/classifier/classifier.spec.js
@@ -334,4 +334,21 @@ describe('Classifier', function () {
       })
     });
   });
+
+  describe('on unmount', function () {
+    const actions = {
+      classify: {
+        saveAnnotations: sinon.stub().callsFake(() => null)
+      }
+    };
+
+    before(function () {
+      wrapper.setProps({ actions });
+      wrapper.unmount();
+    });
+
+    it('should save any annotations in progress', function () {
+      expect(actions.classify.saveAnnotations.callCount).to.equal(1);
+    });
+  });
 });

--- a/app/classifier/classifier.spec.js
+++ b/app/classifier/classifier.spec.js
@@ -105,23 +105,29 @@ describe('Classifier', function () {
     before(function () {
       wrapper = shallow(<Classifier />, mockReduxStore);
     });
-    it('should preserve annotations from an incomplete classification', function () {
-      const newProps = { classification, subject };
-      wrapper.setProps(newProps);
-      const state = wrapper.state();
-      expect(state.annotations).to.deep.equal(classification.annotations);
-      expect(state.workflowHistory).to.deep.equal(['T0', 'T1']);
+
+    describe('with annotations', function () {
+      it('should resume work in progress', function () {
+        const newProps = { classification, subject };
+        wrapper.setProps(newProps);
+        const state = wrapper.state();
+        expect(state.annotations).to.deep.equal(classification.annotations);
+        expect(state.workflowHistory).to.deep.equal(['T0', 'T1']);
+      });
     });
-    it('should reset annotations and workflow history', function () {
-      const newProps = {
-        classification: {
-          annotations: []
+
+    describe('without annotations', function () {
+      it('should reset annotations and workflow history', function () {
+        const newProps = {
+          classification: {
+            annotations: []
+          }
         }
-      }
-      wrapper.setProps(newProps);
-      const state = wrapper.state();
-      expect(state.annotations).to.have.lengthOf(0);
-      expect(state.workflowHistory).to.have.lengthOf(0);
+        wrapper.setProps(newProps);
+        const state = wrapper.state();
+        expect(state.annotations).to.have.lengthOf(0);
+        expect(state.workflowHistory).to.have.lengthOf(0);
+      });
     });
   });
 

--- a/app/redux/ducks/classify.js
+++ b/app/redux/ducks/classify.js
@@ -65,6 +65,7 @@ const CREATE_CLASSIFICATION = 'pfe/classify/CREATE_CLASSIFICATION';
 const NEXT_SUBJECT = 'pfe/classify/NEXT_SUBJECT';
 const RESUME_CLASSIFICATION = 'pfe/classify/RESUME_CLASSIFICATION';
 const RESET_SUBJECTS = 'pfe/classify/RESET_SUBJECTS';
+const SAVE_ANNOTATIONS = 'pfe/classify/SAVE_ANNOTATIONS';
 const SET_WORKFLOW = 'pfe/classify/SET_WORKFLOW';
 
 export default function reducer(state = initialState, action = {}) {
@@ -133,6 +134,11 @@ export default function reducer(state = initialState, action = {}) {
       upcomingSubjects.forEach(subject => subject.destroy());
       upcomingSubjects.splice(0);
       return Object.assign({}, state, { classification, upcomingSubjects });
+    }
+    case SAVE_ANNOTATIONS: {
+      const { annotations } = action.payload;
+      const classification = state.classification.update({ annotations });
+      return Object.assign({}, state, { classification });
     }
     case SET_WORKFLOW: {
       const { workflow } = action.payload;
@@ -229,6 +235,13 @@ export function resumeClassification(classification) {
         payload: { subject }
       });
     });
+  };
+}
+
+export function saveAnnotations(annotations) {
+  return {
+    type: SAVE_ANNOTATIONS,
+    payload: { annotations }
   };
 }
 

--- a/app/redux/ducks/classify.spec.js
+++ b/app/redux/ducks/classify.spec.js
@@ -1,4 +1,5 @@
 import reducer from './classify';
+import apiClient from 'panoptes-client/lib/api-client';
 import { expect } from 'chai';
 
 describe('Classifier actions', function () {
@@ -253,6 +254,23 @@ describe('Classifier actions', function () {
     it('should store the specified workflow', function () {
       const newState = reducer(state, action);
       expect(newState.workflow).to.deep.equal(action.payload.workflow);
+    });
+  });
+  describe('save annotations', function () {
+    const action = {
+      type: 'pfe/classify/SAVE_ANNOTATIONS',
+      payload: {
+        annotations: [1, 2, 3, 4]
+      }
+    };
+    const state = {
+      classification: apiClient.type('classifications').create({}),
+      workflow: { id: '1' },
+      upcomingSubjects: [1, 2]
+    };
+    it('should add annotations to the classification', function () {
+      const newState = reducer(state, action);
+      expect(newState.classification.annotations).to.deep.equal(action.payload.annotations);
     });
   });
 });


### PR DESCRIPTION
Replace `classification.update` with a saveAnnotations action in the classifier, to make it explicit that annotations are saved when the Classifier component unmounts.
Update the wording on a couple of the Classifier tests to make it less confusing.

Staging branch URL: https://save-annotations.pfe-preview.zooniverse.org/

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
