### PR TITLE
Add image rule for mobile

### DIFF
--- a/app/pages/lab/mobile/mobile-section-container.jsx
+++ b/app/pages/lab/mobile/mobile-section-container.jsx
@@ -4,33 +4,34 @@ import filter from 'lodash/filter';
 import every from 'lodash/every';
 import reduce from 'lodash/reduce';
 import MobileSection from './mobile-section';
+import ValidationValue, { convertBooleanToValidation } from './mobile-validations';
 
 const VALID_QUESTION_LENGTH = 200;
 const VALID_TASK_TYPES_FOR_MOBILE = ['single', 'multiple'];
 
 function taskQuestionNotTooLong({ task }) {
-  return task.question ? task.question.length < VALID_QUESTION_LENGTH : false;
+  return convertBooleanToValidation(task.question ? task.question.length < VALID_QUESTION_LENGTH : false);
 }
 
 function taskFeedbackDisabled({ task }) {
-  return !task.feedback || !task.feedback.enabled;
+  return convertBooleanToValidation(!task.feedback || !task.feedback.enabled);
 }
 
 function taskHasTwoAnswers({ task }) {
-  return task.answers ? task.answers.length === 2 : false;
+  return convertBooleanToValidation(task.answers ? task.answers.length === 2 : false);
 }
 
 function workflowFlipbookDisabled({ workflow }) {
-  return (workflow.configuration) ? workflow.configuration.multi_image_mode !== 'flipbook' : true;
+  return convertBooleanToValidation((workflow.configuration) ? workflow.configuration.multi_image_mode !== 'flipbook' : true);
 }
 
 function workflowHasSingleTask({ workflow }) {
-  return filter(workflow.tasks, ({ type }) => type !== 'shortcut').length === 1;
+  return convertBooleanToValidation(filter(workflow.tasks, ({ type }) => type !== 'shortcut').length === 1);
 }
 
 function workflowNotTooManyShortcuts({ task, workflow }) {
   const shortcut = workflow.tasks[task.unlinkedTask];
-  return (shortcut) ? shortcut.answers.length <= 2 : true;
+  return convertBooleanToValidation((shortcut) ? shortcut.answers.length <= 2 : true);
 }
 
 const validatorFns = {
@@ -133,7 +134,7 @@ class MobileSectionContainer extends Component {
       return validationObj;
     }, {});
 
-    const enabled = every(validations, validation => validation);
+    const enabled = every(validations, validation => validation !== ValidationValue.fail);
 
     this.setState({
       enabled,

--- a/app/pages/lab/mobile/mobile-section-container.jsx
+++ b/app/pages/lab/mobile/mobile-section-container.jsx
@@ -34,13 +34,25 @@ function workflowNotTooManyShortcuts({ task, workflow }) {
   return convertBooleanToValidation((shortcut) ? shortcut.answers.length <= 2 : true);
 }
 
+function workflowQuestionHasOneOrLessImages({ task }) {
+  const markdownQuestion = /!\[[^\]]*](:?\([^)]*\)|\[[^\]]*])/g;
+  let validation = convertBooleanToValidation(false);
+  if (task.question) {
+    const matchArray = task.question.match(markdownQuestion);
+    validation = convertBooleanToValidation(matchArray ? matchArray.length < 2 : true, true);
+  }
+
+  return validation;
+}
+
 const validatorFns = {
   taskQuestionNotTooLong,
   taskFeedbackDisabled,
   taskHasTwoAnswers,
   workflowFlipbookDisabled,
   workflowHasSingleTask,
-  workflowNotTooManyShortcuts
+  workflowNotTooManyShortcuts,
+  workflowQuestionHasOneOrLessImages
 };
 
 class MobileSectionContainer extends Component {

--- a/app/pages/lab/mobile/mobile-section-container.spec.js
+++ b/app/pages/lab/mobile/mobile-section-container.spec.js
@@ -19,6 +19,7 @@ import isFunction from 'lodash/isFunction';
 
 import MobileSectionContainer from './mobile-section-container';
 import * as fixtures from './mobile-section-container.fixtures';
+import { convertBooleanToValidation } from './mobile-validations';
 
 let component;
 let wrapper;
@@ -84,7 +85,7 @@ describe('<MobileSectionContainer />', function () {
       let component = wrapper.find('MobileSection').first();
       let validationToTest = component.props().validations[name];
 
-      assert.strictEqual(validationToTest, expectedResult);
+      assert.strictEqual(validationToTest, convertBooleanToValidation(expectedResult));
     }
 
     it('should check whether the task question text is too long', function () {

--- a/app/pages/lab/mobile/mobile-section.jsx
+++ b/app/pages/lab/mobile/mobile-section.jsx
@@ -2,6 +2,8 @@ import React, { Component } from 'react';
 import counterpart from 'counterpart';
 import Translate from 'react-translate-component';
 import map from 'lodash/map';
+import PropTypes from 'prop-types';
+import ValidationValue from './mobile-validations';
 
 counterpart.registerTranslations('en', {
   mobileSection: {
@@ -19,9 +21,11 @@ counterpart.registerTranslations('en', {
       workflowNotTooManyShortcuts: 'Has less than three shortcuts',
       workflowFlipbookDisabled: 'Cannot be a flipbook',
       taskFeedbackDisabled: 'Cannot provide feedback',
+      workflowQuestionHasOneOrLessImages: 'Task question has no more than one image'
     },
     projectEligible: 'Check this box if you think your question fits in this way.  If you have a Yes/No question, we recommend Yes as the first option listed so that it appears on the right.',
     projectIneligible: 'Sorry, but the mobile app will not currently work for this workflow. The following are the requirements for the swipe workflow.',
+    imageWarning: 'It appears that you have more than one image in your task question. While this is allowed for mobile, we will only show the first image.',
     mobileHelp: 'Mobile app:  Check this box if you would like this workflow available in the mobile app',
   }
 });
@@ -31,14 +35,69 @@ const APP_STORE_LINKS = {
   android: 'https://play.google.com/store/apps/details?id=com.zooniversemobile&hl=en'
 };
 
-class MobileSection extends Component {
-  constructor(props) {
-    super(props);
-    this.renderLink = this.renderLink.bind(this);
-    this.renderValidation = this.renderValidation.bind(this);
+const iconFromValidation = (validation) => {
+  switch (validation) {
+    case ValidationValue.pass:
+      return 'fa-check';
+    case ValidationValue.fail:
+      return 'fa-times';
+    case ValidationValue.warning:
+      return 'fa-exclamation-triangle';
+    default:
+      return '';
   }
+};
+
+const iconColorFromValidation = (validation) => {
+  switch (validation) {
+    case ValidationValue.pass:
+      return 'green';
+    case ValidationValue.fail:
+      return 'red';
+    case ValidationValue.warning:
+      return '#FFCC00';
+    default:
+      return '';
+  }
+};
+
+const renderLink = (link, key) => {
+  return (
+    <li key={link}>
+      <small>
+        <a
+          href={link}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <Translate content={`mobileSection.download.${key}`} />
+        </a>
+      </small>
+    </li>
+  );
+};
+
+const renderValidation = (validationValue, validationCheckName) => {
+  const icon = iconFromValidation(validationValue);
+  const color = iconColorFromValidation(validationValue);
+  return (
+    <li key={validationCheckName}>
+      <Translate content={`mobileSection.validations.${validationCheckName}`} component="small" />
+      <i className={`fa ${icon}`} style={{ color }} aria-hidden="true" />
+    </li>
+  );
+};
+
+class MobileSection extends Component {
 
   render() {
+    const warningView = (
+      <p>
+        <i className={'fa fa-exclamation-triangle'} style={{ color: '#FFCC00', paddingRight: 5 }} aria-hidden="true" />
+        <Translate content={'mobileSection.imageWarning'} component="small" />
+      </p>
+    );
+
     const helpTextKey = (this.props.enabled) ? 'projectEligible' : 'projectIneligible';
     return (
       <section>
@@ -49,7 +108,7 @@ class MobileSection extends Component {
 
           <div className="workflow-mobile-form-left-panel">
 
-             <label
+            <label
               className="pill-button"
               htmlFor="mobile_friendly"
             >
@@ -68,8 +127,12 @@ class MobileSection extends Component {
               <Translate content={`mobileSection.${helpTextKey}`} component="small" />
             </p>
 
+            {
+              this.props.validations.workflowQuestionHasOneOrLessImages === ValidationValue.warning ? warningView : null
+            }
+            
             <ul>
-              {map(this.props.validations, this.renderValidation)}
+              {map(this.props.validations, renderValidation)}
             </ul>
 
             <p className="form-help">
@@ -81,7 +144,7 @@ class MobileSection extends Component {
             </p>
 
             <ul>
-              {map(APP_STORE_LINKS, this.renderLink)}
+              {map(APP_STORE_LINKS, renderLink)}
             </ul>
           </div>
 
@@ -92,33 +155,6 @@ class MobileSection extends Component {
         </div>
 
       </section>
-    );
-  }
-
-  renderLink(link, key) {
-    return (
-      <li key={link}>
-        <small>
-          <a
-            href={link}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Translate content={`mobileSection.download.${key}`} />
-          </a>
-        </small>
-      </li>
-    );
-  }
-
-  renderValidation(value, key) {
-    const icon = (value) ? 'fa-check' : 'fa-times';
-    const color = (value) ? 'green' : 'red';
-    return (
-      <li key={key}>
-        <Translate content={`mobileSection.validations.${key}`} component="small" />
-        <i className={`fa ${icon}`} style={{ color }} aria-hidden="true" />
-      </li>
     );
   }
 }

--- a/app/pages/lab/mobile/mobile-section.jsx
+++ b/app/pages/lab/mobile/mobile-section.jsx
@@ -20,7 +20,7 @@ counterpart.registerTranslations('en', {
       workflowFlipbookDisabled: 'Cannot be a flipbook',
       taskFeedbackDisabled: 'Cannot provide feedback',
     },
-    projectEligible: 'Check this box if you think your question fits in this way.  If you have a Yes/No question, we recommend Yes is the first option listed so that it appears on the right.',
+    projectEligible: 'Check this box if you think your question fits in this way.  If you have a Yes/No question, we recommend Yes as the first option listed so that it appears on the right.',
     projectIneligible: 'Sorry, but the mobile app will not currently work for this workflow. The following are the requirements for the swipe workflow.',
     mobileHelp: 'Mobile app:  Check this box if you would like this workflow available in the mobile app',
   }

--- a/app/pages/lab/mobile/mobile-section.jsx
+++ b/app/pages/lab/mobile/mobile-section.jsx
@@ -123,4 +123,13 @@ class MobileSection extends Component {
   }
 }
 
+MobileSection.propTypes = {
+  validations: PropTypes.shape({
+    workflowQuestionHasOneOrLessImages: PropTypes.func
+  }),
+  enabled: PropTypes.bool,
+  toggleChecked: PropTypes.func,
+  checked: PropTypes.bool
+};
+
 export default MobileSection;

--- a/app/pages/lab/mobile/mobile-validations.js
+++ b/app/pages/lab/mobile/mobile-validations.js
@@ -1,0 +1,12 @@
+const ValidationValue = {
+  pass: 'pass',
+  fail: 'fail',
+  warning: 'warning'
+};
+
+export const convertBooleanToValidation = (bool, asWarning = false) => {
+  const failValidation = asWarning ? ValidationValue.warning : ValidationValue.fail;
+  return bool ? ValidationValue.pass : failValidation;
+};
+
+export default ValidationValue;


### PR DESCRIPTION
Staging branch URL: https://addimageruleformobile.pfe-preview.zooniverse.org/

Having to do with https://github.com/zooniverse/mobile/pull/203 . We are only allowing one image in a question to show in a mobile task. However, we didn't want this to be a hard line requirement for project builders, so I made this a check, but it's just a warning instead of a failed checl.

In this PR:
- Add Mobile Validation Enum `ValidationValue` so validations can pass, fail or just be a warning
- Add validation rule for number of images in questions (max 1 allowed)
- Some changes to appease the linter

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [x] Can you post a talk comment?

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
