### PR TITLE
Do not compress gifs in Thumbnail component

### DIFF
--- a/app/components/thumbnail.jsx
+++ b/app/components/thumbnail.jsx
@@ -74,6 +74,7 @@ Thumbnail.getThumbnailSrc = function getThumbnailSrc({ origin, width, height, sr
   if (!src) {
     return undefined;
   }
+  if (src.includes('.gif')) return src;
   let srcPath = src.split('//').pop();
   srcPath = srcPath.replace('static.zooniverse.org/', '');
   return (`${origin}/${width}x${height}/${srcPath}`);


### PR DESCRIPTION
Staging branch URL: https://fix-4821.pfe-preview.zooniverse.org/projects/zooniverse/gravity-spy/classify?env=production

Fixes #4821. This modifies the Thumbnail component to just ignore gifs. You can test by selecting a glitch type in the Gravity Spy survey and check the second example image. These are gifs that slowly loop.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
