### PR TITLE
Remove the word level from the workflow buttons

### DIFF
--- a/app/locales/ar.js
+++ b/app/locales/ar.js
@@ -75,7 +75,7 @@ export default {
       joinIn: 'Join in',
       learnMore: 'Learn more',
       getStarted: 'Get started',
-      workflowAssignment: 'You\'ve unlocked level %(workflowDisplayName)s',
+      workflowAssignment: 'You\'ve unlocked %(workflowDisplayName)s',
       visitLink: 'Visit the project',
       links: 'External Project Links'
     }

--- a/app/locales/de.js
+++ b/app/locales/de.js
@@ -77,7 +77,7 @@ export default {
       joinIn: 'Join in',
       learnMore: 'Learn more',
       getStarted: 'Get started',
-      workflowAssignment: 'You\'ve unlocked level %(workflowDisplayName)s',
+      workflowAssignment: 'You\'ve unlocked %(workflowDisplayName)s',
       visitLink: 'Visit the project',
       links: 'External Project Links'
     }

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -77,7 +77,7 @@ export default {
       joinIn: 'Join in',
       learnMore: 'Learn more',
       getStarted: 'Get started',
-      workflowAssignment: 'You\'ve unlocked level %(workflowDisplayName)s',
+      workflowAssignment: 'You\'ve unlocked %(workflowDisplayName)s',
       visitLink: 'Visit the project',
       links: 'External Project Links'
     }

--- a/app/locales/es.js
+++ b/app/locales/es.js
@@ -75,7 +75,7 @@ export default {
       joinIn: 'Participa',
       learnMore: 'Aprende más',
       getStarted: 'Comenzar',
-      workflowAssignment: 'Has desbloqueado nivel %(workflowDisplayName)s',
+      workflowAssignment: 'Has desbloqueado %(workflowDisplayName)s',
       visitLink: 'Visita el proyecto',
       links: 'Enlaces'
     }

--- a/app/locales/fr.js
+++ b/app/locales/fr.js
@@ -77,7 +77,7 @@ export default {
       joinIn: 'Join in',
       learnMore: 'Learn more',
       getStarted: 'Get started',
-      workflowAssignment: 'You\'ve unlocked level %(workflowDisplayName)s',
+      workflowAssignment: 'You\'ve unlocked %(workflowDisplayName)s',
       visitLink: 'Visit the project',
       links: 'External Project Links'
     }

--- a/app/locales/he.js
+++ b/app/locales/he.js
@@ -75,7 +75,7 @@ export default {
       joinIn: 'Join in',
       learnMore: 'Learn more',
       getStarted: 'Get started',
-      workflowAssignment: 'You\'ve unlocked level %(workflowDisplayName)s',
+      workflowAssignment: 'You\'ve unlocked %(workflowDisplayName)s',
       visitLink: 'Visit the project',
       links: 'External Project Links'
     }

--- a/app/locales/nl.js
+++ b/app/locales/nl.js
@@ -107,7 +107,7 @@ export default {
       joinIn: 'Doe mee!',
       learnMore: 'Lees meer',
       getStarted: 'Beginnen',
-      workflowAssignment: 'Je hebt een nieuw niveau bereikt in %(workflowDisplayName)s',
+      workflowAssignment: 'You\'ve unlocked %(workflowDisplayName)s',
       visitLink: 'Bezoek het project',
       links: 'Links'
     }


### PR DESCRIPTION
Staging branch URL: https://remove-word-level.pfe-preview.zooniverse.org/projects/zooniverse/gravity-spy?env=production

The last minor update prior to the Snapshot Wisconsin implementation of workflow promotion. We had hardcoded the word 'level' on the home page workflow buttons for Gravity Spy, but this doesn't make sense for SW's use case. Gravity Spy can add the word back in their workflow name if they want it. (cc @trouille )

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
