### PR TITLE
Allow project pages to render without a workflow

### DIFF
--- a/app/pages/project/classify.jsx
+++ b/app/pages/project/classify.jsx
@@ -83,15 +83,8 @@ export class ProjectClassifyPage extends React.Component {
   componentDidUpdate(prevProps) {
     const { actions, classification, project, upcomingSubjects, workflow } = this.props;
 
-    if (project !== prevProps.project) {
-      this.loadAppropriateClassification();
-    }
-
     if (workflow !== prevProps.workflow) {
-      if (classification && classification.links.workflow !== workflow.id) {
-        // The current workflow has changed, so reset the subject queue
-        actions.classifier.emptySubjectQueue();
-      }
+      this.loadAppropriateClassification();
     }
 
     if (upcomingSubjects.length !== prevProps.upcomingSubjects.length) {
@@ -284,7 +277,7 @@ export class ProjectClassifyPage extends React.Component {
         {this.state.validUserGroup &&
           <p className="anouncement-banner--group">You are classifying as a student of your classroom.</p>}
 
-        {this.renderClassifier()}
+        {this.props.workflow ? this.renderClassifier() : <p>Loading workflow</p>}
         <ProjectThemeButton />
       </div>
     );

--- a/app/pages/project/index.jsx
+++ b/app/pages/project/index.jsx
@@ -416,6 +416,7 @@ class ProjectPageController extends React.Component {
                 projectRoles={this.state.projectRoles}
                 requestUserProjectPreferences={this.requestUserProjectPreferences.bind(this)}
                 splits={this.state.splits}
+                workflow={this.props.workflow}
               />
             </WorkflowSelection>
           </ProjectTranslations>
@@ -495,7 +496,8 @@ ProjectPageController.defaultProps = {
 
 const mapStateToProps = state => ({
   interventions: state.interventions,
-  translations: state.translations
+  translations: state.translations,
+  workflow: state.classify.workflow
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/app/pages/project/workflow-selection.jsx
+++ b/app/pages/project/workflow-selection.jsx
@@ -193,11 +193,7 @@ class WorkflowSelection extends React.Component {
   render() {
     const { translation, workflow } = this.props;
     const { loadingSelectedWorkflow } = this.state;
-    if (workflow && !loadingSelectedWorkflow) {
-      return React.cloneElement(this.props.children, { translation, loadingSelectedWorkflow, workflow });
-    } else {
-      return <p>Loading workflow.</p>
-    }
+    return React.cloneElement(this.props.children, { translation, loadingSelectedWorkflow });
   }
 }
 


### PR DESCRIPTION
Move the 'Loading workflow' check from workflow selection down to the project classify page, so that it doesn't block other project pages from loading.
Check the stored classification, and possibly reset it, if the workflow state changes while the classify page is mounted.

Staging branch URL: https://workflow-selection.pfe-preview.zooniverse.org

Fixes #4892.

Describe your changes.

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [x] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
