### PR TITLE
Fix hash fragment redirects

### DIFF
--- a/app/main.cjsx
+++ b/app/main.cjsx
@@ -25,7 +25,7 @@ if location?.hash.charAt(1) is '/'
   locationPath = location.pathname
   if locationPath.slice(-1) is '/'
      locationPath = locationPath.replace(/\/+$/, "");
-  urlNoHashPaths = location.origin + locationPath + location.search + hashPathSuffix
+  urlNoHashPaths = location.origin + locationPath + hashPathSuffix + location.search
   location.replace(urlNoHashPaths)
 
 browserHistory.listen ->

--- a/app/main.cjsx
+++ b/app/main.cjsx
@@ -22,7 +22,10 @@ sugarClient.on('subject-queue', (message) => store.dispatch(injectSubjects(messa
 # Redirect any old `/#/foo`-style URLs to `/foo`.
 if location?.hash.charAt(1) is '/'
   hashPathSuffix = location.hash.slice(1)
-  urlNoHashPaths = new URL(location.pathname + hashPathSuffix, location.origin)
+  locationPath = location.pathname
+  if locationPath.slice(-1) is '/'
+     locationPath = locationPath.replace(/\/+$/, "");
+  urlNoHashPaths = location.origin + locationPath + location.search + hashPathSuffix
   location.replace(urlNoHashPaths)
 
 browserHistory.listen ->

--- a/app/main.cjsx
+++ b/app/main.cjsx
@@ -21,7 +21,9 @@ sugarClient.on('subject-queue', (message) => store.dispatch(injectSubjects(messa
 
 # Redirect any old `/#/foo`-style URLs to `/foo`.
 if location?.hash.charAt(1) is '/'
-  location.replace location.hash.slice 1
+  hashPathSuffix = location.hash.slice(1)
+  urlNoHashPaths = new URL(location.pathname + hashPathSuffix, location.origin)
+  location.replace(urlNoHashPaths)
 
 browserHistory.listen ->
   dispatchEvent new CustomEvent 'locationchange'

--- a/app/main.cjsx
+++ b/app/main.cjsx
@@ -19,7 +19,10 @@ apiClient.type('subject_sets').listen('add-or-remove', () => store.dispatch(empt
 sugarClient.on('experiment', (message) => store.dispatch(notify(message)));
 sugarClient.on('subject-queue', (message) => store.dispatch(injectSubjects(message)));
 
-# Redirect any old `/#/foo`-style URLs to `/foo`.
+# Redirect any old `/#/foo`-style URLs to `/foo`
+# ensuring we preserve the location path, search and hash fragments
+# e.g. http://www.penguinwatch.org/#/classify
+# https://www.zooniverse.org/projects/penguintom79/penguin-watch/classify
 if location?.hash.charAt(1) is '/'
   hashPathSuffix = location.hash.slice(1)
   locationPath = location.pathname

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -68,7 +68,7 @@
 
     <div id="panoptes-main-container"></div>
 
-    <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=default,es6,Promise,fetch,Array.prototype.includes,Array.prototype.find,Object.values&amp;flags=gated"></script>
+    <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=default,es6,Promise,fetch,Array.prototype.includes,Array.prototype.find,Object.values,URL&amp;flags=gated"></script>
     <script>('assign' in Object) || document.write('<script src="/fallback-polyfills.js"></'+'script>');</script>
   </body>
 </html>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -68,7 +68,7 @@
 
     <div id="panoptes-main-container"></div>
 
-    <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=default,es6,Promise,fetch,Array.prototype.includes,Array.prototype.find,Object.values,URL&amp;flags=gated"></script>
+    <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=default,es6,Promise,fetch,Array.prototype.includes,Array.prototype.find,Object.values&amp;flags=gated"></script>
     <script>('assign' in Object) || document.write('<script src="/fallback-polyfills.js"></'+'script>');</script>
   </body>
 </html>


### PR DESCRIPTION
Staging branch URL: https://fixhashfragmentredirects.pfe-preview.zooniverse.org/

Fixes #4903.

respect the location path when redirecting from old hash fragment paths style url's, e.g. http://www.penguinwatch.org/#/classify

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
