### PR TITLE
Classification queue: save each queued classification once only

### DIFF
--- a/app/lib/classification-queue.js
+++ b/app/lib/classification-queue.js
@@ -5,8 +5,8 @@ const FAILED_CLASSIFICATION_QUEUE_NAME = 'failed-classifications';
 const MAX_RECENTS = 10;
 
 class ClassificationQueue {
-  constructor(storage, api, onClassificationSaved) {
-    this.storage = storage || window.localStorage;
+  constructor(api, onClassificationSaved) {
+    this.storage = window.localStorage;
     this.apiClient = api || apiClient;
     this.recents = [];
     this.onClassificationSaved = onClassificationSaved;

--- a/app/lib/classification-queue.js
+++ b/app/lib/classification-queue.js
@@ -51,16 +51,6 @@ class ClassificationQueue {
           console.log('Saved classification', actualClassification.id);
           this.onClassificationSaved(actualClassification);
           this.addRecent(actualClassification);
-
-          const indexInQueue = queue.indexOf(classificationData);
-          queue.splice(indexInQueue, 1);
-
-          try {
-            this._saveQueue(queue);
-            console.info('Saved a queued classification, remaining:', queue.length);
-          } catch (error) {
-            console.error('Failed to update classification queue:', error);
-          }
         })
         .catch((error) => {
           if (process.env.BABEL_ENV !== 'test') console.error('Failed to save a queued classification:', error);

--- a/app/lib/classification-queue.js
+++ b/app/lib/classification-queue.js
@@ -13,6 +13,11 @@ class ClassificationQueue {
   }
 
   add(classification) {
+    this.store(classification);
+    return this.flushToBackend();
+  }
+
+  store(classification) {
     const queue = this._loadQueue();
     queue.push(classification);
 
@@ -22,8 +27,6 @@ class ClassificationQueue {
     } catch (error) {
       if (process.env.BABEL_ENV !== 'test') console.error('Failed to queue classification:', error);
     }
-
-    return this.flushToBackend();
   }
 
   length() {
@@ -58,7 +61,7 @@ class ClassificationQueue {
           if (error.status === 422) {
             console.error('Dropping malformed classification permanently', classificationData);
             try {
-              this.add(classificationData);
+              this.store(classificationData);
             } catch (saveQueueError) {
               console.error('Failed to update classification queue:', saveQueueError);
             }

--- a/app/lib/classification-queue.js
+++ b/app/lib/classification-queue.js
@@ -9,7 +9,7 @@ class ClassificationQueue {
     this.storage = window.localStorage;
     this.apiClient = api || apiClient;
     this.recents = [];
-    this.onClassificationSaved = onClassificationSaved;
+    this.onClassificationSaved = onClassificationSaved || function () { return true; };
   }
 
   add(classification) {

--- a/app/lib/classification-queue.js
+++ b/app/lib/classification-queue.js
@@ -50,7 +50,8 @@ class ClassificationQueue {
     if (pendingClassifications.length > 0) {
       if (process.env.BABEL_ENV !== 'test') console.log('Saving queued classifications:', pendingClassifications.length);
       return Promise.all(pendingClassifications.map((classificationData) => {
-        return this.apiClient.type('classifications').create(classificationData).save().then((actualClassification) => {
+        return this.apiClient.type('classifications').create(classificationData).save()
+        .then((actualClassification) => {
           console.log('Saved classification', actualClassification.id);
           this.onClassificationSaved(actualClassification);
           this.addRecent(actualClassification);
@@ -58,13 +59,14 @@ class ClassificationQueue {
         .catch((error) => {
           if (process.env.BABEL_ENV !== 'test') console.error('Failed to save a queued classification:', error);
 
-          if (error.status === 422) {
-            console.error('Dropping malformed classification permanently', classificationData);
+          if (error.status !== 422) {
             try {
               this.store(classificationData);
             } catch (saveQueueError) {
               console.error('Failed to update classification queue:', saveQueueError);
             }
+          } else {
+            console.error('Dropping malformed classification permanently', classificationData);
           }
         });
       }));

--- a/app/lib/classification-queue.js
+++ b/app/lib/classification-queue.js
@@ -23,7 +23,7 @@ class ClassificationQueue {
       if (process.env.BABEL_ENV !== 'test') console.error('Failed to queue classification:', error);
     }
 
-    this.flushToBackend();
+    return this.flushToBackend();
   }
 
   length() {
@@ -46,8 +46,8 @@ class ClassificationQueue {
 
     if (pendingClassifications.length > 0) {
       if (process.env.BABEL_ENV !== 'test') console.log('Saving queued classifications:', pendingClassifications.length);
-      pendingClassifications.forEach((classificationData) => {
-        this.apiClient.type('classifications').create(classificationData).save().then((actualClassification) => {
+      return Promise.all(pendingClassifications.map((classificationData) => {
+        return this.apiClient.type('classifications').create(classificationData).save().then((actualClassification) => {
           console.log('Saved classification', actualClassification.id);
           this.onClassificationSaved(actualClassification);
           this.addRecent(actualClassification);
@@ -74,8 +74,9 @@ class ClassificationQueue {
             }
           }
         });
-      });
+      }));
     }
+    return Promise.resolve([]);
   }
 
   _loadQueue() {

--- a/app/lib/classification-queue.spec.js
+++ b/app/lib/classification-queue.spec.js
@@ -1,16 +1,14 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 import ClassificationQueue from './classification-queue';
-import FakeLocalStorage from '../../test/fake-local-storage';
 import { FakeApiClient, FakeResource } from '../../test/fake-api-client';
 
 describe('ClassificationQueue', function() {
   it('sends classifications to the backend', function(done) {
     let apiClient = new FakeApiClient();
-    let storage = new FakeLocalStorage();
 
     let classificationData = {annotations: [], metadata: {}};
-    let classificationQueue = new ClassificationQueue(storage, apiClient);
+    let classificationQueue = new ClassificationQueue(apiClient);
     classificationQueue.add(classificationData)
     .then(function () {
       expect(apiClient.saves).to.have.lengthOf(1);
@@ -23,10 +21,9 @@ describe('ClassificationQueue', function() {
 
   it('keeps classifications in localStorage if backend fails', function(done) {
     let apiClient = new FakeApiClient({canSave: () => { return false; }});
-    let storage = new FakeLocalStorage();
 
     let classificationData = {annotations: [], metadata: {}};
-    let classificationQueue = new ClassificationQueue(storage, apiClient);
+    let classificationQueue = new ClassificationQueue(apiClient);
     classificationQueue.add(classificationData)
     .catch(function () {
       expect(apiClient.saves).to.have.lengthOf(0);
@@ -46,7 +43,7 @@ describe('ClassificationQueue', function() {
         return new Promise(function (resolve, reject) {});
       });
       apiClient = new FakeApiClient();
-      classificationQueue = new ClassificationQueue(window.localStorage, apiClient);
+      classificationQueue = new ClassificationQueue(apiClient);
       classificationQueue.add({annotations: [], metadata: {}});
       classificationQueue.add({annotations: [], metadata: {}});
     });

--- a/app/lib/classification-queue.spec.js
+++ b/app/lib/classification-queue.spec.js
@@ -16,16 +16,20 @@ describe('ClassificationQueue', function() {
     expect(apiClient.saves).to.have.lengthOf(1);
   });
 
-  it('keeps classifications in localStorage if backend fails', function() {
+  it('keeps classifications in localStorage if backend fails', function(done) {
     let apiClient = new FakeApiClient({canSave: () => { return false; }});
     let storage = new FakeLocalStorage();
 
     let classificationData = {annotations: [], metadata: {}};
     let classificationQueue = new ClassificationQueue(storage, apiClient);
-    classificationQueue.add(classificationData);
-
-    expect(apiClient.saves).to.have.lengthOf(0);
-    expect(classificationQueue.length()).to.equal(1);
+    classificationQueue.add(classificationData)
+    .catch(function () {
+      expect(apiClient.saves).to.have.lengthOf(0);
+      expect(classificationQueue.length()).to.equal(1);
+    })
+    .then(function () {
+      done();
+    });
   });
   describe('with a slow network connection', function () {
     let apiClient;
@@ -37,7 +41,7 @@ describe('ClassificationQueue', function() {
         return new Promise(function (resolve, reject) {});
       });
       apiClient = new FakeApiClient();
-      classificationQueue = new ClassificationQueue(window.storage, apiClient);
+      classificationQueue = new ClassificationQueue(window.localStorage, apiClient);
       classificationQueue.add({annotations: [], metadata: {}});
       classificationQueue.add({annotations: [], metadata: {}});
     });

--- a/app/lib/classification-queue.spec.js
+++ b/app/lib/classification-queue.spec.js
@@ -5,15 +5,20 @@ import FakeLocalStorage from '../../test/fake-local-storage';
 import { FakeApiClient, FakeResource } from '../../test/fake-api-client';
 
 describe('ClassificationQueue', function() {
-  it('sends classifications to the backend', function() {
+  it('sends classifications to the backend', function(done) {
     let apiClient = new FakeApiClient();
     let storage = new FakeLocalStorage();
 
     let classificationData = {annotations: [], metadata: {}};
     let classificationQueue = new ClassificationQueue(storage, apiClient);
-    classificationQueue.add(classificationData);
-
-    expect(apiClient.saves).to.have.lengthOf(1);
+    classificationQueue.add(classificationData)
+    .then(function () {
+      expect(apiClient.saves).to.have.lengthOf(1);
+      expect(classificationQueue.length()).to.equal(0);
+    })
+    .then(function () {
+      done();
+    });
   });
 
   it('keeps classifications in localStorage if backend fails', function(done) {

--- a/app/lib/classification-queue.spec.js
+++ b/app/lib/classification-queue.spec.js
@@ -1,7 +1,8 @@
-import assert from 'assert';
+import { expect } from 'chai';
+import sinon from 'sinon';
 import ClassificationQueue from './classification-queue';
 import FakeLocalStorage from '../../test/fake-local-storage';
-import { FakeApiClient } from '../../test/fake-api-client';
+import { FakeApiClient, FakeResource } from '../../test/fake-api-client';
 
 describe('ClassificationQueue', function() {
   it('sends classifications to the backend', function() {
@@ -12,7 +13,7 @@ describe('ClassificationQueue', function() {
     let classificationQueue = new ClassificationQueue(storage, apiClient);
     classificationQueue.add(classificationData);
 
-    assert.equal(apiClient.saves.length, 1);
+    expect(apiClient.saves).to.have.lengthOf(1);
   });
 
   it('keeps classifications in localStorage if backend fails', function() {
@@ -23,7 +24,28 @@ describe('ClassificationQueue', function() {
     let classificationQueue = new ClassificationQueue(storage, apiClient);
     classificationQueue.add(classificationData);
 
-    assert.equal(apiClient.saves.length, 0);
-    assert.equal(classificationQueue.length(), 1);
+    expect(apiClient.saves).to.have.lengthOf(0);
+    expect(classificationQueue.length()).to.equal(1);
+  });
+  describe('with a slow network connection', function () {
+    let apiClient;
+    let classificationQueue;
+    let saveSpy;
+    before(function () {
+      saveSpy = sinon.stub(FakeResource.prototype, 'save').callsFake(function() {
+        // stub save so that the API call never completes.
+        return new Promise(function (resolve, reject) {});
+      });
+      apiClient = new FakeApiClient();
+      classificationQueue = new ClassificationQueue(window.storage, apiClient);
+      classificationQueue.add({annotations: [], metadata: {}});
+      classificationQueue.add({annotations: [], metadata: {}});
+    });
+    after(function () {
+      saveSpy.restore();
+    });
+    it('saves each classification once', function () {
+      expect(saveSpy.callCount).to.equal(2);
+    });
   });
 });

--- a/app/lib/classification-queue.spec.js
+++ b/app/lib/classification-queue.spec.js
@@ -47,27 +47,27 @@ describe('ClassificationQueue', function() {
     });
   })
 
-  describe('keeps classifications in localStorage if backend fails', function(done) {
+  describe('keeps classifications in localStorage if backend fails', function() {
     beforeEach(function () {
-      let apiClient = new FakeApiClient({canSave: () => { return false; }});
-      let classificationData = {annotations: [], metadata: {}};
+      apiClient = new FakeApiClient({canSave: () => { return false; }});
+      classificationData = {annotations: [], metadata: {}};
       classificationQueue = new ClassificationQueue(apiClient);
     });
-    it('should not save failed classifications', function () {
+    it('should not save failed classifications', function (done) {
       classificationQueue.add(classificationData)
       .then(function () {
         expect(apiClient.saves).to.have.lengthOf(0);
       })
       .then(done, done);
     });
-    it('should queue failed classifications to retry', function () {
+    it('should queue failed classifications to retry', function (done) {
       classificationQueue.add(classificationData)
       .then(function () {
         expect(classificationQueue.length()).to.equal(1);
       })
       .then(done, done);
     });
-    it('should not add failed classifications to recents', function () {
+    it('should not add failed classifications to recents', function (done) {
       classificationQueue.add(classificationData)
       .then(function () {
         expect(classificationQueue.recents).to.have.lengthOf(0);

--- a/app/lib/classification-queue.spec.js
+++ b/app/lib/classification-queue.spec.js
@@ -20,7 +20,8 @@ describe('ClassificationQueue', function() {
     })
     .then(function () {
       done();
-    });
+    })
+    .catch(done);
   });
 
   it('keeps classifications in localStorage if backend fails', function(done) {
@@ -34,7 +35,8 @@ describe('ClassificationQueue', function() {
     })
     .then(function () {
       done();
-    });
+    })
+    .catch(done);
   });
   describe('with a slow network connection', function () {
     let apiClient;

--- a/app/lib/classification-queue.spec.js
+++ b/app/lib/classification-queue.spec.js
@@ -4,11 +4,15 @@ import ClassificationQueue from './classification-queue';
 import { FakeApiClient, FakeResource } from '../../test/fake-api-client';
 
 describe('ClassificationQueue', function() {
+  let classificationQueue;
+  afterEach(function () {
+    classificationQueue._saveQueue([]);
+  });
   it('sends classifications to the backend', function(done) {
     let apiClient = new FakeApiClient();
 
     let classificationData = {annotations: [], metadata: {}};
-    let classificationQueue = new ClassificationQueue(apiClient);
+    classificationQueue = new ClassificationQueue(apiClient);
     classificationQueue.add(classificationData)
     .then(function () {
       expect(apiClient.saves).to.have.lengthOf(1);
@@ -21,9 +25,8 @@ describe('ClassificationQueue', function() {
 
   it('keeps classifications in localStorage if backend fails', function(done) {
     let apiClient = new FakeApiClient({canSave: () => { return false; }});
-
     let classificationData = {annotations: [], metadata: {}};
-    let classificationQueue = new ClassificationQueue(apiClient);
+    classificationQueue = new ClassificationQueue(apiClient);
     classificationQueue.add(classificationData)
     .catch(function () {
       expect(apiClient.saves).to.have.lengthOf(0);
@@ -35,7 +38,6 @@ describe('ClassificationQueue', function() {
   });
   describe('with a slow network connection', function () {
     let apiClient;
-    let classificationQueue;
     let saveSpy;
     before(function () {
       saveSpy = sinon.stub(FakeResource.prototype, 'save').callsFake(function() {

--- a/app/pages/project/classify.jsx
+++ b/app/pages/project/classify.jsx
@@ -29,7 +29,7 @@ function isPresent(val) {
   return val !== undefined && val !== null;
 }
 
-const classificationQueue = new ClassificationQueue(window.localStorage, apiClient, onClassificationSaved);
+const classificationQueue = new ClassificationQueue(apiClient, onClassificationSaved);
 
 // Store this externally to persist during the session.
 let sessionDemoMode = false;

--- a/test/fake-api-client.js
+++ b/test/fake-api-client.js
@@ -26,7 +26,7 @@ export class FakeResourceType {
     return new FakeResource(this, attributes);
   }
 
-  save(attributes) { this.apiClient.save(this.type, attributes)}
+  save(attributes) { return this.apiClient.save(this.type, attributes)}
 }
 
 export class FakeApiClient {


### PR DESCRIPTION
Add a test for the case where the API save request is not resolved between calls to ClassificationQueue.add().

Fix a bug where pending classifications persisted in the queue, resulting in them being sent again each time a new classification was added to the queue.

Fixes some bugs in the fake API classes that break the tests.

Todo:
- [x] Fix the duplicate classification bug #4911
- [x] Fix broken async tests

Staging branch URL: https://classification-queue.pfe-preview.zooniverse.org

Fixes #4911.

Describe your changes.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
