### PR TITLE
Fix fan tool spread angles

### DIFF
--- a/app/classifier/drawing-tools/components/Fan/fan.jsx
+++ b/app/classifier/drawing-tools/components/Fan/fan.jsx
@@ -68,7 +68,9 @@ class Fan extends React.Component {
     const { mark, getEventOffset } = this.props;
     const { x, y } = getEventOffset(e);
     const cursorAngle = Fan.getCursorAngle({ x, y }, mark);
-    let spread = 2 * Math.abs(cursorAngle - mark.rotation);
+    let spread = Math.abs(cursorAngle - mark.rotation);
+    spread = spread > 180 ? 360 - spread : spread;
+    spread = 2 * spread;
     spread = Math.min(spread, MAXIMUM_SPREAD);
     const newMark = Object.assign({}, mark, { spread });
     this.props.onChange(newMark);

--- a/app/classifier/drawing-tools/components/Fan/fan.spec.jsx
+++ b/app/classifier/drawing-tools/components/Fan/fan.spec.jsx
@@ -164,6 +164,19 @@ describe('Fan Tool', function () {
           });
         });
       });
+      it('should update correctly when the cursor crosses the x-axis', function () {
+        const cursor = {
+          x: 300,
+          y: 400
+        };
+        mark.rotation = 315;
+        wrapper.setProps({ mark });
+        wrapper.instance().handleSpread(cursor);
+        expect(onChange.callCount).to.equal(1);
+        const newMark = onChange.getCall(0).args[0];
+        expect(newMark.spread).to.equal(90);
+        onChange.resetHistory();
+      });
     });
   });
 });


### PR DESCRIPTION
Add a test for #4925 and fix it by subtracting the spread angle from 360 at large angles.

Staging branch URL: https://fan-tool-spreads.pfe-preview.zooniverse.org/dev/classifier

Fixes #4925 .

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
