### PR TITLE
Add config to fallback to index.html

### DIFF
--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -12,6 +12,7 @@ var config = {
     allowedHosts: [
       '.zooniverse.org'
     ],
+    historyApiFallback: true,
     https: true,
     host: process.env.HOST || "localhost",
     open: true,


### PR DESCRIPTION
Staging branch URL: https://fix-express-routing.pfe-preview.zooniverse.org/

Follow up from the Webpack v4 update. I added another dev server config to reroute express server 404s back to index.html. This enables us to edit query params in the url and reload the page correctly. I ran into this when trying to add a search query param to the project admin page. 

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
