### PR TITLE
Classifier: use the updateClassification action to update classification metadata

### DIFF
--- a/app/classifier/classifier.jsx
+++ b/app/classifier/classifier.jsx
@@ -144,9 +144,11 @@ class Classifier extends React.Component {
     };
 
     return openFeedbackModal({ feedback: taskFeedback, subjectViewerProps, taskId })
-      .then(() => this.props.classification.update({
-        [`metadata.feedback.${taskId}`]: taskFeedback
-      }));
+      .then(() => {
+        const { actions, classification } = this.props;
+        const feedback = Object.assign({}, classification.metadata.feedback, { [taskId]: taskFeedback });
+        actions.classify.updateClassification({ feedback });
+      });
   }
 
   updateAnnotations(annotations) {

--- a/app/classifier/classifier.jsx
+++ b/app/classifier/classifier.jsx
@@ -192,12 +192,13 @@ class Classifier extends React.Component {
 
   // Whenever a subject image is loaded in the annotator, record its size at that time.
   handleSubjectImageLoad(e, frameIndex) {
+    const { actions, classification } = this.props;
     this.context.geordi.remember({ subjectID: this.props.subject.id });
 
     const { naturalWidth, naturalHeight, clientWidth, clientHeight } = e.target;
-    const changes = {};
-    changes[`metadata.subject_dimensions.${frameIndex}`] = { naturalWidth, naturalHeight, clientWidth, clientHeight };
-    this.props.classification.update(changes);
+    const subject_dimensions = classification.metadata.subject_dimensions.slice();
+    subject_dimensions[frameIndex] = { naturalWidth, naturalHeight, clientWidth, clientHeight };
+    actions.classify.updateClassification({ subject_dimensions });
   }
 
   handleAnnotationChange(classification, newAnnotation) {

--- a/app/classifier/classifier.spec.js
+++ b/app/classifier/classifier.spec.js
@@ -20,8 +20,14 @@ const store = {
   })
 };
 
+const geordi = {
+  keys: {},
+  forget: sinon.stub(),
+  remember: sinon.stub()
+};
+
 const mockReduxStore = {
-  context: { store },
+  context: { geordi, store },
   childContextTypes: { store: PropTypes.object.isRequired }
 };
 
@@ -35,7 +41,10 @@ const classification = mockPanoptesResource('classification', {
       task: 'T1',
       value: 1
     }
-  ]
+  ],
+  metadata: {
+    subject_dimensions: []
+  }
 });
 
 const workflow = mockPanoptesResource('workflow', {
@@ -143,6 +152,45 @@ describe('Classifier', function () {
       const state = wrapper.state();
       expect(state.annotations).to.deep.equal(classification.annotations);
       expect(state.workflowHistory).to.deep.equal(['T0', 'T1']);
+    });
+  });
+
+  describe('on subject image load', function () {
+    const actions = {
+      classify: {
+        updateClassification: sinon.stub().callsFake(changes => changes)
+      }
+    };
+    const fakeEvent = {
+      target: {
+        clientWidth: 500,
+        clientHeight: 250,
+        naturalWidth: 1000,
+        naturalHeight: 500
+      },
+      preventDefault: () => null
+    };
+    beforeEach(function () {
+      wrapper = shallow(
+        <Classifier
+          actions={actions}
+          classification={classification}
+          subject={subject}
+          onComplete={classification.save}
+        />,
+        mockReduxStore
+      );
+      wrapper.instance().handleSubjectImageLoad(fakeEvent, 0);
+    });
+    afterEach(function () {
+      actions.classify.updateClassification.resetHistory();
+    });
+    it('should update the classification with the image dimensions', function () {
+      const expectedChanges = {
+        subject_dimensions: [fakeEvent.target]
+      };
+      const actualChanges = actions.classify.updateClassification.returnValues[0];
+      expect(actualChanges).to.deep.equal(expectedChanges);
     });
   });
 


### PR DESCRIPTION
Staging branch URL: https://update-classification.pfe-preview.zooniverse.org/

Replaces `classification.update()` with `updateClassification()` to update classification metadata in the classifier.

Adds a test for classification update on subject image load.

I couldn't see how to stub the feedback modal in tests, so the feedback changes are untested.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
