### PR TITLE
Classifier: don't persist annotations on unmount

### DIFF
--- a/app/classifier/classifier.jsx
+++ b/app/classifier/classifier.jsx
@@ -93,8 +93,6 @@ class Classifier extends React.Component {
   }
 
   componentWillUnmount() {
-    const annotations = this.state.annotations.slice();
-    this.props.actions.classify.saveAnnotations(annotations);
     try {
       !!this.context.geordi && this.context.geordi.forget(['subjectID']);
     } catch (err) {
@@ -151,6 +149,7 @@ class Classifier extends React.Component {
 
   updateAnnotations(annotations) {
     this.setState({ annotations });
+    this.props.actions.classify.saveAnnotations(annotations);
   }
 
   updateFeedback(taskId) {

--- a/app/classifier/classifier.spec.js
+++ b/app/classifier/classifier.spec.js
@@ -152,6 +152,7 @@ describe('Classifier', function () {
     const actions = {
       classify: {
         completeClassification: sinon.stub(),
+        saveAnnotations: sinon.stub().callsFake(annotations => annotations),
         updateClassification: sinon.stub()
       },
       interventions: {
@@ -230,6 +231,17 @@ describe('Classifier', function () {
           wrapper.update();
           const state = wrapper.state();
           expect(wrapper.find('ClassificationSummary')).to.have.lengthOf(1);
+        })
+        .then(done, done);
+      });
+      it('should reset annotations on going to Talk', function (done) {
+        wrapper.setProps({ workflow });
+        wrapper.instance().completeClassification(fakeEvent)
+        .then(function () {
+          wrapper.update();
+          wrapper.unmount();
+          const annotations = actions.classify.saveAnnotations.returnValues[0];
+          expect(annotations).to.have.lengthOf(0);
         })
         .then(done, done);
       });

--- a/app/classifier/classifier.spec.js
+++ b/app/classifier/classifier.spec.js
@@ -234,14 +234,13 @@ describe('Classifier', function () {
         })
         .then(done, done);
       });
-      it('should reset annotations on going to Talk', function (done) {
+      it('should not update annotations on going to Talk', function (done) {
         wrapper.setProps({ workflow });
         wrapper.instance().completeClassification(fakeEvent)
         .then(function () {
           wrapper.update();
           wrapper.unmount();
-          const annotations = actions.classify.saveAnnotations.returnValues[0];
-          expect(annotations).to.have.lengthOf(0);
+          expect(actions.classify.saveAnnotations.callCount).to.equal(0);
         })
         .then(done, done);
       });
@@ -280,6 +279,7 @@ describe('Classifier', function () {
       const actions = {
         classify: {
           completeClassification: sinon.stub(),
+          saveAnnotations: sinon.stub().callsFake(annotations => annotations),
           updateClassification: sinon.stub()
         },
         feedback: {
@@ -397,20 +397,21 @@ describe('Classifier', function () {
     });
   });
 
-  describe('on unmount', function () {
+  describe('on updating annotations', function () {
     const actions = {
       classify: {
-        saveAnnotations: sinon.stub().callsFake(() => null)
+        saveAnnotations: sinon.stub().callsFake(annotations => annotations)
       }
     };
 
     before(function () {
       wrapper.setProps({ actions });
-      wrapper.unmount();
+      wrapper.instance().updateAnnotations([1, 2, 3]);
     });
 
     it('should save any annotations in progress', function () {
-      expect(actions.classify.saveAnnotations.callCount).to.equal(1);
+      const annotations = actions.classify.saveAnnotations.returnValues[0];
+      expect(annotations).to.deep.equal([1, 2, 3]);
     });
   });
 });


### PR DESCRIPTION
Staging branch URL: https://reset-annotations.pfe-preview.zooniverse.org/

Fixes #4968.

Describe your changes.
Don't save annotations on component unmount. Instead, save annotations to the Redux store whenever the annotations array is updated. Fixes a bug where old annotations could be added to a new classification if the classifier unmounts during the summary step.

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [x] Can you post a talk comment?

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
