### PR TITLE
Minor fixes for classifier tests

### DIFF
--- a/app/classifier/classifier.spec.js
+++ b/app/classifier/classifier.spec.js
@@ -397,15 +397,25 @@ describe('Classifier', function () {
         saveAnnotations: sinon.stub().callsFake(annotations => annotations)
       }
     };
+    const mockAnnotations = [{
+      task: 'a',
+      value: 1
+    }, {
+      task: 'b',
+      value: 2
+    }, {
+      task: 'c',
+      value: 3
+    }];
 
     before(function () {
       wrapper.setProps({ actions });
-      wrapper.instance().updateAnnotations([1, 2, 3]);
+      wrapper.instance().updateAnnotations(mockAnnotations);
     });
 
     it('should save any annotations in progress', function () {
       const annotations = actions.classify.saveAnnotations.returnValues[0];
-      expect(annotations).to.deep.equal([1, 2, 3]);
+      expect(annotations).to.deep.equal(mockAnnotations);
     });
   });
 });

--- a/app/classifier/classifier.spec.js
+++ b/app/classifier/classifier.spec.js
@@ -4,13 +4,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { shallow } from 'enzyme';
 import { Classifier } from './classifier';
-import FakeLocalStorage from '../../test/fake-local-storage';
 import mockPanoptesResource from '../../test/mock-panoptes-resource';
-
-global.innerWidth = 1000;
-global.innerHeight = 1000;
-global.sessionStorage = new FakeLocalStorage();
-sessionStorage.setItem('session_id', JSON.stringify({ id: 0, ttl: 0 }));
 
 const store = {
   subscribe: () => { },

--- a/app/redux/ducks/classify.spec.js
+++ b/app/redux/ducks/classify.spec.js
@@ -1,6 +1,12 @@
 import reducer from './classify';
 import { expect } from 'chai';
 import mockPanoptesResource from '../../../test/mock-panoptes-resource';
+import FakeLocalStorage from '../../../test/fake-local-storage';
+
+global.innerWidth = 1000;
+global.innerHeight = 1000;
+global.sessionStorage = new FakeLocalStorage();
+sessionStorage.setItem('session_id', JSON.stringify({ id: 0, ttl: 0 }));
 
 describe('Classifier actions', function () {
   describe('append subjects', function () {


### PR DESCRIPTION
Moves global variables (for mock classifications) from the classifier tests to the classify action tests (where classifications are tested now.)
Fixes a prop type warning for mock annotations in the classifier tests.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
