### PR TITLE
Fix single answer feedback when the answer is 0

### DIFF
--- a/app/features/feedback/shared/strategies/single-answer-question/reducer.js
+++ b/app/features/feedback/shared/strategies/single-answer-question/reducer.js
@@ -1,6 +1,6 @@
-function singleAnswerQuestionReducer(rule, annotations) {
-  const answerId = annotations || -1
-  const result = rule.answer === answerId.toString()
+function singleAnswerQuestionReducer(rule, answer) {
+  const answerId = (answer > -1) ? answer : -1;
+  const result = rule.answer === answerId.toString();
   return Object.assign({}, rule, {
     success: result
   });

--- a/app/features/feedback/shared/strategies/single-answer-question/reducer.spec.js
+++ b/app/features/feedback/shared/strategies/single-answer-question/reducer.spec.js
@@ -12,14 +12,14 @@ describe('Feedback > Single Answer Question > Reducer', function () {
   })
 
   it('should handle a correct answer', function () {
-    const rule = { answer: '1' }
-    const result = reducer(rule, 1)
+    const rule = { answer: '0' }
+    const result = reducer(rule, 0)
     expect(result.success).to.be.true
   })
 
   it('should handle an incorrect answer', function () {
-    const rule = { answer: '0' }
-    const result = reducer(rule, 1)
+    const rule = { answer: '1' }
+    const result = reducer(rule, 2)
     expect(result.success).to.be.false
   })
 


### PR DESCRIPTION
Change the correct answer test to test for the case where the answer is 0 (ie. falsy) but correct.
Update the incorrect answer test to make sure we aren't being tripped up by 0 values.
Fix the reducer to return the correct value when the supplied answer is 0.

Staging branch URL: https://single-answer-feedback.pfe-preview.zooniverse.org

Fixes #4891.

Describe your changes.

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
