### PR TITLE
Show workflow stats card as 100% if complete

### DIFF
--- a/app/pages/project/stats/stats.jsx
+++ b/app/pages/project/stats/stats.jsx
@@ -279,7 +279,7 @@ export class WorkflowProgress extends React.Component {
         eta = <Eta numDays={this.calcDaysToCompletion(totalCount)}/>;
       }
       if (this.props.workflow.configuration) {
-        if (this.props.workflow.configuration.stats_completeness_type === 'classification') {
+        if (this.props.workflow.configuration.stats_completeness_type === 'classification' && completeness !== 1) {
           completeness = this.props.workflow.classifications_count / totalCount;
           classificationsString += ` / ${totalCount.toLocaleString()}`;
           classificationDiv = (


### PR DESCRIPTION
Staging branch URL: https://workflow-progress-completeness.pfe-preview.zooniverse.org/

Compare workflow "Herbarium_WeDigFLPlants’ Lilies, Wakerobins, and Relatives of Florida," which has a `completed` attribute of `1` and therefore is a completed workflow, between:
- current: https://www.zooniverse.org/projects/zooniverse/notes-from-nature/stats
and
- change: https://workflow-progress-completeness.pfe-preview.zooniverse.org/projects/zooniverse/notes-from-nature/stats?env=production

Fixes #4979.

If from a project's Project Builder/Workflows list a workflow is set to show its completeness statistic on the project's stats page based on classification count and the workflow is complete the stats page still calculates a custom percentage which may be different than 100%. The calculated percentage may not be 100% if there are custom retirement rules or due to other factors. Regardless, if a workflow has a `completeness` of `1` I think it should show as 100% complete on the project stats page.

This change checks if a workflow has `completeness` of `1` before calculating a custom completeness percentage.

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
