### PR TITLE
Fix the gold standard checkbox

### DIFF
--- a/app/classifier/classifier.jsx
+++ b/app/classifier/classifier.jsx
@@ -402,7 +402,6 @@ class Classifier extends React.Component {
             >
               {!!this.props.expertClassifier &&
                 <ExpertOptions
-                  classification={currentClassification}
                   userRoles={this.props.userRoles}
                   demoMode={this.props.demoMode}
                   onChangeDemoMode={this.props.onChangeDemoMode}

--- a/app/classifier/classifier.jsx
+++ b/app/classifier/classifier.jsx
@@ -296,7 +296,7 @@ class Classifier extends React.Component {
   }
 
   render() {
-    const { interventions, user } = this.props;
+    const { actions, interventions, user } = this.props;
     const { showIntervention, showSummary, workflowHistory } = this.state;
     const currentTaskKey = workflowHistory.length > 0 ? workflowHistory[workflowHistory.length - 1] : null;
     const largeFormatImage = this.props.workflow.configuration.image_layout && this.props.workflow.configuration.image_layout.includes('no-max-height');
@@ -436,7 +436,7 @@ class Classifier extends React.Component {
                   <strong>Gold standard mode:</strong>
                   <br />
                   Please ensure this classification is completely accurate.{' '}
-                  <button type="button" className="secret-button" onClick={currentClassification.update.bind(currentClassification, { gold_standard: undefined })}>
+                  <button type="button" className="secret-button" onClick={() => actions.classify.toggleGoldStandard(undefined)}>
                     <u>Disable</u>
                   </button>
                 </small>

--- a/app/classifier/expert-options.jsx
+++ b/app/classifier/expert-options.jsx
@@ -1,11 +1,14 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import TriggeredModalForm from 'modal-form/triggered';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
 import isAdmin from '../lib/is-admin';
+import { toggleGoldStandard } from '../redux/ducks/classify';
 
 function ExpertOptions(props) {
   function handleGoldStandardChange(e) {
-    props.classification.update({ gold_standard: e.target.checked || undefined });
+    props.actions.toggleGoldStandard(e.target.checked || undefined);
   }
 
   function handleDemoModeChange(e) {
@@ -19,7 +22,12 @@ function ExpertOptions(props) {
       {(props.userRoles.includes('owner') || props.userRoles.includes('expert')) &&
         <p>
           <label>
-            <input type="checkbox" checked={!!props.classification.gold_standard} onChange={handleGoldStandardChange} />{' '}
+            <input
+              type="checkbox"
+              checked={!!props.classification.gold_standard}
+              onChange={handleGoldStandardChange}
+            />
+            {' '}
             Gold standard mode
           </label>{' '}
           <TriggeredModalForm
@@ -57,4 +65,15 @@ ExpertOptions.propTypes = {
   userRoles: PropTypes.arrayOf(PropTypes.string)
 };
 
-export default ExpertOptions;
+const mapStateToProps = state => ({
+  classification: state.classify.classification
+});
+
+const mapDispatchToProps = dispatch => ({
+  actions: {
+    toggleGoldStandard: bindActionCreators(toggleGoldStandard, dispatch)
+  }
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(ExpertOptions);
+export { ExpertOptions };

--- a/app/redux/ducks/classify.js
+++ b/app/redux/ducks/classify.js
@@ -105,6 +105,7 @@ const RESUME_CLASSIFICATION = 'pfe/classify/RESUME_CLASSIFICATION';
 const RESET_SUBJECTS = 'pfe/classify/RESET_SUBJECTS';
 const SAVE_ANNOTATIONS = 'pfe/classify/SAVE_ANNOTATIONS';
 const SET_WORKFLOW = 'pfe/classify/SET_WORKFLOW';
+const TOGGLE_GOLD_STANDARD = 'pfe/classify/TOGGLE_GOLD_STANDARD';
 
 export default function reducer(state = initialState, action = {}) {
   switch (action.type) {
@@ -191,6 +192,12 @@ export default function reducer(state = initialState, action = {}) {
     case SET_WORKFLOW: {
       const { workflow } = action.payload;
       return Object.assign({}, state, { workflow });
+    }
+    case TOGGLE_GOLD_STANDARD: {
+      const { goldStandard } = action.payload;
+      const { classification } = state;
+      classification.update({ gold_standard: goldStandard });
+      return Object.assign({}, state, { classification });
     }
     default:
       return state;
@@ -314,6 +321,13 @@ export function setWorkflow(workflow) {
   return {
     type: SET_WORKFLOW,
     payload: { workflow }
+  };
+}
+
+export function toggleGoldStandard(goldStandard) {
+  return {
+    type: TOGGLE_GOLD_STANDARD,
+    payload: { goldStandard }
   };
 }
 

--- a/app/redux/ducks/classify.spec.js
+++ b/app/redux/ducks/classify.spec.js
@@ -354,4 +354,43 @@ describe('Classifier actions', function () {
       expect(newState.classification.annotations).to.deep.equal(action.payload.annotations);
     });
   });
+  describe('toggle gold standard', function () {
+    it('should set gold standard classifications', function () {
+      const action = {
+        type: 'pfe/classify/TOGGLE_GOLD_STANDARD',
+        payload: {
+          goldStandard: true
+        }
+      };
+      const state = {
+        classification: mockPanoptesResource('classifications', {})
+      };
+      const newState = reducer(state, action);
+      expect(newState.classification.gold_standard).to.be.true;
+    });
+    it('should unset gold standard classifications', function () {
+      const action = {
+        type: 'pfe/classify/TOGGLE_GOLD_STANDARD',
+        payload: {
+          goldStandard: false
+        }
+      };
+      const state = {
+        classification: mockPanoptesResource('classifications', {})
+      };
+      const newState = reducer(state, action);
+      expect(newState.classification.gold_standard).to.be.false;
+    });
+    it('should unset gold standard classifications if undefined', function () {
+      const action = {
+        type: 'pfe/classify/TOGGLE_GOLD_STANDARD',
+        payload: {}
+      };
+      const state = {
+        classification: mockPanoptesResource('classifications', {})
+      };
+      const newState = reducer(state, action);
+      expect(newState.classification.gold_standard).to.be.undefined;
+    });
+  });
 });


### PR DESCRIPTION
Staging branch URL: https://gold-standard.pfe-preview.zooniverse.org/

Fixes #4984.
Fixes #4564.

Adds an action to toggle `classification.gold_standard` and binds the gold standard checkbox to that action.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
