### PR TITLE
Only use workflow assignment split if workflow assignment is enabled

### DIFF
--- a/app/pages/project/index.jsx
+++ b/app/pages/project/index.jsx
@@ -248,10 +248,10 @@ class ProjectPageController extends React.Component {
             this.setState({ background, organization, owner, pages, projectAvatar, projectIsComplete, projectRoles, projectPreferences, splits });
             this.loadFieldGuide(project.id);
             this.props.actions.translations.loadTranslations('project_page', pages.map(page => page.id), this.props.translations.locale);
-            return { projectPreferences, splits };
+            return { project, projectPreferences, splits };
           })
-          .then(({ projectPreferences, splits }) => {
-            this.handleSplitWorkflowAssignment(projectPreferences, splits);
+          .then(({ project, projectPreferences, splits }) => {
+            if (project.experimental_tools.includes('workflow assignment')) this.handleSplitWorkflowAssignment(projectPreferences, splits);
           })
           .then(() => {
             this.setState({ ready: true })


### PR DESCRIPTION
Staging branch URL: https://check-for-experimental-tool.pfe-preview.zooniverse.org/

The Snapshot WI split experiment is delayed a week, but in the meantime I double checked the code I added and noticed that the class method that handles the split data to update user's project preferences didn't check to make sure that workflow assignment is enabled for the project. This PR adds a check before the method is called. 

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
