### PR TITLE
Fix page scroll when drawing

### DIFF
--- a/app/classifier/drawing-tools/root.jsx
+++ b/app/classifier/drawing-tools/root.jsx
@@ -34,12 +34,15 @@ export default class DrawingToolRoot extends React.Component {
   focusDrawingTool() {
     const x = window.scrollX;
     const y = window.scrollY;
+    const { root } = this;
     try {
-      if (this.root) this.root.focus();
+      if (root && root.focus) {
+        root.focus();
+        window.scrollTo(x, y);
+      }
     } catch (error) {
       console.info('Edge currently does not support focus on SVG elements:', error);
     }
-    window.scrollTo(x, y);
   }
 
   render() {


### PR DESCRIPTION
Only try to scroll the window in browsers that support focus() on SVG elements (currently webkit, blink and Firefox.) This should fix an annoying jump to the top of the page that some volunteers are encountering when they try to draw.

Staging branch URL: https://fix-drawing-scroll.pfe-preview.zooniverse.org

Fixes #5007 .

Describe your changes.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
