### PR TITLE
Persist Gold Standard Mode with Indicator

### DIFF
--- a/app/classifier/classifier.jsx
+++ b/app/classifier/classifier.jsx
@@ -299,6 +299,7 @@ class Classifier extends React.Component {
     const { actions, goldStandardMode, interventions, user } = this.props;
     const { showIntervention, showSummary, workflowHistory } = this.state;
     const currentTaskKey = workflowHistory.length > 0 ? workflowHistory[workflowHistory.length - 1] : null;
+    const taskAreaVariant = goldStandardMode ? 'goldStandardMode' : 'default';
     const largeFormatImage = this.props.workflow.configuration.image_layout && this.props.workflow.configuration.image_layout.includes('no-max-height');
     const classifierClassNames = classNames({
       classifier: true,
@@ -345,7 +346,7 @@ class Classifier extends React.Component {
           playIterations={this.props.workflow.configuration.playIterations}
         />
         <ThemeProvider theme={{ mode: this.props.theme }}>
-          <TaskArea variant={goldStandardMode ? 'goldStandardMode' : 'default'}>
+          <TaskArea variant={taskAreaVariant}>
             <TaskTabs
               projectPreferences={this.props.preferences}
               tutorial={this.props.tutorial}

--- a/app/classifier/classifier.jsx
+++ b/app/classifier/classifier.jsx
@@ -296,7 +296,7 @@ class Classifier extends React.Component {
   }
 
   render() {
-    const { actions, interventions, user } = this.props;
+    const { actions, goldStandardMode, interventions, user } = this.props;
     const { showIntervention, showSummary, workflowHistory } = this.state;
     const currentTaskKey = workflowHistory.length > 0 ? workflowHistory[workflowHistory.length - 1] : null;
     const largeFormatImage = this.props.workflow.configuration.image_layout && this.props.workflow.configuration.image_layout.includes('no-max-height');
@@ -345,7 +345,7 @@ class Classifier extends React.Component {
           playIterations={this.props.workflow.configuration.playIterations}
         />
         <ThemeProvider theme={{ mode: this.props.theme }}>
-          <TaskArea>
+          <TaskArea variant={goldStandardMode ? 'goldStandardMode' : 'default'}>
             <TaskTabs
               projectPreferences={this.props.preferences}
               tutorial={this.props.tutorial}
@@ -486,6 +486,7 @@ Classifier.propTypes = {
     active: PropTypes.bool,
     rules: PropTypes.object
   }),
+  goldStandardMode: PropTypes.bool,
   interventions: PropTypes.shape({
     notifications: PropTypes.array
   }),
@@ -543,6 +544,7 @@ Classifier.defaultProps = {
   feedback: {
     active: false
   },
+  goldStandardMode: false,
   interventions: {
     notifications: []
   },
@@ -567,6 +569,7 @@ Classifier.defaultProps = {
 
 const mapStateToProps = state => ({
   feedback: state.feedback,
+  goldStandardMode: state.classify.goldStandardMode,
   interventions: state.interventions,
   theme: state.userInterface.theme
 });

--- a/app/classifier/components/TaskArea/TaskArea.jsx
+++ b/app/classifier/components/TaskArea/TaskArea.jsx
@@ -1,12 +1,25 @@
 import styled from 'styled-components';
 import theme from 'styled-theming';
+import PropTypes from 'prop-types';
 import { zooTheme } from '../../../theme';
 
+const backgroundColor = theme.variants('mode', 'variant', {
+  default: {
+    light: 'white',
+    dark: zooTheme.colors.darkTheme.background.default
+  },
+  goldStandardMode: {
+    light: zooTheme.colors.lightTheme.background.goldStandard,
+    dark: zooTheme.colors.darkTheme.background.goldStandard
+  }
+});
+
 const TaskArea = styled.div`
-  background-color: ${theme('mode', {
+  ${'' /* background-color: ${theme('mode', {
     dark: zooTheme.colors.darkTheme.background.default,
     light: 'white'
-  })};
+  })}; */}
+  background-color: ${backgroundColor};
   border: solid thin ${theme('mode', {
     dark: zooTheme.colors.darkTheme.background.border,
     light: zooTheme.colors.lightTheme.background.border
@@ -24,5 +37,13 @@ const TaskArea = styled.div`
     margin-left: 1em;
   }
 `;
+
+TaskArea.propTypes = {
+  variant: PropTypes.oneOf(['default', 'goldStandardMode'])
+};
+
+TaskArea.defaultProps = {
+  variant: 'default'
+};
 
 export default TaskArea;

--- a/app/classifier/components/TaskArea/TaskArea.jsx
+++ b/app/classifier/components/TaskArea/TaskArea.jsx
@@ -3,11 +3,7 @@ import theme from 'styled-theming';
 import PropTypes from 'prop-types';
 import { zooTheme } from '../../../theme';
 
-const backgroundColor = theme.variants('mode', 'variant', {
-  default: {
-    light: 'white',
-    dark: zooTheme.colors.darkTheme.background.default
-  },
+const background = theme.variants('mode', 'variant', {
   goldStandardMode: {
     light: zooTheme.colors.lightTheme.background.goldStandard,
     dark: zooTheme.colors.darkTheme.background.goldStandard
@@ -15,11 +11,11 @@ const backgroundColor = theme.variants('mode', 'variant', {
 });
 
 const TaskArea = styled.div`
-  ${'' /* background-color: ${theme('mode', {
+  background: ${background};
+  background-color: ${theme('mode', {
     dark: zooTheme.colors.darkTheme.background.default,
     light: 'white'
-  })}; */}
-  background-color: ${backgroundColor};
+  })};
   border: solid thin ${theme('mode', {
     dark: zooTheme.colors.darkTheme.background.border,
     light: zooTheme.colors.lightTheme.background.border

--- a/app/classifier/components/TaskNavButtons/components/DoneButton/DoneButton.jsx
+++ b/app/classifier/components/TaskNavButtons/components/DoneButton/DoneButton.jsx
@@ -5,7 +5,7 @@ import styled, { ThemeProvider } from 'styled-components';
 import theme from 'styled-theming';
 import { darken, lighten } from 'polished';
 import Translate from 'react-translate-component';
-import { pxToRem, zooTheme } from '../../../../../theme';
+import { zooTheme } from '../../../../../theme';
 
 export const StyledDoneButton = styled.button.attrs({
   disabled: props => props.disabled,

--- a/app/redux/ducks/classify.spec.js
+++ b/app/redux/ducks/classify.spec.js
@@ -292,7 +292,7 @@ describe('Classifier actions', function () {
       }
     };
     const state = {
-      classification: mockPanoptesResource('classifications', { 
+      classification: mockPanoptesResource('classifications', {
         id: '1',
         metadata: {
           b: 3,
@@ -355,7 +355,7 @@ describe('Classifier actions', function () {
     });
   });
   describe('toggle gold standard', function () {
-    it('should set gold standard classifications', function () {
+    it('should set gold standard classifications and mode', function () {
       const action = {
         type: 'pfe/classify/TOGGLE_GOLD_STANDARD',
         payload: {
@@ -367,8 +367,9 @@ describe('Classifier actions', function () {
       };
       const newState = reducer(state, action);
       expect(newState.classification.gold_standard).to.be.true;
+      expect(newState.goldStandardMode).to.be.true;
     });
-    it('should unset gold standard classifications', function () {
+    it('should unset gold standard classifications and mode', function () {
       const action = {
         type: 'pfe/classify/TOGGLE_GOLD_STANDARD',
         payload: {
@@ -380,6 +381,7 @@ describe('Classifier actions', function () {
       };
       const newState = reducer(state, action);
       expect(newState.classification.gold_standard).to.be.false;
+      expect(newState.goldStandardMode).to.be.false;
     });
     it('should unset gold standard classifications if undefined', function () {
       const action = {

--- a/app/theme/colors.js
+++ b/app/theme/colors.js
@@ -2,7 +2,8 @@ export default {
   darkTheme: {
     background: {
       border: '#2D2D2D',
-      default: '#333333'
+      default: '#333333',
+      goldStandard: 'blue'
     },
     button: {
       answer: {
@@ -22,7 +23,8 @@ export default {
   lightTheme: {
     background: {
       border: '#ebebeb',
-      default: '#EEF2F5'
+      default: '#EEF2F5',
+      goldStandard: 'red'
     },
     button: {
       answer: {

--- a/app/theme/colors.js
+++ b/app/theme/colors.js
@@ -3,7 +3,7 @@ export default {
     background: {
       border: '#2D2D2D',
       default: '#333333',
-      goldStandard: 'blue'
+      goldStandard: 'linear-gradient(0deg, rgba(240,178,0,1) 0%, rgba(240,178,0,0) 25%)'
     },
     button: {
       answer: {
@@ -24,7 +24,7 @@ export default {
     background: {
       border: '#ebebeb',
       default: '#EEF2F5',
-      goldStandard: 'red'
+      goldStandard: 'linear-gradient(0deg, rgba(240,178,0,1) 0%, rgba(240,178,0,0) 25%)'
     },
     button: {
       answer: {


### PR DESCRIPTION
Staging branch URL:
https://persist-gsm.pfe-preview.zooniverse.org/

Fixes #4994 

Describe your changes.
This PR persists gold standard mode through consecutive classifications. The PR also makes it more evident a user is in GS mode by providing a gold gradient background. This is to keep users from accidentally submitting classifications that are not supposed to be tagged `gold_standard`.

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [x] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
