### PR TITLE
Add workflow image layout to project admin form

### DIFF
--- a/app/pages/admin/project-status.jsx
+++ b/app/pages/admin/project-status.jsx
@@ -161,6 +161,17 @@ class ProjectStatus extends Component {
     }
   }
 
+  toggleWorkflowImageHeight(workflow, e) {
+    const noMaxHeight = e.target.checked;
+    const { image_layout } = workflow.configuration;
+    const newLayout = image_layout && image_layout.slice ? image_layout.slice() : []
+    const index = newLayout.indexOf('no-max-height');
+    newLayout.splice(index, 1);
+    if (noMaxHeight) {
+      newLayout.push('no-max-height');
+    }
+    workflow.update({ 'configuration.image_layout': newLayout }).save();
+  }
   renderWorkflows() {
     if (this.state.workflows.length === 0) {
       return <div>No workflows found</div>;
@@ -205,6 +216,22 @@ class ProjectStatus extends Component {
                   })}
                 </select>
               </label>
+              <fieldset>
+                <legend>Subject image layout</legend>
+                <label>
+                  <input
+                    type="checkbox"
+                    name="configuration.image_layout"
+                    value="no-max-height"
+                    checked={
+                      workflow.configuration.image_layout &&
+                      workflow.configuration.image_layout.indexOf('no-max-height') > -1
+                    }
+                    onChange={event => this.toggleWorkflowImageHeight(workflow, event)}
+                  />
+                  no max height
+                </label>
+              </fieldset>
             </li>
           );
         })}

--- a/app/pages/admin/project-status.jsx
+++ b/app/pages/admin/project-status.jsx
@@ -223,7 +223,7 @@ class ProjectStatus extends Component {
                     type="checkbox"
                     name="configuration.image_layout"
                     value="no-max-height"
-                    checked={
+                    defaultChecked={
                       workflow.configuration.image_layout &&
                       workflow.configuration.image_layout.indexOf('no-max-height') > -1
                     }


### PR DESCRIPTION
Add an image layout section to the workflow settings on the project admin page, with a checkbox for the no-max-height setting.

Staging branch URL: https://no-max-height.pfe-preview.zooniverse.org

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
