### PR TITLE
Update seenThisSession on classification complete

### DIFF
--- a/app/classifier/classifier.spec.js
+++ b/app/classifier/classifier.spec.js
@@ -6,6 +6,9 @@ import { shallow } from 'enzyme';
 import { Classifier } from './classifier';
 import mockPanoptesResource from '../../test/mock-panoptes-resource';
 
+global.innerWidth = 1000;
+global.innerHeight = 1000;
+
 const store = {
   subscribe: () => { },
   dispatch: () => { },
@@ -38,6 +41,10 @@ const classification = mockPanoptesResource('classification', {
   ],
   metadata: {
     subject_dimensions: []
+  },
+  links: {
+    workflow: 'test',
+    subjects: ['a']
   }
 });
 

--- a/app/pages/project/classify.jsx
+++ b/app/pages/project/classify.jsx
@@ -10,7 +10,6 @@ import { bindActionCreators } from 'redux';
 import counterpart from 'counterpart';
 import { Split } from 'seven-ten';
 
-import seenThisSession from '../../lib/seen-this-session';
 import ClassificationQueue from '../../lib/classification-queue';
 
 import * as classifierActions from '../../redux/ducks/classify';
@@ -172,10 +171,6 @@ export class ProjectClassifyPage extends React.Component {
     const { classification } = this.props;
     console.info('Completed classification', classification);
 
-    let workflow = null;
-    let subjects = null;
-    ({ workflow, subjects } = classification.links);
-    seenThisSession.add(workflow, subjects);
     if (!this.state.demoMode) {
       classificationQueue.add(classification);
     }

--- a/app/redux/ducks/classify.js
+++ b/app/redux/ducks/classify.js
@@ -127,6 +127,8 @@ export default function reducer(state = initialState, action = {}) {
     case COMPLETE_CLASSIFICATION: {
       const { annotations } = action.payload;
       const classification = finishClassification(state.workflow, state.classification, annotations);
+      const { workflow, subjects } = classification.links;
+      seenThisSession.add(workflow, subjects);
       return Object.assign({}, state, { classification });
     }
     case CREATE_CLASSIFICATION: {

--- a/app/redux/ducks/classify.spec.js
+++ b/app/redux/ducks/classify.spec.js
@@ -259,7 +259,13 @@ describe('Classifier actions', function () {
       }
     };
     const state = {
-      classification: mockPanoptesResource('classifications', { id: '1' }),
+      classification: mockPanoptesResource('classifications', {
+        id: '1',
+        links: {
+          subjects: ['1'],
+          workflow: '1'
+        }
+      }),
       workflow: {
         id: '1',
         tasks: {


### PR DESCRIPTION
Call seenThisSession when the redux completeClassification() action is called.
Remove seenThisSession from the project classify page.
Update tests.

Pure functions can't be stubbed or spied on with Sinon, so this change isn't testable at the moment.

Staging branch URL: https://pr-5030.pfe-preview.zooniverse.org/

Describe your changes.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
