### PR TITLE
Add a test for seenThisSession on classification complete

### DIFF
--- a/app/redux/ducks/classify.spec.js
+++ b/app/redux/ducks/classify.spec.js
@@ -276,11 +276,16 @@ describe('Classifier actions', function () {
       upcomingSubjects: [1, 2]
     };
     const subject = {
-        id: '2',
-        locations: [],
-        metadata: [],
-        destroy: function () {}
-      }
+      id: '2',
+      locations: [],
+      metadata: [],
+      destroy: function () {}
+    };
+    it('should mark the workflow subject as seen', function () {
+      expect(seenThisSession.check(state.workflow, subject)).to.be.false;
+      const newState = reducer(state, action);
+      expect(seenThisSession.check(newState.workflow, subject)).to.be.true;
+    });
     it('should set the classification completed flag', function () {
       const newState = reducer(state, action);
       expect(newState.classification.completed).to.be.true;
@@ -292,10 +297,6 @@ describe('Classifier actions', function () {
     it('should record the classification annotations', function () {
       const newState = reducer(state, action);
       expect(newState.classification.annotations).to.deep.equal(action.payload.annotations);
-    });
-    it('should mark the workflow subject as seen', function () {
-      const newState = reducer(state, action);
-      expect(seenThisSession.check(newState.workflow, subject)).to.be.true;
     });
   });
   describe('update classification', function () {

--- a/app/redux/ducks/classify.spec.js
+++ b/app/redux/ducks/classify.spec.js
@@ -2,6 +2,7 @@ import reducer from './classify';
 import { expect } from 'chai';
 import mockPanoptesResource from '../../../test/mock-panoptes-resource';
 import FakeLocalStorage from '../../../test/fake-local-storage';
+import seenThisSession from '../../lib/seen-this-session';
 
 global.innerWidth = 1000;
 global.innerHeight = 1000;
@@ -262,18 +263,24 @@ describe('Classifier actions', function () {
       classification: mockPanoptesResource('classifications', {
         id: '1',
         links: {
-          subjects: ['1'],
-          workflow: '1'
+          subjects: ['2'],
+          workflow: '3'
         }
       }),
       workflow: {
-        id: '1',
+        id: '3',
         tasks: {
           a: {}
         }
       },
       upcomingSubjects: [1, 2]
     };
+    const subject = {
+        id: '2',
+        locations: [],
+        metadata: [],
+        destroy: function () {}
+      }
     it('should set the classification completed flag', function () {
       const newState = reducer(state, action);
       expect(newState.classification.completed).to.be.true;
@@ -285,6 +292,10 @@ describe('Classifier actions', function () {
     it('should record the classification annotations', function () {
       const newState = reducer(state, action);
       expect(newState.classification.annotations).to.deep.equal(action.payload.annotations);
+    });
+    it('should mark the workflow subject as seen', function () {
+      const newState = reducer(state, action);
+      expect(seenThisSession.check(newState.workflow, subject)).to.be.true;
     });
   });
   describe('update classification', function () {


### PR DESCRIPTION
Test that subjects are marked as seen, for a workflow, when a classification completes.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
