### PR TITLE
Remove preferences change listener from workflow selection

### DIFF
--- a/app/classifier/tasks/drawing/marking-initializer.cjsx
+++ b/app/classifier/tasks/drawing/marking-initializer.cjsx
@@ -82,7 +82,7 @@ module.exports = createReactClass
     @onChange()
 
   handleInitRelease: (e) ->
-    pref = @props.preferences.preferences
+    pref = @props.preferences?.preferences ? {}
     taskDescription = @props.workflow.tasks[@props.annotation.task]
     mark = @props.annotation.value[@props.annotation.value.length - 1]
     MarkComponent = drawingTools[taskDescription.tools[mark.tool].type]

--- a/app/pages/project/classify.jsx
+++ b/app/pages/project/classify.jsx
@@ -185,13 +185,20 @@ export class ProjectClassifyPage extends React.Component {
   }
 
   maybePromptWorkflowAssignmentDialog(props) {
+    const { actions, preferences, project, splits } = props;
     if (this.state.promptWorkflowAssignmentDialog) {
-      WorkflowAssignmentDialog.start({ splits: props.splits, project: props.project }).then(() =>
+      WorkflowAssignmentDialog.start({ splits, project }).then(() =>
         this.setState({ promptWorkflowAssignmentDialog: false })
       ).then(() => {
-        if (props.preferences.preferences.selected_workflow !== props.preferences.settings.workflow_id) {
-          props.preferences.update({ 'preferences.selected_workflow': props.preferences.settings.workflow_id });
-          props.preferences.save();
+        if (preferences.preferences.selected_workflow !== preferences.settings.workflow_id) {
+          preferences.update({ 'preferences.selected_workflow': preferences.settings.workflow_id });
+          preferences.save();
+          apiClient
+            .type('workflows')
+            .get(preferences.settings.workflow_id, {})
+            .then((newWorkflow) => {
+              actions.classifier.setWorkflow(newWorkflow);
+            });
         }
       });
     }

--- a/app/pages/project/home/home-workflow-button.jsx
+++ b/app/pages/project/home/home-workflow-button.jsx
@@ -15,7 +15,7 @@ export default class ProjectHomeWorkflowButton extends React.Component {
     if (this.props.disabled) {
       e.preventDefault();
     } else {
-      this.props.onChangePreferences('preferences.selected_workflow', this.props.workflow.id);
+      this.props.preferences.update({ 'preferences.selected_workflow': this.props.workflow.id });
     }
   }
 
@@ -57,7 +57,7 @@ export default class ProjectHomeWorkflowButton extends React.Component {
 
 ProjectHomeWorkflowButton.defaultProps = {
   disabled: false,
-  onChangePreferences: () => {},
+  preferences: {},
   project: {},
   workflow: {},
   workflowAssignment: false
@@ -65,7 +65,9 @@ ProjectHomeWorkflowButton.defaultProps = {
 
 ProjectHomeWorkflowButton.propTypes = {
   disabled: PropTypes.bool,
-  onChangePreferences: PropTypes.func.isRequired,
+  preferences: PropTypes.shape({
+    update: PropTypes.func
+  }),
   project: PropTypes.shape({
     slug: PropTypes.string
   }).isRequired,

--- a/app/pages/project/home/home-workflow-button.spec.js
+++ b/app/pages/project/home/home-workflow-button.spec.js
@@ -3,6 +3,7 @@ import assert from 'assert';
 import { shallow } from 'enzyme';
 import sinon from 'sinon';
 import ProjectHomeWorkflowButton from './home-workflow-button';
+import mockPanoptesResource from '../../../../test/mock-panoptes-resource';
 
 const testWorkflowWithLevel = {
   id: '2342',
@@ -20,17 +21,17 @@ const testProject = {
   slug: 'zooniverse/project'
 };
 
+const preferences = mockPanoptesResource('project-preferences', {});
+
 describe('ProjectHomeWorkflowButton', function() {
   let wrapper;
   let handleWorkflowSelectionSpy;
-  let onChangePreferencesSpy;
   before(function() {
     handleWorkflowSelectionSpy = sinon.spy(ProjectHomeWorkflowButton.prototype, 'handleWorkflowSelection');
-    onChangePreferencesSpy = sinon.spy();
     wrapper = shallow(
       <ProjectHomeWorkflowButton
         disabled={false}
-        onChangePreferences={onChangePreferencesSpy}
+        preferences={preferences}
         project={testProject}
         workflow={testWorkflowWithoutLevel}
         workflowAssignment={false}
@@ -55,7 +56,7 @@ describe('ProjectHomeWorkflowButton', function() {
   it('calls handleWorkflowSelection onClick', function() {
     wrapper.find('Link').simulate('click');
     assert.equal(handleWorkflowSelectionSpy.calledOnce, true);
-    assert.equal(onChangePreferencesSpy.calledOnce, true);
+    assert.equal(preferences.update.calledOnce, true);
   });
 
   it('uses the project slug in the Link href', function() {
@@ -67,7 +68,7 @@ describe('ProjectHomeWorkflowButton', function() {
       wrapper = shallow(
         <ProjectHomeWorkflowButton
           disabled={true}
-          onChangePreferences={onChangePreferencesSpy}
+          preferences={preferences}
           project={testProject}
           workflow={testWorkflowWithoutLevel}
           workflowAssignment={false}
@@ -90,7 +91,7 @@ describe('ProjectHomeWorkflowButton', function() {
       wrapper = shallow(
         <ProjectHomeWorkflowButton
           disabled={false}
-          onChangePreferences={onChangePreferencesSpy}
+          preferences={preferences}
           project={testProject}
           workflow={testWorkflowWithoutLevel}
           workflowAssignment={true}

--- a/app/pages/project/home/home-workflow-button.spec.js
+++ b/app/pages/project/home/home-workflow-button.spec.js
@@ -2,7 +2,8 @@ import React from 'react';
 import assert from 'assert';
 import { shallow } from 'enzyme';
 import sinon from 'sinon';
-import ProjectHomeWorkflowButton from './home-workflow-button';
+import apiClient from 'panoptes-client/lib/api-client';
+import { ProjectHomeWorkflowButton } from './home-workflow-button';
 import mockPanoptesResource from '../../../../test/mock-panoptes-resource';
 
 const testWorkflowWithLevel = {
@@ -23,23 +24,43 @@ const testProject = {
 
 const preferences = mockPanoptesResource('project-preferences', {});
 
+const actions = {
+  classifier: {
+    setWorkflow: sinon.stub()
+  }
+};
+
+const user = mockPanoptesResource('user', {});
+
 describe('ProjectHomeWorkflowButton', function() {
   let wrapper;
   let handleWorkflowSelectionSpy;
   before(function() {
     handleWorkflowSelectionSpy = sinon.spy(ProjectHomeWorkflowButton.prototype, 'handleWorkflowSelection');
+    sinon.stub(apiClient, 'type').callsFake(() => {
+      return {
+        get: () => Promise.resolve(testWorkflowWithoutLevel)
+      }
+    });
     wrapper = shallow(
       <ProjectHomeWorkflowButton
+        actions={actions}
         disabled={false}
         preferences={preferences}
         project={testProject}
+        user={user}
         workflow={testWorkflowWithoutLevel}
         workflowAssignment={false}
       />
     );
   });
+  afterEach(function () {
+    actions.classifier.setWorkflow.resetHistory();
+    preferences.update.resetHistory();
+  });
   after(function () {
     handleWorkflowSelectionSpy.restore();
+    apiClient.type.restore();
   });
 
   it('renders without crashing', function () {});
@@ -56,9 +77,29 @@ describe('ProjectHomeWorkflowButton', function() {
   it('calls handleWorkflowSelection onClick', function() {
     wrapper.find('Link').simulate('click');
     assert.equal(handleWorkflowSelectionSpy.calledOnce, true);
-    assert.equal(preferences.update.calledOnce, true);
   });
 
+  it('should update user preferences on workflow selection', function (done) {
+    wrapper.instance().handleWorkflowSelection()
+    .then(function () {
+      assert.equal(preferences.update.calledOnce, true);
+    })
+    .then(done, done);
+  });
+  it('should clear the current workflow', function (done) {
+    wrapper.instance().handleWorkflowSelection()
+    .then(function () {
+      assert.equal(actions.classifier.setWorkflow.firstCall.calledWith(null), true);
+    })
+    .then(done, done);
+  });
+  it('should select a new workflow', function (done) {
+    wrapper.instance().handleWorkflowSelection()
+    .then(function () {
+      assert.equal(actions.classifier.setWorkflow.secondCall.calledWith(testWorkflowWithoutLevel), true);
+    })
+    .then(done, done);
+  });
   it('uses the project slug in the Link href', function() {
     assert.equal(wrapper.find('Link').props().to.includes(testProject.slug), true);
   });

--- a/app/pages/project/home/home-workflow-buttons.jsx
+++ b/app/pages/project/home/home-workflow-buttons.jsx
@@ -31,7 +31,7 @@ export default class ProjectHomeWorkflowButtons extends React.Component {
 
     return (
       <div className="project-home-workflow-buttons">
-        {this.props.showWorkflowButtons && this.props.activeWorkflows.length > 0 && this.props.preferences &&
+        {this.props.showWorkflowButtons && this.props.activeWorkflows.length > 0 &&
           (<div className="project-home-page__container project-home-workflow-buttons__workflow-choice-container">
             <div className="project-home-page__content">
               <h3 className="workflow-choice-container__call-to-action">
@@ -48,6 +48,7 @@ export default class ProjectHomeWorkflowButtons extends React.Component {
                     disabled={this.shouldWorkflowBeDisabled(workflow)}
                     preferences={this.props.preferences}
                     project={this.props.project}
+                    user={this.props.user}
                     workflow={workflow}
                     workflowAssignment={this.props.workflowAssignment}
                   />);

--- a/app/pages/project/home/home-workflow-buttons.jsx
+++ b/app/pages/project/home/home-workflow-buttons.jsx
@@ -46,7 +46,7 @@ export default class ProjectHomeWorkflowButtons extends React.Component {
                   <ProjectHomeWorkflowButton
                     key={workflow.id}
                     disabled={this.shouldWorkflowBeDisabled(workflow)}
-                    onChangePreferences={this.props.onChangePreferences}
+                    preferences={this.props.preferences}
                     project={this.props.project}
                     workflow={workflow}
                     workflowAssignment={this.props.workflowAssignment}
@@ -64,7 +64,6 @@ export default class ProjectHomeWorkflowButtons extends React.Component {
 
 ProjectHomeWorkflowButtons.defaultProps = {
   activeWorkflows: [],
-  onChangePreferences: () => {},
   preferences: {},
   project: {},
   showWorkflowButtons: false,
@@ -75,7 +74,6 @@ ProjectHomeWorkflowButtons.defaultProps = {
 
 ProjectHomeWorkflowButtons.propTypes = {
   activeWorkflows: PropTypes.arrayOf(PropTypes.object).isRequired,
-  onChangePreferences: PropTypes.func.isRequired,
   preferences: PropTypes.shape({
     preferences: PropTypes.object,
     settings: PropTypes.objectOf(PropTypes.string)

--- a/app/pages/project/home/home-workflow-buttons.spec.js
+++ b/app/pages/project/home/home-workflow-buttons.spec.js
@@ -2,6 +2,7 @@ import React from 'react';
 import assert from 'assert';
 import { shallow } from 'enzyme';
 import ProjectHomeWorkflowButtons from './home-workflow-buttons';
+import ProjectHomeWorkflowButton from './home-workflow-button';
 
 
 const testWorkflows = [
@@ -41,13 +42,13 @@ describe('ProjectHomeWorkflowButtons', function() {
     });
 
     it('should render active workflow button options that have a level', function() {
-      assert.equal(wrapper.find('ProjectHomeWorkflowButton').length, 3);
+      assert.equal(wrapper.find(ProjectHomeWorkflowButton).length, 3);
     });
 
     it('should disable the button levels that user has not reached', function() {
-      assert.equal(wrapper.find('ProjectHomeWorkflowButton').first().props().disabled, false);
-      assert.equal(wrapper.find('ProjectHomeWorkflowButton').at(1).props().disabled, false);
-      assert.equal(wrapper.find('ProjectHomeWorkflowButton').last().props().disabled, true);
+      assert.equal(wrapper.find(ProjectHomeWorkflowButton).first().props().disabled, false);
+      assert.equal(wrapper.find(ProjectHomeWorkflowButton).at(1).props().disabled, false);
+      assert.equal(wrapper.find(ProjectHomeWorkflowButton).last().props().disabled, true);
     });
   });
 
@@ -56,7 +57,7 @@ describe('ProjectHomeWorkflowButtons', function() {
       wrapper = shallow(
         <ProjectHomeWorkflowButtons activeWorkflows={testWorkflows} showWorkflowButtons={true} />
       );
-      assert.equal(wrapper.find('ProjectHomeWorkflowButton').length, 3);
+      assert.equal(wrapper.find(ProjectHomeWorkflowButton).length, 3);
     });
   });
 
@@ -68,7 +69,7 @@ describe('ProjectHomeWorkflowButtons', function() {
     });
 
     it('should not render the workflow buttons', function() {
-      assert.equal(wrapper.find('ProjectHomeWorkflowButton').length, 0);
+      assert.equal(wrapper.find(ProjectHomeWorkflowButton).length, 0);
     });
   });
 });

--- a/app/pages/project/home/index.jsx
+++ b/app/pages/project/home/index.jsx
@@ -95,7 +95,6 @@ export default class ProjectHomeContainer extends React.Component {
       <ProjectHomePage
         activeWorkflows={this.state.activeWorkflows}
         background={this.props.background}
-        onChangePreferences={this.props.onChangePreferences}
         organization={this.props.organization}
         preferences={this.props.preferences}
         project={this.props.project}
@@ -118,7 +117,6 @@ ProjectHomeContainer.defaultProps = {
   background: {
     src: ''
   },
-  onChangePreferences: () => {},
   organization: null,
   preferences: {},
   project: {},
@@ -142,7 +140,6 @@ ProjectHomeContainer.propTypes = {
   background: PropTypes.shape({
     src: PropTypes.string
   }),
-  onChangePreferences: PropTypes.func.isRequired,
   organization: PropTypes.shape({
     display_name: PropTypes.string,
     slug: PropTypes.string

--- a/app/pages/project/home/project-home.jsx
+++ b/app/pages/project/home/project-home.jsx
@@ -84,7 +84,6 @@ const ProjectHomePage = (props) => {
         <VisibilitySplit splits={props.splits} splitKey='workflow.assignment' elementKey='div'>
           <ProjectHomeWorkflowButtons
             activeWorkflows={props.activeWorkflows}
-            onChangePreferences={props.onChangePreferences}
             preferences={props.preferences}
             project={props.project}
             projectIsComplete={props.projectIsComplete}
@@ -176,7 +175,6 @@ ProjectHomePage.contextTypes = {
 
 ProjectHomePage.defaultProps = {
   activeWorkflows: [],
-  onChangePreferences: () => {},
   organization: null,
   preferences: {},
   project: {},
@@ -192,7 +190,6 @@ ProjectHomePage.propTypes = {
   background: PropTypes.shape({
     src: PropTypes.string
   }).isRequired,
-  onChangePreferences: PropTypes.func.isRequired,
   organization: PropTypes.shape({
     display_name: PropTypes.string,
     slug: PropTypes.string

--- a/app/pages/project/index.jsx
+++ b/app/pages/project/index.jsx
@@ -140,7 +140,6 @@ class ProjectPageController extends React.Component {
   }
 
   getUserProjectPreferences(project, user) {
-    this.listenToProjectPreferences(null);
 
     const userPreferences = user ?
       user.get('project_preferences', { project_id: project.id })
@@ -159,18 +158,9 @@ class ProjectPageController extends React.Component {
             }));
         })
     :
-      Promise.resolve(apiClient.type('project_preferences').create({
-        id: 'GUEST_PREFERENCES_DO_NOT_SAVE',
-        links: {
-          project: project.id
-        },
-        preferences: {}}));
+      Promise.resolve(null);
 
     return userPreferences
-      .then((projectPreferences) => {
-        this.listenToProjectPreferences(projectPreferences);
-        return projectPreferences;
-      })
       .catch((error) => {
         console.warn(error.message);
       });
@@ -284,13 +274,11 @@ class ProjectPageController extends React.Component {
   }
 
   requestUserProjectPreferences(project, user) {
-    this.listenToProjectPreferences(null);
 
     if (user) {
       return user.get('project_preferences', { project_id: project.id })
         .then(([projectPreferences]) => {
           this.setState({ projectPreferences });
-          this.listenToProjectPreferences(projectPreferences);
         })
         .catch((error) => {
           console.warn(error.message);
@@ -298,16 +286,6 @@ class ProjectPageController extends React.Component {
     } else {
       return Promise.resolve();
     }
-  }
-
-  listenToProjectPreferences(projectPreferences) {
-    if (this._listenedToProjectPreferences) {
-      this._listenedToProjectPreferences.stopListening('change', this._boundForceUpdate);
-    }
-    if (projectPreferences) {
-      projectPreferences.listen('change', this._boundForceUpdate);
-    }
-    this._listenedToProjectPreferences = projectPreferences;
   }
 
   loadFieldGuide(projectId) {

--- a/app/pages/project/index.jsx
+++ b/app/pages/project/index.jsx
@@ -397,7 +397,6 @@ class ProjectPageController extends React.Component {
               projectRoles={this.state.projectRoles}
               translations={this.props.translations}
               user={this.props.user}
-              onChangePreferences={this.handleProjectPreferencesChange.bind(this)}
             >
               <ProjectPage
                 {...this.props}
@@ -405,7 +404,6 @@ class ProjectPageController extends React.Component {
                 guide={this.state.guide}
                 guideIcons={this.state.guideIcons}
                 loading={this.state.loading}
-                onChangePreferences={this.handleProjectPreferencesChange.bind(this)}
                 organization={this.state.organization}
                 owner={this.state.owner}
                 pages={this.state.pages}

--- a/app/pages/project/workflow-selection.jsx
+++ b/app/pages/project/workflow-selection.jsx
@@ -177,7 +177,9 @@ class WorkflowSelection extends React.Component {
   }
 
   handlePreferencesChange(key, value) {
-    this.props.preferences.update({ [key]: value });
+    if (this.props.user) {
+      this.props.preferences.update({ [key]: value }).save();
+    }
   }
 
   workflowSelectionErrorHandler() {

--- a/app/pages/project/workflow-selection.jsx
+++ b/app/pages/project/workflow-selection.jsx
@@ -177,7 +177,7 @@ class WorkflowSelection extends React.Component {
   }
 
   handlePreferencesChange(key, value) {
-    this.props.onChangePreferences(key, value);
+    this.props.preferences.update({ [key]: value });
   }
 
   workflowSelectionErrorHandler() {
@@ -207,7 +207,6 @@ WorkflowSelection.defaultProps = {
   location: {
     query: {}
   },
-  onChangePreferences() { return null; },
   preferences: {},
   projectRoles: [],
   translation: {
@@ -233,7 +232,6 @@ WorkflowSelection.propTypes = {
       workflow: PropTypes.string
     })
   }),
-  onChangePreferences: PropTypes.func,
   preferences: PropTypes.shape({
     save: PropTypes.func,
     update: PropTypes.func


### PR DESCRIPTION
Staging branch URL: https://pr-5035.pfe-preview.zooniverse.org

Removes `listenToProjectPreferences` from the top-level project page component and the `onChangePreferences` callback from its children. Instead, the project workflow buttons are connected to the redux store and set a new workflow when clicked.

Selecting a new workflow clears the current workflow, loads the new workflow from Panoptes, then stores it.

User preferences are still updated on workflow change, but only so as to persist workflow selection across browser sessions. Updating user project preferences does not trigger a re-render of the project components and the fake preferences for anonymous users can be completely removed too.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
