### PR TITLE
Add a timer to the classification queue

### DIFF
--- a/app/lib/classification-queue.js
+++ b/app/lib/classification-queue.js
@@ -3,12 +3,14 @@ import apiClient from 'panoptes-client/lib/api-client';
 
 const FAILED_CLASSIFICATION_QUEUE_NAME = 'failed-classifications';
 const MAX_RECENTS = 10;
+const RETRY_INTERVAL = 5 * 60 * 1000;
 
 class ClassificationQueue {
   constructor(api, onClassificationSaved) {
     this.storage = window.localStorage;
     this.apiClient = api || apiClient;
     this.recents = [];
+    this.flushTimeout = null;
     this.onClassificationSaved = onClassificationSaved || function () { return true; };
   }
 
@@ -46,6 +48,10 @@ class ClassificationQueue {
     const pendingClassifications = this._loadQueue();
     const failedClassifications = [];
     this._saveQueue(failedClassifications);
+    if (this.flushTimeout) {
+      clearTimeout(this.flushTimeout);
+      this.flushTimeout = null;
+    }
 
     if (process.env.BABEL_ENV !== 'test') console.log('Saving queued classifications:', pendingClassifications.length);
     return Promise.all(pendingClassifications.map((classificationData) => {
@@ -61,6 +67,9 @@ class ClassificationQueue {
         if (error.status !== 422) {
           try {
             this.store(classificationData);
+            if (!this.flushTimeout) {
+              this.flushTimeout = setTimeout(this.flushToBackend.bind(this), RETRY_INTERVAL);
+            }
           } catch (saveQueueError) {
             console.error('Failed to update classification queue:', saveQueueError);
           }


### PR DESCRIPTION
Add a timer to flush the failed classification queue five minutes after the current run. Flush should either run the next time that it's called manually, or in five minutes time if it hasn't been invoked yet.

Staging branch URL: https://classification-queue.pfe-preview.zooniverse.org/

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
