### PR TITLE
Text task performance fixes

### DIFF
--- a/app/classifier/tasks/text/index.jsx
+++ b/app/classifier/tasks/text/index.jsx
@@ -77,9 +77,9 @@ export default class TextTask extends React.Component {
   handleChange() {
     const value = this.textInput.current.value;
     if (value.length < this.state.value.length) {
-      this.setState({ rows: 1, value }, this.handleResize);
+      this.setState({ rows: 1, value });
     } else {
-      this.setState({ value }, this.handleResize);
+      this.setState({ value });
     }
 
     this.debouncedUpdateAnnotation(value);

--- a/app/classifier/tasks/text/index.jsx
+++ b/app/classifier/tasks/text/index.jsx
@@ -9,7 +9,7 @@ import TextTaskSummary from './summary';
 const LINEHEIGHT = 22.5;
 const NOOP = Function.prototype;
 
-export default class TextTask extends React.Component {
+export default class TextTask extends React.PureComponent {
   constructor(props) {
     super(props);
 

--- a/app/classifier/tasks/text/index.spec.js
+++ b/app/classifier/tasks/text/index.spec.js
@@ -94,8 +94,14 @@ describe('TextTask', function () {
       expect(handleChangeSpy.calledOnce).to.be.true;
     });
     it('should call handleResize after an onChange event', function () {
+      wrapper.instance().textInput.current.value = 'text change';
       wrapper.find('textarea').first().simulate('change', { target: { value: 'text change' }});
       expect(handleResizeSpy.calledOnce).to.be.true;
+    });
+    it('should not call handleResize if state doesn\'t change', function () {
+      wrapper.instance().textInput.current.value = 'testing the [deletion]text task[/deletion] tag selection';
+      wrapper.find('textarea').first().simulate('change', { target: { value: 'testing the [deletion]text task[/deletion] tag selection' }});
+      expect(handleResizeSpy.called).to.be.false;
     });
   });
 

--- a/app/classifier/tasks/text/index.spec.js
+++ b/app/classifier/tasks/text/index.spec.js
@@ -39,12 +39,14 @@ describe('TextTask', function () {
 
   describe('input onChange event handler', function () {
     let handleChangeSpy;
+    let handleResizeSpy;
     let onChangeSpy;
     let setStateSpy;
     let wrapper;
 
     before(function () {
       handleChangeSpy = sinon.spy(TextTask.prototype, 'handleChange');
+      handleResizeSpy = sinon.spy(TextTask.prototype, 'handleResize');
       onChangeSpy = sinon.spy();
       setStateSpy = sinon.spy(TextTask.prototype, 'setState');
     });
@@ -60,12 +62,14 @@ describe('TextTask', function () {
 
     afterEach(function () {
       handleChangeSpy.resetHistory();
+      handleResizeSpy.resetHistory();
       onChangeSpy.resetHistory();
       setStateSpy.resetHistory();
     });
 
     after(function () {
       handleChangeSpy.restore();
+      handleResizeSpy.restore();
       setStateSpy.restore();
     });
 
@@ -88,6 +92,10 @@ describe('TextTask', function () {
     it('should call handleChange when the onChange event fires', function () {
       wrapper.find('textarea').first().simulate('change', { target: { value: 'text change' }});
       expect(handleChangeSpy.calledOnce).to.be.true;
+    });
+    it('should call handleResize after an onChange event', function () {
+      wrapper.find('textarea').first().simulate('change', { target: { value: 'text change' }});
+      expect(handleResizeSpy.calledOnce).to.be.true;
     });
   });
 


### PR DESCRIPTION
Expect handleResize to be called once when the text value changes.
Fix code that was calling handleResize twice on change.
Use PureComponent, so that unchanged props and state don't trigger a render.

Staging branch URL: https://text-task.pfe-preview.zooniverse.org/

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
