### PR TITLE
Don't override markdown links to new tabs

### DIFF
--- a/app/components/wrapped-markdown.jsx
+++ b/app/components/wrapped-markdown.jsx
@@ -13,10 +13,12 @@ class WrappedMarkdown extends React.Component {
   onClick = (e) => {
     const rightButtonPressed = (!!e.button && e.button > 0);
     const modifierKey = (e.ctrlKey || e.metaKey);
+    const hasNamedTarget = e.target.target;
     if (e.target.origin === window.location.origin &&
       e.target.pathname !== window.location.pathname &&
       !rightButtonPressed &&
-      !modifierKey) {
+      !modifierKey &&
+      !hasNamedTarget) {
       const newURL = e.target.pathname + e.target.search + e.target.hash;
       browserHistory.push(newURL);
       e.preventDefault();


### PR DESCRIPTION
Internal links in markdown are overridden with history.push, so that we don't reload the site and reset classification state. Don't do this if the link has a target attribute, as this means it is probably opening in a new tab or window.

Staging branch URL: https://target-blank.pfe-preview.zooniverse.org

Fixes: #5044 

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
