### PR TITLE
Fix freehand line static methods and tests

### DIFF
--- a/app/classifier/drawing-tools/freehand-helpers.coffee
+++ b/app/classifier/drawing-tools/freehand-helpers.coffee
@@ -2,6 +2,7 @@ round = require 'lodash/round'
 
 createPathFromCoords = (coordsArray) ->
   [firstCoord, otherCoords...] = coordsArray
+  return '' unless firstCoord?
   path = "M #{firstCoord.x},#{firstCoord.y} "
   path += "L #{x},#{y} " for {x, y} in otherCoords
   path

--- a/app/classifier/drawing-tools/freehand-line.cjsx
+++ b/app/classifier/drawing-tools/freehand-line.cjsx
@@ -22,11 +22,15 @@ module.exports = createReactClass
       _inProgress: false
 
     initStart: (coords, mark) ->
-      mark.points.push roundCoords coords
-      _inProgress: true
+      points = mark.points.slice()
+      points.push roundCoords coords
+      _inProgress = true
+      { _inProgress, points }
 
     initMove: (coords, mark) ->
-      mark.points.push roundCoords coords
+      points = mark.points.slice()
+      points.push roundCoords coords
+      { points }
 
     initRelease: (coords, mark) ->
       points: filterDupeCoords mark.points
@@ -35,7 +39,7 @@ module.exports = createReactClass
     initValid: (mark) ->
       path = createPathFromCoords mark.points
       properties = svgPathProperties path
-      properties.getTotalLength() > MINIMUM_LENGTH
+      properties?.getTotalLength() > MINIMUM_LENGTH
 
   getDeletePosition: ([startCoords, otherCoords...]) ->
     scale = (@props.scale.horizontal + @props.scale.vertical) / 2

--- a/app/classifier/drawing-tools/freehand-segment-line.cjsx
+++ b/app/classifier/drawing-tools/freehand-segment-line.cjsx
@@ -24,12 +24,16 @@ module.exports = createReactClass
       _currentlyDrawing: false
 
     initStart: (coords, mark) ->
-      mark.points.push roundCoords coords
-      _inProgress: true
-      _currentlyDrawing: true
+      points = mark.points.slice()
+      points.push roundCoords coords
+      _inProgress = true
+      _currentlyDrawing = true
+      { _inProgress, _currentlyDrawing, points }
 
     initMove: (coords, mark) ->
-      mark.points.push roundCoords coords
+      points = mark.points.slice()
+      points.push roundCoords coords
+      { points }
 
     initRelease: (coords, mark) ->
       _currentlyDrawing: false

--- a/app/classifier/drawing-tools/generic-tests.spec.js
+++ b/app/classifier/drawing-tools/generic-tests.spec.js
@@ -116,7 +116,7 @@ for (const toolType in drawingTools) {
     const mark = TaskComponent.defaultValues({ x, y }, props);
 
     if (TaskComponent.initStart) {
-      TaskComponent.initStart({ x, y }, mark);
+      Object.assign(mark, TaskComponent.initStart({ x, y }, mark));
     }
 
     before(function () {

--- a/app/classifier/drawing-tools/generic-tests.spec.js
+++ b/app/classifier/drawing-tools/generic-tests.spec.js
@@ -64,8 +64,9 @@ for (const toolType in drawingTools) {
     it ('should make changes with initMove', function() {
       const initialMark = Object.assign({}, mark);
       if (TaskComponent.initMove) {
-        TaskComponent.initMove(cursors[1], mark);
+        const markChanges = TaskComponent.initMove(cursors[1], mark);
         expect(initialMark).to.not.equal(mark);
+        expect(markChanges).to.be.an('object');
       }
     });
 


### PR DESCRIPTION
Updates the generic drawing tool tests to expect initMove to return an object.
Applies changes to the mock mark before rendering the tool component.
Fixes the freehand line tools to conform with the behaviour expected by the marking initialiser in the drawing task.

Staging branch URL: https://test-drawing-tools.pfe-preview.zooniverse.org/

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
