### PR TITLE
Load translation strings on workflow change

### DIFF
--- a/app/pages/project/classify.jsx
+++ b/app/pages/project/classify.jsx
@@ -13,6 +13,7 @@ import { Split } from 'seven-ten';
 import ClassificationQueue from '../../lib/classification-queue';
 
 import * as classifierActions from '../../redux/ducks/classify';
+import * as translationActions from '../../redux/ducks/translations';
 
 import Classifier from '../../classifier';
 import FinishedBanner from './finished-banner';
@@ -185,7 +186,7 @@ export class ProjectClassifyPage extends React.Component {
   }
 
   maybePromptWorkflowAssignmentDialog(props) {
-    const { actions, preferences, project, splits } = props;
+    const { actions, preferences, project, splits, translations } = props;
     if (this.state.promptWorkflowAssignmentDialog) {
       WorkflowAssignmentDialog.start({ splits, project }).then(() =>
         this.setState({ promptWorkflowAssignmentDialog: false })
@@ -197,6 +198,7 @@ export class ProjectClassifyPage extends React.Component {
             .type('workflows')
             .get(preferences.settings.workflow_id, {})
             .then((newWorkflow) => {
+              actions.translations.load('workflow', newWorkflow.id, translations.locale);
               actions.classifier.setWorkflow(newWorkflow);
             });
         }
@@ -300,6 +302,9 @@ ProjectClassifyPage.propTypes = {
       fetchSubjects: PropTypes.func,
       nextSubject: PropTypes.func,
       refillSubjectQueue: PropTypes.func
+    }),
+    translations: PropTypes.shape({
+      load: PropTypes.func
     })
   }),
   classification: PropTypes.shape({}),
@@ -316,6 +321,9 @@ ProjectClassifyPage.propTypes = {
   }),
   project: PropTypes.object,
   storage: PropTypes.object,
+  translations: PropTypes.shape({
+    locale: PropTypes.string
+  }),
   upcomingSubjects: PropTypes.arrayOf(PropTypes.object),
   user: PropTypes.object,
   workflow: PropTypes.object
@@ -333,6 +341,7 @@ window.classificationQueue = classificationQueue;
 
 const mapStateToProps = state => ({
   classification: state.classify.classification,
+  translations: state.translations,
   upcomingSubjects: state.classify.upcomingSubjects,
   theme: state.userInterface.theme,
   workflow: state.classify.workflow
@@ -340,7 +349,8 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = dispatch => ({
   actions: {
-    classifier: bindActionCreators(classifierActions, dispatch)
+    classifier: bindActionCreators(classifierActions, dispatch),
+    translations: bindActionCreators(translationActions, dispatch)
   }
 });
 

--- a/app/pages/project/home/home-workflow-button.jsx
+++ b/app/pages/project/home/home-workflow-button.jsx
@@ -7,6 +7,7 @@ import apiClient from 'panoptes-client/lib/api-client';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import * as classifierActions from '../../../redux/ducks/classify';
+import * as translationActions from '../../../redux/ducks/translations';
 
 class ProjectHomeWorkflowButton extends React.Component {
   constructor(props) {
@@ -16,7 +17,7 @@ class ProjectHomeWorkflowButton extends React.Component {
   }
 
   handleWorkflowSelection(e) {
-    const { actions, disabled, preferences, user, workflow } = this.props;
+    const { actions, disabled, preferences, user, translations, workflow } = this.props;
     if (disabled) {
       e.preventDefault();
     } else {
@@ -28,6 +29,7 @@ class ProjectHomeWorkflowButton extends React.Component {
           if (user) {
             preferences.update({ 'preferences.selected_workflow': newWorkflow.id }).save();
           }
+          actions.translations.load('workflow', newWorkflow.id, translations.locale);
           actions.classifier.setWorkflow(newWorkflow);
         });
     }
@@ -70,6 +72,14 @@ class ProjectHomeWorkflowButton extends React.Component {
 }
 
 ProjectHomeWorkflowButton.defaultProps = {
+  actions: {
+    classifier: {
+      setWorkflow: () => null
+    },
+    translations: {
+      load: () => null
+    }
+  },
   disabled: false,
   preferences: {},
   project: {},
@@ -81,6 +91,9 @@ ProjectHomeWorkflowButton.propTypes = {
   actions: PropTypes.shape({
     classifier: PropTypes.shape({
       setWorkflow: PropTypes.func
+    }),
+    translations: PropTypes.shape({
+      load: PropTypes.func
     })
   }),
   disabled: PropTypes.bool,
@@ -90,6 +103,9 @@ ProjectHomeWorkflowButton.propTypes = {
   project: PropTypes.shape({
     slug: PropTypes.string
   }).isRequired,
+  translations: PropTypes.shape({
+    locale: PropTypes.string
+  }),
   workflow: PropTypes.shape({
     configuration: PropTypes.shape({
       level: PropTypes.string
@@ -100,11 +116,14 @@ ProjectHomeWorkflowButton.propTypes = {
   workflowAssignment: PropTypes.bool
 };
 
-const mapStateToProps = state => ({});
+const mapStateToProps = state => ({
+  translations: state.translations
+});
 
 const mapDispatchToProps = dispatch => ({
   actions: {
-    classifier: bindActionCreators(classifierActions, dispatch)
+    classifier: bindActionCreators(classifierActions, dispatch),
+    translations: bindActionCreators(translationActions, dispatch)
   }
 });
 

--- a/app/pages/project/home/home-workflow-button.spec.js
+++ b/app/pages/project/home/home-workflow-button.spec.js
@@ -27,12 +27,19 @@ const preferences = mockPanoptesResource('project-preferences', {});
 const actions = {
   classifier: {
     setWorkflow: sinon.stub()
+  },
+  translations: {
+    load: sinon.stub()
   }
+};
+
+const translations = {
+  locale: 'en'
 };
 
 const user = mockPanoptesResource('user', {});
 
-describe('ProjectHomeWorkflowButton', function() {
+describe('ProjectHomeWorkflowButton', function () {
   let wrapper;
   let handleWorkflowSelectionSpy;
   before(function() {
@@ -48,6 +55,7 @@ describe('ProjectHomeWorkflowButton', function() {
         disabled={false}
         preferences={preferences}
         project={testProject}
+        translations={translations}
         user={user}
         workflow={testWorkflowWithoutLevel}
         workflowAssignment={false}
@@ -97,6 +105,13 @@ describe('ProjectHomeWorkflowButton', function() {
     wrapper.instance().handleWorkflowSelection()
     .then(function () {
       assert.equal(actions.classifier.setWorkflow.secondCall.calledWith(testWorkflowWithoutLevel), true);
+    })
+    .then(done, done);
+  });
+  it('should load workflow translations', function (done) {
+    wrapper.instance().handleWorkflowSelection()
+    .then(function () {
+      assert.equal(actions.translations.load.calledWith('workflow', testWorkflowWithoutLevel.id, translations.locale), true);
     })
     .then(done, done);
   });


### PR DESCRIPTION
When we change workflow from the home workflow buttons, or the workflow assignment popup, load the associated translation strings.

Staging branch URL: https://pr-5066.pfe-preview.zooniverse.org

Fixes #5066 .

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
