### PR TITLE
Test feedback helpers

### DIFF
--- a/app/features/feedback/shared/helpers/generate-rules.js
+++ b/app/features/feedback/shared/helpers/generate-rules.js
@@ -24,7 +24,7 @@ function generateRules(subject, workflow) {
   _.forEach(workflowRules, (rules, taskId) => {
     const taskRules = _.reduce(rules, (result, workflowRule) => {
       const matchingSubjectRule = _.find(subjectRules, subjectRule =>
-        subjectRule.id === workflowRule.id);
+        subjectRule.id.toString() === workflowRule.id.toString());
 
       if (matchingSubjectRule) {
         const ruleStrategy = workflowRule.strategy;

--- a/app/features/feedback/shared/helpers/generate-rules.spec.js
+++ b/app/features/feedback/shared/helpers/generate-rules.spec.js
@@ -1,0 +1,159 @@
+import { expect } from 'chai';
+import generateRules from './generate-rules';
+
+describe('feedback: generateRules', function () {
+  describe('without feedback defined', function () {
+    const subject = {};
+    const workflow = {};
+    it('should return an empty object', function () {
+      expect(generateRules(subject, workflow)).to.be.empty;
+    });
+  });
+  describe('with task feedback enabled', function () {
+    const subject = {
+      metadata: {
+        '#feedback_1_id': '51',
+        '#feedback_1_answer': '0',
+        '#feedback_1_failureMessage': 'Actually, this sound is from noise (background)',
+        '#feedback_1_successMessage': 'Correct!'
+      }
+    };
+    const workflow = {
+      tasks: {
+        T0: {
+          feedback: {
+            enabled: true,
+            rules: [{
+              id: '51',
+              strategy: 'singleAnswerQuestion',
+              failureEnabled: true,
+              successEnabled: true,
+              defaultFailureMessage: '"Actually, that\'s not correct"',
+              defaultSuccessMessage: '"Correct"'
+            }]
+          }
+        }
+      },
+      T1: {
+        feedback: {
+          enabled: false,
+          rules: [{
+            id: '52',
+            strategy: 'singleAnswerQuestion',
+            failureEnabled: true,
+            successEnabled: true,
+            defaultFailureMessage: '"Actually, that\'s not correct"',
+            defaultSuccessMessage: '"Correct"'
+          }]
+        }
+      }
+    };
+    it('should generate rules for tasks with feedback enabled', function () {
+      expect(generateRules(subject, workflow)).to.have.property('T0');
+    });
+    it('should not generate rules for tasks with feedback disabled', function () {
+      expect(generateRules(subject, workflow)).not.to.have.property('T1');
+    });
+    it('should copy subject rules', function () {
+      const taskFeedbackRule = generateRules(subject, workflow).T0[0];
+      expect(taskFeedbackRule).to.have.property('failureMessage');
+      expect(taskFeedbackRule.failureMessage).to.equal('Actually, this sound is from noise (background)');
+    });
+    describe('if the rule ID is a number', function () {
+      const newSubject = {
+        metadata: {
+          '#feedback_1_id': 51,
+          '#feedback_1_answer': '0',
+          '#feedback_1_failureMessage': 'Actually, this sound is from noise (background)',
+          '#feedback_1_successMessage': 'Correct!'
+        }
+      };
+      const newWorkflow = {
+        tasks: {
+          T0: {
+            feedback: {
+              enabled: true,
+              rules: [{
+                id: '51',
+                strategy: 'singleAnswerQuestion',
+                failureEnabled: true,
+                successEnabled: true,
+                defaultFailureMessage: '"Actually, that\'s not correct"',
+                defaultSuccessMessage: '"Correct"'
+              }]
+            }
+          }
+        },
+        T1: {
+          feedback: {
+            enabled: false,
+            rules: [{
+              id: '52',
+              strategy: 'singleAnswerQuestion',
+              failureEnabled: true,
+              successEnabled: true,
+              defaultFailureMessage: '"Actually, that\'s not correct"',
+              defaultSuccessMessage: '"Correct"'
+            }]
+          }
+        }
+      };
+      it('should find tasks with feedback', function () {
+        expect(generateRules(newSubject, newWorkflow)).to.have.property('T0');
+      });
+      it('should copy matching feedback rules', function () {
+        const taskFeedbackRule = generateRules(newSubject, newWorkflow).T0[0];
+        expect(taskFeedbackRule).to.have.property('failureMessage');
+        expect(taskFeedbackRule.failureMessage).to.equal('Actually, this sound is from noise (background)');
+      });
+    });
+    describe('if the rule ID is an alphanumeric string', function () {
+      const newSubject = {
+        metadata: {
+          '#feedback_1_id': 'feedback rule',
+          '#feedback_1_answer': '0',
+          '#feedback_1_failureMessage': 'Actually, this sound is from noise (background)',
+          '#feedback_1_successMessage': 'Correct!'
+        }
+      };
+      const newWorkflow = {
+        tasks: {
+          T0: {
+            feedback: {
+              enabled: true,
+              rules: [{
+                id: 'feedback rule',
+                strategy: 'singleAnswerQuestion',
+                failureEnabled: true,
+                successEnabled: true,
+                defaultFailureMessage: '"Actually, that\'s not correct"',
+                defaultSuccessMessage: '"Correct"'
+              }]
+            }
+          }
+        },
+        T1: {
+          feedback: {
+            enabled: false,
+            rules: [{
+              id: '52',
+              strategy: 'singleAnswerQuestion',
+              failureEnabled: true,
+              successEnabled: true,
+              defaultFailureMessage: '"Actually, that\'s not correct"',
+              defaultSuccessMessage: '"Correct"'
+            }]
+          }
+        }
+      };
+      it('should find tasks with feedback', function () {
+        expect(generateRules(newSubject, newWorkflow)).to.have.property('T0');
+      });
+      it('should copy matching feedback rules', function () {
+        const taskFeedbackRule = generateRules(newSubject, newWorkflow).T0[0];
+        expect(taskFeedbackRule).to.have.property('failureMessage');
+        expect(taskFeedbackRule.failureMessage).to.equal('Actually, this sound is from noise (background)');
+      });
+    });
+  });
+});

--- a/app/features/feedback/shared/helpers/get-feedback-from-tasks.spec.js
+++ b/app/features/feedback/shared/helpers/get-feedback-from-tasks.spec.js
@@ -1,0 +1,42 @@
+import { expect } from 'chai';
+import getFeedbackFromTasks from './get-feedback-from-tasks';
+
+describe('Feedback: getFeedbackFromTasks', function () {
+  const tasks = {
+    T0: {
+      feedback: {
+        enabled: true,
+        rules: [{
+          id: '51',
+          strategy: 'singleAnswerQuestion',
+          failureEnabled: true,
+          successEnabled: true,
+          defaultFailureMessage: '"Actually, that\'s not correct"',
+          defaultSuccessMessage: '"Correct"'
+        }]
+      }
+    },
+    T1: {
+      feedback: {
+        enabled: false,
+        rules: [{
+          id: '52',
+          strategy: 'singleAnswerQuestion',
+          failureEnabled: true,
+          successEnabled: true,
+          defaultFailureMessage: '"Actually, that\'s not correct"',
+          defaultSuccessMessage: '"Correct"'
+        }]
+      }
+    }
+  };
+  it('should include tasks with feedback enabled', function () {
+    expect(getFeedbackFromTasks(tasks)).to.have.property('T0');
+  });
+  it('should ignore tasks with feedback disabled', function () {
+    expect(getFeedbackFromTasks(tasks)).not.to.have.property('T1');
+  });
+  it('should copy rules from tasks with feedback enabled', function () {
+    expect(getFeedbackFromTasks(tasks).T0).to.deep.equal(tasks.T0.feedback.rules);
+  });
+});

--- a/app/features/feedback/shared/helpers/rule-checker.js
+++ b/app/features/feedback/shared/helpers/rule-checker.js
@@ -5,7 +5,9 @@ import _ from 'lodash';
 // functions.
 function validateRuleProperties(rule) {
   return _.reduce(rule, (errors, value, key) => {
-    if (_.isBoolean(value)) {
+    if (_.isFinite(value)) {
+      return errors;
+    } else if (_.isBoolean(value)) {
       return errors;
     } else if (_.isUndefined(value) || _.isEmpty(value)) {
       return errors.concat([key]);


### PR DESCRIPTION
Add some quick tests for the shared feedback helper functions. Test that rules are correctly extracted from workflow tasks, and that gold standard subject rules are correctly merged with workflow rules when feedback is enabled.

Includes a test to reproduce #5058, and a fix.

Staging branch URL: https://pr-5068.pfe-preview.zooniverse.org

Fixes #5058.

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
