### PR TITLE
Disable classify links on projects with no active workflows

### DIFF
--- a/app/lib/nav-helpers/getProjectLinks.js
+++ b/app/lib/nav-helpers/getProjectLinks.js
@@ -3,7 +3,7 @@ import _ from 'lodash';
 import isAdmin from '../is-admin';
 import userHasLabAccess from './userHasLabAccess';
 
-function getProjectLinks({ project, projectRoles, workflow, user }) {
+function getProjectLinks({ project, projectRoles, user }) {
   const { id, redirect, slug } = project;
 
   const links = {
@@ -44,6 +44,8 @@ function getProjectLinks({ project, projectRoles, workflow, user }) {
     }
   };
 
+  const canClassify = project.links.active_workflows && project.links.active_workflows.length > 0;
+
   // For projects with external front ends
   if (redirect) {
     const redirectUrl = `${redirect.replace(/\/+$/, '')}/classify`;
@@ -52,7 +54,7 @@ function getProjectLinks({ project, projectRoles, workflow, user }) {
     _.unset(links, 'about');
   }
 
-  if (!workflow) {
+  if (!canClassify) {
     links.classify.disabled = true;
   }
 

--- a/app/lib/nav-helpers/getProjectLinks.spec.js
+++ b/app/lib/nav-helpers/getProjectLinks.spec.js
@@ -8,21 +8,20 @@ import {
   projectRoles,
   projectWithRedirect,
   projectWithoutRedirect,
-  randomUser,
-  workflow
+  randomUser
 } from '../../../test';
 
 
 describe('getProjectLinks', function() {
   it('should use the project slug in building the navbar links', function() {
-    const navLinks = getProjectLinks({ project: projectWithoutRedirect, projectRoles, workflow, user: projectOwnerUser });
+    const navLinks = getProjectLinks({ project: projectWithoutRedirect, projectRoles, user: projectOwnerUser });
     Object.keys(navLinks).forEach((link) => {
       expect(navLinks[link].url.includes(projectWithoutRedirect.slug));
     });
   });
 
   it('should return about, classify, talk, and collections set of navbar links', function() {
-    const navLinks = getProjectLinks({ project: projectWithoutRedirect, projectRoles, workflow, user: null });
+    const navLinks = getProjectLinks({ project: projectWithoutRedirect, projectRoles, user: null });
     expect(Object.keys(navLinks).indexOf('about') > -1).to.be.true;
     expect(Object.keys(navLinks).indexOf('classify') > -1).to.be.true;
     expect(Object.keys(navLinks).indexOf('talk') > -1).to.be.true;
@@ -31,45 +30,45 @@ describe('getProjectLinks', function() {
 
   describe('without a user', function() {
     it('should not return a recents link', function() {
-      const navLinks = getProjectLinks({ project: projectWithoutRedirect, projectRoles, workflow, user: null });
+      const navLinks = getProjectLinks({ project: projectWithoutRedirect, projectRoles, user: null });
       expect(Object.keys(navLinks).indexOf('recents') > -1).to.be.false;
     });
 
     it('should not return a lab link', function() {
-      const navLinks = getProjectLinks({ project: projectWithoutRedirect, projectRoles, workflow, user: null });
+      const navLinks = getProjectLinks({ project: projectWithoutRedirect, projectRoles, user: null });
       expect(Object.keys(navLinks).indexOf('lab') > -1).to.be.false;
     });
 
     it('should not return an admin link', function() {
-      const navLinks = getProjectLinks({ project: projectWithoutRedirect, projectRoles, workflow, user: null });
+      const navLinks = getProjectLinks({ project: projectWithoutRedirect, projectRoles, user: null });
       expect(Object.keys(navLinks).indexOf('admin') > -1).to.be.false;
     });
   });
 
   describe('with a user', function() {
     it('should return a recents link', function() {
-      const navLinks = getProjectLinks({ project: projectWithoutRedirect, projectRoles, workflow, user: randomUser });
+      const navLinks = getProjectLinks({ project: projectWithoutRedirect, projectRoles, user: randomUser });
       expect(Object.keys(navLinks).indexOf('recents') > -1).to.be.true;
     });
 
     it('should not return a lab link if the user is not the project owner or a collaborator', function() {
-      const navLinks = getProjectLinks({ project: projectWithoutRedirect, projectRoles, workflow, user: randomUser });
+      const navLinks = getProjectLinks({ project: projectWithoutRedirect, projectRoles, user: randomUser });
       expect(Object.keys(navLinks).indexOf('lab') > -1).to.be.false;
     });
 
     it('should not return an admin page link if the user is not an admin', function() {
-      const navLinks = getProjectLinks({ project: projectWithoutRedirect, projectRoles, workflow, user: randomUser });
+      const navLinks = getProjectLinks({ project: projectWithoutRedirect, projectRoles, user: randomUser });
       expect(Object.keys(navLinks).indexOf('admin') > -1).to.be.false;
     });
 
     describe('who have a project role', function() {
       it('should return the lab link if the user is the project owner', function() {
-        const navLinks = getProjectLinks({ project: projectWithoutRedirect, projectRoles, workflow, user: projectOwnerUser });
+        const navLinks = getProjectLinks({ project: projectWithoutRedirect, projectRoles, user: projectOwnerUser });
         expect(Object.keys(navLinks).indexOf('lab') > -1).to.be.true;
       });
 
       it('should return the lab link if the user is a project collaborator', function() {
-        const navLinks = getProjectLinks({ project: projectWithoutRedirect, projectRoles, workflow, user: projectCollabUser });
+        const navLinks = getProjectLinks({ project: projectWithoutRedirect, projectRoles, user: projectCollabUser });
         expect(Object.keys(navLinks).indexOf('lab') > -1).to.be.true;
       });
     });
@@ -84,7 +83,7 @@ describe('getProjectLinks', function() {
       });
 
       it('should return the admin link if the user is an admin', function() {
-        const navLinks = getProjectLinks({ project: projectWithoutRedirect, projectRoles, workflow, user: adminUser });
+        const navLinks = getProjectLinks({ project: projectWithoutRedirect, projectRoles, user: adminUser });
         expect(Object.keys(navLinks).indexOf('admin') > -1).to.be.true;
       });
     });
@@ -92,20 +91,29 @@ describe('getProjectLinks', function() {
 
   describe('a project with a redirect', function() {
     it('should reset the classify link to the redirected project\'s classify page', function() {
-      const navLinks = getProjectLinks({ project: projectWithRedirect, projectRoles, workflow, user: randomUser });
+      const navLinks = getProjectLinks({ project: projectWithRedirect, projectRoles, user: randomUser });
       expect(navLinks.classify.url.includes(projectWithRedirect.redirect)).to.be.true;
       expect(navLinks.classify.isExternalLink).to.be.true;
     });
 
     it('should not return the about link', function() {
-      const navLinks = getProjectLinks({ project: projectWithRedirect, projectRoles, workflow, user: randomUser });
+      const navLinks = getProjectLinks({ project: projectWithRedirect, projectRoles, user: randomUser });
       expect(Object.keys(navLinks).indexOf('about') > -1).to.be.false;
+    });
+  });
+
+  describe('a project with active workflows', function() {
+    it('should not disable the classify link', function() {
+      const project = Object.assign({}, projectWithoutRedirect);
+      project.links.active_workflows = ['1', '2'];
+      const navLinks = getProjectLinks({ project, projectRoles, user: null });
+      expect(navLinks.classify).not.to.have.property('disabled');
     });
   });
 
   describe('a project without a workflow', function() {
     it('should return the classify link with disabled: true', function() {
-      const navLinks = getProjectLinks({ project: projectWithoutRedirect, projectRoles, workflow: null, user: null });
+      const navLinks = getProjectLinks({ project: projectWithoutRedirect, projectRoles, user: null });
       expect(navLinks.classify.disabled).to.be.true;
     });
   });

--- a/app/lib/nav-helpers/getProjectLinks.spec.js
+++ b/app/lib/nav-helpers/getProjectLinks.spec.js
@@ -113,7 +113,9 @@ describe('getProjectLinks', function() {
 
   describe('a project without a workflow', function() {
     it('should return the classify link with disabled: true', function() {
-      const navLinks = getProjectLinks({ project: projectWithoutRedirect, projectRoles, user: null });
+      const project = Object.assign({}, projectWithoutRedirect);
+      project.links.active_workflows = [];
+      const navLinks = getProjectLinks({ project, projectRoles, user: null });
       expect(navLinks.classify.disabled).to.be.true;
     });
   });

--- a/app/pages/notifications/notification-section.jsx
+++ b/app/pages/notifications/notification-section.jsx
@@ -31,11 +31,11 @@ export default class NotificationSection extends Component {
         name: 'Zooniverse'
       });
     } else {
-      apiClient.type('projects').get({ id: this.props.projectID, cards: true })
+      apiClient.type('projects').get(this.props.projectID)
       .catch((error) => {
         this.setState({ error });
       })
-      .then(([project]) => {
+      .then((project) => {
         this.setState({
           name: project.display_name,
           avatar: project.avatar_src

--- a/app/pages/project/classify.jsx
+++ b/app/pages/project/classify.jsx
@@ -19,6 +19,7 @@ import Classifier from '../../classifier';
 import FinishedBanner from './finished-banner';
 import WorkflowAssignmentDialog from '../../components/workflow-assignment-dialog';
 import ProjectThemeButton from './components/ProjectThemeButton';
+import WorkflowSelection from './workflow-selection';
 import { zooTheme } from '../../theme';
 
 function onClassificationSaved(actualClassification) {
@@ -270,20 +271,30 @@ export class ProjectClassifyPage extends React.Component {
 
   render() {
     return (
-      <div
-        className={`${(this.props.theme === zooTheme.mode.light) ? 'classify-page' : 'classify-page classify-page--dark-theme'}`}
+      <WorkflowSelection
+        actions={this.props.actions}
+        location={this.props.location}
+        preferences={this.props.preferences}
+        project={this.props.project}
+        projectRoles={this.props.projectRoles}
+        translations={this.props.translations}
+        user={this.props.user}
       >
-        <Helmet title={`${this.props.project.display_name} » ${counterpart('project.classifyPage.title')}`} />
+        <div
+          className={`${(this.props.theme === zooTheme.mode.light) ? 'classify-page' : 'classify-page classify-page--dark-theme'}`}
+        >
+          <Helmet title={`${this.props.project.display_name} » ${counterpart('project.classifyPage.title')}`} />
 
-        {this.props.projectIsComplete &&
-          <FinishedBanner project={this.props.project} />}
+          {this.props.projectIsComplete &&
+            <FinishedBanner project={this.props.project} />}
 
-        {this.state.validUserGroup &&
-          <p className="anouncement-banner--group">You are classifying as a student of your classroom.</p>}
+          {this.state.validUserGroup &&
+            <p className="anouncement-banner--group">You are classifying as a student of your classroom.</p>}
 
-        {this.props.workflow ? this.renderClassifier() : <p>Loading workflow</p>}
-        <ProjectThemeButton />
-      </div>
+          {this.props.workflow ? this.renderClassifier() : <p>Loading workflow</p>}
+          <ProjectThemeButton />
+        </div>
+      </WorkflowSelection>
     );
   }
 }

--- a/app/pages/project/components/ProjectNavbar/ProjectNavbarContainer.jsx
+++ b/app/pages/project/components/ProjectNavbar/ProjectNavbarContainer.jsx
@@ -47,7 +47,7 @@ class ProjectNavbarContainer extends Component {
 
   getProjectLinks() {
     const { project, projectRoles, user, workflow } = this.props;
-    const links = getProjectLinks({ project, projectRoles, workflow, user });
+    const links = getProjectLinks({ project, projectRoles, user });
 
     return _.map(links, link => ({
       disabled: link.disabled || false,

--- a/app/pages/project/components/ProjectNavbar/ProjectNavbarContainer.jsx
+++ b/app/pages/project/components/ProjectNavbar/ProjectNavbarContainer.jsx
@@ -46,7 +46,7 @@ class ProjectNavbarContainer extends Component {
   }
 
   getProjectLinks() {
-    const { project, projectRoles, user, workflow } = this.props;
+    const { project, projectRoles, user } = this.props;
     const links = getProjectLinks({ project, projectRoles, user });
 
     return _.map(links, link => ({
@@ -115,8 +115,7 @@ ProjectNavbarContainer.propTypes = {
   translation: PropTypes.shape({
     display_name: PropTypes.string
   }),
-  user: PropTypes.object,
-  workflow: PropTypes.object
+  user: PropTypes.object
 };
 
 export default ProjectNavbarContainer;

--- a/app/pages/project/components/ProjectNavbar/components/NavLink/NavLink.spec.js
+++ b/app/pages/project/components/ProjectNavbar/components/NavLink/NavLink.spec.js
@@ -30,7 +30,7 @@ describe('NavLink', function() {
       const navLinks = getProjectLinks({ project: projectWithoutRedirect, projectRoles, user: null });
       const navLinksWithLabels = buildLinksWithLabels(navLinks);
       const classifyLink = navLinksWithLabels[1];
-      const wrapper = shallow(<NavLink url={classifyLink.url} label={classifyLink.label} disabled={classifyLink.disabled} />);
+      const wrapper = shallow(<NavLink url={classifyLink.url} label={classifyLink.label} disabled={true} />);
       expect(wrapper.name()).to.equal('styled.span');
     });
   });

--- a/app/pages/project/components/ProjectNavbar/components/NavLink/NavLink.spec.js
+++ b/app/pages/project/components/ProjectNavbar/components/NavLink/NavLink.spec.js
@@ -27,7 +27,7 @@ describe('NavLink', function() {
 
   describe('when the link is disabled', function() {
     it('should be the StyledLinkPlaceholder component ', function() {
-      const navLinks = getProjectLinks({ project: projectWithoutRedirect, projectRoles, workflow: null, user: null });
+      const navLinks = getProjectLinks({ project: projectWithoutRedirect, projectRoles, user: null });
       const navLinksWithLabels = buildLinksWithLabels(navLinks);
       const classifyLink = navLinksWithLabels[1];
       const wrapper = shallow(<NavLink url={classifyLink.url} label={classifyLink.label} disabled={classifyLink.disabled} />);
@@ -39,7 +39,7 @@ describe('NavLink', function() {
     let wrapper;
     let firstLink;
     before(function() {
-      const navLinks = getProjectLinks({ project: projectWithoutRedirect, projectRoles, workflow, user: null });
+      const navLinks = getProjectLinks({ project: projectWithoutRedirect, projectRoles, user: null });
       const navLinksWithLabels = buildLinksWithLabels(navLinks);
       firstLink = navLinksWithLabels[0];
       wrapper = shallow(<NavLink url={firstLink.url} label={firstLink.label} />);

--- a/app/pages/project/home/project-home.jsx
+++ b/app/pages/project/home/project-home.jsx
@@ -16,6 +16,7 @@ import ExternalLinksBlock from '../../../components/ExternalLinksBlock';
 
 const ProjectHomePage = (props) => {
   const projectIsNotRedirected = props.project && !props.project.redirect;
+  const canClassify = props.project.links.active_workflows && props.project.links.active_workflows.length > 0;
   const avatarSrc = props.researcherAvatar || '/assets/simple-avatar.png';
 
   const descriptionClass = classnames(
@@ -60,7 +61,7 @@ const ProjectHomePage = (props) => {
             <Link to={`/projects/${props.project.slug}/about`} className="project-home-page__button call-to-action__button call-to-action__button--learn-more">
               <Translate content="project.home.learnMore" />
             </Link>}
-          {showGetStartedLink &&
+          {canClassify && showGetStartedLink &&
             <VisibilitySplit splits={props.splits} splitKey='workflow.assignment' elementKey='link'>
               <Link
                 to={`/projects/${props.project.slug}/classify`}

--- a/app/pages/project/home/project-home.spec.js
+++ b/app/pages/project/home/project-home.spec.js
@@ -26,7 +26,10 @@ const project = {
       site: 'facebook.com/',
       url: 'https://www.facebook.com/find-the-thing'
     }
-  ]
+  ],
+  links: {
+    active_workflows: ['1']
+  }
 };
 
 const talkSubjects = [

--- a/app/pages/project/index.jsx
+++ b/app/pages/project/index.jsx
@@ -15,7 +15,6 @@ import * as interventionActions from '../../redux/ducks/interventions';
 import * as translationActions from '../../redux/ducks/translations';
 import ProjectPage from './project-page';
 import ProjectTranslations from './project-translations';
-import WorkflowSelection from './workflow-selection';
 import getAllLinked from '../../lib/get-all-linked';
 
 counterpart.registerTranslations('en', require('../../locales/en').default);
@@ -367,34 +366,24 @@ class ProjectPageController extends React.Component {
           <ProjectTranslations
             project={this.state.project}
           >
-            <WorkflowSelection
-              actions={this.props.actions}
-              location={this.props.location}
+            <ProjectPage
+              {...this.props}
+              background={this.state.background}
+              guide={this.state.guide}
+              guideIcons={this.state.guideIcons}
+              loading={this.state.loading}
+              organization={this.state.organization}
+              owner={this.state.owner}
+              pages={this.state.pages}
               preferences={this.state.projectPreferences}
               project={this.state.project}
+              projectAvatar={this.state.projectAvatar}
+              projectIsComplete={this.state.projectIsComplete}
               projectRoles={this.state.projectRoles}
-              translations={this.props.translations}
-              user={this.props.user}
-            >
-              <ProjectPage
-                {...this.props}
-                background={this.state.background}
-                guide={this.state.guide}
-                guideIcons={this.state.guideIcons}
-                loading={this.state.loading}
-                organization={this.state.organization}
-                owner={this.state.owner}
-                pages={this.state.pages}
-                preferences={this.state.projectPreferences}
-                project={this.state.project}
-                projectAvatar={this.state.projectAvatar}
-                projectIsComplete={this.state.projectIsComplete}
-                projectRoles={this.state.projectRoles}
-                requestUserProjectPreferences={this.requestUserProjectPreferences.bind(this)}
-                splits={this.state.splits}
-                workflow={this.props.workflow}
-              />
-            </WorkflowSelection>
+              requestUserProjectPreferences={this.requestUserProjectPreferences.bind(this)}
+              splits={this.state.splits}
+              workflow={this.props.workflow}
+            />
           </ProjectTranslations>
         }
         {!!this.state.loading &&

--- a/app/pages/project/project-page.jsx
+++ b/app/pages/project/project-page.jsx
@@ -42,7 +42,6 @@ export default class ProjectPage extends React.Component {
           routes={this.props.routes}
           user={this.props.user}
           translation={this.props.translation}
-          workflow={this.props.workflow}
         />
         {(this.props.project.configuration && this.props.project.configuration.announcement) &&
           <div className="informational project-announcement-banner">

--- a/app/pages/project/project-page.spec.js
+++ b/app/pages/project/project-page.spec.js
@@ -4,7 +4,7 @@ import { shallow, mount } from 'enzyme';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import GeordiLogger from '../../lib/zooniverse-logging';
-import { project } from '../dev-classifier/mock-data';
+import { projectWithoutRedirect } from '../../../test/mockObjects';
 import ProjectPage from './project-page';
 import ProjectNavbar from './components/ProjectNavbar';
 import ProjectHomeContainer from './home/';
@@ -22,6 +22,8 @@ function Page() {
 }
 
 describe('ProjectPage', function () {
+  const project = projectWithoutRedirect;
+
   it('should render without crashing', function () {
     shallow(<ProjectPage><Page /></ProjectPage>);
   });

--- a/app/pages/project/workflow-selection.jsx
+++ b/app/pages/project/workflow-selection.jsx
@@ -20,21 +20,14 @@ class WorkflowSelection extends React.Component {
     this.getSelectedWorkflow(this.props);
   }
 
-  componentWillUpdate(nextProps, nextState) {
-    const { preferences } = nextProps;
+  componentDidUpdate(prevProps, prevState) {
+    const { preferences, workflow } = this.props;
     const userSelectedWorkflow = (preferences && preferences.preferences) ? this.sanitiseID(preferences.preferences.selected_workflow) : undefined;
-    if (userSelectedWorkflow &&
-      this.props.workflow
-    ) {
-      if (!nextState.loadingSelectedWorkflow &&
-        userSelectedWorkflow !== this.props.workflow.id
-      ) {
-        this.getSelectedWorkflow(nextProps);
+    if (userSelectedWorkflow && workflow) {
+      if (!this.state.loadingSelectedWorkflow && userSelectedWorkflow !== workflow.id) {
+        this.getSelectedWorkflow(this.props);
       }
     }
-  }
-
-  componentDidUpdate(prevProps, prevState) {
     if (prevProps.project.id !== this.props.project.id) {
       this.getSelectedWorkflow(this.props);
     }

--- a/test/mockObjects.js
+++ b/test/mockObjects.js
@@ -41,14 +41,20 @@ export const projectWithoutRedirect = {
   id: '2',
   slug: 'zooniverse/find-the-thing',
   title: 'Find the Thing',
-  urls: [socialMediaUrl, externalUrl]
+  urls: [socialMediaUrl, externalUrl],
+  links: {
+    active_workflows: ['35']
+  }
 };
 
 export const projectWithRedirect = {
   id: '3',
   redirect: 'https://www.redirected-project.org',
   title: 'Find the Thing',
-  urls: [socialMediaUrl, externalUrl]
+  urls: [socialMediaUrl, externalUrl],
+  links: {
+    active_workflows: ['35']
+  }
 };
 
 export const workflow = { id: '35' };


### PR DESCRIPTION
Staging branch URL: https://pr-5078.pfe-preview.zooniverse.org

Check for `project.links.active_workflows` before rendering classify links on the home page or in the project navigation. Move workflow selection down to the project classify page, rather than wrapping the whole project.

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
