### PR TITLE
Workflow selection

### DIFF
--- a/app/pages/project/classify.jsx
+++ b/app/pages/project/classify.jsx
@@ -82,7 +82,7 @@ export class ProjectClassifyPage extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { actions, classification, project, upcomingSubjects, workflow } = this.props;
+    const { classification, upcomingSubjects, workflow } = this.props;
 
     if (workflow !== prevProps.workflow) {
       this.loadAppropriateClassification();
@@ -271,30 +271,20 @@ export class ProjectClassifyPage extends React.Component {
 
   render() {
     return (
-      <WorkflowSelection
-        actions={this.props.actions}
-        location={this.props.location}
-        preferences={this.props.preferences}
-        project={this.props.project}
-        projectRoles={this.props.projectRoles}
-        translations={this.props.translations}
-        user={this.props.user}
+      <div
+        className={`${(this.props.theme === zooTheme.mode.light) ? 'classify-page' : 'classify-page classify-page--dark-theme'}`}
       >
-        <div
-          className={`${(this.props.theme === zooTheme.mode.light) ? 'classify-page' : 'classify-page classify-page--dark-theme'}`}
-        >
-          <Helmet title={`${this.props.project.display_name} » ${counterpart('project.classifyPage.title')}`} />
+        <Helmet title={`${this.props.project.display_name} » ${counterpart('project.classifyPage.title')}`} />
 
-          {this.props.projectIsComplete &&
-            <FinishedBanner project={this.props.project} />}
+        {this.props.projectIsComplete &&
+          <FinishedBanner project={this.props.project} />}
 
-          {this.state.validUserGroup &&
-            <p className="anouncement-banner--group">You are classifying as a student of your classroom.</p>}
+        {this.state.validUserGroup &&
+          <p className="anouncement-banner--group">You are classifying as a student of your classroom.</p>}
 
-          {this.props.workflow ? this.renderClassifier() : <p>Loading workflow</p>}
-          <ProjectThemeButton />
-        </div>
-      </WorkflowSelection>
+        {this.props.workflow ? this.renderClassifier() : <p>Loading workflow</p>}
+        <ProjectThemeButton />
+      </div>
     );
   }
 }
@@ -365,4 +355,21 @@ const mapDispatchToProps = dispatch => ({
   }
 });
 
-export default connect(mapStateToProps, mapDispatchToProps)(ProjectClassifyPage);
+const ConnectedClassifyPage = connect(mapStateToProps, mapDispatchToProps)(ProjectClassifyPage);
+
+function ConnectedClassifyPageWithWorkflow(props) {
+  return (
+    <WorkflowSelection
+      actions={props.actions}
+      location={props.location}
+      preferences={props.preferences}
+      project={props.project}
+      projectRoles={props.projectRoles}
+      translations={props.translations}
+      user={props.user}
+    >
+      <ConnectedClassifyPage {...props} />
+    </WorkflowSelection>
+  );
+}
+export default ConnectedClassifyPageWithWorkflow;

--- a/app/pages/project/classify.jsx
+++ b/app/pages/project/classify.jsx
@@ -309,7 +309,6 @@ ProjectClassifyPage.propTypes = {
     })
   }),
   classification: PropTypes.shape({}),
-  loadingSelectedWorkflow: PropTypes.bool,
   location: PropTypes.shape({
     query: PropTypes.shape({
       group: PropTypes.string

--- a/app/pages/project/classify.jsx
+++ b/app/pages/project/classify.jsx
@@ -364,7 +364,6 @@ function ConnectedClassifyPageWithWorkflow(props) {
       preferences={props.preferences}
       project={props.project}
       projectRoles={props.projectRoles}
-      translations={props.translations}
       user={props.user}
     >
       <ConnectedClassifyPage {...props} />

--- a/app/pages/project/classify.spec.js
+++ b/app/pages/project/classify.spec.js
@@ -30,7 +30,6 @@ describe('ProjectClassifyPage', function () {
       <ProjectClassifyPage
         actions={actions}
         classification={null}
-        loadingSelectedWorkflow={false}
         project={project}
         upcomingSubjects={[]}
         workflow={workflow}
@@ -134,7 +133,6 @@ describe('ProjectClassifyPage', function () {
         <ProjectClassifyPage
           actions={actions}
           classification={classification}
-          loadingSelectedWorkflow={false}
           project={project}
           upcomingSubjects={[]}
           workflow={newWorkflow}
@@ -169,7 +167,6 @@ describe('ProjectClassifyPage', function () {
         <ProjectClassifyPage
           actions={actions}
           classification={classification}
-          loadingSelectedWorkflow={false}
           project={project}
           upcomingSubjects={[]}
           workflow={workflow}

--- a/app/pages/project/project-page.jsx
+++ b/app/pages/project/project-page.jsx
@@ -51,7 +51,6 @@ export default class ProjectPage extends React.Component {
           </div>}
         {React.cloneElement(this.props.children, {
           background: this.props.background,
-          loadingSelectedWorkflow: this.props.loadingSelectedWorkflow,
           onChangePreferences: this.props.onChangePreferences,
           organization: this.props.organization,
           owner: this.props.owner,

--- a/app/pages/project/workflow-selection.jsx
+++ b/app/pages/project/workflow-selection.jsx
@@ -188,7 +188,8 @@ class WorkflowSelection extends React.Component {
   render() {
     const { translation, workflow } = this.props;
     const { loadingSelectedWorkflow } = this.state;
-    return React.cloneElement(this.props.children, { translation, loadingSelectedWorkflow });
+    const childrenWithTranslation = React.cloneElement(this.props.children, { translation });
+    return loadingSelectedWorkflow ? <p>Loading workflow</p> : childrenWithTranslation;
   }
 }
 

--- a/app/pages/project/workflow-selection.jsx
+++ b/app/pages/project/workflow-selection.jsx
@@ -21,7 +21,7 @@ class WorkflowSelection extends React.Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
-    const { preferences, workflow } = this.props;
+    const { locale, preferences, workflow } = this.props;
     const userSelectedWorkflow = (preferences && preferences.preferences) ? this.sanitiseID(preferences.preferences.selected_workflow) : undefined;
     if (userSelectedWorkflow && workflow) {
       if (!this.state.loadingSelectedWorkflow && userSelectedWorkflow !== workflow.id) {
@@ -31,8 +31,8 @@ class WorkflowSelection extends React.Component {
     if (prevProps.project.id !== this.props.project.id) {
       this.getSelectedWorkflow(this.props);
     }
-    if (prevProps.translations.locale !== this.props.translations.locale) {
-      this.props.actions.translations.load('workflow', this.props.workflow.id, this.props.translations.locale);
+    if (workflow && prevProps.locale !== locale) {
+      this.props.actions.translations.load('workflow', workflow.id, locale);
     }
   }
 
@@ -72,11 +72,11 @@ class WorkflowSelection extends React.Component {
     }
 
     if (selectedWorkflowID) return this.getWorkflow(selectedWorkflowID, activeFilter);
-    if (process.env.BABEL_ENV !== 'test') console.warn('Cannot select a workflow.')
+    if (process.env.BABEL_ENV !== 'test') console.warn('Cannot select a workflow.');
   }
 
   getWorkflow(selectedWorkflowID, activeFilter = true) {
-    const { actions, project, translations } = this.props;
+    const { actions, locale, project } = this.props;
     const sanitisedWorkflowID = this.sanitiseID(selectedWorkflowID);
     let isValidWorkflow = false;
 
@@ -106,7 +106,7 @@ class WorkflowSelection extends React.Component {
     return awaitWorkflow
     .then((workflow) => {
       if (workflow) {
-        actions.translations.load('workflow', workflow.id, translations.locale);
+        actions.translations.load('workflow', workflow.id, locale);
         actions.classifier.setWorkflow(workflow);
         this.setState({ loadingSelectedWorkflow: false });
       } else {
@@ -186,10 +186,8 @@ class WorkflowSelection extends React.Component {
   }
 
   render() {
-    const { translation, workflow } = this.props;
     const { loadingSelectedWorkflow } = this.state;
-    const childrenWithTranslation = React.cloneElement(this.props.children, { translation });
-    return loadingSelectedWorkflow ? <p>Loading workflow</p> : childrenWithTranslation;
+    return loadingSelectedWorkflow ? <p>Loading workflow</p> : this.props.children;
   }
 }
 
@@ -200,18 +198,12 @@ WorkflowSelection.defaultProps = {
     }
   },
   children: null,
+  locale: 'en',
   location: {
     query: {}
   },
   preferences: {},
   projectRoles: [],
-  translation: {
-    id: '',
-    display_name: ''
-  },
-  translations: {
-    locale: 'en'
-  },
   user: null,
   workflow: null
 };
@@ -228,6 +220,7 @@ WorkflowSelection.propTypes = {
       workflow: PropTypes.string
     })
   }),
+  locale: PropTypes.string,
   preferences: PropTypes.shape({
     save: PropTypes.func,
     update: PropTypes.func
@@ -241,12 +234,6 @@ WorkflowSelection.propTypes = {
     uncacheLink: PropTypes.func
   }).isRequired,
   projectRoles: PropTypes.arrayOf(PropTypes.object),
-  translation: PropTypes.shape({
-    display_name: PropTypes.string
-  }),
-  translations: PropTypes.shape({
-    locale: PropTypes.string
-  }),
   workflow: PropTypes.shape({
     id: PropTypes.string
   })
@@ -257,6 +244,7 @@ WorkflowSelection.contextTypes = {
 };
 
 const mapStateToProps = state => ({
+  locale: state.translations.locale,
   workflow: state.classify.workflow
 });
 

--- a/app/pages/project/workflow-selection.spec.js
+++ b/app/pages/project/workflow-selection.spec.js
@@ -78,11 +78,8 @@ const preferences = mockPanoptesResource(
 describe('WorkflowSelection', function () {
   const actions = {
     translations: {
-      load: () => null
+      load: sinon.stub()
     }
-  };
-  const translations = {
-    locale: 'en'
   };
   const wrapper = mount(
     <WorkflowSelection
@@ -90,8 +87,8 @@ describe('WorkflowSelection', function () {
       project={project}
       preferences={preferences}
       projectRoles={projectRoles}
+      locale='en'
       location={location}
-      translations={translations}
     >
       <StubPage />
     </WorkflowSelection>,
@@ -119,6 +116,7 @@ describe('WorkflowSelection', function () {
 
   beforeEach(function () {
     workflowStub.resetHistory();
+    actions.translations.load.resetHistory();
     wrapper.update();
   });
 
@@ -325,6 +323,14 @@ describe('WorkflowSelection', function () {
       wrapper.setProps({ project: projectWithoutWorkflows });
 
       sinon.assert.notCalled(workflowStub)
+    });
+  });
+
+  describe('on language change', function () {
+    it('should load new translation strings', function () {
+      const workflow = mockPanoptesResource('workflows', { id: '1', tasks: {} });
+      wrapper.setProps({ locale: 'it', workflow });
+      sinon.assert.calledWith(actions.translations.load, 'workflow', '1', 'it');
     });
   });
 });

--- a/app/pages/project/workflow-selection.spec.js
+++ b/app/pages/project/workflow-selection.spec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import assert from 'assert';
+import { expect } from 'chai';
 import { mount } from 'enzyme';
 import sinon from 'sinon';
 import apiClient from 'panoptes-client/lib/api-client';
@@ -132,24 +132,24 @@ describe('WorkflowSelection', function () {
   it('should fetch a random active workflow by default', function () {
     controller.getSelectedWorkflow({ project });
     const selectedWorkflowID = workflowStub.getCall(0).args[0];
-    sinon.assert.calledOnce(workflowStub);
-    assert.notEqual(project.links.active_workflows.indexOf(selectedWorkflowID.toString()), -1);
+    expect(workflowStub.calledOnce).to.be.true;
+    expect(project.links.active_workflows).to.include(selectedWorkflowID.toString());
   });
 
   it('should respect the workflow query param if "allow workflow query" is set', function () {
     location.query.workflow = '6';
     project.experimental_tools = ['allow workflow query'];
     controller.getSelectedWorkflow({ project });
-    sinon.assert.calledOnce(workflowStub);
-    sinon.assert.calledWith(workflowStub, '6', true);
+    expect(workflowStub.calledOnce).to.be.true;
+    expect(workflowStub.calledWith('6', true)).to.be.true;
   });
 
   it('should sanitise the workflow query param if "allow workflow query" is set', function () {
     location.query.workflow = '6random78';
     project.experimental_tools = ['allow workflow query'];
     controller.getSelectedWorkflow({ project });
-    sinon.assert.calledOnce(workflowStub);
-    sinon.assert.calledWith(workflowStub, '6', true);
+    expect(workflowStub.calledOnce).to.be.true;
+    expect(workflowStub.calledWith('6', true)).to.be.true;
   });
 
   describe('with a logged-in user', function () {
@@ -161,32 +161,32 @@ describe('WorkflowSelection', function () {
     it('should load the specified workflow for the project owner', function () {
       const user = owner;
       controller.getSelectedWorkflow({ project, preferences, user });
-      sinon.assert.calledOnce(workflowStub);
-      sinon.assert.calledWith(workflowStub, '6', false);
+      expect(workflowStub.calledOnce).to.be.true;
+      expect(workflowStub.calledWith('6', false)).to.be.true;
     });
 
     it('should load the specified workflow for a collaborator', function () {
       const user = apiClient.type('users').create({ id: '2' });
       controller.getSelectedWorkflow({ project, preferences, user });
-      sinon.assert.calledOnce(workflowStub);
-      sinon.assert.calledWith(workflowStub, '6', false);
+      expect(workflowStub.calledOnce).to.be.true;
+      expect(workflowStub.calledWith('6', false)).to.be.true;
     });
 
     it('should load the specified workflow for a tester', function () {
       const user = apiClient.type('users').create({ id: '3' });
       controller.getSelectedWorkflow({ project, preferences, user });
-      sinon.assert.calledOnce(workflowStub);
-      sinon.assert.calledWith(workflowStub, '6', false);
+      expect(workflowStub.calledOnce).to.be.true;
+      expect(workflowStub.calledWith('6', false)).to.be.true;
     });
 
     it('should load an active workflow for a general user', function () {
       const user = apiClient.type('users').create({ id: '4' });
       controller.getSelectedWorkflow({ project, preferences, user });
-      sinon.assert.calledOnce(workflowStub);
+      expect(workflowStub.calledOnce).to.be.true;
       const selectedWorkflowID = workflowStub.getCall(0).args[0];
       const activeFilter = workflowStub.getCall(0).args[1];
-      assert.notEqual(project.links.active_workflows.indexOf(selectedWorkflowID), -1);
-      assert.equal(activeFilter, true);
+      expect(project.links.active_workflows).to.include(selectedWorkflowID);
+      expect(activeFilter).to.be.true;
     });
   });
 
@@ -201,53 +201,53 @@ describe('WorkflowSelection', function () {
     it('should try to load the stored workflow', function () {
       preferences.update({ 'preferences.selected_workflow': '4' });
       controller.getSelectedWorkflow({ project, preferences });
-      sinon.assert.calledOnce(workflowStub);
-      sinon.assert.calledWith(workflowStub, '4', true);
+      expect(workflowStub.calledOnce).to.be.true;
+      expect(workflowStub.calledWith('4', true)).to.be.true;
     });
 
     it('should parse the stored user workflow as an int', function () {
       preferences.update({ 'preferences.selected_workflow': '4random' });
       controller.getSelectedWorkflow({ project, preferences });
-      sinon.assert.calledOnce(workflowStub);
-      sinon.assert.calledWith(workflowStub, '4', true);
+      expect(workflowStub.calledOnce).to.be.true;
+      expect(workflowStub.calledWith('4', true)).to.be.true;
     });
 
     it('should clear an invalid workflow string from user preferences', function () {
       preferences.update({ 'preferences.selected_workflow': '4' });
       controller.clearInactiveWorkflow('4');
-      assert.equal(preferences.preferences.selected_workflow, undefined);
+      expect(preferences.preferences.selected_workflow).to.be.undefined;
     });
 
     it('should clear an invalid workflow int from user preferences', function () {
       preferences.update({ 'preferences.selected_workflow': 4 });
       controller.clearInactiveWorkflow('4');
-      assert.equal(preferences.preferences.selected_workflow, undefined);
+      expect(preferences.preferences.selected_workflow).to.be.undefined;
     });
 
     it('should try to load a stored project workflow', function () {
       preferences.update({ 'settings.workflow_id': '2' });
       controller.getSelectedWorkflow({ project, preferences });
-      sinon.assert.calledOnce(workflowStub);
-      sinon.assert.calledWith(workflowStub, '2', true);
+      expect(workflowStub.calledOnce).to.be.true;
+      expect(workflowStub.calledWith('2', true)).to.be.true;
     });
 
     it('parse the stored project workflow as an int', function () {
       preferences.update({ 'settings.workflow_id': '2random' });
       controller.getSelectedWorkflow({ project, preferences });
-      sinon.assert.calledOnce(workflowStub);
-      sinon.assert.calledWith(workflowStub, '2', true);
+      expect(workflowStub.calledOnce).to.be.true;
+      expect(workflowStub.calledWith('2', true)).to.be.true;
     });
 
     it('should clear an invalid workflow string from project settings', function () {
       preferences.update({ 'settings.workflow_id': '2' });
       controller.clearInactiveWorkflow('2');
-      assert.equal(preferences.settings.workflow_id, undefined);
+      expect(preferences.settings.workflow_id).to.be.undefined;
     });
 
     it('should clear an invalid workflow int from project settings', function () {
       preferences.update({ 'settings.workflow_id': 2 });
       controller.clearInactiveWorkflow('2');
-      assert.equal(preferences.settings.workflow_id, undefined);
+      expect(preferences.settings.workflow_id).to.be.undefined;
     });
   });
 
@@ -261,8 +261,8 @@ describe('WorkflowSelection', function () {
     it('should load the project default workflow', function () {
       const user = apiClient.type('users').create({ id: '4' });
       controller.getSelectedWorkflow({ project, preferences, user });
-      sinon.assert.calledOnce(workflowStub);
-      sinon.assert.calledWith(workflowStub, '1', true);
+      expect(workflowStub.calledOnce).to.be.true;
+      expect(workflowStub.calledWith('1', true)).to.be.true;
     });
   });
 
@@ -284,8 +284,8 @@ describe('WorkflowSelection', function () {
         }
       );
       wrapper.setProps({ project: newProject });
-      sinon.assert.calledOnce(workflowStub);
-      sinon.assert.calledWith(workflowStub, '10', true);
+      expect(workflowStub.calledOnce).to.be.true;
+      expect(workflowStub.calledWith('10', true)).to.be.true;
     });
   });
 
@@ -322,7 +322,7 @@ describe('WorkflowSelection', function () {
 
       wrapper.setProps({ project: projectWithoutWorkflows });
 
-      sinon.assert.notCalled(workflowStub)
+      expect(workflowStub.notCalled).to.be.true;
     });
   });
 
@@ -330,7 +330,7 @@ describe('WorkflowSelection', function () {
     it('should load new translation strings', function () {
       const workflow = mockPanoptesResource('workflows', { id: '1', tasks: {} });
       wrapper.setProps({ locale: 'it', workflow });
-      sinon.assert.calledWith(actions.translations.load, 'workflow', '1', 'it');
+      expect(actions.translations.load.calledWith('workflow', '1', 'it')).to.be.true;
     });
   });
 });


### PR DESCRIPTION
Staging branch URL: https://pr-5083.pfe-preview.zooniverse.org

Tidies up a few things I missed in #5078.

- Properly wraps the classify page, so that it doesn't mount until workflow selection is complete.
- Adds the stored locale to the WorkflowSelection component, so that workflow translations update when the language changes.
- Removes the `loadingSelectedWorkflow` prop, which doesn't seem to be used anywhere in the classify page or classifier.

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
