### PR TITLE
[WIP] Update intervention handling for new payloads

### DIFF
--- a/app/main.cjsx
+++ b/app/main.cjsx
@@ -16,7 +16,7 @@ style = require '../css/main.styl'
 store = configureStore()
 auth.listen('change', () => store.dispatch(emptySubjectQueue()));
 apiClient.type('subject_sets').listen('add-or-remove', () => store.dispatch(emptySubjectQueue()));
-sugarClient.on('experiment', (message) => store.dispatch(notify(message)));
+sugarClient.on('experiment', (message) => store.dispatch(handleInterventionMessage(message)));
 
 # Redirect any old `/#/foo`-style URLs to `/foo`
 # ensuring we preserve the location path, search and hash fragments

--- a/app/main.cjsx
+++ b/app/main.cjsx
@@ -17,7 +17,6 @@ store = configureStore()
 auth.listen('change', () => store.dispatch(emptySubjectQueue()));
 apiClient.type('subject_sets').listen('add-or-remove', () => store.dispatch(emptySubjectQueue()));
 sugarClient.on('experiment', (message) => store.dispatch(notify(message)));
-sugarClient.on('subject-queue', (message) => store.dispatch(injectSubjects(message)));
 
 # Redirect any old `/#/foo`-style URLs to `/foo`
 # ensuring we preserve the location path, search and hash fragments


### PR DESCRIPTION
Update the intervention handlers to respect the new payloads defined in:
- Message - https://github.com/zooniverse/interventions-gateway/blob/1ff6208733e64d242808565d2559e378154dcf42/interventions_gateway_api.rb#L37
- Subject Queue prepend - https://github.com/zooniverse/interventions-gateway/blob/1ff6208733e64d242808565d2559e378154dcf42/interventions_gateway_api.rb#L58

TODO: 
- [ ] Update the classifer intervention code for the new payload data

Staging branch URL:

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
