### PR TITLE
Notifications: fix project avatars

### DIFF
--- a/app/pages/notifications/notification-section.jsx
+++ b/app/pages/notifications/notification-section.jsx
@@ -42,6 +42,11 @@ export default class NotificationSection extends Component {
             this.setState({
               name: project.display_name,
               avatar: avatar.src
+            })
+            .catch(() => {
+              this.setState({
+                name: project.display_name
+              });
             });
           });
         } else {

--- a/app/pages/notifications/notification-section.jsx
+++ b/app/pages/notifications/notification-section.jsx
@@ -31,15 +31,25 @@ export default class NotificationSection extends Component {
         name: 'Zooniverse'
       });
     } else {
-      apiClient.type('projects').get(this.props.projectID)
+      apiClient.type('projects').get(this.props.projectID, { include: 'avatar' })
       .catch((error) => {
         this.setState({ error });
       })
       .then((project) => {
-        this.setState({
-          name: project.display_name,
-          avatar: project.avatar_src
-        });
+        if (project.links.avatar) {
+          apiClient.type('avatars').get(project.links.avatar.id)
+          .then((avatar) => {
+            this.setState({
+              name: project.display_name,
+              avatar: avatar.src
+            });
+          });
+        } else {
+          this.setState({
+            name: project.display_name
+          });
+        }
+        
       });
     }
   }
@@ -153,7 +163,7 @@ export default class NotificationSection extends Component {
   }
 
   avatarFor() {
-    const src = this.state.avatar ? `//${this.state.avatar}` : '/assets/simple-avatar.jpg';
+    const src = this.state.avatar || '/assets/simple-avatar.jpg';
     let avatar;
 
     if (this.state.unread > 0) return this.unreadCircle();


### PR DESCRIPTION
Get project avatars when requesting projects and display them instead of the default blue avatar.

Fixes a small problem mentioned on Talk. https://www.zooniverse.org/talk/17/796253?comment=1317721&page=1

Staging branch URL: https://pr-5088.pfe-preview.zooniverse.org

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
