### PR TITLE
Validate message interventions against classifications

### DIFF
--- a/app/classifier/classifier.jsx
+++ b/app/classifier/classifier.jsx
@@ -213,7 +213,6 @@ class Classifier extends React.Component {
 
   onNextSubject() {
     this.setState({ showIntervention: false, showSummary: false });
-    this.props.actions.interventions.dismiss();
     this.props.onClickNext();
   }
 
@@ -236,7 +235,7 @@ class Classifier extends React.Component {
   }
 
   completeClassification(e) {
-    const { actions, classification, onComplete, interventions, project, subject, user, workflow } = this.props;
+    const { actions, classification, onComplete, intervention, project, subject, user, workflow } = this.props;
     const originalElement = e.currentTarget;
     const isCmdClick = e.metaKey;
     const annotations = this.state.annotations.slice();
@@ -245,7 +244,7 @@ class Classifier extends React.Component {
 
     const showIntervention = user &&
       user.intervention_notifications &&
-      (interventions.notifications.length > 0);
+      intervention;
     const showSummary = !workflow.configuration.hide_classification_summaries ||
       this.subjectIsGravitySpyGoldStandard();
     const showLastStep = showIntervention || showSummary;
@@ -296,7 +295,7 @@ class Classifier extends React.Component {
   }
 
   render() {
-    const { actions, goldStandardMode, interventions, user } = this.props;
+    const { actions, goldStandardMode, intervention, user } = this.props;
     const { showIntervention, showSummary, workflowHistory } = this.state;
     const currentTaskKey = workflowHistory.length > 0 ? workflowHistory[workflowHistory.length - 1] : null;
     const taskAreaVariant = goldStandardMode ? 'goldStandardMode' : 'default';
@@ -355,7 +354,7 @@ class Classifier extends React.Component {
             />
             {showIntervention &&
               <Intervention
-                notifications={interventions.notifications}
+                intervention={intervention}
                 user={user}
               />
             }
@@ -488,8 +487,8 @@ Classifier.propTypes = {
     rules: PropTypes.object
   }),
   goldStandardMode: PropTypes.bool,
-  interventions: PropTypes.shape({
-    notifications: PropTypes.array
+  intervention: PropTypes.shape({
+    message: PropTypes.string
   }),
   minicourse: PropTypes.shape({
     id: PropTypes.string,
@@ -546,9 +545,7 @@ Classifier.defaultProps = {
     active: false
   },
   goldStandardMode: false,
-  interventions: {
-    notifications: []
-  },
+  intervention: null,
   minicourse: null,
   onClickNext: () => null,
   onComplete: () => Promise.resolve(),
@@ -571,7 +568,7 @@ Classifier.defaultProps = {
 const mapStateToProps = state => ({
   feedback: state.feedback,
   goldStandardMode: state.classify.goldStandardMode,
-  interventions: state.interventions,
+  intervention: state.classify.intervention,
   theme: state.userInterface.theme
 });
 

--- a/app/classifier/classifier.spec.js
+++ b/app/classifier/classifier.spec.js
@@ -248,25 +248,21 @@ describe('Classifier', function () {
       expect(changes.interventions.opt_in).to.be.false;
     });
     describe('with an intervention message', function () {
-      const interventions = {
-        notifications: [{
-          data:{
-            message: 'Hello!'
-          }
-        }]
+      const intervention = {
+        message: 'Hello!'
       };
       const user = {
         intervention_notifications: true
       };
       it('should record that an intervention was received', function (done) {
-        wrapper.setProps({ workflow, interventions, user });
+        wrapper.setProps({ workflow, intervention, user });
         wrapper.instance().completeClassification(fakeEvent)
         .then(done, done);
         const changes = actions.classify.updateClassification.getCall(0).args[0];
         expect(changes.interventions.message).to.be.true;
       });
       it('should record whether the user is reading interventions', function () {
-        wrapper.setProps({ workflow, interventions, user });
+        wrapper.setProps({ workflow, intervention, user });
         wrapper.instance().completeClassification(fakeEvent);
         const changes = actions.classify.updateClassification.getCall(0).args[0];
         expect(changes.interventions.opt_in).to.equal(user.intervention_notifications);

--- a/app/classifier/components/Intervention/Intervention.jsx
+++ b/app/classifier/components/Intervention/Intervention.jsx
@@ -13,9 +13,8 @@ const StyledInterventionMessage = styled.div`
   }
 `;
 
-function Intervention({ notifications, user }) {
-  const notification = notifications[notifications.length - 1];
-  const { message } = notification;
+function Intervention({ intervention, user }) {
+  const { message } = intervention;
   const checkbox = React.createRef();
 
   function onChange() {
@@ -41,11 +40,9 @@ function Intervention({ notifications, user }) {
 }
 
 Intervention.propTypes = {
-  notifications: PropTypes.arrayOf(PropTypes.shape({
-    data: PropTypes.shape({
+  intervention: PropTypes.shape({
       message: PropTypes.string
-    })
-  })).isRequired,
+    }).isRequired,
   user: PropTypes.shape({
     intervention_notifications: PropTypes.bool
   }).isRequired

--- a/app/classifier/components/Intervention/Intervention.spec.js
+++ b/app/classifier/components/Intervention/Intervention.spec.js
@@ -6,8 +6,8 @@ import Intervention from './Intervention';
 
 describe('Intervention', function () {
   let wrapper;
-  const notifications = [{ message: 'Hello!' }];
-  const { message } = notifications[0];
+  const intervention = { message: 'Hello!' };
+  const { message } = intervention;
   const user = {
     id: 'a',
     update: sinon.stub().callsFake(() => {
@@ -17,7 +17,7 @@ describe('Intervention', function () {
   before(function () {
     wrapper = mount(
       <Intervention
-        notifications={notifications}
+        intervention={intervention}
         user={user}
       />);
   });

--- a/app/redux/ducks/classify.js
+++ b/app/redux/ducks/classify.js
@@ -118,7 +118,11 @@ export default function reducer(state = initialState, action = {}) {
   switch (action.type) {
     case ADD_INTERVENTION: {
       const intervention = action.payload;
-      return Object.assign({}, state, { intervention });
+      const { classification } = state;
+      if (classification && classification.links.project === intervention.project_id) {
+        return Object.assign({}, state, { intervention });
+      }
+      return state;
     }
     case APPEND_SUBJECTS: {
       const { subjects, workflowID } = action.payload;

--- a/app/redux/ducks/classify.js
+++ b/app/redux/ducks/classify.js
@@ -95,10 +95,12 @@ function finishClassification(workflow, classification, annotations) {
 const initialState = {
   classification: null,
   goldStandardMode: false,
+  intervention: null,
   upcomingSubjects: [],
   workflow: null
 };
 
+const ADD_INTERVENTION = 'pfe/classify/ADD_INTERVENTION';
 const APPEND_SUBJECTS = 'pfe/classify/APPEND_SUBJECTS';
 const FETCH_SUBJECTS = 'pfe/classify/FETCH_SUBJECTS';
 const PREPEND_SUBJECTS = 'pfe/classify/PREPEND_SUBJECTS';
@@ -114,6 +116,10 @@ const TOGGLE_GOLD_STANDARD = 'pfe/classify/TOGGLE_GOLD_STANDARD';
 
 export default function reducer(state = initialState, action = {}) {
   switch (action.type) {
+    case ADD_INTERVENTION: {
+      const intervention = action.payload;
+      return Object.assign({}, state, { intervention });
+    }
     case APPEND_SUBJECTS: {
       const { subjects, workflowID } = action.payload;
       const { workflow } = state;
@@ -138,7 +144,8 @@ export default function reducer(state = initialState, action = {}) {
       if (state.upcomingSubjects.length > 0) {
         const subject = state.upcomingSubjects[0];
         const classification = createNewClassification(project, workflow, subject, goldStandardMode);
-        return Object.assign({}, state, { classification });
+        const intervention = null;
+        return Object.assign({}, state, { classification, intervention });
       }
       return state;
     }
@@ -156,10 +163,12 @@ export default function reducer(state = initialState, action = {}) {
       const subject = upcomingSubjects[0];
       if (subject) {
         const classification = createNewClassification(project, workflow, subject, goldStandardMode);
-        return Object.assign({}, state, { classification, upcomingSubjects });
+        const intervention = null;
+        return Object.assign({}, state, { classification, intervention, upcomingSubjects });
       }
       return Object.assign({}, state, {
         classification: null,
+        intervention: null,
         upcomingSubjects: []
       });
     }
@@ -211,6 +220,13 @@ export default function reducer(state = initialState, action = {}) {
     default:
       return state;
   }
+}
+
+export function addIntervention(data) {
+  return {
+    type: ADD_INTERVENTION,
+    payload: data
+  };
 }
 
 export function appendSubjects(subjects, workflowID) {

--- a/app/redux/ducks/classify.spec.js
+++ b/app/redux/ducks/classify.spec.js
@@ -11,18 +11,32 @@ sessionStorage.setItem('session_id', JSON.stringify({ id: 0, ttl: 0 }));
 
 describe('Classifier actions', function () {
   describe('add intervention', function () {
-    const state = {
-      intervention: null
-    };
     const action = {
       type: 'pfe/classify/ADD_INTERVENTION',
       payload: {
-        message: 'Hi there!'
+        message: 'Hi there!',
+        project_id: '1'
       }
     };
-    it('should store the intervention', function () {
-      const newState = reducer(state, action);
-      expect(newState.intervention).to.deep.equal(action.payload);
+    describe('with a valid project', function () {
+      const state = {
+        classification: { id: '1', links: { project: '1' } },
+        intervention: null
+      };
+      it('should store the intervention', function () {
+        const newState = reducer(state, action);
+        expect(newState.intervention).to.deep.equal(action.payload);
+      });
+    });
+    describe('with an invalid project', function () {
+      const state = {
+        classification: { id: '1', links: { project: '2' } },
+        intervention: null
+      };
+      it('should ignore the intervention', function () {
+        const newState = reducer(state, action);
+        expect(newState.intervention).to.be.null;
+      });
     });
   });
   describe('append subjects', function () {

--- a/app/redux/ducks/classify.spec.js
+++ b/app/redux/ducks/classify.spec.js
@@ -10,6 +10,21 @@ global.sessionStorage = new FakeLocalStorage();
 sessionStorage.setItem('session_id', JSON.stringify({ id: 0, ttl: 0 }));
 
 describe('Classifier actions', function () {
+  describe('add intervention', function () {
+    const state = {
+      intervention: null
+    };
+    const action = {
+      type: 'pfe/classify/ADD_INTERVENTION',
+      payload: {
+        message: 'Hi there!'
+      }
+    };
+    it('should store the intervention', function () {
+      const newState = reducer(state, action);
+      expect(newState.intervention).to.deep.equal(action.payload);
+    });
+  });
   describe('append subjects', function () {
     const action = {
       type: 'pfe/classify/APPEND_SUBJECTS',
@@ -113,6 +128,10 @@ describe('Classifier actions', function () {
         const newState = reducer(state, action);
         expect(newState.classification).to.be.null;
       });
+      it('should clear any stored interventions', function () {
+        const newState = reducer(state, action);
+        expect(newState.intervention).to.be.null;
+      });
     });
     describe('with multiple subjects in the queue', function () {
       const state = {
@@ -139,7 +158,11 @@ describe('Classifier actions', function () {
       it('should create a classification for the next subject in the queue', function () {
         const newState = reducer(state, action);
         expect(newState.classification.links.subjects).to.deep.equal(['2']);
-      })
+      });
+      it('should clear any stored interventions', function () {
+        const newState = reducer(state, action);
+        expect(newState.intervention).to.be.null;
+      });
     });
   });
   describe('reset subjects', function () {
@@ -205,6 +228,10 @@ describe('Classifier actions', function () {
     it('should create a classification for the current workflow', function () {
       const newState = reducer(state, action);
       expect(newState.classification.links.workflow).to.equal('1');
+    });
+    it('should clear any stored interventions', function () {
+      const newState = reducer(state, action);
+      expect(newState.intervention).to.be.null;
     });
     it('should do nothing if the queue is empty', function () {
       state.upcomingSubjects = [];

--- a/app/redux/ducks/interventions.js
+++ b/app/redux/ducks/interventions.js
@@ -1,28 +1,18 @@
 import apiClient from 'panoptes-client/lib/api-client';
 import { sugarClient } from 'panoptes-client/lib/sugar';
-import { prependSubjects } from './classify';
+import { addIntervention, prependSubjects } from './classify';
 
-const ADD_NOTIFICATION = 'pfe/interventions/ADD_NOTIFICATION';
-const DISMISS_NOTIFICATION = 'pfe/interventions/DISMISS_NOTIFICATION';
 const ERROR = 'pfe/interventions/ERROR';
 const FETCH_SUBJECTS = 'pfe/interventions/FETCH_SUBJECTS';
 const SUBSCRIBE = 'pfe/interventions/SUBSCRIBE';
 const UNSUBSCRIBE = 'pfe/interventions/UNSUBSCRIBE';
 
 const initialState = {
-  error: null,
-  notifications: []
+  error: null
 };
 
 export default function reducer(state = initialState, action = {}) {
-  const { notifications } = state;
   switch (action.type) {
-    case ADD_NOTIFICATION:
-      notifications.push(action.payload);
-      return Object.assign({}, state, { notifications });
-    case DISMISS_NOTIFICATION:
-      notifications.pop();
-      return Object.assign({}, state, { notifications });
     case ERROR: {
       const error = action.payload;
       return Object.assign({}, state, { error });
@@ -71,7 +61,7 @@ function prependSubjectQueue(data) {
       dispatch(prependSubjects(subjects, workflowID));
     });
   };
-};
+}
 
 export function processIntervention(message) {
   // Example message data from sugar
@@ -111,7 +101,7 @@ export function processIntervention(message) {
 
   switch(event_type) {
     case 'message':
-      return { type: ADD_NOTIFICATION, payload: data };
+      return addIntervention(data);
       break;
     case 'subject_queue':
       return prependSubjectQueue(data);
@@ -121,6 +111,3 @@ export function processIntervention(message) {
   }
 }
 
-export function dismiss() {
-  return { type: DISMISS_NOTIFICATION };
-}

--- a/app/redux/ducks/interventions.spec.js
+++ b/app/redux/ducks/interventions.spec.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import apiClient from 'panoptes-client/lib/api-client';
 import { sugarClient } from 'panoptes-client/lib/sugar';
-import reducer, { processIntervention, subscribe, unsubscribe, dismiss } from './interventions';
+import reducer, { processIntervention, subscribe, unsubscribe } from './interventions';
 import mockPanoptesResource from '../../../test/mock-panoptes-resource';
 
 describe('Intervention actions', function () {
@@ -16,37 +16,9 @@ describe('Intervention actions', function () {
     subscribeSpy.restore();
     unsubscribeSpy.restore();
   });
-  describe('add notification', function () {
-    const state = {
-      error: null,
-      notifications: []
-    };
-    const action = {
-      type: 'pfe/interventions/ADD_NOTIFICATION',
-      payload: 'Hello'
-    };
-    it('should store a notification', function () {
-      const newState = reducer(state, action);
-      expect(newState.notifications).to.deep.equal(['Hello']);
-    });
-  });
-  describe('dismiss notification', function () {
-    const state = {
-      error: null,
-      notifications: ['Goodbye','Hello']
-    };
-    const action = {
-      type: 'pfe/interventions/DISMISS_NOTIFICATION'
-    };
-    it('should remove the most recent notification', function () {
-      const newState = reducer(state, action);
-      expect(newState.notifications).to.deep.equal(['Goodbye']);
-    });
-  });
   describe('subscribe', function () {
     const state = {
-      error: null,
-      notifications: []
+      error: null
     };
     const action = {
       type: 'pfe/interventions/SUBSCRIBE',
@@ -64,8 +36,7 @@ describe('Intervention actions', function () {
   });
   describe('unsubscribe', function () {
     const state = {
-      error: null,
-      notifications: []
+      error: null
     };
     const action = {
       type: 'pfe/interventions/UNSUBSCRIBE',
@@ -83,8 +54,7 @@ describe('Intervention actions', function () {
   });
   describe('on error', function () {
     const state = {
-      error: null,
-      notifications: ['Goodbye','Hello']
+      error: null
     };
     const action = {
       type: 'pfe/interventions/ERROR',
@@ -180,7 +150,7 @@ describe('Intervention actions', function () {
         it('should store the message data', function () {
           const action = processIntervention(message);
           const expectedAction = {
-            type: 'pfe/interventions/ADD_NOTIFICATION',
+            type: 'pfe/classify/ADD_INTERVENTION',
             payload: message.data
           };
           expect(action).to.deep.equal(expectedAction);
@@ -245,14 +215,6 @@ describe('Intervention actions', function () {
           payload: 'A channel'
         };
         expect(unsubscribe('A channel')).to.deep.equal(expectedAction);
-      });
-    });
-    describe('dismiss', function () {
-      it('should create a dismiss action', function () {
-        const expectedAction = {
-          type: 'pfe/interventions/DISMISS_NOTIFICATION'
-        };
-        expect(dismiss()).to.deep.equal(expectedAction);
       });
     });
   });


### PR DESCRIPTION
Intervention messages are shown when we classify, so store them in the classifier store. Clear any current intervention message when we start a new classification.

Replace notifications array with a single intervention object. Update the classifier to show interventions if a stored intervention exists.

Add simple validation of the message project ID against classification.links.project.

Staging branch URL: https://pr-5089.pfe-preview.zooniverse.org

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
