### PR TITLE
Use input widget state to style task inputs

### DIFF
--- a/app/classifier/tasks/components/TaskInputField/TaskInputField.jsx
+++ b/app/classifier/tasks/components/TaskInputField/TaskInputField.jsx
@@ -9,7 +9,7 @@ import { pxToRem, zooTheme } from '../../../../theme';
 import TaskInputLabel from './components/TaskInputLabel';
 import { doesTheLabelHaveAnImage } from './helpers';
 
-export const StyledTaskInputField = styled.label`
+const StyledTaskLabel = styled.span`
   align-items: baseline;
   background-color: ${theme('mode', {
     dark: zooTheme.colors.darkTheme.background.default,
@@ -29,8 +29,16 @@ export const StyledTaskInputField = styled.label`
   margin: ${pxToRem(10)} 0;
   padding: ${(props) => { return doesTheLabelHaveAnImage(props.label) ? '0' : '1ch 2ch'; }};
   position: relative;
+`;
 
-  &:hover, &:focus, &[data-focus=true] {
+export const StyledTaskInputField = styled.label`
+  input {
+    opacity: 0.01;
+    position: absolute;
+  }
+
+  ${StyledTaskLabel}:hover,
+  input:focus + ${StyledTaskLabel} {
     background: ${theme('mode', {
       dark: `linear-gradient(
         ${zooTheme.colors.darkTheme.button.answer.gradient.top},
@@ -59,7 +67,8 @@ export const StyledTaskInputField = styled.label`
     })};
   }
 
-  &:active {
+  input:active + ${StyledTaskLabel},
+  input:checked + ${StyledTaskLabel} {
     background: ${theme('mode', {
       dark: `linear-gradient(
         ${zooTheme.colors.darkTheme.button.answer.gradient.top},
@@ -80,37 +89,6 @@ export const StyledTaskInputField = styled.label`
       dark: zooTheme.colors.darkTheme.font,
       light: 'black'
     })};
-  }
-
-  &.active {
-    background: ${theme('mode', {
-      dark: zooTheme.colors.teal.mid,
-      light: zooTheme.colors.teal.mid
-    })};
-    border: ${theme('mode', {
-      dark: `2px solid ${zooTheme.colors.teal.mid}`,
-      light: '2px solid transparent'
-    })};
-    color: ${theme('mode', {
-      dark: zooTheme.colors.darkTheme.font,
-      light: 'white'
-    })}
-  }
-
-  &.active:hover, &.active:focus, &.active[data-focus=true] {
-    background: ${theme('mode', {
-      dark: zooTheme.colors.teal.mid,
-      light: zooTheme.colors.teal.mid
-    })};
-    border: ${theme('mode', {
-      dark: `2px solid ${zooTheme.colors.teal.dark}`,
-      light: `2px solid ${zooTheme.colors.teal.dark}`
-    })};
-  }
-
-  input {
-    opacity: 0.01;
-    position: absolute;
   }
 `;
 
@@ -139,48 +117,29 @@ function shouldInputBeAutoFocused(annotation, index, name, type) {
 }
 
 export class TaskInputField extends React.Component {
-  constructor() {
-    super();
-    this.unFocus = this.unFocus.bind(this);
-  }
-
   onChange(e) {
-    this.unFocus();
     this.props.onChange(e);
-  }
-
-  onFocus() {
-    if (this.field) this.field.dataset.focus = true;
-  }
-
-  onBlur() {
-    this.unFocus();
-  }
-
-  unFocus() {
-    if (this.field) this.field.dataset.focus = false;
   }
 
   render() {
     return (
       <ThemeProvider theme={{ mode: this.props.theme }}>
-        <StyledTaskInputField
-          ref={(node) => { this.field = node; }}
-          className={this.props.className}
-          label={this.props.label}
-          data-focus={false}
-        >
+        <StyledTaskInputField>
           <input
             autoFocus={shouldInputBeAutoFocused(this.props.annotation, this.props.index, this.props.name, this.props.type)}
             checked={shouldInputBeChecked(this.props.annotation, this.props.index, this.props.type)}
             name={this.props.name}
-            onBlur={this.onBlur.bind(this)}
             onChange={this.onChange.bind(this)}
-            onFocus={this.onFocus.bind(this)}
             type={this.props.type}
             value={this.props.index}
           />
-          <TaskInputLabel label={this.props.label} labelIcon={this.props.labelIcon} labelStatus={this.props.labelStatus} />
+          <StyledTaskLabel
+            ref={(node) => { this.field = node; }}
+            className={this.props.className}
+            label={this.props.label}
+          >
+            <TaskInputLabel label={this.props.label} labelIcon={this.props.labelIcon} labelStatus={this.props.labelStatus} />
+          </StyledTaskLabel>
         </StyledTaskInputField>
       </ThemeProvider>
     );

--- a/app/classifier/tasks/components/TaskInputField/TaskInputField.jsx
+++ b/app/classifier/tasks/components/TaskInputField/TaskInputField.jsx
@@ -9,6 +9,21 @@ import { pxToRem, zooTheme } from '../../../../theme';
 import TaskInputLabel from './components/TaskInputLabel';
 import { doesTheLabelHaveAnImage } from './helpers';
 
+const hoverStyles = {
+  gradientTop: theme('mode', {
+    dark: zooTheme.colors.darkTheme.button.answer.gradient.top,
+    light: zooTheme.colors.lightTheme.button.answer.gradient.top
+  }),
+  gradientBottom: theme('mode', {
+    dark: zooTheme.colors.darkTheme.button.answer.gradient.bottom,
+    light: zooTheme.colors.lightTheme.button.answer.gradient.bottom
+  }),
+  color: theme('mode', {
+    dark: zooTheme.colors.darkTheme.font,
+    light: 'black'
+  })
+};
+
 export const StyledTaskLabel = styled.span`
   align-items: baseline;
   background-color: ${theme('mode', {
@@ -30,32 +45,14 @@ export const StyledTaskLabel = styled.span`
   padding: ${(props) => { return doesTheLabelHaveAnImage(props.label) ? '0' : '1ch 2ch'; }};
   
   &:hover {
-    background: ${theme('mode', {
-      dark: `linear-gradient(
-        ${zooTheme.colors.darkTheme.button.answer.gradient.top},
-        ${zooTheme.colors.darkTheme.button.answer.gradient.bottom}
-      )`,
-      light: `linear-gradient(
-        ${zooTheme.colors.lightTheme.button.answer.gradient.top},
-        ${zooTheme.colors.lightTheme.button.answer.gradient.bottom}
-      )`
-    })};
+    background: linear-gradient(${hoverStyles.gradientTop}, ${hoverStyles.gradientBottom});
     border-width: 2px;
     border-style: solid;
     border-left-color: transparent;
     border-right-color: transparent;
-    border-top-color: ${theme('mode', {
-      dark: zooTheme.colors.darkTheme.button.answer.gradient.top,
-      light: zooTheme.colors.lightTheme.button.answer.gradient.top
-    })};
-    border-bottom-color: ${theme('mode', {
-      dark: zooTheme.colors.darkTheme.button.answer.gradient.bottom,
-      light: zooTheme.colors.lightTheme.button.answer.gradient.bottom
-    })};
-    color: ${theme('mode', {
-      dark: zooTheme.colors.darkTheme.font,
-      light: 'black'
-    })};
+    border-top-color: ${hoverStyles.gradientTop};
+    border-bottom-color: ${hoverStyles.gradientBottom};
+    color: ${hoverStyles.color};
   }
 `;
 
@@ -68,55 +65,25 @@ export const StyledTaskInputField = styled.label`
   }
 
   input:focus + ${StyledTaskLabel} {
-    background: ${theme('mode', {
-      dark: `linear-gradient(
-        ${zooTheme.colors.darkTheme.button.answer.gradient.top},
-        ${zooTheme.colors.darkTheme.button.answer.gradient.bottom}
-      )`,
-      light: `linear-gradient(
-        ${zooTheme.colors.lightTheme.button.answer.gradient.top},
-        ${zooTheme.colors.lightTheme.button.answer.gradient.bottom}
-      )`
-    })};
+    background: linear-gradient(${hoverStyles.gradientTop}, ${hoverStyles.gradientBottom});
     border-width: 2px;
     border-style: solid;
     border-left-color: transparent;
     border-right-color: transparent;
-    border-top-color: ${theme('mode', {
-      dark: zooTheme.colors.darkTheme.button.answer.gradient.top,
-      light: zooTheme.colors.lightTheme.button.answer.gradient.top
-    })};
-    border-bottom-color: ${theme('mode', {
-      dark: zooTheme.colors.darkTheme.button.answer.gradient.bottom,
-      light: zooTheme.colors.lightTheme.button.answer.gradient.bottom
-    })};
-    color: ${theme('mode', {
-      dark: zooTheme.colors.darkTheme.font,
-      light: 'black'
-    })};
+    border-top-color: ${hoverStyles.gradientTop};
+    border-bottom-color: ${hoverStyles.gradientBottom};
+    color: ${hoverStyles.color};
   }
 
   input:active + ${StyledTaskLabel} {
-    background: ${theme('mode', {
-      dark: `linear-gradient(
-        ${zooTheme.colors.darkTheme.button.answer.gradient.top},
-        ${zooTheme.colors.darkTheme.button.answer.gradient.bottom}
-      )`,
-      light: `linear-gradient(
-        ${zooTheme.colors.lightTheme.button.answer.gradient.top},
-        ${zooTheme.colors.lightTheme.button.answer.gradient.bottom}
-      )`
-    })};
+    background: linear-gradient(${hoverStyles.gradientTop}, ${hoverStyles.gradientBottom});
     border-width: 2px;
     border-style: solid;
     border-color: ${theme('mode', {
       dark: zooTheme.colors.teal.dark,
       light: zooTheme.colors.teal.mid
     })};
-    color: ${theme('mode', {
-      dark: zooTheme.colors.darkTheme.font,
-      light: 'black'
-    })};
+    color: ${hoverStyles.color};
   }
 
   input:checked + ${StyledTaskLabel} {

--- a/app/classifier/tasks/components/TaskInputField/TaskInputField.jsx
+++ b/app/classifier/tasks/components/TaskInputField/TaskInputField.jsx
@@ -124,7 +124,9 @@ export class TaskInputField extends React.Component {
   render() {
     return (
       <ThemeProvider theme={{ mode: this.props.theme }}>
-        <StyledTaskInputField>
+        <StyledTaskInputField
+          className={this.props.className}
+        >
           <input
             autoFocus={shouldInputBeAutoFocused(this.props.annotation, this.props.index, this.props.name, this.props.type)}
             checked={shouldInputBeChecked(this.props.annotation, this.props.index, this.props.type)}
@@ -133,11 +135,7 @@ export class TaskInputField extends React.Component {
             type={this.props.type}
             value={this.props.index}
           />
-          <StyledTaskLabel
-            ref={(node) => { this.field = node; }}
-            className={this.props.className}
-            label={this.props.label}
-          >
+          <StyledTaskLabel>
             <TaskInputLabel label={this.props.label} labelIcon={this.props.labelIcon} labelStatus={this.props.labelStatus} />
           </StyledTaskLabel>
         </StyledTaskInputField>

--- a/app/classifier/tasks/components/TaskInputField/TaskInputField.jsx
+++ b/app/classifier/tasks/components/TaskInputField/TaskInputField.jsx
@@ -116,32 +116,26 @@ function shouldInputBeAutoFocused(annotation, index, name, type) {
   return index === annotation.value;
 }
 
-export class TaskInputField extends React.Component {
-  onChange(e) {
-    this.props.onChange(e);
-  }
-
-  render() {
-    return (
-      <ThemeProvider theme={{ mode: this.props.theme }}>
-        <StyledTaskInputField
-          className={this.props.className}
-        >
-          <input
-            autoFocus={shouldInputBeAutoFocused(this.props.annotation, this.props.index, this.props.name, this.props.type)}
-            checked={shouldInputBeChecked(this.props.annotation, this.props.index, this.props.type)}
-            name={this.props.name}
-            onChange={this.onChange.bind(this)}
-            type={this.props.type}
-            value={this.props.index}
-          />
-          <StyledTaskLabel>
-            <TaskInputLabel label={this.props.label} labelIcon={this.props.labelIcon} labelStatus={this.props.labelStatus} />
-          </StyledTaskLabel>
-        </StyledTaskInputField>
-      </ThemeProvider>
-    );
-  }
+export function TaskInputField(props) {
+  return (
+    <ThemeProvider theme={{ mode: props.theme }}>
+      <StyledTaskInputField
+        className={props.className}
+      >
+        <input
+          autoFocus={shouldInputBeAutoFocused(props.annotation, props.index, props.name, props.type)}
+          checked={shouldInputBeChecked(props.annotation, props.index, props.type)}
+          name={props.name}
+          onChange={props.onChange}
+          type={props.type}
+          value={props.index}
+        />
+        <StyledTaskLabel>
+          <TaskInputLabel label={props.label} labelIcon={props.labelIcon} labelStatus={props.labelStatus} />
+        </StyledTaskLabel>
+      </StyledTaskInputField>
+    </ThemeProvider>
+  );
 }
 
 TaskInputField.defaultProps = {
@@ -180,4 +174,4 @@ const mapStateToProps = state => ({
   theme: state.userInterface.theme
 });
 
-export default connect(mapStateToProps)(TaskInputField);
+export default connect(mapStateToProps)(React.memo(TaskInputField));

--- a/app/classifier/tasks/components/TaskInputField/TaskInputField.jsx
+++ b/app/classifier/tasks/components/TaskInputField/TaskInputField.jsx
@@ -96,8 +96,7 @@ export const StyledTaskInputField = styled.label`
     })};
   }
 
-  input:active + ${StyledTaskLabel},
-  input:checked + ${StyledTaskLabel} {
+  input:active + ${StyledTaskLabel} {
     background: ${theme('mode', {
       dark: `linear-gradient(
         ${zooTheme.colors.darkTheme.button.answer.gradient.top},
@@ -117,6 +116,29 @@ export const StyledTaskInputField = styled.label`
     color: ${theme('mode', {
       dark: zooTheme.colors.darkTheme.font,
       light: 'black'
+    })};
+  }
+
+  input:checked + ${StyledTaskLabel} {
+    background: ${theme('mode', {
+      dark: zooTheme.colors.teal.mid,
+      light: zooTheme.colors.teal.mid
+    })};
+    border: ${theme('mode', {
+      dark: `2px solid ${zooTheme.colors.teal.mid}`,
+      light: '2px solid transparent'
+    })};
+    color: ${theme('mode', {
+      dark: zooTheme.colors.darkTheme.font,
+      light: 'white'
+    })}
+  }
+
+  input:focus:checked + ${StyledTaskLabel},
+  input:checked + ${StyledTaskLabel}:hover {
+    border: ${theme('mode', {
+      dark: `2px solid ${zooTheme.colors.teal.dark}`,
+      light: `2px solid ${zooTheme.colors.teal.dark}`
     })};
   }
 `;

--- a/app/classifier/tasks/components/TaskInputField/TaskInputField.jsx
+++ b/app/classifier/tasks/components/TaskInputField/TaskInputField.jsx
@@ -63,7 +63,7 @@ export const StyledTaskLabel = styled.span`
   cursor: pointer;
   display: flex;
   margin: ${pxToRem(10)} 0;
-  padding: ${(props) => { return doesTheLabelHaveAnImage(props.label) ? '0' : '1ch 2ch'; }};
+  padding: ${props => (doesTheLabelHaveAnImage(props.label) ? '0' : '1ch 2ch')};
   
   &:hover {
     background: linear-gradient(${HOVER.gradientTop}, ${HOVER.gradientBottom});
@@ -157,23 +157,13 @@ TaskInputField.defaultProps = {
 };
 
 TaskInputField.propTypes = {
-  annotation: PropTypes.shape({
-    _key: PropTypes.number,
-    task: PropTypes.string,
-    value: PropTypes.oneOfType([
-      PropTypes.arrayOf(PropTypes.number), // mulitple choice
-      PropTypes.number, // single choice
-      PropTypes.arrayOf(PropTypes.object), // drawing task
-      PropTypes.object // null
-    ])
-  }).isRequired,
   autoFocus: PropTypes.bool,
   checked: PropTypes.bool,
   className: PropTypes.string,
   index: PropTypes.number.isRequired,
   label: PropTypes.string,
   labelIcon: PropTypes.oneOfType([PropTypes.node, PropTypes.object]),
-  labelStatus: PropTypes.oneOfType([PropTypes.node, PropTypes.object]),  
+  labelStatus: PropTypes.oneOfType([PropTypes.node, PropTypes.object]),
   name: PropTypes.string,
   onChange: PropTypes.func,
   theme: PropTypes.string,

--- a/app/classifier/tasks/components/TaskInputField/TaskInputField.jsx
+++ b/app/classifier/tasks/components/TaskInputField/TaskInputField.jsx
@@ -9,7 +9,22 @@ import { pxToRem, zooTheme } from '../../../../theme';
 import TaskInputLabel from './components/TaskInputLabel';
 import { doesTheLabelHaveAnImage } from './helpers';
 
-const hoverStyles = {
+const DEFAULT = {
+  backgroundColor: theme('mode', {
+    dark: zooTheme.colors.darkTheme.background.default,
+    light: zooTheme.colors.lightTheme.background.default
+  }),
+  border: theme('mode', {
+    dark: `2px solid ${zooTheme.colors.darkTheme.font}`,
+    light: '2px solid transparent'
+  }),
+  color: theme('mode', {
+    dark: zooTheme.colors.darkTheme.font,
+    light: zooTheme.colors.lightTheme.font
+  })
+};
+
+const HOVER = {
   gradientTop: theme('mode', {
     dark: zooTheme.colors.darkTheme.button.answer.gradient.top,
     light: zooTheme.colors.lightTheme.button.answer.gradient.top
@@ -24,35 +39,41 @@ const hoverStyles = {
   })
 };
 
+const CHECKED = {
+  background: theme('mode', {
+    dark: zooTheme.colors.teal.mid,
+    light: zooTheme.colors.teal.mid
+  }),
+  border: theme('mode', {
+    dark: `2px solid ${zooTheme.colors.teal.mid}`,
+    light: '2px solid transparent'
+  }),
+  color: theme('mode', {
+    dark: zooTheme.colors.darkTheme.font,
+    light: 'white'
+  })
+};
+
 export const StyledTaskLabel = styled.span`
   align-items: baseline;
-  background-color: ${theme('mode', {
-    dark: zooTheme.colors.darkTheme.background.default,
-    light: zooTheme.colors.lightTheme.background.default
-  })};
-  border: ${theme('mode', {
-    dark: `2px solid ${zooTheme.colors.darkTheme.font}`,
-    light: '2px solid transparent'
-  })};
+  background-color: ${DEFAULT.backgroundColor};
+  border: ${DEFAULT.border};
   box-shadow: 1px 1px 2px 0 rgba(0,0,0,0.5);
-  color: ${theme('mode', {
-    dark: zooTheme.colors.darkTheme.font,
-    light: zooTheme.colors.lightTheme.font
-  })};
+  color: ${DEFAULT.color};
   cursor: pointer;
   display: flex;
   margin: ${pxToRem(10)} 0;
   padding: ${(props) => { return doesTheLabelHaveAnImage(props.label) ? '0' : '1ch 2ch'; }};
   
   &:hover {
-    background: linear-gradient(${hoverStyles.gradientTop}, ${hoverStyles.gradientBottom});
+    background: linear-gradient(${HOVER.gradientTop}, ${HOVER.gradientBottom});
     border-width: 2px;
     border-style: solid;
     border-left-color: transparent;
     border-right-color: transparent;
-    border-top-color: ${hoverStyles.gradientTop};
-    border-bottom-color: ${hoverStyles.gradientBottom};
-    color: ${hoverStyles.color};
+    border-top-color: ${HOVER.gradientTop};
+    border-bottom-color: ${HOVER.gradientBottom};
+    color: ${HOVER.color};
   }
 `;
 
@@ -65,40 +86,31 @@ export const StyledTaskInputField = styled.label`
   }
 
   input:focus + ${StyledTaskLabel} {
-    background: linear-gradient(${hoverStyles.gradientTop}, ${hoverStyles.gradientBottom});
+    background: linear-gradient(${HOVER.gradientTop}, ${HOVER.gradientBottom});
     border-width: 2px;
     border-style: solid;
     border-left-color: transparent;
     border-right-color: transparent;
-    border-top-color: ${hoverStyles.gradientTop};
-    border-bottom-color: ${hoverStyles.gradientBottom};
-    color: ${hoverStyles.color};
+    border-top-color: ${HOVER.gradientTop};
+    border-bottom-color: ${HOVER.gradientBottom};
+    color: ${HOVER.color};
   }
 
   input:active + ${StyledTaskLabel} {
-    background: linear-gradient(${hoverStyles.gradientTop}, ${hoverStyles.gradientBottom});
+    background: linear-gradient(${HOVER.gradientTop}, ${HOVER.gradientBottom});
     border-width: 2px;
     border-style: solid;
     border-color: ${theme('mode', {
       dark: zooTheme.colors.teal.dark,
       light: zooTheme.colors.teal.mid
     })};
-    color: ${hoverStyles.color};
+    color: ${HOVER.color};
   }
 
   input:checked + ${StyledTaskLabel} {
-    background: ${theme('mode', {
-      dark: zooTheme.colors.teal.mid,
-      light: zooTheme.colors.teal.mid
-    })};
-    border: ${theme('mode', {
-      dark: `2px solid ${zooTheme.colors.teal.mid}`,
-      light: '2px solid transparent'
-    })};
-    color: ${theme('mode', {
-      dark: zooTheme.colors.darkTheme.font,
-      light: 'white'
-    })}
+    background: ${CHECKED.background};
+    border: ${CHECKED.border};
+    color: ${CHECKED.color}
   }
 
   input:focus:checked + ${StyledTaskLabel},

--- a/app/classifier/tasks/components/TaskInputField/TaskInputField.jsx
+++ b/app/classifier/tasks/components/TaskInputField/TaskInputField.jsx
@@ -92,22 +92,6 @@ export const StyledTaskInputField = styled.label`
   }
 `;
 
-function shouldInputBeChecked(annotation, index, type) {
-  if (type === 'radio') {
-    const toolIndex = annotation._toolIndex || 0;
-    if (toolIndex) {
-      return index === toolIndex;
-    }
-    return index === annotation.value;
-  }
-
-  if (type === 'checkbox') {
-    return (annotation.value && annotation.value.length > 0) ? annotation.value.includes(index) : false;
-  }
-
-  return false;
-}
-
 function shouldInputBeAutoFocused(annotation, index, name, type) {
   if (type === 'radio' && name === 'drawing-tool') {
     return index === 0;
@@ -124,7 +108,7 @@ export function TaskInputField(props) {
       >
         <input
           autoFocus={shouldInputBeAutoFocused(props.annotation, props.index, props.name, props.type)}
-          checked={shouldInputBeChecked(props.annotation, props.index, props.type)}
+          defaultChecked={props.checked}
           name={props.name}
           onChange={props.onChange}
           type={props.type}
@@ -139,6 +123,7 @@ export function TaskInputField(props) {
 }
 
 TaskInputField.defaultProps = {
+  checked: false,
   className: '',
   label: '',
   labelIcon: null,
@@ -159,6 +144,7 @@ TaskInputField.propTypes = {
       PropTypes.object // null
     ])
   }).isRequired,
+  checked: PropTypes.bool,
   className: PropTypes.string,
   index: PropTypes.number.isRequired,
   label: PropTypes.string,

--- a/app/classifier/tasks/components/TaskInputField/TaskInputField.jsx
+++ b/app/classifier/tasks/components/TaskInputField/TaskInputField.jsx
@@ -9,7 +9,7 @@ import { pxToRem, zooTheme } from '../../../../theme';
 import TaskInputLabel from './components/TaskInputLabel';
 import { doesTheLabelHaveAnImage } from './helpers';
 
-const StyledTaskLabel = styled.span`
+export const StyledTaskLabel = styled.span`
   align-items: baseline;
   background-color: ${theme('mode', {
     dark: zooTheme.colors.darkTheme.background.default,
@@ -28,16 +28,45 @@ const StyledTaskLabel = styled.span`
   display: flex;
   margin: ${pxToRem(10)} 0;
   padding: ${(props) => { return doesTheLabelHaveAnImage(props.label) ? '0' : '1ch 2ch'; }};
-  position: relative;
+  
+  &:hover {
+    background: ${theme('mode', {
+      dark: `linear-gradient(
+        ${zooTheme.colors.darkTheme.button.answer.gradient.top},
+        ${zooTheme.colors.darkTheme.button.answer.gradient.bottom}
+      )`,
+      light: `linear-gradient(
+        ${zooTheme.colors.lightTheme.button.answer.gradient.top},
+        ${zooTheme.colors.lightTheme.button.answer.gradient.bottom}
+      )`
+    })};
+    border-width: 2px;
+    border-style: solid;
+    border-left-color: transparent;
+    border-right-color: transparent;
+    border-top-color: ${theme('mode', {
+      dark: zooTheme.colors.darkTheme.button.answer.gradient.top,
+      light: zooTheme.colors.lightTheme.button.answer.gradient.top
+    })};
+    border-bottom-color: ${theme('mode', {
+      dark: zooTheme.colors.darkTheme.button.answer.gradient.bottom,
+      light: zooTheme.colors.lightTheme.button.answer.gradient.bottom
+    })};
+    color: ${theme('mode', {
+      dark: zooTheme.colors.darkTheme.font,
+      light: 'black'
+    })};
+  }
 `;
 
 export const StyledTaskInputField = styled.label`
+  position: relative;
+
   input {
     opacity: 0.01;
     position: absolute;
   }
 
-  ${StyledTaskLabel}:hover,
   input:focus + ${StyledTaskLabel} {
     background: ${theme('mode', {
       dark: `linear-gradient(

--- a/app/classifier/tasks/components/TaskInputField/TaskInputField.jsx
+++ b/app/classifier/tasks/components/TaskInputField/TaskInputField.jsx
@@ -92,14 +92,6 @@ export const StyledTaskInputField = styled.label`
   }
 `;
 
-function shouldInputBeAutoFocused(annotation, index, name, type) {
-  if (type === 'radio' && name === 'drawing-tool') {
-    return index === 0;
-  }
-
-  return index === annotation.value;
-}
-
 export function TaskInputField(props) {
   return (
     <ThemeProvider theme={{ mode: props.theme }}>
@@ -107,7 +99,7 @@ export function TaskInputField(props) {
         className={props.className}
       >
         <input
-          autoFocus={shouldInputBeAutoFocused(props.annotation, props.index, props.name, props.type)}
+          autoFocus={props.autoFocus}
           defaultChecked={props.checked}
           name={props.name}
           onChange={props.onChange}
@@ -123,6 +115,7 @@ export function TaskInputField(props) {
 }
 
 TaskInputField.defaultProps = {
+  autoFocus: false,
   checked: false,
   className: '',
   label: '',
@@ -144,6 +137,7 @@ TaskInputField.propTypes = {
       PropTypes.object // null
     ])
   }).isRequired,
+  autoFocus: PropTypes.bool,
   checked: PropTypes.bool,
   className: PropTypes.string,
   index: PropTypes.number.isRequired,

--- a/app/classifier/tasks/components/TaskInputField/TaskInputField.spec.jsx
+++ b/app/classifier/tasks/components/TaskInputField/TaskInputField.spec.jsx
@@ -12,8 +12,8 @@ import sinon from 'sinon';
 import { TaskInputField, StyledTaskInputField } from './TaskInputField';
 import { mockReduxStore, radioTypeAnnotation } from '../../testHelpers';
 
-describe('TaskInputField', function() {
-  describe('render', function() {
+describe('TaskInputField', function () {
+  describe('render', function () {
     let wrapper;
     before(function () {
       wrapper = mount(<TaskInputField annotation={radioTypeAnnotation} index={0} type="radio" />, mockReduxStore);
@@ -39,24 +39,24 @@ describe('TaskInputField', function() {
       wrapper.setProps({ className: 'active' });
       expect(wrapper.props().className).to.include('active');
     });
-  })
+  });
 
 
-  describe('onChange method', function() {
+  describe('onChange method', function () {
     let onChangePropsSpy;
     let wrapper;
-    before(function() {
+    before(function () {
       onChangePropsSpy = sinon.spy();
       wrapper = mount(<TaskInputField annotation={radioTypeAnnotation} onChange={onChangePropsSpy} index={0} type="radio" />, mockReduxStore);
     });
 
-    afterEach(function() {
+    afterEach(function () {
       onChangePropsSpy.resetHistory();
     });
 
-    it('should call onChange when the on change event is fired', function() {
+    it('should call onChange when the on change event is fired', function () {
       wrapper.find('input').simulate('change');
-      expect(onChangePropsSpy.calledOnce).to.be.true;
+      expect(onChangePropsSpy).to.have.been.calledOnce;
     });
   });
 });

--- a/app/classifier/tasks/components/TaskInputField/TaskInputField.spec.jsx
+++ b/app/classifier/tasks/components/TaskInputField/TaskInputField.spec.jsx
@@ -44,25 +44,21 @@ describe('TaskInputField', function() {
 
   describe('onChange method', function() {
     let onChangeSpy;
-    let unFocusSpy;
     let onChangePropsSpy;
     let wrapper;
     before(function() {
       onChangeSpy = sinon.spy(TaskInputField.prototype, 'onChange');
-      unFocusSpy = sinon.spy(TaskInputField.prototype, 'unFocus');
       onChangePropsSpy = sinon.spy();
       wrapper = mount(<TaskInputField annotation={radioTypeAnnotation} onChange={onChangePropsSpy} index={0} type="radio" />, mockReduxStore);
     });
 
     afterEach(function() {
       onChangeSpy.resetHistory();
-      unFocusSpy.resetHistory();
       onChangePropsSpy.resetHistory();
     });
 
     after(function() {
       onChangeSpy.restore();
-      unFocusSpy.restore();
     });
 
     it('should call onChange when the on change event is fired', function() {
@@ -70,119 +66,9 @@ describe('TaskInputField', function() {
       expect(onChangeSpy.calledOnce).to.be.true;
     });
 
-    it('should call onFocus in the onChange method', function() {
-      wrapper.find('input').simulate('change');
-      expect(unFocusSpy.calledOnce).to.be.true;
-    });
-
     it('should call props.onChange in the onChange method', function() {
       wrapper.find('input').simulate('change');
       expect(onChangePropsSpy.calledOnce).to.be.true;
     });
   });
-
-  describe('onFocus method', function() {
-    let wrapper;
-    let onFocusSpy;
-    before(function() {
-      onFocusSpy = sinon.spy(TaskInputField.prototype, 'onFocus');
-      wrapper = mount(<TaskInputField annotation={radioTypeAnnotation} index={0} type="radio" />, mockReduxStore);
-    });
-
-    afterEach(function() {
-      onFocusSpy.resetHistory();
-    });
-
-    after(function() {
-      onFocusSpy.restore();
-    });
-
-    it('should call onFocus when the on focus event fires', function() {
-      wrapper.find('input').simulate('focus');
-      expect(onFocusSpy.calledOnce).to.be.true;
-    });
-
-    // This isn't working. Can data attributes update in tests?
-    // it('should set the data-focus attribute to true if this.field is defined', function() {
-    //   wrapper.find('input').simulate('focus');
-    //   wrapper.update();
-    //   expect(wrapper.instance().field).to.exist;
-    //   expect(wrapper.find(StyledTaskInputField).props()['data-focus']).to.be.true;
-    // });
-
-    // it('should not set the data-focus attribute to true if this.field is not defined', function() {
-    //   wrapper.instance().field = null;
-    //   wrapper.find('input').simulate('focus');
-    //   expect(wrapper.instance().field).to.not.exist;     
-    //   expect(wrapper.find(StyledTaskInputField).props()['data-focus']).to.be.false;
-    // });
-  });
-
-  describe('onBlur method', function() {
-    let wrapper;
-    let unFocusSpy;
-    let onBlurSpy;
-    before(function() {
-      onBlurSpy = sinon.spy(TaskInputField.prototype, 'onBlur');
-      unFocusSpy = sinon.spy(TaskInputField.prototype, 'unFocus');      
-      wrapper = mount(<TaskInputField annotation={radioTypeAnnotation} index={0} type="radio" />, mockReduxStore);      
-    });
-
-    afterEach(function() {
-      onBlurSpy.resetHistory();
-      unFocusSpy.resetHistory();
-    });
-
-    afterEach(function() {
-      onBlurSpy.restore();
-      unFocusSpy.restore();
-    });
-
-    it('should call onBlur when the on blur event fires', function() {
-      wrapper.find('input').simulate('blur');
-      expect(onBlurSpy.calledOnce).to.be.true;
-    });
-
-    it('should call unFocus in the onBlur method', function() {
-      wrapper.find('input').simulate('blur');
-      expect(unFocusSpy.calledOnce).to.be.true;
-    });
-  });
-
-  // describe.only('unFocus method', function() {
-  //   let wrapper;
-  //   let unFocusSpy;
-  //   before(function () {
-  //     unFocusSpy = sinon.spy(TaskInputField.prototype, 'unFocus');
-  //     wrapper = mount(<TaskInputField annotation={radioTypeAnnotation} index={0} type="radio" />, mockReduxStore);
-  //   });
-
-  //   afterEach(function () {
-  //     unFocusSpy.resetHistory();
-  //   });
-
-  //   afterEach(function () {
-  //     unFocusSpy.restore();
-  //   });
-
-  //   it('should set the data-focus attribute to true if this.field is defined', function() {
-  //     wrapper.instance().onFocus(); // set data-field focus to true
-  //     wrapper.update();
-  //     wrapper.instance().unFocus();
-  //     wrapper.update();
-  //     expect(wrapper.instance().field).to.exist;
-  //     expect(wrapper.find(StyledTaskInputField).props()['data-focus']).to.be.false;
-  //   });
-
-  //   it('should not set the data-focus attribute to true if this.field is not defined', function() {
-  //     wrapper.instance().onFocus(); // set data-field focus to true
-  //     wrapper.update();
-  //     console.log(wrapper.debug())
-  //     wrapper.instance().field = null;
-  //     expect(wrapper.instance().field).to.not.exist;
-  //     wrapper.instance().unFocus();
-  //     wrapper.update();
-  //     expect(wrapper.find(StyledTaskInputField).props()['data-focus']).to.be.true;
-  //   });
-  // });
 });

--- a/app/classifier/tasks/components/TaskInputField/TaskInputField.spec.jsx
+++ b/app/classifier/tasks/components/TaskInputField/TaskInputField.spec.jsx
@@ -43,30 +43,18 @@ describe('TaskInputField', function() {
 
 
   describe('onChange method', function() {
-    let onChangeSpy;
     let onChangePropsSpy;
     let wrapper;
     before(function() {
-      onChangeSpy = sinon.spy(TaskInputField.prototype, 'onChange');
       onChangePropsSpy = sinon.spy();
       wrapper = mount(<TaskInputField annotation={radioTypeAnnotation} onChange={onChangePropsSpy} index={0} type="radio" />, mockReduxStore);
     });
 
     afterEach(function() {
-      onChangeSpy.resetHistory();
       onChangePropsSpy.resetHistory();
     });
 
-    after(function() {
-      onChangeSpy.restore();
-    });
-
     it('should call onChange when the on change event is fired', function() {
-      wrapper.find('input').simulate('change');
-      expect(onChangeSpy.calledOnce).to.be.true;
-    });
-
-    it('should call props.onChange in the onChange method', function() {
       wrapper.find('input').simulate('change');
       expect(onChangePropsSpy.calledOnce).to.be.true;
     });

--- a/app/classifier/tasks/components/TaskInputField/index.js
+++ b/app/classifier/tasks/components/TaskInputField/index.js
@@ -1,2 +1,2 @@
 
-export { default, StyledTaskInputField } from './TaskInputField';
+export { default, StyledTaskInputField, StyledTaskLabel } from './TaskInputField';

--- a/app/classifier/tasks/drawing/index.cjsx
+++ b/app/classifier/tasks/drawing/index.cjsx
@@ -97,10 +97,12 @@ module.exports = createReactClass
       tool._key ?= Math.random()
       count = (true for mark in @props.annotation.value when mark.tool is i).length
       translation = @props.translation.tools[i]
+      checked = i is (@props.annotation._toolIndex ? 0)
       <div>
         <TaskInputField
           annotation={@props.annotation}
-          className={if i is (@props.annotation._toolIndex ? 0) then 'active' else ''}
+          checked = {checked}
+          className={if checked then 'active' else ''}
           index={i}
           key={tool._key}
           label={translation.label}

--- a/app/classifier/tasks/drawing/index.cjsx
+++ b/app/classifier/tasks/drawing/index.cjsx
@@ -97,10 +97,11 @@ module.exports = createReactClass
       tool._key ?= Math.random()
       count = (true for mark in @props.annotation.value when mark.tool is i).length
       translation = @props.translation.tools[i]
-      checked = i is (@props.annotation._toolIndex ? 0)
+      checked = i is (@props.annotation._toolIndex ? 0) 
       <div>
         <TaskInputField
           annotation={@props.annotation}
+          autoFocus={checked}
           checked = {checked}
           className={if checked then 'active' else ''}
           index={i}

--- a/app/classifier/tasks/highlighter/components/HighlighterButton.jsx
+++ b/app/classifier/tasks/highlighter/components/HighlighterButton.jsx
@@ -6,20 +6,21 @@ import styled, { ThemeProvider } from 'styled-components';
 import theme from 'styled-theming';
 import { pxToRem, zooTheme } from '../../../../theme';
 
-import { StyledTaskInputField } from '../../components/TaskInputField';
+import { StyledTaskLabel } from '../../components/TaskInputField';
 import HighlighterButtonLabel from './HighlighterButtonLabel';
 
 
 // TODO: the focus and hover styles while the component has the active class is not working
-export const StyledHighlighterButton = styled(StyledTaskInputField)`
+export const StyledHighlighterButton = styled(StyledTaskLabel)`
   font-size: inherit;
   width: 100%;
-`.withComponent('button');
+`;
 
 export function HighlighterButton(props) {
   return (
     <ThemeProvider theme={{ mode: props.theme }}>
       <StyledHighlighterButton
+        as="button"
         autoFocus={props.autoFocus}
         type="button"
         value={props.value}

--- a/app/classifier/tasks/multiple/index.jsx
+++ b/app/classifier/tasks/multiple/index.jsx
@@ -30,11 +30,13 @@ export default class MultipleChoiceTask extends React.Component {
       if (!answer._key) {
         answer._key = Math.random();
       }
+      const checked = (annotation.value && annotation.value.length > 0) ? annotation.value.includes(i) : false
 
       answers.push(
         <TaskInputField
           annotation={annotation}
-          className={annotation.value.includes(i) ? 'active' : ''}
+          checked={checked}
+          className={checked ? 'active' : ''}
           index={i}
           key={answer._key}
           label={translation.answers[i].label}

--- a/app/classifier/tasks/multiple/index.jsx
+++ b/app/classifier/tasks/multiple/index.jsx
@@ -30,11 +30,12 @@ export default class MultipleChoiceTask extends React.Component {
       if (!answer._key) {
         answer._key = Math.random();
       }
-      const checked = (annotation.value && annotation.value.length > 0) ? annotation.value.includes(i) : false
+      const checked = (annotation.value && annotation.value.length > 0) ? annotation.value.includes(i) : false;
 
       answers.push(
         <TaskInputField
           annotation={annotation}
+          autoFocus={checked}
           checked={checked}
           className={checked ? 'active' : ''}
           index={i}

--- a/app/classifier/tasks/multiple/index.spec.js
+++ b/app/classifier/tasks/multiple/index.spec.js
@@ -1,10 +1,11 @@
 /* eslint prefer-arrow-callback: 0, func-names: 0, 'react/jsx-boolean-value': ['error', 'always'], 'react/jsx-filename-extension': 0 */
 /* global describe, it, beforeEach */
-import { mount } from 'enzyme';
+import { shallow } from 'enzyme';
 import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import MultipleTask from './';
+import GenericTask from '../generic';
 import { mockReduxStore, checkboxTypeAnnotation, checkboxTypeTask } from '../testHelpers';
 
 const annotation = Object.assign({}, checkboxTypeAnnotation, {
@@ -16,7 +17,7 @@ describe('MultipleChoiceTask', function () {
     let wrapper;
 
     beforeEach(function () {
-      wrapper = mount(<MultipleTask
+      wrapper = shallow(<MultipleTask
         task={checkboxTypeTask}
         annotation={annotation}
         translation={checkboxTypeTask}
@@ -28,12 +29,12 @@ describe('MultipleChoiceTask', function () {
     });
 
     it('should have a question', function () {
-      const question = wrapper.find('.question');
-      expect(question.hostNodes()).to.have.lengthOf(1);
+      const question = wrapper.find(GenericTask).prop('question');
+      expect(question).to.equal(checkboxTypeTask.question);
     });
 
     it('should have answers', function () {
-      expect(wrapper.find('TaskInputField')).to.have.lengthOf(checkboxTypeTask.answers.length);
+      expect(wrapper.find(GenericTask).prop('answers')).to.have.lengthOf(checkboxTypeTask.answers.length);
     });
   });
 
@@ -46,7 +47,7 @@ describe('MultipleChoiceTask', function () {
       handleChangeSpy = sinon.spy(MultipleTask.prototype, 'handleChange');
       onChangeSpy = sinon.spy();
       setStateSpy = sinon.spy(MultipleTask.prototype, 'setState');
-      wrapper = mount(
+      wrapper = shallow(
         <MultipleTask
           task={checkboxTypeTask}
           translation={checkboxTypeTask}
@@ -67,14 +68,16 @@ describe('MultipleChoiceTask', function () {
       setStateSpy.restore();
     });
 
-    it('should call props.onChange when the onChange event fires', function () {
-      wrapper.find('input').first().simulate('change', { target: { checked: true } });
+    it('should call props.onChange when an answer changes', function () {
+      const firstAnswer = wrapper.find(GenericTask).prop('answers')[0];
+      firstAnswer.props.onChange({ target: { checked: true } });
       expect(onChangeSpy.calledOnce).to.be.true;
     });
 
     it('should call handleChange with the answer array index', function() {
       wrapper.setProps({ annotation });
-      wrapper.find('input').first().simulate('change', { target: { checked: true } });
+      const firstAnswer = wrapper.find(GenericTask).prop('answers')[0];
+      firstAnswer.props.onChange({ target: { checked: true } });
       expect(handleChangeSpy.calledWith(0)).to.be.true;
     });
   });
@@ -106,7 +109,7 @@ describe('MultipleChoiceSummary', function () {
   let summary;
 
   beforeEach(function () {
-    summary = mount(<MultipleTask.Summary task={checkboxTypeTask} annotation={annotation} translation={checkboxTypeTask} />);
+    summary = shallow(<MultipleTask.Summary task={checkboxTypeTask} annotation={annotation} translation={checkboxTypeTask} />);
   });
 
   it('should render without crashing', function () {
@@ -127,7 +130,7 @@ describe('MultipleChoiceSummary', function () {
   });
 
   it('should return "No answer" when an empty annotation is provided', function () {
-    summary = mount(<MultipleTask.Summary task={checkboxTypeTask} annotation={{ value: [] }} />);
+    summary = shallow(<MultipleTask.Summary task={checkboxTypeTask} annotation={{ value: [] }} />);
     const answer = summary.find('.answer');
     expect(answer.text()).to.equal('No answer');
   });

--- a/app/classifier/tasks/multiple/index.spec.js
+++ b/app/classifier/tasks/multiple/index.spec.js
@@ -71,14 +71,14 @@ describe('MultipleChoiceTask', function () {
     it('should call props.onChange when an answer changes', function () {
       const firstAnswer = wrapper.find(GenericTask).prop('answers')[0];
       firstAnswer.props.onChange({ target: { checked: true } });
-      expect(onChangeSpy.calledOnce).to.be.true;
+      expect(onChangeSpy).to.have.been.calledOnce;
     });
 
     it('should call handleChange with the answer array index', function() {
       wrapper.setProps({ annotation });
       const firstAnswer = wrapper.find(GenericTask).prop('answers')[0];
       firstAnswer.props.onChange({ target: { checked: true } });
-      expect(handleChangeSpy.calledWith(0)).to.be.true;
+      expect(handleChangeSpy).to.have.been.calledWith(0);
     });
   });
 

--- a/app/classifier/tasks/single/index.jsx
+++ b/app/classifier/tasks/single/index.jsx
@@ -35,6 +35,7 @@ export default class SingleChoiceTask extends React.Component {
       answers.push(
         <TaskInputField
           annotation={annotation}
+          autoFocus={checked}
           checked={checked}
           className={checked ? 'active' : ''}
           index={i}

--- a/app/classifier/tasks/single/index.jsx
+++ b/app/classifier/tasks/single/index.jsx
@@ -30,11 +30,13 @@ export default class SingleChoiceTask extends React.Component {
       if (!answer._key) {
         answer._key = Math.random();
       }
+      const checked = i === annotation.value;
 
       answers.push(
         <TaskInputField
           annotation={annotation}
-          className={(i === annotation.value) ? 'active' : ''}
+          checked={checked}
+          className={checked ? 'active' : ''}
           index={i}
           key={answer._key}
           label={translation.answers[i].label}

--- a/app/classifier/tasks/single/index.spec.js
+++ b/app/classifier/tasks/single/index.spec.js
@@ -70,13 +70,13 @@ describe('SingleChoiceTask', function () {
     it('should call handleChange with the answer array index', function () {
       const firstAnswer = wrapper.find(GenericTask).prop('answers')[0];
       firstAnswer.props.onChange({ target: { checked: true } });
-      expect(handleChangeSpy.calledWith(0)).to.be.true;
+      expect(handleChangeSpy).to.have.been.calledWith(0);
     });
 
     it('should call props.onChange when an answer changes and the target is checked', function () {
       const firstAnswer = wrapper.find(GenericTask).prop('answers')[0];
       firstAnswer.props.onChange({ target: { checked: true } });
-      expect(onChangeSpy.calledOnce).to.be.true;
+      expect(onChangeSpy).to.have.been.calledOnce;
     });
   });
 

--- a/app/classifier/tasks/single/index.spec.js
+++ b/app/classifier/tasks/single/index.spec.js
@@ -1,10 +1,11 @@
 /* eslint prefer-arrow-callback: 0, func-names: 0, 'react/jsx-boolean-value': ['error', 'always'], 'react/jsx-filename-extension': 0 */
 /* global describe, it, beforeEach */
-import { mount } from 'enzyme';
+import { shallow } from 'enzyme';
 import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import SingleTask from './';
+import GenericTask from '../generic';
 import { mockReduxStore, radioTypeAnnotation, radioTypeTask } from '../testHelpers';
 
 const annotation = Object.assign({}, radioTypeAnnotation, {
@@ -16,7 +17,7 @@ describe('SingleChoiceTask', function () {
     let wrapper;
 
     beforeEach(function () {
-      wrapper = mount(<SingleTask task={radioTypeTask} annotation={annotation} translation={radioTypeTask} />, mockReduxStore);
+      wrapper = shallow(<SingleTask task={radioTypeTask} annotation={annotation} translation={radioTypeTask} />, mockReduxStore);
     });
 
     it('should render without crashing', function () {
@@ -24,12 +25,12 @@ describe('SingleChoiceTask', function () {
     });
 
     it('should have a question', function () {
-      const question = wrapper.find('.question');
-      expect(question.hostNodes()).to.have.lengthOf(1);
+      const question = wrapper.find(GenericTask).prop('question');
+      expect(question).to.equal(radioTypeTask.question);
     });
 
     it('should have answers', function () {
-      expect(wrapper.find('TaskInputField')).to.have.lengthOf(radioTypeTask.answers.length);
+      expect(wrapper.find(GenericTask).prop('answers')).to.have.lengthOf(radioTypeTask.answers.length);
     });
   });
 
@@ -45,7 +46,7 @@ describe('SingleChoiceTask', function () {
     });
 
     beforeEach(function() {
-      wrapper = mount(
+      wrapper = shallow(
         <SingleTask
           task={radioTypeTask}
           translation={radioTypeTask}
@@ -67,13 +68,14 @@ describe('SingleChoiceTask', function () {
     });
 
     it('should call handleChange with the answer array index', function () {
-      wrapper.find('input').first().simulate('change');
+      const firstAnswer = wrapper.find(GenericTask).prop('answers')[0];
+      firstAnswer.props.onChange({ target: { checked: true } });
       expect(handleChangeSpy.calledWith(0)).to.be.true;
     });
 
-    it('should call props.onChange when the onChange event fires and the target is checked', function () {
-      const firstInput = wrapper.find('input').first();
-      firstInput.simulate('change', { target: { checked: true } });
+    it('should call props.onChange when an answer changes and the target is checked', function () {
+      const firstAnswer = wrapper.find(GenericTask).prop('answers')[0];
+      firstAnswer.props.onChange({ target: { checked: true } });
       expect(onChangeSpy.calledOnce).to.be.true;
     });
   });
@@ -109,7 +111,7 @@ describe('SingleChoiceSummary', function () {
   let summary;
 
   beforeEach(function () {
-    summary = mount(<SingleTask.Summary task={radioTypeTask} annotation={annotation} translation={radioTypeTask} />);
+    summary = shallow(<SingleTask.Summary task={radioTypeTask} annotation={annotation} translation={radioTypeTask} />);
   });
 
   it('should render without crashing', function () {
@@ -130,13 +132,13 @@ describe('SingleChoiceSummary', function () {
   });
 
   it('should have the correct answer label when the value if falsy (i.e. 0)', function () {
-    summary = mount(<SingleTask.Summary task={radioTypeTask} annotation={{ value: 0 }} translation={radioTypeTask} />);
+    summary = shallow(<SingleTask.Summary task={radioTypeTask} annotation={{ value: 0 }} translation={radioTypeTask} />);
     const answers = summary.find('.answer');
     expect(answers.text()).to.not.equal('No answer');
   });
 
   it('should return "No answer" when annotation is null', function () {
-    summary = mount(<SingleTask.Summary task={radioTypeTask} annotation={{ value: null }} translation={radioTypeTask} />);
+    summary = shallow(<SingleTask.Summary task={radioTypeTask} annotation={{ value: null }} translation={radioTypeTask} />);
     const answers = summary.find('.answer');
     expect(answers.text()).to.equal('No answer');
   });


### PR DESCRIPTION
Use checkbox/radio button state (active, checked or focussed) to control the style of adjacent task labels.
Remove onFocus(), onBlur(), unfocus() and associated tests from TaskInputField.
Convert TaskInputField to a function and add React.memo() for speed.
Works around some problems with the multiple choice and single answer task tests by rewriting them to use shallow rendering. Full mounting of those components won't work until enzyme supports `React.memo()`.
Fixes #5096.

This PR should fix slow/laggy behaviour on phones, where there could be a noticeable delay between tapping an answer and seeing it change colour.

Staging branch URL: https://pr-5091.pfe-preview.zooniverse.org

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
