### PR TITLE
Fetch featured project when not logged in

### DIFF
--- a/app/pages/home-not-logged-in.jsx
+++ b/app/pages/home-not-logged-in.jsx
@@ -28,6 +28,7 @@ export default class HomePage extends React.Component {
     this.resizeTimeout = NaN;
     this.state = {
       count: 0,
+      featuredProject: null,
       promotedProjects: [],
       screenWidth: 0,
       volunteerCount: 1500000
@@ -41,12 +42,21 @@ export default class HomePage extends React.Component {
     addEventListener('resize', this.handleResize);
     this.handleResize();
     this.getClassificationCounts();
+    this.getFeaturedProject();
     this.getVolunteerCount();
     this.getPromotedProjects();
   }
 
   componentWillUnmount() {
     removeEventListener('resize', this.handleResize);
+  }
+
+  getFeaturedProject() {
+    const query = { featured: true, launch_approved: true, cards: true };
+    return apiClient.type('projects').get(query)
+      .then(([featuredProject]) => {
+        this.setState({ featuredProject });
+      });
   }
 
   getVolunteerCount() {
@@ -128,7 +138,7 @@ export default class HomePage extends React.Component {
         </div>
 
         <div className="flex-container">
-          <FeaturedProject />
+          <FeaturedProject project={this.state.featuredProject} />
         </div>
 
         <div className="flex-container">


### PR DESCRIPTION
Fetch the featured project when the not-logged-in home page mounts, and pass it to the featured project component.

Staging branch URL: https://pr-5101.pfe-preview.zooniverse.org

Fixes #5098.

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
