### PR TITLE
Remove unused annotation prop from task inputs

### DIFF
--- a/app/classifier/tasks/drawing/index.cjsx
+++ b/app/classifier/tasks/drawing/index.cjsx
@@ -92,17 +92,17 @@ module.exports = createReactClass
     annotation: null
     onChange: Function.prototype
 
-  render: ->
-    tools = for tool, i in @props.task.tools
+  tools: ->
+    @props.task.tools.map (tool, i) =>
       tool._key ?= Math.random()
-      count = (true for mark in @props.annotation.value when mark.tool is i).length
+      marksByType = @props.annotation.value.filter (mark) -> mark.tool is i
+      count = marksByType.length
       translation = @props.translation.tools[i]
-      checked = i is (@props.annotation._toolIndex ? 0) 
+      checked = i is (@props.annotation._toolIndex ? 0)
       <div>
         <TaskInputField
-          annotation={@props.annotation}
           autoFocus={checked}
-          checked = {checked}
+          checked={checked}
           className={if checked then 'active' else ''}
           index={i}
           key={tool._key}
@@ -117,10 +117,11 @@ module.exports = createReactClass
           <GridButtons {...@props} />}
       </div>
 
+  render: ->
     <GenericTask
       question={@props.translation.instruction}
       help={@props.translation.help}
-      answers={tools}
+      answers={@tools()}
       required={@props.task.required}
     />
 

--- a/app/classifier/tasks/multiple/index.jsx
+++ b/app/classifier/tasks/multiple/index.jsx
@@ -34,7 +34,6 @@ export default class MultipleChoiceTask extends React.Component {
 
       answers.push(
         <TaskInputField
-          annotation={annotation}
           autoFocus={checked}
           checked={checked}
           className={checked ? 'active' : ''}

--- a/app/classifier/tasks/single/index.jsx
+++ b/app/classifier/tasks/single/index.jsx
@@ -34,7 +34,6 @@ export default class SingleChoiceTask extends React.Component {
 
       answers.push(
         <TaskInputField
-          annotation={annotation}
           autoFocus={checked}
           checked={checked}
           className={checked ? 'active' : ''}


### PR DESCRIPTION
Staging branch URL: https://pr-5104.pfe-preview.zooniverse.org

#5091 removed the annotation prop from TaskInputField but I forgot to remove it from the instances of the component itself. This removes that prop from the input field in multiple choice, single answer and drawing tasks. It also tidies up the drawing task render method to make the tool choices easier to understand.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
