### PR TITLE
Fix broken policies page links

### DIFF
--- a/app/layout/site-footer.jsx
+++ b/app/layout/site-footer.jsx
@@ -101,7 +101,7 @@ class AppFooter extends React.Component {
                 </a>, 'footer.discover.howToGuide')}
               </li>
               <li>
-                {this.loggableLink(<a href="https://help.zooniverse.org/getting-started/policies">
+                {this.loggableLink(<a href="https://help.zooniverse.org/getting-started/lab-policies">
                   <Translate content="footer.discover.projectBuilderPolicies" />
                 </a>, 'footer.discover.projectBuilderPolicies')}
               </li>

--- a/app/pages/lab/index.cjsx
+++ b/app/pages/lab/index.cjsx
@@ -255,7 +255,7 @@ module.exports = createReactClass
             <button type="button" className="major-button" onClick={@showProjectCreator}>Create a new project</button>{' '}
             <a href="https://help.zooniverse.org/getting-started" className="standard-button">How-to</a>{' '}
             <a href="https://help.zooniverse.org/getting-started/glossary" className="standard-button">Glossary</a>{' '}
-            <a href="https://help.zooniverse.org/getting-started/policies" className="standard-button">Policies</a>{' '}
+            <a href="https://help.zooniverse.org/getting-started/lab-policies" className="standard-button">Policies</a>{' '}
             <a href="https://help.zooniverse.org/best-practices" className="standard-button">Best Practices</a>{' '}
             <a href="/talk/18" className="standard-button">Project Builder Talk</a>{' '}
           </p>


### PR DESCRIPTION
Policies page is now at https://help.zooniverse.org/getting-started/lab-policies

Staging branch URL: https://pr-5105.pfe-preview.zooniverse.org

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
