### PR TITLE
Improve workflow selection for anonymous users

### DIFF
--- a/app/pages/project/classify.jsx
+++ b/app/pages/project/classify.jsx
@@ -195,11 +195,11 @@ export class ProjectClassifyPage extends React.Component {
         if (preferences.preferences.selected_workflow !== preferences.settings.workflow_id) {
           preferences.update({ 'preferences.selected_workflow': preferences.settings.workflow_id });
           preferences.save();
+          actions.translations.load('workflow', preferences.settings.workflow_id, translations.locale);
           apiClient
             .type('workflows')
             .get(preferences.settings.workflow_id, {})
             .then((newWorkflow) => {
-              actions.translations.load('workflow', newWorkflow.id, translations.locale);
               actions.classifier.setWorkflow(newWorkflow);
             });
         }

--- a/app/pages/project/home/home-workflow-button.jsx
+++ b/app/pages/project/home/home-workflow-button.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Link } from 'react-router';
+import { browserHistory, Link } from 'react-router';
 import classnames from 'classnames';
 import Translate from 'react-translate-component';
 import apiClient from 'panoptes-client/lib/api-client';
@@ -17,22 +17,20 @@ class ProjectHomeWorkflowButton extends React.Component {
   }
 
   handleWorkflowSelection(e) {
-    const { actions, disabled, preferences, user, translations, workflow } = this.props;
-    if (disabled) {
-      e.preventDefault();
-    } else {
-      actions.classifier.setWorkflow(null);
-      return apiClient
-        .type('workflows')
-        .get(workflow.id, {})
-        .then((newWorkflow) => {
-          if (user) {
-            preferences.update({ 'preferences.selected_workflow': newWorkflow.id }).save();
-          }
-          actions.translations.load('workflow', newWorkflow.id, translations.locale);
-          actions.classifier.setWorkflow(newWorkflow);
-        });
+    const { actions, preferences, user, translations, workflow } = this.props;
+    e.preventDefault();
+    actions.classifier.setWorkflow(null);
+    if (user) {
+      preferences.update({ 'preferences.selected_workflow': workflow.id }).save();
     }
+    actions.translations.load('workflow', workflow.id, translations.locale);
+    return apiClient
+      .type('workflows')
+      .get(workflow.id, {})
+      .then((newWorkflow) => {
+        actions.classifier.setWorkflow(newWorkflow);
+        browserHistory.push(`/projects/${this.props.project.slug}/classify`)
+      });
   }
 
   render() {

--- a/app/pages/project/home/home-workflow-button.spec.js
+++ b/app/pages/project/home/home-workflow-button.spec.js
@@ -39,6 +39,10 @@ const translations = {
 
 const user = mockPanoptesResource('user', {});
 
+const fakeEvent = {
+  preventDefault: sinon.stub()
+};
+
 describe('ProjectHomeWorkflowButton', function () {
   let wrapper;
   let handleWorkflowSelectionSpy;
@@ -83,33 +87,33 @@ describe('ProjectHomeWorkflowButton', function () {
   });
 
   it('calls handleWorkflowSelection onClick', function() {
-    wrapper.find('Link').simulate('click');
+    wrapper.find('Link').simulate('click', fakeEvent);
     assert.equal(handleWorkflowSelectionSpy.calledOnce, true);
   });
 
   it('should update user preferences on workflow selection', function (done) {
-    wrapper.instance().handleWorkflowSelection()
+    wrapper.instance().handleWorkflowSelection(fakeEvent)
     .then(function () {
       assert.equal(preferences.update.calledOnce, true);
     })
     .then(done, done);
   });
   it('should clear the current workflow', function (done) {
-    wrapper.instance().handleWorkflowSelection()
+    wrapper.instance().handleWorkflowSelection(fakeEvent)
     .then(function () {
       assert.equal(actions.classifier.setWorkflow.firstCall.calledWith(null), true);
     })
     .then(done, done);
   });
   it('should select a new workflow', function (done) {
-    wrapper.instance().handleWorkflowSelection()
+    wrapper.instance().handleWorkflowSelection(fakeEvent)
     .then(function () {
       assert.equal(actions.classifier.setWorkflow.secondCall.calledWith(testWorkflowWithoutLevel), true);
     })
     .then(done, done);
   });
   it('should load workflow translations', function (done) {
-    wrapper.instance().handleWorkflowSelection()
+    wrapper.instance().handleWorkflowSelection(fakeEvent)
     .then(function () {
       assert.equal(actions.translations.load.calledWith('workflow', testWorkflowWithoutLevel.id, translations.locale), true);
     })

--- a/app/pages/project/workflow-selection.jsx
+++ b/app/pages/project/workflow-selection.jsx
@@ -12,12 +12,17 @@ class WorkflowSelection extends React.Component {
     super();
     this.state = {
       error: null,
-      loadingSelectedWorkflow: true
+      loadingSelectedWorkflow: false
     };
   }
 
   componentDidMount() {
-    this.getSelectedWorkflow(this.props);
+    const { project, workflow } = this.props;
+    const linkedActiveWorkflows = project.links.active_workflows || [];
+    const workflowExistsForProject = workflow && linkedActiveWorkflows.indexOf(workflow.id) > -1;
+    if (!workflowExistsForProject) {
+      this.getSelectedWorkflow(this.props);
+    }
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -87,6 +92,7 @@ class WorkflowSelection extends React.Component {
     }
     let awaitWorkflow;
     if (isValidWorkflow) {
+      actions.translations.load('workflow', sanitisedWorkflowID, locale);
       awaitWorkflow = apiClient
         .type('workflows')
         .get(sanitisedWorkflowID, {}) // the empty query here forces the client to bypass its internal cache
@@ -106,7 +112,6 @@ class WorkflowSelection extends React.Component {
     return awaitWorkflow
     .then((workflow) => {
       if (workflow) {
-        actions.translations.load('workflow', workflow.id, locale);
         actions.classifier.setWorkflow(workflow);
         this.setState({ loadingSelectedWorkflow: false });
       } else {


### PR DESCRIPTION
Staging branch URL: https://pr-5107.pfe-preview.zooniverse.org

- Changes the project home page workflow links so that they defer loading the classify page until the new workflow has loaded.
- Changes workflow selection so that a new workflow is not loaded if there is already an active workflow for the project on mount.
- Updates components that load workflows so that translations are loaded in parallel with workflows, rather than after workflows load.

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
