### PR TITLE
Update project workflow link tests

### DIFF
--- a/app/pages/project/home/home-workflow-button.spec.js
+++ b/app/pages/project/home/home-workflow-button.spec.js
@@ -91,19 +91,13 @@ describe('ProjectHomeWorkflowButton', function () {
     assert.equal(handleWorkflowSelectionSpy.calledOnce, true);
   });
 
-  it('should update user preferences on workflow selection', function (done) {
+  it('should update user preferences before loadiing a workflow', function () {
     wrapper.instance().handleWorkflowSelection(fakeEvent)
-    .then(function () {
-      assert.equal(preferences.update.calledOnce, true);
-    })
-    .then(done, done);
+    assert.equal(preferences.update.calledOnce, true);
   });
-  it('should clear the current workflow', function (done) {
+  it('should clear the current workflow before loading a workflow', function () {
     wrapper.instance().handleWorkflowSelection(fakeEvent)
-    .then(function () {
-      assert.equal(actions.classifier.setWorkflow.firstCall.calledWith(null), true);
-    })
-    .then(done, done);
+    assert.equal(actions.classifier.setWorkflow.firstCall.calledWith(null), true);
   });
   it('should select a new workflow', function (done) {
     wrapper.instance().handleWorkflowSelection(fakeEvent)
@@ -112,12 +106,9 @@ describe('ProjectHomeWorkflowButton', function () {
     })
     .then(done, done);
   });
-  it('should load workflow translations', function (done) {
+  it('should load workflow translations before loading the workflow', function () {
     wrapper.instance().handleWorkflowSelection(fakeEvent)
-    .then(function () {
-      assert.equal(actions.translations.load.calledWith('workflow', testWorkflowWithoutLevel.id, translations.locale), true);
-    })
-    .then(done, done);
+    assert.equal(actions.translations.load.calledWith('workflow', testWorkflowWithoutLevel.id, translations.locale), true);
   });
   it('uses the project slug in the Link href', function() {
     assert.equal(wrapper.find('Link').props().to.includes(testProject.slug), true);

--- a/app/pages/project/home/home-workflow-button.spec.js
+++ b/app/pages/project/home/home-workflow-button.spec.js
@@ -85,30 +85,41 @@ describe('ProjectHomeWorkflowButton', function () {
   it('renders the workflow display name as the Link text', function() {
     expect(wrapper.render().text()).to.equal(testWorkflowWithoutLevel.display_name);
   });
-
-  it('calls handleWorkflowSelection onClick', function() {
-    wrapper.find('Link').simulate('click', fakeEvent);
-    expect(handleWorkflowSelectionSpy).to.have.been.calledOnce;
-  });
-
-  it('should update user preferences before loadiing a workflow', function () {
-    wrapper.instance().handleWorkflowSelection(fakeEvent)
-    expect(preferences.update).to.have.been.calledOnce;
-  });
-  it('should clear the current workflow before loading a workflow', function () {
-    wrapper.instance().handleWorkflowSelection(fakeEvent)
-    expect(actions.classifier.setWorkflow.firstCall).to.have.been.calledWith(null);
-  });
-  it('should select a new workflow', function (done) {
-    wrapper.instance().handleWorkflowSelection(fakeEvent)
-    .then(function () {
-      expect(actions.classifier.setWorkflow.secondCall).to.have.been.calledWith(testWorkflowWithoutLevel);
-    })
-    .then(done, done);
-  });
-  it('should load workflow translations before loading the workflow', function () {
-    wrapper.instance().handleWorkflowSelection(fakeEvent)
-    expect(actions.translations.load).to.have.been.calledWith('workflow', testWorkflowWithoutLevel.id, translations.locale);
+  
+  describe('on click', function () {
+    it('calls handleWorkflowSelection onClick', function() {
+      wrapper.find('Link').simulate('click', fakeEvent);
+      expect(handleWorkflowSelectionSpy).to.have.been.calledOnce;
+    });
+    it('should select a new workflow', function (done) {
+      wrapper.instance().handleWorkflowSelection(fakeEvent)
+      .then(function () {
+        expect(actions.classifier.setWorkflow.secondCall).to.have.been.calledWith(testWorkflowWithoutLevel);
+      })
+      .then(done, done);
+    });
+    describe('workflow selection', function () {
+      beforeEach(function () {
+        wrapper.instance().handleWorkflowSelection(fakeEvent);
+      });
+      afterEach(function () {
+        actions.classifier.setWorkflow.resetHistory();
+        actions.translations.load.resetHistory();
+        fakeEvent.preventDefault.resetHistory();
+      })
+      it('should update user preferences before loadiing a workflow', function () {
+        expect(preferences.update).to.have.been.calledOnce;
+      });
+      it('should clear the current workflow before loading a workflow', function () {
+        expect(actions.classifier.setWorkflow.firstCall).to.have.been.calledWith(null);
+      });
+      it('should prevent the default click action on links', function () {
+        expect(fakeEvent.preventDefault).to.have.been.calledOnce;
+      });
+      it('should load workflow translations before loading the workflow', function () {
+        expect(actions.translations.load).to.have.been.calledWith('workflow', testWorkflowWithoutLevel.id, translations.locale);
+      });
+    });
   });
   it('uses the project slug in the Link href', function() {
     expect(wrapper.find('Link').props().to).to.have.string(testProject.slug);

--- a/app/pages/project/home/home-workflow-button.spec.js
+++ b/app/pages/project/home/home-workflow-button.spec.js
@@ -75,7 +75,9 @@ describe('ProjectHomeWorkflowButton', function () {
     apiClient.type.restore();
   });
 
-  it('renders without crashing', function () {});
+  it('renders with default props', function () {
+    expect(shallow(<ProjectHomeWorkflowButton />)).to.be.ok;
+  });
 
   it('renders a Link component', function () {
     expect(wrapper.find('Link')).to.have.lengthOf(1);

--- a/app/pages/project/home/home-workflow-button.spec.js
+++ b/app/pages/project/home/home-workflow-button.spec.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import assert from 'assert';
+import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import sinon from 'sinon';
 import apiClient from 'panoptes-client/lib/api-client';
@@ -78,40 +78,40 @@ describe('ProjectHomeWorkflowButton', function () {
   it('renders without crashing', function () {});
 
   it('renders a Link component', function () {
-    assert.equal(wrapper.find('Link').length, 1);
-    assert.equal(wrapper.find('span').length, 0);
+    expect(wrapper.find('Link')).to.have.lengthOf(1);
+    expect(wrapper.find('span')).to.have.lengthOf(0);
   });
 
   it('renders the workflow display name as the Link text', function() {
-    assert.equal(wrapper.render().text(), testWorkflowWithoutLevel.display_name);
+    expect(wrapper.render().text()).to.equal(testWorkflowWithoutLevel.display_name);
   });
 
   it('calls handleWorkflowSelection onClick', function() {
     wrapper.find('Link').simulate('click', fakeEvent);
-    assert.equal(handleWorkflowSelectionSpy.calledOnce, true);
+    expect(handleWorkflowSelectionSpy).to.have.been.calledOnce;
   });
 
   it('should update user preferences before loadiing a workflow', function () {
     wrapper.instance().handleWorkflowSelection(fakeEvent)
-    assert.equal(preferences.update.calledOnce, true);
+    expect(preferences.update).to.have.been.calledOnce;
   });
   it('should clear the current workflow before loading a workflow', function () {
     wrapper.instance().handleWorkflowSelection(fakeEvent)
-    assert.equal(actions.classifier.setWorkflow.firstCall.calledWith(null), true);
+    expect(actions.classifier.setWorkflow.firstCall).to.have.been.calledWith(null);
   });
   it('should select a new workflow', function (done) {
     wrapper.instance().handleWorkflowSelection(fakeEvent)
     .then(function () {
-      assert.equal(actions.classifier.setWorkflow.secondCall.calledWith(testWorkflowWithoutLevel), true);
+      expect(actions.classifier.setWorkflow.secondCall).to.have.been.calledWith(testWorkflowWithoutLevel);
     })
     .then(done, done);
   });
   it('should load workflow translations before loading the workflow', function () {
     wrapper.instance().handleWorkflowSelection(fakeEvent)
-    assert.equal(actions.translations.load.calledWith('workflow', testWorkflowWithoutLevel.id, translations.locale), true);
+    expect(actions.translations.load).to.have.been.calledWith('workflow', testWorkflowWithoutLevel.id, translations.locale);
   });
   it('uses the project slug in the Link href', function() {
-    assert.equal(wrapper.find('Link').props().to.includes(testProject.slug), true);
+    expect(wrapper.find('Link').props().to).to.have.string(testProject.slug);
   });
 
   describe('when props.disabled is true', function() {
@@ -128,12 +128,12 @@ describe('ProjectHomeWorkflowButton', function () {
     });
 
     it('renders a span instead of a Link component', function() {
-      assert.equal(wrapper.find('span').length, 1);
-      assert.equal(wrapper.find('Link').length, 0);
+      expect(wrapper.find('span')).to.have.lengthOf(1);
+      expect(wrapper.find('Link')).to.have.lengthOf(0);
     });
 
     it('applies the call-to-action-button--disabled class', function() {
-      assert.equal(wrapper.hasClass('project-home-page__button--disabled'), true);
+      expect(wrapper.hasClass('project-home-page__button--disabled')).to.be.true;
     });
   });
 
@@ -151,16 +151,16 @@ describe('ProjectHomeWorkflowButton', function () {
     });
 
     it('renders null when the workflow does not have a level set in its configuration', function() {
-      assert.equal(wrapper.isEmptyRender(), true);
+      expect(wrapper.isEmptyRender()).to.be.true;
     });
 
     it('renders a Link when the workflow has a level set in its configuration', function() {
       wrapper.setProps({ workflow: testWorkflowWithLevel });
-      assert.equal(wrapper.find('Link').length, 1);
+      expect(wrapper.find('Link')).to.have.lengthOf(1);
     });
 
     it('renders a Translate component for the Link text', function() {
-      assert.equal(wrapper.find('Translate').length, 1);
+      expect(wrapper.find('Translate')).to.have.lengthOf(1);
     });
   });
 });


### PR DESCRIPTION
Staging branch URL: https://pr-5115.pfe-preview.zooniverse.org

Updates project home workflow button tests to convert them from `assert` to `expect` and test for changes that were made in #5107.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
