### PR TITLE
Add a load workflows action to the redux classify store

### DIFF
--- a/app/pages/project/classify.jsx
+++ b/app/pages/project/classify.jsx
@@ -195,15 +195,7 @@ export class ProjectClassifyPage extends React.Component {
         this.setState({ promptWorkflowAssignmentDialog: false })
       ).then(() => {
         if (preferences.preferences.selected_workflow !== preferences.settings.workflow_id) {
-          preferences.update({ 'preferences.selected_workflow': preferences.settings.workflow_id });
-          preferences.save();
-          actions.translations.load('workflow', preferences.settings.workflow_id, translations.locale);
-          apiClient
-            .type('workflows')
-            .get(preferences.settings.workflow_id, {})
-            .then((newWorkflow) => {
-              actions.classifier.setWorkflow(newWorkflow);
-            });
+          actions.classifier.loadWorkflow(preferences.settings.workflow_id, translations.locale, preferences);
         }
       });
     }

--- a/app/pages/project/classify.jsx
+++ b/app/pages/project/classify.jsx
@@ -119,11 +119,13 @@ export class ProjectClassifyPage extends React.Component {
     const { actions, project, workflow } = this.props;
 
     this.maybePromptWorkflowAssignmentDialog(this.props);
-    actions.classifier.fetchSubjects(workflow)
-    .then(() => actions.classifier.createClassification(project))
-    .catch((error) => {
-      this.setState({ rejected: { classification: error }});
-    });
+    if (workflow) {
+      actions.classifier.fetchSubjects(workflow)
+      .then(() => actions.classifier.createClassification(project))
+      .catch((error) => {
+        this.setState({ rejected: { classification: error }});
+      });
+    }
   }
 
   loadAppropriateClassification() {

--- a/app/pages/project/home/home-workflow-button.jsx
+++ b/app/pages/project/home/home-workflow-button.jsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { browserHistory, Link } from 'react-router';
 import classnames from 'classnames';
 import Translate from 'react-translate-component';
-import apiClient from 'panoptes-client/lib/api-client';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import * as classifierActions from '../../../redux/ducks/classify';
@@ -16,21 +15,17 @@ class ProjectHomeWorkflowButton extends React.Component {
     this.handleWorkflowSelection = this.handleWorkflowSelection.bind(this);
   }
 
-  handleWorkflowSelection(e) {
-    const { actions, preferences, user, translations, workflow } = this.props;
-    e.preventDefault();
-    actions.classifier.setWorkflow(null);
-    if (user) {
-      preferences.update({ 'preferences.selected_workflow': workflow.id }).save();
+  componentDidUpdate() {
+    const { classifierWorkflow, project, workflow } = this.props;
+    if (classifierWorkflow && classifierWorkflow.id === workflow.id) {
+      browserHistory.push(`/projects/${project.slug}/classify`);
     }
-    actions.translations.load('workflow', workflow.id, translations.locale);
-    return apiClient
-      .type('workflows')
-      .get(workflow.id, {})
-      .then((newWorkflow) => {
-        actions.classifier.setWorkflow(newWorkflow);
-        browserHistory.push(`/projects/${this.props.project.slug}/classify`)
-      });
+  }
+
+  handleWorkflowSelection(e) {
+    const { actions, preferences, translations, workflow } = this.props;
+    e.preventDefault();
+    actions.classifier.loadWorkflow(workflow.id, translations.locale, preferences);
   }
 
   render() {
@@ -115,6 +110,7 @@ ProjectHomeWorkflowButton.propTypes = {
 };
 
 const mapStateToProps = state => ({
+  classifierWorkflow: state.classify.workflow,
   translations: state.translations
 });
 

--- a/app/pages/project/home/home-workflow-button.jsx
+++ b/app/pages/project/home/home-workflow-button.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { browserHistory, Link } from 'react-router';
+import { browserHistory } from 'react-router';
 import classnames from 'classnames';
 import Translate from 'react-translate-component';
 import { connect } from 'react-redux';
@@ -24,25 +24,16 @@ class ProjectHomeWorkflowButton extends React.Component {
 
   handleWorkflowSelection(e) {
     const { actions, preferences, translations, workflow } = this.props;
-    e.preventDefault();
     actions.classifier.loadWorkflow(workflow.id, translations.locale, preferences);
   }
 
   render() {
     // To disable the anchor tag, use class to set pointer-events: none style.
     // Except IE, which supports a disabled attribute instead.
-    const linkClasses = classnames({
+    const buttonClasses = classnames({
       'project-home-page__button': true,
       'project-home-page__button--disabled': this.props.disabled
     });
-
-    if (this.props.disabled) {
-      return (
-        <span className={linkClasses}>
-          {this.props.workflow.display_name}
-        </span>
-      );
-    }
 
     if (this.props.workflowAssignment &&
         this.props.workflow.configuration &&
@@ -51,15 +42,16 @@ class ProjectHomeWorkflowButton extends React.Component {
     }
 
     return (
-      <Link
-        to={`/projects/${this.props.project.slug}/classify`}
-        className={linkClasses}
+      <button
+        disabled={this.props.disabled}
+        type="button"
+        className={buttonClasses}
         onClick={this.handleWorkflowSelection}
       >
         {(this.props.workflowAssignment && !this.props.disabled) ?
           <Translate content="project.home.workflowAssignment" with={{ workflowDisplayName: this.props.workflow.display_name }} /> :
           this.props.workflow.display_name}
-      </Link>
+      </button>
     );
   }
 }

--- a/app/pages/project/home/home-workflow-button.spec.js
+++ b/app/pages/project/home/home-workflow-button.spec.js
@@ -26,6 +26,7 @@ const preferences = mockPanoptesResource('project-preferences', {});
 
 const actions = {
   classifier: {
+    loadWorkflow: sinon.stub(),
     setWorkflow: sinon.stub()
   },
   translations: {
@@ -89,37 +90,21 @@ describe('ProjectHomeWorkflowButton', function () {
   });
   
   describe('on click', function () {
-    it('calls handleWorkflowSelection onClick', function() {
+    before(function () {
       wrapper.find('Link').simulate('click', fakeEvent);
+    });
+    after(function () {
+      fakeEvent.preventDefault.resetHistory();
+    });
+    it('calls handleWorkflowSelection onClick', function() {
       expect(handleWorkflowSelectionSpy).to.have.been.calledOnce;
     });
-    it('should select a new workflow', function (done) {
-      wrapper.instance().handleWorkflowSelection(fakeEvent)
-      .then(function () {
-        expect(actions.classifier.setWorkflow.secondCall).to.have.been.calledWith(testWorkflowWithoutLevel);
-      })
-      .then(done, done);
+    it('should load a new workflow', function () {
+      expect(actions.classifier.loadWorkflow).to.have.been.calledWith(testWorkflowWithoutLevel.id, translations.locale, preferences);
     });
     describe('workflow selection', function () {
-      beforeEach(function () {
-        wrapper.instance().handleWorkflowSelection(fakeEvent);
-      });
-      afterEach(function () {
-        actions.classifier.setWorkflow.resetHistory();
-        actions.translations.load.resetHistory();
-        fakeEvent.preventDefault.resetHistory();
-      })
-      it('should update user preferences before loadiing a workflow', function () {
-        expect(preferences.update).to.have.been.calledOnce;
-      });
-      it('should clear the current workflow before loading a workflow', function () {
-        expect(actions.classifier.setWorkflow.firstCall).to.have.been.calledWith(null);
-      });
       it('should prevent the default click action on links', function () {
         expect(fakeEvent.preventDefault).to.have.been.calledOnce;
-      });
-      it('should load workflow translations before loading the workflow', function () {
-        expect(actions.translations.load).to.have.been.calledWith('workflow', testWorkflowWithoutLevel.id, translations.locale);
       });
     });
   });

--- a/app/pages/project/home/home-workflow-button.spec.js
+++ b/app/pages/project/home/home-workflow-button.spec.js
@@ -80,18 +80,17 @@ describe('ProjectHomeWorkflowButton', function () {
     expect(shallow(<ProjectHomeWorkflowButton />)).to.be.ok;
   });
 
-  it('renders a Link component', function () {
-    expect(wrapper.find('Link')).to.have.lengthOf(1);
-    expect(wrapper.find('span')).to.have.lengthOf(0);
+  it('renders an active button', function () {
+    expect(wrapper.find('button').prop('disabled')).to.be.false;
   });
 
-  it('renders the workflow display name as the Link text', function() {
+  it('renders the workflow display name as the button label', function() {
     expect(wrapper.render().text()).to.equal(testWorkflowWithoutLevel.display_name);
   });
   
   describe('on click', function () {
     before(function () {
-      wrapper.find('Link').simulate('click', fakeEvent);
+      wrapper.find('button').simulate('click', fakeEvent);
     });
     after(function () {
       fakeEvent.preventDefault.resetHistory();
@@ -102,14 +101,6 @@ describe('ProjectHomeWorkflowButton', function () {
     it('should load a new workflow', function () {
       expect(actions.classifier.loadWorkflow).to.have.been.calledWith(testWorkflowWithoutLevel.id, translations.locale, preferences);
     });
-    describe('workflow selection', function () {
-      it('should prevent the default click action on links', function () {
-        expect(fakeEvent.preventDefault).to.have.been.calledOnce;
-      });
-    });
-  });
-  it('uses the project slug in the Link href', function() {
-    expect(wrapper.find('Link').props().to).to.have.string(testProject.slug);
   });
 
   describe('when props.disabled is true', function() {
@@ -125,9 +116,8 @@ describe('ProjectHomeWorkflowButton', function () {
       );
     });
 
-    it('renders a span instead of a Link component', function() {
-      expect(wrapper.find('span')).to.have.lengthOf(1);
-      expect(wrapper.find('Link')).to.have.lengthOf(0);
+    it('renders a disabled button', function() {
+      expect(wrapper.find('button').prop('disabled')).to.be.true;
     });
 
     it('applies the call-to-action-button--disabled class', function() {
@@ -152,9 +142,9 @@ describe('ProjectHomeWorkflowButton', function () {
       expect(wrapper.isEmptyRender()).to.be.true;
     });
 
-    it('renders a Link when the workflow has a level set in its configuration', function() {
+    it('renders a button when the workflow has a level set in its configuration', function() {
       wrapper.setProps({ workflow: testWorkflowWithLevel });
-      expect(wrapper.find('Link')).to.have.lengthOf(1);
+      expect(wrapper.find('button')).to.have.lengthOf(1);
     });
 
     it('renders a Translate component for the Link text', function() {

--- a/app/pages/project/workflow-selection.jsx
+++ b/app/pages/project/workflow-selection.jsx
@@ -91,9 +91,10 @@ class WorkflowSelection extends React.Component {
       isValidWorkflow = project.links.workflows.indexOf(sanitisedWorkflowID) > -1;
     }
     let awaitWorkflow;
+    let awaitTranslation;
     if (isValidWorkflow) {
       actions.classifier.reset();
-      actions.translations.load('workflow', sanitisedWorkflowID, locale);
+      awaitTranslation = actions.translations.load('workflow', sanitisedWorkflowID, locale);
       awaitWorkflow = apiClient
         .type('workflows')
         .get(sanitisedWorkflowID, {}) // the empty query here forces the client to bypass its internal cache
@@ -108,10 +109,11 @@ class WorkflowSelection extends React.Component {
         });
     } else {
       awaitWorkflow = Promise.resolve(null);
+      awaitTranslation = Promise.resolve(null);
     }
 
-    return awaitWorkflow
-    .then((workflow) => {
+    return Promise.all([awaitWorkflow, awaitTranslation])
+    .then(([workflow]) => {
       if (workflow) {
         actions.classifier.setWorkflow(workflow);
         this.setState({ loadingSelectedWorkflow: false });

--- a/app/pages/project/workflow-selection.jsx
+++ b/app/pages/project/workflow-selection.jsx
@@ -92,6 +92,7 @@ class WorkflowSelection extends React.Component {
     }
     let awaitWorkflow;
     if (isValidWorkflow) {
+      actions.classifier.reset();
       actions.translations.load('workflow', sanitisedWorkflowID, locale);
       awaitWorkflow = apiClient
         .type('workflows')

--- a/app/pages/project/workflow-selection.spec.js
+++ b/app/pages/project/workflow-selection.spec.js
@@ -77,6 +77,9 @@ const preferences = mockPanoptesResource(
 
 describe('WorkflowSelection', function () {
   const actions = {
+    classifier: {
+      reset: sinon.spy()
+    },
     translations: {
       load: sinon.stub()
     }

--- a/app/redux/ducks/classify.js
+++ b/app/redux/ducks/classify.js
@@ -89,6 +89,11 @@ function completeAnnotations(workflow, annotations) {
   return annotations;
 }
 
+function destroySubjects(subjects) {
+  subjects.forEach(subject => subject.destroy());
+  subjects.splice(0);
+}
+
 function finishClassification(workflow, classification, annotations) {
   return classification.update({
     annotations: completeAnnotations(workflow, annotations),
@@ -118,6 +123,7 @@ const RESUME_CLASSIFICATION = 'pfe/classify/RESUME_CLASSIFICATION';
 const RESET_SUBJECTS = 'pfe/classify/RESET_SUBJECTS';
 const SAVE_ANNOTATIONS = 'pfe/classify/SAVE_ANNOTATIONS';
 const FETCH_WORKFLOW = 'pfe/classify/FETCH_WORKFLOW';
+const RESET = 'pfe/classify/RESET';
 const SET_WORKFLOW = 'pfe/classify/SET_WORKFLOW';
 const TOGGLE_GOLD_STANDARD = 'pfe/classify/TOGGLE_GOLD_STANDARD';
 
@@ -206,11 +212,15 @@ export default function reducer(state = initialState, action = {}) {
       }
       return Object.assign({}, state, { classification });
     }
+    case RESET: {
+      const upcomingSubjects = state.upcomingSubjects.slice();
+      destroySubjects(upcomingSubjects);
+      return Object.assign({}, initialState);
+    }
     case RESET_SUBJECTS: {
       const classification = null;
       const upcomingSubjects = state.upcomingSubjects.slice();
-      upcomingSubjects.forEach(subject => subject.destroy());
-      upcomingSubjects.splice(0);
+      destroySubjects(upcomingSubjects);
       return Object.assign({}, state, { classification, upcomingSubjects });
     }
     case SAVE_ANNOTATIONS: {
@@ -382,6 +392,12 @@ export function loadWorkflow(workflowId, locale, preferences) {
       return dispatch(setWorkflow(null));
     });
   };
+}
+
+export function reset() {
+  return {
+    type: RESET
+  }
 }
 
 export function setWorkflow(workflow) {

--- a/app/redux/ducks/classify.js
+++ b/app/redux/ducks/classify.js
@@ -360,7 +360,6 @@ export function loadWorkflow(workflowId, locale, preferences) {
     }
     dispatch(setWorkflow(null));
     dispatch(emptySubjectQueue());
-    dispatch(translations.load('workflow', workflowId, locale));
     dispatch({
       type: FETCH_WORKFLOW,
       payload: {
@@ -368,14 +367,15 @@ export function loadWorkflow(workflowId, locale, preferences) {
         locale
       }
     });
-    return awaitWorkflow(workflowId)
-    .then(function (workflow) {
+    const awaitTranslation = dispatch(translations.load('workflow', workflowId, locale));
+    return Promise.all([awaitWorkflow(workflowId), awaitTranslation])
+    .then(([workflow]) => {
       if (preferences) {
         preferences.save();
       }
       return dispatch(setWorkflow(workflow));
     })
-    .catch(function () {
+    .catch(() => {
       if (preferences) {
         preferences.update({ 'preferences.selected_workflow': undefined });
       }

--- a/app/redux/ducks/classify.js
+++ b/app/redux/ducks/classify.js
@@ -376,6 +376,9 @@ export function loadWorkflow(workflowId, locale, preferences) {
       return dispatch(setWorkflow(workflow));
     })
     .catch(function () {
+      if (preferences) {
+        preferences.update({ 'preferences.selected_workflow': undefined });
+      }
       return dispatch(setWorkflow(null));
     });
   };

--- a/app/redux/ducks/classify.js
+++ b/app/redux/ducks/classify.js
@@ -368,8 +368,7 @@ export function loadWorkflow(workflowId, locale, preferences) {
     if (preferences) {
       preferences.update({ 'preferences.selected_workflow': workflowId });
     }
-    dispatch(setWorkflow(null));
-    dispatch(emptySubjectQueue());
+    dispatch(reset());
     dispatch({
       type: FETCH_WORKFLOW,
       payload: {

--- a/app/redux/ducks/classify.js
+++ b/app/redux/ducks/classify.js
@@ -379,6 +379,10 @@ export function loadWorkflow(workflowId, locale, preferences) {
     const awaitTranslation = dispatch(translations.load('workflow', workflowId, locale));
     return Promise.all([awaitWorkflow(workflowId), awaitTranslation])
     .then(([workflow]) => {
+      if (!workflow) {
+        const error = new Error(`workflow ${workflowId}: empty response from Panoptes.`);
+        throw error;
+      }
       return dispatch(setWorkflow(workflow));
     })
     .catch((error) => {
@@ -387,7 +391,7 @@ export function loadWorkflow(workflowId, locale, preferences) {
         if (preferences) {
           preferences.update({ 'preferences.selected_workflow': undefined });
           if (preferences.settings && preferences.settings.workflow_id === workflowId) {
-            preferences.update({ 'settings.workflow_id' : undefined });
+            preferences.update({ 'settings.workflow_id': undefined });
           }
         }
       }
@@ -405,7 +409,7 @@ export function loadWorkflow(workflowId, locale, preferences) {
 export function reset() {
   return {
     type: RESET
-  }
+  };
 }
 
 export function setWorkflow(workflow) {

--- a/app/redux/ducks/classify.spec.js
+++ b/app/redux/ducks/classify.spec.js
@@ -576,5 +576,164 @@ describe('Classifier actions', function () {
       })
       .then(done, done);
     });
+
+    describe('on error', function () {
+      describe('404 API errors', function () {
+        before(function () {
+          apiClient.type.restore();
+          const fakeError = {
+            status: 404
+          };
+          sinon.stub(apiClient, 'type').callsFake(function (type) {
+            if (type === 'workflows') {
+              return {
+                get: sinon.stub().callsFake(() => Promise.reject(fakeError))
+              };
+            }
+            if (type === 'translations') {
+              const fakeTranslation = {
+                strings: {}
+              };
+              return {
+                get: sinon.stub().callsFake(() => Promise.resolve([fakeTranslation]))
+              };
+            }
+          });
+        });
+
+        it('should clear the workflow ID from user preferences', function (done) {
+          awaitWorkflow
+          .then(function () {
+            expect(fakePreferences.update).to.have.been.calledWith({ 'preferences.selected_workflow': undefined });
+          })
+          .then(done, done);
+        });
+
+        it('should set the stored workflow to null', function (done) {
+          awaitWorkflow
+          .then(function () {
+            expect(storeState.workflow).to.be.null;
+          })
+          .then(done, done);
+        });
+      });
+
+      describe('500 API errors', function () {
+        before(function () {
+          apiClient.type.restore();
+          const fakeError = {
+            status: 500
+          };
+          sinon.stub(apiClient, 'type').callsFake(function (type) {
+            if (type === 'workflows') {
+              return {
+                get: sinon.stub().callsFake(() => Promise.reject(fakeError))
+              };
+            }
+            if (type === 'translations') {
+              const fakeTranslation = {
+                strings: {}
+              };
+              return {
+                get: sinon.stub().callsFake(() => Promise.resolve([fakeTranslation]))
+              };
+            }
+          });
+        });
+
+        it('should not clear the workflow ID from user preferences', function (done) {
+          awaitWorkflow
+          .then(function () {
+            expect(fakePreferences.update).to.not.have.been.calledWith({ 'preferences.selected_workflow': undefined });
+          })
+          .then(done, done);
+        });
+
+        it('should set the stored workflow to null', function (done) {
+          awaitWorkflow
+          .then(function () {
+            expect(storeState.workflow).to.be.null;
+          })
+          .then(done, done);
+        });
+      });
+
+      describe('200 responses with an undefined workflow', function () {
+        before(function () {
+          apiClient.type.restore();
+          sinon.stub(apiClient, 'type').callsFake(function (type) {
+            if (type === 'workflows') {
+              return {
+                get: sinon.stub().callsFake(() => Promise.resolve(undefined))
+              };
+            }
+            if (type === 'translations') {
+              const fakeTranslation = {
+                strings: {}
+              };
+              return {
+                get: sinon.stub().callsFake(() => Promise.resolve([fakeTranslation]))
+              };
+            }
+          });
+        });
+
+        it('should not clear the workflow ID from user preferences', function (done) {
+          awaitWorkflow
+          .then(function () {
+            expect(fakePreferences.update).to.not.have.been.calledWith({ 'preferences.selected_workflow': undefined });
+          })
+          .then(done, done);
+        });
+
+        it('should set the stored workflow to null', function (done) {
+          awaitWorkflow
+          .then(function () {
+            expect(storeState.workflow).to.be.null;
+          })
+          .then(done, done);
+        });
+      });
+
+      describe('translations API errors', function () {
+        before(function () {
+          apiClient.type.restore();
+          const fakeError = {
+            status: 500
+          };
+          sinon.stub(apiClient, 'type').callsFake(function (type) {
+            if (type === 'workflows') {
+              return {
+                get: sinon.stub().callsFake(() => Promise.resolve(fakeWorkflow))
+              };
+            }
+            if (type === 'translations') {
+              const fakeTranslation = {
+                strings: {}
+              };
+              return {
+                get: sinon.stub().callsFake(() => Promise.reject(fakeError))
+              };
+            }
+          });
+        });
+
+        it('should not clear the workflow ID from user preferences', function (done) {
+          awaitWorkflow
+          .then(function () {
+            expect(fakePreferences.update).to.not.have.been.calledWith({ 'preferences.selected_workflow': undefined });
+          })
+          .then(done, done);
+        });
+
+        it('should load a workflow', function (done) {
+          awaitWorkflow
+          .then(function () {
+            expect(storeState.workflow).to.deep.equal(fakeWorkflow);
+          })
+          .then(done, done);
+        });
+      });
+    });
   });
 });

--- a/app/redux/ducks/classify.spec.js
+++ b/app/redux/ducks/classify.spec.js
@@ -528,12 +528,15 @@ describe('Classifier actions', function () {
       fakePreferences.save.resetHistory();
     });
 
-    it('should clear the existing workflow', function () {
-      expect(storeState.workflow).to.be.null;
-    });
-
-    it('should clear the subjectQueue', function () {
-      expect(storeState.upcomingSubjects).to.deep.equal([]);
+    it('should reset the classify store', function () {
+      const expectedState = {
+        classification: null,
+        goldStandardMode: false,
+        intervention: null,
+        upcomingSubjects: [],
+        workflow: null
+      };
+      expect(storeState).to.deep.equal(expectedState);
     });
 
     it('should update user preferences', function () {

--- a/app/redux/ducks/classify.spec.js
+++ b/app/redux/ducks/classify.spec.js
@@ -522,7 +522,7 @@ describe('Classifier actions', function () {
     });
 
     it('should load the workflow translation', function () {
-      const loadTranslations = fakeDispatch.returnValues[2];
+      const loadTranslations = fakeDispatch.returnValues[3];
       const expectedAction = {
         type: 'pfe/translations/LOAD',
         translated_type: 'workflow',


### PR DESCRIPTION
Staging branch URL: https://pr-5124.pfe-preview.zooniverse.org

Add a `loadWorkflows` action creator to the classifier. Given a workflow ID, locale and optional preferences, it clears the current workflow, empties the subject queue, loads the workflow translations, loads the workflow and updates preferences to store the workflow ID. If the API request errors, the stored workflow is set to null and the preference changes are rolled back.

Classifier state is reset before loading a new workflow, which fixes #5149.

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
