### PR TITLE
[WIP] Link workflow translation id to classification

### DIFF
--- a/app/pages/project/classify.jsx
+++ b/app/pages/project/classify.jsx
@@ -54,6 +54,8 @@ export class ProjectClassifyPage extends React.Component {
     Split.classifierVisited();
     if (this.props.workflow) {
       this.loadAppropriateClassification();
+      const { actions, translations } = this.props;
+      actions.classifier.setWorkflowTranslationId(translations.strings.workflow.id);
     }
 
     this.validateUserGroup(this.props, this.context);
@@ -82,10 +84,15 @@ export class ProjectClassifyPage extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { classification, upcomingSubjects, workflow } = this.props;
+    const { actions, classification, upcomingSubjects, workflow, translations } = this.props;
+
+    if (translations !== prevProps.translations) {
+      actions.classifier.setWorkflowTranslationId(translations.strings.workflow.id);
+    }
 
     if (workflow !== prevProps.workflow) {
       this.loadAppropriateClassification();
+      actions.classifier.setWorkflowTranslationId(translations.strings.workflow.id);
     }
 
     if (upcomingSubjects.length !== prevProps.upcomingSubjects.length) {
@@ -322,7 +329,12 @@ ProjectClassifyPage.propTypes = {
   project: PropTypes.object,
   storage: PropTypes.object,
   translations: PropTypes.shape({
-    locale: PropTypes.string
+    locale: PropTypes.string,
+    strings: PropTypes.shape({
+      workflow: PropTypes.shape({ 
+        id: PropTypes.string
+      })
+    })
   }),
   upcomingSubjects: PropTypes.arrayOf(PropTypes.object),
   user: PropTypes.object,

--- a/app/redux/ducks/classify.js
+++ b/app/redux/ducks/classify.js
@@ -32,7 +32,7 @@ function awaitSubjectSet(workflow) {
   }
 }
 
-function createNewClassification(project, workflow, subject, goldStandardMode) {
+function createNewClassification(project, workflow, subject, goldStandardMode, workflowTranslationId) {
   const source = subject.metadata.intervention ? 'sugar' : 'api';
   const classification = apiClient.type('classifications').create({
     annotations: [],
@@ -48,7 +48,8 @@ function createNewClassification(project, workflow, subject, goldStandardMode) {
     links: {
       project: project.id,
       workflow: workflow.id,
-      subjects: [subject.id]
+      subjects: [subject.id],
+      translation: workflowTranslationId
     }
   });
 
@@ -96,6 +97,7 @@ const initialState = {
   classification: null,
   goldStandardMode: false,
   intervention: null,
+  workflowTranslationId: '',
   upcomingSubjects: [],
   workflow: null
 };
@@ -112,6 +114,7 @@ const RESUME_CLASSIFICATION = 'pfe/classify/RESUME_CLASSIFICATION';
 const RESET_SUBJECTS = 'pfe/classify/RESET_SUBJECTS';
 const SAVE_ANNOTATIONS = 'pfe/classify/SAVE_ANNOTATIONS';
 const SET_WORKFLOW = 'pfe/classify/SET_WORKFLOW';
+const SET_WORKFLOW_TRANSLATION_ID = 'pfe/classify/SET_WORKFLOW_TRANSLATION_ID';
 const TOGGLE_GOLD_STANDARD = 'pfe/classify/TOGGLE_GOLD_STANDARD';
 
 export default function reducer(state = initialState, action = {}) {
@@ -145,9 +148,10 @@ export default function reducer(state = initialState, action = {}) {
       const { goldStandardMode } = state;
       const { project } = action.payload;
       const { workflow } = state;
+      const { workflowTranslationId } = state;
       if (state.upcomingSubjects.length > 0) {
         const subject = state.upcomingSubjects[0];
-        const classification = createNewClassification(project, workflow, subject, goldStandardMode);
+        const classification = createNewClassification(project, workflow, subject, goldStandardMode, workflowTranslationId);
         const intervention = null;
         return Object.assign({}, state, { classification, intervention });
       }
@@ -162,11 +166,12 @@ export default function reducer(state = initialState, action = {}) {
       const { goldStandardMode } = state;
       const { project } = action.payload;
       const { workflow } = state;
+      const { workflowTranslationId } = state;
       const upcomingSubjects = state.upcomingSubjects.slice();
       upcomingSubjects.shift();
       const subject = upcomingSubjects[0];
       if (subject) {
-        const classification = createNewClassification(project, workflow, subject, goldStandardMode);
+        const classification = createNewClassification(project, workflow, subject, goldStandardMode, workflowTranslationId);
         const intervention = null;
         return Object.assign({}, state, { classification, intervention, upcomingSubjects });
       }
@@ -214,6 +219,10 @@ export default function reducer(state = initialState, action = {}) {
     case SET_WORKFLOW: {
       const { workflow } = action.payload;
       return Object.assign({}, state, { workflow });
+    }
+    case SET_WORKFLOW_TRANSLATION_ID: {
+      const { workflowTranslationId } = action.payload;
+      return Object.assign({}, state, { workflowTranslationId });
     }
     case TOGGLE_GOLD_STANDARD: {
       const { goldStandard } = action.payload;
@@ -350,6 +359,13 @@ export function setWorkflow(workflow) {
   return {
     type: SET_WORKFLOW,
     payload: { workflow }
+  };
+}
+
+export function setWorkflowTranslationId(workflowTranslationId) {
+  return {
+    type: SET_WORKFLOW_TRANSLATION_ID,
+    payload: { workflowTranslationId }
   };
 }
 

--- a/app/redux/ducks/translations.js
+++ b/app/redux/ducks/translations.js
@@ -50,7 +50,7 @@ const initialState = {
 
 // Reducer
 export default function reducer(state = initialState, action = {}) {
-  let type, languageStrings, strings, translations;
+  let type, id, languageStrings, strings, translations;
   switch (action.type) {
     case SET_LANGUAGES:
       const languages = Object.assign({}, state.languages, { [action.payload.type]: action.payload.languages });
@@ -60,8 +60,8 @@ export default function reducer(state = initialState, action = {}) {
       const rtl = RTL_LANGUAGES.indexOf(locale) > -1;
       return Object.assign({}, state, { locale, rtl });
     case SET_TRANSLATION:
-      ({ type, languageStrings } = action.payload);
-      let translation = {};
+      ({ type, id, languageStrings } = action.payload);
+      let translation = { id: id };
       Object.keys(languageStrings).map((translationKey) => {
         const newTranslation = explodeTranslationKey(translationKey, languageStrings[translationKey]);
         translation = merge(translation, newTranslation);
@@ -121,6 +121,7 @@ export function load(resource_type, translated_id, language) {
             type: SET_TRANSLATION,
             payload: {
               type: resource_type,
+              id: translation.id,
               languageStrings: translation.strings
             }
           });
@@ -129,6 +130,7 @@ export function load(resource_type, translated_id, language) {
             type: SET_TRANSLATION,
             payload: {
               type: resource_type,
+              id: '',
               languageStrings: {}
             }
           });
@@ -189,4 +191,3 @@ export function setLocale(locale) {
   counterpart.setLocale(locale);
   return { type: SET_LOCALE, payload: locale };
 }
-


### PR DESCRIPTION
UPDATE: linking classification and translation less preferable than storing in metadata (related PR incoming)

Staging branch URL:

Towards #5125.

Links workflow translation to classification.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
