### PR TITLE
Add simple URL checks to the external URL editor

### DIFF
--- a/app/pages/lab/external-links-editor.jsx
+++ b/app/pages/lab/external-links-editor.jsx
@@ -64,6 +64,7 @@ export default class ExternalLinksEditor extends React.Component {
           <input
             type="text"
             name={`urls.${idx}.label`}
+            required
             value={link.label}
             onChange={handleInputChange.bind(this.props.project)}
             onMouseDown={this.handleDisableDrag}
@@ -72,8 +73,10 @@ export default class ExternalLinksEditor extends React.Component {
         </AutoSave>
         <AutoSave tag="td" resource={this.props.project}>
           <input
-            type="text"
+            type="url"
             name={`urls.${idx}.url`}
+            pattern="https?://.+"
+            required
             value={link.url}
             onChange={handleInputChange.bind(this.props.project)}
             onMouseDown={this.handleDisableDrag}

--- a/app/pages/lab/external-links-editor.jsx
+++ b/app/pages/lab/external-links-editor.jsx
@@ -2,7 +2,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import DragReorderable from 'drag-reorderable';
 import AutoSave from '../../components/auto-save.coffee';
-import handleInputChange from '../../lib/handle-input-change.coffee';
 
 export default class ExternalLinksEditor extends React.Component {
   constructor(props) {
@@ -10,6 +9,7 @@ export default class ExternalLinksEditor extends React.Component {
     this.handleAddLink = this.handleAddLink.bind(this);
     this.handleLinkReorder = this.handleLinkReorder.bind(this);
     this.handleRemoveLink = this.handleRemoveLink.bind(this);
+    this.handleLinkChange = this.handleLinkChange.bind(this);
     this.renderRow = this.renderRow.bind(this);
     this.renderTable = this.renderTable.bind(this);
   }
@@ -47,6 +47,17 @@ export default class ExternalLinksEditor extends React.Component {
     }
   }
 
+  handleLinkChange(event) {
+    const { project } = this.props;
+    const { name, type, value } = event.target;
+    let sanitisedValue = value;
+    if (type === 'url' && value.length > 4) {
+      const isURL = value.substring(0, 4) === 'http';
+      sanitisedValue = isURL ? value : '';
+    }
+    project.update({ [name]: sanitisedValue });
+  }
+
   handleDisableDrag(event) {
     event.target.parentElement.parentElement.setAttribute('draggable', false);
   }
@@ -66,7 +77,7 @@ export default class ExternalLinksEditor extends React.Component {
             name={`urls.${idx}.label`}
             required
             value={link.label}
-            onChange={handleInputChange.bind(this.props.project)}
+            onChange={this.handleLinkChange}
             onMouseDown={this.handleDisableDrag}
             onMouseUp={this.handleEnableDrag}
           />
@@ -78,7 +89,7 @@ export default class ExternalLinksEditor extends React.Component {
             pattern="https?://.+"
             required
             value={link.url}
-            onChange={handleInputChange.bind(this.props.project)}
+            onChange={this.handleLinkChange}
             onMouseDown={this.handleDisableDrag}
             onMouseUp={this.handleEnableDrag}
           />


### PR DESCRIPTION
Make both text inputs required.
Use input[type=url] for URLs and add simple pattern matching for http[s]:// URLs.
Add some string validation on change for both inputs.

Staging branch URL: https://pr-5140.pfe-preview.zooniverse.org

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
