### PR TITLE
Dont render invalid urls on Project home page

### DIFF
--- a/app/components/ExternalLinksBlock/ExternalLinksBlockContainer.jsx
+++ b/app/components/ExternalLinksBlock/ExternalLinksBlockContainer.jsx
@@ -9,11 +9,17 @@ export default class ExternalLinksBlockContainer extends React.Component {
 
     const partitionedLinks = _.partition(allExternalLinks, link => (link.site));
 
-    const external = partitionedLinks[1].map(link => ({
-      isExternalLink: true,
-      label: link.label,
-      url: link.url
-    }));
+    const external = partitionedLinks[1]
+      .map(link => {
+        if (isURL(link.url)) {
+          return {
+            isExternalLink: true,
+            label: link.label,
+            url: link.url
+          }
+        }
+      })
+      .filter(link => link);
 
     const social = partitionedLinks[0].map(link => ({
       isExternalLink: true,
@@ -42,4 +48,8 @@ export default class ExternalLinksBlockContainer extends React.Component {
 
     return null;
   }
+}
+
+function isURL(str) {
+  return str.substring(0, 4) === 'http';
 }


### PR DESCRIPTION
Staging branch URL: https://dont-render-invalid-urls.pfe-preview.zooniverse.org/

Related to #5140, prevents a suspicious URL from being rendered on the project home page.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
