### PR TITLE
Implement XSS safety - External links on Project pages are now rendered in Markdown

### DIFF
--- a/app/components/ExternalLinksBlock/ExternalLinksBlock.jsx
+++ b/app/components/ExternalLinksBlock/ExternalLinksBlock.jsx
@@ -26,19 +26,18 @@ export const StyledExternalLinksBlock = styled.div`
       margin-top: 1.5em;
     }
 
-      a i {
-        margin: 0 1ch;
+      a {
         text-decoration: none;
       }
 
-        &:hover, &:focus {
-          text-decoration: none;
-        }
+      a:hover, a:focus {
+        text-decoration: underline;
+      }
 
-      .link-title:hover, .link-title:focus {
-          text-decoration: underline;
-        }
-
+      i {
+        margin: 0 1ch;
+        text-decoration: none;
+      }
 `;
 
 export const StyledExternalLink = styled(ExternalLink)`

--- a/app/components/ExternalLinksBlock/components/ExternalLink/ExternalLink.jsx
+++ b/app/components/ExternalLinksBlock/components/ExternalLink/ExternalLink.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { socialIcons } from '../../../../lib/nav-helpers';
+import { Markdown } from 'markdownz';
 
 export default function ExternalLink({ className, isExternalLink, isSocialLink, label, path, site, url }) {
   let iconClasses;
@@ -8,8 +9,6 @@ export default function ExternalLink({ className, isExternalLink, isSocialLink, 
   const linkProps = {
     className,
     href: url,
-    rel: 'noopener noreferrer',
-    target: '_blank'
   };
 
   if (isExternalLink) {
@@ -18,17 +17,18 @@ export default function ExternalLink({ className, isExternalLink, isSocialLink, 
 
   if (isSocialLink) {
     const icon = socialIcons[site].icon;
-    linkProps['aria-label'] = socialIcons[site].ariaLabel;
     iconClasses = `fa ${icon} fa-fw`;
     linkLabel = path;
   }
 
   if (isExternalLink || isSocialLink) {
     return (
-      <a {...linkProps}>
-        <span className="link-title">{linkLabel}</span>
+      <div className={linkProps.className}>
+        <Markdown tag="span" className="link-title" inline={true}>
+          {`[${linkLabel}](+tab+${linkProps.href})`}
+        </Markdown>
         {iconClasses && <i className={iconClasses} />}
-      </a>
+      </div>
     );
   }
 

--- a/app/components/ExternalLinksBlock/components/ExternalLink/ExternalLink.spec.jsx
+++ b/app/components/ExternalLinksBlock/components/ExternalLink/ExternalLink.spec.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import { expect } from 'chai';
 import ExternalLink from './ExternalLink';
 import { socialIcons } from '../../../../lib/nav-helpers';
@@ -25,23 +25,20 @@ describe('ExternalLink', function() {
   });
 
   describe('when the link is external', function() {
-    let wrapper;
+    let wrapper, markdownLink, markdownHtml;
     before(function() {
-      wrapper = shallow(
+      wrapper = mount(
         <ExternalLink
           isExternalLink={true}
           url={MOCK_EXTERNAL_URL}
         />
       );
+      markdownLink = wrapper.find('span.link-title');
+      markdownHtml = markdownLink.props().dangerouslySetInnerHTML.__html;
     });
 
-    it('should add props to open the url in a new tab', function () {
-      expect(wrapper.props().target).to.equal('_blank');
-      expect(wrapper.props().rel).to.equal('noopener noreferrer');
-    });
-
-    it('should use props.url for the href', function () {
-      expect(wrapper.props().href).to.equal(MOCK_EXTERNAL_URL);
+    it('should render the markdown hyperlink correctly', function () {
+      expect(markdownHtml).to.equal('<a href="https://www.google.com" target="_blank" ref="noopener nofollow"></a>')
     });
 
     it('should have the Font Awesome external link icon', function () {
@@ -50,9 +47,9 @@ describe('ExternalLink', function() {
   });
 
   describe('when the link is to social media', function () {
-    let wrapper;
+    let wrapper, markdownLink, markdownHtml;
     before(function() {
-      wrapper = shallow(
+      wrapper = mount(
         <ExternalLink
           isExternalLink={true}
           isSocialLink={true}
@@ -60,21 +57,14 @@ describe('ExternalLink', function() {
           site={MOCK_SOCIAL_SITE}
           url={MOCK_SOCIAL_URL}
         />);
+      markdownLink = wrapper.find('span.link-title');
+      markdownHtml = markdownLink.props().dangerouslySetInnerHTML.__html;
     });
 
-    it('should add props for the aria-label', function () {
-      expect(wrapper.props()['aria-label']).to.equal(socialIcons[MOCK_SOCIAL_SITE].ariaLabel);
+    it('should render the markdown hyperlink correctly', function () {
+      expect(markdownHtml).to.equal('<a href="https://www.facebook.com/my-profile" target="_blank" ref="noopener nofollow">my-profile</a>')
     });
-
-    it('should add props to open the url in a new tab', function () {
-      expect(wrapper.props().target).to.equal('_blank');
-      expect(wrapper.props().rel).to.equal('noopener noreferrer');
-    });
-
-    it('should use props.url for the href', function () {
-      expect(wrapper.props().href).to.equal(MOCK_SOCIAL_URL);
-    });
-
+    
     it('should use the correct font awesome icon', function () {
       expect(wrapper.find('i').hasClass(socialIcons[MOCK_SOCIAL_SITE].icon)).to.be.true;
     });


### PR DESCRIPTION
## PR Overview
This PR fixes an XSS vulnerability on External links of the Project pages, by rendering the External links in Markdown (which auto-sanitises the URLs)

Fixes #5138

Staging branch: https://fix-xss.pfe-preview.zooniverse.org

![screen shot 2018-12-11 at 16 59 48](https://user-images.githubusercontent.com/13952701/49816996-07419f00-fd67-11e8-94c3-8a9729a8c966.png)
_Screenshot shows an example project with an External Link that has JavaScript code as its URL. The <Markdown> element prevents the code from rendering properly._

![screen shot 2018-12-11 at 17 01 39](https://user-images.githubusercontent.com/13952701/49817884-54bf0b80-fd69-11e8-9a7d-d4f134a52d4d.png)
_The external links on the example project, without the new fixes in this PR._

Minor side effects of this PR:
- Invalid URLs are no longer rendered as hyperlinks - it looks terrible when this happens, but it's safer than the current behaviour.
- Small style changes - note that the icons are no longer clickable.

### Primary Testing

Baseline comparison (without fixes in branch):
- go to https://master.pfe-preview.zooniverse.org/projects/darkeshard/transformers
- Find the external link on the Project Home page, titled "DECEPTICON HACK", which has the "URL": `javascript:alert('mwa ha ha')`
- Click on the link. The JavaScript `alert` should trigger, which indicates an XSS vulnerability. ☠️ (Users should not be able to run their own custom JavaScript code on their Project pages. Or anywhere, really.)

Fix confirmation:
- go to https://fix-xss.pfe-preview.zooniverse.org/projects/darkeshard/transformers
- Find the external link on the Project Home page, titled "DECEPTICON HACK". _It should not render as a hyperlink that can be clicked._
- The "link" should be unclickable, and the JavaScript `alert` should not be able to trigger. 👍  

### Basic Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [ ] Does talk load correctly?
- [x] Can you post a talk comment?

### Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] ~~If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?~~
- [ ] Are the tests passing locally and on Travis?

### Status
Priority patch. Ready for review. Tagging @eatyourgreens and @camallen 