### PR TITLE
don't render a link as a fallback

### DIFF
--- a/app/components/ExternalLinksBlock/components/ExternalLink/ExternalLink.jsx
+++ b/app/components/ExternalLinksBlock/components/ExternalLink/ExternalLink.jsx
@@ -25,10 +25,10 @@ export default function ExternalLink({ className, isExternalLink, isSocialLink, 
 
   if (isExternalLink || isSocialLink) {
     return (
-      <a {...linkProps}>
+      <span>
         <span className="link-title">{linkLabel}</span>
         {iconClasses && <i className={iconClasses} />}
-      </a>
+      </span>
     );
   }
 

--- a/app/components/ExternalLinksBlock/components/ExternalLink/ExternalLink.spec.jsx
+++ b/app/components/ExternalLinksBlock/components/ExternalLink/ExternalLink.spec.jsx
@@ -35,12 +35,12 @@ describe('ExternalLink', function() {
       );
     });
 
-    it('should add props to open the url in a new tab', function () {
+    xit('should add props to open the url in a new tab', function () {
       expect(wrapper.props().target).to.equal('_blank');
       expect(wrapper.props().rel).to.equal('noopener noreferrer');
     });
 
-    it('should use props.url for the href', function () {
+    xit('should use props.url for the href', function () {
       expect(wrapper.props().href).to.equal(MOCK_EXTERNAL_URL);
     });
 
@@ -62,16 +62,16 @@ describe('ExternalLink', function() {
         />);
     });
 
-    it('should add props for the aria-label', function () {
+    xit('should add props for the aria-label', function () {
       expect(wrapper.props()['aria-label']).to.equal(socialIcons[MOCK_SOCIAL_SITE].ariaLabel);
     });
 
-    it('should add props to open the url in a new tab', function () {
+    xit('should add props to open the url in a new tab', function () {
       expect(wrapper.props().target).to.equal('_blank');
       expect(wrapper.props().rel).to.equal('noopener noreferrer');
     });
 
-    it('should use props.url for the href', function () {
+    xit('should use props.url for the href', function () {
       expect(wrapper.props().href).to.equal(MOCK_SOCIAL_URL);
     });
 


### PR DESCRIPTION
Staging branch URL:

Fixes # .

ExternalLink will render as a label. Ignore this PR if others are successfully merged.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
