### PR TITLE
Restore social link ARIA labels

### DIFF
--- a/app/components/ExternalLinksBlock/ExternalLinksBlockContainer.jsx
+++ b/app/components/ExternalLinksBlock/ExternalLinksBlockContainer.jsx
@@ -22,7 +22,7 @@ export default class ExternalLinksBlockContainer extends React.Component {
       .filter(link => link);
 
     const social = partitionedLinks[0].map(link => ({
-      isExternalLink: true,
+      isExternalLink: false,
       isSocialLink: true,
       label: link.label,
       path: link.path,

--- a/app/components/ExternalLinksBlock/components/ExternalLink/ExternalLink.jsx
+++ b/app/components/ExternalLinksBlock/components/ExternalLink/ExternalLink.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { socialIcons } from '../../../../lib/nav-helpers';
 import { Markdown } from 'markdownz';
+import { socialIcons } from '../../../../lib/nav-helpers';
 
 export default function ExternalLink({ className, isExternalLink, isSocialLink, label, path, site, url }) {
   let iconClasses;
@@ -9,19 +9,12 @@ export default function ExternalLink({ className, isExternalLink, isSocialLink, 
   const linkProps = {
     className,
     href: url,
+    rel: 'noopener noreferrer',
+    target: '_blank'
   };
 
   if (isExternalLink) {
     iconClasses = 'fa fa-external-link fa-fw';
-  }
-
-  if (isSocialLink) {
-    const icon = socialIcons[site].icon;
-    iconClasses = `fa ${icon} fa-fw`;
-    linkLabel = path;
-  }
-
-  if (isExternalLink || isSocialLink) {
     return (
       <div className={linkProps.className}>
         <Markdown tag="span" className="link-title" inline={true}>
@@ -29,6 +22,19 @@ export default function ExternalLink({ className, isExternalLink, isSocialLink, 
         </Markdown>
         {iconClasses && <i className={iconClasses} />}
       </div>
+    );
+  }
+
+  if (isSocialLink) {
+    const icon = socialIcons[site].icon;
+    iconClasses = `fa ${icon} fa-fw`;
+    linkLabel = path;
+    linkProps['aria-label'] = socialIcons[site].ariaLabel;
+    return (
+      <a {...linkProps}>
+        <span className="link-title">{linkLabel}</span>
+        {iconClasses && <i className={iconClasses} />}
+      </a>
     );
   }
 

--- a/app/components/ExternalLinksBlock/components/ExternalLink/ExternalLink.jsx
+++ b/app/components/ExternalLinksBlock/components/ExternalLink/ExternalLink.jsx
@@ -30,12 +30,15 @@ export default function ExternalLink({ className, isExternalLink, isSocialLink, 
     iconClasses = `fa ${icon} fa-fw`;
     linkLabel = path;
     linkProps['aria-label'] = socialIcons[site].ariaLabel;
-    return (
-      <a {...linkProps}>
-        <span className="link-title">{linkLabel}</span>
-        {iconClasses && <i className={iconClasses} />}
-      </a>
-    );
+    const isValidLink = !!icon && linkProps.href.substring(0, 8) === 'https://';
+    if (isValidLink) {
+      return (
+        <a {...linkProps}>
+          <span className="link-title">{linkLabel}</span>
+          {iconClasses && <i className={iconClasses} />}
+        </a>
+      );
+    }
   }
 
   return null;

--- a/app/components/ExternalLinksBlock/components/ExternalLink/ExternalLink.spec.jsx
+++ b/app/components/ExternalLinksBlock/components/ExternalLink/ExternalLink.spec.jsx
@@ -47,30 +47,37 @@ describe('ExternalLink', function() {
   });
 
   describe('when the link is to social media', function () {
-    let wrapper, markdownLink, markdownHtml;
-    before(function() {
-      wrapper = mount(
-        <ExternalLink
-          isExternalLink={true}
-          isSocialLink={true}
-          path={MOCK_SOCIAL_PATH}
-          site={MOCK_SOCIAL_SITE}
-          url={MOCK_SOCIAL_URL}
-        />);
-      markdownLink = wrapper.find('span.link-title');
-      markdownHtml = markdownLink.props().dangerouslySetInnerHTML.__html;
-    });
+      let wrapper;
+      before(function() {
+        wrapper = shallow(
+          <ExternalLink
+            isExternalLink={false}
+            isSocialLink={true}
+            path={MOCK_SOCIAL_PATH}
+            site={MOCK_SOCIAL_SITE}
+            url={MOCK_SOCIAL_URL}
+          />);
+      });
 
-    it('should render the markdown hyperlink correctly', function () {
-      expect(markdownHtml).to.equal('<a href="https://www.facebook.com/my-profile" target="_blank" ref="noopener nofollow">my-profile</a>')
-    });
-    
-    it('should use the correct font awesome icon', function () {
-      expect(wrapper.find('i').hasClass(socialIcons[MOCK_SOCIAL_SITE].icon)).to.be.true;
-    });
+      it('should add props for the aria-label', function () {
+        expect(wrapper.props()['aria-label']).to.equal(socialIcons[MOCK_SOCIAL_SITE].ariaLabel);
+      });
 
-    it('should use prop.path as the label', function () {
-      expect(wrapper.text().includes(MOCK_SOCIAL_PATH)).to.be.true;
+      it('should add props to open the url in a new tab', function () {
+        expect(wrapper.props().target).to.equal('_blank');
+        expect(wrapper.props().rel).to.equal('noopener noreferrer');
+      });
+
+      it('should use props.url for the href', function () {
+        expect(wrapper.props().href).to.equal(MOCK_SOCIAL_URL);
+      });
+
+      it('should use the correct font awesome icon', function () {
+        expect(wrapper.find('i').hasClass(socialIcons[MOCK_SOCIAL_SITE].icon)).to.be.true;
+      });
+
+      it('should use prop.path as the label', function () {
+        expect(wrapper.text().includes(MOCK_SOCIAL_PATH)).to.be.true;
+      });
     });
-  });
 });


### PR DESCRIPTION
Restore social media link rendering that was removed in #5142, so that the social media icons have accessible labels again.

https://pr-5146.pfe-preview.zooniverse.org

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
