### PR TITLE
Classifier: Load tutorial translations on props change

### DIFF
--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -85,23 +85,24 @@ ClassifierWrapper = createReactClass
       this.props.actions.translations.load('tutorial', tutorial.id, this.props.translations.locale) if tutorial?
       this.props.actions.translations.load('minicourse', minicourse.id, this.props.translations.locale) if minicourse?
 
-  componentWillReceiveProps: (nextProps) ->
-    if nextProps.workflow isnt @props.workflow
-      Tutorial.find nextProps.workflow
+    if prevProps.workflow isnt @props.workflow
+      Tutorial.find @props.workflow
       .then (tutorial) =>
-        {user, preferences} = nextProps
+        {user, preferences} = @props
         Tutorial.startIfNecessary tutorial, user, preferences, @context.geordi, @context.store
         @setState {tutorial}
-      MiniCourse.find nextProps.workflow
+        this.props.actions.translations.load('tutorial', tutorial.id, this.props.translations.locale) if tutorial?
+      MiniCourse.find @props.workflow
       .then (minicourse) =>
         @setState {minicourse}
+        this.props.actions.translations.load('minicourse', minicourse.id, this.props.translations.locale) if minicourse?
 
-    if @props.user isnt nextProps.user
+    if @props.user isnt prevProps.user
       @setState expertClassifier: null
-      @checkExpertClassifier nextProps
+      @checkExpertClassifier @props
 
-    unless nextProps.classification is @props.classification
-      @loadClassificationsCount nextProps.subject
+    unless prevProps.classification is @props.classification
+      @loadClassificationsCount @props.subject
 
   onComplete: ->
     classificationsThisSession += 1


### PR DESCRIPTION
Add translations.load actions for tutorials and minicourses if they are reloaded after a props change in the ClassifierWrapper.
Remove componentWillReceiveProps from the ClassifierWrapper and replace it with componentDidUpdate.

Staging branch URL:

Fixes #5151.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
