### PR TITLE
Add translations actions tests

### DIFF
--- a/app/redux/ducks/translations.js
+++ b/app/redux/ducks/translations.js
@@ -80,12 +80,16 @@ export default function reducer(state = initialState, action = {}) {
 // Action Creators
 export function listLanguages(translated_type, translated_id) {
   return (dispatch) => {
-    dispatch({ type: LOAD, payload: { translated_type, translated_id} });
-    apiClient
+    dispatch({
+      type: LOAD,
+      translated_type,
+      translated_id
+    });
+    return apiClient
       .type('translations')
       .get({ translated_type, translated_id })
       .then((translations) => {
-        dispatch({
+        return dispatch({
           type: SET_LANGUAGES,
           payload: {
             type: translated_type,
@@ -94,7 +98,7 @@ export function listLanguages(translated_type, translated_id) {
         });
       })
       .catch((error) => {
-        dispatch({ type: ERROR, payload: error });
+        return dispatch({ type: ERROR, payload: error });
       });
   };
 }

--- a/app/redux/ducks/translations.spec.js
+++ b/app/redux/ducks/translations.spec.js
@@ -1,0 +1,194 @@
+import apiClient from 'panoptes-client/lib/api-client';
+import { expect } from 'chai';
+import counterpart from 'counterpart';
+import sinon from 'sinon';
+import mockPanoptesResource from '../../../test/mock-panoptes-resource';
+import reducer, { load, listLanguages, setLocale } from './translations';
+
+describe('translations actions', function () {
+  let state;
+  let newState;
+  const initialState = {
+    locale: 'en',
+    languages: {
+      project: []
+    },
+    rtl: false,
+    strings: {
+      project: {},
+      workflow: {},
+      tutorial: {},
+      minicourse: {},
+      field_guide: {},
+      project_page: {}
+    }
+  };
+  const fakeDispatch = sinon.stub().callsFake(function (action) {
+    if (typeof action === 'function') {
+      action = action(fakeDispatch);
+    }
+    return reducer(state, action);
+  });
+
+  const fakeTranslation = mockPanoptesResource('translations', {
+    id: '456',
+    translated_type: 'Workflow',
+    translated_id: '123',
+    strings: {
+      'tasks.T0.question': 'How are you?',
+      'tasks.T0.answers.0.label': 'Good',
+      'tasks.T0.answers.1.label': 'Bad'
+    }
+  });
+
+  before(function () {
+    sinon.stub(counterpart, 'setLocale');
+  });
+
+  after(function () {
+    counterpart.setLocale.restore();
+  });
+
+  beforeEach(function () {
+    state = initialState;
+  });
+
+  describe('load', function () {
+    let awaitTranslations;
+
+    before(function () {
+      sinon.stub(apiClient, 'type').callsFake(function (type) {
+        return {
+          get: sinon.stub().callsFake(function () {
+            return Promise.resolve([fakeTranslation]);
+          })
+        };
+      });
+      awaitTranslations = load('workflow', '123', 'es')(fakeDispatch);
+    });
+
+    after(function () {
+      apiClient.type.restore();
+      counterpart.setLocale.resetHistory();
+      fakeDispatch.resetHistory();
+    });
+
+    it('should set the counterpart locale', function () {
+      expect(counterpart.setLocale).to.have.been.calledOnce;
+      expect(counterpart.setLocale).to.have.been.calledWith('es');
+    });
+
+    it('should dispatch a load action', function () {
+      const load = {
+        type: 'pfe/translations/LOAD',
+        translated_type: 'workflow',
+        translated_id: '123',
+        language: 'es'
+      };
+      expect(fakeDispatch.firstCall).to.have.been.calledWith(load);
+    });
+
+    it('should load the expected translation', function (done) {
+      awaitTranslations.then(function (newState) {
+        expect(newState.strings.workflow['123'].id).to.equal(fakeTranslation.id);
+      })
+      .then(done, done);
+    });
+
+    it('should explode translation strings into nested objects for backwards compatibility with old projects', function (done) {
+      const tasks = {
+        T0: {
+          question: fakeTranslation.strings['tasks.T0.question'],
+          answers: {
+            0: {
+              label: fakeTranslation.strings['tasks.T0.answers.0.label']
+            },
+            1: {
+              label: fakeTranslation.strings['tasks.T0.answers.1.label']
+            }
+          }
+        }
+      };
+      awaitTranslations.then(function (newState) {
+        expect(newState.strings.workflow['123'].strings.tasks).to.deep.equal(tasks);
+      })
+      .then(done, done);
+    });
+
+    it('should not change state', function () {
+      expect(state).to.deep.equal(initialState);
+    });
+  });
+
+  describe('listLanguages', function () {
+    let awaitLanguages;
+    const fakeTranslations = [
+      { language: 'es'},
+      { language: 'en'}
+    ];
+
+    before(function () {
+      sinon.stub(apiClient, 'type').callsFake(function (type) {
+        return {
+          get: sinon.stub().callsFake(function () {
+            return Promise.resolve(fakeTranslations);
+          })
+        };
+      });
+      awaitLanguages = listLanguages('project', '123')(fakeDispatch);
+    });
+
+    after(function () {
+      apiClient.type.restore();
+      fakeDispatch.resetHistory();
+    });
+
+    it('should dispatch a load action', function () {
+      const load = {
+        type: 'pfe/translations/LOAD',
+        translated_type: 'project',
+        translated_id: '123'
+      };
+      expect(fakeDispatch.firstCall).to.have.been.calledWith(load);
+    });
+
+    it('should list the expected languages', function (done) {
+      awaitLanguages.then(function (newState) {
+        expect(newState.languages.project).to.deep.equal(['es', 'en']);
+      })
+      .then(done, done);
+    });
+
+    it('should not change state', function () {
+      expect(state).to.deep.equal(initialState);
+    });
+  });
+
+  describe('setLocale', function () {
+    before(function () {
+      newState = fakeDispatch(setLocale('es'));
+    });
+
+    it('should set the locale', function () {
+      expect(newState.locale).to.equal('es');
+    });
+
+    it('should set the counterpart locale', function () {
+      expect(counterpart.setLocale).to.have.been.calledOnce;
+      expect(counterpart.setLocale).to.have.been.calledWith('es');
+    });
+
+    it('should not set the rtl flag for ltr languages', function () {
+      expect(newState.rtl).to.be.false;
+    });
+
+    it('should set the rtl flag for rtl languages', function () {
+      newState = fakeDispatch(setLocale('he'));
+      expect(newState.rtl).to.be.true;
+    });
+
+    it('should not change state', function () {
+      expect(state).to.deep.equal(initialState);
+    });
+  });
+});


### PR DESCRIPTION
Add tests for translations load, listLanguages and setLocale.
Update listLanguages action to be testable and consistent with load action.

Staging branch URL: https://pr-5154.pfe-preview.zooniverse.org

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
