### PR TITLE
Fix mini-course translation API errors

### DIFF
--- a/app/classifier/index.cjsx
+++ b/app/classifier/index.cjsx
@@ -77,13 +77,13 @@ ClassifierWrapper = createReactClass
     MiniCourse.find @props.workflow
     .then (minicourse) =>
       @setState {minicourse}
-      this.props.actions.translations.load('minicourse', minicourse.id, this.props.translations.locale) if minicourse?
+      this.props.actions.translations.load('tutorial', minicourse.id, this.props.translations.locale) if minicourse?
 
   componentDidUpdate: (prevProps) ->
     { tutorial, minicourse } = @state
     if prevProps.translations.locale isnt this.props.translations.locale
       this.props.actions.translations.load('tutorial', tutorial.id, this.props.translations.locale) if tutorial?
-      this.props.actions.translations.load('minicourse', minicourse.id, this.props.translations.locale) if minicourse?
+      this.props.actions.translations.load('tutorial', minicourse.id, this.props.translations.locale) if minicourse?
 
   componentWillReceiveProps: (nextProps) ->
     if nextProps.workflow isnt @props.workflow

--- a/app/classifier/mini-course.cjsx
+++ b/app/classifier/mini-course.cjsx
@@ -43,7 +43,7 @@ module.exports = createReactClass
         awaitMiniCourseMedia.then (mediaByID) =>
           minicourseContent =
             <Provider store={store}>
-              <Translations original={minicourse} type="minicourse">
+              <Translations original={minicourse} type="tutorial">
                 <MiniCourseComponent projectPreferences={projectPreferences} user={user} minicourse={minicourse} media={mediaByID} geordi={geordi} />
               </Translations>
             </Provider>


### PR DESCRIPTION
We now store translations by translated type and translated ID, so we can store more than one tutorial translation at a time. Replace the old minicourse translation type with tutorial.

Staging branch URL: https://pr-5166.pfe-preview.zooniverse.org

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
