### PR TITLE
Validate project assigned workflows

### DIFF
--- a/app/pages/project/classify.jsx
+++ b/app/pages/project/classify.jsx
@@ -149,14 +149,21 @@ export class ProjectClassifyPage extends React.Component {
 
   shouldWorkflowAssignmentPrompt(nextProps) {
     // Only for Gravity Spy which is assigning workflows to logged in users
+    const { preferences, project, workflow } = this.props;
     if (nextProps.project.experimental_tools.indexOf('workflow assignment') > -1) {
       const assignedWorkflowID = nextProps.preferences &&
         nextProps.preferences.settings &&
         nextProps.preferences.settings.workflow_id;
-      const currentWorkflowID = this.props.preferences && this.props.preferences.preferences.selected_workflow;
+      const currentWorkflowID = workflow && workflow.id;
       if (assignedWorkflowID && currentWorkflowID && assignedWorkflowID !== currentWorkflowID) {
-        if (this.state.promptWorkflowAssignmentDialog === false) {
-          this.setState({ promptWorkflowAssignmentDialog: true });
+        const isActiveWorkflow = project.links.active_workflows &&
+          project.links.active_workflows.indexOf(assignedWorkflowID) > -1;
+        if (isActiveWorkflow) {
+          if (this.state.promptWorkflowAssignmentDialog === false) {
+            this.setState({ promptWorkflowAssignmentDialog: true });
+          }
+        } else {
+          preferences.update({ 'settings.workflow_id': undefined }).save();
         }
       }
     }

--- a/app/pages/project/classify.jsx
+++ b/app/pages/project/classify.jsx
@@ -62,10 +62,6 @@ export class ProjectClassifyPage extends React.Component {
   }
 
   componentWillReceiveProps(nextProps, nextContext) {
-    if (nextProps.user !== null) {
-      this.shouldWorkflowAssignmentPrompt(nextProps, nextContext);
-    }
-
     const currentGroup = this.props.location.query && this.props.location.query.group;
     const nextGroup = nextProps.location.query && nextProps.location.query.group;
 
@@ -84,7 +80,11 @@ export class ProjectClassifyPage extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { classification, upcomingSubjects, workflow } = this.props;
+    const { classification, upcomingSubjects, user, workflow } = this.props;
+
+    if (user !== null) {
+      this.shouldWorkflowAssignmentPrompt();
+    }
 
     if (workflow !== prevProps.workflow) {
       this.loadAppropriateClassification();
@@ -147,13 +147,13 @@ export class ProjectClassifyPage extends React.Component {
     }
   }
 
-  shouldWorkflowAssignmentPrompt(nextProps) {
+  shouldWorkflowAssignmentPrompt() {
     // Only for Gravity Spy which is assigning workflows to logged in users
     const { preferences, project, workflow } = this.props;
-    if (nextProps.project.experimental_tools.indexOf('workflow assignment') > -1) {
-      const assignedWorkflowID = nextProps.preferences &&
-        nextProps.preferences.settings &&
-        nextProps.preferences.settings.workflow_id;
+    if (project.experimental_tools.indexOf('workflow assignment') > -1) {
+      const assignedWorkflowID = preferences &&
+        preferences.settings &&
+        preferences.settings.workflow_id;
       const currentWorkflowID = workflow && workflow.id;
       if (assignedWorkflowID && currentWorkflowID && assignedWorkflowID !== currentWorkflowID) {
         const isActiveWorkflow = project.links.active_workflows &&


### PR DESCRIPTION
Check that project assigned workflows are active before showing the workflow assignment popup. If they are not active, clear `preferences.settings.workflow_id`. Update workflow assignment to use `componentDidUpdate` rather than `componentWillReceiveProps`.

Staging branch URL: https://pr-5171.pfe-preview.zooniverse.org

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
