### PR TITLE
Reset the classifier on auth change

### DIFF
--- a/app/main.cjsx
+++ b/app/main.cjsx
@@ -12,9 +12,9 @@ style = require '../css/main.styl'
 `import { Provider } from 'react-redux';`
 `import configureStore from './redux/store';`
 `import { processIntervention } from './redux/ducks/interventions';`
-`import { emptySubjectQueue } from './redux/ducks/classify';`
+`import { reset } from './redux/ducks/classify';`
 store = configureStore()
-auth.listen('change', () => store.dispatch(emptySubjectQueue()));
+auth.listen('change', () => store.dispatch(reset()));
 apiClient.type('subject_sets').listen('add-or-remove', () => store.dispatch(emptySubjectQueue()));
 sugarClient.on('experiment', (message) => store.dispatch(processIntervention(message)));
 

--- a/app/main.cjsx
+++ b/app/main.cjsx
@@ -1,7 +1,6 @@
 React = require 'react'
 ReactDOM = require 'react-dom'
 apiClient = require 'panoptes-client/lib/api-client'
-auth = require 'panoptes-client/lib/auth'
 { applyRouterMiddleware, Router, browserHistory } = require 'react-router'
 useScroll = require 'react-router-scroll/lib/useScroll'
 routes = require './router'
@@ -12,9 +11,7 @@ style = require '../css/main.styl'
 `import { Provider } from 'react-redux';`
 `import configureStore from './redux/store';`
 `import { processIntervention } from './redux/ducks/interventions';`
-`import { reset } from './redux/ducks/classify';`
 store = configureStore()
-auth.listen('change', () => store.dispatch(reset()));
 apiClient.type('subject_sets').listen('add-or-remove', () => store.dispatch(emptySubjectQueue()));
 sugarClient.on('experiment', (message) => store.dispatch(processIntervention(message)));
 

--- a/app/pages/project/classify.jsx
+++ b/app/pages/project/classify.jsx
@@ -360,8 +360,10 @@ const mapDispatchToProps = dispatch => ({
 const ConnectedClassifyPage = connect(mapStateToProps, mapDispatchToProps)(ProjectClassifyPage);
 
 function ConnectedClassifyPageWithWorkflow(props) {
+  const workflowKey = props.workflow ? props.workflow.id : 'no-workflow';
   return (
     <WorkflowSelection
+      key={workflowKey}
       actions={props.actions}
       location={props.location}
       preferences={props.preferences}

--- a/app/pages/project/workflow-selection.jsx
+++ b/app/pages/project/workflow-selection.jsx
@@ -26,7 +26,9 @@ class WorkflowSelection extends React.Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
-    const { locale, preferences, workflow } = this.props;
+    const { actions, locale, preferences, user, workflow } = this.props;
+    const prevUser = prevProps.user && prevProps.user.login;
+    const currentUser = user && user.login;
     const userSelectedWorkflow = (preferences && preferences.preferences) ? this.sanitiseID(preferences.preferences.selected_workflow) : undefined;
     if (userSelectedWorkflow && workflow) {
       if (!this.state.loadingSelectedWorkflow && userSelectedWorkflow !== workflow.id) {
@@ -37,7 +39,10 @@ class WorkflowSelection extends React.Component {
       this.getSelectedWorkflow(this.props);
     }
     if (workflow && prevProps.locale !== locale) {
-      this.props.actions.translations.load('workflow', workflow.id, locale);
+      actions.translations.load('workflow', workflow.id, locale);
+    }
+    if (currentUser !== prevUser) {
+      actions.classifier.reset();
     }
   }
 

--- a/app/pages/project/workflow-selection.jsx
+++ b/app/pages/project/workflow-selection.jsx
@@ -93,7 +93,6 @@ class WorkflowSelection extends React.Component {
     let awaitWorkflow;
     let awaitTranslation;
     if (isValidWorkflow) {
-      actions.classifier.reset();
       awaitTranslation = actions.translations.load('workflow', sanitisedWorkflowID, locale);
       awaitWorkflow = apiClient
         .type('workflows')

--- a/app/pages/project/workflow-selection.jsx
+++ b/app/pages/project/workflow-selection.jsx
@@ -48,8 +48,8 @@ class WorkflowSelection extends React.Component {
     let selectedWorkflowID;
     let activeFilter = true;
     const workflowFromURL = this.sanitiseID(this.props.location.query.workflow);
-    const userSelectedWorkflow = (preferences && preferences.preferences) ? this.sanitiseID(preferences.preferences.selected_workflow) : undefined;
-    const projectSetWorkflow = (preferences && preferences.settings) ? this.sanitiseID(preferences.settings.workflow_id) : undefined;
+    const userSelectedWorkflow = (user && preferences && preferences.preferences) ? this.sanitiseID(preferences.preferences.selected_workflow) : undefined;
+    const projectSetWorkflow = (user && preferences && preferences.settings) ? this.sanitiseID(preferences.settings.workflow_id) : undefined;
     if (workflowFromURL &&
       this.checkUserRoles(project, user)
     ) {

--- a/app/pages/project/workflow-selection.spec.js
+++ b/app/pages/project/workflow-selection.spec.js
@@ -84,6 +84,7 @@ describe('WorkflowSelection', function () {
   let workflowStub;
   const actions = {
     classifier: {
+      reset: sinon.spy(),
       setWorkflow: sinon.spy()
     },
     translations: {
@@ -243,6 +244,10 @@ describe('WorkflowSelection', function () {
         location.query = {};
         preferences.update({ preferences: {}});
         wrapper.setProps({ user });
+      });
+
+      afterEach(function () {
+        actions.classifier.reset.resetHistory();
       });
 
       it('should try to load the stored workflow', function () {
@@ -649,6 +654,24 @@ describe('WorkflowSelection', function () {
       const workflow = mockPanoptesResource('workflows', { id: '1', tasks: {} });
       wrapper.setProps({ locale: 'it', workflow });
       expect(actions.translations.load).to.have.been.calledWith('workflow', '1', 'it');
+    });
+  });
+
+  describe('on user change', function () {
+    before(function () {
+      const user = mockPanoptesResource('users', { id: 2, login: 'test-person' });
+      sinon.stub(controller, 'getWorkflow').callsFake(() => {});
+      wrapper.setProps({ user });
+    })
+
+    after(function () {
+      controller.getWorkflow.restore();
+      wrapper.setProps({ user: undefined });
+      actions.classifier.reset.resetHistory();
+    });
+
+    it('should reset the classifier', function () {
+      expect(actions.classifier.reset).to.have.been.calledOnce;
     });
   });
 });

--- a/app/pages/project/workflow-selection.spec.js
+++ b/app/pages/project/workflow-selection.spec.js
@@ -167,6 +167,37 @@ describe('WorkflowSelection', function () {
       expect(workflowStub).to.have.been.calledWith('6', true);
     });
 
+    describe('without a logged-in user', function () {
+      before(function () {
+        project.update({ 'configuration.default_workflow': '1' });
+      });
+
+      afterEach(function () {
+        preferences.update({
+          settings: {},
+          preferences: {}
+        });
+      });
+
+      after(function () {
+        project.update({ 'configuration.default_workflow': undefined });
+      });
+
+      it('should ignore project-assigned workflows', function () {
+        preferences.update({ 'settings.workflow_id': '4' });
+        controller.getSelectedWorkflow({ project, preferences });
+        expect(workflowStub).to.have.been.calledOnce;
+        expect(workflowStub).to.have.been.calledWith('1', true);
+      });
+
+      it('should ignore user-selected workflows', function () {
+        preferences.update({ 'preferences.selected_workflow': '5' });
+        controller.getSelectedWorkflow({ project, preferences });
+        expect(workflowStub).to.have.been.calledOnce;
+        expect(workflowStub).to.have.been.calledWith('1', true);
+      });
+    });
+
     describe('with a logged-in user', function () {
       beforeEach(function () {
         controller.setupSplits = () => null;
@@ -206,23 +237,24 @@ describe('WorkflowSelection', function () {
     });
 
     describe('with a workflow saved in preferences', function () {
+      const user = mockPanoptesResource('users', { id: '4' });
+
       beforeEach(function () {
         location.query = {};
         preferences.update({ preferences: {}});
-        const user = mockPanoptesResource('users', { id: '4' });
         wrapper.setProps({ user });
       });
 
       it('should try to load the stored workflow', function () {
         preferences.update({ 'preferences.selected_workflow': '4' });
-        controller.getSelectedWorkflow({ project, preferences });
+        controller.getSelectedWorkflow({ project, preferences, user });
         expect(workflowStub).to.have.been.calledOnce;
         expect(workflowStub).to.have.been.calledWith('4', true);
       });
 
       it('should parse the stored user workflow as an int', function () {
         preferences.update({ 'preferences.selected_workflow': '4random' });
-        controller.getSelectedWorkflow({ project, preferences });
+        controller.getSelectedWorkflow({ project, preferences, user });
         expect(workflowStub).to.have.been.calledOnce;
         expect(workflowStub).to.have.been.calledWith('4', true);
       });
@@ -241,14 +273,14 @@ describe('WorkflowSelection', function () {
 
       it('should try to load a stored project workflow', function () {
         preferences.update({ 'settings.workflow_id': '2' });
-        controller.getSelectedWorkflow({ project, preferences });
+        controller.getSelectedWorkflow({ project, preferences, user });
         expect(workflowStub).to.have.been.calledOnce;
         expect(workflowStub).to.have.been.calledWith('2', true);
       });
 
       it('parse the stored project workflow as an int', function () {
         preferences.update({ 'settings.workflow_id': '2random' });
-        controller.getSelectedWorkflow({ project, preferences });
+        controller.getSelectedWorkflow({ project, preferences, user });
         expect(workflowStub).to.have.been.calledOnce;
         expect(workflowStub).to.have.been.calledWith('2', true);
       });

--- a/app/pages/project/workflow-selection.spec.js
+++ b/app/pages/project/workflow-selection.spec.js
@@ -84,7 +84,6 @@ describe('WorkflowSelection', function () {
   let workflowStub;
   const actions = {
     classifier: {
-      reset: sinon.spy(),
       setWorkflow: sinon.spy()
     },
     translations: {

--- a/app/redux/ducks/classify.js
+++ b/app/redux/ducks/classify.js
@@ -237,7 +237,7 @@ export default function reducer(state = initialState, action = {}) {
     }
     case SET_WORKFLOW: {
       const { workflow } = action.payload;
-      return Object.assign({}, state, { workflow });
+      return Object.assign({}, initialState, { workflow });
     }
     case TOGGLE_GOLD_STANDARD: {
       const { goldStandard } = action.payload;
@@ -375,7 +375,6 @@ export function loadWorkflow(workflowId, locale, preferences) {
     if (preferences) {
       preferences.update({ 'preferences.selected_workflow': workflowId });
     }
-    dispatch(reset());
     dispatch({
       type: FETCH_WORKFLOW,
       payload: {

--- a/app/redux/ducks/classify.spec.js
+++ b/app/redux/ducks/classify.spec.js
@@ -528,17 +528,6 @@ describe('Classifier actions', function () {
       fakePreferences.save.resetHistory();
     });
 
-    it('should reset the classify store', function () {
-      const expectedState = {
-        classification: null,
-        goldStandardMode: false,
-        intervention: null,
-        upcomingSubjects: [],
-        workflow: null
-      };
-      expect(storeState).to.deep.equal(expectedState);
-    });
-
     it('should update user preferences', function () {
       expect(fakePreferences.update).to.have.been.calledWith({ 'preferences.selected_workflow': 'a' });
     });
@@ -551,6 +540,20 @@ describe('Classifier actions', function () {
         language: 'en'
       };
       expect(fakeDispatch).to.have.been.calledWith(expectedAction);
+    });
+
+    it('should reset the classify store', function (done) {
+      const expectedState = {
+        classification: null,
+        goldStandardMode: false,
+        intervention: null,
+        upcomingSubjects: [],
+        workflow: fakeWorkflow
+      };
+      awaitWorkflow.then(function () {
+        expect(storeState).to.deep.equal(expectedState);
+      })
+      .then(done, done);
     });
 
     it('should save user preferences', function (done) {


### PR DESCRIPTION
Reset the classifier store to its initial state on log in or log out. This should clear the stored workflow, empty the subject queue and destroy any incomplete classifications.

Key workflow selection by workflow ID, so that workflow selection mounts and runs again when the stored workflow is reset to null.

Staging branch URL: https://pr-5186.pfe-preview.zooniverse.org

Fixes #5184.

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
