### PR TITLE
Add spec tests for workflow selection

### DIFF
--- a/app/pages/project/workflow-selection.jsx
+++ b/app/pages/project/workflow-selection.jsx
@@ -99,7 +99,8 @@ class WorkflowSelection extends React.Component {
         .type('workflows')
         .get(sanitisedWorkflowID, {}) // the empty query here forces the client to bypass its internal cache
         .catch((error) => {
-          if (error.status === 404) {
+          const errorType = error.status && parseInt(error.status / 100, 10);
+          if (errorType === 4) {
             this.clearInactiveWorkflow(sanitisedWorkflowID)
             .then(this.getSelectedWorkflow(this.props));
           } else {

--- a/app/pages/project/workflow-selection.spec.js
+++ b/app/pages/project/workflow-selection.spec.js
@@ -463,6 +463,37 @@ describe('WorkflowSelection', function () {
           .then(done, done);
         });
       });
+
+      describe('on application JS errors', function () {
+        before(function () {
+          sinon.stub(apiClient, 'type').callsFake((method, url, payload) => {
+            const fakeError = new Error('simulated client error.');
+            return {
+              get: sinon.stub().callsFake(() => Promise.reject(fakeError))
+            };
+          });
+        });
+
+        after(function () {
+          apiClient.type.restore();
+        });
+
+        it('should not clear user preferences', function (done) {
+          awaitWorkflow
+          .then(function () {
+            expect(controller.clearInactiveWorkflow).to.have.not.been.called;
+          })
+          .then(done, done);
+        });
+
+        it('should not try to load another workflow', function (done) {
+          awaitWorkflow
+          .then(function () {
+            expect(controller.getSelectedWorkflow).to.have.not.been.called;
+          })
+          .then(done, done);
+        });
+      });
     });
 
     describe('with an invalid workflow ID', function () {

--- a/app/pages/project/workflow-selection.spec.js
+++ b/app/pages/project/workflow-selection.spec.js
@@ -540,6 +540,42 @@ describe('WorkflowSelection', function () {
         })
         .then(done, done);
       });
+
+      describe('when the project default workflow is invalid', function () {
+        before(function () {
+          project.update({ 'configuration.default_workflow': '10' });
+          sinon.stub(project, 'uncacheLink');
+        });
+
+        after(function () {
+          project.update({ configuration: {} });
+          project.uncacheLink.restore();
+        });
+
+        it('should not clear user preferences', function (done) {
+          awaitWorkflow
+          .then(function () {
+            expect(controller.clearInactiveWorkflow).to.have.not.been.called;
+          })
+          .then(done, done);
+        });
+
+        it('should not try to load another workflow', function (done) {
+          awaitWorkflow
+          .then(function () {
+            expect(controller.getSelectedWorkflow).to.have.not.been.called;
+          })
+          .then(done, done);
+        });
+
+        it('should uncache project workflow links', function (done) {
+          awaitWorkflow
+          .then(function () {
+            expect(project.uncacheLink).to.have.been.calledWith('workflows');
+          })
+          .then(done, done);
+        });
+      })
     });
   });
 

--- a/app/pages/project/workflow-selection.spec.js
+++ b/app/pages/project/workflow-selection.spec.js
@@ -98,234 +98,237 @@ describe('WorkflowSelection', function () {
     { context }
   );
   const controller = wrapper.instance();
-  const workflowStub = sinon.stub(controller, 'getWorkflow').callsFake(() => {});
 
-  before(function () {
-    sinon.stub(apiClient, 'request').callsFake((method, url, payload) => {
-      let response = [];
-      if (url === '/workflows') {
-        const workflow = mockPanoptesResource(
-          'workflows',
+  describe('selecting a workflow ID', function () {
+    const workflowStub = sinon.stub(controller, 'getWorkflow').callsFake(() => {});
+
+    before(function () {
+      sinon.stub(apiClient, 'request').callsFake((method, url, payload) => {
+        let response = [];
+        if (url === '/workflows') {
+          const workflow = mockPanoptesResource(
+            'workflows',
+            {
+              id: payload.id,
+              tasks: []
+            }
+          );
+          response = [workflow];
+        }
+        return Promise.resolve(response);
+      });
+    });
+
+    beforeEach(function () {
+      workflowStub.resetHistory();
+      actions.translations.load.resetHistory();
+      wrapper.update();
+    });
+
+    afterEach(function () {
+      project.experimental_tools = [];
+      location.query = {};
+    });
+
+    after(function () {
+      apiClient.request.restore();
+    });
+
+    it('should fetch a random active workflow by default', function () {
+      controller.getSelectedWorkflow({ project });
+      const selectedWorkflowID = workflowStub.getCall(0).args[0];
+      expect(workflowStub).to.have.been.calledOnce;
+      expect(project.links.active_workflows).to.include(selectedWorkflowID.toString());
+    });
+
+    it('should respect the workflow query param if "allow workflow query" is set', function () {
+      location.query.workflow = '6';
+      project.experimental_tools = ['allow workflow query'];
+      controller.getSelectedWorkflow({ project });
+      expect(workflowStub).to.have.been.calledOnce;
+      expect(workflowStub).to.have.been.calledWith('6', true);
+    });
+
+    it('should sanitise the workflow query param if "allow workflow query" is set', function () {
+      location.query.workflow = '6random78';
+      project.experimental_tools = ['allow workflow query'];
+      controller.getSelectedWorkflow({ project });
+      expect(workflowStub).to.have.been.calledOnce;
+      expect(workflowStub).to.have.been.calledWith('6', true);
+    });
+
+    describe('with a logged-in user', function () {
+      beforeEach(function () {
+        controller.setupSplits = () => null;
+        location.query.workflow = '6';
+      });
+
+      it('should load the specified workflow for the project owner', function () {
+        const user = owner;
+        controller.getSelectedWorkflow({ project, preferences, user });
+        expect(workflowStub).to.have.been.calledOnce;
+        expect(workflowStub).to.have.been.calledWith('6', false);
+      });
+
+      it('should load the specified workflow for a collaborator', function () {
+        const user = apiClient.type('users').create({ id: '2' });
+        controller.getSelectedWorkflow({ project, preferences, user });
+        expect(workflowStub).to.have.been.calledOnce;
+        expect(workflowStub).to.have.been.calledWith('6', false);
+      });
+
+      it('should load the specified workflow for a tester', function () {
+        const user = apiClient.type('users').create({ id: '3' });
+        controller.getSelectedWorkflow({ project, preferences, user });
+        expect(workflowStub).to.have.been.calledOnce;
+        expect(workflowStub).to.have.been.calledWith('6', false);
+      });
+
+      it('should load an active workflow for a general user', function () {
+        const user = apiClient.type('users').create({ id: '4' });
+        controller.getSelectedWorkflow({ project, preferences, user });
+        expect(workflowStub).to.have.been.calledOnce;
+        const selectedWorkflowID = workflowStub.getCall(0).args[0];
+        const activeFilter = workflowStub.getCall(0).args[1];
+        expect(project.links.active_workflows).to.include(selectedWorkflowID);
+        expect(activeFilter).to.be.true;
+      });
+    });
+
+    describe('with a workflow saved in preferences', function () {
+      beforeEach(function () {
+        location.query = {};
+        preferences.update({ preferences: {}});
+        const user = mockPanoptesResource('users', { id: '4' });
+        wrapper.setProps({ user });
+      });
+
+      it('should try to load the stored workflow', function () {
+        preferences.update({ 'preferences.selected_workflow': '4' });
+        controller.getSelectedWorkflow({ project, preferences });
+        expect(workflowStub).to.have.been.calledOnce;
+        expect(workflowStub).to.have.been.calledWith('4', true);
+      });
+
+      it('should parse the stored user workflow as an int', function () {
+        preferences.update({ 'preferences.selected_workflow': '4random' });
+        controller.getSelectedWorkflow({ project, preferences });
+        expect(workflowStub).to.have.been.calledOnce;
+        expect(workflowStub).to.have.been.calledWith('4', true);
+      });
+
+      it('should clear an invalid workflow string from user preferences', function () {
+        preferences.update({ 'preferences.selected_workflow': '4' });
+        controller.clearInactiveWorkflow('4');
+        expect(preferences.preferences.selected_workflow).to.be.undefined;
+      });
+
+      it('should clear an invalid workflow int from user preferences', function () {
+        preferences.update({ 'preferences.selected_workflow': 4 });
+        controller.clearInactiveWorkflow('4');
+        expect(preferences.preferences.selected_workflow).to.be.undefined;
+      });
+
+      it('should try to load a stored project workflow', function () {
+        preferences.update({ 'settings.workflow_id': '2' });
+        controller.getSelectedWorkflow({ project, preferences });
+        expect(workflowStub).to.have.been.calledOnce;
+        expect(workflowStub).to.have.been.calledWith('2', true);
+      });
+
+      it('parse the stored project workflow as an int', function () {
+        preferences.update({ 'settings.workflow_id': '2random' });
+        controller.getSelectedWorkflow({ project, preferences });
+        expect(workflowStub).to.have.been.calledOnce;
+        expect(workflowStub).to.have.been.calledWith('2', true);
+      });
+
+      it('should clear an invalid workflow string from project settings', function () {
+        preferences.update({ 'settings.workflow_id': '2' });
+        controller.clearInactiveWorkflow('2');
+        expect(preferences.settings.workflow_id).to.be.undefined;
+      });
+
+      it('should clear an invalid workflow int from project settings', function () {
+        preferences.update({ 'settings.workflow_id': 2 });
+        controller.clearInactiveWorkflow('2');
+        expect(preferences.settings.workflow_id).to.be.undefined;
+      });
+    });
+
+    describe('without a saved workflow', function () {
+      beforeEach(function () {
+        location.query = {};
+        project.update({ 'configuration.default_workflow': '1' });
+        preferences.update({ settings: {}, preferences: {}});
+      });
+
+      it('should load the project default workflow', function () {
+        const user = apiClient.type('users').create({ id: '4' });
+        controller.getSelectedWorkflow({ project, preferences, user });
+        expect(workflowStub).to.have.been.calledOnce;
+        expect(workflowStub).to.have.been.calledWith('1', true);
+      });
+    });
+
+    describe('on project change', function () {
+      it('should load a workflow for the new project', function () {
+        const newProject = mockPanoptesResource('projects',
           {
-            id: payload.id,
-            tasks: []
+            id: 'b',
+            display_name: 'Another test project',
+            experimental_tools: [],
+            configuration: {
+              default_workflow: '10'
+            },
+            links: {
+              active_workflows: ['10'],
+              owner: { id: '1' },
+              workflows: ['10']
+            }
           }
         );
-        response = [workflow];
-      }
-      return Promise.resolve(response);
-    });
-  });
-
-  beforeEach(function () {
-    workflowStub.resetHistory();
-    actions.translations.load.resetHistory();
-    wrapper.update();
-  });
-
-  afterEach(function () {
-    project.experimental_tools = [];
-    location.query = {};
-  });
-
-  after(function () {
-    apiClient.request.restore();
-  });
-
-  it('should fetch a random active workflow by default', function () {
-    controller.getSelectedWorkflow({ project });
-    const selectedWorkflowID = workflowStub.getCall(0).args[0];
-    expect(workflowStub).to.have.been.calledOnce;
-    expect(project.links.active_workflows).to.include(selectedWorkflowID.toString());
-  });
-
-  it('should respect the workflow query param if "allow workflow query" is set', function () {
-    location.query.workflow = '6';
-    project.experimental_tools = ['allow workflow query'];
-    controller.getSelectedWorkflow({ project });
-    expect(workflowStub).to.have.been.calledOnce;
-    expect(workflowStub).to.have.been.calledWith('6', true);
-  });
-
-  it('should sanitise the workflow query param if "allow workflow query" is set', function () {
-    location.query.workflow = '6random78';
-    project.experimental_tools = ['allow workflow query'];
-    controller.getSelectedWorkflow({ project });
-    expect(workflowStub).to.have.been.calledOnce;
-    expect(workflowStub).to.have.been.calledWith('6', true);
-  });
-
-  describe('with a logged-in user', function () {
-    beforeEach(function () {
-      controller.setupSplits = () => null;
-      location.query.workflow = '6';
+        wrapper.setProps({ project: newProject });
+        expect(workflowStub).to.have.been.calledOnce;
+        expect(workflowStub).to.have.been.calledWith('10', true);
+      });
     });
 
-    it('should load the specified workflow for the project owner', function () {
-      const user = owner;
-      controller.getSelectedWorkflow({ project, preferences, user });
-      expect(workflowStub).to.have.been.calledOnce;
-      expect(workflowStub).to.have.been.calledWith('6', false);
-    });
-
-    it('should load the specified workflow for a collaborator', function () {
-      const user = apiClient.type('users').create({ id: '2' });
-      controller.getSelectedWorkflow({ project, preferences, user });
-      expect(workflowStub).to.have.been.calledOnce;
-      expect(workflowStub).to.have.been.calledWith('6', false);
-    });
-
-    it('should load the specified workflow for a tester', function () {
-      const user = apiClient.type('users').create({ id: '3' });
-      controller.getSelectedWorkflow({ project, preferences, user });
-      expect(workflowStub).to.have.been.calledOnce;
-      expect(workflowStub).to.have.been.calledWith('6', false);
-    });
-
-    it('should load an active workflow for a general user', function () {
-      const user = apiClient.type('users').create({ id: '4' });
-      controller.getSelectedWorkflow({ project, preferences, user });
-      expect(workflowStub).to.have.been.calledOnce;
-      const selectedWorkflowID = workflowStub.getCall(0).args[0];
-      const activeFilter = workflowStub.getCall(0).args[1];
-      expect(project.links.active_workflows).to.include(selectedWorkflowID);
-      expect(activeFilter).to.be.true;
-    });
-  });
-
-  describe('with a workflow saved in preferences', function () {
-    beforeEach(function () {
-      location.query = {};
-      preferences.update({ preferences: {}});
-      const user = mockPanoptesResource('users', { id: '4' });
-      wrapper.setProps({ user });
-    });
-
-    it('should try to load the stored workflow', function () {
-      preferences.update({ 'preferences.selected_workflow': '4' });
-      controller.getSelectedWorkflow({ project, preferences });
-      expect(workflowStub).to.have.been.calledOnce;
-      expect(workflowStub).to.have.been.calledWith('4', true);
-    });
-
-    it('should parse the stored user workflow as an int', function () {
-      preferences.update({ 'preferences.selected_workflow': '4random' });
-      controller.getSelectedWorkflow({ project, preferences });
-      expect(workflowStub).to.have.been.calledOnce;
-      expect(workflowStub).to.have.been.calledWith('4', true);
-    });
-
-    it('should clear an invalid workflow string from user preferences', function () {
-      preferences.update({ 'preferences.selected_workflow': '4' });
-      controller.clearInactiveWorkflow('4');
-      expect(preferences.preferences.selected_workflow).to.be.undefined;
-    });
-
-    it('should clear an invalid workflow int from user preferences', function () {
-      preferences.update({ 'preferences.selected_workflow': 4 });
-      controller.clearInactiveWorkflow('4');
-      expect(preferences.preferences.selected_workflow).to.be.undefined;
-    });
-
-    it('should try to load a stored project workflow', function () {
-      preferences.update({ 'settings.workflow_id': '2' });
-      controller.getSelectedWorkflow({ project, preferences });
-      expect(workflowStub).to.have.been.calledOnce;
-      expect(workflowStub).to.have.been.calledWith('2', true);
-    });
-
-    it('parse the stored project workflow as an int', function () {
-      preferences.update({ 'settings.workflow_id': '2random' });
-      controller.getSelectedWorkflow({ project, preferences });
-      expect(workflowStub).to.have.been.calledOnce;
-      expect(workflowStub).to.have.been.calledWith('2', true);
-    });
-
-    it('should clear an invalid workflow string from project settings', function () {
-      preferences.update({ 'settings.workflow_id': '2' });
-      controller.clearInactiveWorkflow('2');
-      expect(preferences.settings.workflow_id).to.be.undefined;
-    });
-
-    it('should clear an invalid workflow int from project settings', function () {
-      preferences.update({ 'settings.workflow_id': 2 });
-      controller.clearInactiveWorkflow('2');
-      expect(preferences.settings.workflow_id).to.be.undefined;
-    });
-  });
-
-  describe('without a saved workflow', function () {
-    beforeEach(function () {
-      location.query = {};
-      project.update({ 'configuration.default_workflow': '1' });
-      preferences.update({ settings: {}, preferences: {}});
-    });
-
-    it('should load the project default workflow', function () {
-      const user = apiClient.type('users').create({ id: '4' });
-      controller.getSelectedWorkflow({ project, preferences, user });
-      expect(workflowStub).to.have.been.calledOnce;
-      expect(workflowStub).to.have.been.calledWith('1', true);
-    });
-  });
-
-  describe('on project change', function () {
-    it('should load a workflow for the new project', function () {
-      const newProject = mockPanoptesResource('projects',
-        {
-          id: 'b',
-          display_name: 'Another test project',
+    describe('when loading a project without linked active workflows', function() {
+      it('should not attempt to call getWorkflow', function() {
+        const projectWithoutActiveWorkflows = mockPanoptesResource('projects', {
+          id: 'y',
+          display_name: 'A test project',
+          configuration: {},
           experimental_tools: [],
-          configuration: {
-            default_workflow: '10'
-          },
           links: {
-            active_workflows: ['10'],
             owner: { id: '1' },
-            workflows: ['10']
+            workflows: ['20']
           }
-        }
-      );
-      wrapper.setProps({ project: newProject });
-      expect(workflowStub).to.have.been.calledOnce;
-      expect(workflowStub).to.have.been.calledWith('10', true);
-    });
-  });
+        });
 
-  describe('when loading a project without linked active workflows', function() {
-    it('should not attempt to call getWorkflow', function() {
-      const projectWithoutActiveWorkflows = mockPanoptesResource('projects', {
-        id: 'y',
-        display_name: 'A test project',
-        configuration: {},
-        experimental_tools: [],
-        links: {
-          owner: { id: '1' },
-          workflows: ['20']
-        }
+        wrapper.setProps({ project: projectWithoutActiveWorkflows });
+
+        expect(workflowStub).to.have.not.been.called;
       });
-
-      wrapper.setProps({ project: projectWithoutActiveWorkflows });
-
-      expect(workflowStub).to.have.not.been.called;
     });
-  });
 
-  describe('when loading a project without any linked workflows', function () {
-    it('should not attempt to call getWorkflow', function () {
-      const projectWithoutWorkflows = mockPanoptesResource('projects', {
-        id: 'z',
-        display_name: 'I have no workflows project',
-        configuration: {},
-        experimental_tools: [],
-        links: {
-          owner: { id: '1' }
-        }
+    describe('when loading a project without any linked workflows', function () {
+      it('should not attempt to call getWorkflow', function () {
+        const projectWithoutWorkflows = mockPanoptesResource('projects', {
+          id: 'z',
+          display_name: 'I have no workflows project',
+          configuration: {},
+          experimental_tools: [],
+          links: {
+            owner: { id: '1' }
+          }
+        });
+
+        wrapper.setProps({ project: projectWithoutWorkflows });
+
+        expect(workflowStub.notCalled).to.be.true;
       });
-
-      wrapper.setProps({ project: projectWithoutWorkflows });
-
-      expect(workflowStub.notCalled).to.be.true;
     });
   });
 

--- a/app/pages/project/workflow-selection.spec.js
+++ b/app/pages/project/workflow-selection.spec.js
@@ -420,6 +420,14 @@ describe('WorkflowSelection', function () {
         })
         .then(done, done);
       });
+
+      it('should try to load another workflow', function (done) {
+        awaitWorkflow
+        .then(function () {
+          expect(controller.getSelectedWorkflow).to.have.been.calledOnce;
+        })
+        .then(done, done);
+      });
     });
 
     describe('on 500 errors', function () {
@@ -442,6 +450,14 @@ describe('WorkflowSelection', function () {
         awaitWorkflow
         .then(function () {
           expect(controller.clearInactiveWorkflow).to.have.not.been.called;
+        })
+        .then(done, done);
+      });
+
+      it('should not try to load another workflow', function (done) {
+        awaitWorkflow
+        .then(function () {
+          expect(controller.getSelectedWorkflow).to.have.not.been.called;
         })
         .then(done, done);
       });

--- a/app/pages/project/workflow-selection.spec.js
+++ b/app/pages/project/workflow-selection.spec.js
@@ -15,7 +15,9 @@ const location = {
 };
 
 const context = {
-  router: {}
+  router: {
+    push: sinon.stub()
+  }
 };
 
 const projectRoles = [
@@ -50,6 +52,7 @@ const project = mockPanoptesResource('projects',
     id: 'a',
     display_name: 'A test project',
     experimental_tools: [],
+    slug: 'test/test-project',
     links: {
       active_workflows: ['1', '2', '3', '4', '5'],
       owner: { id: '1' },
@@ -539,6 +542,29 @@ describe('WorkflowSelection', function () {
           expect(controller.getSelectedWorkflow).to.have.been.calledOnce;
         })
         .then(done, done);
+      });
+
+      describe('when a workflow query param is present', function () {
+        before(function () {
+          const location = {
+            query: {
+              workflow: '5'
+            }
+          };
+          wrapper.setProps({ location });
+        });
+
+        after(function () {
+          wrapper.setProps({ location : {} });
+        });
+
+        it('should redirect to the classify page', function (done) {
+          awaitWorkflow
+          .then(function () {
+            expect(context.router.push).to.have.been.calledWith(`/projects/${project.slug}/classify`);
+          })
+          .then(done, done);
+        });
       });
 
       describe('when the project default workflow is invalid', function () {

--- a/app/redux/ducks/classify.js
+++ b/app/redux/ducks/classify.js
@@ -387,7 +387,8 @@ export function loadWorkflow(workflowId, locale, preferences) {
     return Promise.all([awaitWorkflow(workflowId), awaitTranslation])
     .then(([workflow]) => setWorkflow(workflow))
     .catch((error) => {
-      if (error.status && error.status === 404) {
+      const errorType = error.status && parseInt(error.status / 100, 10);
+      if (errorType === 4) {
         // Clear all stored preferences if this workflow doesn't exist for this user.
         if (preferences) {
           preferences.update({ 'preferences.selected_workflow': undefined });


### PR DESCRIPTION
Spec out how loading a workflow from the API should work in the Workflow Selection component, based on the workflow tests in #5124. Adds some tests for successful workflow requests and a couple of failing tests for API errors, reproducing #5173 and #5165.

Update workflow error handling so that it only runs if the workflow ID is invalid, rather than for all workflow IDs.

Fixes #5173.
Fixes #5165.

Staging branch URL: https://pr-5187.pfe-preview.zooniverse.org

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
