### PR TITLE
Remove underline from Project Title icon

### DIFF
--- a/app/pages/project/components/ProjectNavbar/components/ProjectTitle/ProjectTitle.jsx
+++ b/app/pages/project/components/ProjectNavbar/components/ProjectTitle/ProjectTitle.jsx
@@ -9,8 +9,9 @@ import { pxToRem, zooTheme } from '../../../../../../theme';
 
 export const H1 = styled.h1`
   color: white;
-  display: inline-flex;
-  flex-direction: column;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
   font-family: Karla;
   font-size: ${pxToRem(27)};
   font-weight: bold;
@@ -87,17 +88,18 @@ function ProjectTitle({ launched, link, redirect, title, underReview }) {
           <span>
             {title}
             {redirect && <span>{' '}<i className="fa fa-external-link" /></span>}
-            {launched &&
-              <StyledCheckMarkWrapper
-                className="fa-stack"
-                aria-label={zooniverseApprovedTranslation}
-                title={zooniverseApprovedTranslation}
-              >
-                <i className="fa fa-circle fa-stack-2x" />
-                <StyledCheckMark className="fa fa-check fa-stack-1x" />
-              </StyledCheckMarkWrapper>}
           </span>
         </TitleComponent>
+        {launched &&
+          <StyledCheckMarkWrapper
+            className="fa-stack"
+            aria-label={zooniverseApprovedTranslation}
+            title={zooniverseApprovedTranslation}
+          >
+            <i className="fa fa-circle fa-stack-2x" />
+            <StyledCheckMark className="fa fa-check fa-stack-1x" />
+          </StyledCheckMarkWrapper>
+        }
       </H1>
     </ThemeProvider>
   );


### PR DESCRIPTION
Fixes #4529.

@beckyrother mentioned that the icon in the project title shouldn't be underlined on rollover. Here's her screenshot: 

![38954147-8321b260-4316-11e8-91b2-3e18d7ba3e72](https://user-images.githubusercontent.com/3202211/51498959-74007e00-1d96-11e9-970f-be78296f2a69.png)

Here's the updated title on rollover. 

On `ProjectNavbarWide`: 

![screen capture on 2019-01-21 at 15-39-14](https://user-images.githubusercontent.com/3202211/51499011-ad38ee00-1d96-11e9-9d8b-3195bdd2f33c.gif)

And `ProjectNavbarNarrow`: 

<img width="358" alt="screen shot 2019-01-21 at 4 24 34 pm" src="https://user-images.githubusercontent.com/3202211/51499680-32250700-1d99-11e9-974a-d4dd697587b2.png">

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [x] Can you post a talk comment?

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] Are the tests passing locally and on Travis?
