### PR TITLE
Mobile-friendly homepage text

### DIFF
--- a/css/home-page.styl
+++ b/css/home-page.styl
@@ -161,8 +161,7 @@ $flex-section
       min-width: 50%
 
       @media (max-width: 900px)
-        margin: 0
-        padding: 0 2em 1em
+        margin: 0 2em 1em
 
       a
         display: inline-block

--- a/css/home-page.styl
+++ b/css/home-page.styl
@@ -35,7 +35,7 @@ $flex-section
     .home-mobile-video-image
       display: block
 
-    @media (min-width: 900px)
+    @media (min-width: 901px)
       video
         display: block
 
@@ -43,8 +43,10 @@ $flex-section
         display: none
 
     @media (max-width: 900px)
-      justify-content: center
       min-height: 100vh
+
+    @media (max-width: 768px)
+      padding: 2em
 
     video, .home-mobile-video-image
       @extends $absolute-fill
@@ -110,6 +112,10 @@ $flex-section
         padding: 0 10vw
         text-align: left
 
+      @media (max-width: 768px)
+        max-width: 100%
+        padding: 0 2em
+
       span
         margin: 1.5em 0
 
@@ -153,6 +159,10 @@ $flex-section
       flex-basis: 0
       margin: 0 5vw 5vh 10vw
       min-width: 50%
+
+      @media (max-width: 900px)
+        margin: 0
+        padding: 0 2em 1em
 
       a
         display: inline-block
@@ -207,7 +217,7 @@ $flex-section
   margin: 0 auto
   max-width: 1440px
 
-  @media (min-width: 1440px)
+  @media (min-width: 1441px)
     border-left: 1px solid LIGHT_GREY
     border-right: 1px solid LIGHT_GREY
 
@@ -353,7 +363,7 @@ $flex-section
 
   .home-featured
     background: #fff
-    padding: 4em 0
+    padding: 4em 2em
 
     .secondary-kicker
       font-size: 1.25em
@@ -422,6 +432,9 @@ $flex-section
       margin: 2em 22vw
       align-items: stretch
 
+      @media (max-width: 768px)
+        margin: 2em
+
       &:before
         content: ""
         position : absolute
@@ -437,7 +450,7 @@ $flex-section
     background-color: BACKGROUND_COLOR
     padding: 4em
 
-    @media (max-width: 700px)
+    @media (max-width: 768px)
       padding: 4em 2em
 
     hr
@@ -567,6 +580,7 @@ $flex-section
       flex-direction: column
       margin-right: 3em
       max-width: 100%
+      padding-bottom: 5em
       min-width: 16em
 
       @media(max-width: 400px)


### PR DESCRIPTION
I noticed a handful of issues with homepage text when viewing on mobile. I've annotated the changes in comments within the code so it's easier to see what changes go with what.

Here are the monster before and after screenshots: 
![diff](https://user-images.githubusercontent.com/3202211/51654191-be375a00-1f64-11e9-8871-03927193a527.png)


Required Manual Testing
 
- [x] Does the non-logged in home page render correctly?
- [x]   Does the logged in home page render correctly?
- [x]   Does the projects page render correctly?
- [x]   Can you load project home pages?
- [x]   Can you load the classification page?
- [x]   Can you submit a classification?
- [x]   Does talk load correctly?
- [x]   Can you post a talk comment?

Review Checklist
  

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x]   Does it work on mobile?
- [x]   Can you rm -rf node_modules/ && npm install and app works as expected?
- [x]   If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x]   Are the tests passing locally and on Travis?

Optional

- [ ]   Have you replaced any ChangeListener or PromiseRenderer components with code that updates component state?
- [ ]   If changes are made to the classifier, does the dev classifier still work?
- [ ]   Have you resized and compressed any image you've added?
- [ ]   Have you added in flow type annotations?
- [ ]   Have you followed the Springer guidelines for commit messages?