### PR TITLE
Specify the delimiter to use when parsing survey task csvs

### DIFF
--- a/app/classifier/tasks/survey/editor.cjsx
+++ b/app/classifier/tasks/survey/editor.cjsx
@@ -353,7 +353,7 @@ module.exports = createReactClass
       reader.readAsText file
 
   parseFileContent: (content, inputType) ->
-    {errors, data} = Papa?.parse content.trim(), header: true
+    {errors, data} = Papa?.parse content.trim(), header: true, delimiter: ','
 
     cleanRows = for row in data
       clean = {}


### PR DESCRIPTION
Staging branch URL: https://pr-5227.pfe-preview.zooniverse.org

Fixes #5208 by specifying the delimiter to use. Papaparse patched their auto-detection of delimiters and now is detecting both the comma and the semi-colon as delimiters in the survey task csvs. We still only want it to parse the comma separated values and manually handle the separation of the semi-colon separated values (answer options for a single question for instance). 

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
