### PR TITLE
Workflow selection: default preferences to null

### DIFF
--- a/app/pages/project/index.jsx
+++ b/app/pages/project/index.jsx
@@ -139,22 +139,20 @@ class ProjectPageController extends React.Component {
   }
 
   getUserProjectPreferences(project, user) {
-
     const userPreferences = user ?
       user.get('project_preferences', { project_id: project.id })
         .then(([projectPreferences]) => {
-          let newPreferences;
-          return projectPreferences ||
-            (newPreferences = apiClient.type('project_preferences').create({
+          if (projectPreferences) {
+            return projectPreferences;
+          } else {
+            return apiClient.type('project_preferences').create({
               links: {
                 project: project.id
               },
               preferences: {}
             })
-            .save()
-            .catch((error) => {
-              console.warn(error.message);
-            }));
+            .save();
+          }
         })
     :
       Promise.resolve(null);
@@ -162,6 +160,7 @@ class ProjectPageController extends React.Component {
     return userPreferences
       .catch((error) => {
         console.warn(error.message);
+        return null;
       });
   }
 

--- a/app/pages/project/workflow-selection.jsx
+++ b/app/pages/project/workflow-selection.jsx
@@ -165,7 +165,7 @@ WorkflowSelection.defaultProps = {
   location: {
     query: {}
   },
-  preferences: {},
+  preferences: null,
   projectRoles: [],
   user: null,
   workflow: null


### PR DESCRIPTION
Set preferences to null by default, otherwise the loadWorkflows action will fail with 'preferences.update is not a function'.

Staging branch URL: https://pr-5236.pfe-preview.zooniverse.org

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
