### PR TITLE
Remove componentDidUpdate from ProjectNavbar

### DIFF
--- a/app/pages/project/components/ProjectNavbar/ProjectNavbar.jsx
+++ b/app/pages/project/components/ProjectNavbar/ProjectNavbar.jsx
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
@@ -10,15 +9,6 @@ export const SettingsMenu = styled.div`
   text-align: right;
 `;
 
-function haveNavLinksChanged(oldProps, newProps) {
-  const oldLinks = oldProps.navLinks.map(link => link.label);
-  const newLinks = newProps.navLinks.map(link => link.label);
-
-  // returns an array of values not included in the other using SameValueZero for equality comparison
-  return _.difference(oldLinks, newLinks).length > 0 ||
-    oldLinks.length !== newLinks.length;
-}
-
 class ProjectNavbar extends Component {
   constructor(props) {
     super(props);
@@ -27,12 +17,6 @@ class ProjectNavbar extends Component {
       loading: true,
       useWide: false
     };
-  }
-
-  componentDidUpdate(prevProps) {
-    if (haveNavLinksChanged(prevProps, this.props)) {
-      this.setBreakpoint();
-    }
   }
 
   setBreakpoint(size) {


### PR DESCRIPTION
Removes componentDidUpdate from the project nav, since calling setBreakpoint without an argument does nothing.

Staging branch URL: https://pr-5240.pfe-preview.zooniverse.org

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
