### PR TITLE
Add Pull Reminders Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ If you write a new component, write a test. Each component should have its own `
 Mocha throws an error (`Illegal import declaration`) when compiling coffeescript files that contain ES6 import statements with template strings. Convert these imports to `require` statements.
 You can run the tests with `npm test`.
 
-## Deployment 
+## Deployment
 
 See https://github.com/zooniverse/how-to-zooniverse/blob/master/Devops/how-PFE-deploys.md for details on how PFE deploys.
 
@@ -274,3 +274,5 @@ Thanks to [BrowserStack](https://www.browserstack.com) for supporting open
 source and allowing us to test this project on multiple platforms.
 
 [![BrowserStack logo](https://static.zooniverse.org/browserstack-logo-300x158.png)](https://www.browserstack.com)
+
+[![pullreminders](https://pullreminders.com/badge.svg)](https://pullreminders.com?ref=badge)


### PR DESCRIPTION
Describe your changes.
This PR adds support for [Pull Reminders](https://pullreminders.com/?utm_source=github&utm_medium=marketplace) by including a badge on the README. More info on the badge [here](https://pullreminders.com/badge).

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
