### PR TITLE
Remove workflow contents export button

### DIFF
--- a/app/pages/lab/data-exports.jsx
+++ b/app/pages/lab/data-exports.jsx
@@ -13,7 +13,6 @@ counterpart.registerTranslations('en', {
     classificationExport: 'Request new classification export',
     subjectExport: 'Request new subject export',
     workflowExport: 'Request new workflow export',
-    workflowContentsExport: 'Request new workflow contents export',
     commentsExport: 'Request new talk comments export',
     tagsExport: 'Request new talk tags export',
   }
@@ -69,13 +68,6 @@ export default function DataExports (props) {
               project={props.project}
               buttonKey="projectDetails.workflowExport"
               exportType="workflows_export"
-            />
-          </div>
-          <div className="row">
-            <DataExportButton
-              project={props.project}
-              buttonKey="projectDetails.workflowContentsExport"
-              exportType="workflow_contents_export"
             />
           </div>
           <hr />

--- a/app/pages/lab/data-exports.jsx
+++ b/app/pages/lab/data-exports.jsx
@@ -45,7 +45,8 @@ export default function DataExports (props) {
       </div>
       <div className="columns-container">
         <div>
-          Project Data<br />
+          <h4>Project Data</h4>
+
           <div className="row">
             <DataExportButton
               project={props.project}
@@ -77,7 +78,7 @@ export default function DataExports (props) {
           </div>
           <hr />
 
-          Talk Data<br />
+          <h4>Talk Data</h4>
           <div className="row">
             <TalkDataExportButton
               project={props.project}

--- a/app/pages/lab/data-exports.jsx
+++ b/app/pages/lab/data-exports.jsx
@@ -70,6 +70,11 @@ export default function DataExports (props) {
               exportType="workflows_export"
             />
           </div>
+          <div className="row">
+            <p>
+              <strong>Looking for workflow contents exports?</strong> The workflow contents exports have been merged into the normal workflow export. The "strings" column is now available directly in the workflows export, and the "version" column from the workflow contents export is called "minor_version" in the workflows export. This means you no longer need to look up rows from two files in order to know what the actual setup of the workflow was for the version number specified by a classificatio.
+            </p>
+          </div>
           <hr />
 
           Talk Data<br />

--- a/app/pages/lab/data-exports.jsx
+++ b/app/pages/lab/data-exports.jsx
@@ -7,6 +7,7 @@ import { projectsWithWarnings } from './data-exports-warnings'
 import WorkflowClassificationExportButton from './workflow-classification-export-button';
 import DataExportButton from  '../../partials/data-export-button';
 import TalkDataExportButton from  '../../talk/data-export-button';
+import DataExportDownloadLink from '../../partials/data-export-download-link';
 
 counterpart.registerTranslations('en', {
   projectDetails: {
@@ -73,7 +74,12 @@ export default function DataExports (props) {
           </div>
           <div className="row">
             <p>
-              <strong>Looking for workflow contents exports?</strong> The workflow contents exports have been merged into the normal workflow export. The "strings" column is now available directly in the workflows export, and the "version" column from the workflow contents export is called "minor_version" in the workflows export. This means you no longer need to look up rows from two files in order to know what the actual setup of the workflow was for the version number specified by a classificatio.
+              <strong>Workflow contents export: </strong>
+              <DataExportDownloadLink 
+                project={props.project} 
+                exportType="workflow_contents_export" />
+              {' '}
+              This export can no longer be generated. We've generated one just prior to disabling the generation. The workflow contents exports have been merged into the normal workflow export. The "strings" column is now available directly in the workflows export, and the "version" column from the workflow contents export is called "minor_version" in the workflows export. This means you no longer need to look up rows from two files in order to know what the actual setup of the workflow was for the version number specified by a classification.
             </p>
           </div>
           <hr />

--- a/app/pages/lab/data-exports.spec.js
+++ b/app/pages/lab/data-exports.spec.js
@@ -50,13 +50,6 @@ describe('DataExports', function () {
 
   });
 
-  it('should show a workflow contents export button', function () {
-    const buttonToTest = findByExportType(dataExportButtons, 'workflow_contents_export');
-    assert.equal(buttonToTest.length, 1);
-    assert.equal(buttonToTest.prop('project'), testProject);
-
-  });
-
   it('should show a Talk comments export button', function () {
     const buttonToTest = findByExportType(talkDataExportButtons, 'comments'); assert.equal(buttonToTest.length, 1);
     assert.equal(buttonToTest.prop('project'), testProject);

--- a/app/partials/data-export-button.cjsx
+++ b/app/partials/data-export-button.cjsx
@@ -3,6 +3,7 @@ createReactClass = require 'create-react-class'
 apiClient = require 'panoptes-client/lib/api-client'
 moment = require 'moment'
 Translate = require 'react-translate-component'
+DataExportDownloadLink = require('./data-export-download-link').default
 
 module.exports = createReactClass
   displayName: 'DataExportButton'
@@ -14,18 +15,6 @@ module.exports = createReactClass
   getInitialState: ->
     exportRequested: false
     exportError: null
-    mostRecent: null
-
-  componentDidMount: ->
-    @exportGet()
-
-  exportGet: ->
-    @props.project.get(@props.exportType)
-      .then ([exported]) =>
-        @setState mostRecent: exported
-      .catch (error) =>
-        if error.status isnt 404
-          @setState exportError: error
 
   requestDataExport: ->
     @setState exportError: null
@@ -51,17 +40,7 @@ module.exports = createReactClass
         </button> {' '}
         <small className="form-help">
           CSV format.{' '}
-          { if @recentAndReady(@state.mostRecent)
-              <span>
-                Most recent data available requested{' '}
-                <a href={@state.mostRecent.src}>{moment(@state.mostRecent.updated_at).fromNow()}</a>.
-              </span>
-            else if @pending(@state.mostRecent)
-              <span>
-                Processing your request.
-              </span>
-            else
-              <span>Never previously requested.</span>}
+          <DataExportDownloadLink project={@props.project} exportType={@props.exportType} />
           <br />
         </small>
 

--- a/app/partials/data-export-download-link.jsx
+++ b/app/partials/data-export-download-link.jsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import apiClient from 'panoptes-client/lib/api-client';
+import moment from 'moment';
+import Translate from 'react-translate-component';
+
+export default class DataExportDownloadLink extends React.Component {
+    constructor(props) {
+        super(props)
+
+        this.state = {
+            requested: false,
+            mostRecent: null,
+            error: null
+        }
+
+        this.recentAndReady = this.recentAndReady.bind(this);
+        this.pending = this.pending.bind(this);
+    }
+
+    recentAndReady(exported) {
+        return (exported.metadata.state === 'ready' || !exported.metadata.state);
+    }
+
+    pending(exported) {
+        return !!exported;
+    }
+
+    componentDidMount() {
+        this.props.project.get(this.props.exportType).then((response) => {
+            console.log(response);
+            if (response.errors) {
+                this.setState({requested: true, error: response.errors});
+            } else {
+                this.setState({ requested: true, mostRecent: response[0] });
+            }
+        }).catch((error) => {
+            if (error.status != 404) {
+                this.setState({requested: true, error: error});
+            } else {
+                this.setState({requested: true});
+            }
+        })
+    }
+
+    render() {
+        if (!this.state.requested) {
+            return (<span>Loading status of export</span>);
+        } else if (this.state.error) {
+            return (<span>Error loading export information</span>);
+        } else if (this.recentAndReady(this.state.mostRecent)) {
+            return (<span>
+                Most recent data available requested{' '}
+                <a href={this.state.mostRecent.src}>{moment(this.state.mostRecent.updated_at).fromNow()}</a>.
+              </span >);
+        } else if (this.pending(this.state.mostRecent)) {
+            return (<span>Export is being generated.</span>);
+        } else {
+            return (<span>Never previously requested.</span>);
+        }
+    }
+}
+
+DataExportDownloadLink.propTypes = {
+    project: PropTypes.object,
+    exportType: PropTypes.string
+}
+
+DataExportDownloadLink.defaultProps = {
+    contentType: 'text/csv'
+}

--- a/app/partials/data-export-download-link.jsx
+++ b/app/partials/data-export-download-link.jsx
@@ -14,12 +14,13 @@ export default class DataExportDownloadLink extends React.Component {
             error: null
         }
 
+        this.getExport = this.getExport.bind(this);
         this.recentAndReady = this.recentAndReady.bind(this);
         this.pending = this.pending.bind(this);
     }
 
     recentAndReady(exported) {
-        return (exported.metadata.state === 'ready' || !exported.metadata.state);
+        return exported && (exported.metadata.state === 'ready' || !exported.metadata.state);
     }
 
     pending(exported) {
@@ -27,8 +28,11 @@ export default class DataExportDownloadLink extends React.Component {
     }
 
     componentDidMount() {
-        this.props.project.get(this.props.exportType).then((response) => {
-            console.log(response);
+        this.getExport();
+    }
+
+    getExport() {
+        return this.props.project.get(this.props.exportType).then((response) => {
             if (response.errors) {
                 this.setState({requested: true, error: response.errors});
             } else {

--- a/app/partials/data-export-download-link.spec.js
+++ b/app/partials/data-export-download-link.spec.js
@@ -1,0 +1,58 @@
+import React from 'react';
+import assert from 'assert';
+import { shallow } from 'enzyme';
+import sinon from 'sinon';
+import DataExportDownloadLink from './data-export-download-link';
+
+describe('DataExportDownloadLink', function () {
+    let project;
+    let wrapper;
+
+    before(function () {
+        project = { get: sinon.fake.resolves("foo") }
+        wrapper = shallow(<DataExportDownloadLink project={project} exportType="fake_export" />);
+    });
+
+    it('renders without crashing', function () {
+        const container = wrapper.find('span');
+        assert.equal(container.length, 1);
+    });
+
+    it('loads the exports', function () {
+        assert.equal(project.get.lastArg, "fake_export");
+    });
+
+    it('renders a link to the export', function (done) {
+        const href = "https://foo.bar/file.csv";
+        project.get = sinon.fake.resolves([{ metadata: { state: 'ready' }, src: href, updated_at: "2019-01-01T23:12:10Z" }]);
+        wrapper = shallow(<DataExportDownloadLink project={project} exportType="fake_export" />);
+        wrapper.instance().getExport().then(() => {
+            assert.equal(wrapper.find('a').prop('href'), href);
+        }).then(done, done);
+    });
+
+    it('renders an error when panoptes fails', function (done) {
+        project.get = sinon.fake.resolves({errors: "Something went wrong. Oops"});
+        wrapper = shallow(<DataExportDownloadLink project={project} exportType="fake_export" />);
+        wrapper.instance().getExport().then(() => {
+            assert.equal(wrapper.text(), "Error loading export information");
+        }).then(done, done);
+    });
+
+    it('renders a message when export is still generating', function (done) {
+        project.get = sinon.fake.resolves([{ metadata: { state: 'pending' }}]);
+        wrapper = shallow(<DataExportDownloadLink project={project} exportType="fake_export" />);
+        wrapper.instance().getExport().then(() => {
+            assert.equal(wrapper.text(), "Export is being generated.");
+        }).then(done, done);
+    });
+
+    it('renders a message when export was never requested', function (done) {
+        project.get = sinon.fake.resolves([]);
+        wrapper = shallow(<DataExportDownloadLink project={project} exportType="fake_export" />);
+        wrapper.instance().getExport().then(() => {
+            assert.equal(wrapper.text(), 'Never previously requested.');
+        }).then(done, done);
+    });
+});
+


### PR DESCRIPTION
Panoptes is going to remove the API to get a distinct workflow_contents export, because that resource itself is going away. This removes the button from the exports page.

I've split up the existing DataExportButton component and extracted a DataExportDownloadLink. This allowed me to keep the link for the workflow_contents export, while not letting people request new ones.

The logic was easy to pick apart, it was already neatly packaged into different functions. However, I've had to go from Coffee to ES, so someone having a look at that conversion would be appreciated.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
