### PR TITLE
Add a workflow selection strategy for classrooms

### DIFF
--- a/app/pages/project/classify.jsx
+++ b/app/pages/project/classify.jsx
@@ -365,9 +365,10 @@ function ConnectedClassifyPageWithWorkflow(props) {
   const workflowKey = props.workflow ? props.workflow.id : 'no-workflow';
   
   //Check for WildCam Lab classrooms (see https://github.com/zooniverse/edu-api-front-end)
+  const workflowFromUrl = props.location.query && props.location.query.workflow;
   const isProjectForClassrooms = (props.project && props.project.experimental_tools && props.project.experimental_tools.indexOf('wildcam classroom') > -1);
   const isUrlForClassrooms = props.location.query && props.location.query.classroom;
-  const isClassroom = isProjectForClassrooms && isUrlForClassrooms;
+  const isClassroom = isProjectForClassrooms && isUrlForClassrooms && workflowFromUrl;
   
   const WorkflowStrategy = isClassroom ? ClassroomWorkflowSelection : WorkflowSelection;
   return (

--- a/app/pages/project/classify.jsx
+++ b/app/pages/project/classify.jsx
@@ -363,7 +363,12 @@ const ConnectedClassifyPage = connect(mapStateToProps, mapDispatchToProps)(Proje
 
 function ConnectedClassifyPageWithWorkflow(props) {
   const workflowKey = props.workflow ? props.workflow.id : 'no-workflow';
-  const isClassroom = true; // TODO: add a conditional check for classrooms here.
+  
+  //Check for WildCam Lab classrooms (see https://github.com/zooniverse/edu-api-front-end)
+  const isProjectForClassrooms = (props.project && props.project.experimental_tools && props.project.experimental_tools.indexOf('wildcam classroom') > -1);
+  const isUrlForClassrooms = props.location.query && props.location.query.classroom;
+  const isClassroom = isProjectForClassrooms && isUrlForClassrooms;
+  
   const WorkflowStrategy = isClassroom ? ClassroomWorkflowSelection : WorkflowSelection;
   return (
     <WorkflowStrategy

--- a/app/pages/project/classify.jsx
+++ b/app/pages/project/classify.jsx
@@ -20,6 +20,7 @@ import FinishedBanner from './finished-banner';
 import WorkflowAssignmentDialog from '../../components/workflow-assignment-dialog';
 import ProjectThemeButton from './components/ProjectThemeButton';
 import WorkflowSelection from './workflow-selection';
+import ClassroomWorkflowSelection from './workflow-selection-classroom';
 import { zooTheme } from '../../theme';
 
 function onClassificationSaved(actualClassification) {
@@ -362,8 +363,10 @@ const ConnectedClassifyPage = connect(mapStateToProps, mapDispatchToProps)(Proje
 
 function ConnectedClassifyPageWithWorkflow(props) {
   const workflowKey = props.workflow ? props.workflow.id : 'no-workflow';
+  const isClassroom = true; // TODO: add a conditional check for classrooms here.
+  const WorkflowStrategy = isClassroom ? ClassroomWorkflowSelection : WorkflowSelection;
   return (
-    <WorkflowSelection
+    <WorkflowStrategy
       key={workflowKey}
       actions={props.actions}
       location={props.location}
@@ -373,7 +376,7 @@ function ConnectedClassifyPageWithWorkflow(props) {
       user={props.user}
     >
       <ConnectedClassifyPage {...props} />
-    </WorkflowSelection>
+    </WorkflowStrategy>
   );
 }
 export default ConnectedClassifyPageWithWorkflow;

--- a/app/pages/project/workflow-selection-classroom.jsx
+++ b/app/pages/project/workflow-selection-classroom.jsx
@@ -1,0 +1,29 @@
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import * as classifierActions from '../../redux/ducks/classify';
+import * as translationActions from '../../redux/ducks/translations';
+import { WorkflowSelection } from './workflow-selection';
+
+export class ClassroomWorkflowSelection extends WorkflowSelection {
+  getSelectedWorkflow({ location }) {
+    const workflowFromURL = this.sanitiseID(location.query.workflow);
+    if (workflowFromURL) return this.getWorkflow(workflowFromURL, false);
+    if (process.env.BABEL_ENV !== 'test') console.warn('Cannot select a workflow.');
+    return Promise.resolve(null);
+  }
+}
+
+const mapStateToProps = state => ({
+  locale: state.translations.locale,
+  workflow: state.classify.workflow
+});
+
+const mapDispatchToProps = dispatch => ({
+  actions: {
+    classifier: bindActionCreators(classifierActions, dispatch),
+    translations: bindActionCreators(translationActions, dispatch)
+  }
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(ClassroomWorkflowSelection);
+

--- a/app/pages/project/workflow-selection-classroom.jsx
+++ b/app/pages/project/workflow-selection-classroom.jsx
@@ -5,9 +5,10 @@ import * as translationActions from '../../redux/ducks/translations';
 import { WorkflowSelection } from './workflow-selection';
 
 export class ClassroomWorkflowSelection extends WorkflowSelection {
-  getSelectedWorkflow({ location }) {
+  getSelectedWorkflow(props) {
+    const { actions, locale, location, preferences } = props;
     const workflowFromURL = this.sanitiseID(location.query.workflow);
-    if (workflowFromURL) return this.getWorkflow(workflowFromURL, false);
+    if (workflowFromURL) return actions.classifier.loadWorkflow(workflowFromURL, locale, preferences);
     if (process.env.BABEL_ENV !== 'test') console.warn('Cannot select a workflow.');
     return Promise.resolve(null);
   }

--- a/app/pages/project/workflow-selection-classroom.spec.js
+++ b/app/pages/project/workflow-selection-classroom.spec.js
@@ -1,0 +1,170 @@
+import React from 'react';
+import { expect } from 'chai';
+import { mount } from 'enzyme';
+import sinon from 'sinon';
+import { ClassroomWorkflowSelection } from './workflow-selection-classroom';
+import mockPanoptesResource from '../../../test/mock-panoptes-resource';
+
+function StubPage(props) {
+  return <p>{props.workflow ? props.workflow.id : 'Hello'}</p>;
+}
+
+const location = {
+  query: {
+    workflow: '1234'
+  }
+};
+
+const context = {
+  router: {
+    push: sinon.stub()
+  }
+};
+
+const projectRoles = [
+  {
+    roles: ['owner'],
+    links: {
+      owner: {
+        id: '1'
+      }
+    }
+  },
+  {
+    roles: ['collaborator'],
+    links: {
+      owner: {
+        id: '2'
+      }
+    }
+  },
+  {
+    roles: ['tester'],
+    links: {
+      owner: {
+        id: '3'
+      }
+    }
+  }
+];
+
+const project = mockPanoptesResource('projects',
+  {
+    id: 'a',
+    display_name: 'A test project',
+    experimental_tools: [],
+    slug: 'test/test-project',
+    links: {
+      active_workflows: ['1', '2', '3', '4', '5'],
+      owner: { id: '1' },
+      workflows: ['1', '2', '3', '4', '5']
+    }
+  }
+);
+
+const owner = mockPanoptesResource(
+  'users',
+  {
+    id: project.links.owner.id
+  }
+);
+
+const preferences = mockPanoptesResource(
+  'project_preferences',
+  {
+    preferences: {},
+    links: {
+      project: project.id
+    }
+  }
+);
+
+describe('ClassroomWorkflowSelection', function () {
+  let wrapper;
+  let controller;
+  let workflowStub;
+  const actions = {
+    classifier: {
+      loadWorkflow: sinon.spy(),
+      reset: sinon.spy(),
+      setWorkflow: sinon.spy()
+    },
+    translations: {
+      load: sinon.stub().callsFake(() => Promise.resolve([]))
+    }
+  };
+
+  before(function () {
+    workflowStub = sinon.stub(ClassroomWorkflowSelection.prototype, 'getWorkflow').callsFake(() => {});
+    wrapper = mount(
+        <ClassroomWorkflowSelection
+          actions={actions}
+          project={project}
+          preferences={preferences}
+          projectRoles={projectRoles}
+          locale='en'
+          location={location}
+        >
+          <StubPage />
+        </ClassroomWorkflowSelection>,
+        { context }
+      );
+    controller = wrapper.instance();
+  });
+
+  describe('selecting a workflow ID', function () {
+
+    beforeEach(function () {
+      workflowStub.resetHistory();
+      actions.translations.load.resetHistory();
+      wrapper.update();
+    });
+
+    afterEach(function () {
+      project.experimental_tools = [];
+      location.query = {};
+    });
+
+    after(function () {
+      workflowStub.restore();
+    });
+
+    it('should always load the workflow specified in the URL', function () {
+      location.query.workflow = '1234';
+      controller.getSelectedWorkflow({ location });
+      expect(workflowStub).to.have.been.calledOnce;
+      expect(workflowStub).to.have.been.calledWith(location.query.workflow, false);
+    });
+
+    it('should sanitise the workflow query param', function () {
+      location.query.workflow = '1234rty'
+      controller.getSelectedWorkflow({ location });
+      expect(workflowStub).to.have.been.calledOnce;
+      expect(workflowStub).to.have.been.calledWith('1234', false);
+    });
+
+    it('should not load a workflow without a workflow query parameter', function () {
+      location.query = {}
+      controller.getSelectedWorkflow({ location });
+      expect(workflowStub).to.have.not.been.called;
+    });
+  });
+
+  describe('with a valid workflow loaded', function () {
+    it('should render the child component', function () {
+      const workflow = mockPanoptesResource('workflows',
+        {
+          id: 'a',
+          tasks: [],
+          links: {
+            project: project.id
+          }
+        }
+      );
+      expect(wrapper.find(StubPage)).to.have.lengthOf(0);
+      wrapper.setProps({ workflow });
+      const child = wrapper.find(StubPage);
+      expect(wrapper.find(StubPage)).to.have.lengthOf(1);
+    });
+  });
+});

--- a/app/pages/project/workflow-selection-classroom.spec.js
+++ b/app/pages/project/workflow-selection-classroom.spec.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { expect } from 'chai';
-import { mount } from 'enzyme';
+import { shallow } from 'enzyme';
 import sinon from 'sinon';
 import { ClassroomWorkflowSelection } from './workflow-selection-classroom';
 import mockPanoptesResource from '../../../test/mock-panoptes-resource';
@@ -97,28 +97,12 @@ describe('ClassroomWorkflowSelection', function () {
 
   before(function () {
     workflowStub = sinon.stub(ClassroomWorkflowSelection.prototype, 'getWorkflow').callsFake(() => {});
-    wrapper = mount(
-        <ClassroomWorkflowSelection
-          actions={actions}
-          project={project}
-          preferences={preferences}
-          projectRoles={projectRoles}
-          locale='en'
-          location={location}
-        >
-          <StubPage />
-        </ClassroomWorkflowSelection>,
-        { context }
-      );
-    controller = wrapper.instance();
   });
 
   describe('selecting a workflow ID', function () {
 
     beforeEach(function () {
-      workflowStub.resetHistory();
-      actions.translations.load.resetHistory();
-      wrapper.update();
+      actions.classifier.loadWorkflow.resetHistory();
     });
 
     afterEach(function () {
@@ -132,26 +116,77 @@ describe('ClassroomWorkflowSelection', function () {
 
     it('should always load the workflow specified in the URL', function () {
       location.query.workflow = '1234';
-      controller.getSelectedWorkflow({ location });
-      expect(workflowStub).to.have.been.calledOnce;
-      expect(workflowStub).to.have.been.calledWith(location.query.workflow, false);
+      wrapper = shallow(
+        <ClassroomWorkflowSelection
+          actions={actions}
+          project={project}
+          preferences={preferences}
+          projectRoles={projectRoles}
+          locale='en'
+          location={location}
+        >
+          <StubPage />
+        </ClassroomWorkflowSelection>,
+        { context }
+      );
+      expect(actions.classifier.loadWorkflow).to.have.been.calledOnce;
+      expect(actions.classifier.loadWorkflow).to.have.been.calledWith(location.query.workflow, 'en', preferences);
     });
 
     it('should sanitise the workflow query param', function () {
-      location.query.workflow = '1234rty'
-      controller.getSelectedWorkflow({ location });
-      expect(workflowStub).to.have.been.calledOnce;
-      expect(workflowStub).to.have.been.calledWith('1234', false);
+      location.query.workflow = '12345rty'
+      wrapper = shallow(
+        <ClassroomWorkflowSelection
+          actions={actions}
+          project={project}
+          preferences={preferences}
+          projectRoles={projectRoles}
+          locale='en'
+          location={location}
+        >
+          <StubPage />
+        </ClassroomWorkflowSelection>,
+        { context }
+      );
+      expect(actions.classifier.loadWorkflow).to.have.been.calledOnce;
+      expect(actions.classifier.loadWorkflow).to.have.been.calledWith('12345', 'en', preferences);
     });
 
     it('should not load a workflow without a workflow query parameter', function () {
       location.query = {}
-      controller.getSelectedWorkflow({ location });
-      expect(workflowStub).to.have.not.been.called;
+      wrapper = shallow(
+        <ClassroomWorkflowSelection
+          actions={actions}
+          project={project}
+          preferences={preferences}
+          projectRoles={projectRoles}
+          locale='en'
+          location={location}
+        >
+          <StubPage />
+        </ClassroomWorkflowSelection>,
+        { context }
+      );
+      expect(actions.classifier.loadWorkflow).to.have.not.been.called;
     });
   });
 
   describe('with a valid workflow loaded', function () {
+    before(function () {
+      wrapper = shallow(
+        <ClassroomWorkflowSelection
+          actions={actions}
+          project={project}
+          preferences={preferences}
+          projectRoles={projectRoles}
+          locale='en'
+          location={location}
+        >
+          <StubPage />
+        </ClassroomWorkflowSelection>,
+        { context }
+      );
+    })
     it('should render the child component', function () {
       const workflow = mockPanoptesResource('workflows',
         {

--- a/app/pages/project/workflow-selection-classroom.spec.js
+++ b/app/pages/project/workflow-selection-classroom.spec.js
@@ -11,7 +11,8 @@ function StubPage(props) {
 
 const location = {
   query: {
-    workflow: '1234'
+    workflow: '1234',
+    classroom: '1'
   }
 };
 
@@ -52,7 +53,7 @@ const project = mockPanoptesResource('projects',
   {
     id: 'a',
     display_name: 'A test project',
-    experimental_tools: [],
+    experimental_tools: ['wildcam classroom'],
     slug: 'test/test-project',
     links: {
       active_workflows: ['1', '2', '3', '4', '5'],


### PR DESCRIPTION
Add a new workflow strategy for classrooms, which always loads the workflow from a workflow query parameter.

ToDo:

- [x] Conditional logic to choose the selection strategy
- [x] Tests

Staging branch URL: https://pr-5259.pfe-preview.zooniverse.org

Fixes #5256.

Describe your changes.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
