### PR TITLE
Preview video formats other than mp4

### DIFF
--- a/app/components/thumbnail.jsx
+++ b/app/components/thumbnail.jsx
@@ -42,21 +42,21 @@ export default class Thumbnail extends React.Component {
       maxHeight: this.props.height
     };
 
-    if (this.props.format === 'mp4') {
+    if (this.props.type === 'video') {
       return (
         <div>
           <video style={style} controls={this.props.controls} onClick={this.playVideo}>
-            <source src={this.props.src} type="video/mp4" />
+            <source src={this.props.src} type={`video/${this.props.format}`} />
           </video>
         </div>
       );
     }
 
-    if (this.props.format === 'audio') {
+    if (this.props.type === 'audio') {
       return (
         <div>
           <audio style={style} controls={this.props.controls} onClick={this.playVideo}>
-            <source src={this.props.src} />
+            <source src={this.props.src} type={`audio/${this.props.format}`} />
           </audio>
         </div>
       );
@@ -82,10 +82,11 @@ Thumbnail.getThumbnailSrc = function getThumbnailSrc({ origin, width, height, sr
 
 Thumbnail.defaultProps = {
   controls: true,
-  format: 'image',
+  format: '',
   height: MAX_THUMBNAIL_DIMENSION,
   origin: 'https://thumbnails.zooniverse.org',
   src: '',
+  type: 'image',
   width: MAX_THUMBNAIL_DIMENSION
 };
 
@@ -95,5 +96,6 @@ Thumbnail.propTypes = {
   height: PropTypes.number,
   origin: PropTypes.string,
   src: PropTypes.string,
+  type: PropTypes.string,
   width: PropTypes.number
 };

--- a/app/lib/get-subject-location.coffee
+++ b/app/lib/get-subject-location.coffee
@@ -1,6 +1,6 @@
 READABLE_FORMATS =
   image: ['jpeg', 'png', 'svg+xml', 'gif']
-  video: ['mp4']
+  video: ['mp4', 'mpeg', 'x-m4v']
   audio: ['mp3', 'm4a', 'mpeg']
   text: ['plain']
   application: ['json']

--- a/app/lib/get-subject-locations.js
+++ b/app/lib/get-subject-locations.js
@@ -2,7 +2,7 @@ const READABLE_FORMATS = {
   image: [
     'jpeg', 'png', 'svg+xml', 'gif'
   ],
-  video: ['mp4', 'mpeg'],
+  video: ['mp4', 'mpeg', 'x-m4v'],
   audio: ['mp3', 'm4a', 'mpeg'],
   application: ['json']
 };

--- a/app/pages/project/home/project-home.jsx
+++ b/app/pages/project/home/project-home.jsx
@@ -102,9 +102,12 @@ const ProjectHomePage = (props) => {
             const locations = getSubjectLocations(subject);
             let format = '';
             let src = '';
+            let type = '';
             if (locations.image) {
+              type = 'image';
               [format, src] = locations.image;
             } else if (locations.video) {
+              type = 'video';
               [format, src] = locations.video;
             }
             return (
@@ -113,6 +116,7 @@ const ProjectHomePage = (props) => {
                   <Thumbnail
                     alt=""
                     controls={false}
+                    type={type}
                     format={format}
                     height={240}
                     src={src}

--- a/app/talk/discussion-preview.cjsx
+++ b/app/talk/discussion-preview.cjsx
@@ -43,7 +43,14 @@ module.exports = createReactClass
           subject = getSubjectLocation(@props.subject)
           <div className="subject-preview">
             <Link to={@discussionLink()}>
-              <Thumbnail src={subject.src} format={subject.format} width={100} height={150} controls={false} />
+              <Thumbnail
+                src={subject.src}
+                type={subject.type}
+                format={subject.format}
+                width={100}
+                height={150}
+                controls={false}
+              />
             </Link>
           </div>
         }

--- a/app/talk/search-result.jsx
+++ b/app/talk/search-result.jsx
@@ -55,7 +55,14 @@ export default class TalkSearchResult extends React.Component {
       <div className="talk-search-result talk-module">
         {this.state.subject && (
           <CommentLink comment={comment} project={this.props.project}>
-            <Thumbnail src={this.state.subject.src} format={this.state.subject.format} width={100} height={150} controls={false} />
+            <Thumbnail
+              src={this.state.subject.src}
+              type={this.state.subject.type}
+              format={this.state.subject.format}
+              width={100}
+              height={150}
+              controls={false}
+            />
           </CommentLink>
         )}
         <CommentContextIcon comment={comment} />

--- a/app/talk/tags.cjsx
+++ b/app/talk/tags.cjsx
@@ -76,7 +76,12 @@ module.exports = createReactClass
                         Subject {tag.subject.id}
                       </Link>
                     </p>
-                    <Thumbnail src={getSubjectLocation(tag.subject).src} width={300} format={getSubjectLocation(tag.subject).format} />
+                    <Thumbnail
+                      src={getSubjectLocation(tag.subject).src}
+                      width={300}
+                      type={getSubjectLocation(tag.subject).type}
+                      format={getSubjectLocation(tag.subject).format}
+                      />
                     <ul className="tag-list">
                       {for subjectTag in tag.subjectTags
                         <li key={"tag-#{ tag.id }-#{ subjectTag.id }"}>


### PR DESCRIPTION
Staging branch URL: https://pr-5270.pfe-preview.zooniverse.org

Fixes #5269 

Remove explicit  references to `.mp4` files from the code.
Pass a type prop to thumbnail previews, with value `image|audio|video`.
Add `x-m4v` to the list of allowed subject video formats when rendering subjects.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
