### PR TITLE
Add subject frame duration slider

### DIFF
--- a/app/components/subject-viewer.cjsx
+++ b/app/components/subject-viewer.cjsx
@@ -65,7 +65,7 @@ module.exports = createReactClass
   getInitialState: ->
     loading: true
     playing: false
-    playFrameDuration: 667
+    playFrameDurationRate: 2
     frame: @getInitialFrame()
     frameDimensions: {}
     inFlipbookMode: @props.allowFlipbook
@@ -161,18 +161,16 @@ module.exports = createReactClass
                 <div className="subject-frame-duration">
                   <i className="fa fa-angle-right fa-lg fa-fw subject-frame-duration--slower"></i>
                   <input
-                    aria-valuemin="-2000"
-                    aria-valuemax="-100"
-                    aria-valuenow={@state.playFrameDuration * -1}
+                    arial-label="Playback Speed Rate Adjustment"
                     className="subject-frame-duration--range"
                     id="frame-duration"
-                    min="-2000"
-                    max="-100"
+                    min="0.25"
+                    max="10"
                     name="frame-duration"
                     onChange={@handleFrameDurationChange}
-                    step="50"
+                    step="0.25"
                     type="range"
-                    value={@state.playFrameDuration * -1}
+                    value={@state.playFrameDurationRate}
                   />
                   <i className="fa fa-angle-double-right fa-lg fa-fw subject-frame-duration--faster"></i>
                 </div>
@@ -292,7 +290,7 @@ module.exports = createReactClass
       if @state.playing is on and (counter < flips or infiniteLoop is on)
         counter++
         @handleFrameChange (@state.frame + 1) %% totalFrames
-        setTimeout flip, @state.playFrameDuration
+        setTimeout flip, (1000 / @state.playFrameDurationRate)
         if counter is flips and infiniteLoop is off
           @setPlaying false
       else @setPlaying false
@@ -301,7 +299,7 @@ module.exports = createReactClass
       setTimeout flip, 0
 
   handleFrameDurationChange: (event) ->
-    @setState playFrameDuration: event.target.value * -1
+    @setState playFrameDurationRate: event.target.value
 
   handleFrameChange: (frame) ->
     @setState {frame}

--- a/app/components/subject-viewer.cjsx
+++ b/app/components/subject-viewer.cjsx
@@ -149,7 +149,7 @@ module.exports = createReactClass
             {if not @state.inFlipbookMode or @props.subject?.locations.length < 2 or subjectHasMixedLocationTypes @props.subject
               null
             else
-              <span className="subject-frame-play-controls">
+              <span>
                 {if @state.playing
                   <button aria-label="Pause" title="Pause" type="button" className="secret-button subject-tools__play" onClick={@setPlaying.bind this, false}>
                     <i className="fa fa-pause fa-lg fa-fw"></i>
@@ -158,7 +158,24 @@ module.exports = createReactClass
                   <button aria-label="Play" title="Play" type="button" className="secret-button subject-tools__play" onClick={@setPlaying.bind this, true}>
                     <i className="fa fa-play fa-lg fa-fw"></i>
                   </button>}
-                <input type="range" id="frame-duration" name="frame-duration" min="-2000" max="-100" value={@state.playFrameDuration * -1} step="50" onChange={@handleFrameDurationChange} />
+                <div className="subject-frame-duration">
+                  <i className="fa fa-angle-right fa-lg fa-fw subject-frame-duration--slower"></i>
+                  <input
+                    aria-valuemin="-2000"
+                    aria-valuemax="-100"
+                    aria-valuenow={@state.playFrameDuration * -1}
+                    className="subject-frame-duration--range"
+                    id="frame-duration"
+                    min="-2000"
+                    max="-100"
+                    name="frame-duration"
+                    onChange={@handleFrameDurationChange}
+                    step="50"
+                    type="range"
+                    value={@state.playFrameDuration * -1}
+                  />
+                  <i className="fa fa-angle-double-right fa-lg fa-fw subject-frame-duration--faster"></i>
+                </div>
               </span>}
           </span>
 

--- a/app/components/subject-viewer.cjsx
+++ b/app/components/subject-viewer.cjsx
@@ -159,22 +159,36 @@ module.exports = createReactClass
                     <i className="fa fa-play fa-lg fa-fw"></i>
                   </button>}
                 <div className="subject-frame-duration">
-                  <button aria-label="Slower" title="Slower" type="button" className="secret-button" onClick={@setFrameDuration.bind this, -0.25}>
+                  <button
+                    aria-label="Slower"
+                    className="secret-button"
+                    onKeyDown={@keyDownFrameDuration.bind this, -0.25}
+                    onMouseDown={@mouseDownFrameDuration.bind this, -0.25}
+                    title="Slower"
+                    type="button"
+                  >
                     <i className="fa fa-angle-right fa-lg fa-fw subject-frame-duration--slower"></i>
                   </button>
                   <input
-                    arial-label="Playback Speed Rate Adjustment"
+                    aria-label="Playback Speed Rate Adjustment"
                     className="subject-frame-duration--range"
                     id="frame-duration"
-                    min="0.25"
                     max="10"
+                    min="0.25"
                     name="frame-duration"
                     onChange={@handleFrameDurationChange}
                     step="0.25"
                     type="range"
                     value={@state.playFrameDurationRate}
                   />
-                  <button aria-label="Faster" title="Faster" type="button" className="secret-button" onClick={@setFrameDuration.bind this, 0.25}>
+                  <button
+                    aria-label="Faster"
+                    className="secret-button"
+                    onKeyDown={@keyDownFrameDuration.bind this, 0.25}
+                    onMouseDown={@mouseDownFrameDuration.bind this, 0.25}
+                    title="Faster"
+                    type="button"
+                  >
                     <i className="fa fa-angle-double-right fa-lg fa-fw subject-frame-duration--faster"></i>
                   </button>
                 </div>
@@ -303,9 +317,14 @@ module.exports = createReactClass
       setTimeout flip, 0
 
   handleFrameDurationChange: (event) ->
-    @setState playFrameDurationRate: event.target.value
+    @setState playFrameDurationRate: parseFloat(event.target.value)
 
-  setFrameDuration: (step) ->
+  keyDownFrameDuration: (step, event) ->
+    if event.which is 13 or event.which is 32
+      if 0.25 <= (@state.playFrameDurationRate + step) <= 10
+        @setState playFrameDurationRate: @state.playFrameDurationRate + step
+
+  mouseDownFrameDuration: (step) ->
     if 0.25 <= (@state.playFrameDurationRate + step) <= 10
       @setState playFrameDurationRate: @state.playFrameDurationRate + step
 

--- a/app/components/subject-viewer.cjsx
+++ b/app/components/subject-viewer.cjsx
@@ -159,7 +159,9 @@ module.exports = createReactClass
                     <i className="fa fa-play fa-lg fa-fw"></i>
                   </button>}
                 <div className="subject-frame-duration">
-                  <i className="fa fa-angle-right fa-lg fa-fw subject-frame-duration--slower"></i>
+                  <button aria-label="Slower" title="Slower" type="button" className="secret-button" onClick={@setFrameDuration.bind this, -0.25}>
+                    <i className="fa fa-angle-right fa-lg fa-fw subject-frame-duration--slower"></i>
+                  </button>
                   <input
                     arial-label="Playback Speed Rate Adjustment"
                     className="subject-frame-duration--range"
@@ -172,7 +174,9 @@ module.exports = createReactClass
                     type="range"
                     value={@state.playFrameDurationRate}
                   />
-                  <i className="fa fa-angle-double-right fa-lg fa-fw subject-frame-duration--faster"></i>
+                  <button aria-label="Faster" title="Faster" type="button" className="secret-button" onClick={@setFrameDuration.bind this, 0.25}>
+                    <i className="fa fa-angle-double-right fa-lg fa-fw subject-frame-duration--faster"></i>
+                  </button>
                 </div>
               </span>}
           </span>
@@ -300,6 +304,10 @@ module.exports = createReactClass
 
   handleFrameDurationChange: (event) ->
     @setState playFrameDurationRate: event.target.value
+
+  setFrameDuration: (step) ->
+    if 0.25 <= (@state.playFrameDurationRate + step) <= 10
+      @setState playFrameDurationRate: @state.playFrameDurationRate + step
 
   handleFrameChange: (frame) ->
     @setState {frame}

--- a/app/components/subject-viewer.cjsx
+++ b/app/components/subject-viewer.cjsx
@@ -49,7 +49,6 @@ module.exports = createReactClass
     subject: null
     isFavorite: false
     user: null
-    playFrameDuration: 667
     playIterations: 3
     onFrameChange: NOOP
     onLoad: NOOP
@@ -66,6 +65,7 @@ module.exports = createReactClass
   getInitialState: ->
     loading: true
     playing: false
+    playFrameDuration: 667
     frame: @getInitialFrame()
     frameDimensions: {}
     inFlipbookMode: @props.allowFlipbook
@@ -158,6 +158,7 @@ module.exports = createReactClass
                   <button aria-label="Play" title="Play" type="button" className="secret-button subject-tools__play" onClick={@setPlaying.bind this, true}>
                     <i className="fa fa-play fa-lg fa-fw"></i>
                   </button>}
+                <input type="range" id="frame-duration" name="frame-duration" min="-2000" max="-100" value={@state.playFrameDuration * -1} step="50" onChange={@handleFrameDurationChange} />
               </span>}
           </span>
 
@@ -274,13 +275,16 @@ module.exports = createReactClass
       if @state.playing is on and (counter < flips or infiniteLoop is on)
         counter++
         @handleFrameChange (@state.frame + 1) %% totalFrames
-        setTimeout flip, @props.playFrameDuration
+        setTimeout flip, @state.playFrameDuration
         if counter is flips and infiniteLoop is off
           @setPlaying false
       else @setPlaying false
 
     if playing is on
       setTimeout flip, 0
+
+  handleFrameDurationChange: (event) ->
+    @setState playFrameDuration: event.target.value * -1
 
   handleFrameChange: (frame) ->
     @setState {frame}

--- a/css/classify.styl
+++ b/css/classify.styl
@@ -151,6 +151,19 @@
         right: -0.5em
         top: -0.5em
 
+  .subject-frame-duration
+    display: inline-block;
+
+    &--slower
+      margin-right: -.4em
+
+    &--range
+      max-width: 5em
+      vertical-align: -.3em;
+
+    &--faster
+      margin-left: -.4em
+
   .subject-frame-pip
     @extends $reset-button
     background: transparent


### PR DESCRIPTION
Staging branch URL: https://pr-5274.pfe-preview.zooniverse.org/projects/markb-panoptes/backyard-worlds-test-project-mb/classify

Closes #5092.

Describe your changes.
- adds slider to control multi-image frame rate duration

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [x] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
