### PR TITLE
Add invert subject button to Talk

### DIFF
--- a/app/components/subject-viewer.cjsx
+++ b/app/components/subject-viewer.cjsx
@@ -58,6 +58,7 @@ module.exports = createReactClass
     linkToFullImage: false
     frameWrapper: null
     allowFlipbook: true
+    allowInvert: false
     allowSeparateFrames: false
     metadataPrefixes: ['#', '!']
     metadataFilters: ['#', '!']
@@ -181,7 +182,7 @@ module.exports = createReactClass
             </span>
         </span>}
         <span>
-          {if @props.workflow?.configuration?.invert_subject
+          {if @props.workflow?.configuration?.invert_subject or @props.allowInvert
             <button type="button" className="secret-button" aria-label="Invert image" title="Invert image" onClick={@toggleModification.bind this, 'invert'}>
               <i className="fa fa-adjust "></i>
             </button>}{' '}

--- a/app/components/svg-renderer.jsx
+++ b/app/components/svg-renderer.jsx
@@ -1,0 +1,189 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import Draggable from '../lib/draggable';
+import getSubjectLocation from '../lib/get-subject-location';
+import SVGImage from './svg-image';
+import SVGTransparentRect from './svg-transparent-rect';
+
+export default class SVGRenderer extends React.Component {
+  constructor(props) {
+    super(props);
+    this.getScreenCurrentTransformationMatrix = this.getScreenCurrentTransformationMatrix.bind(this);
+    this.getEventOffset = this.getEventOffset.bind(this);
+    this.normalizeDifference = this.normalizeDifference.bind(this);
+    this.eventCoordsToSVGCoords = this.eventCoordsToSVGCoords.bind(this);
+  }
+
+  getSizeRect() {
+    const clientRect = this.sizeRect && this.sizeRect.getBoundingClientRect();
+
+    if (clientRect) {
+      const { width, height } = clientRect;
+      let { left, right, top, bottom } = clientRect;
+      left += pageXOffset;
+      right += pageXOffset;
+      top += pageYOffset;
+      bottom += pageYOffset;
+      return { left, right, top, bottom, width, height };
+    }
+    return { left: 0, right: 0, top: 0, bottom: 0, width: 0, height: 0 };
+  }
+
+  getScale() {
+    const sizeRect = this.getSizeRect();
+    let horizontal = this.props.naturalWidth ? sizeRect.width / this.props.naturalWidth : 0.001;
+    let vertical = this.props.naturalHeight ? sizeRect.height / this.props.naturalHeight : 0.001;
+    horizontal = Math.max(horizontal, 0.001);
+    vertical = Math.max(vertical, 0.001);
+
+    return { horizontal, vertical };
+  }
+
+  // get current transformation matrix
+  getScreenCurrentTransformationMatrix() {
+    const svg = this.svgSubjectArea;
+    return svg.getScreenCTM();
+  }
+
+  // find the original matrix for the SVG coordinate system
+  getMatrixForWindowCoordsToSVGUserSpaceCoords() {
+    const { transformationContainer } = this;
+    return transformationContainer.getScreenCTM().inverse();
+  }
+
+  // get the offset of event coordiantes in terms of the SVG coordinate system
+  getEventOffset(e) {
+    return this.eventCoordsToSVGCoords(e.clientX, e.clientY);
+  }
+
+  // transforms the difference between two event coordinates
+  // into the difference as represent in the SVG coordinate system
+  normalizeDifference(e, d) {
+    const difference = {};
+    const normalizedPoint1 = this.eventCoordsToSVGCoords(e.pageX - d.x, e.pageY - d.y);
+    const normalizedPoint2 = this.eventCoordsToSVGCoords(e.pageX, e.pageY);
+    difference.x = normalizedPoint2.x - normalizedPoint1.x;
+    difference.y = normalizedPoint2.y - normalizedPoint1.y;
+    return difference;
+  }
+
+  // transforms the event coordinates
+  // to points in the SVG coordinate system
+  eventCoordsToSVGCoords(x, y) {
+    const svg = this.svgSubjectArea;
+    const newPoint = svg.createSVGPoint();
+    newPoint.x = x;
+    newPoint.y = y;
+    const matrixForWindowCoordsToSVGUserSpaceCoords = this.getMatrixForWindowCoordsToSVGUserSpaceCoords();
+    const pointforSVGSystem = newPoint.matrixTransform(matrixForWindowCoordsToSVGUserSpaceCoords);
+    return pointforSVGSystem;
+  }
+
+  render() {
+    const { type, src } = getSubjectLocation(this.props.subject, this.props.frame);
+    const createdViewBox = `${this.props.viewBoxDimensions.x} ${this.props.viewBoxDimensions.y} ${this.props.viewBoxDimensions.width} ${this.props.viewBoxDimensions.height}`;
+
+    // disable subject pointer events by default.
+    // Tasks then need to enable pointer events, when required, in SVGProps.
+    const svgProps = {
+      style: {}
+    };
+
+    // pan/zoom should override any custom pointer event styles
+    // if (this.props.panEnabled === true) {
+    //   svgProps.style.pointerEvents = 'all';
+    // }
+
+    return (
+      <div className="frame-annotator">
+        <div className={`subject svg-subject ${this.props.type}`}>
+          <svg
+            ref={(element) => { if (element) this.svgSubjectArea = element; }}
+            viewBox={createdViewBox}
+            {...svgProps}
+          >
+            <g
+              ref={(element) => { if (element) this.transformationContainer = element; }}
+              transform={this.props.transform}
+            >
+              <rect
+                ref={(rect) => { this.sizeRect = rect; }}
+                width={this.props.naturalWidth}
+                height={this.props.naturalHeight}
+                fill="rgba(0, 0, 0, 0.01)"
+                fillOpacity="0.01"
+                stroke="none"
+              />
+              {type === 'image' && this.props.naturalWidth && (
+                <Draggable onDrag={this.props.panEnabled ? this.props.panByDrag : () => {}}>
+                  <SVGImage
+                    className={this.props.panEnabled ? 'pan-active' : ''}
+                    src={src}
+                    width={this.props.naturalWidth}
+                    height={this.props.naturalHeight}
+                    modification={this.props.modification}
+                  />
+                </Draggable>
+              )}
+              {type === 'application' && this.props.naturalWidth && (
+                <Draggable onDrag={this.props.panEnabled ? this.props.panByDrag : () => {}}>
+                  <SVGTransparentRect
+                    className={this.props.panEnabled ? 'pan-active' : ''}
+                    width={this.props.naturalWidth}
+                    height={this.props.naturalHeight}
+                    modification={this.props.modification}
+                  />
+                </Draggable>
+              )}
+            </g>
+          </svg>
+        </div>
+        {this.props.children}
+      </div>
+    );
+  }
+}
+
+SVGRenderer.propTypes = {
+  annotation: PropTypes.shape({
+    task: PropTypes.string
+  }),
+  annotations: PropTypes.arrayOf(PropTypes.object),
+  children: PropTypes.node,
+  frame: PropTypes.number,
+  modification: PropTypes.object,
+  naturalHeight: PropTypes.number,
+  naturalWidth: PropTypes.number,
+  onChange: PropTypes.func,
+  panByDrag: PropTypes.func,
+  panEnabled: PropTypes.bool,
+  preferences: PropTypes.object,
+  subject: PropTypes.shape({
+    already_seen: PropTypes.bool,
+    retired: PropTypes.bool
+  }),
+  transform: PropTypes.string,
+  viewBoxDimensions: PropTypes.shape({
+    height: PropTypes.number,
+    width: PropTypes.number,
+    x: PropTypes.number,
+    y: PropTypes.number
+  }),
+  workflow: PropTypes.shape({
+    tasks: PropTypes.object
+  }),
+  progressMarker: PropTypes.func
+};
+
+SVGRenderer.defaultProps = {
+  annotation: null,
+  annotations: [],
+  frame: 0,
+  onChange: () => {},
+  onLoad: () => {},
+  project: null,
+  subject: null,
+  user: null,
+  workflow: null,
+  progressMarker: () => {}
+};

--- a/app/components/svg-renderer.jsx
+++ b/app/components/svg-renderer.jsx
@@ -1,98 +1,13 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import Draggable from '../lib/draggable';
 import getSubjectLocation from '../lib/get-subject-location';
 import SVGImage from './svg-image';
 import SVGTransparentRect from './svg-transparent-rect';
 
 export default class SVGRenderer extends React.Component {
-  constructor(props) {
-    super(props);
-    this.getScreenCurrentTransformationMatrix = this.getScreenCurrentTransformationMatrix.bind(this);
-    this.getEventOffset = this.getEventOffset.bind(this);
-    this.normalizeDifference = this.normalizeDifference.bind(this);
-    this.eventCoordsToSVGCoords = this.eventCoordsToSVGCoords.bind(this);
-  }
-
-  getSizeRect() {
-    const clientRect = this.sizeRect && this.sizeRect.getBoundingClientRect();
-
-    if (clientRect) {
-      const { width, height } = clientRect;
-      let { left, right, top, bottom } = clientRect;
-      left += pageXOffset;
-      right += pageXOffset;
-      top += pageYOffset;
-      bottom += pageYOffset;
-      return { left, right, top, bottom, width, height };
-    }
-    return { left: 0, right: 0, top: 0, bottom: 0, width: 0, height: 0 };
-  }
-
-  getScale() {
-    const sizeRect = this.getSizeRect();
-    let horizontal = this.props.naturalWidth ? sizeRect.width / this.props.naturalWidth : 0.001;
-    let vertical = this.props.naturalHeight ? sizeRect.height / this.props.naturalHeight : 0.001;
-    horizontal = Math.max(horizontal, 0.001);
-    vertical = Math.max(vertical, 0.001);
-
-    return { horizontal, vertical };
-  }
-
-  // get current transformation matrix
-  getScreenCurrentTransformationMatrix() {
-    const svg = this.svgSubjectArea;
-    return svg.getScreenCTM();
-  }
-
-  // find the original matrix for the SVG coordinate system
-  getMatrixForWindowCoordsToSVGUserSpaceCoords() {
-    const { transformationContainer } = this;
-    return transformationContainer.getScreenCTM().inverse();
-  }
-
-  // get the offset of event coordiantes in terms of the SVG coordinate system
-  getEventOffset(e) {
-    return this.eventCoordsToSVGCoords(e.clientX, e.clientY);
-  }
-
-  // transforms the difference between two event coordinates
-  // into the difference as represent in the SVG coordinate system
-  normalizeDifference(e, d) {
-    const difference = {};
-    const normalizedPoint1 = this.eventCoordsToSVGCoords(e.pageX - d.x, e.pageY - d.y);
-    const normalizedPoint2 = this.eventCoordsToSVGCoords(e.pageX, e.pageY);
-    difference.x = normalizedPoint2.x - normalizedPoint1.x;
-    difference.y = normalizedPoint2.y - normalizedPoint1.y;
-    return difference;
-  }
-
-  // transforms the event coordinates
-  // to points in the SVG coordinate system
-  eventCoordsToSVGCoords(x, y) {
-    const svg = this.svgSubjectArea;
-    const newPoint = svg.createSVGPoint();
-    newPoint.x = x;
-    newPoint.y = y;
-    const matrixForWindowCoordsToSVGUserSpaceCoords = this.getMatrixForWindowCoordsToSVGUserSpaceCoords();
-    const pointforSVGSystem = newPoint.matrixTransform(matrixForWindowCoordsToSVGUserSpaceCoords);
-    return pointforSVGSystem;
-  }
-
   render() {
     const { type, src } = getSubjectLocation(this.props.subject, this.props.frame);
     const createdViewBox = `${this.props.viewBoxDimensions.x} ${this.props.viewBoxDimensions.y} ${this.props.viewBoxDimensions.width} ${this.props.viewBoxDimensions.height}`;
-
-    // disable subject pointer events by default.
-    // Tasks then need to enable pointer events, when required, in SVGProps.
-    const svgProps = {
-      style: {}
-    };
-
-    // pan/zoom should override any custom pointer event styles
-    // if (this.props.panEnabled === true) {
-    //   svgProps.style.pointerEvents = 'all';
-    // }
 
     return (
       <div className="frame-annotator">
@@ -100,7 +15,6 @@ export default class SVGRenderer extends React.Component {
           <svg
             ref={(element) => { if (element) this.svgSubjectArea = element; }}
             viewBox={createdViewBox}
-            {...svgProps}
           >
             <g
               ref={(element) => { if (element) this.transformationContainer = element; }}
@@ -115,25 +29,19 @@ export default class SVGRenderer extends React.Component {
                 stroke="none"
               />
               {type === 'image' && this.props.naturalWidth && (
-                <Draggable onDrag={this.props.panEnabled ? this.props.panByDrag : () => {}}>
-                  <SVGImage
-                    className={this.props.panEnabled ? 'pan-active' : ''}
-                    src={src}
-                    width={this.props.naturalWidth}
-                    height={this.props.naturalHeight}
-                    modification={this.props.modification}
-                  />
-                </Draggable>
+                <SVGImage
+                  src={src}
+                  width={this.props.naturalWidth}
+                  height={this.props.naturalHeight}
+                  modification={this.props.modification}
+                />
               )}
               {type === 'application' && this.props.naturalWidth && (
-                <Draggable onDrag={this.props.panEnabled ? this.props.panByDrag : () => {}}>
-                  <SVGTransparentRect
-                    className={this.props.panEnabled ? 'pan-active' : ''}
-                    width={this.props.naturalWidth}
-                    height={this.props.naturalHeight}
-                    modification={this.props.modification}
-                  />
-                </Draggable>
+                <SVGTransparentRect
+                  width={this.props.naturalWidth}
+                  height={this.props.naturalHeight}
+                  modification={this.props.modification}
+                />
               )}
             </g>
           </svg>
@@ -145,19 +53,11 @@ export default class SVGRenderer extends React.Component {
 }
 
 SVGRenderer.propTypes = {
-  annotation: PropTypes.shape({
-    task: PropTypes.string
-  }),
-  annotations: PropTypes.arrayOf(PropTypes.object),
   children: PropTypes.node,
   frame: PropTypes.number,
   modification: PropTypes.object,
   naturalHeight: PropTypes.number,
   naturalWidth: PropTypes.number,
-  onChange: PropTypes.func,
-  panByDrag: PropTypes.func,
-  panEnabled: PropTypes.bool,
-  preferences: PropTypes.object,
   subject: PropTypes.shape({
     already_seen: PropTypes.bool,
     retired: PropTypes.bool
@@ -168,22 +68,10 @@ SVGRenderer.propTypes = {
     width: PropTypes.number,
     x: PropTypes.number,
     y: PropTypes.number
-  }),
-  workflow: PropTypes.shape({
-    tasks: PropTypes.object
-  }),
-  progressMarker: PropTypes.func
+  })
 };
 
 SVGRenderer.defaultProps = {
-  annotation: null,
-  annotations: [],
   frame: 0,
-  onChange: () => {},
-  onLoad: () => {},
-  project: null,
-  subject: null,
-  user: null,
-  workflow: null,
-  progressMarker: () => {}
+  subject: null
 };

--- a/app/subjects/subject-page.jsx
+++ b/app/subjects/subject-page.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import SubjectViewer from '../components/subject-viewer';
+import SVGRenderer from '../components/svg-renderer';
 import ActiveUsers from '../talk/active-users';
 import ProjectLinker from '../talk/lib/project-linker';
 import SubjectCommentForm from './comment-form';
@@ -15,24 +16,30 @@ const SubjectPage = (props) => {
     <div className="subject-page talk">
       <div className="talk-list-content">
         <section>
-          {props.subject &&
-            <div>
-              <h1>Subject {props.subject.id}</h1>
-              <SubjectViewer
-                subject={props.subject}
-                user={props.user}
-                project={props.project}
-                linkToFullImage={true}
-                metadataFilters={['#']}
-                isFavorite={props.isFavorite}
-              />
+          {props.subject
+            && (
+              <div>
+                <h1>
+                  Subject {props.subject.id}
+                </h1>
+                <SubjectViewer
+                  allowInvert={true}
+                  frameWrapper={SVGRenderer}
+                  isFavorite={props.isFavorite}
+                  linkToFullImage={true}
+                  metadataFilters={['#']}
+                  project={props.project}
+                  subject={props.subject}
+                  user={props.user}
+                />
 
-              <SubjectCommentList subject={props.subject} {...props} />
-              <SubjectCollectionList collections={props.collections} {...props} />
-              <SubjectDiscussionList subject={props.subject} {...props} />
-              <SubjectMentionList subject={props.subject} {...props} />
-              <SubjectCommentForm subject={props.subject} {...props} />
-            </div>}
+                <SubjectCommentList subject={props.subject} {...props} />
+                <SubjectCollectionList collections={props.collections} {...props} />
+                <SubjectDiscussionList subject={props.subject} {...props} />
+                <SubjectMentionList subject={props.subject} {...props} />
+                <SubjectCommentForm subject={props.subject} {...props} />
+              </div>
+            )}
         </section>
         <div className="talk-sidebar">
           <section>

--- a/app/talk/comment.cjsx
+++ b/app/talk/comment.cjsx
@@ -15,6 +15,7 @@ upvotedByCurrentUser = require './lib/upvoted-by-current-user'
 talkClient = require 'panoptes-client/lib/talk-client'
 Avatar = require '../partials/avatar'
 SubjectViewer = require '../components/subject-viewer'
+`import SVGRenderer from '../components/svg-renderer';` 
 SingleSubmitButton = require '../components/single-submit-button'
 DisplayRoles = require './lib/display-roles'
 CommentContextIcon = require './lib/comment-context-icon'
@@ -136,7 +137,7 @@ module.exports = createReactClass
         <Link to="#{baseLink}users/#{comment.user_login}">{comment.user_display_name}</Link>
         {if comment.reply_id
           <span>
-            {' '}in reply to <Link to="#{baseLink}users/#{comment.reply_user_login}">{comment.reply_user_display_name}</Link>'s{' '}
+            {' '}in reply to <Link to="#{baseLink}users/#{comment.reply_user_login}">{comment.reply_user_display_name}</Link>&apos;s{' '}
             <button className="link-style" type="button" onClick={(e) => @onClickRenderReplies(e, comment)}>
               comment
             </button>
@@ -197,7 +198,7 @@ module.exports = createReactClass
               </div>
               }
 
-            In reply to <Link to={profile_link}>{@props.data.reply_user_display_name}</Link>'s{' '}
+            In reply to <Link to={profile_link}>{@props.data.reply_user_display_name}</Link>&apos;s{' '}
 
             <button className="link-style" type="button" onClick={(e) => @onClickRenderReplies(e, @props.data)}>comment</button>
           </div>
@@ -215,12 +216,14 @@ module.exports = createReactClass
               <div className="polaroid-image">
                 {@commentSubjectTitle(@props.data, @props.subject)}
                 <SubjectViewer
+                  allowInvert={true}
+                  frameWrapper={SVGRenderer}
+                  linkToFullImage={true}
+                  metadataFilters={['#']}
+                  project={@props.project}
                   subject={@props.subject}
                   user={@props.user}
-                  project={@props.project}
-                  linkToFullImage={true}
-                  allowInvert={true}
-                  metadataFilters={['#']} />
+                />
               </div>
             }
 

--- a/app/talk/comment.cjsx
+++ b/app/talk/comment.cjsx
@@ -219,6 +219,7 @@ module.exports = createReactClass
                   user={@props.user}
                   project={@props.project}
                   linkToFullImage={true}
+                  allowInvert={true}
                   metadataFilters={['#']} />
               </div>
             }


### PR DESCRIPTION
Staging branch URL: https://pr-5275.pfe-preview.zooniverse.org/projects/markb-panoptes/backyard-worlds-test-project-mb/talk/187/319

Closes #5094.

Describe your changes.
- adds invert button to Talk discussion
- adds invert button to Talk subject page
- adds simplified svg layer on subject

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
