### PR TITLE
Adds invert subject to Talk, refactors invert to css filter

### DIFF
--- a/app/components/subject-viewer.cjsx
+++ b/app/components/subject-viewer.cjsx
@@ -58,6 +58,7 @@ module.exports = createReactClass
     linkToFullImage: false
     frameWrapper: null
     allowFlipbook: true
+    allowInvert: false
     allowSeparateFrames: false
     metadataPrefixes: ['#', '!']
     metadataFilters: ['#', '!']
@@ -69,6 +70,7 @@ module.exports = createReactClass
     frame: @getInitialFrame()
     frameDimensions: {}
     inFlipbookMode: @props.allowFlipbook
+    invert: false
     promptingToSignIn: false
 
   getInitialFrame: ->
@@ -103,6 +105,7 @@ module.exports = createReactClass
     rootClasses = classnames('subject-viewer', {
       'default-root-style': @props.defaultStyle
       'subject-viewer--flipbook': @state.inFlipbookMode
+      'subject-viewer--invert': @state.invert
       "subject-viewer--layout-#{@props.workflow?.configuration?.multi_image_layout}": @props.workflow?.configuration?.multi_image_layout
     })
 
@@ -181,8 +184,8 @@ module.exports = createReactClass
             </span>
         </span>}
         <span>
-          {if @props.workflow?.configuration?.invert_subject
-            <button type="button" className="secret-button" aria-label="Invert image" title="Invert image" onClick={@toggleModification.bind this, 'invert'}>
+          {if @props.workflow?.configuration?.invert_subject or @props.allowInvert
+            <button type="button" className="secret-button" aria-label="Invert image" title="Invert image" onClick={@toggleInvert.bind this, @state.invert}>
               <i className="fa fa-adjust "></i>
             </button>}{' '}
           {if @props.workflow?.configuration?.enable_subject_flags
@@ -229,7 +232,7 @@ module.exports = createReactClass
     @signInAttentionTimeout = setTimeout (=> @setState loading: false), 3000
 
   renderFrame: (frame, props = {}) ->
-    <FrameViewer {...@props} {...props} frame={frame} modification={@state?.modification} onLoad={@handleFrameLoad} />
+    <FrameViewer {...@props} {...props} frame={frame} onLoad={@handleFrameLoad} />
 
   hiddenPreloadedImages: ->
     # Render this to ensure that all a subject's location images are cached and ready to display.
@@ -250,15 +253,8 @@ module.exports = createReactClass
   toggleInFlipbookMode: () ->
     @setInFlipbookMode not @state.inFlipbookMode
 
-  toggleModification: (type) ->
-    mods = @state?.modification
-    if !mods
-      mods = {}
-    if mods[type] is undefined
-      mods[type] = true
-    else
-      mods[type] = not mods[type]
-    @setState modification: mods
+  toggleInvert: (invert) ->
+    @setState invert: !invert
 
   setInFlipbookMode: (inFlipbookMode) ->
     @setState {inFlipbookMode}

--- a/app/components/svg-image.jsx
+++ b/app/components/svg-image.jsx
@@ -1,26 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-const FILTERS = {
-  invert: "url('#svg-invert-filter')"
-};
-
-const INVERT =
-  `<svg style="position: fixed; right: 100%; top: 100%; visibility: hidden;">
-    <defs>
-      <filter id="svg-invert-filter" color-interpolation-filters="sRGB">
-        <feComponentTransfer>
-          <feFuncR type="table" tableValues="1 0"/>
-          <feFuncG type="table" tableValues="1 0"/>
-          <feFuncB type="table" tableValues="1 0"/>
-        </feComponentTransfer>
-      </filter>
-    </defs>
-  </svg>`;
-
-
 class SVGImage extends React.Component {
-
   constructor() {
     super();
     this.fixWeirdSize = this.fixWeirdSize.bind(this);
@@ -46,31 +27,16 @@ class SVGImage extends React.Component {
     }
   }
 
-  filterFinder() {
-    if (this.props.modification.invert) {
-      if (!document.getElementById('svg-invert-filter')) {
-        document.body.insertAdjacentHTML('afterbegin', INVERT);
-      }
-      return { filter: FILTERS.invert };
-    }
-    return {};
-  }
-
   render() {
     const imageProps = Object.assign({}, this.props);
     delete imageProps.modification;
-    return <image ref="image" xlinkHref={this.props.src} style={this.filterFinder()} {...imageProps} />;
+    return <image ref="image" xlinkHref={this.props.src} {...imageProps} />;
   }
 }
 SVGImage.propTypes = {
   src: PropTypes.string.isRequired,
   height: PropTypes.number.isRequired,
-  width: PropTypes.number.isRequired,
-  modification: PropTypes.object
-};
-
-SVGImage.defaultProps = {
-  modification: {}
+  width: PropTypes.number.isRequired
 };
 
 export default SVGImage;

--- a/app/subjects/subject-page.jsx
+++ b/app/subjects/subject-page.jsx
@@ -22,6 +22,7 @@ const SubjectPage = (props) => {
                 subject={props.subject}
                 user={props.user}
                 project={props.project}
+                allowInvert={true}
                 linkToFullImage={true}
                 metadataFilters={['#']}
                 isFavorite={props.isFavorite}

--- a/app/talk/comment.cjsx
+++ b/app/talk/comment.cjsx
@@ -136,7 +136,7 @@ module.exports = createReactClass
         <Link to="#{baseLink}users/#{comment.user_login}">{comment.user_display_name}</Link>
         {if comment.reply_id
           <span>
-            {' '}in reply to <Link to="#{baseLink}users/#{comment.reply_user_login}">{comment.reply_user_display_name}</Link>'s{' '}
+            {' '}in reply to <Link to="#{baseLink}users/#{comment.reply_user_login}">{comment.reply_user_display_name}</Link>&apos;s{' '}
             <button className="link-style" type="button" onClick={(e) => @onClickRenderReplies(e, comment)}>
               comment
             </button>
@@ -197,7 +197,7 @@ module.exports = createReactClass
               </div>
               }
 
-            In reply to <Link to={profile_link}>{@props.data.reply_user_display_name}</Link>'s{' '}
+            In reply to <Link to={profile_link}>{@props.data.reply_user_display_name}</Link>&apos;s{' '}
 
             <button className="link-style" type="button" onClick={(e) => @onClickRenderReplies(e, @props.data)}>comment</button>
           </div>
@@ -218,6 +218,7 @@ module.exports = createReactClass
                   subject={@props.subject}
                   user={@props.user}
                   project={@props.project}
+                  allowInvert={true}
                   linkToFullImage={true}
                   metadataFilters={['#']} />
               </div>

--- a/css/subject-viewer.styl
+++ b/css/subject-viewer.styl
@@ -107,6 +107,16 @@
           background-color: #bbc0c0
           color: #575959
 
+  &.subject-viewer--invert
+    // Classifier
+    svg
+      filter: invert(100%)
+    // Talk
+    .subject-container
+      .subject-image-frame:only-child
+        img, video
+          filter: invert(100%)
+
   // Multi-image layouts
   &:not(.subject-viewer--flipbook)
     .subject-container
@@ -118,10 +128,6 @@
     &.subject-viewer--layout-grid3
       .subject-container > *
         width: 33%
-
-  &.subject-viewer--invert
-    .subject
-      filter: invert(100%)
 
 .subject
   .subject-tools

--- a/css/subject-viewer.styl
+++ b/css/subject-viewer.styl
@@ -119,6 +119,10 @@
       .subject-container > *
         width: 33%
 
+  &.subject-viewer--invert
+    .subject
+      filter: invert(100%)
+
 .subject
   .subject-tools
     button:not(:last-child)


### PR DESCRIPTION
Staging branch URL: https://pr-5276.pfe-preview.zooniverse.org/projects/markb-panoptes/backyard-worlds-test-project-mb/talk/187/319

Closes #5094.

Describe your changes.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
