### PR TITLE
hide subject intervention metadata

### DIFF
--- a/app/redux/ducks/classify.js
+++ b/app/redux/ducks/classify.js
@@ -47,6 +47,7 @@ function awaitWorkflow(workflowId) {
 
 function createNewClassification(project, workflow, subject, goldStandardMode) {
   const source = subject.metadata.intervention ? 'sugar' : 'api';
+  subject.update({ 'metadata.intervention': undefined });
   const classification = apiClient.type('classifications').create({
     annotations: [],
     metadata: {

--- a/app/redux/ducks/classify.js
+++ b/app/redux/ducks/classify.js
@@ -46,7 +46,9 @@ function awaitWorkflow(workflowId) {
 }
 
 function createNewClassification(project, workflow, subject, goldStandardMode) {
+  // Record whether this subject was received from Sugar or from the Panoptes API.
   const source = subject.metadata.intervention ? 'sugar' : 'api';
+  // Delete the metadata key because we don't want volunteers to see it.
   subject.update({ 'metadata.intervention': undefined });
   const classification = apiClient.type('classifications').create({
     annotations: [],

--- a/app/redux/ducks/interventions.js
+++ b/app/redux/ducks/interventions.js
@@ -54,6 +54,8 @@ function prependSubjectQueue(data) {
       return [];
     })
     .then(subjects => subjects.map((subject) => {
+      /* record that this subject was added by an intervention, rather than
+      queued from the API. */
       subject.update({ 'metadata.intervention': true });
       return subject;
     }))


### PR DESCRIPTION
avoid showing the intervention state of a subject in the UI

Staging branch URL: https://pr-5278.pfe-preview.zooniverse.org

Fixes #5277.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
