### PR TITLE
Disable test workflow button if no tasks are defined

### DIFF
--- a/app/pages/lab/workflow.cjsx
+++ b/app/pages/lab/workflow.cjsx
@@ -442,17 +442,20 @@ EditWorkflowPage = createReactClass
             </div>}
 
           <div className={if @isThereNotADefinedTask() then 'disabled-section' else ''}>
-            <a
-              disabled={@isThereNotADefinedTask()}
-              href={@workflowLink()}
-              className="standard-button"
-              target="from-lab"
-              onClick={@handleViewClick}
-            >
-              Test this workflow
-            </a>
+            {if not @isThereNotADefinedTask()
+              <a
+                href={@workflowLink()}
+                className="standard-button"
+                target="from-lab"
+                onClick={@handleViewClick}
+              >
+                Test this workflow
+              </a>}
             {if @isThereNotADefinedTask()
-              <p>You need to add a task and content to be able to test this workflow.</p>}
+              <div>
+                <span className="standard-button">Test this workflow</span>
+                <p>You need to add a task and content to be able to test this workflow.</p>
+              </div>}
           </div>
 
           <hr />

--- a/app/pages/lab/workflow.cjsx
+++ b/app/pages/lab/workflow.cjsx
@@ -70,6 +70,10 @@ EditWorkflowPage = createReactClass
     changes["tasks.#{taskKey}"] = taskDescription
     @props.workflow.update(changes).save()
 
+  isThereNotADefinedTask: () ->
+    workflowTasks = Object.keys(@props.workflow.tasks)
+    workflowTasks.length is 0
+
   render: ->
     window.editingWorkflow = @props.workflow
 
@@ -437,8 +441,18 @@ EditWorkflowPage = createReactClass
 
             </div>}
 
-          <div>
-            <a href={@workflowLink()} className="standard-button" target="from-lab" onClick={@handleViewClick}>Test this workflow</a>
+          <div className={if @isThereNotADefinedTask() then 'disabled-section' else ''}>
+            <a
+              disabled={@isThereNotADefinedTask()}
+              href={@workflowLink()}
+              className="standard-button"
+              target="from-lab"
+              onClick={@handleViewClick}
+            >
+              Test this workflow
+            </a>
+            {if @isThereNotADefinedTask()
+              <p>You need to add a task and content to be able to test this workflow.</p>}
           </div>
 
           <hr />


### PR DESCRIPTION
Staging branch URL:

Toward #5279.

Describe your changes.
This disables the test workflow button if no tasks are defined. The drawing task and survey task still break the classifier if no drawing tools or none of the survey task items are defined, but doing validations/default values for those are a bit more involved and should be fixed individually.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
