### PR TITLE
Add invert subject to talk

### DIFF
--- a/app/components/subject-viewer.cjsx
+++ b/app/components/subject-viewer.cjsx
@@ -59,6 +59,7 @@ module.exports = createReactClass
     frameWrapper: null
     allowFlipbook: true
     allowSeparateFrames: false
+    talkInvert: false
     metadataPrefixes: ['#', '!']
     metadataFilters: ['#', '!']
     workflow: null
@@ -69,6 +70,7 @@ module.exports = createReactClass
     frame: @getInitialFrame()
     frameDimensions: {}
     inFlipbookMode: @props.allowFlipbook
+    invert: false
     promptingToSignIn: false
 
   getInitialFrame: ->
@@ -103,6 +105,7 @@ module.exports = createReactClass
     rootClasses = classnames('subject-viewer', {
       'default-root-style': @props.defaultStyle
       'subject-viewer--flipbook': @state.inFlipbookMode
+      'subject-viewer--invert': @state.invert
       "subject-viewer--layout-#{@props.workflow?.configuration?.multi_image_layout}": @props.workflow?.configuration?.multi_image_layout
     })
 
@@ -181,8 +184,12 @@ module.exports = createReactClass
             </span>
         </span>}
         <span>
-          {if @props.workflow?.configuration?.invert_subject
+          {if @props.workflow?.configuration?.invert_subject && not @props.talkInvert
             <button type="button" className="secret-button" aria-label="Invert image" title="Invert image" onClick={@toggleModification.bind this, 'invert'}>
+              <i className="fa fa-adjust "></i>
+            </button>}{' '}
+          {if @props.talkInvert
+            <button type="button" className="secret-button" aria-label="Invert image" title="Invert image" onClick={@toggleInvert.bind this, @state.invert}>
               <i className="fa fa-adjust "></i>
             </button>}{' '}
           {if @props.workflow?.configuration?.enable_subject_flags
@@ -259,6 +266,9 @@ module.exports = createReactClass
     else
       mods[type] = not mods[type]
     @setState modification: mods
+
+  toggleInvert: (invert) ->
+    @setState invert: !invert
 
   setInFlipbookMode: (inFlipbookMode) ->
     @setState {inFlipbookMode}

--- a/app/components/subject-viewer.cjsx
+++ b/app/components/subject-viewer.cjsx
@@ -184,12 +184,8 @@ module.exports = createReactClass
             </span>
         </span>}
         <span>
-          {if @props.workflow?.configuration?.invert_subject && not @props.talkInvert
+          {if @props.workflow?.configuration?.invert_subject or @props.talkInvert
             <button type="button" className="secret-button" aria-label="Invert image" title="Invert image" onClick={@toggleModification.bind this, 'invert'}>
-              <i className="fa fa-adjust "></i>
-            </button>}{' '}
-          {if @props.talkInvert
-            <button type="button" className="secret-button" aria-label="Invert image" title="Invert image" onClick={@toggleInvert.bind this, @state.invert}>
               <i className="fa fa-adjust "></i>
             </button>}{' '}
           {if @props.workflow?.configuration?.enable_subject_flags
@@ -258,6 +254,9 @@ module.exports = createReactClass
     @setInFlipbookMode not @state.inFlipbookMode
 
   toggleModification: (type) ->
+    if type is 'invert'
+      @setState (prevState) -> { invert: !prevState.invert }
+
     mods = @state?.modification
     if !mods
       mods = {}
@@ -266,9 +265,6 @@ module.exports = createReactClass
     else
       mods[type] = not mods[type]
     @setState modification: mods
-
-  toggleInvert: (invert) ->
-    @setState invert: !invert
 
   setInFlipbookMode: (inFlipbookMode) ->
     @setState {inFlipbookMode}

--- a/app/subjects/subject-page.jsx
+++ b/app/subjects/subject-page.jsx
@@ -24,6 +24,7 @@ const SubjectPage = (props) => {
                 project={props.project}
                 linkToFullImage={true}
                 metadataFilters={['#']}
+                talkInvert={true}
                 isFavorite={props.isFavorite}
               />
 

--- a/app/talk/comment.cjsx
+++ b/app/talk/comment.cjsx
@@ -136,7 +136,7 @@ module.exports = createReactClass
         <Link to="#{baseLink}users/#{comment.user_login}">{comment.user_display_name}</Link>
         {if comment.reply_id
           <span>
-            {' '}in reply to <Link to="#{baseLink}users/#{comment.reply_user_login}">{comment.reply_user_display_name}</Link>'s{' '}
+            {' '}in reply to <Link to="#{baseLink}users/#{comment.reply_user_login}">{comment.reply_user_display_name}</Link>&apos;s{' '}
             <button className="link-style" type="button" onClick={(e) => @onClickRenderReplies(e, comment)}>
               comment
             </button>
@@ -197,7 +197,7 @@ module.exports = createReactClass
               </div>
               }
 
-            In reply to <Link to={profile_link}>{@props.data.reply_user_display_name}</Link>'s{' '}
+            In reply to <Link to={profile_link}>{@props.data.reply_user_display_name}</Link>&apos;s{' '}
 
             <button className="link-style" type="button" onClick={(e) => @onClickRenderReplies(e, @props.data)}>comment</button>
           </div>
@@ -219,7 +219,9 @@ module.exports = createReactClass
                   user={@props.user}
                   project={@props.project}
                   linkToFullImage={true}
-                  metadataFilters={['#']} />
+                  metadataFilters={['#']}
+                  talkInvert={true}
+                />
               </div>
             }
 

--- a/css/subject-viewer.styl
+++ b/css/subject-viewer.styl
@@ -107,6 +107,13 @@
           background-color: #bbc0c0
           color: #575959
 
+  &.subject-viewer--invert
+    // Talk
+    .subject-container
+      .subject-image-frame:only-child
+        img, video
+          filter: invert(100%)
+
   // Multi-image layouts
   &:not(.subject-viewer--flipbook)
     .subject-container

--- a/css/subject-viewer.styl
+++ b/css/subject-viewer.styl
@@ -111,7 +111,10 @@
     // Talk
     .subject-container
       .subject-image-frame:only-child
-        img, video
+        img
+          filter: invert(100%)
+      .subject-video-frame:only-child
+        video
           filter: invert(100%)
 
   // Multi-image layouts


### PR DESCRIPTION
Staging branch URL: https://pr-5284.pfe-preview.zooniverse.org/projects/markb-panoptes/backyard-worlds-test-project-mb/talk/187/319

Closes #5094.

- adds invert button to Talk subject page and Talk comment page subject viewer
- inverts subject image or video using CSS `filter: invert(100%)`, does not work with IE
- keeps classification invert button functionality as is (supporting IE)

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [x] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
