### PR TITLE
Add form link to publications page (Mk II)

### DIFF
--- a/app/locales/ar.js
+++ b/app/locales/ar.js
@@ -268,10 +268,11 @@ export default {
         header: {
           showAll: 'All Publications'
         },
-        publication: {
-          viewPublication: 'View publication.',
-          viewOpenAccess: 'View open access version.'
-        }
+        submitNewPublication: 'To submit a new publication or update an existing one, please use [this form](https://docs.google.com/forms/d/e/1FAIpQLSdbAKVT2tGs1WfBqWNrMekFE5lL4ZuMnWlwJuCuNM33QO2ZYg/viewform). We aim to post links to published papers that can be accessed by the public. Articles accepted for publication but not yet published are also fine.'
+      },
+      publication: {
+        viewPublication: 'View publication.',
+        viewOpenAccess: 'View open access version.'
       }
     },
     acknowledgements: {

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -272,7 +272,8 @@ export default {
       content: {
         header: {
           showAll: 'All Publications'
-        }
+        },
+        submitNewPublication: 'To submit a new publication or update an existing one, please use [this form](https://docs.google.com/forms/d/e/1FAIpQLSdbAKVT2tGs1WfBqWNrMekFE5lL4ZuMnWlwJuCuNM33QO2ZYg/viewform). We aim to post links to published papers that can be accessed by the public. Articles accepted for publication but not yet published are also fine.'
       },
       publication: {
         viewPublication: 'View publication.',

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -279,7 +279,6 @@ export default {
         viewPublication: 'View publication.',
         viewOpenAccess: 'View open access version.'
       }
-
     },
     team: {
       nav: {

--- a/app/locales/es.js
+++ b/app/locales/es.js
@@ -205,7 +205,8 @@ export default {
       content: {
         header: {
           showAll: 'All Publications'
-        }
+        },
+        submitNewPublication: 'To submit a new publication or update an existing one, please use [this form](https://docs.google.com/forms/d/e/1FAIpQLSdbAKVT2tGs1WfBqWNrMekFE5lL4ZuMnWlwJuCuNM33QO2ZYg/viewform). We aim to post links to published papers that can be accessed by the public. Articles accepted for publication but not yet published are also fine.'
       },
       publication: {
         viewPublication: 'View publication.',

--- a/app/locales/fr.js
+++ b/app/locales/fr.js
@@ -255,6 +255,29 @@ export default {
       accelerateResearch: '### We accelerate important research by working together\n\nThe major challenge of 21st century research is dealing with the flood of information we can now collect about the world around us. Computers can help, but in many fields the human ability for pattern recognition — and our ability to be surprised — makes us superior. With the help of Zooniverse volunteers, researchers can analyze their information more quickly and accurately than would otherwise be possible, saving time and resources, advancing the ability of computers to do the same tasks, and leading to faster progress and understanding of the world, getting to exciting results more quickly.\n\nOur projects combine contributions from many individual volunteers, relying on a version of the ‘wisdom of crowds’ to produce reliable and accurate data. By having many people look at the data we often can also estimate how likely we are to make an error. The product of a Zooniverse projects is often exactly what’s needed to make progress in many fields of research.',
       discoveries: '### Volunteers and professionals make real discoveries together\n\nZooniverse projects are constructed with the aim of converting volunteers\' efforts into measurable results. These projects have produced a large number of [published research papers](/about/publications), as well as several open-source sets of analyzed data. In some cases, Zooniverse volunteers have even made completely unexpected and scientifically significant discoveries.\n\nA significant amount of this research takes place on the Zooniverse discussion boards, where volunteers can work together with each other and with the research teams. These boards are integrated with each project to allow for everything from quick hashtagging to in-depth collaborative analysis. There is also a central Zooniverse board for general chat and discussion about Zooniverse-wide matters.\n\nMany of the most interesting discoveries from Zooniverse projects have come from discussion between volunteers and researchers. We encourage all users to join the conversation on the discussion boards for more in-depth participation.'
     },
+    publications: {
+      nav: {
+        showAll: 'Show All',
+        space: 'Space',
+        physics: 'Physics',
+        climate: 'Climate',
+        humanities: 'Humanities',
+        nature: 'Nature',
+        medicine: 'Medicine',
+        meta: 'Meta',
+      },
+      content: {
+        header: {
+          showAll: 'All Publications'
+        },
+        submitNewPublication: 'To submit a new publication or update an existing one, please use [this form](https://docs.google.com/forms/d/e/1FAIpQLSdbAKVT2tGs1WfBqWNrMekFE5lL4ZuMnWlwJuCuNM33QO2ZYg/viewform). We aim to post links to published papers that can be accessed by the public. Articles accepted for publication but not yet published are also fine.'
+      },
+      publication: {
+        viewPublication: 'View publication.',
+        viewOpenAccess: 'View open access version.'
+      }
+
+    },
     team: {
       nav: {
         showAll: 'Show All',

--- a/app/locales/he.js
+++ b/app/locales/he.js
@@ -267,7 +267,8 @@ export default {
       content: {
         header: {
           showAll: 'All Publications'
-        }
+        },
+        submitNewPublication: 'To submit a new publication or update an existing one, please use [this form](https://docs.google.com/forms/d/e/1FAIpQLSdbAKVT2tGs1WfBqWNrMekFE5lL4ZuMnWlwJuCuNM33QO2ZYg/viewform). We aim to post links to published papers that can be accessed by the public. Articles accepted for publication but not yet published are also fine.'
       },
       publication: {
         viewPublication: 'View publication.',

--- a/app/locales/it.js
+++ b/app/locales/it.js
@@ -272,7 +272,8 @@ export default {
       content: {
         header: {
           showAll: 'Tutte le pubblicazioni'
-        }
+        },
+        submitNewPublication: 'To submit a new publication or update an existing one, please use [this form](https://docs.google.com/forms/d/e/1FAIpQLSdbAKVT2tGs1WfBqWNrMekFE5lL4ZuMnWlwJuCuNM33QO2ZYg/viewform). We aim to post links to published papers that can be accessed by the public. Articles accepted for publication but not yet published are also fine.'
       },
       publication: {
         viewPublication: 'Leggi pubblicazioni.',

--- a/app/locales/nl.js
+++ b/app/locales/nl.js
@@ -242,7 +242,8 @@ export default {
       content: {
         header: {
           showAll: 'All Publications'
-        }
+        },
+        submitNewPublication: 'To submit a new publication or update an existing one, please use [this form](https://docs.google.com/forms/d/e/1FAIpQLSdbAKVT2tGs1WfBqWNrMekFE5lL4ZuMnWlwJuCuNM33QO2ZYg/viewform). We aim to post links to published papers that can be accessed by the public. Articles accepted for publication but not yet published are also fine.'
       },
       publication: {
         viewPublication: 'View publication.',

--- a/app/pages/about/publications-page.jsx
+++ b/app/pages/about/publications-page.jsx
@@ -3,6 +3,7 @@ import apiClient from 'panoptes-client/lib/api-client';
 import Publications from '../../lib/publications';
 import counterpart from 'counterpart';
 import Loading from '../../components/loading-indicator';
+import { Markdown } from 'markdownz';
 
 export default class PublicationsPage extends React.Component {
 
@@ -128,12 +129,14 @@ export default class PublicationsPage extends React.Component {
 
   render() {
     const sideBarNav = counterpart('about.publications.nav');
+    const submitNewPublication = counterpart('about.publications.content.submitNewPublication')
     return (
       <div className="publications-page secondary-page-copy">
         <aside className="secondary-page-side-bar">
           { this.renderSideBarNav(sideBarNav) }
         </aside>
         <section className="publications-content">
+          <Markdown>{submitNewPublication}</Markdown>
           { this.renderHeading(sideBarNav) }
           { this.state.projects != null 
               ? this.renderProjects()

--- a/app/pages/about/publications-page.jsx
+++ b/app/pages/about/publications-page.jsx
@@ -136,8 +136,8 @@ export default class PublicationsPage extends React.Component {
           { this.renderSideBarNav(sideBarNav) }
         </aside>
         <section className="publications-content">
-          <Markdown>{submitNewPublication}</Markdown>
           { this.renderHeading(sideBarNav) }
+          <Markdown>{submitNewPublication}</Markdown>
           { this.state.projects != null 
               ? this.renderProjects()
               : <Loading />


### PR DESCRIPTION
## PR Overview

This PR adds a small bit of text to the [Publications](https://www.zooniverse.org/about/publications) page, providing a small bit of extra info to users. 

As described in the original PR, the intention of this update is:
> Short text & form link to the top of publications page for easy access.

Replaces #5285, by fixing the layout and hooking up the intended text to our language translatomatics.

![screen shot 2019-03-01 at 16 56 44](https://user-images.githubusercontent.com/13952701/53653479-47683d80-3c43-11e9-9a38-0eae7dd407ff.png)
_The "Submit New Publication" text appears above the list of publications._
_Note: the tops of the sidebar and main section don't align no more because the new text is in a Markdown block that adds unnecessary margins. I am ashamed_

**Collateral Updates:**
- All the locale files were updated so the structure of the `pages.about.publications` section of every language matches that of the English's.
  - Basically, don't worry that a lot of locale files were updated with mundane fixes unrelated to the "Submit New Publication" text. _Fuhgeddaboudit._

### Status
This is ready for review. Tagging @snblickhan as the OG PR originator. 