### PR TITLE
Add subject viewer to feedback modal

### DIFF
--- a/app/classifier/classifier.jsx
+++ b/app/classifier/classifier.jsx
@@ -133,11 +133,14 @@ class Classifier extends React.Component {
     const subjectViewerProps = {
       subject: this.props.subject,
       workflow: this.props.workflow,
+      project: this.props.project,
+      user: this.props.user,
       preferences: this.props.preferences,
       annotations: annotations,
       annotation: {},
       frame: 0,
       frameWrapper: FrameAnnotator,
+      showCollect: false,
       zoomControls: false
     };
 

--- a/app/components/subject-viewer.cjsx
+++ b/app/components/subject-viewer.cjsx
@@ -58,6 +58,7 @@ module.exports = createReactClass
     frameWrapper: null
     allowFlipbook: true
     allowSeparateFrames: false
+    showCollect: true
     talkInvert: false
     metadataPrefixes: ['#', '!']
     metadataFilters: ['#', '!']
@@ -238,13 +239,14 @@ module.exports = createReactClass
               </button>{' '}
             </span>}
           {if @props.subject?
-            if  @props.user?
+            if @props.user?
               <span>
                 {if @props.project? and not @props.workflow?.configuration?.disable_favorites
                   <span>
                     <FavoritesButton className="secret-button" project={@props.project} subject={@props.subject} user={@props.user} isFavorite={@props.isFavorite} />{' '}
                   </span>}
-                <CollectionsManagerIcon className="secret-button" project={@props.project} subject={@props.subject} user={@props.user} />
+                {if @props.showCollect
+                  <CollectionsManagerIcon className="secret-button" project={@props.project} subject={@props.subject} user={@props.user} />}
               </span>
             else
               <span>

--- a/app/features/feedback/classifier/components/feedback-modal.jsx
+++ b/app/features/feedback/classifier/components/feedback-modal.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import Translate from 'react-translate-component';
 import counterpart from 'counterpart';
-import FrameViewer from '../../../../components/frame-viewer';
+import SubjectViewer from '../../../../components/subject-viewer';
 import ModalFocus from '../../../../components/modal-focus';
 
 /* eslint-disable max-len */
@@ -28,9 +28,9 @@ class FeedbackModal extends React.Component {
   render() {
     const { messages, subjectViewerProps } = this.props;
     return (
-      <ModalFocus className="feedbackmodal">
+      <ModalFocus className="classifier feedbackmodal">
         <Translate content="FeedbackModal.title" component="h2" />
-        {subjectViewerProps && (<FrameViewer {...subjectViewerProps} />)}
+        {subjectViewerProps && (<SubjectViewer {...subjectViewerProps} />)}
         <ul>
           {messages.map(message =>
             <li key={Math.random()}>

--- a/css/feedback.styl
+++ b/css/feedback.styl
@@ -1,6 +1,7 @@
 .feedbackmodal
-
-  .subject-tools,
+  display: flex
+  flex-direction: column
+  
   .warning-banner
     display: none !important
 


### PR DESCRIPTION
Staging branch URL:

- demo with current PFE: https://master.pfe-preview.zooniverse.org/projects/markb-panoptes/backyard-worlds-test-project-mb/classify?reload=0&workflow=3312
- demo with changes to PFE feedback: https://add-subject-viewer-feedback-modal.pfe-preview.zooniverse.org/projects/markb-panoptes/backyard-worlds-test-project-mb/classify?reload=0&workflow=3312

Uses SubjectViewer instead of FrameViewer in the feedback modal. Provides multi-image subject image buttons and other related controls. Hides Collection button, as I think issues with modal on top of modal, but allows favoriting, which might be handy if user wants to follow-up on why they got feedback right or wrong.

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [x] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
