### PR TITLE
Fix project admin state active radio

### DIFF
--- a/app/pages/admin/project-status.jsx
+++ b/app/pages/admin/project-status.jsx
@@ -245,6 +245,13 @@ class ProjectStatus extends Component {
       return <LoadingIndicator />;
     }
 
+    let projectState;
+    if (project.state === '') {
+      projectState = 'live';
+    } else {
+      projectState = project.state;
+    }
+
     return (
       <div className="project-status">
         <ProjectIcon project={project} />
@@ -258,7 +265,7 @@ class ProjectStatus extends Component {
                 name="project-state-buttons"
                 type="radio"
                 value=""
-                checked={project.state === ''}
+                checked={projectState === 'live'}
                 onChange={this.handleProjectStateChange}
               />
               Active
@@ -269,7 +276,7 @@ class ProjectStatus extends Component {
                 name="project-state-buttons"
                 type="radio"
                 value="paused"
-                checked={project.state === 'paused'}
+                checked={projectState === 'paused'}
                 onChange={this.handleProjectStateChange}
               />
               Paused
@@ -280,7 +287,7 @@ class ProjectStatus extends Component {
                 name="project-state-buttons"
                 type="radio"
                 value="finished"
-                checked={project.state === 'finished'}
+                checked={projectState === 'finished'}
                 onChange={this.handleProjectStateChange}
               />
               Finished

--- a/app/pages/admin/project-status.jsx
+++ b/app/pages/admin/project-status.jsx
@@ -245,12 +245,7 @@ class ProjectStatus extends Component {
       return <LoadingIndicator />;
     }
 
-    let projectState;
-    if (project.state === '') {
-      projectState = 'live';
-    } else {
-      projectState = project.state;
-    }
+    const projectState = project.state || 'live';
 
     return (
       <div className="project-status">


### PR DESCRIPTION
Staging branch URL: https://pr-5292.pfe-preview.zooniverse.org/admin/project_status/markb-panoptes/nfnorgtest-moths

Fixes on project admin page, Project state section, if project is "Active" the radio input won't show as checked. This is due to how this Active state is updated (as `state: ''`) and returned (as '`state: 'live'`), see [this comment](https://github.com/zooniverse/Panoptes-Front-End/pull/4204#pullrequestreview-81558681).

This is the lowest of priorities.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
