### PR TITLE
WIP Get publications data from S3

### DIFF
--- a/app/pages/about/publications-page-container.jsx
+++ b/app/pages/about/publications-page-container.jsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { string } from 'prop-types';
+
+import PublicationsPage from './publications-page';
+import Loading from '../../components/loading-indicator';
+
+export default class PublicationsPageContainer extends React.Component {
+  constructor() {
+    super();
+    this.state = {
+      error: null,
+      loading: false,
+      publications: null
+    };
+  }
+
+  componentDidMount() {
+    this.loadPublications();
+  }
+
+  loadPublications() {
+    this.setState({ loading: true });
+    fetch(this.props.publicationsUrl)
+      .then(response => response.json())
+      .then(json => this.setState({
+        loading: false,
+        publications: json
+      }))
+      .catch(error => this.setState({
+        error,
+        loading: false
+      }))
+  }
+
+  render() {
+    const { error, loading, publications } = this.state;
+    const { publicationsUrl, ...props } = this.props;
+
+    if (loading || !loading && !publications && !error) {
+      return <Loading />
+    }
+
+    if (error) {
+      return <div>Error loading publications :(</div>
+    }
+
+    return <PublicationsPage {...props} publications={publications} />
+  }
+}
+
+PublicationsPageContainer.propTypes = {
+  publicationsUrl: string
+}
+
+PublicationsPageContainer.defaultProps = {
+  publicationsUrl: 'https://static.zooniverse.org/publications/publications.json'
+}

--- a/app/pages/about/publications-page.jsx
+++ b/app/pages/about/publications-page.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import apiClient from 'panoptes-client/lib/api-client';
-import Publications from '../../lib/publications';
 import counterpart from 'counterpart';
 import Loading from '../../components/loading-indicator';
 import { Markdown } from 'markdownz';
@@ -26,8 +25,8 @@ export default class PublicationsPage extends React.Component {
 
   projectSlugs() {
     const slugs = [];
-    Object.keys(Publications).forEach((category) => {
-      Publications[category].forEach((project) => {
+    Object.keys(this.props.publications).forEach((category) => {
+      this.props.publications[category].forEach((project) => {
         slugs.push(project.slug);
       });
     });
@@ -72,9 +71,9 @@ export default class PublicationsPage extends React.Component {
 
   renderHeading(sideBarNav) {
     return (
-      <h2> 
-        { this.state.currentSort === 'showAll' 
-            ? counterpart('about.publications.content.header.showAll') 
+      <h2>
+        { this.state.currentSort === 'showAll'
+            ? counterpart('about.publications.content.header.showAll')
             : sideBarNav[this.state.currentSort]
         }
       </h2>
@@ -83,19 +82,19 @@ export default class PublicationsPage extends React.Component {
 
   renderProjects() {
     return (
-      Object.keys(Publications).map((category) => {
+      Object.keys(this.props.publications).map((category) => {
         if (this.state.currentSort === category || this.state.currentSort === 'showAll') {
           return (
             <div key={category} className="publications-list">
               {
-                Publications[category].map((projectListing) => {
-                  const project = this.state.projects[projectListing.slug]; 
+                this.props.publications[category].map((projectListing) => {
+                  const project = this.state.projects[projectListing.slug];
                   return (
                     <div key={projectListing.name !== undefined ? projectListing.name : projectListing.slug}>
                       <div>
                         <h3 className="project-name">
-                          { project !== undefined  
-                              ? project.display_name 
+                          { project !== undefined
+                              ? project.display_name
                               : projectListing.name
                           }
                         </h3>
@@ -113,7 +112,7 @@ export default class PublicationsPage extends React.Component {
                               </p>
                             </div>
                           </li>
-                        ))}                        
+                        ))}
                       </ul>
                     </div>
                   );
@@ -138,7 +137,7 @@ export default class PublicationsPage extends React.Component {
         <section className="publications-content">
           { this.renderHeading(sideBarNav) }
           <Markdown>{submitNewPublication}</Markdown>
-          { this.state.projects != null 
+          { this.state.projects != null
               ? this.renderProjects()
               : <Loading />
           }
@@ -151,4 +150,4 @@ export default class PublicationsPage extends React.Component {
     const src = project !== undefined ? `//${project.avatar_src}` : '/assets/simple-avatar.png';
     return <img src={src} alt="Project Avatar" />;
   }
-} 
+}

--- a/app/router.cjsx
+++ b/app/router.cjsx
@@ -42,7 +42,7 @@ createReactClass = require 'create-react-class'
 `import EmailSettingsPage from './pages/settings/email';`
 `import AboutPage from './pages/about/index';`
 `import AboutHome from './pages/about/about-home';`
-`import PublicationsPage from './pages/about/publications-page';`
+`import PublicationsPage from './pages/about/publications-page-container';`
 `import TeamPage from './pages/about/team-page';`
 `import Acknowledgements from './pages/about/acknowledgements';`
 `import Contact from './pages/about/contact';`


### PR DESCRIPTION
Staging branch URL:

Fetches publications data from a file in the `zooniverse-static` s3 bucket, which itself is built from the Contentful CMS via https://github.com/zooniverse/build-publications-json.

To do:

- [ ] Write tests
- [ ] Fix avatars
- [ ] Fix missing titles

Describe your changes.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
