### PR TITLE
Fallback for task that is missing an editor in the lab

### DIFF
--- a/app/classifier/tasks/next-task-selector.cjsx
+++ b/app/classifier/tasks/next-task-selector.cjsx
@@ -22,8 +22,8 @@ module.exports = createReactClass
       <option value="">(Submit classification and load next subject)</option>
       {for key, definition of @props.workflow.tasks
         unless definition.type is 'shortcut'
-          text = tasks[definition.type].getTaskText definition
-          if text.length > MAX_TEXT_LENGTH_IN_MENU
+          text = tasks[definition.type]?.getTaskText definition
+          if text and text.length > MAX_TEXT_LENGTH_IN_MENU
             text = text[0...MAX_TEXT_LENGTH_IN_MENU] + '...'
           <option key={key}, value={key}>{text}</option>}
     </select>

--- a/app/pages/lab/workflow.cjsx
+++ b/app/pages/lab/workflow.cjsx
@@ -130,10 +130,15 @@ EditWorkflowPage = createReactClass
                   for key, definition of @props.workflow.tasks
                     unless definition.type is 'shortcut'
                       classNames = ['secret-button', 'nav-list-item']
+                      taskDefinition = tasks[definition.type]?.getTaskText definition
                       if key is @state.selectedTaskKey
                         classNames.push 'active'
                       <div key={key}>
-                        <button type="button" className={classNames.join ' '} onClick={@setState.bind this, selectedTaskKey: key, null}>
+                        <button
+                          type="button"
+                          className={classNames.join ' '}
+                          onClick={@setState.bind this, selectedTaskKey: key, null}
+                        >
                           {switch definition.type
                             when 'single' then <i className="fa fa-dot-circle-o fa-fw"></i>
                             when 'multiple' then <i className="fa fa-check-square-o fa-fw"></i>
@@ -147,7 +152,7 @@ EditWorkflowPage = createReactClass
                             when 'slider' then <i className="fa fa-sliders fa-fw"></i>
                             when 'highlighter' then <i className="fa fa-i-cursor"></i>}
                           {' '}
-                          {tasks[definition.type].getTaskText definition}
+                          {taskDefinition || 'Task edtior is unavailable'}
                           {if key is @props.workflow.first_task
                             <small> <em>(first)</em></small>}
                           <small style={{float: 'right'}}>{key}</small>
@@ -241,7 +246,7 @@ EditWorkflowPage = createReactClass
                   else
                     for taskKey, definition of @props.workflow.tasks
                       unless definition.type is 'shortcut'
-                        <option key={taskKey} value={taskKey}>{tasks[definition.type].getTaskText definition}</option>}
+                        <option key={taskKey} value={taskKey}>{tasks[definition.type]?.getTaskText definition}</option>}
                 </select>
               </AutoSave>
             </div>
@@ -473,7 +478,7 @@ EditWorkflowPage = createReactClass
 
         <div className={taskEditorClasses}>
           {if @state.selectedTaskKey? and @props.workflow.tasks[@state.selectedTaskKey]?
-            TaskEditorComponent = tasks[@props.workflow.tasks[@state.selectedTaskKey].type].Editor
+            TaskEditorComponent = tasks[@props.workflow.tasks[@state.selectedTaskKey].type]?.Editor
             <div>
               {if 'shortcut' in @props.project.experimental_tools
                 <ShortcutEditor workflow={@props.workflow} task={@props.workflow.tasks[@state.selectedTaskKey]} >
@@ -485,14 +490,16 @@ EditWorkflowPage = createReactClass
                     onChange={@handleTaskChange.bind this, @state.selectedTaskKey}
                   />
                 </ShortcutEditor>
-              else
+              else if TaskEditorComponent
                 <TaskEditorComponent
                   workflow={@props.workflow}
                   task={@props.workflow.tasks[@state.selectedTaskKey]}
                   taskPrefix="tasks.#{@state.selectedTaskKey}"
                   project={@props.project}
                   onChange={@handleTaskChange.bind this, @state.selectedTaskKey}
-                />}
+                />
+              else 
+                <div>Editor is not available.</div>}
               <hr />
               <br />
 

--- a/app/pages/lab/workflow.cjsx
+++ b/app/pages/lab/workflow.cjsx
@@ -152,7 +152,7 @@ EditWorkflowPage = createReactClass
                             when 'slider' then <i className="fa fa-sliders fa-fw"></i>
                             when 'highlighter' then <i className="fa fa-i-cursor"></i>}
                           {' '}
-                          {taskDefinition || 'Task edtior is unavailable'}
+                          {taskDefinition || 'Task editor is unavailable'}
                           {if key is @props.workflow.first_task
                             <small> <em>(first)</em></small>}
                           <small style={{float: 'right'}}>{key}</small>


### PR DESCRIPTION
Staging branch URL:

This adds a fallback UI for tasks that do not have editors like the annotation task for the light curve viewer. This is to make it easier to do other workflow editor actions by preventing the app from crashing like linking subject sets, tutorials, etc in the UI. 

Try on staging at: https://pr-5295.pfe-preview.zooniverse.org/lab/1862/workflows/3280

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
