### PR TITLE
Fix feedback single-answer-question left null

### DIFF
--- a/app/features/feedback/shared/strategies/single-answer-question/reducer.js
+++ b/app/features/feedback/shared/strategies/single-answer-question/reducer.js
@@ -1,5 +1,5 @@
 function singleAnswerQuestionReducer(rule, answer) {
-  const answerId = (answer > -1) ? answer : -1;
+  const answerId = (answer > -1) && (answer !== null) ? answer : -1;
   const result = rule.answer === answerId.toString();
   return Object.assign({}, rule, {
     success: result

--- a/app/features/feedback/shared/strategies/single-answer-question/reducer.spec.js
+++ b/app/features/feedback/shared/strategies/single-answer-question/reducer.spec.js
@@ -23,15 +23,27 @@ describe('Feedback > Single Answer Question > Reducer', function () {
     expect(result.success).to.be.false
   })
 
-  it('should handle a correct empty answer', function () {
+  it('should handle a correct undefined answer', function () {
     const rule = { answer: '-1' }
     const result = reducer(rule, undefined)
     expect(result.success).to.be.true
   })
 
-  it('should handle an incorrect empty answer', function () {
+  it('should handle an incorrect undefined answer', function () {
     const rule = { answer: '0' }
     const result = reducer(rule, undefined)
+    expect(result.success).to.be.false
+  })
+
+  it('should handle a correct null answer', function () {
+    const rule = { answer: '-1' }
+    const result = reducer(rule, null)
+    expect(result.success).to.be.true
+  })
+
+  it('should handle an incorrect null answer', function () {
+    const rule = { answer: '0' }
+    const result = reducer(rule, null)
     expect(result.success).to.be.false
   })
 })


### PR DESCRIPTION
Staging branch URL: https://pr-5297.pfe-preview.zoonvierse.org/projects/markb-panoptes/feedback-testing-mb/classify?workflow=3313

Fixes: [don't select an answer, click Next/Done](https://master.pfe-preview.zooniverse.org/projects/markb-panoptes/feedback-testing-mb/classify?workflow=3313)

Describe your changes.
- adds check for null answer
- updates tests for null answer

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
