### PR TITLE
Update notification to delivered onClick

### DIFF
--- a/app/pages/notifications/comment.cjsx
+++ b/app/pages/notifications/comment.cjsx
@@ -32,7 +32,11 @@ module.exports = createReactClass
         {if notification.delivered is false and !@props.startedDiscussion
           <i title="Unread" className="fa fa-star fa-lg" />}
 
-        <Link to={notification.url} className="message-link">
+        <Link
+          className="message-link"
+          onClick={() => notification.update({ delivered: true }).save()}
+          to={notification.url}
+        >
           {comment.discussion_title}
         </Link>
 

--- a/app/pages/notifications/comment.cjsx
+++ b/app/pages/notifications/comment.cjsx
@@ -34,7 +34,7 @@ module.exports = createReactClass
 
         <Link
           className="message-link"
-          onClick={() => notification.update({ delivered: true }).save()}
+          onClick={() => @props.markAsRead(notification)}
           to={notification.url}
         >
           {comment.discussion_title}

--- a/app/pages/notifications/data-request.cjsx
+++ b/app/pages/notifications/data-request.cjsx
@@ -14,7 +14,7 @@ module.exports = createReactClass
 
   stopPropagation: (e) ->
     e.stopPropagation()
-    notification.update({ delivered: true }).save()
+    @props.markAsRead(notification)
 
   render: ->
     notification = @props.notification

--- a/app/pages/notifications/data-request.cjsx
+++ b/app/pages/notifications/data-request.cjsx
@@ -14,6 +14,7 @@ module.exports = createReactClass
 
   stopPropagation: (e) ->
     e.stopPropagation()
+    notification.update({ delivered: true }).save()
 
   render: ->
     notification = @props.notification

--- a/app/pages/notifications/message.cjsx
+++ b/app/pages/notifications/message.cjsx
@@ -26,7 +26,7 @@ module.exports = createReactClass
           <i title="Unread" className="fa fa-star fa-lg" />}
         <Link
           className="message-link" 
-          onClick={() => notification.update({ delivered: true }).save()}
+          onClick={() => @props.markAsRead(notification)}
           to="/inbox/#{notification.source.conversation_id}" 
         >
           {notification.message}{' '}
@@ -41,7 +41,7 @@ module.exports = createReactClass
           </Link>{' '}
           <Link
             className="time-ago"
-            onClick={() => notification.update({ delivered: true }).save()}
+            onClick={() => @props.markAsRead(notification)}
             to={"/inbox/#{notification.source.conversation_id}"}
           >
             {moment(@props.data.message.created_at).fromNow()}

--- a/app/pages/notifications/message.cjsx
+++ b/app/pages/notifications/message.cjsx
@@ -24,7 +24,11 @@ module.exports = createReactClass
       <div className="conversation-message talk-module">
         {if notification.delivered is false
           <i title="Unread" className="fa fa-star fa-lg" />}
-        <Link to="/inbox/#{notification.source.conversation_id}" className="message-link">
+        <Link
+          className="message-link" 
+          onClick={() => notification.update({ delivered: true }).save()}
+          to="/inbox/#{notification.source.conversation_id}" 
+        >
           {notification.message}{' '}
           in {@props.data.conversation.title}
         </Link>
@@ -35,7 +39,11 @@ module.exports = createReactClass
           <Link className="user-profile-link" to="#{baseLink}users/#{@props.data.messageUser.login}">
             <Avatar user={@props.data.messageUser} />{' '}{@props.data.messageUser.display_name}
           </Link>{' '}
-          <Link to={"/inbox/#{notification.source.conversation_id}"} className="time-ago">
+          <Link
+            className="time-ago"
+            onClick={() => notification.update({ delivered: true }).save()}
+            to={"/inbox/#{notification.source.conversation_id}"}
+          >
             {moment(@props.data.message.created_at).fromNow()}
           </Link>
         </div>

--- a/app/pages/notifications/moderation.cjsx
+++ b/app/pages/notifications/moderation.cjsx
@@ -28,7 +28,12 @@ module.exports = createReactClass
         {if notification.delivered is false
           <i title="Unread" className="fa fa-star fa-lg" />}
         <div className="title">
-          <Link to={path}>{notification.message}</Link>
+          <Link
+            onClick={() => notification.update({ delivered: true }).save()}
+            to={path}
+          >
+            {notification.message}
+          </Link>
         </div>
 
         <Markdown>{@props.data.comment.body}</Markdown>
@@ -55,7 +60,10 @@ module.exports = createReactClass
 
           {' '}
 
-          <Link to={path}>
+          <Link
+            onClick={() => notification.update({ delivered: true }).save()}
+            to={path}
+          >
             {notification.message}{' '}
             {moment(notification.created_at).fromNow()}
           </Link>

--- a/app/pages/notifications/moderation.cjsx
+++ b/app/pages/notifications/moderation.cjsx
@@ -29,7 +29,7 @@ module.exports = createReactClass
           <i title="Unread" className="fa fa-star fa-lg" />}
         <div className="title">
           <Link
-            onClick={() => notification.update({ delivered: true }).save()}
+            onClick={() => @props.markAsRead(notification)}
             to={path}
           >
             {notification.message}
@@ -61,7 +61,7 @@ module.exports = createReactClass
           {' '}
 
           <Link
-            onClick={() => notification.update({ delivered: true }).save()}
+            onClick={() => @props.markAsRead(notification)}
             to={path}
           >
             {notification.message}{' '}

--- a/app/pages/notifications/notification-section.jsx
+++ b/app/pages/notifications/notification-section.jsx
@@ -32,30 +32,29 @@ export default class NotificationSection extends Component {
       });
     } else {
       apiClient.type('projects').get(this.props.projectID, { include: 'avatar' })
-      .catch((error) => {
-        this.setState({ error });
-      })
-      .then((project) => {
-        if (project.links.avatar) {
-          apiClient.type('avatars').get(project.links.avatar.id)
-          .then((avatar) => {
-            this.setState({
-              name: project.display_name,
-              avatar: avatar.src
-            })
-            .catch(() => {
-              this.setState({
-                name: project.display_name
+        .catch((error) => {
+          this.setState({ error });
+        })
+        .then((project) => {
+          if (project.links.avatar) {
+            apiClient.type('avatars').get(project.links.avatar.id)
+              .catch(() => {
+                this.setState({
+                  name: project.display_name
+                });
+              })
+              .then((avatar) => {
+                this.setState({
+                  name: project.display_name,
+                  avatar: avatar.src
+                });
               });
+          } else {
+            this.setState({
+              name: project.display_name
             });
-          });
-        } else {
-          this.setState({
-            name: project.display_name
-          });
-        }
-        
-      });
+          }
+        });
     }
   }
 

--- a/app/pages/notifications/notification-section.jsx
+++ b/app/pages/notifications/notification-section.jsx
@@ -38,15 +38,15 @@ export default class NotificationSection extends Component {
         .then((project) => {
           if (project.links.avatar) {
             apiClient.type('avatars').get(project.links.avatar.id)
-              .catch(() => {
-                this.setState({
-                  name: project.display_name
-                });
-              })
               .then((avatar) => {
                 this.setState({
                   name: project.display_name,
                   avatar: avatar.src
+                });
+              })
+              .catch(() => {
+                this.setState({
+                  name: project.display_name
                 });
               });
           } else {
@@ -137,6 +137,19 @@ export default class NotificationSection extends Component {
         if (count === 0) this.context.notificationsCounter.setUnread(0);
       });
     });
+  }
+
+  markAsRead(readNotification) {
+    const { notificationsCounter } = this.context;
+    const { user } = this.props;
+    const { notifications } = this.state;
+    const relatedNotifications = notifications.filter(
+      notification => notification.source_id === readNotification.source_id
+    );
+    relatedNotifications.push(readNotification);
+    const readRequests = relatedNotifications
+      .map(relatedNotification => relatedNotification.update({ delivered: true }).save());
+    Promise.all(readRequests).then(() => notificationsCounter.update(user));
   }
 
   avatarFor() {
@@ -244,6 +257,7 @@ export default class NotificationSection extends Component {
                 <Notification
                   data={item.data}
                   key={item.notification.id}
+                  markAsRead={this.markAsRead}
                   notification={item.notification}
                   user={this.props.user}
                 />);

--- a/app/pages/notifications/started-discussion.cjsx
+++ b/app/pages/notifications/started-discussion.cjsx
@@ -29,7 +29,7 @@ module.exports = createReactClass
 
           <div className="title">
             <Link
-              onClick={() => notification.update({ delivered: true }).save()}
+              onClick={() => @props.markAsRead(notification)}
               to={"#{slug}/talk/#{@props.data.discussion.board_id}/#{@props.data.discussion.id}"}
             >
               {@props.notification.message}

--- a/app/pages/notifications/started-discussion.cjsx
+++ b/app/pages/notifications/started-discussion.cjsx
@@ -28,7 +28,10 @@ module.exports = createReactClass
             <i title="Unread" className="fa fa-star fa-lg" />}
 
           <div className="title">
-            <Link to={"#{slug}/talk/#{@props.data.discussion.board_id}/#{@props.data.discussion.id}"}>
+            <Link
+              onClick={() => notification.update({ delivered: true }).save()}
+              to={"#{slug}/talk/#{@props.data.discussion.board_id}/#{@props.data.discussion.id}"}
+            >
               {@props.notification.message}
             </Link>
           </div>


### PR DESCRIPTION
Staging branch URL: https://pr-5301.pfe-preview.zooniverse.org

Fixes issue noted in Talk/Troubleshooting - https://www.zooniverse.org/talk/17/735435?comment=1555431.

Updates notification delivered attribute to true when click link to related resource.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
