### PR TITLE
Fix notification-section markAsRead

### DIFF
--- a/app/pages/notifications/notification-section.spec.js
+++ b/app/pages/notifications/notification-section.spec.js
@@ -93,4 +93,77 @@ describe('Notification Section', function() {
       assert.equal(wrapper.find('.fa-chevron-up').length, 1);
     });
   });
+
+  describe('will update notifications as read', function () {
+    const newNotifications = [
+      {
+        id: '123',
+        delivered: false,
+        source: {
+          discussion_id: '456'
+        },
+        source_type: 'Comment',
+        update: sinon.stub().returnsThis(),
+        save: sinon.stub().resolves({})
+      },
+      {
+        id: '124',
+        delivered: false,
+        source: {
+          discussion_id: '456'
+        },
+        source_type: 'Comment',
+        update: sinon.stub().returnsThis(),
+        save: sinon.stub().rejects()
+      },
+      {
+        id: '125',
+        delivered: false,
+        source_type: 'Moderation',
+        source: {},
+        update: sinon.stub().returnsThis(),
+        save: sinon.stub().resolves({})
+      },
+      {
+        id: '126',
+        delivered: false,
+        source: {
+          discussion_id: '789'
+        },
+        source_type: 'Comment',
+        update: sinon.stub().returnsThis(),
+        save: sinon.stub().resolves({})
+      }
+    ];
+    const notificationsCounter = {
+      update: sinon.stub()
+    };
+    wrapper = shallow(
+      <NotificationSection expanded={true} />,
+      { context: { notificationsCounter }, disableLifeCycleMethods: true }
+    );
+    wrapper.setState({ notifications: newNotifications });
+    wrapper.instance().markAsRead(newNotifications[0]);
+
+    it('should update read notification as read (delivered)', function () {
+      assert.equal(newNotifications[0].update.calledWith({ delivered: true }), true);
+      assert.equal(newNotifications[0].save.called, true);
+    });
+
+    it('should update related notifications as read (delivered)', function () {
+      assert.equal(newNotifications[1].update.calledWith({ delivered: true }), true);
+      assert.equal(newNotifications[1].save.called, true);
+    });
+
+    it('should not update unrelated notifications', function () {
+      assert.equal(newNotifications[2].update.called, false);
+      assert.equal(newNotifications[2].save.called, false);
+      assert.equal(newNotifications[3].update.called, false);
+      assert.equal(newNotifications[3].save.called, false);
+    });
+
+    it('should update the notifications counter', function () {
+      assert.equal(notificationsCounter.update.called, true);
+    });
+  });
 });


### PR DESCRIPTION
Staging branch URL:

I hope fixes #5301, as currently notifications still not marked as "read" (`delivered: true`) after clicking to related source.

Describe your changes.
- binds `markAsRead`
- refactor `markAsRead`, including filtering on `subscription_id`, though imperfect, I think best option that applies to all sources (i.e. comment, moderation, data request, etc.)
- [x] tests

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
