### PR TITLE
Get detail task translations by workflow ID

### DIFF
--- a/app/classifier/drawing-tools/components/DetailsSubTaskForm/DetailsSubTaskForm.jsx
+++ b/app/classifier/drawing-tools/components/DetailsSubTaskForm/DetailsSubTaskForm.jsx
@@ -115,7 +115,7 @@ export class DetailsSubTaskForm extends React.Component {
   }
   
   render() {
-    const { theme, tasks, toolProps, translations } = this.props;
+    const { theme, tasks, toolProps, translations, workflow } = this.props;
 
     const detailsAreComplete = this.areDetailsComplete(tasks, toolProps);
 
@@ -131,8 +131,9 @@ export class DetailsSubTaskForm extends React.Component {
               {toolProps.details.map((detailTask, i) => {
                 if (!detailTask._key) detailTask._key = Math.random();
                 const TaskComponent = tasks[detailTask.type];
-                const detailTranslation = translations.strings.workflow.tasks ?
-                  translations.strings.workflow.tasks[toolProps.taskKey].tools[toolProps.mark.tool].details[i] :
+                const workflowTranslation = translations.strings.workflow[workflow.id]
+                const detailTranslation = workflowTranslation ?
+                  workflowTranslation.strings.tasks[toolProps.taskKey].tools[toolProps.mark.tool].details[i] :
                   detailTask;
                 
                 return (
@@ -167,7 +168,8 @@ export class DetailsSubTaskForm extends React.Component {
 
 const mapStateToProps = state => ({
   theme: state.userInterface.theme,
-  translations: state.translations
+  translations: state.translations,
+  workflow: state.classify.workflow
 });
 
 export default connect(mapStateToProps)(DetailsSubTaskForm);

--- a/app/classifier/drawing-tools/components/DetailsSubTaskForm/DetailsSubTaskForm.spec.js
+++ b/app/classifier/drawing-tools/components/DetailsSubTaskForm/DetailsSubTaskForm.spec.js
@@ -17,6 +17,11 @@ const store = {
   subscribe: () => { },
   dispatch: () => { },
   getState: () => ({
+    classify: {
+      workflow: {
+        id: 'a'
+      }
+    },
     translations: {
       languages: {},
       locale: 'en',
@@ -70,7 +75,12 @@ describe('DetailsSubTaskForm', function() {
   describe('render', function() {
     let wrapper;
     before(function () {
-      wrapper = shallow(<DetailsSubTaskForm tasks={tasks} translations={translations} toolProps={toolProps} />, mockReduxStore);
+      wrapper = shallow(<DetailsSubTaskForm
+        tasks={tasks}
+        translations={translations}
+        toolProps={toolProps}
+        workflow={{ id: 'a' }}
+      />, mockReduxStore);
     });
 
     it('should render without crashing', function () {


### PR DESCRIPTION
Translations are now keyed by resource ID, so get workflow translations by workflow ID before getting the strings for individual detail tasks.

Staging branch URL: https://pr-5310.pfe-preview.zooniverse.org

Fixes #5309.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
