### PR TITLE
Autofocus collection manager modal

### DIFF
--- a/app/collections/collection-search.cjsx
+++ b/app/collections/collection-search.cjsx
@@ -11,6 +11,11 @@ module.exports = createReactClass
     multi: PropTypes.bool.isRequired
     onChange: PropTypes.func
 
+  componentDidMount: ->
+    if @props.autoFocus
+      @refs.collectionSelect.focus()
+    
+
   getDefaultProps: ->
     multi: false
 

--- a/app/collections/collections-manager.jsx
+++ b/app/collections/collections-manager.jsx
@@ -21,10 +21,7 @@ class CollectionsManager extends React.Component {
 
   onChange() {
     const collections = this.search.getSelected();
-
-    if (collections.length > 0) {
-      this.setState({ hasCollectionSelected: true });
-    }
+    this.setState({ hasCollectionSelected: collections.length > 0 });
   }
 
   addToCollections() {
@@ -65,6 +62,7 @@ class CollectionsManager extends React.Component {
   }
 
   render() {
+    const { autoFocus } = this.props;
     return (
       <div className="collections-manager">
         <h2 className="collections-manager__header">
@@ -79,6 +77,7 @@ class CollectionsManager extends React.Component {
             </ul>}
           <CollectionSearch
             ref={(node) => { this.search = node; }}
+            autoFocus={autoFocus}
             onChange={this.onChange}
             multi={true}
           />
@@ -106,12 +105,14 @@ class CollectionsManager extends React.Component {
 }
 
 CollectionsManager.defaultProps = {
+  autoFocus: false,
   onSuccess: () => {},
   project: null,
   subjectIDs: []
 };
 
 CollectionsManager.propTypes = {
+  autoFocus: PropTypes.bool,
   onSuccess: PropTypes.func,
   project: PropTypes.shape({
     id: PropTypes.string

--- a/app/collections/manager-icon.jsx
+++ b/app/collections/manager-icon.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import Dialog from 'modal-form/dialog';
 import CollectionsManager from './collections-manager';
+import ModalFocus from '../components/modal-focus';
 
 class CollectionsManagerIcon extends React.Component {
   constructor(props) {
@@ -37,13 +38,17 @@ class CollectionsManagerIcon extends React.Component {
 
         {this.state.open &&
           <Dialog tag="div" closeButton={true} onCancel={this.close}>
-            <CollectionsManager
-              autoFocus={true}
-              onSuccess={this.close}
-              project={this.props.project}
-              subjectIDs={subjectIDs}
-              user={this.props.user}
-            />
+            <ModalFocus
+              onEscape={this.close}
+            >
+              <CollectionsManager
+                autoFocus={true}
+                onSuccess={this.close}
+                project={this.props.project}
+                subjectIDs={subjectIDs}
+                user={this.props.user}
+              />
+            </ModalFocus>
           </Dialog>}
       </button>
     );

--- a/app/collections/manager-icon.jsx
+++ b/app/collections/manager-icon.jsx
@@ -38,6 +38,7 @@ class CollectionsManagerIcon extends React.Component {
         {this.state.open &&
           <Dialog tag="div" closeButton={true} onCancel={this.close}>
             <CollectionsManager
+              autoFocus={true}
               onSuccess={this.close}
               project={this.props.project}
               subjectIDs={subjectIDs}


### PR DESCRIPTION
Staging branch URL: https://pr-5313.pfe-preview.zooniverse.org

Add an autoFocus prop to the collections manager popup and focus the search input when it opens.

Also fixes a bug where the Add button would remain active if you delete the selected collection.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
