### PR TITLE
Change Live to Published for translations

### DIFF
--- a/app/pages/lab/translations/index.jsx
+++ b/app/pages/lab/translations/index.jsx
@@ -58,22 +58,19 @@ class TranslationsManager extends React.Component {
         }
         <h2>Project language menu</h2>
         <p>
-          Tick languages here to add a language menu to your project,
-          and make those translations available to your volunteers.
+          Tick languages here to publish those translations, and make them available to your volunteers.
         </p>
         <table>
           <tr>
             <th>Language</th>
-            <th>Code</th>
-            <th>Live?</th>
+            <th>Published?</th>
           </tr>
           {languageMenuCodes.map((language) => {
             const disabled = language === project.primary_language;
             const checked = projectLanguages.indexOf(language) > -1;
             return (
               <tr key={language}>
-                <td>{languageMenu[language]}</td>
-                <td>{language}</td>
+                <td>{languageMenu[language]} ({language})</td>
                 <td>
                   <input
                     type="checkbox"


### PR DESCRIPTION
Update the wording of the lab translations page to make it clear that ticking a language checkbox publishes that language for your project.

Staging branch URL: https://pr-5315.pfe-preview.zooniverse.org

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
