### PR TITLE
Add a workflow selection strategy for the workflow query param

### DIFF
--- a/app/pages/project/classify.jsx
+++ b/app/pages/project/classify.jsx
@@ -21,6 +21,7 @@ import WorkflowAssignmentDialog from '../../components/workflow-assignment-dialo
 import ProjectThemeButton from './components/ProjectThemeButton';
 import WorkflowSelection from './workflow-selection';
 import ClassroomWorkflowSelection from './workflow-selection-classroom';
+import URLWorkflowSelection from './workflow-selection-url';
 import { zooTheme } from '../../theme';
 
 function onClassificationSaved(actualClassification) {
@@ -361,16 +362,25 @@ const mapDispatchToProps = dispatch => ({
 
 const ConnectedClassifyPage = connect(mapStateToProps, mapDispatchToProps)(ProjectClassifyPage);
 
-function ConnectedClassifyPageWithWorkflow(props) {
-  const workflowKey = props.workflow ? props.workflow.id : 'no-workflow';
-  
+function WorkflowStrategy(props) {
   //Check for WildCam Lab classrooms (see https://github.com/zooniverse/edu-api-front-end)
   const workflowFromUrl = props.location.query && props.location.query.workflow;
   const isProjectForClassrooms = (props.project && props.project.experimental_tools && props.project.experimental_tools.indexOf('wildcam classroom') > -1);
   const isUrlForClassrooms = props.location.query && props.location.query.classroom;
   const isClassroom = isProjectForClassrooms && isUrlForClassrooms && workflowFromUrl;
   
-  const WorkflowStrategy = isClassroom ? ClassroomWorkflowSelection : WorkflowSelection;
+  if (isClassroom) {
+    return <ClassroomWorkflowSelection {...props} />;
+  }
+  if (workflowFromUrl) {
+    return <URLWorkflowSelection {...props} />;
+  }
+  return <WorkflowSelection {...props} />;
+}
+
+function ConnectedClassifyPageWithWorkflow(props) {
+  const workflowKey = props.workflow ? props.workflow.id : 'no-workflow';
+
   return (
     <WorkflowStrategy
       key={workflowKey}

--- a/app/pages/project/workflow-selection-url.jsx
+++ b/app/pages/project/workflow-selection-url.jsx
@@ -1,0 +1,43 @@
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import * as classifierActions from '../../redux/ducks/classify';
+import * as translationActions from '../../redux/ducks/translations';
+import { WorkflowSelection } from './workflow-selection';
+
+export class URLWorkflowSelection extends WorkflowSelection {
+  getSelectedWorkflow(props) {
+    const { actions, locale, location, preferences, project, user } = props;
+    const workflowFromURL = this.sanitiseID(location.query.workflow);
+    const projectAllowsWorkflowQuery =
+      project.experimental_tools &&
+      project.experimental_tools.indexOf('allow workflow query') > -1;
+    // admin users can load any workflow. Others can only load active workflows
+    const validWorkflows = this.checkUserRoles(project, user) ?
+      project.links.workflows :
+      project.links.active_workflows;
+    const isValidWorkflow = validWorkflows.indexOf ? validWorkflows.indexOf(workflowFromURL) > -1 : false;
+    // admin users can always use query params
+    const canUseQueryParams = projectAllowsWorkflowQuery || this.checkUserRoles(project, user);
+    if (isValidWorkflow && canUseQueryParams && workflowFromURL) {
+      return actions.classifier.loadWorkflow(workflowFromURL, locale, preferences);
+    }
+    if (process.env.BABEL_ENV !== 'test') console.warn('Cannot select a workflow.');
+    this.context.router.push(`/projects/${this.props.project.slug}/classify`);
+    return Promise.resolve(null);
+  }
+}
+
+const mapStateToProps = state => ({
+  locale: state.translations.locale,
+  workflow: state.classify.workflow
+});
+
+const mapDispatchToProps = dispatch => ({
+  actions: {
+    classifier: bindActionCreators(classifierActions, dispatch),
+    translations: bindActionCreators(translationActions, dispatch)
+  }
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(URLWorkflowSelection);
+

--- a/app/pages/project/workflow-selection-url.spec.js
+++ b/app/pages/project/workflow-selection-url.spec.js
@@ -1,0 +1,279 @@
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import sinon from 'sinon';
+import { URLWorkflowSelection } from './workflow-selection-url';
+import mockPanoptesResource from '../../../test/mock-panoptes-resource';
+
+function StubPage(props) {
+  return <p>{props.workflow ? props.workflow.id : 'Hello'}</p>;
+}
+
+const location = {
+  query: {
+    workflow: '1234',
+    classroom: '1'
+  }
+};
+
+const context = {
+  router: {
+    push: sinon.stub()
+  }
+};
+
+const projectRoles = [
+  {
+    roles: ['owner'],
+    links: {
+      owner: {
+        id: '1'
+      }
+    }
+  },
+  {
+    roles: ['collaborator'],
+    links: {
+      owner: {
+        id: '2'
+      }
+    }
+  },
+  {
+    roles: ['tester'],
+    links: {
+      owner: {
+        id: '3'
+      }
+    }
+  }
+];
+
+const project = mockPanoptesResource('projects',
+  {
+    id: 'a',
+    display_name: 'A test project',
+    experimental_tools: [],
+    slug: 'test/test-project',
+    links: {
+      active_workflows: ['1', '2', '3', '4', '5'],
+      owner: { id: '1' },
+      workflows: ['1', '2', '3', '4', '5', '6']
+    }
+  }
+);
+
+const owner = mockPanoptesResource(
+  'users',
+  {
+    id: project.links.owner.id
+  }
+);
+
+const volunteer = mockPanoptesResource(
+  'users',
+  {
+    id: '4'
+  }
+);
+
+const preferences = mockPanoptesResource(
+  'project_preferences',
+  {
+    preferences: {},
+    links: {
+      project: project.id
+    }
+  }
+);
+
+describe('URLWorkflowSelection', function () {
+  let wrapper;
+  let controller;
+  let workflowStub;
+  const actions = {
+    classifier: {
+      loadWorkflow: sinon.spy(),
+      reset: sinon.spy(),
+      setWorkflow: sinon.spy()
+    },
+    translations: {
+      load: sinon.stub().callsFake(() => Promise.resolve([]))
+    }
+  };
+
+  before(function () {
+    workflowStub = sinon.stub(URLWorkflowSelection.prototype, 'getWorkflow').callsFake(() => {});
+  });
+
+  describe('selecting a workflow ID', function () {
+
+    beforeEach(function () {
+      actions.classifier.loadWorkflow.resetHistory();
+    });
+
+    afterEach(function () {
+      project.experimental_tools = [];
+      location.query = {};
+      context.router.push.resetHistory();
+    });
+
+    after(function () {
+      workflowStub.restore();
+    });
+
+    it('should load active workflows for approved projects', function () {
+      project.experimental_tools = ['allow workflow query'];
+      location.query.workflow = '1';
+      wrapper = shallow(
+        <URLWorkflowSelection
+          actions={actions}
+          project={project}
+          preferences={preferences}
+          projectRoles={projectRoles}
+          user={owner}
+          locale='en'
+          location={location}
+        >
+          <StubPage />
+        </URLWorkflowSelection>,
+        { context }
+      );
+      expect(actions.classifier.loadWorkflow).to.have.been.calledOnce;
+      expect(actions.classifier.loadWorkflow).to.have.been.calledWith(location.query.workflow, 'en', preferences);
+    });
+
+    it('should load inactive workflows for project owners', function () {
+      location.query.workflow = '6';
+      wrapper = shallow(
+        <URLWorkflowSelection
+          actions={actions}
+          project={project}
+          preferences={preferences}
+          projectRoles={projectRoles}
+          user={owner}
+          locale='en'
+          location={location}
+        >
+          <StubPage />
+        </URLWorkflowSelection>,
+        { context }
+      );
+      expect(actions.classifier.loadWorkflow).to.have.been.calledOnce;
+      expect(actions.classifier.loadWorkflow).to.have.been.calledWith(location.query.workflow, 'en', preferences);
+    });
+
+    it('should sanitise the workflow query param', function () {
+      project.experimental_tools = ['allow workflow query'];
+      location.query.workflow = '1rty'
+      wrapper = shallow(
+        <URLWorkflowSelection
+          actions={actions}
+          project={project}
+          preferences={preferences}
+          projectRoles={projectRoles}
+          locale='en'
+          location={location}
+        >
+          <StubPage />
+        </URLWorkflowSelection>,
+        { context }
+      );
+      expect(actions.classifier.loadWorkflow).to.have.been.calledOnce;
+      expect(actions.classifier.loadWorkflow).to.have.been.calledWith('1', 'en', preferences);
+    });
+
+    it('should not load inactive workflows for general users', function () {
+      project.experimental_tools = ['allow workflow query'];
+      location.query.workflow = '6'
+      wrapper = shallow(
+        <URLWorkflowSelection
+          actions={actions}
+          project={project}
+          preferences={preferences}
+          projectRoles={projectRoles}
+          locale='en'
+          location={location}
+        >
+          <StubPage />
+        </URLWorkflowSelection>,
+        { context }
+      );
+      expect(actions.classifier.loadWorkflow).to.have.not.been.called;
+    });
+
+    it('should redirect to /classify on failure', function () {
+      project.experimental_tools = ['allow workflow query'];
+      location.query.workflow = '6'
+      wrapper = shallow(
+        <URLWorkflowSelection
+          actions={actions}
+          project={project}
+          preferences={preferences}
+          projectRoles={projectRoles}
+          locale='en'
+          location={location}
+        >
+          <StubPage />
+        </URLWorkflowSelection>,
+        { context }
+      );
+      expect(context.router.push).to.have.been.calledOnceWith(`/projects/${project.slug}/classify`);
+    });
+
+    it('should not load a workflow without a workflow query parameter', function () {
+      project.experimental_tools = ['allow workflow query'];
+      location.query = {}
+      wrapper = shallow(
+        <URLWorkflowSelection
+          actions={actions}
+          project={project}
+          preferences={preferences}
+          projectRoles={projectRoles}
+          user={volunteer}
+          locale='en'
+          location={location}
+        >
+          <StubPage />
+        </URLWorkflowSelection>,
+        { context }
+      );
+      expect(actions.classifier.loadWorkflow).to.have.not.been.called;
+      expect(context.router.push).to.have.been.calledOnceWith(`/projects/${project.slug}/classify`);
+    });
+  });
+
+  describe('with a valid workflow loaded', function () {
+    before(function () {
+      wrapper = shallow(
+        <URLWorkflowSelection
+          actions={actions}
+          project={project}
+          preferences={preferences}
+          projectRoles={projectRoles}
+          locale='en'
+          location={location}
+        >
+          <StubPage />
+        </URLWorkflowSelection>,
+        { context }
+      );
+    })
+
+    it('should render the child component', function () {
+      const workflow = mockPanoptesResource('workflows',
+        {
+          id: 'a',
+          tasks: [],
+          links: {
+            project: project.id
+          }
+        }
+      );
+      expect(wrapper.find(StubPage)).to.have.lengthOf(0);
+      wrapper.setProps({ workflow });
+      const child = wrapper.find(StubPage);
+      expect(wrapper.find(StubPage)).to.have.lengthOf(1);
+    });
+  });
+});

--- a/app/pages/project/workflow-selection.jsx
+++ b/app/pages/project/workflow-selection.jsx
@@ -6,6 +6,12 @@ import isAdmin from '../../lib/is-admin';
 import * as classifierActions from '../../redux/ducks/classify';
 import * as translationActions from '../../redux/ducks/translations';
 
+/*
+PLEASE DO NOT ADD NEW WORKFLOW SELECTION RULES TO THIS COMPONENT.
+Implement a new selection strategy component which extends this class and overrides getSelectedWorkflow.
+See workflow-select-classroom.jsx and workflow-selection-url.jsx for examples.
+New strategies should then be added to WorkflowStrategy at the bottom of classify.jsx.
+*/
 class WorkflowSelection extends React.Component {
   constructor() {
     super();

--- a/app/pages/project/workflow-selection.jsx
+++ b/app/pages/project/workflow-selection.jsx
@@ -44,20 +44,9 @@ class WorkflowSelection extends React.Component {
     // if none of those are set, select random workflow
     let selectedWorkflowID;
     let activeFilter = true;
-    const workflowFromURL = this.sanitiseID(this.props.location.query.workflow);
     const userSelectedWorkflow = (user && preferences && preferences.preferences) ? this.sanitiseID(preferences.preferences.selected_workflow) : undefined;
     const projectSetWorkflow = (user && preferences && preferences.settings) ? this.sanitiseID(preferences.settings.workflow_id) : undefined;
-    if (workflowFromURL &&
-      this.checkUserRoles(project, user)
-    ) {
-      selectedWorkflowID = workflowFromURL;
-      activeFilter = false;
-    } else if (workflowFromURL &&
-      project.experimental_tools &&
-      project.experimental_tools.indexOf('allow workflow query') > -1
-    ) {
-      selectedWorkflowID = workflowFromURL;
-    } else if (userSelectedWorkflow) {
+    if (userSelectedWorkflow) {
       selectedWorkflowID = userSelectedWorkflow;
     } else if (projectSetWorkflow) {
       selectedWorkflowID = projectSetWorkflow;
@@ -88,10 +77,6 @@ class WorkflowSelection extends React.Component {
         // Don't try again and get caught in a loop
         this.workflowSelectionErrorHandler();
       } else {
-        if (this.props.location.query && this.props.location.query.workflow) {
-          this.context.router.push(`/projects/${this.props.project.slug}/classify`);
-        }
-
         this.clearInactiveWorkflow(selectedWorkflowID)
           .then(() => {
             this.getSelectedWorkflow(this.props);

--- a/app/pages/project/workflow-selection.spec.js
+++ b/app/pages/project/workflow-selection.spec.js
@@ -134,22 +134,6 @@ describe('WorkflowSelection', function () {
       expect(project.links.active_workflows).to.include(selectedWorkflowID.toString());
     });
 
-    it('should respect the workflow query param if "allow workflow query" is set', function () {
-      location.query.workflow = '6';
-      project.experimental_tools = ['allow workflow query'];
-      controller.getSelectedWorkflow({ project });
-      expect(workflowStub).to.have.been.calledOnce;
-      expect(workflowStub).to.have.been.calledWith('6', true);
-    });
-
-    it('should sanitise the workflow query param if "allow workflow query" is set', function () {
-      location.query.workflow = '6random78';
-      project.experimental_tools = ['allow workflow query'];
-      controller.getSelectedWorkflow({ project });
-      expect(workflowStub).to.have.been.calledOnce;
-      expect(workflowStub).to.have.been.calledWith('6', true);
-    });
-
     describe('without a logged-in user', function () {
       before(function () {
         project.update({ 'configuration.default_workflow': '1' });
@@ -184,28 +168,6 @@ describe('WorkflowSelection', function () {
     describe('with a logged-in user', function () {
       beforeEach(function () {
         controller.setupSplits = () => null;
-        location.query.workflow = '6';
-      });
-
-      it('should load the specified workflow for the project owner', function () {
-        const user = owner;
-        controller.getSelectedWorkflow({ project, preferences, user });
-        expect(workflowStub).to.have.been.calledOnce;
-        expect(workflowStub).to.have.been.calledWith('6', false);
-      });
-
-      it('should load the specified workflow for a collaborator', function () {
-        const user = mockPanoptesResource('users', { id: '2' });
-        controller.getSelectedWorkflow({ project, preferences, user });
-        expect(workflowStub).to.have.been.calledOnce;
-        expect(workflowStub).to.have.been.calledWith('6', false);
-      });
-
-      it('should load the specified workflow for a tester', function () {
-        const user = mockPanoptesResource('users', { id: '3' });
-        controller.getSelectedWorkflow({ project, preferences, user });
-        expect(workflowStub).to.have.been.calledOnce;
-        expect(workflowStub).to.have.been.calledWith('6', false);
       });
 
       it('should load an active workflow for a general user', function () {
@@ -421,29 +383,6 @@ describe('WorkflowSelection', function () {
           expect(controller.getSelectedWorkflow).to.have.been.calledOnce;
         })
         .then(done, done);
-      });
-
-      describe('when a workflow query param is present', function () {
-        before(function () {
-          const location = {
-            query: {
-              workflow: '5'
-            }
-          };
-          wrapper.setProps({ location });
-        });
-
-        after(function () {
-          wrapper.setProps({ location : {} });
-        });
-
-        it('should redirect to the classify page', function (done) {
-          awaitWorkflow
-          .then(function () {
-            expect(context.router.push).to.have.been.calledWith(`/projects/${project.slug}/classify`);
-          })
-          .then(done, done);
-        });
       });
 
       describe('when the project default workflow is invalid', function () {


### PR DESCRIPTION
Staging branch URL: https://pr-5318.pfe-preview.zooniverse.org

Prompted by #5125, this adds a new workflow selection strategy to use when a workflow query param is present, and removes those rules from the default selection strategy component. I've also added a note to `WorkflowSelection` saying that it shouldn't be overloaded with new rules any more. Rather, add new strategies using this one or classroom selection as examples.

I've also updated the classify page component to add a simple strategy selector, which uses the query param strategy if a query param is present. If workflow ID validation fails, the query param is removed from the location, which was the existing behaviour and, I think, will fall back to loading the project default workflow.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
