### PR TITLE
Add a component to force a full refresh on entering a given route

### DIFF
--- a/app/router.cjsx
+++ b/app/router.cjsx
@@ -69,6 +69,16 @@ ONE_UP_REDIRECT = createReactClass
   render: ->
     null
 
+# Used to force a refresh on entering a route, causing it to be fetched from
+# the server - and allowing us to reverse proxy other apps to routes in PFE.
+#
+# Usage: <Route path="path/to/location" component={RELOAD} />
+RELOAD = createReactClass
+  componentDidMount: ->
+    window.location.reload()
+  render: ->
+    null
+
 module.exports =
   <Route path="/" component={require './partials/app'}>
     <IndexRoute component={HomePageRoot} />


### PR DESCRIPTION
Required for allowing the LCV app to be reverse proxied to PFE. This will need us to add the actual route using it once we're ready to go live.

cc @adammcmaster @camallen 

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
