### PR TITLE
Allow Tasks with Two Plus Options to be Mobile Friendly

### DIFF
--- a/app/pages/lab/mobile/mobile-section-container.fixtures.js
+++ b/app/pages/lab/mobile/mobile-section-container.fixtures.js
@@ -180,6 +180,16 @@ const validationFixtures = {
         }
       ]
     }
+  },
+  questionHasOneImage: {
+    task: {
+      question: '![image.jpg](https://panoptes-uploads.zooniverse.org/staging/location.jpeg)'
+    }
+  },
+  questionHasTwoImages: {
+    task: {
+      question: '![image.jpg](https://panoptes-uploads.zooniverse.org/staging/location.jpeg) ![image.jpg](https://panoptes-uploads.zooniverse.org/staging/location.jpeg)'
+    }
   }
 };
 

--- a/app/pages/lab/mobile/mobile-section-container.fixtures.js
+++ b/app/pages/lab/mobile/mobile-section-container.fixtures.js
@@ -71,15 +71,6 @@ const validationFixtures = {
       question: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla ut dui erat. Vivamus est nisl, accumsan non urna at, elementum tempor urna. Sed eget pulvinar eros. Nunc placerat metus bibendum lacus elementum, vitae sagittis mi tincidunt.'
     }
   },
-  taskHasThreeAnswers: {
-    task: {
-      answers: [
-        { label: 'Yes' },
-        { label: 'No' },
-        { label: 'Maybe' }
-      ]
-    }
-  },
   taskFeedbackEnabled: {
     task: {
       feedback: {

--- a/app/pages/lab/mobile/mobile-section-container.jsx
+++ b/app/pages/lab/mobile/mobile-section-container.jsx
@@ -11,15 +11,16 @@ const VALID_TASK_TYPES_FOR_MOBILE = ['single', 'drawing'];
 const MARKDOWN_IMAGE = /!\[[^\]]*](:?\([^)]*\)|\[[^\]]*])/g;
 
 function taskQuestionNotTooLong({ task }) {
-  let { question } = task;
-  if (question) {
-    const matchArray = question.match(MARKDOWN_IMAGE);
-    if (matchArray) {
-      matchArray.map((imageLink) => {
-        question = question.replace(imageLink, '');
-      });
-    }
-  }
+  const { question } = task;
+  // TODO: Code to remove markdown images from character count. Change must be made in mobile app checks before addition.
+  // if (question) {
+  //   const matchArray = question.match(MARKDOWN_IMAGE);
+  //   if (matchArray) {
+  //     matchArray.map((imageLink) => {
+  //       question = question.replace(imageLink, '');
+  //     });
+  //   }
+  // }
   return convertBooleanToValidation(question ? question.length < VALID_QUESTION_LENGTH : false);
 }
 

--- a/app/pages/lab/mobile/mobile-section-container.jsx
+++ b/app/pages/lab/mobile/mobile-section-container.jsx
@@ -71,7 +71,6 @@ const validatorFns = {
   single: {
     taskQuestionNotTooLong,
     taskFeedbackDisabled,
-    taskHasTwoAnswers,
     workflowFlipbookDisabled,
     workflowHasSingleTask,
     workflowNotTooManyShortcuts: workflowHasNoMoreThanXShortcuts(2),

--- a/app/pages/lab/mobile/mobile-section-container.jsx
+++ b/app/pages/lab/mobile/mobile-section-container.jsx
@@ -17,10 +17,6 @@ function taskFeedbackDisabled({ task }) {
   return convertBooleanToValidation(!task.feedback || !task.feedback.enabled);
 }
 
-function taskHasTwoAnswers({ task }) {
-  return convertBooleanToValidation(task.answers ? task.answers.length === 2 : false);
-}
-
 function workflowFlipbookDisabled({ workflow }) {
   return convertBooleanToValidation((workflow.configuration) ? workflow.configuration.multi_image_mode !== 'flipbook' : true);
 }

--- a/app/pages/lab/mobile/mobile-section-container.jsx
+++ b/app/pages/lab/mobile/mobile-section-container.jsx
@@ -8,9 +8,19 @@ import ValidationValue, { convertBooleanToValidation } from './mobile-validation
 
 const VALID_QUESTION_LENGTH = 200;
 const VALID_TASK_TYPES_FOR_MOBILE = ['single', 'drawing'];
+const MARKDOWN_IMAGE = /!\[[^\]]*](:?\([^)]*\)|\[[^\]]*])/g;
 
 function taskQuestionNotTooLong({ task }) {
-  return convertBooleanToValidation(task.question ? task.question.length < VALID_QUESTION_LENGTH : false);
+  let { question } = task;
+  if (question) {
+    const matchArray = question.match(MARKDOWN_IMAGE);
+    if (matchArray) {
+      matchArray.map((imageLink) => {
+        question = question.replace(imageLink, '');
+      });
+    }
+  }
+  return convertBooleanToValidation(question ? question.length < VALID_QUESTION_LENGTH : false);
 }
 
 function taskFeedbackDisabled({ task }) {
@@ -33,10 +43,9 @@ function workflowHasNoMoreThanXShortcuts(shortcutsLimit) {
 }
 
 function workflowQuestionHasOneOrLessImages({ task }) {
-  const markdownQuestion = /!\[[^\]]*](:?\([^)]*\)|\[[^\]]*])/g;
   let validation = convertBooleanToValidation(false);
   if (task.question) {
-    const matchArray = task.question.match(markdownQuestion);
+    const matchArray = task.question.match(MARKDOWN_IMAGE);
     validation = convertBooleanToValidation(matchArray ? matchArray.length < 2 : true, true);
   }
 

--- a/app/pages/lab/mobile/mobile-section-container.spec.js
+++ b/app/pages/lab/mobile/mobile-section-container.spec.js
@@ -70,7 +70,7 @@ describe('<MobileSectionContainer />', function () {
       assert.strictEqual(isPlainObject(validations), true);
     });
 
-    function testValidationProp(name, props = {}, expectedResult = true) {
+    function testValidationProp(name, props = {}, expectedResult = true, asWarning = false) {
       const task = fixtures.task(props.task);
       const workflow = fixtures.workflow(props.workflow);
       const project = fixtures.project({
@@ -85,7 +85,7 @@ describe('<MobileSectionContainer />', function () {
       let component = wrapper.find('MobileSection').first();
       let validationToTest = component.props().validations[name];
 
-      assert.strictEqual(validationToTest, convertBooleanToValidation(expectedResult));
+      assert.strictEqual(validationToTest, convertBooleanToValidation(expectedResult, asWarning));
     }
 
     it('should check whether the task question text is too long', function () {
@@ -126,6 +126,11 @@ describe('<MobileSectionContainer />', function () {
     it('should check whether workflow has no subtasks', function () {
       testValidationProp('drawingTaskHasNoSubtasks', validationFixtures.drawingTaskHasNoSubtasks, true);
       testValidationProp('drawingTaskHasNoSubtasks', validationFixtures.drawingTaskHasSubtasks, false);
+    });
+
+    it('should check whether workflow question has one image', function () {
+      testValidationProp('workflowQuestionHasOneOrLessImages', validationFixtures.questionHasOneImage, true, true);
+      testValidationProp('workflowQuestionHasOneOrLessImages', validationFixtures.questionHasTwoImages, false, true);
     });
   });
 

--- a/app/pages/lab/mobile/mobile-section-container.spec.js
+++ b/app/pages/lab/mobile/mobile-section-container.spec.js
@@ -93,11 +93,6 @@ describe('<MobileSectionContainer />', function () {
       testValidationProp('taskQuestionNotTooLong', validationFixtures.taskQuestionTooLong, false);
     });
 
-    it('should check whether the task has two answers', function () {
-      testValidationProp('taskHasTwoAnswers');
-      testValidationProp('taskHasTwoAnswers', validationFixtures.taskHasThreeAnswers, false);
-    });
-
     it('should check whether the task uses feedback', function () {
       testValidationProp('taskFeedbackDisabled');
       testValidationProp('taskFeedbackDisabled', validationFixtures.taskFeedbackEnabled, false);
@@ -149,7 +144,6 @@ describe('<MobileSectionContainer />', function () {
     it('should equal false if any of the validations aren\'t met', function () {
       [
         fixtures.validationFixtures.taskQuestionTooLong,
-        fixtures.validationFixtures.taskHasThreeAnswers,
         fixtures.validationFixtures.taskFeedbackEnabled,
         fixtures.validationFixtures.workflowFlipbookEnabled,
         fixtures.validationFixtures.workflowHasMultipleTasks,

--- a/app/pages/lab/mobile/mobile-section.jsx
+++ b/app/pages/lab/mobile/mobile-section.jsx
@@ -164,7 +164,7 @@ class MobileSection extends Component {
 
 MobileSection.propTypes = {
   validations: PropTypes.shape({
-    workflowQuestionHasOneOrLessImages: PropTypes.func
+    workflowQuestionHasOneOrLessImages: PropTypes.string
   }),
   enabled: PropTypes.bool,
   toggleChecked: PropTypes.func,

--- a/app/pages/lab/mobile/mobile-section.jsx
+++ b/app/pages/lab/mobile/mobile-section.jsx
@@ -26,7 +26,7 @@ counterpart.registerTranslations('en', {
       drawingTaskHasOneTool: 'Drawing task must have only 1 tool',
       drawingTaskHasNoSubtasks: 'Drawing tool must not have any subtasks'
     },
-    projectEligible: 'Check this box if you think your question fits in this way.  If you have a Yes/No question, we recommend Yes as the first option listed so that it appears on the right.',
+    projectEligible: 'Check this box if you think your question fits in this way.  If you have a Yes/No two choice question, we recommend Yes as the first option listed so that it appears on the right.',
     projectIneligible: 'Sorry, but the mobile app will not currently work for this workflow. The following are the requirements for the swipe workflow.',
     imageWarning: 'It appears that you have more than one image in your task question. While this is allowed for mobile, we will only show the first image.',
     mobileHelp: 'Mobile app:  Check this box if you would like this workflow available in the mobile app',

--- a/app/pages/lab/mobile/mobile-section.jsx
+++ b/app/pages/lab/mobile/mobile-section.jsx
@@ -16,7 +16,6 @@ counterpart.registerTranslations('en', {
     },
     validations: {
       workflowHasSingleTask: 'Has one Task',
-      taskHasTwoAnswers: 'Has two available answers (e.g. Yes/No)',
       taskQuestionNotTooLong: 'Question has less than 200 characters',
       workflowNotTooManyShortcuts: 'Has less than three shortcuts',
       workflowDoesNotContainShortcuts: 'Has no shortcuts',
@@ -134,7 +133,7 @@ class MobileSection extends Component {
             {
               this.props.validations.workflowQuestionHasOneOrLessImages === ValidationValue.warning ? warningView : null
             }
-            
+
             <ul>
               {map(this.props.validations, renderValidation)}
             </ul>


### PR DESCRIPTION
Staging branch URL: https://pr-5326.pfe-preview.zooniverse.org

Describe your changes.
Previously, only question tasks with two choices could be marked as `mobile_friendly`. This PR allows project owners to add a workflow to the mobile app if there are more than two questions.

Additional changes:
- Improve tests to cover warning state when a workflow question contains more than one image
- There's a minor bug where a markdown image tag counts against a task question's 200 character max count. I added code to fix the bug but some changes are also needed in the app to reflect this. For now, the code is commented out, but I don't mind removing if it's unnecessary.

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [x] Can you post a talk comment?

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
