### PR TITLE
Clear interventions after they've been displayed

### DIFF
--- a/app/classifier/classifier.jsx
+++ b/app/classifier/classifier.jsx
@@ -370,6 +370,7 @@ class Classifier extends React.Component {
             {showIntervention &&
               <Intervention
                 intervention={intervention}
+                onUnmount={actions.classify.clearIntervention}
                 user={user}
               />
             }

--- a/app/classifier/components/Intervention/Intervention.jsx
+++ b/app/classifier/components/Intervention/Intervention.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { memo, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import counterpart from 'counterpart';
 import styled from 'styled-components';
@@ -14,9 +14,14 @@ const StyledInterventionMessage = styled.div`
   }
 `;
 
-function Intervention({ intervention, user }) {
+function Intervention({ onUnmount, intervention, user }) {
   const { message } = intervention;
   const checkbox = React.createRef();
+
+  useEffect(() => {
+    // the return value of an effect will be called to clean up after the component
+    return onUnmount;
+  });
 
   function onChange() {
     // Invert the checked value because true means do not send me messages.
@@ -40,13 +45,19 @@ function Intervention({ intervention, user }) {
   );
 }
 
+Intervention.defaultProps = {
+  onUnmount: () => true
+};
+
 Intervention.propTypes = {
   intervention: PropTypes.shape({
       message: PropTypes.string
     }).isRequired,
+    onUnmount: PropTypes.func,
   user: PropTypes.shape({
     intervention_notifications: PropTypes.bool
   }).isRequired
 };
 
-export default Intervention;
+export default memo(Intervention);
+export { Intervention }

--- a/app/classifier/components/Intervention/Intervention.spec.js
+++ b/app/classifier/components/Intervention/Intervention.spec.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { mount } from 'enzyme';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import Intervention from './Intervention';
+import { Intervention } from './Intervention';
 import { Markdown } from 'markdownz';
 
 describe('Intervention', function () {
@@ -15,10 +15,13 @@ describe('Intervention', function () {
       return { save: () => true };
     })
   };
+  const onUnmount = sinon.stub()
+
   before(function () {
     wrapper = mount(
       <Intervention
         intervention={intervention}
+        onUnmount={onUnmount}
         user={user}
       />);
   });
@@ -46,4 +49,14 @@ describe('Intervention', function () {
       expect(user.update.calledWith(changes)).to.be.true;
     })
   });
+
+  describe('on unmount', function () {
+    before(function () {
+      wrapper.unmount()
+    });
+
+    it('should call onUnmount', function () {
+      expect(onUnmount).to.have.been.calledOnce
+    })
+  })
 });

--- a/app/redux/ducks/classify.js
+++ b/app/redux/ducks/classify.js
@@ -122,6 +122,7 @@ const initialState = {
 };
 
 const ADD_INTERVENTION = 'pfe/classify/ADD_INTERVENTION';
+const CLEAR_INTERVENTION = 'pfe/classify/CLEAR_INTERVENTION';
 const APPEND_SUBJECTS = 'pfe/classify/APPEND_SUBJECTS';
 const FETCH_SUBJECTS = 'pfe/classify/FETCH_SUBJECTS';
 const PREPEND_SUBJECTS = 'pfe/classify/PREPEND_SUBJECTS';
@@ -146,6 +147,10 @@ export default function reducer(state = initialState, action = {}) {
         return Object.assign({}, state, { intervention });
       }
       return state;
+    }
+    case CLEAR_INTERVENTION: {
+      const intervention = null;
+      return Object.assign({}, state, { intervention });
     }
     case APPEND_SUBJECTS: {
       const { subjects, workflowID } = action.payload;
@@ -190,12 +195,10 @@ export default function reducer(state = initialState, action = {}) {
       const subject = upcomingSubjects[0];
       if (subject) {
         const classification = createNewClassification(project, workflow, subject, goldStandardMode);
-        const intervention = null;
-        return Object.assign({}, state, { classification, intervention, upcomingSubjects });
+        return Object.assign({}, state, { classification, upcomingSubjects });
       }
       return Object.assign({}, state, {
         classification: null,
-        intervention: null,
         upcomingSubjects: []
       });
     }
@@ -257,6 +260,12 @@ export function addIntervention(data) {
   return {
     type: ADD_INTERVENTION,
     payload: data
+  };
+}
+
+export function clearIntervention() {
+  return {
+    type: CLEAR_INTERVENTION
   };
 }
 

--- a/app/redux/ducks/classify.spec.js
+++ b/app/redux/ducks/classify.spec.js
@@ -51,6 +51,22 @@ describe('Classifier actions', function () {
       });
     });
   });
+
+  describe('clear intervention', function () {
+    const action = {
+      type: 'pfe/classify/CLEAR_INTERVENTION',
+    };
+    const state = {
+      intervention: {
+        message: 'this is an intervention'
+      }
+    };
+    it('should clear intervention messages', function () {
+      const newState = reducer(state, action);
+      expect(newState.intervention).to.be.null;
+    });
+  });
+
   describe('append subjects', function () {
     const subjects = [
         mockSubject('3'),
@@ -157,7 +173,10 @@ describe('Classifier actions', function () {
       const state = {
         classification: { id: '1' },
         workflow: { id: '1' },
-        upcomingSubjects: [subjects[0]]
+        upcomingSubjects: [subjects[0]],
+        intervention: {
+          message: 'This is a test intervention'
+        }
       };
       it('should empty the queue', function () {
         const newState = reducer(state, action);
@@ -167,15 +186,18 @@ describe('Classifier actions', function () {
         const newState = reducer(state, action);
         expect(newState.classification).to.be.null;
       });
-      it('should clear any stored interventions', function () {
+      it('should not clear any stored interventions', function () {
         const newState = reducer(state, action);
-        expect(newState.intervention).to.be.null;
+        expect(newState.intervention).to.eql(state.intervention);
       });
     });
     describe('with multiple subjects in the queue', function () {
       const state = {
         workflow: { id: '1' },
-        upcomingSubjects: subjects
+        upcomingSubjects: subjects,
+        intervention: {
+          message: 'This is a test intervention'
+        }
       };
       it('should shift the first subject off the queue', function () {
         const newState = reducer(state, action);
@@ -185,9 +207,9 @@ describe('Classifier actions', function () {
         const newState = reducer(state, action);
         expect(newState.classification.links.subjects).to.deep.equal(['2']);
       });
-      it('should clear any stored interventions', function () {
+      it('should not clear any stored interventions', function () {
         const newState = reducer(state, action);
-        expect(newState.intervention).to.be.null;
+        expect(newState.intervention).to.eql(state.intervention);
       });
     });
   });


### PR DESCRIPTION
Staging branch URL: https://pr-5341.pfe-preview.zooniverse.org

Fixes #5337.

Adds a `clearIntervention` action to the classifier and calls it from the `Intervention` component on component cleanup. Changes the `nextSubject` action so that it doesn't clear any stored interventions by default.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
