### PR TITLE
Force reload of publications page route

### DIFF
--- a/app/router.cjsx
+++ b/app/router.cjsx
@@ -43,7 +43,6 @@ createReactClass = require 'create-react-class'
 `import EmailSettingsPage from './pages/settings/email';`
 `import AboutPage from './pages/about/index';`
 `import AboutHome from './pages/about/about-home';`
-`import PublicationsPage from './pages/about/publications-page';`
 `import TeamPage from './pages/about/team-page';`
 `import Acknowledgements from './pages/about/acknowledgements';`
 `import Contact from './pages/about/contact';`
@@ -88,7 +87,7 @@ module.exports =
     <Route path="about" component={AboutPage} ignoreScrollBehavior>
       <IndexRoute component={AboutHome} />
       <Route path="team" component={TeamPage} />
-      <Route path="publications" component={PublicationsPage} />
+      <Route path="publications" component={RELOAD} />
       <Route path="acknowledgements" component={Acknowledgements} />
       <Route path="resources" component={Resources} />
       <Route path="contact" component={Contact} />


### PR DESCRIPTION
Uses the RELOAD component to force a reload of `/about/publications` and ensure it's fetched from the new content pages app

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
