### PR TITLE
add links to the opt out message

### DIFF
--- a/app/classifier/components/Intervention/Intervention.jsx
+++ b/app/classifier/components/Intervention/Intervention.jsx
@@ -8,7 +8,7 @@ const StyledInterventionMessage = styled.div`
   border-bottom: solid 1px;
   margin: 0 2em 1em;
   padding: 0 0 .7em;
-  
+
   label: {
     font-size: 0.7em;
   }
@@ -39,7 +39,9 @@ function Intervention({ onUnmount, intervention, user }) {
           type="checkbox"
           onChange={onChange}
         />
-        {counterpart('classifier.interventions.optOut')}
+        <Markdown>
+          {counterpart('classifier.interventions.optOut')}
+        </Markdown>
       </label>
     </StyledInterventionMessage>
   );

--- a/app/classifier/components/Intervention/Intervention.spec.js
+++ b/app/classifier/components/Intervention/Intervention.spec.js
@@ -4,7 +4,6 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { Intervention } from './Intervention';
 import { Markdown } from 'markdownz';
-import counterpart from 'counterpart';
 
 describe('Intervention', function () {
   let wrapper;

--- a/app/classifier/components/Intervention/Intervention.spec.js
+++ b/app/classifier/components/Intervention/Intervention.spec.js
@@ -7,6 +7,7 @@ import { Markdown } from 'markdownz';
 import counterpart from 'counterpart';
 
 describe('Intervention', function () {
+  let wrapper;
   const intervention = { message: 'Hello!' };
   const { message } = intervention;
   const user = {
@@ -17,12 +18,15 @@ describe('Intervention', function () {
   };
   const onUnmount = sinon.stub()
 
-  let wrapper = mount(
+  before(function () {
+    wrapper = mount(
     <Intervention
       intervention={intervention}
       onUnmount={onUnmount}
       user={user}
-    />);
+      />
+    );
+  });
 
   it('should render', function () {
     expect(wrapper).to.be.ok;

--- a/app/classifier/components/Intervention/Intervention.spec.js
+++ b/app/classifier/components/Intervention/Intervention.spec.js
@@ -4,9 +4,9 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { Intervention } from './Intervention';
 import { Markdown } from 'markdownz';
+import counterpart from 'counterpart';
 
 describe('Intervention', function () {
-  let wrapper;
   const intervention = { message: 'Hello!' };
   const { message } = intervention;
   const user = {
@@ -17,20 +17,31 @@ describe('Intervention', function () {
   };
   const onUnmount = sinon.stub()
 
-  before(function () {
-    wrapper = mount(
-      <Intervention
-        intervention={intervention}
-        onUnmount={onUnmount}
-        user={user}
-      />);
-  });
+  let wrapper = mount(
+    <Intervention
+      intervention={intervention}
+      onUnmount={onUnmount}
+      user={user}
+    />);
+
   it('should render', function () {
     expect(wrapper).to.be.ok;
   });
   it('should show a notification message', () => {
     const newlineMsg = intervention.message + "\n"
-    expect(wrapper.find(Markdown).text()).to.equal(newlineMsg);
+    expect(wrapper.find(Markdown).first().text()).to.equal(newlineMsg);
+  });
+  it('should show an opt-out message', () => {
+    const optOutHTML = '<div class="markdown "><p>I do not want to take part in this messaging ' +
+      '<a href="https://docs.google.com/document/d/1gLyN6Dgff8dOCOC88f47OD6TtFrfSJltsLgJMKkYMso/preview" ' +
+      'target="_blank" ref="noopener nofollow">study</a>. Do not show me further messages.</p>' +
+      '\n' + '</div>'
+    expect(wrapper.find(Markdown).last().html()).to.equal(optOutHTML);
+  });
+  it('should show a fallback to english opt-out message', () => {
+    counterpart.setLocale('fr');
+    const optOutText = 'I do not want to take part in this messaging study. Do not show me further messages.\n'
+    expect(wrapper.find(Markdown).last().text()).to.equal(optOutText);
   });
   describe('opt-out checkbox', function () {
     let optOut;

--- a/app/classifier/components/Intervention/Intervention.spec.js
+++ b/app/classifier/components/Intervention/Intervention.spec.js
@@ -24,10 +24,8 @@ describe('Intervention', function () {
         intervention={intervention}
         onUnmount={onUnmount}
         user={user}
-      />
-    );
+      />);
   });
-
   it('should render', function () {
     expect(wrapper).to.be.ok;
   });

--- a/app/classifier/components/Intervention/Intervention.spec.js
+++ b/app/classifier/components/Intervention/Intervention.spec.js
@@ -20,10 +20,10 @@ describe('Intervention', function () {
 
   before(function () {
     wrapper = mount(
-    <Intervention
-      intervention={intervention}
-      onUnmount={onUnmount}
-      user={user}
+      <Intervention
+        intervention={intervention}
+        onUnmount={onUnmount}
+        user={user}
       />
     );
   });
@@ -36,16 +36,11 @@ describe('Intervention', function () {
     expect(wrapper.find(Markdown).first().text()).to.equal(newlineMsg);
   });
   it('should show an opt-out message', () => {
-    const optOutHTML = '<div class="markdown "><p>I do not want to take part in this messaging ' +
-      '<a href="https://docs.google.com/document/d/1gLyN6Dgff8dOCOC88f47OD6TtFrfSJltsLgJMKkYMso/preview" ' +
-      'target="_blank" ref="noopener nofollow">study</a>. Do not show me further messages.</p>' +
-      '\n' + '</div>'
-    expect(wrapper.find(Markdown).last().html()).to.equal(optOutHTML);
-  });
-  it('should show a fallback to english opt-out message', () => {
-    counterpart.setLocale('fr');
-    const optOutText = 'I do not want to take part in this messaging study. Do not show me further messages.\n'
-    expect(wrapper.find(Markdown).last().text()).to.equal(optOutText);
+    const expectedMarkdown = 'I do not want to take part in this messaging [study]' +
+      '(+tab+https://docs.google.com/document/d/1gLyN6Dgff8dOCOC88f47OD6TtFrfSJltsLgJMKkYMso/preview).' +
+      ' Do not show me further messages.'
+    const receivedMarkdown = wrapper.find(Markdown).last().props().children;
+    expect(receivedMarkdown).to.equal(expectedMarkdown);
   });
   describe('opt-out checkbox', function () {
     let optOut;

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -26,7 +26,7 @@ export default {
       declineButton: 'No, thanks'
     },
     interventions: {
-      optOut: "Don't show me these messages again."
+      optOut: 'I do not want to take part in this messaging [study](+tab+https://docs.google.com/document/d/1gLyN6Dgff8dOCOC88f47OD6TtFrfSJltsLgJMKkYMso/preview). Do not show me further messages.'
     }
   },
   project: {


### PR DESCRIPTION
use markdown to render the optOut string correctly with a link to study. ~Also test the default translation fall back works~

Staging branch URL:

Fixes # .

Describe your changes.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
