### PR TITLE
Change `RELOAD` component to redirect when not in production

### DIFF
--- a/app/router.cjsx
+++ b/app/router.cjsx
@@ -75,7 +75,10 @@ ONE_UP_REDIRECT = createReactClass
 # Usage: <Route path="path/to/location" component={RELOAD} />
 RELOAD = createReactClass
   componentDidMount: ->
-    window.location.reload()
+    if window.location.hostname is 'www.zooniverse.org'
+      window.location.reload()
+    else
+      window.location = @props.newUrl
   render: ->
     null
 
@@ -88,7 +91,7 @@ module.exports =
     <Route path="about" component={AboutPage} ignoreScrollBehavior>
       <IndexRoute component={AboutHome} />
       <Route path="team" component={TeamPage} />
-      <Route path="publications" component={PublicationsPage} />
+      <Route path="publications" component={() => <RELOAD newUrl='https://fe-content-pages.zooniverse.org/about/publications' />} />
       <Route path="acknowledgements" component={Acknowledgements} />
       <Route path="resources" component={Resources} />
       <Route path="contact" component={Contact} />


### PR DESCRIPTION
The RELOAD component will now redirect to a new URL (passed as the `newUrl` prop). This means that in staging, going to a route which returns this component will redirect to `newUrl`, rather than getting trapped in a refresh loop.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
