### PR TITLE
Only show intervention messages if workflow matches payload

### DIFF
--- a/app/redux/ducks/classify.js
+++ b/app/redux/ducks/classify.js
@@ -150,7 +150,7 @@ export default function reducer(state = initialState, action = {}) {
       // to allow project level as well as targetted workflow messages
       let matchesWorkflow = true;
       if (intervention.hasOwnProperty('workflow_id')) {
-        matchesWorkflow = workflow === String(intervention.workflow_id);
+        matchesWorkflow = workflow === intervention.workflow_id.toString();
       }
       if (classification && matchesProject && matchesWorkflow ) {
         return Object.assign({}, state, { intervention });

--- a/app/redux/ducks/classify.js
+++ b/app/redux/ducks/classify.js
@@ -146,11 +146,11 @@ export default function reducer(state = initialState, action = {}) {
       const { classification } = state;
       const { project, workflow } = classification.links;
       const matchesProject = project === intervention.project_id;
-      // only test workflow matches known state
-      // if the incoming payload has this property
+      // only test workflow matches known state if the incoming payload has this property
+      // to allow project level as well as targetted workflow messages
       let matchesWorkflow = true;
       if (intervention.hasOwnProperty('workflow_id')) {
-        let matchesWorkflow = workflow === intervention.workflow_id;
+        matchesWorkflow = workflow === intervention.workflow_id;
       }
       if (classification && matchesProject && matchesWorkflow ) {
         return Object.assign({}, state, { intervention });

--- a/app/redux/ducks/classify.js
+++ b/app/redux/ducks/classify.js
@@ -141,11 +141,17 @@ const TOGGLE_GOLD_STANDARD = 'pfe/classify/TOGGLE_GOLD_STANDARD';
 export default function reducer(state = initialState, action = {}) {
   switch (action.type) {
     case ADD_INTERVENTION: {
+      // this action payload is the json intervention object from sugar
       const intervention = action.payload;
       const { classification } = state;
       const { project, workflow } = classification.links;
       const matchesProject = project === intervention.project_id;
-      const matchesWorkflow = workflow === intervention.workflow_id;
+      // only test workflow matches known state
+      // if the incoming payload has this property
+      let matchesWorkflow = true;
+      if (intervention.hasOwnProperty('workflow_id')) {
+        let matchesWorkflow = workflow === intervention.workflow_id;
+      }
       if (classification && matchesProject && matchesWorkflow ) {
         return Object.assign({}, state, { intervention });
       }

--- a/app/redux/ducks/classify.js
+++ b/app/redux/ducks/classify.js
@@ -144,6 +144,9 @@ export default function reducer(state = initialState, action = {}) {
       // this action payload is the json intervention object from sugar
       const intervention = action.payload;
       const { classification } = state;
+      if (!classification) {
+        return state;
+      }
       const { project, workflow } = classification && classification.links;
       const matchesProject = project === intervention.project_id.toString();
       // only test workflow matches known state if the incoming payload has this property

--- a/app/redux/ducks/classify.js
+++ b/app/redux/ducks/classify.js
@@ -152,7 +152,7 @@ export default function reducer(state = initialState, action = {}) {
       // only test workflow matches known state if the incoming payload has this property
       // to allow project level as well as targetted workflow messages
       let matchesWorkflow = true;
-      if (intervention.hasOwnProperty('workflow_id')) {
+      if (intervention && intervention.workflow_id) {
         matchesWorkflow = workflow === intervention.workflow_id.toString();
       }
       if (classification && matchesProject && matchesWorkflow ) {

--- a/app/redux/ducks/classify.js
+++ b/app/redux/ducks/classify.js
@@ -143,7 +143,10 @@ export default function reducer(state = initialState, action = {}) {
     case ADD_INTERVENTION: {
       const intervention = action.payload;
       const { classification } = state;
-      if (classification && classification.links.project === intervention.project_id) {
+      const { project, workflow } = classification.links;
+      const matchesProject = project === intervention.project_id;
+      const matchesWorkflow = workflow === intervention.workflow_id;
+      if (classification && matchesProject && matchesWorkflow ) {
         return Object.assign({}, state, { intervention });
       }
       return state;

--- a/app/redux/ducks/classify.js
+++ b/app/redux/ducks/classify.js
@@ -155,7 +155,7 @@ export default function reducer(state = initialState, action = {}) {
       if (intervention && intervention.workflow_id) {
         matchesWorkflow = workflow === intervention.workflow_id.toString();
       }
-      if (classification && matchesProject && matchesWorkflow ) {
+      if (matchesProject && matchesWorkflow ) {
         return Object.assign({}, state, { intervention });
       }
       return state;

--- a/app/redux/ducks/classify.js
+++ b/app/redux/ducks/classify.js
@@ -145,7 +145,7 @@ export default function reducer(state = initialState, action = {}) {
       const intervention = action.payload;
       const { classification } = state;
       const { project, workflow } = classification.links;
-      const matchesProject = project === String(intervention.project_id);
+      const matchesProject = project === intervention.project_id.toString();
       // only test workflow matches known state if the incoming payload has this property
       // to allow project level as well as targetted workflow messages
       let matchesWorkflow = true;

--- a/app/redux/ducks/classify.js
+++ b/app/redux/ducks/classify.js
@@ -145,12 +145,12 @@ export default function reducer(state = initialState, action = {}) {
       const intervention = action.payload;
       const { classification } = state;
       const { project, workflow } = classification.links;
-      const matchesProject = project === intervention.project_id;
+      const matchesProject = project === String(intervention.project_id);
       // only test workflow matches known state if the incoming payload has this property
       // to allow project level as well as targetted workflow messages
       let matchesWorkflow = true;
       if (intervention.hasOwnProperty('workflow_id')) {
-        matchesWorkflow = workflow === intervention.workflow_id;
+        matchesWorkflow = workflow === String(intervention.workflow_id);
       }
       if (classification && matchesProject && matchesWorkflow ) {
         return Object.assign({}, state, { intervention });

--- a/app/redux/ducks/classify.js
+++ b/app/redux/ducks/classify.js
@@ -144,7 +144,7 @@ export default function reducer(state = initialState, action = {}) {
       // this action payload is the json intervention object from sugar
       const intervention = action.payload;
       const { classification } = state;
-      const { project, workflow } = classification.links;
+      const { project, workflow } = classification && classification.links;
       const matchesProject = project === intervention.project_id.toString();
       // only test workflow matches known state if the incoming payload has this property
       // to allow project level as well as targetted workflow messages

--- a/app/redux/ducks/classify.spec.js
+++ b/app/redux/ducks/classify.spec.js
@@ -21,7 +21,7 @@ function mockSubject(id) {
   });
 }
 
-describe.only('Classifier actions', function () {
+describe('Classifier actions', function () {
   describe('add intervention', function () {
     const action = {
       type: 'pfe/classify/ADD_INTERVENTION',
@@ -36,6 +36,20 @@ describe.only('Classifier actions', function () {
       intervention: null
     };
 
+    describe('with non string payload IDs', function () {
+      const intIDAction = {
+        type: 'pfe/classify/ADD_INTERVENTION',
+        payload: {
+          message: 'Hi there!',
+          project_id: 1,
+          workflow_id: 2
+        }
+      };
+      it('should store the intervention', function () {
+        const newState = reducer(state, intIDAction);
+        expect(newState.intervention).to.deep.equal(intIDAction.payload);
+      });
+    });
     describe('with a valid project id but no workflow id', function () {
       const noWorkflowIdAction = {
         type: 'pfe/classify/ADD_INTERVENTION',

--- a/app/redux/ducks/classify.spec.js
+++ b/app/redux/ducks/classify.spec.js
@@ -27,27 +27,48 @@ describe('Classifier actions', function () {
       type: 'pfe/classify/ADD_INTERVENTION',
       payload: {
         message: 'Hi there!',
-        project_id: '1'
+        project_id: '1',
+        workflow_id: '2'
       }
     };
-    describe('with a valid project', function () {
+    describe('with a valid project and workflow', function () {
       const state = {
-        classification: { id: '1', links: { project: '1' } },
+        classification: { id: '1', links: { project: '1', workflow: '2' } },
         intervention: null
       };
       it('should store the intervention', function () {
         const newState = reducer(state, action);
         expect(newState.intervention).to.deep.equal(action.payload);
       });
+      describe('with an invalid workflow', function () {
+        const state = {
+          classification: { id: '1', links: { project: '1', workflow: '1' } },
+          intervention: null
+        };
+        it('should not store the intervention', function () {
+          const newState = reducer(state, action);
+          expect(newState.intervention).to.be.null;
+        });
+      });
     });
-    describe('with an invalid project', function () {
+    describe('with an invalid project and valid workflow', function () {
       const state = {
-        classification: { id: '1', links: { project: '2' } },
+        classification: { id: '1', links: { project: '2', workflow: '1' } },
         intervention: null
       };
       it('should ignore the intervention', function () {
         const newState = reducer(state, action);
         expect(newState.intervention).to.be.null;
+      });
+      describe('with an invalid workflow', function () {
+        const state = {
+          classification: { id: '1', links: { project: '2', workflow: '2' } },
+          intervention: null
+        };
+        it('should not store the intervention', function () {
+          const newState = reducer(state, action);
+          expect(newState.intervention).to.be.null;
+        });
       });
     });
   });

--- a/app/redux/ducks/classify.spec.js
+++ b/app/redux/ducks/classify.spec.js
@@ -31,6 +31,23 @@ describe('Classifier actions', function () {
         workflow_id: '2'
       }
     };
+    describe('with a valid project id but no workflow id', function () {
+      const noWorkflowIdAction = {
+        type: 'pfe/classify/ADD_INTERVENTION',
+        payload: {
+          message: 'Hi there!',
+          project_id: '1'
+        }
+      };
+      const state = {
+        classification: { id: '1', links: { project: '1', workflow: '2' } },
+        intervention: null
+      };
+      it('should store the intervention', function () {
+        const newState = reducer(state, noWorkflowIdAction);
+        expect(newState.intervention).to.deep.equal(noWorkflowIdAction.payload);
+      });
+    });
     describe('with a valid project and workflow', function () {
       const state = {
         classification: { id: '1', links: { project: '1', workflow: '2' } },

--- a/app/redux/ducks/classify.spec.js
+++ b/app/redux/ducks/classify.spec.js
@@ -21,7 +21,7 @@ function mockSubject(id) {
   });
 }
 
-describe('Classifier actions', function () {
+describe.only('Classifier actions', function () {
   describe('add intervention', function () {
     const action = {
       type: 'pfe/classify/ADD_INTERVENTION',
@@ -31,6 +31,11 @@ describe('Classifier actions', function () {
         workflow_id: '2'
       }
     };
+    const state = {
+      classification: { id: '1', links: { project: '1', workflow: '2' } },
+      intervention: null
+    };
+
     describe('with a valid project id but no workflow id', function () {
       const noWorkflowIdAction = {
         type: 'pfe/classify/ADD_INTERVENTION',
@@ -39,51 +44,43 @@ describe('Classifier actions', function () {
           project_id: '1'
         }
       };
-      const state = {
-        classification: { id: '1', links: { project: '1', workflow: '2' } },
-        intervention: null
-      };
       it('should store the intervention', function () {
         const newState = reducer(state, noWorkflowIdAction);
         expect(newState.intervention).to.deep.equal(noWorkflowIdAction.payload);
       });
     });
     describe('with a valid project and workflow', function () {
-      const state = {
-        classification: { id: '1', links: { project: '1', workflow: '2' } },
-        intervention: null
-      };
       it('should store the intervention', function () {
         const newState = reducer(state, action);
         expect(newState.intervention).to.deep.equal(action.payload);
       });
       describe('with an invalid workflow', function () {
-        const state = {
+        const invalidWorkflowState = {
           classification: { id: '1', links: { project: '1', workflow: '1' } },
           intervention: null
         };
         it('should not store the intervention', function () {
-          const newState = reducer(state, action);
+          const newState = reducer(invalidWorkflowState, action);
           expect(newState.intervention).to.be.null;
         });
       });
     });
     describe('with an invalid project and valid workflow', function () {
-      const state = {
+      const invalidProjectState = {
         classification: { id: '1', links: { project: '2', workflow: '1' } },
         intervention: null
       };
       it('should ignore the intervention', function () {
-        const newState = reducer(state, action);
+        const newState = reducer(invalidProjectState, action);
         expect(newState.intervention).to.be.null;
       });
       describe('with an invalid workflow', function () {
-        const state = {
+        const invalidProjectWorkflowState = {
           classification: { id: '1', links: { project: '2', workflow: '2' } },
           intervention: null
         };
         it('should not store the intervention', function () {
-          const newState = reducer(state, action);
+          const newState = reducer(invalidProjectWorkflowState, action);
           expect(newState.intervention).to.be.null;
         });
       });


### PR DESCRIPTION
Ensure we only show intervention messages for specified project, workflow combinations, if the intervention payload has a `workflow_id`. If there is no specified payload `workflow_id` default to project wide messages but still check the `project_id` matches the current store state.

Also ensure we compare project and workflow ids as strings as as sugar messages have int link ID values.

Staging branch URL:

Fixes # .

Describe your changes.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
