### PR TITLE
Track intervention UUID in classification metadata for downstream clients

### DIFF
--- a/app/redux/ducks/classify.js
+++ b/app/redux/ducks/classify.js
@@ -152,7 +152,6 @@ export default function reducer(state = initialState, action = {}) {
     case STORE_INTERVENTION_UUID: {
       const { intervention } = state;
       let lastInterventionUUID = null
-      console.log(intervention);
       if (intervention && intervention.hasOwnProperty('uuid')) {
         lastInterventionUUID = intervention.uuid;
       }

--- a/app/redux/ducks/classify.js
+++ b/app/redux/ducks/classify.js
@@ -122,6 +122,7 @@ const initialState = {
   classification: null,
   goldStandardMode: false,
   intervention: null,
+  lastInterventionUUID: null,
   upcomingSubjects: [],
   workflow: null
 };

--- a/app/redux/ducks/classify.js
+++ b/app/redux/ducks/classify.js
@@ -186,7 +186,8 @@ export default function reducer(state = initialState, action = {}) {
     case CREATE_CLASSIFICATION: {
       const { goldStandardMode } = state;
       const { project } = action.payload;
-      const { workflow, lastInterventionUUID } = state;
+      const { workflow } = state;
+      let { lastInterventionUUID} = state;
       if (state.upcomingSubjects.length > 0) {
         const subject = state.upcomingSubjects[0];
         const classification = createNewClassification(
@@ -196,7 +197,9 @@ export default function reducer(state = initialState, action = {}) {
           goldStandardMode,
           lastInterventionUUID
         );
-        return Object.assign({}, state, { classification });
+        // clear any intervention UUID after we've stored it on the metadata
+        lastInterventionUUID = null;
+        return Object.assign({}, state, { classification, lastInterventionUUID });
       }
       return state;
     }

--- a/app/redux/ducks/classify.js
+++ b/app/redux/ducks/classify.js
@@ -123,6 +123,7 @@ const initialState = {
 
 const ADD_INTERVENTION = 'pfe/classify/ADD_INTERVENTION';
 const CLEAR_INTERVENTION = 'pfe/classify/CLEAR_INTERVENTION';
+const STORE_INTERVENTION_UUID = 'pfe/classify/STORE_INTERVENTION_UUID';
 const APPEND_SUBJECTS = 'pfe/classify/APPEND_SUBJECTS';
 const FETCH_SUBJECTS = 'pfe/classify/FETCH_SUBJECTS';
 const PREPEND_SUBJECTS = 'pfe/classify/PREPEND_SUBJECTS';
@@ -147,6 +148,15 @@ export default function reducer(state = initialState, action = {}) {
         return Object.assign({}, state, { intervention });
       }
       return state;
+    }
+    case STORE_INTERVENTION_UUID: {
+      const { intervention } = state;
+      let lastInterventionUUID = null
+      console.log(intervention);
+      if (intervention && intervention.hasOwnProperty('uuid')) {
+        lastInterventionUUID = intervention.uuid;
+      }
+      return Object.assign({}, state, { lastInterventionUUID });
     }
     case CLEAR_INTERVENTION: {
       const intervention = null;

--- a/app/redux/ducks/classify.js
+++ b/app/redux/ducks/classify.js
@@ -157,7 +157,7 @@ export default function reducer(state = initialState, action = {}) {
     case STORE_INTERVENTION_UUID: {
       const { intervention } = state;
       let lastInterventionUUID = null
-      if (intervention && intervention.hasOwnProperty('uuid')) {
+      if (intervention && intervention.uuid) {
         lastInterventionUUID = intervention.uuid;
       }
       return Object.assign({}, state, { lastInterventionUUID });

--- a/app/redux/ducks/classify.js
+++ b/app/redux/ducks/classify.js
@@ -283,8 +283,9 @@ export function addIntervention(data) {
 }
 
 export function clearIntervention() {
-  return {
-    type: CLEAR_INTERVENTION
+  return (dispatch) => {
+    dispatch({type: STORE_INTERVENTION_UUID});
+    dispatch({type: CLEAR_INTERVENTION});
   };
 }
 

--- a/app/redux/ducks/classify.js
+++ b/app/redux/ducks/classify.js
@@ -185,7 +185,6 @@ export default function reducer(state = initialState, action = {}) {
       if (state.upcomingSubjects.length > 0) {
         const subject = state.upcomingSubjects[0];
         const classification = createNewClassification(project, workflow, subject, goldStandardMode);
-        const intervention = null;
         return Object.assign({}, state, { classification, intervention });
       }
       return state;

--- a/app/redux/ducks/classify.spec.js
+++ b/app/redux/ducks/classify.spec.js
@@ -318,7 +318,7 @@ describe('Classifier actions', function () {
         upcomingSubjects: [mockSubject('1')],
         lastInterventionUUID: '2d931510-d99f-494a-8c67-87feb05e1594'
       };
-      it('should record the lastInteventionUUID as metadata.intervention_uuid', function () {
+      it('should record the lastInterventionUUID as metadata.intervention_uuid', function () {
         const newState = reducer(interventionUUIDState, action);
         expect(newState.classification.metadata.intervention_uuid).to.equal(interventionUUIDState.lastInterventionUUID);
       });

--- a/app/redux/ducks/classify.spec.js
+++ b/app/redux/ducks/classify.spec.js
@@ -1,4 +1,4 @@
-import reducer, { loadWorkflow } from './classify';
+import reducer, { clearIntervention, loadWorkflow } from './classify';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import apiClient from 'panoptes-client/lib/api-client';
@@ -512,6 +512,36 @@ describe('Classifier actions', function () {
       };
       const newState = reducer(state, action);
       expect(newState.classification.gold_standard).to.be.undefined;
+    });
+  });
+
+  describe('clear intervention', function () {
+    const state = {
+      intervention: {
+        message: 'this is an intervention',
+        uuid: '2d931510-d99f-494a-8c67-87feb05e1594'
+      }
+    };
+    let storeState = Object.assign({}, state);
+
+    function fakeDispatch(action) {
+      if(typeof action === 'function') {
+        action = action(fakeDispatch);
+      }
+      storeState = reducer(storeState, action);
+      return storeState;
+    }
+
+    before(function () {
+      clearIntervention()(fakeDispatch);
+    });
+
+    it('should store the intervention UUID to link the next classification', function () {
+      expect(storeState.lastInterventionUUID).to.equal(state.intervention.uuid);
+    });
+
+    it('should clear intervention messages', function () {
+      expect(storeState.intervention).to.be.null;
     });
   });
 

--- a/app/redux/ducks/classify.spec.js
+++ b/app/redux/ducks/classify.spec.js
@@ -307,6 +307,20 @@ describe('Classifier actions', function () {
       const newState = reducer(state, action);
       expect(newState).to.deep.equal(state);
     });
+    it('should record the lastInteventionUUID as metadata.intervention_uuid', function () {
+      const interventionUUIDState = {
+        classification: { id: '1' },
+        workflow: { id: '1' },
+        upcomingSubjects: [mockSubject('1')],
+        lastInterventionUUID: '2d931510-d99f-494a-8c67-87feb05e1594'
+      };
+      const newState = reducer(interventionUUIDState, action);
+      expect(newState.classification.metadata.intervention_uuid).to.equal(interventionUUIDState.lastInterventionUUID);
+    });
+    it('should not record the lastInteventionUUID if not set', function () {
+      const newState = reducer(state, action);
+      expect(newState.classification.metadata.hasOwnProperty('intervention_uuid')).to.be.false;
+    });
   });
   describe('resume classification', function () {
     const subject1 = mockSubject('1');

--- a/app/redux/ducks/classify.spec.js
+++ b/app/redux/ducks/classify.spec.js
@@ -307,19 +307,25 @@ describe('Classifier actions', function () {
       const newState = reducer(state, action);
       expect(newState).to.deep.equal(state);
     });
-    it('should record the lastInteventionUUID as metadata.intervention_uuid', function () {
+    it('should not record the lastInteventionUUID if not set', function () {
+      const newState = reducer(state, action);
+      expect(newState.classification.metadata.hasOwnProperty('intervention_uuid')).to.be.false;
+    });
+    describe('with lastInteventionUUID set', function () {
       const interventionUUIDState = {
         classification: { id: '1' },
         workflow: { id: '1' },
         upcomingSubjects: [mockSubject('1')],
         lastInterventionUUID: '2d931510-d99f-494a-8c67-87feb05e1594'
       };
-      const newState = reducer(interventionUUIDState, action);
-      expect(newState.classification.metadata.intervention_uuid).to.equal(interventionUUIDState.lastInterventionUUID);
-    });
-    it('should not record the lastInteventionUUID if not set', function () {
-      const newState = reducer(state, action);
-      expect(newState.classification.metadata.hasOwnProperty('intervention_uuid')).to.be.false;
+      it('should record the lastInteventionUUID as metadata.intervention_uuid', function () {
+        const newState = reducer(interventionUUIDState, action);
+        expect(newState.classification.metadata.intervention_uuid).to.equal(interventionUUIDState.lastInterventionUUID);
+      });
+      it('should clear any lastInteventionUUID if set', function () {
+        const newState = reducer(interventionUUIDState, action);
+        expect(newState.lastInterventionUUID).to.be.null;
+      });
     });
   });
   describe('resume classification', function () {

--- a/app/redux/ducks/classify.spec.js
+++ b/app/redux/ducks/classify.spec.js
@@ -624,6 +624,7 @@ describe('Classifier actions', function () {
         classification: null,
         goldStandardMode: false,
         intervention: null,
+        lastInterventionUUID: null,
         upcomingSubjects: [],
         workflow: fakeWorkflow
       };

--- a/app/redux/ducks/classify.spec.js
+++ b/app/redux/ducks/classify.spec.js
@@ -67,6 +67,29 @@ describe('Classifier actions', function () {
     });
   });
 
+  describe('store last intervention uuid', function () {
+    const action = {
+      type: 'pfe/classify/STORE_INTERVENTION_UUID',
+    };
+    const state = {
+      intervention: {
+        message: 'this is an intervention',
+        uuid: '2d931510-d99f-494a-8c67-87feb05e1594'
+      }
+    };
+    it('should store the intervention UUID to link the next classification', function () {
+      const newState = reducer(state, action);
+      expect(newState.lastInterventionUUID).to.equal(state.intervention.uuid);
+    });
+    describe('when no intervention exists', function () {
+      const noInterventionState = {};
+      it('should not store the last intervention UUID', function () {
+        const newState = reducer(noInterventionState, action);
+        expect(newState.lastInterventionUUID).to.be.null;
+      });
+    });
+  });
+
   describe('append subjects', function () {
     const subjects = [
         mockSubject('3'),

--- a/app/redux/ducks/classify.spec.js
+++ b/app/redux/ducks/classify.spec.js
@@ -283,9 +283,15 @@ describe('Classifier actions', function () {
       const newState = reducer(state, action);
       expect(newState.classification.links.workflow).to.equal('1');
     });
-    it('should clear any stored interventions', function () {
-      const newState = reducer(state, action);
-      expect(newState.intervention).to.be.null;
+    it('should not clear any stored interventions', function () {
+      const interventionState = {
+        classification: { id: '1' },
+        workflow: { id: '1' },
+        upcomingSubjects: [mockSubject('1')],
+        intervention: {}
+      };
+      const newState = reducer(interventionState, action);
+      expect(newState.intervention).to.equal(interventionState.intervention);
     });
     it('should clear the subject intervention flag', function () {
       const newState = reducer(state, action);


### PR DESCRIPTION
Track the intervention payload UUID in the next classification metadata, this links the any classification after an intervention message was seen.

linked to https://github.com/zooniverse/interventions-gateway/issues/28

Staging branch URL:

Fixes # .

Describe your changes.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
