### PR TITLE
Only clear interventions on Intervention unmount

### DIFF
--- a/app/classifier/components/Intervention/Intervention.jsx
+++ b/app/classifier/components/Intervention/Intervention.jsx
@@ -20,7 +20,9 @@ function Intervention(props) {
   const checkbox = React.createRef();
 
   useEffect(() => {
-    // the return value of an effect will be called to clean up after the component
+     /* the return value of an effect will be called to clean up after the component.
+     Passing an empty array ([]) as a second argument tells React that your effect doesn’t depend on any values from props or state
+     so it never needs to re-run, https://reactjs.org/docs/hooks-effect.html#tip-optimizing-performance-by-skipping-effects */
     return onUnmount;
   }, []);
 

--- a/app/classifier/components/Intervention/Intervention.jsx
+++ b/app/classifier/components/Intervention/Intervention.jsx
@@ -14,14 +14,15 @@ const StyledInterventionMessage = styled.div`
   }
 `;
 
-function Intervention({ onUnmount, intervention, user }) {
+function Intervention(props) {
+  const { onUnmount, intervention, user } = props;
   const { message } = intervention;
   const checkbox = React.createRef();
 
   useEffect(() => {
     // the return value of an effect will be called to clean up after the component
     return onUnmount;
-  });
+  }, []);
 
   function onChange() {
     // Invert the checked value because true means do not send me messages.

--- a/app/classifier/components/Intervention/Intervention.spec.js
+++ b/app/classifier/components/Intervention/Intervention.spec.js
@@ -57,6 +57,16 @@ describe('Intervention', function () {
     })
   });
 
+  describe('on props change', function () {
+    before(function () {
+      wrapper.setProps({ intervention: {message: 'Hello' } });
+    });
+
+    it('should not call onUnmount', function () {
+      expect(onUnmount).to.have.not.been.called
+    });
+  });
+
   describe('on unmount', function () {
     before(function () {
       wrapper.unmount()
@@ -64,6 +74,6 @@ describe('Intervention', function () {
 
     it('should call onUnmount', function () {
       expect(onUnmount).to.have.been.calledOnce
-    })
-  })
+    });
+  });
 });


### PR DESCRIPTION
Staging branch URL: https://pr-5349.pfe-preview.zooniverse.org

Expect that the Intervention component will not call `props.unMount` on props change. Update `useEffect` to pass that test.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
