### PR TITLE
Fix intervention message html and add styling

### DIFF
--- a/app/classifier/components/Intervention/Intervention.jsx
+++ b/app/classifier/components/Intervention/Intervention.jsx
@@ -32,17 +32,20 @@ function Intervention({ onUnmount, intervention, user }) {
   return (
     <StyledInterventionMessage>
       <Markdown>{message}</Markdown>
-      <label>
-        <input
-          ref={checkbox}
-          autoFocus={true}
-          type="checkbox"
-          onChange={onChange}
-        />
+      <div className="classification-intervention-message-with-optOut">
         <Markdown>
-          {counterpart('classifier.interventions.optOut')}
+          {counterpart('classifier.interventions.studyInfo')}
         </Markdown>
-      </label>
+        <label>
+          <input
+            ref={checkbox}
+            autoFocus={true}
+            type="checkbox"
+            onChange={onChange}
+          />
+          {counterpart('classifier.interventions.optOut')}
+        </label>
+      </div>
     </StyledInterventionMessage>
   );
 }

--- a/app/classifier/components/Intervention/Intervention.spec.js
+++ b/app/classifier/components/Intervention/Intervention.spec.js
@@ -32,10 +32,9 @@ describe('Intervention', function () {
     const newlineMsg = intervention.message + "\n"
     expect(wrapper.find(Markdown).first().text()).to.equal(newlineMsg);
   });
-  it('should show an opt-out message', () => {
+  it('should show a study info message', () => {
     const expectedMarkdown = 'I do not want to take part in this messaging [study]' +
-      '(+tab+https://docs.google.com/document/d/1gLyN6Dgff8dOCOC88f47OD6TtFrfSJltsLgJMKkYMso/preview).' +
-      ' Do not show me further messages.'
+      '(+tab+https://docs.google.com/document/d/1gLyN6Dgff8dOCOC88f47OD6TtFrfSJltsLgJMKkYMso/preview).'
     const receivedMarkdown = wrapper.find(Markdown).last().props().children;
     expect(receivedMarkdown).to.equal(expectedMarkdown);
   });
@@ -47,6 +46,11 @@ describe('Intervention', function () {
     });
     after(function () {
       user.update.resetHistory();
+    });
+    it('should have an explanatory label', () => {
+      const expectedLabel = 'Do not show me further messages.'
+      const optOutLabel = wrapper.find('label').text();
+      expect(optOutLabel).to.equal(expectedLabel);
     });
     it('should update the user when checked/unchecked', function () {
       expect(user.update.callCount).to.equal(1);

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -26,7 +26,8 @@ export default {
       declineButton: 'No, thanks'
     },
     interventions: {
-      optOut: 'I do not want to take part in this messaging [study](+tab+https://docs.google.com/document/d/1gLyN6Dgff8dOCOC88f47OD6TtFrfSJltsLgJMKkYMso/preview). Do not show me further messages.'
+      optOut: 'Do not show me further messages.',
+      studyInfo: 'I do not want to take part in this messaging [study](+tab+https://docs.google.com/document/d/1gLyN6Dgff8dOCOC88f47OD6TtFrfSJltsLgJMKkYMso/preview).'
     }
   },
   project: {

--- a/css/default-classification-summary.styl
+++ b/css/default-classification-summary.styl
@@ -30,4 +30,14 @@
     margin: 0
     list-style-type: none
 
+.classification-intervention-message-with-optOut
+  border: 1px solid rgba(gray, 0.5)
+  border-radius: 3px
+  font-size: 0.8em
+  margin: 0.5em 0
+  padding: 0.8em 1.5vw
+
+  p
+    margin: 0 0 0.5em 0
+
 


### PR DESCRIPTION
Ensure the intervention opt-out is valid HTML and ensure the UI is visually distinct from the researcher messaging.

<img width="517" alt="Screenshot 2019-05-21 at 12 19 43" src="https://user-images.githubusercontent.com/295329/58093539-a0060180-7bc6-11e9-8d5b-f96ea0648d52.png">

Staging branch URL:

Fixes # .

Describe your changes.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
