### PR TITLE
Pass the intervention UUID when clearing seen messages

### DIFF
--- a/app/classifier/components/Intervention/Intervention.jsx
+++ b/app/classifier/components/Intervention/Intervention.jsx
@@ -16,14 +16,16 @@ const StyledInterventionMessage = styled.div`
 
 function Intervention(props) {
   const { onUnmount, intervention, user } = props;
-  const { message } = intervention;
+  const { message, uuid } = intervention;
   const checkbox = React.createRef();
 
   useEffect(() => {
      /* the return value of an effect will be called to clean up after the component.
      Passing an empty array ([]) as a second argument tells React that your effect doesn’t depend on any values from props or state
      so it never needs to re-run, https://reactjs.org/docs/hooks-effect.html#tip-optimizing-performance-by-skipping-effects */
-    return onUnmount;
+    return function cleanup() {
+      onUnmount(uuid);
+    }
   }, []);
 
   function onChange() {

--- a/app/classifier/components/Intervention/Intervention.spec.js
+++ b/app/classifier/components/Intervention/Intervention.spec.js
@@ -7,7 +7,10 @@ import { Markdown } from 'markdownz';
 
 describe('Intervention', function () {
   let wrapper;
-  const intervention = { message: 'Hello!' };
+  const intervention = {
+    message: 'Hello!',
+    uuid: '12345'
+  };
   const { message } = intervention;
   const user = {
     id: 'a',
@@ -63,7 +66,12 @@ describe('Intervention', function () {
 
   describe('on props change', function () {
     before(function () {
-      wrapper.setProps({ intervention: {message: 'Hello' } });
+      wrapper.setProps({
+        intervention: {
+          message: 'Hello',
+          uuid: '12345'
+        }
+      });
     });
 
     it('should not call onUnmount', function () {
@@ -77,7 +85,7 @@ describe('Intervention', function () {
     });
 
     it('should call onUnmount', function () {
-      expect(onUnmount).to.have.been.calledOnce
+      expect(onUnmount.withArgs(intervention.uuid)).to.have.been.calledOnce
     });
   });
 });

--- a/app/redux/ducks/classify.js
+++ b/app/redux/ducks/classify.js
@@ -168,14 +168,19 @@ export default function reducer(state = initialState, action = {}) {
       return state;
     }
     case STORE_INTERVENTION_UUID: {
-      const { intervention } = state;
+      const uuid = action.payload;
       let lastInterventionUUID = null
-      if (intervention && intervention.uuid) {
-        lastInterventionUUID = intervention.uuid;
+      if (uuid) {
+        lastInterventionUUID = uuid;
+        return Object.assign({}, state, { lastInterventionUUID });
       }
-      return Object.assign({}, state, { lastInterventionUUID });
+      return state;
     }
     case CLEAR_INTERVENTION: {
+      const uuid = action.payload
+      if (uuid && state.intervention && uuid !== state.intervention.uuid) {
+        return state;
+      }
       const intervention = null;
       return Object.assign({}, state, { intervention });
     }
@@ -298,10 +303,16 @@ export function addIntervention(data) {
   };
 }
 
-export function clearIntervention() {
+export function clearIntervention(uuid) {
   return (dispatch) => {
-    dispatch({type: STORE_INTERVENTION_UUID});
-    dispatch({type: CLEAR_INTERVENTION});
+    dispatch({
+      type: STORE_INTERVENTION_UUID,
+      payload: uuid
+    });
+    dispatch({
+      type: CLEAR_INTERVENTION,
+      payload: uuid
+    });
   };
 }
 

--- a/app/redux/ducks/classify.spec.js
+++ b/app/redux/ducks/classify.spec.js
@@ -585,7 +585,8 @@ describe('Classifier actions', function () {
       intervention: {
         message: 'this is an intervention',
         uuid: '2d931510-d99f-494a-8c67-87feb05e1594'
-      }
+      },
+      lastInterventionUUID: null
     };
     let storeState = Object.assign({}, state);
 
@@ -621,6 +622,26 @@ describe('Classifier actions', function () {
       });
 
       it('should clear intervention messages', function () {
+        expect(storeState.intervention).to.be.null;
+      });
+    });
+
+    describe('without a UUID', function () {
+      before(function () {
+        storeState = {
+          intervention: {
+            message: 'this is an intervention'
+          },
+          lastInterventionUUID: null
+        };
+        clearIntervention()(fakeDispatch);
+      });
+
+      it('should not store an intervention UUID', function () {
+        expect(storeState.lastInterventionUUID).to.be.null;
+      });
+
+      it('should clear any intervention messages', function () {
         expect(storeState.intervention).to.be.null;
       });
     });

--- a/app/redux/ducks/classify.spec.js
+++ b/app/redux/ducks/classify.spec.js
@@ -107,10 +107,19 @@ describe('Classifier actions', function () {
     };
     const state = {
       intervention: {
-        message: 'this is an intervention'
+        message: 'this is an intervention',
+        uuid: '2d931510-d99f-494a-8c67-87feb05e1594'
       }
     };
-    it('should clear intervention messages', function () {
+
+    it('should not clear intervention messages without a matching UUID', function () {
+      action.payload = '12345';
+      const newState = reducer(state, action);
+      expect(newState.intervention).to.eql(state.intervention);
+    });
+
+    it('should clear intervention messages with matching UUID', function () {
+      action.payload = '2d931510-d99f-494a-8c67-87feb05e1594';
       const newState = reducer(state, action);
       expect(newState.intervention).to.be.null;
     });
@@ -126,13 +135,20 @@ describe('Classifier actions', function () {
         uuid: '2d931510-d99f-494a-8c67-87feb05e1594'
       }
     };
+
     it('should store the intervention UUID to link the next classification', function () {
+      action.payload = state.intervention.uuid
       const newState = reducer(state, action);
       expect(newState.lastInterventionUUID).to.equal(state.intervention.uuid);
     });
+
     describe('when no intervention exists', function () {
-      const noInterventionState = {};
       it('should not store the last intervention UUID', function () {
+        const noInterventionState = {
+          intervention: null,
+          lastInterventionUUID: null
+        };
+        action.payload = undefined;
         const newState = reducer(noInterventionState, action);
         expect(newState.lastInterventionUUID).to.be.null;
       });
@@ -581,16 +597,32 @@ describe('Classifier actions', function () {
       return storeState;
     }
 
-    before(function () {
-      clearIntervention()(fakeDispatch);
+    describe('without a matching UUID', function () {
+      before(function () {
+        clearIntervention('12345')(fakeDispatch);
+      });
+
+      it('should store the intervention UUID to link the next classification', function () {
+        expect(storeState.lastInterventionUUID).to.equal('12345');
+      });
+
+      it('should not clear intervention messages', function () {
+        expect(storeState.intervention).to.equal(state.intervention);
+      });
     });
 
-    it('should store the intervention UUID to link the next classification', function () {
-      expect(storeState.lastInterventionUUID).to.equal(state.intervention.uuid);
-    });
+    describe('with a matching UUID', function () {
+      before(function () {
+        clearIntervention('2d931510-d99f-494a-8c67-87feb05e1594')(fakeDispatch);
+      });
 
-    it('should clear intervention messages', function () {
-      expect(storeState.intervention).to.be.null;
+      it('should store the intervention UUID to link the next classification', function () {
+        expect(storeState.lastInterventionUUID).to.equal('2d931510-d99f-494a-8c67-87feb05e1594');
+      });
+
+      it('should clear intervention messages', function () {
+        expect(storeState.intervention).to.be.null;
+      });
     });
   });
 


### PR DESCRIPTION
Staging branch URL: https://pr-5351.pfe-preview.zooniverse.org

Pass the current message UUID when unmounting the Intervention component. Store that UUID, not the one currently in state, in case a new message has been received. Compare UUIDs before deleting messages.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
