### PR TITLE
record the last intervention UUID on the interventions metadata object

### DIFF
--- a/app/classifier/classifier.jsx
+++ b/app/classifier/classifier.jsx
@@ -262,7 +262,7 @@ class Classifier extends React.Component {
       {},
       classification.metadata.interventions,
       {
-        message: !!showIntervention,
+        messageShown: !!showIntervention,
         opt_in: !!user && user.intervention_notifications
       }
     );

--- a/app/classifier/classifier.jsx
+++ b/app/classifier/classifier.jsx
@@ -258,15 +258,20 @@ class Classifier extends React.Component {
     }
     const { already_seen, finished_workflow, retired, selection_state, user_has_finished_workflow, selected_at } = subject;
     const workflowTranslation = translations.strings.workflow[workflow.id];
+    const mergedInterventions = Object.assign(
+      {},
+      classification.metadata.interventions,
+      {
+        message: !!showIntervention,
+        opt_in: !!user && user.intervention_notifications
+      }
+    );
     actions.classify.updateMetadata({
       viewport: {
         width: innerWidth,
         height: innerHeight
       },
-      interventions: {
-        message: !!showIntervention,
-        opt_in: !!user && user.intervention_notifications
-      },
+      interventions: mergedInterventions,
       subject_selection_state: {
         already_seen,
         finished_workflow,

--- a/app/classifier/classifier.spec.js
+++ b/app/classifier/classifier.spec.js
@@ -261,7 +261,7 @@ describe('Classifier', function () {
       wrapper.instance().completeClassification(fakeEvent)
       .then(done, done);
       const changes = actions.classify.updateMetadata.getCall(0).args[0];
-      expect(changes.interventions.message).to.be.false;
+      expect(changes.interventions.messageShown).to.be.false;
       expect(changes.interventions.opt_in).to.be.false;
       expect(changes.interventions.uuid).to.equal(existingUUID);
     });
@@ -286,7 +286,7 @@ describe('Classifier', function () {
         wrapper.instance().completeClassification(fakeEvent)
         .then(done, done);
         const changes = actions.classify.updateMetadata.getCall(0).args[0];
-        expect(changes.interventions.message).to.be.true;
+        expect(changes.interventions.messageShown).to.be.true;
       });
       it('should record whether the user is reading interventions', function () {
         wrapper.setProps({ workflow, intervention, user });

--- a/app/classifier/classifier.spec.js
+++ b/app/classifier/classifier.spec.js
@@ -222,7 +222,9 @@ describe('Classifier', function () {
         }
       }
     };
+    const existingUUID = '123456';
     beforeEach(function () {
+      classification.metadata.interventions = {uuid: existingUUID};
       checkForFeedback = sinon.stub(Classifier.prototype, 'checkForFeedback').callsFake(() => Promise.resolve());
       wrapper = shallow(
         <Classifier
@@ -261,6 +263,7 @@ describe('Classifier', function () {
       const changes = actions.classify.updateMetadata.getCall(0).args[0];
       expect(changes.interventions.message).to.be.false;
       expect(changes.interventions.opt_in).to.be.false;
+      expect(changes.interventions.uuid).to.equal(existingUUID);
     });
     it('should record translation metadata', function (done) {
       wrapper.setProps({ workflow });
@@ -378,7 +381,7 @@ describe('Classifier', function () {
     after(function () {
       feedbackCheckSpy.restore();
     })
-    
+
     describe('when the task changes', function () {
 
       beforeEach(function () {
@@ -402,7 +405,7 @@ describe('Classifier', function () {
         expect(feedbackUpdateSpy).to.have.been.calledWith(prevAnnotation);
       });
     });
-    
+
     describe('when a classification is complete', function () {
       let newAnnotation;
 
@@ -425,7 +428,7 @@ describe('Classifier', function () {
           expect(feedbackCheckSpy.callCount).to.equal(1);
         })
         .then(done, done);
-      
+
       });
 
       it('should update feedback for the last annotation', function (done) {
@@ -438,7 +441,7 @@ describe('Classifier', function () {
           expect(feedbackUpdateSpy).to.have.been.calledWith(newAnnotation);
         })
         .then(done, done);
-      
+
       });
     })
 

--- a/app/redux/ducks/classify.js
+++ b/app/redux/ducks/classify.js
@@ -61,7 +61,8 @@ function createNewClassification(project, workflow, subject, goldStandardMode, l
   }
   // record if this classification had an intervention payload directly before it
   if (lastInterventionUUID) {
-    newMetadata.intervention_uuid = lastInterventionUUID
+    newMetadata.interventions = newMetadata.interventions || {};
+    newMetadata.interventions.uuid = lastInterventionUUID
   }
   const classification = apiClient.type('classifications').create({
     annotations: [],

--- a/app/redux/ducks/classify.spec.js
+++ b/app/redux/ducks/classify.spec.js
@@ -459,8 +459,9 @@ describe('Classifier actions', function () {
         }
       }
     };
-    // ensure state is reset after each test
+    // setup state to be reset in beforeEach function
     let state = null;
+
     beforeEach(function () {
       state = {
         classification: mockPanoptesResource('classifications', {

--- a/app/redux/ducks/classify.spec.js
+++ b/app/redux/ducks/classify.spec.js
@@ -367,9 +367,9 @@ describe('Classifier actions', function () {
         upcomingSubjects: [mockSubject('1')],
         lastInterventionUUID: '2d931510-d99f-494a-8c67-87feb05e1594'
       };
-      it('should record the lastInterventionUUID as metadata.intervention_uuid', function () {
+      it('should record the lastInterventionUUID as metadata.interventions.uuid', function () {
         const newState = reducer(interventionUUIDState, action);
-        expect(newState.classification.metadata.intervention_uuid).to.equal(interventionUUIDState.lastInterventionUUID);
+        expect(newState.classification.metadata.interventions.uuid).to.equal(interventionUUIDState.lastInterventionUUID);
       });
       it('should clear any lastInteventionUUID if set', function () {
         const newState = reducer(interventionUUIDState, action);
@@ -459,22 +459,26 @@ describe('Classifier actions', function () {
         }
       }
     };
-    const state = {
-      classification: mockPanoptesResource('classifications', {
-        id: '1',
-        metadata: {
-          b: 3,
-          c: 4
-        }
-      }),
-      workflow: {
-        id: '1',
-        tasks: {
-          a: {}
-        }
-      },
-      upcomingSubjects: [mockSubject('1'), mockSubject('2')]
-    };
+    // ensure state is reset after each test
+    let state = null;
+    beforeEach(function () {
+      state = {
+        classification: mockPanoptesResource('classifications', {
+          id: '1',
+          metadata: {
+            b: 3,
+            c: 4
+          }
+        }),
+        workflow: {
+          id: '1',
+          tasks: {
+            a: {}
+          }
+        },
+        upcomingSubjects: [mockSubject('1'), mockSubject('2')]
+      };
+    });
     it('should add new keys to classification metadata', function () {
       const newState = reducer(state, action);
       expect(newState.classification.metadata.a).to.equal(1);

--- a/app/redux/ducks/classify.spec.js
+++ b/app/redux/ducks/classify.spec.js
@@ -450,6 +450,8 @@ describe('Classifier actions', function () {
     });
   });
   describe('update classification metadata', function () {
+    // setup state to be reset in beforeEach function
+    let state = null;
     const action = {
       type: 'pfe/classify/UPDATE_METADATA',
       payload: {
@@ -459,8 +461,6 @@ describe('Classifier actions', function () {
         }
       }
     };
-    // setup state to be reset in beforeEach function
-    let state = null;
 
     beforeEach(function () {
       state = {


### PR DESCRIPTION
Avoid storing intervention metadata in different places instead consolidate all interventions metadata to the one object store.

Staging branch URL:

Fixes # .

Describe your changes.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
