### PR TITLE
do not clobber intervention state on incoming data

### DIFF
--- a/app/redux/ducks/classify.js
+++ b/app/redux/ducks/classify.js
@@ -151,7 +151,8 @@ export default function reducer(state = initialState, action = {}) {
       // this action payload is the json intervention object from sugar
       const intervention = action.payload;
       const { classification } = state;
-      if (!classification) {
+      const existingIntervention = state.intervention;
+      if (!classification || existingIntervention) {
         return state;
       }
       const { project, workflow } = classification && classification.links;

--- a/app/redux/ducks/classify.spec.js
+++ b/app/redux/ducks/classify.spec.js
@@ -99,6 +99,17 @@ describe('Classifier actions', function () {
         });
       });
     });
+    describe('with an existing intervention and a valid payload', function () {
+      it('should ignore the intervention', function () {
+        const existingIntervention = {
+          message: 'this is an intervention',
+          uuid: '123456'
+        };
+        state.intervention = existingIntervention;
+        const newState = reducer(state, action);
+        expect(newState.intervention).to.deep.equal(existingIntervention);
+      });
+    });
   });
 
   describe('clear intervention', function () {


### PR DESCRIPTION
drop incoming intervention messages if one is already stored in state to avoid the clobbering existing intervention data.

If we don't clobber the stored incoming intervention state we avoid potential UI updates while i'm looking at a message and we avoid the need to track with UUID should be cleared. 

Alternative implementation to #5351

Staging branch URL:

Fixes # .

Describe your changes.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
