### PR TITLE
Request Talk boards with project prop

### DIFF
--- a/app/talk/board.cjsx
+++ b/app/talk/board.cjsx
@@ -9,7 +9,7 @@ DiscussionPreview = require './discussion-preview'
 apiClient = require 'panoptes-client/lib/api-client'
 talkClient = require 'panoptes-client/lib/talk-client'
 FollowBoard = require './follow-board'
-NewDiscussionForm = require './discussion-new-form'
+DiscussionNewForm = require './discussion-new-form'
 Paginator = require './lib/paginator'
 Moderation = require './lib/moderation'
 StickyDiscussionList = require './sticky-discussion-list'
@@ -274,7 +274,7 @@ module.exports = createReactClass
           </button>
 
           {if @state.newDiscussionOpen
-            <NewDiscussionForm
+            <DiscussionNewForm
               boardId={+@props.params.board}
               onCreateDiscussion={@onCreateDiscussion}
               user={@props.user}

--- a/app/talk/discussion-new-form.cjsx
+++ b/app/talk/discussion-new-form.cjsx
@@ -19,6 +19,7 @@ module.exports = createReactClass
   propTypes:
     boardId: PropTypes.number
     onCreateDiscussion: PropTypes.func
+    project: PropTypes.object
     subject: PropTypes.object # subject response
 
   getInitialState: ->
@@ -33,15 +34,21 @@ module.exports = createReactClass
     @updateBoards newProps.subject if newProps.subject isnt @props.subject
 
   updateBoards: (subject) ->
-    subject?.get 'project'
-      .then (project) =>
-        talkClient.type 'boards'
-          .get
-            section: projectSection(project)
-            subject_default: false
-            page_size: 50
-          .then (boards) =>
-            @setState {boards}
+    if @props.project?.id
+      @getProjectBoards(@props.project)
+    else
+      subject?.get 'project'
+        .then (project) =>
+          @getProjectBoards(project)
+    
+  getProjectBoards: (project) ->
+    talkClient.type 'boards'
+      .get
+        section: projectSection(project)
+        subject_default: false
+        page_size: 50
+      .then (boards) =>
+        @setState {boards}
 
   discussionValidations: (commentBody) ->
     discussionTitle = ReactDOM.findDOMNode(@).querySelector('.new-discussion-title').value


### PR DESCRIPTION
Staging branch URL:  https://pr-5358.pfe-preview.zooniverse.org/
- please see linked issue below, then relatedly - https://pr-5358.pfe-preview.zooniverse.org/projects/pangorilla/wild-gabon/talk/subjects/12048508?env=production

Fixes #5357.

Describe your changes.
- checks for project prop, if exists, requests related boards, if project prop doesn't exist, requests project from subject resource then requests related boards

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
