### PR TITLE
Show translated options in dropdown tasks

### DIFF
--- a/app/classifier/tasks/dropdown/index.jsx
+++ b/app/classifier/tasks/dropdown/index.jsx
@@ -21,7 +21,7 @@ export function DropdownSummary(props) {
   }
 
   function getOptionLabel(value, i) {
-    const select = props.task.selects[i];
+    const select = props.translation.selects[i];
     const optionsKeys = getOptionsKeys();
     const optionsKey = select.condition ? optionsKeys[select.condition] : '*';
     const options = select.options[optionsKey];
@@ -144,7 +144,7 @@ export default class DropdownTask extends React.Component {
   }
 
   getOptions(i) {
-    const select = this.props.task.selects[i];
+    const select = this.props.translation.selects[i];
     // the root select's optionsKey is '*' by default and cannot be changed, while any other select's optionsKey is based on conditional answers selected
     const optionsKey = select.condition ? this.getOptionsKey(i) : '*';
     const options = select.options[optionsKey];

--- a/app/classifier/tasks/dropdown/index.spec.js
+++ b/app/classifier/tasks/dropdown/index.spec.js
@@ -10,52 +10,53 @@ import DropdownTask from '.';
 import { workflow } from '../../../pages/dev-classifier/mock-data';
 import { mockReduxStore } from '../testHelpers';
 
-const singleSelect = {
-  instruction: 'Is there something here?',
-  selects: [{
-    id: 'numbers123',
-    title: 'Numbers',
-    options: {
-      '*': [
-        { label: '0', value: 0 },
-        { label: 'One', value: 1 },
-        { label: 'Two', value: 2 },
-        { label: 'Three', value: 3 }
-      ]
-    }
-  }]
-};
+function getMockTasks() {
+  const singleSelect = {
+    instruction: 'Is there something here?',
+    selects: [{
+      id: 'numbers123',
+      title: 'Numbers',
+      options: {
+        '*': [
+          { label: '0', value: 0 },
+          { label: 'One', value: 1 },
+          { label: 'Two', value: 2 },
+          { label: 'Three', value: 3 }
+        ]
+      }
+    }]
+  };
 
-const singleSelectTranslation = {
-  instruction: 'Is there something here?',
-  selects: [{
-    id: 'numbers123',
-    title: 'Numbers',
-    options: {
-      '*': [
-        { label: '0', value: 0 },
-        { label: 'Ein', value: 1 },
-        { label: 'Zwei', value: 2 },
-        { label: 'Drei', value: 3 }
-      ]
-    }
-  }]
-};
+  const singleSelectTranslation = {
+    instruction: 'Is there something here?',
+    selects: [{
+      id: 'numbers123',
+      title: 'Numbers',
+      options: {
+        '*': [
+          { label: '0', value: 0 },
+          { label: 'Ein', value: 1 },
+          { label: 'Zwei', value: 2 },
+          { label: 'Drei', value: 3 }
+        ]
+      }
+    }]
+  };
 
-const multiSelects = workflow.tasks.dropdown;
+  const multiSelects = workflow.tasks.dropdown;
 
-// multiSelects:
-//   1 - Country (required:true)
-//   2 - State (condition:Country, required:true, allowCreate:false)
-//   3 - County (condition:State, allowCreate:true)
-//   4 - City (condition:County, allowCreate:false)
-//   5 - Best State Team (condition:State, allowCreate:true)
+  // multiSelects:
+  //   1 - Country (required:true)
+  //   2 - State (condition:Country, required:true, allowCreate:false)
+  //   3 - County (condition:State, allowCreate:true)
+  //   4 - City (condition:County, allowCreate:false)
+  //   5 - Best State Team (condition:State, allowCreate:true)
+
+  return { singleSelect, singleSelectTranslation, multiSelects }
+}
 
 describe('DropdownTask:static methods', function () {
-  after(function () {
-    singleSelect.selects[0].required = false;
-    singleSelect.selects[0].allowCreate = false;
-  })
+  const { singleSelect, multiSelects } = getMockTasks();
 
   it('should have the correct question text', function () {
     assert.equal(DropdownTask.getTaskText(singleSelect), singleSelect.instruction);
@@ -114,6 +115,7 @@ describe('DropdownTask', function () {
     
     before(function () {
       const annotation = { value: [{ value: 0, option: true }] };
+      const { singleSelect, singleSelectTranslation } = getMockTasks();
 
       wrapper = shallow(
         <DropdownTask
@@ -141,6 +143,7 @@ describe('DropdownTask', function () {
       let annotation;
       let wrapper;
       let onChangeSpy;
+      const { multiSelects } = getMockTasks();
 
       beforeEach(function () {
         annotation = { value: [] };
@@ -226,6 +229,7 @@ describe('DropdownTask', function () {
     describe('and first annotation provided (Country),', function () {
       let annotation;
       let wrapper;
+      const { multiSelects } = getMockTasks();
 
       beforeEach(function () {
         annotation = { value: [
@@ -265,6 +269,7 @@ describe('DropdownTask', function () {
     describe('and all annotations provided, no custom answers,', function () {
       let annotation;
       let wrapper;
+      const { multiSelects } = getMockTasks();
 
       beforeEach(function () {
         annotation = { value: [
@@ -305,6 +310,7 @@ describe('DropdownTask', function () {
     describe('and all annotations provided, including custom answers,', function () {
       let annotation;
       let wrapper;
+      const { multiSelects } = getMockTasks();
 
       beforeEach(function () {
         annotation = { value: [
@@ -344,6 +350,7 @@ describe('DropdownTask', function () {
     describe('and component updated', function () {
       let onChangeSpy
       let wrapper
+      const { singleSelect, multiSelects } = getMockTasks();
 
       before(function () {
         const annotation1 = { value: [] };

--- a/app/classifier/tasks/dropdown/index.spec.js
+++ b/app/classifier/tasks/dropdown/index.spec.js
@@ -52,6 +52,11 @@ const multiSelects = workflow.tasks.dropdown;
 //   5 - Best State Team (condition:State, allowCreate:true)
 
 describe('DropdownTask:static methods', function () {
+  after(function () {
+    singleSelect.selects[0].required = false;
+    singleSelect.selects[0].allowCreate = false;
+  })
+
   it('should have the correct question text', function () {
     assert.equal(DropdownTask.getTaskText(singleSelect), singleSelect.instruction);
   });

--- a/app/classifier/tasks/dropdown/index.spec.js
+++ b/app/classifier/tasks/dropdown/index.spec.js
@@ -26,6 +26,22 @@ const singleSelect = {
   }]
 };
 
+const singleSelectTranslation = {
+  instruction: 'Is there something here?',
+  selects: [{
+    id: 'numbers123',
+    title: 'Numbers',
+    options: {
+      '*': [
+        { label: '0', value: 0 },
+        { label: 'Ein', value: 1 },
+        { label: 'Zwei', value: 2 },
+        { label: 'Drei', value: 3 }
+      ]
+    }
+  }]
+};
+
 const multiSelects = workflow.tasks.dropdown;
 
 // multiSelects:
@@ -89,19 +105,29 @@ describe('DropdownTask:static methods', function () {
 
 describe('DropdownTask', function () {
   describe('with single select', function () {
-    const annotation = { value: [{ value: 0, option: true }] };
+    let wrapper;
+    
+    before(function () {
+      const annotation = { value: [{ value: 0, option: true }] };
 
-    const wrapper = shallow(
-      <DropdownTask
-        task={singleSelect}
-        translation={singleSelect}
-        annotation={annotation}
-        onChange={function (a) { return a; }}
-      />, mockReduxStore
-    );
+      wrapper = shallow(
+        <DropdownTask
+          task={singleSelect}
+          translation={singleSelectTranslation}
+          annotation={annotation}
+          onChange={function (a) { return a; }}
+        />, mockReduxStore
+      );
+    })
 
     it('should show that 0 is selected', function () {
       assert.deepEqual(wrapper.find(Select).prop('value'), { label: '0', value: 0 });
+    });
+
+    it('should show translated labels', function () {
+      const annotation = { value: [{ value: 1, option: true }] };
+      wrapper.setProps({ annotation });
+      assert.deepEqual(wrapper.find(Select).prop('value'), { label: 'Ein', value: 1 });
     });
   });
 
@@ -311,15 +337,17 @@ describe('DropdownTask', function () {
     });
 
     describe('and component updated', function () {
-      const annotation1 = { value: [] };
-      const annotation2 = { value: [] };
-      const onChangeSpy = sinon.spy();
+      let onChangeSpy
+      let wrapper
 
-      const wrapper = mount(<DropdownTask task={multiSelects} translation={multiSelects} annotation={annotation1} onChange={onChangeSpy} />, mockReduxStore);
-      wrapper.setProps({ task: singleSelect, annotation: annotation2 });
+      before(function () {
+        const annotation1 = { value: [] };
+        const annotation2 = { value: [] };
+        onChangeSpy = sinon.spy();
 
-      // first call on mount should set first task's default values, second call on update should be to set second task's default values
-      const newAnnotation = onChangeSpy.secondCall.args[0];
+        wrapper = mount(<DropdownTask task={multiSelects} translation={multiSelects} annotation={annotation1} onChange={onChangeSpy} />, mockReduxStore);
+        wrapper.setProps({ task: singleSelect, annotation: annotation2 });
+      })
 
       it('should render all selects', function () {
         const renderedSelects = wrapper.find(Select);
@@ -327,10 +355,14 @@ describe('DropdownTask', function () {
       });
 
       it('should have an annotation with values equal in length to the number of selects', function () {
+        // first call on mount should set first task's default values, second call on update should be to set second task's default values
+        const newAnnotation = onChangeSpy.secondCall.args[0];
         assert.equal(newAnnotation.value.length, singleSelect.selects.length);
       });
 
       it('should have an annotation reflecting nothing selected', function () {
+        // first call on mount should set first task's default values, second call on update should be to set second task's default values
+        const newAnnotation = onChangeSpy.secondCall.args[0];
         newAnnotation.value.forEach((annotationValue) => {
           const { option, value } = annotationValue;
           assert.equal(value, null);


### PR DESCRIPTION
Staging branch URL: https://pr-5373.pfe-preview.zooniverse.org

Fixes #5370.

Use the `translations` object, instead of the `task` object, to get dropdown menu options.
Update tests.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
