### PR TITLE
Add state: live to project queries on home

### DIFF
--- a/app/lib/get-social-data.js
+++ b/app/lib/get-social-data.js
@@ -3,10 +3,16 @@ import talkClient from 'panoptes-client/lib/talk-client';
 import Publications from './publications';
 
 function getNewestProject() {
-  return apiClient.type('projects').get({ cards: true, page_size: 1, sort: '-launch_date', launch_approved: true })
-  .then(([newestProject]) => {
-    return newestProject;
-  });
+  return apiClient.type('projects').get({
+    cards: true,
+    launch_approved: true,
+    page_size: 1,
+    sort: '-launch_date',
+    state: 'live'
+  })
+    .then(([newestProject]) => {
+      return newestProject;
+    });
 }
 
 function getBlogPosts(returnPosts) {
@@ -20,9 +26,15 @@ function getBlogPosts(returnPosts) {
 }
 
 function getRecentProjects() {
-  const query = { launch_approved: true, page_size: 3, sort: '-updated_at', cards: true };
+  const query = {
+    cards: true,
+    launch_approved: true,
+    page_size: 3,
+    sort: '-updated_at',
+    state: 'live'
+  };
   return apiClient.type('projects').get(query)
-  .then(recentProjects => recentProjects);
+    .then(recentProjects => recentProjects);
 }
 
 function getPublication() {


### PR DESCRIPTION
Staging branch URL: https://pr-5376.pfe-preview.zooniverse.org

This is trivial, but noticed the other day if a project is launched, then set back to development for a quick fix (oh no forgot something), it'll still show on zooniverse.org's Latest Project or Project Updates. This PR edits those queries to mirror [zooniverse.org/projects's queries](https://github.com/zooniverse/Panoptes-Front-End/blob/master/app/pages/projects/index.jsx#L95-L100).

If testing watch out for admin mode, which changes response, and if testing on staging the Latest Project doesn't make sense, I think old staging projects are causing a strange response. Also [status and state are equivalent](https://github.com/zooniverse/Panoptes-Front-End/blob/master/app/pages/projects/project-filtering-interface.jsx#L60) for these purposes.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
