### PR TITLE
add retirement config selectors to admin page

### DIFF
--- a/app/pages/admin/project-status.jsx
+++ b/app/pages/admin/project-status.jsx
@@ -59,7 +59,6 @@ class ProjectStatus extends Component {
   onChangeWorkflowRetirement(workflow, event) {
     this.setState({ error: null });
     let selected = event.target.value;
-    console.log(selected);
     return workflow.update({ 'retirement.criteria': selected }).save()
       .then(() => this.getWorkflows())
       .catch(error => this.setState({ error }));
@@ -209,7 +208,7 @@ class ProjectStatus extends Component {
                 Level:{' '}
                 <select
                   id='promotionLevels'
-                  onChange={this.onChangeWorkflowLevel.bind(null, workflow)}
+                  onChange={(event) => this.onChangeWorkflowLevel(workflow, event)}
                   value={workflow.configuration.level && workflow.configuration.level}
                 >
                   <option value="none">none</option>
@@ -232,7 +231,7 @@ class ProjectStatus extends Component {
                 Retirement:{' '}
                 <select
                   id='retirementConfig'
-                  onChange={this.onChangeWorkflowRetirement.bind(null, workflow)}
+                  onChange={(event) => this.onChangeWorkflowRetirement(workflow, event)}
                   value={workflow.retirement.criteria}
                 >
                   <option value="never_retire">Never Retire</option>

--- a/app/pages/admin/project-status.jsx
+++ b/app/pages/admin/project-status.jsx
@@ -18,6 +18,7 @@ class ProjectStatus extends Component {
   constructor(props) {
     super(props);
     this.onChangeWorkflowLevel = this.onChangeWorkflowLevel.bind(this);
+    this.onChangeWorkflowRetirement = this.onChangeWorkflowRetirement.bind(this);
     this.getWorkflows = this.getWorkflows.bind(this);
     this.forceUpdate = this.forceUpdate.bind(this);
     this.renderWorkflows = this.renderWorkflows.bind(this);
@@ -55,6 +56,15 @@ class ProjectStatus extends Component {
       .catch(error => this.setState({ error }));
   }
 
+  onChangeWorkflowRetirement(workflow, event) {
+    this.setState({ error: null });
+    let selected = event.target.value;
+    console.log(selected);
+    return workflow.update({ 'retirement.criteria': selected }).save()
+      .then(() => this.getWorkflows())
+      .catch(error => this.setState({ error }));
+  }
+
   getFeaturedProject() {
     return apiClient.type('projects')
       .get({ featured: true, cards: true })
@@ -77,7 +87,7 @@ class ProjectStatus extends Component {
   }
 
   getWorkflows() {
-    const fields = 'display_name,active,configuration';
+    const fields = 'display_name,active,configuration,retirement';
     return getWorkflowsInOrder(this.state.project, { fields }).then((workflows) => {
       const usedWorkflowLevels = this.getUsedWorkflowLevels(workflows);
       this.setState({ usedWorkflowLevels, workflows });
@@ -198,6 +208,7 @@ class ProjectStatus extends Component {
               <label>
                 Level:{' '}
                 <select
+                  id='promotionLevels'
                   onChange={this.onChangeWorkflowLevel.bind(null, workflow)}
                   value={workflow.configuration.level && workflow.configuration.level}
                 >
@@ -214,6 +225,18 @@ class ProjectStatus extends Component {
                       </option>
                     );
                   })}
+                </select>
+              </label>
+              {' | '}
+              <label>
+                Retirement:{' '}
+                <select
+                  id='retirementConfig'
+                  onChange={this.onChangeWorkflowRetirement.bind(null, workflow)}
+                  value={workflow.retirement.criteria}
+                >
+                  <option value="never_retire">Never Retire</option>
+                  <option value="classification_count">Classification Count - {(workflow.retirement.options && workflow.retirement.options.count) || ''}</option>
                 </select>
               </label>
               <fieldset>

--- a/app/pages/admin/project-status.spec.js
+++ b/app/pages/admin/project-status.spec.js
@@ -15,18 +15,24 @@ const workflows = [
   {
     active: true,
     configuration: {},
+    retirement: {
+      criteria: 'classification_count',
+      options: { count: 15 }
+    },
     display_name: 'Test Workflow 1',
     id: '1'
   },
   {
     active: true,
     configuration: {},
+    retirement: { criteria: 'never_retire' },
     display_name: 'Test Workflow 2',
     id: '2'
   },
   {
     active: false,
     configuration: {},
+    retirement: { criteria: 'never_retire' },
     display_name: 'Test Workflow 3',
     id: '3'
   }
@@ -37,12 +43,14 @@ describe('ProjectStatus', function () {
   let handleDialogSuccessStub;
   let loadingIndicator;
   let onChangeWorkflowLevelStub;
+  let onChangeWorkflowRetirementStub;
   let wrapper;
 
   before(function () {
     sinon.stub(ProjectStatus.prototype, 'getProject').callsFake(() => Promise.resolve(project));
     sinon.stub(ProjectStatus.prototype, 'getWorkflows').callsFake(() => Promise.resolve(workflows));
     onChangeWorkflowLevelStub = sinon.stub(ProjectStatus.prototype, 'onChangeWorkflowLevel');
+    onChangeWorkflowRetirementStub = sinon.stub(ProjectStatus.prototype, 'onChangeWorkflowRetirement');
     handleDialogCancelStub = sinon.stub(ProjectStatus.prototype, 'handleDialogCancel');
     handleDialogSuccessStub = sinon.stub(ProjectStatus.prototype, 'handleDialogSuccess');
 
@@ -51,6 +59,7 @@ describe('ProjectStatus', function () {
 
   after(function () {
     onChangeWorkflowLevelStub.restore();
+    onChangeWorkflowRetirementStub.restore();
     handleDialogCancelStub.restore();
     handleDialogSuccessStub.restore();
     ProjectStatus.prototype.getProject.restore();
@@ -131,8 +140,13 @@ describe('ProjectStatus', function () {
     });
 
     it('calls #onChangeWorkflowLevel when a user changes a workflow\'s configuration level', function () {
-      wrapper.find('select').first().simulate('change');
+      wrapper.find('select#promotionLevels').first().simulate('change');
       sinon.assert.calledOnce(onChangeWorkflowLevelStub);
+    });
+
+    it('calls #onChangeWorkflowRetirement when a user changes a workflow\'s retirement configuration', function () {
+      wrapper.find('select#retirementConfig').first().simulate('change');
+      sinon.assert.calledOnce(onChangeWorkflowRetirementStub);
     });
 
     it('renders the WorkflowDefaultDialog component when dialogIsOpen state is true', function () {


### PR DESCRIPTION
Fixes #5367 - allow admins to change a workflow's retirement config between `classification_count` and `never_retire`

Staging branch URL: http://pr-5377.pfe-preview.zooniverse.org

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
