### PR TITLE
Edit project home workflows request to initially filter on completeness

### DIFF
--- a/app/pages/project/home/index.jsx
+++ b/app/pages/project/home/index.jsx
@@ -36,11 +36,21 @@ export default class ProjectHomeContainer extends React.Component {
     }
   }
 
-  fetchAllWorkflows(props, query) {
+  fetchWorkflows(props, query) {
     if (this.state.activeWorkflows.length === 0) {
-      getWorkflowsInOrder(props.project, query)
-        .then((activeWorkflows) => {
-          this.setState({ activeWorkflows });
+      const newQuery = query;
+      newQuery.complete = false;
+      getWorkflowsInOrder(props.project, newQuery)
+        .then((incompleteWorkflows) => {
+          if (incompleteWorkflows.length > 0) {
+            this.setState({ activeWorkflows: incompleteWorkflows });
+          } else {
+            delete newQuery.complete;
+            getWorkflowsInOrder(props.project, newQuery)
+              .then((activeWorkflows) => {
+                this.setState({ activeWorkflows });
+              });
+          }
         });
     }
   }
@@ -84,7 +94,7 @@ export default class ProjectHomeContainer extends React.Component {
 
     if ((props.project.configuration && props.project.configuration.user_chooses_workflow && !workflowAssignment) ||
       (workflowAssignment && props.user)) {
-      this.setState({ showWorkflowButtons: true }, this.fetchAllWorkflows.bind(this, this.props, { active: true, fields: 'active,completeness,configuration,display_name' }));
+      this.setState({ showWorkflowButtons: true }, this.fetchWorkflows.bind(this, this.props, { active: true, fields: 'active,completeness,configuration,display_name' }));
     } else {
       this.setState({ showWorkflowButtons: false });
     }


### PR DESCRIPTION
Staging branch URL: https://pr-5394.pfe-preview.zooniverse.org
- [staging project with some complete workflows](https://pr-5394.pfe-preview.zooniverse.org/projects/markb-panoptes/some-completed-workflows)
- [staging project with all complete workflows](https://pr-5394.pfe-preview.zooniverse.org/projects/markb-panoptes/all-completed-workflows)

See #5338.

Based on new API workflow request functionality allowing [filter on workflow completeness](https://github.com/zooniverse/Panoptes/pull/3138), this PR refactors the project home page workflow request to initially request incomplete workflows, but if response empty request all active workflows.

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [x] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
