### PR TITLE
Conditionally render organization link section

### DIFF
--- a/app/pages/organization/organization-container.spec.js
+++ b/app/pages/organization/organization-container.spec.js
@@ -16,6 +16,7 @@ const params = {
 };
 
 export const organization = mockPanoptesResource('organizations', {
+  announcement: 'Test announcement',
   categories: ['Plants', 'Bugs', 'Butterflies'],
   display_name: 'Test Org',
   description: 'A brief test description',

--- a/app/pages/organization/organization-page.jsx
+++ b/app/pages/organization/organization-page.jsx
@@ -197,7 +197,7 @@ class OrganizationPage extends React.Component {
                   </button>
                 </div>}
             </div>
-            {this.props.organization.urls && (
+            {this.props.organization.urls && this.props.organization.urls.length && (
               <ExternalLinksBlockContainer
                 header={<Translate className="organization-details__heading" content="organization.home.links" component="h4" />}
                 resource={this.props.organization}

--- a/app/pages/organization/organization-page.jsx
+++ b/app/pages/organization/organization-page.jsx
@@ -197,10 +197,12 @@ class OrganizationPage extends React.Component {
                   </button>
                 </div>}
             </div>
-            <ExternalLinksBlockContainer
-              header={<Translate className="organization-details__heading" content="organization.home.links" component="h4" />}
-              resource={this.props.organization}
-            />
+            {this.props.organization.urls && (
+              <ExternalLinksBlockContainer
+                header={<Translate className="organization-details__heading" content="organization.home.links" component="h4" />}
+                resource={this.props.organization}
+              />
+            )}
           </div>
         </section>
       </div>

--- a/app/pages/organization/organization-page.spec.js
+++ b/app/pages/organization/organization-page.spec.js
@@ -20,6 +20,17 @@ const noAnnounceCatUrlsOrg = mockPanoptesResource('organizations', {
   urls: null
 });
 
+const emptyArrayUrlsOrg = mockPanoptesResource('organizations', {
+  display_name: 'Test Org',
+  description: 'A brief test description',
+  id: '9876',
+  introduction: 'A brief test introduction',
+  links: {
+    organization_roles: ['1']
+  },
+  urls: []
+});
+
 const organizationPages = [{
   content: 'test content',
   url_key: 'about'
@@ -150,8 +161,13 @@ describe('OrganizationPage', function () {
     });
   });
 
-  it('should not show ExternalLinks section if no urls', function () {
+  it('should not render ExternalLinks section if no urls', function () {
     const wrapper = shallow(<OrganizationPage organization={noAnnounceCatUrlsOrg} />);
+    assert.equal(wrapper.find('ExternalLinksBlockContainer').length, 0);
+  });
+
+  it('should not render ExternalLinks section if urls empty array', function () {
+    const wrapper = shallow(<OrganizationPage organization={emptyArrayUrlsOrg} />);
     assert.equal(wrapper.find('ExternalLinksBlockContainer').length, 0);
   });
 

--- a/app/pages/organization/organization-page.spec.js
+++ b/app/pages/organization/organization-page.spec.js
@@ -7,6 +7,18 @@ import { shallow } from 'enzyme';
 import sinon from 'sinon';
 import OrganizationPage from './organization-page';
 import { organization } from './organization-container.spec';
+import mockPanoptesResource from '../../../test/mock-panoptes-resource';
+
+const noAnnounceCatUrlsOrg = mockPanoptesResource('organizations', {
+  display_name: 'Test Org',
+  description: 'A brief test description',
+  id: '9876',
+  introduction: 'A brief test introduction',
+  links: {
+    organization_roles: ['1']
+  },
+  urls: null
+});
 
 const organizationPages = [{
   content: 'test content',
@@ -75,15 +87,13 @@ describe('OrganizationPage', function () {
   });
 
   it('should not show announcement if not defined', function () {
-    const wrapper = shallow(<OrganizationPage organization={organization} />);
+    const wrapper = shallow(<OrganizationPage organization={noAnnounceCatUrlsOrg} />);
     const announcement = wrapper.find('.project-announcement-banner');
     assert.equal(announcement.length, 0);
   });
 
   it('should show announcement if defined', function () {
-    const orgWithAnnouncement = organization;
-    orgWithAnnouncement.announcement = 'test announcement';
-    const wrapper = shallow(<OrganizationPage organization={orgWithAnnouncement} />);
+    const wrapper = shallow(<OrganizationPage organization={organization} />);
     const announcement = wrapper.find('.project-announcement-banner');
     assert.equal(announcement.length, 1);
   });
@@ -101,9 +111,7 @@ describe('OrganizationPage', function () {
   });
 
   it('should not show category buttons if the organization does not have categories', function () {
-    const noCategoriesOrg = organization;
-    delete noCategoriesOrg.categories;
-    const wrapper = shallow(<OrganizationPage organization={noCategoriesOrg} />);
+    const wrapper = shallow(<OrganizationPage organization={noAnnounceCatUrlsOrg} />);
     const categories = wrapper.find('.organization-page__category-button');
     assert.equal(categories.length, 0);
   });
@@ -140,6 +148,11 @@ describe('OrganizationPage', function () {
       assert.equal(aboutPageExpanded.length, 1);
       assert.equal(aboutPageExpanded.contains('test content'), true);
     });
+  });
+
+  it('should not show ExternalLinks section if no urls', function () {
+    const wrapper = shallow(<OrganizationPage organization={noAnnounceCatUrlsOrg} />);
+    assert.equal(wrapper.find('ExternalLinksBlockContainer').length, 0);
   });
 
   it('should show organization links', function () {


### PR DESCRIPTION
Staging branch URL: https://pr-5395.pfe-preview.zooniverse.org
- staging example: https://pr-5395.pfe-preview.zooniverse.org/organizations/markb-panoptes/test-urls

Fixes if organization has no external or social links, then organization page won't render.

Describe your changes.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
