### PR TITLE
Fit project nav into the browser viewport

### DIFF
--- a/app/pages/project/components/ProjectNavbar/ProjectNavbar.jsx
+++ b/app/pages/project/components/ProjectNavbar/ProjectNavbar.jsx
@@ -22,8 +22,9 @@ class ProjectNavbar extends Component {
   setBreakpoint(size) {
     // `size` is undefined when the component is first mounted, as there hasn't
     // been time for the callback to fire.
+    // size.width will be 0 when the navbar begins to render, so ignore that too.
     
-    if (size) {
+    if (size && size.width) {
       const useWide = size.width < document.body.clientWidth;
       const newState = (this.state.loading) ? { useWide, loading: false } : { useWide };
       this.setState(newState);
@@ -31,19 +32,10 @@ class ProjectNavbar extends Component {
   }
 
   render() {
-    const NavBarComponent = (this.state.useWide) ? ProjectNavbarWide : ProjectNavbarNarrow;
-
-    return (
-      <React.Fragment>
-        {!this.state.loading &&
-          <NavBarComponent {...this.props}>
-            <SettingsMenu>
-              <LanguagePicker
-                project={this.props.project}
-              />
-            </SettingsMenu>
-          </NavBarComponent>
-        }
+    const { loading, useWide } = this.state;
+    const NavBarComponent = useWide ? ProjectNavbarWide : ProjectNavbarNarrow;
+    const navBar = loading ?
+      (
         <SizeAwareProjectNavbarWide
           {...this.props}
           onSize={this.setBreakpoint}
@@ -52,8 +44,18 @@ class ProjectNavbar extends Component {
             position: 'absolute'
           }}
         />
-      </React.Fragment>
-    );
+      ) :
+      (
+        <NavBarComponent {...this.props}>
+          <SettingsMenu>
+            <LanguagePicker
+              project={this.props.project}
+            />
+          </SettingsMenu>
+        </NavBarComponent>
+      )
+
+      return navBar;
   }
 }
 


### PR DESCRIPTION
Render a wide navbar initially, until we can calculate a breakpoint, then render the appropriate navbar component, depending on the viewport size. This ensures that the page width will not overflow the viewport on small screens, which allows us to draw without scrolling the page sideways.

Staging branch URL: https://pr-5400.pfe-preview.zooniverse.org

Fixes #5399.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
