### PR TITLE
Project Builder: Link to the production translation editor

### DIFF
--- a/app/pages/lab/translations/index.jsx
+++ b/app/pages/lab/translations/index.jsx
@@ -53,7 +53,7 @@ class TranslationsManager extends React.Component {
         {!hasTranslations &&
           <React.Fragment>
             <h2>Add translations to your project</h2>
-            <p>Add some translators to your project from the <Link to={`/lab/${project.id}/collaborators`}>Collaborators page</Link> and invite them to add translations at <a href={`https://pandora.zooniverse.org/#/project/${project.id}`}>https://pandora.zooniverse.org/#/project/{project.id}</a></p>
+            <p>Add some translators to your project from the <Link to={`/lab/${project.id}/collaborators`}>Collaborators page</Link> and invite them to add translations at <a href={`https://translations.zooniverse.org/#/project/${project.id}`}>https://translations.zooniverse.org/#/project/{project.id}</a></p>
           </React.Fragment>
         }
         <h2>Project language menu</h2>

--- a/app/pages/lab/translations/translation-tools.jsx
+++ b/app/pages/lab/translations/translation-tools.jsx
@@ -14,7 +14,7 @@ function TranslationTools(props) {
         </span>
         <i className="fa fa-hand-o-right fa-fw" /> Preview
       </Link>
-      <a href={`https://pandora.zooniverse.org/?#/project/${project.id}?language=${languageCode}`}>
+      <a href={`https://translations.zooniverse.org/?#/project/${project.id}?language=${languageCode}`}>
         <i className="fa fa-pencil fa-fw" /> Edit
       </a>
     </span>


### PR DESCRIPTION
Staging branch URL: https://pr-5407.pfe-preview.zooniverse.org

Updates the translation pages in the project builder to link to https://translations.zooniverse.org
~~Waiting on zooniverse/pandora#116 and the Panoptes translations editor being deployed.~~

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
