### PR TITLE
Add browser based validation for the real name field

### DIFF
--- a/app/partials/register-form.cjsx
+++ b/app/partials/register-form.cjsx
@@ -28,6 +28,7 @@ counterpart.registerTranslations 'en',
     email: 'Email address'
     emailConflict: 'An account with this address already exists'
     realName: 'Real name'
+    realNamePatternHelp: "Enter a real name, not an email address", 
     whyRealName: 'We’ll use this to give you credit in scientific papers, posters, etc'
     agreeToPrivacyPolicy: 'You agree to our %(link)s (required)'
     privacyPolicy: 'privacy policy'
@@ -164,7 +165,14 @@ module.exports = createReactClass
           <Translate content="registerForm.realName" />
           <Translate className="form-help info right-align" content="registerForm.optional" />
         </span>
-        <input type="text" ref="realName" className="standard-input full" disabled={@props.user?} />
+        <input
+          type="text"
+          pattern='[^@]+'
+          ref="realName"
+          className="standard-input full"
+          disabled={@props.user?}
+          title={counterpart('registerForm.realNamePatternHelp')}
+        />
         <Translate component="span" className="form-help info" content="registerForm.whyRealName" />
       </label>
 

--- a/app/partials/register-form.cjsx
+++ b/app/partials/register-form.cjsx
@@ -28,7 +28,7 @@ counterpart.registerTranslations 'en',
     email: 'Email address'
     emailConflict: 'An account with this address already exists'
     realName: 'Real name'
-    realNamePatternHelp: "Enter a real name, not an email address", 
+    realNamePatternHelp: "Enter a name, not an email address", 
     whyRealName: 'We’ll use this to give you credit in scientific papers, posters, etc'
     agreeToPrivacyPolicy: 'You agree to our %(link)s (required)'
     privacyPolicy: 'privacy policy'


### PR DESCRIPTION
Staging branch URL: https://pr-5412.pfe-preview.zooniverse.org/

Fixes #4553 

Adds a regex browser validation to prevent users from submitting email addresses in the real name field. 

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
