### PR TITLE
Set locale from project primary language

### DIFF
--- a/app/pages/project/index.jsx
+++ b/app/pages/project/index.jsx
@@ -242,7 +242,7 @@ class ProjectPageController extends React.Component {
           ]) => {
             const ready = true;
             this.setState({ background, organization, owner, pages, projectAvatar, projectIsComplete, projectRoles, projectPreferences, splits });
-            this.loadFieldGuide(project.id);
+            this.loadFieldGuide(project.id, locale);
             actions.translations.load('project_page', pages.map(page => page.id), locale);
             return { project, projectPreferences, splits };
           })
@@ -294,13 +294,13 @@ class ProjectPageController extends React.Component {
     }
   }
 
-  loadFieldGuide(projectId) {
+  loadFieldGuide(projectId, locale) {
     return apiClient.type('field_guides').get({ project_id: projectId })
     .then(([guide]) => {
       this.setState({ guide });
       if (guide && guide.id) {
         const { actions, translations } = this.props;
-        actions.translations.load('field_guide', guide.id, translations.locale);
+        actions.translations.load('field_guide', guide.id, locale);
         getAllLinked(guide, 'attached_images')
         .then((images) => {
           const guideIcons = {};


### PR DESCRIPTION
Use a project's primary language to set the locale on initial load, unless a language query param is present.

Staging branch URL: https://pr-5414.pfe-preview.zooniverse.org

Fixes #5333.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
