### PR TITLE
Add translator as a Talk role

### DIFF
--- a/app/talk/lib/roles.coffee
+++ b/app/talk/lib/roles.coffee
@@ -1,7 +1,8 @@
 module.exports = [
 # Role          | Can access:
-  "admin"       # admin, moderator, ream, all
-  "moderator"   # moderator, team, all
-  "team"        # team, all
+  "admin"       # admin, moderator, team, translator, all
+  "moderator"   # moderator, team, translator, all
+  "team"        # team, translator, all
+  "translator"  # translator, all
   "all"         # all *
   ]


### PR DESCRIPTION
Staging branch URL: https://pr-5416.pfe-preview.zooniverse.org

This should allow Talk owners/admins to set up boards that can only be accessed by translators. Translators are added at the bottom of the permissions tree, so don't have access to any other restricted boards.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
