### PR TITLE
Question tasks: test the autofocus prop

### DIFF
--- a/app/classifier/tasks/multiple/index.jsx
+++ b/app/classifier/tasks/multiple/index.jsx
@@ -34,7 +34,7 @@ export default class MultipleChoiceTask extends React.Component {
 
       answers.push(
         <TaskInputField
-          autoFocus={checked}
+          autoFocus={autoFocus && checked}
           checked={checked}
           className={checked ? 'active' : ''}
           index={i}

--- a/app/classifier/tasks/multiple/index.spec.js
+++ b/app/classifier/tasks/multiple/index.spec.js
@@ -70,8 +70,8 @@ describe('MultipleChoiceTask', function () {
         mockReduxStore
       );
       const answers = wrapper.dive().prop('answers');
-      it(`should pass autofocus ${autofocus} to its children`, function () {
-        answers.forEach(function (answer) {
+      answers.forEach(function (answer) {
+        it(`should pass autofocus ${autofocus} for answer ${answer.props.index}`, function () {
           const hasFocus = autofocus && annotation.value.includes(answer.props.index);
           expect(answer.props.autoFocus).to.equal(hasFocus);
         })

--- a/app/classifier/tasks/multiple/index.spec.js
+++ b/app/classifier/tasks/multiple/index.spec.js
@@ -38,6 +38,47 @@ describe('MultipleChoiceTask', function () {
     });
   });
 
+  describe('with an empty annotation', function () {
+    const annotation = Object.assign({}, checkboxTypeAnnotation, { value: [] });
+    [true, false].forEach(function testAutofocus(autofocus) {
+      const wrapper = shallow(
+        <MultipleTask
+          autoFocus={autofocus}
+          task={checkboxTypeTask}
+          annotation={annotation}
+          translation={checkboxTypeTask}
+        />,
+        mockReduxStore
+      );
+      const genericTask = wrapper.dive();
+      it(`should pass autofocus ${autofocus} to its children`, function () {
+        expect(genericTask.prop('autoFocus')).to.equal(autofocus);
+      })
+    });
+  });
+
+  describe('with an annotation', function () {
+    const annotation = Object.assign({}, checkboxTypeAnnotation, { value: [0, 1] });
+    [true, false].forEach(function testAutofocus(autofocus) {
+      const wrapper = shallow(
+        <MultipleTask
+          autoFocus={autofocus}
+          task={checkboxTypeTask}
+          annotation={annotation}
+          translation={checkboxTypeTask}
+        />,
+        mockReduxStore
+      );
+      const answers = wrapper.dive().prop('answers');
+      it(`should pass autofocus ${autofocus} to its children`, function () {
+        answers.forEach(function (answer) {
+          const hasFocus = autofocus && annotation.value.includes(answer.props.index);
+          expect(answer.props.autoFocus).to.equal(hasFocus);
+        })
+      })
+    });
+  });
+
   describe('input onChange event handler', function() {
     let handleChangeSpy;
     let onChangeSpy;

--- a/app/classifier/tasks/single/index.jsx
+++ b/app/classifier/tasks/single/index.jsx
@@ -34,7 +34,7 @@ export default class SingleChoiceTask extends React.Component {
 
       answers.push(
         <TaskInputField
-          autoFocus={checked}
+          autoFocus={autoFocus && checked}
           checked={checked}
           className={checked ? 'active' : ''}
           index={i}

--- a/app/classifier/tasks/single/index.spec.js
+++ b/app/classifier/tasks/single/index.spec.js
@@ -34,6 +34,47 @@ describe('SingleChoiceTask', function () {
     });
   });
 
+  describe('with an empty annotation', function () {
+    const annotation = Object.assign({}, radioTypeAnnotation, { value: null });
+    [true, false].forEach(function testAutofocus(autofocus) {
+      const wrapper = shallow(
+        <SingleTask
+          autoFocus={autofocus}
+          task={radioTypeTask}
+          annotation={annotation}
+          translation={radioTypeTask}
+        />,
+        mockReduxStore
+      );
+      const genericTask = wrapper.dive();
+      it(`should pass autofocus ${autofocus} to its children`, function () {
+        expect(genericTask.prop('autoFocus')).to.equal(autofocus);
+      })
+    });
+  });
+
+  describe('with an annotation', function () {
+    const annotation = Object.assign({}, radioTypeAnnotation, { value: 1 });
+    [true, false].forEach(function testAutofocus(autofocus) {
+      const wrapper = shallow(
+        <SingleTask
+          autoFocus={autofocus}
+          task={radioTypeTask}
+          annotation={annotation}
+          translation={radioTypeTask}
+        />,
+        mockReduxStore
+      );
+      const answers = wrapper.dive().prop('answers');
+      it(`should pass autofocus ${autofocus} to its children`, function () {
+        answers.forEach(function (answer) {
+          const hasFocus = autofocus && answer.props.index === annotation.value;
+          expect(answer.props.autoFocus).to.equal(hasFocus);
+        })
+      })
+    });
+  });
+
   describe('input onChange event handler', function() {
     let handleChangeSpy;
     let onChangeSpy;

--- a/app/classifier/tasks/single/index.spec.js
+++ b/app/classifier/tasks/single/index.spec.js
@@ -66,8 +66,8 @@ describe('SingleChoiceTask', function () {
         mockReduxStore
       );
       const answers = wrapper.dive().prop('answers');
-      it(`should pass autofocus ${autofocus} to its children`, function () {
-        answers.forEach(function (answer) {
+      answers.forEach(function (answer) {
+        it(`should pass autofocus ${autofocus} for answer ${answer.props.index}`, function () {
           const hasFocus = autofocus && answer.props.index === annotation.value;
           expect(answer.props.autoFocus).to.equal(hasFocus);
         })


### PR DESCRIPTION
Adds tests to the question task to check autofocus in the cases where autoFocus is true or false, and where the task has a selected answer or not.

Staging branch URL: https://pr-5422.pfe-preview.zooniverse.org

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
