### PR TITLE
change download export link wording

### DIFF
--- a/app/partials/data-export-download-link.jsx
+++ b/app/partials/data-export-download-link.jsx
@@ -54,7 +54,7 @@ export default class DataExportDownloadLink extends React.Component {
             return (<span>Error loading export information</span>);
         } else if (this.recentAndReady(this.state.mostRecent)) {
             return (<span>
-                {Most recent data available requested `${moment(this.state.mostRecent.updated_at).fromNow()}`}
+                {`Most recent data available requested ${moment(this.state.mostRecent.updated_at).fromNow()}`}
                 <a href={this.state.mostRecent.src}>Download your data export</a>.
               </span >);
         } else if (this.pending(this.state.mostRecent)) {

--- a/app/partials/data-export-download-link.jsx
+++ b/app/partials/data-export-download-link.jsx
@@ -54,7 +54,7 @@ export default class DataExportDownloadLink extends React.Component {
             return (<span>Error loading export information</span>);
         } else if (this.recentAndReady(this.state.mostRecent)) {
             return (<span>
-                Most recent data available requested{` ${moment(this.state.mostRecent.updated_at).fromNow()}`}
+                {Most recent data available requested `${moment(this.state.mostRecent.updated_at).fromNow()}`}
                 <a href={this.state.mostRecent.src}>Download your data export</a>.
               </span >);
         } else if (this.pending(this.state.mostRecent)) {

--- a/app/partials/data-export-download-link.jsx
+++ b/app/partials/data-export-download-link.jsx
@@ -54,8 +54,8 @@ export default class DataExportDownloadLink extends React.Component {
             return (<span>Error loading export information</span>);
         } else if (this.recentAndReady(this.state.mostRecent)) {
             return (<span>
-                {`Most recent data available requested ${moment(this.state.mostRecent.updated_at).fromNow()}`}
-                <a href={this.state.mostRecent.src}>Download your data export</a>.
+                {`Most recent data available requested ${moment(this.state.mostRecent.updated_at).fromNow()}, `}
+                <a href={this.state.mostRecent.src}>download your data export</a>.
               </span >);
         } else if (this.pending(this.state.mostRecent)) {
             return (<span>Export is being generated.</span>);

--- a/app/partials/data-export-download-link.jsx
+++ b/app/partials/data-export-download-link.jsx
@@ -54,8 +54,8 @@ export default class DataExportDownloadLink extends React.Component {
             return (<span>Error loading export information</span>);
         } else if (this.recentAndReady(this.state.mostRecent)) {
             return (<span>
-                Most recent data available requested{' '}
-                <a href={this.state.mostRecent.src}>{moment(this.state.mostRecent.updated_at).fromNow()}</a>.
+                Most recent data available requested{` ${moment(this.state.mostRecent.updated_at).fromNow()}`}
+                <a href={this.state.mostRecent.src}>Download your data export</a>.
               </span >);
         } else if (this.pending(this.state.mostRecent)) {
             return (<span>Export is being generated.</span>);


### PR DESCRIPTION
clarify the link wording to make it explicit so users know they can download their file

Staging branch URL: https://pr-5427.pfe-preview.zooniverse.org

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
