### PR TITLE
use subject's uploading project as fallback for talk

### DIFF
--- a/app/collections/show-list.cjsx
+++ b/app/collections/show-list.cjsx
@@ -36,22 +36,14 @@ SubjectNode = createReactClass
     if @props.projectContext
       @updateProjectState(@props.projectContext)
     else
-      @fetchProject(@props.subject)
+    # otherwise use the original project context
+      @props.subject.get('project')
         .then (project) =>
           @updateProjectState(project)
 
   updateProjectState: (project) ->
     @setState {project}
     @isFavorite(project)
-
-  # use the collection project if there is only 1 project for this collection
-  # fallback to the subject project link if no other project context can be determined
-  fetchProject: (subject) ->
-    projectRequest = if @props.collection?.links.projects?.length == 1
-      projectId = @props.collection?.links.projects[0]
-      apiClient.type('projects').get(projectId)
-    else
-      subject.get('project')
 
   isFavorite: (project) ->
     if @props.collection.favorite and @props.collection.links.owner.id is @props.user.id


### PR DESCRIPTION
if we can't determine the URL context for a talk board, then fallback to the subjects' uploading project context, do not use the collection context as it is missing project links for collections originally created in a project talk context but then used to collect subjects across the zooniverse. I.e. the collection project link was only set on create and not when adding subjects in other project contexts

Staging branch URL: https://pr-5440.pfe-preview.zooniverse.org

Describe your changes.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
