### PR TITLE
Fix undefined rule error for feedback

### DIFF
--- a/app/features/feedback/shared/helpers/generate-rules.spec.js
+++ b/app/features/feedback/shared/helpers/generate-rules.spec.js
@@ -83,20 +83,41 @@ describe('feedback: generateRules', function () {
   });
 
   describe('with no matching rules', function () {
-    const workflow = {
-      tasks: {
-        T0: mockTaskWithRule('1')
-      }
-    };
+    describe('when the workflow rule ID is truthy', function () {
+      const workflow = {
+        tasks: {
+          T0: mockTaskWithRule('1')
+        }
+      };
 
-    it('should return an empty object for a numeric rule ID', function () {
-      const subject = mockSubjectWithRule(0);
-      expect(generateRules(subject, workflow)).to.be.empty;
-    });
+      it('should return an empty object for a falsy subject rule ID', function () {
+        const subject = mockSubjectWithRule(0);
+        expect(generateRules(subject, workflow)).to.be.empty;
+      });
 
-    it('should return an empty object for a string rule ID', function () {
-      const subject = mockSubjectWithRule('0');
-      expect(generateRules(subject, workflow)).to.be.empty;
-    });
+      it('should return an empty object for a truthy subject rule ID', function () {
+        const subject = mockSubjectWithRule('0');
+        expect(generateRules(subject, workflow)).to.be.empty;
+      });
+    })
+
+    describe('when the workflow rule ID is falsy', function () {
+      const workflow = {
+        tasks: {
+          T0: mockTaskWithRule(0)
+        }
+      };
+
+      it('should return an empty object for a numeric subject rule ID', function () {
+        const subject = mockSubjectWithRule(1);
+        expect(generateRules(subject, workflow)).to.be.empty;
+      });
+
+      it('should return an empty object for a string subject rule ID', function () {
+        const subject = mockSubjectWithRule('1');
+        expect(generateRules(subject, workflow)).to.be.empty;
+      });
+      
+    })
   });
 });

--- a/app/features/feedback/shared/helpers/generate-rules.spec.js
+++ b/app/features/feedback/shared/helpers/generate-rules.spec.js
@@ -81,4 +81,22 @@ describe('feedback: generateRules', function () {
     };
     testSubjectAndWorkflow(subject, workflow);
   });
+
+  describe('with no matching rules', function () {
+    const workflow = {
+      tasks: {
+        T0: mockTaskWithRule('1')
+      }
+    };
+
+    it('should return an empty object for a numeric rule ID', function () {
+      const subject = mockSubjectWithRule(0);
+      expect(generateRules(subject, workflow)).to.be.empty;
+    });
+
+    it('should return an empty object for a string rule ID', function () {
+      const subject = mockSubjectWithRule('0');
+      expect(generateRules(subject, workflow)).to.be.empty;
+    });
+  });
 });

--- a/app/features/feedback/shared/helpers/metadata-to-rules.js
+++ b/app/features/feedback/shared/helpers/metadata-to-rules.js
@@ -1,18 +1,21 @@
-import _ from 'lodash';
-
 // Converts a subject metadata object into an array of feedback objects
-function metadataToRules(metadata) {
-  const rulesObject = _.reduce(metadata, (result, value, key) => {
-    const [prefix, ruleKey, propKey] = key.split('_');
-    const stringValue = value.toString()
+function metadataToRules(metadata = {}) {
+  const metadataKeys = Object.keys(metadata);
+  const rules = metadataKeys.reduce(function (result, key) {
+    const [prefix, ruleIndex, propKey] = key.split('_');
+    const value = metadata[key];
+    const stringValue = value.toString();
 
     if (prefix === '#feedback' && stringValue) {
-      _.set(result, `${ruleKey}.${propKey}`, value);
+      const rule = result[ruleIndex] || {};
+      rule[propKey] = value;
+      result[ruleIndex] = rule;
     }
 
     return result;
-  }, {});
-  return _.toArray(rulesObject);
+  }, []);
+
+  return rules.filter(Boolean);
 }
 
 export default metadataToRules;

--- a/app/features/feedback/shared/helpers/metadata-to-rules.js
+++ b/app/features/feedback/shared/helpers/metadata-to-rules.js
@@ -4,8 +4,9 @@ import _ from 'lodash';
 function metadataToRules(metadata) {
   const rulesObject = _.reduce(metadata, (result, value, key) => {
     const [prefix, ruleKey, propKey] = key.split('_');
+    const stringValue = value.toString()
 
-    if (prefix === '#feedback' && value) {
+    if (prefix === '#feedback' && stringValue) {
       _.set(result, `${ruleKey}.${propKey}`, value);
     }
 

--- a/app/features/feedback/shared/helpers/metadata-to-rules.spec.js
+++ b/app/features/feedback/shared/helpers/metadata-to-rules.spec.js
@@ -1,0 +1,36 @@
+import { expect } from 'chai';
+import metadataToRules from './metadata-to-rules';
+
+describe('feedback: metadataToRules', function () {
+  function mockSubjectWithRule(ruleID) {
+    return {
+      metadata: {
+        '#feedback_1_id': ruleID,
+        '#feedback_1_answer': '0',
+        '#feedback_1_failureMessage': 'Actually, this sound is from noise (background)',
+        '#feedback_1_successMessage': 'Correct!'
+      }
+    };
+  }
+
+  function expectedRules(ruleID) {
+    return [{
+      id: ruleID,
+      answer: '0',
+      failureMessage: 'Actually, this sound is from noise (background)',
+      successMessage: 'Correct!'
+    }];
+  }
+
+  it('should generate a rules object for string IDs', function () {
+    const subject = mockSubjectWithRule('0');
+    const rules = metadataToRules(subject.metadata);
+    expect(rules).to.eql(expectedRules('0'));
+  });
+
+  it('should generate a rules object for numerical IDs', function () {
+    const subject = mockSubjectWithRule(0);
+    const rules = metadataToRules(subject.metadata);
+    expect(rules).to.eql(expectedRules(0));
+  });
+});


### PR DESCRIPTION
Add a feedback test for the case where the subject rule doesn't match a workflow task rule.
Convert metadata values to strings before checking their existence.
Spec the function that converts subject metadata to feedback rules.

Staging branch URL: https://pr-5445.pfe-preview.zooniverse.org

Fixes #5444.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
