### PR TITLE
Use translated workflow description on project home page

### DIFF
--- a/app/pages/project/home/home-workflow-buttons.jsx
+++ b/app/pages/project/home/home-workflow-buttons.jsx
@@ -38,8 +38,8 @@ export default class ProjectHomeWorkflowButtons extends React.Component {
                 <Translate content="project.home.getStarted" />{' '}
                 <i className="fa fa-arrow-down" aria-hidden="true" />
               </h3>
-              {this.props.project.workflow_description && (
-                <p className="workflow-choice-container__description">{this.props.project.workflow_description}</p>
+              {this.props.translation.workflow_description && (
+                <p className="workflow-choice-container__description">{this.props.translation.workflow_description}</p>
               )}
               {this.props.activeWorkflows.map((workflow) => {
                 return (
@@ -69,6 +69,7 @@ ProjectHomeWorkflowButtons.defaultProps = {
   project: {},
   showWorkflowButtons: false,
   splits: {},
+  translation: {},
   user: null,
   workflowAssignment: false
 };
@@ -81,11 +82,13 @@ ProjectHomeWorkflowButtons.propTypes = {
   }),
   project: PropTypes.shape({
     redirect: PropTypes.string,
-    slug: PropTypes.string,
-    workflow_description: PropTypes.string
+    slug: PropTypes.string
   }).isRequired,
   showWorkflowButtons: PropTypes.bool.isRequired,
   splits: PropTypes.object,
+  translation: PropTypes.shape({
+    workflow_description: PropTypes.string
+  }).isRequired,
   user: PropTypes.object,
   workflowAssignment: PropTypes.bool
 };

--- a/app/pages/project/home/project-home.jsx
+++ b/app/pages/project/home/project-home.jsx
@@ -91,6 +91,7 @@ const ProjectHomePage = (props) => {
             showWorkflowButtons={props.showWorkflowButtons}
             workflowAssignment={props.project.experimental_tools.includes('workflow assignment')}
             splits={props.splits}
+            translation={props.translation}
             user={props.user}
           />
         </VisibilitySplit>


### PR DESCRIPTION
Pass the project translation down to the HomeWorkflowButtons component and use that to display the workflow description.

![Screenshot showing a workflow description displayed in very bad Italian.](https://user-images.githubusercontent.com/59547/61056139-b7a17f80-a3ea-11e9-9608-f6676aa0c659.png)


Staging branch URL: https://pr-5456.pfe-preview.zooniverse.org

Towards #5451.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
