### PR TITLE
Add front-end for the volunteer list page

### DIFF
--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -42,6 +42,7 @@ export default {
         faq: 'FAQ',
         education: 'Education',
         team: 'The Team',
+        volunteers: 'Volunteers',
       }
     },
     nav: {

--- a/app/pages/lab/actions/project.js
+++ b/app/pages/lab/actions/project.js
@@ -10,7 +10,22 @@ var projectActions = {
       private: true
     }, projectData);
 
-    return projects.create(allProjectData).save();
+    return projects.create(allProjectData)
+      .save()
+      .then(function (projectResource) {
+        apiClient.post(projectResource._getURL('pages'), {
+          project_pages: {
+            language: projectResource.primary_language,
+            title: 'Volunteers',
+            url_key: 'volunteers',
+          }
+        })
+        .catch(function(error) {
+          console.error(error)
+        })
+        return projectResource
+      })
+
   }
 }
 

--- a/app/pages/project/about/index.jsx
+++ b/app/pages/project/about/index.jsx
@@ -11,7 +11,8 @@ const SLUG_MAP = {
   team: 'team',
   results: 'results',
   education: 'education',
-  faq: 'faq'
+  faq: 'faq',
+  volunteers: 'volunteers'
 };
 
 class AboutProject extends Component {
@@ -71,7 +72,7 @@ class AboutProject extends Component {
           title: matchingPage.title,
           content
         };
-      } else if (['science_case', 'team'].includes(url_key)) {
+      } else if (['science_case', 'team', 'volunteers'].includes(url_key)) {
         return { slug: SLUG_MAP[url_key] };
       }
       return null;

--- a/app/pages/project/about/simple-pages.jsx
+++ b/app/pages/project/about/simple-pages.jsx
@@ -1,8 +1,7 @@
+import counterpart from 'counterpart';
 import PropTypes from 'prop-types';
 import React from 'react';
 import AboutPageLayout from './about-page-layout';
-import Translate from 'react-translate-component';
-import counterpart from 'counterpart';
 
 counterpart.registerTranslations('en', {
   aboutPages: {
@@ -11,16 +10,17 @@ counterpart.registerTranslations('en', {
       faq: 'This project has no frequently asked questions yet.',
       research: 'This project has no science case yet.',
       results: 'This project has no results to report yet.',
+      volunteers: 'No-one has classified on this project yet.',
     }
   }
 });
 
 const SimplePageRenderer = ({ pageSlug, noContent, pages, project }) => {
   const matchingPage = pages.find(page => page.slug === pageSlug);
-  const mainContent = (matchingPage && matchingPage.content && matchingPage.content !== '') 
-      ? matchingPage.content 
+  const mainContent = (matchingPage && matchingPage.content && matchingPage.content !== '')
+      ? matchingPage.content
       : noContent;
-      
+
   return <AboutPageLayout project={project} mainContent={mainContent} />;
 }
 
@@ -62,6 +62,13 @@ const AboutProjectResults = (props) => (
   />
 );
 
+const AboutProjectVolunteers = (props) => (
+  <SimplePageRenderer {...props}
+    pageSlug="volunteers"
+    noContent={counterpart('aboutPages.missingContent.volunteers')}
+  />
+);
+
 const SimplePagePropTypes = {
   pages: PropTypes.array,
   project: PropTypes.object,
@@ -71,10 +78,12 @@ AboutProjectEducation.propTypes = SimplePagePropTypes;
 AboutProjectFAQ.propTypes = SimplePagePropTypes;
 AboutProjectResearch.propTypes = SimplePagePropTypes;
 AboutProjectResults.propTypes = SimplePagePropTypes;
+AboutProjectVolunteers.propTypes = SimplePagePropTypes
 
 export {
   AboutProjectEducation,
   AboutProjectFAQ,
   AboutProjectResearch,
   AboutProjectResults,
+  AboutProjectVolunteers
 };

--- a/app/router.cjsx
+++ b/app/router.cjsx
@@ -9,7 +9,7 @@ createReactClass = require 'create-react-class'
 `import CollectionCollaborators from './collections/collaborators';`
 `import ProjectHomePage from './pages/project/home';`
 `import AboutProject from './pages/project/about/index';`
-`import { AboutProjectResearch, AboutProjectEducation, AboutProjectFAQ, AboutProjectResults } from './pages/project/about/simple-pages';`
+`import { AboutProjectResearch, AboutProjectEducation, AboutProjectFAQ, AboutProjectResults, AboutProjectVolunteers } from './pages/project/about/simple-pages';`
 `import AboutProjectTeam from './pages/project/about/team';`
 `import UserSettingsList from './pages/admin/user-settings-list';`
 `import UserSettings from './pages/admin/user-settings';`
@@ -156,6 +156,7 @@ module.exports =
         <Route path="faq" component={AboutProjectFAQ} />
         <Route path="education" component={AboutProjectEducation} />
         <Route path="team" component={AboutProjectTeam} />
+        <Route path="volunteers" component={AboutProjectVolunteers} />
       </Route>
       <Route path="notifications" component={NotificationsPage} />
       <Route path="talk" component={require './pages/project/talk'}>


### PR DESCRIPTION
Adds a new about page for projects called `volunteers`, hooks up the route, and auto-creates this page when building a new project. This page will be auto-populated by the API, which @camallen is working on.

This was done during the July 17 Oxford hackday, so reviews welcome as it may be shonky