### PR TITLE
Don't display private messages from deleted users

### DIFF
--- a/app/pages/home-for-user/recent-messages.jsx
+++ b/app/pages/home-for-user/recent-messages.jsx
@@ -83,19 +83,23 @@ class RecentCollectionsSection extends React.Component {
       return [];
     })
     .then((users) => {
-      let partner = users.find((potentialPartner) => {
-        return potentialPartner !== currentUser;
-      });
-      if (partner === undefined) {
-        // Why're you talking to yourself?
-        partner = currentUser;
+      if (users.length > 0) {
+        let partner = users.find((potentialPartner) => {
+          return potentialPartner !== currentUser;
+        });
+        if (partner === undefined) {
+          // Why're you talking to yourself?
+          partner = currentUser;
+        }
+        const newState = Object.assign({}, this.state.conversationPartners);
+        newState[conversation.id] = partner;
+        this.setState({
+          conversationPartners: newState,
+        });
+        return partner;
+      } else {
+        return null;
       }
-      const newState = Object.assign({}, this.state.conversationPartners);
-      newState[conversation.id] = partner;
-      this.setState({
-        conversationPartners: newState,
-      });
-      return partner;
     });
   };
 
@@ -131,24 +135,31 @@ class RecentCollectionsSection extends React.Component {
       this.setState({
         messageAuthors: authorState,
       });
-      return author.get('avatar')
-      .catch(() => {
-        return [];
-      })
-      .then((avatars) => {
-        const avatar = [].concat(avatars)[0]; // Why's this an array?
-        const avatarState = Object.assign({}, this.state.avatars);
-        avatarState[author.id] = avatar;
-        this.setState({
-          avatars: avatarState,
+      if (author) {
+        return author.get('avatar')
+        .catch(() => {
+          return [];
+        })
+        .then((avatars) => {
+          const avatar = [].concat(avatars)[0]; // Why's this an array?
+          const avatarState = Object.assign({}, this.state.avatars);
+          avatarState[author.id] = avatar;
+          this.setState({
+            avatars: avatarState,
+          });
+          return author;
         });
-        return author;
-      });
+      } else {
+        return [];
+      }
     });
   };
 
   renderConversation = (conversation, index, allConversations) => {
     const partner = this.state.conversationPartners[conversation.id];
+    if (!partner) {
+      return (<div></div>);
+    }
     const message = this.state.lastMessages[conversation.id];
     const sentLastMessage = !!message && (this.state.messageAuthors[message.id] === this.context.user);
 

--- a/app/pages/home-for-user/recent-messages.jsx
+++ b/app/pages/home-for-user/recent-messages.jsx
@@ -150,7 +150,7 @@ class RecentCollectionsSection extends React.Component {
           return author;
         });
       } else {
-        return [];
+        return {};
       }
     });
   };
@@ -158,7 +158,7 @@ class RecentCollectionsSection extends React.Component {
   renderConversation = (conversation, index, allConversations) => {
     const partner = this.state.conversationPartners[conversation.id];
     if (!partner) {
-      return (<div></div>);
+      return null;
     }
     const message = this.state.lastMessages[conversation.id];
     const sentLastMessage = !!message && (this.state.messageAuthors[message.id] === this.context.user);

--- a/app/talk/inbox.cjsx
+++ b/app/talk/inbox.cjsx
@@ -47,21 +47,24 @@ ConversationLink = createReactClass
 
   render: ->
     unread = @props.conversation.is_unread
-    <div className="conversation-link #{if unread then 'unread' else ''}">
-      <div>
-        {@state.users.map (user, i) =>
-          <div key={user.id}>
-            <strong><Link key={user.id} to="/users/#{user.login}">{user.display_name}</Link></strong>
-            <div>{timeAgo(@state.messages[0]?.updated_at)}{', ' if i isnt (@state.users.length-1)}</div>
-          </div>}
-      </div>
+    if @state.users.length > 0
+      <div className="conversation-link #{if unread then 'unread' else ''}">
+        <div>
+          {@state.users.map (user, i) =>
+            <div key={user.id}>
+              <strong><Link key={user.id} to="/users/#{user.login}">{user.display_name}</Link></strong>
+              <div>{timeAgo(@state.messages[0]?.updated_at)}{', ' if i isnt (@state.users.length-1)}</div>
+            </div>}
+        </div>
 
-      <Link to="/inbox/#{@props.conversation.id}">
-        {if unread
-          <i className="fa fa-comments-o"/>}
-        {@props.conversation.title}
-      </Link>
-    </div>
+        <Link to="/inbox/#{@props.conversation.id}">
+          {if unread
+            <i className="fa fa-comments-o"/>}
+          {@props.conversation.title}
+        </Link>
+      </div>
+    else
+      <div></div>
 
 module.exports = createReactClass
   displayName: 'TalkInbox'


### PR DESCRIPTION
Staging branch URL: https://skip-deleted-user-messages.pfe-preview.zooniverse.org/

Messages from deleted users are broken, and often this comes up with spam messages that we don't want cluttering up the message list.

This PR simply doesn't display those messages in the inbox – this is obviously not ideal (this results in less than 10 messages being listed on the page, and the empty `div` is ugly) but it's the quickest workaround I can think of and imho it'll do for now.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?