### PR TITLE
Remove Autosave component from AccountInformationPage

### DIFF
--- a/app/locales/ar.js
+++ b/app/locales/ar.js
@@ -627,6 +627,7 @@ export default {
       displayNameHelp: 'How your name will appear to other users in Talk and on your Profile Page',
       realName: 'Real name (optional)',
       realNameHelp: 'Public; we’ll use this to give acknowledgement in papers, on posters, etc.',
+      save: 'Save',
       changePassword: {
         heading: 'Change your password',
         currentPassword: 'Current password (required)',

--- a/app/locales/cs.js
+++ b/app/locales/cs.js
@@ -985,6 +985,7 @@ export default {
       interventions: 'Zobrazovat upozornění ohledně projektové intervence (dotazníky apod.).',
       interventionsHelp: 'Povolit projektům zobrazovat zprávy v době, kdy klasifikujete.',
       interventionsPreferences: 'Předvolby upozornění',
+      save: 'Save',
       changePassword: {
         heading: 'Změnit heslo',
         currentPassword: 'Současné heslo (povinné)',

--- a/app/locales/de.js
+++ b/app/locales/de.js
@@ -978,6 +978,7 @@ export default {
       displayNameHelp: 'Wie Dein Name anderen Nutzern bei Talk und auf Deiner Profilseite angezeigt wird.',
       realName: 'Richtiger Name (optional)',
       realNameHelp: 'Öffentlich. Wir werden diesen Namen in wissenschaftlichen Veröffentlichungen und auf Postern etc. für Anerkennung der Mithilfe nutzen.',
+      save: 'Save',
       changePassword: {
         heading: 'Ändere Dein Passwort',
         currentPassword: 'Derzeitiges Passwort (notwendig)',

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -986,6 +986,7 @@ export default {
       interventions: 'Show project intervention notifications.',
       interventionsHelp: 'Allow projects to display messages while you are classifying.',
       interventionsPreferences: 'Notification preferences',
+      save: 'Save',
       changePassword: {
         heading: 'Change your password',
         currentPassword: 'Current password (required)',

--- a/app/locales/es.js
+++ b/app/locales/es.js
@@ -574,6 +574,7 @@ export default {
       displayNameHelp: 'How your name will appear to other users in Talk and on your Profile Page',
       realName: 'Real name (optional)',
       realNameHelp: 'Public; we’ll use this to give acknowledgement in papers, on posters, etc.',
+      save: 'Save',
       changePassword: {
         heading: 'Change your password',
         currentPassword: 'Current password (required)',

--- a/app/locales/fr.js
+++ b/app/locales/fr.js
@@ -980,6 +980,7 @@ export default {
       displayNameHelp: 'How your name will appear to other users in Talk and on your Profile Page',
       realName: 'Real name (optional)',
       realNameHelp: 'Public; we’ll use this to give acknowledgement in papers, on posters, etc.',
+      save: 'Save',
       changePassword: {
         heading: 'Change your password',
         currentPassword: 'Current password (required)',

--- a/app/locales/he.js
+++ b/app/locales/he.js
@@ -627,6 +627,7 @@ export default {
       displayNameHelp: 'How your name will appear to other users in Talk and on your Profile Page',
       realName: 'Real name (optional)',
       realNameHelp: 'Public; we’ll use this to give acknowledgement in papers, on posters, etc.',
+      save: 'Save',
       changePassword: {
         heading: 'Change your password',
         currentPassword: 'Current password (required)',

--- a/app/locales/it.js
+++ b/app/locales/it.js
@@ -986,6 +986,7 @@ export default {
 	  interventions: 'Show project intervention notifications.',
       interventionsHelp: 'Permetti ai progetti di notificare messaggi mentre stai classificando.',
       interventionsPreferences: 'Preferenze di notifica',
+      save: 'Save',
       changePassword: {
         heading: 'Modifica della password',
         currentPassword: 'Password attuale (campo obbligatorio)',

--- a/app/locales/nl.js
+++ b/app/locales/nl.js
@@ -611,6 +611,7 @@ export default {
       displayNameHelp: 'How your name will appear to other users in Talk and on your Profile Page',
       realName: 'Real name (optional)',
       realNameHelp: 'Public; we’ll use this to give acknowledgement in papers, on posters, etc.',
+      save: 'Save',
       changePassword: {
         heading: 'Change your password',
         currentPassword: 'Current password (required)',

--- a/app/locales/pt.js
+++ b/app/locales/pt.js
@@ -981,6 +981,7 @@ export default {
       interventions: 'Show project intervention notifications.',
       interventionsHelp: 'Allow projects to display messages while you are classifying.',
       interventionsPreferences: 'Notification preferences',
+      save: 'Save',
       changePassword: {
         heading: 'Change your password',
         currentPassword: 'Current password (required)',

--- a/app/pages/settings/AccountInformationPage.jsx
+++ b/app/pages/settings/AccountInformationPage.jsx
@@ -1,70 +1,140 @@
 import React from 'react';
 import counterpart from 'counterpart';
-import AutoSave from '../../components/auto-save';
-import handleInputChange from '../../lib/handle-input-change';
 import ChangePasswordForm from './ChangePasswordForm';
 
-export default function AccountInformationPage(props) {
-  return (
-    <div className="account-information-tab">
-      <div className="columns-container">
-        <div className="content-container column">
-          <p>
-            <AutoSave resource={props.user}>
-              <span className="form-label">
-                <label htmlFor="displayName">{counterpart('userSettings.account.displayName')}</label>
-              </span>
-              <br />
-              <input
-                type="text"
-                id="displayName"
-                className="standard-input full"
-                name="display_name"
-                value={props.user.display_name}
-                onChange={handleInputChange.bind(props.user)}
-              />
-            </AutoSave>
-            <span className="form-help">{counterpart('userSettings.account.displayNameHelp')}</span>
-            <br />
-            <AutoSave resource={props.user}>
-              <label htmlFor="realName">
-                <span className="form-label">{counterpart('userSettings.account.realName')}</span>
-              </label>
-              <br />
-              <input
-                type="text"
-                id="realName"
-                className="standard-input full"
-                name="credited_name"
-                value={props.user.credited_name}
-                onChange={handleInputChange.bind(props.user)}
-              />
-            </AutoSave>
-            <span className="form-help">{counterpart('userSettings.account.realNameHelp')}</span>
-          </p>
-          <fieldset>
-            <legend>{counterpart('userSettings.account.interventionsPreferences')}</legend>
-            <AutoSave resource={props.user}>
-              <label className="form-label">
-                <input
-                  type="checkbox"
-                  className="standard-input"
-                  name="intervention_notifications"
-                  checked={props.user.intervention_notifications}
-                  onChange={handleInputChange.bind(props.user)}
-                />
-                {counterpart('userSettings.account.interventions')}
-              </label>
-            </AutoSave>
-            <br />
-            <span className="form-help">{counterpart('userSettings.account.interventionsHelp')}</span>
-          </fieldset>
+export default class AccountInformationPage extends React.Component {
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      displayName: props.user.display_name,
+      creditedName: props.user.credited_name,
+      interventionNotifications: props.user.intervention_notifications,
+      inProgress: false,
+      success: false,
+      error: null
+    };
+    this.handleSubmit = this.handleSubmit.bind(this);
+  }
+
+  handleSubmit(e) {
+    e.preventDefault();
+
+    this.setState({
+      inProgress: true,
+      success: false,
+      error: null
+    });
+
+    this.props.user.update({
+      display_name: this.state.displayName,
+      credited_name: this.state.creditedName,
+      intervention_notifications: this.state.interventionNotifications
+    });
+
+    this.props.user.save()
+      .then(() => {
+        this.setState({
+          inProgress: false,
+          success: true
+        });
+      })
+      .catch(error => {
+        this.setState({
+          error: error,
+          inProgress: false
+        });
+      });
+  }
+
+  submitDisabled() {
+    return this.state.displayName == this.props.user.display_name
+      && this.state.creditedName == this.props.user.credited_name
+      && this.state.interventionNotifications == this.props.user.intervention_notifications
+      || this.state.displayName.length == 0;
+  }
+
+  renderStatus() {
+    let status = null;
+    if (this.state.inProgress) {
+      status = <i className="fa fa-spinner fa-spin form-help"></i>;
+    } else if (this.state.success) {
+      status = <i className="fa fa-check-circle form-help success"></i>;
+    } else if (this.state.error) {
+      status = <small className="form-help error">{this.state.error.toString()}</small>;
+    }
+    return status;
+  }
+
+  render() {
+    return (
+      <div className="account-information-tab">
+        <div className="columns-container">
+          <div className="content-container column">
+            <form onSubmit={this.handleSubmit}>
+              <p>
+                  <span className="form-label">
+                    <label htmlFor="displayName">{counterpart('userSettings.account.displayName')}</label>
+                  </span>
+                  <br />
+                  <input
+                    type="text"
+                    id="displayName"
+                    className="standard-input full"
+                    name="display_name"
+                    value={this.state.displayName}
+                    onChange={(e) => { this.setState({ displayName: e.target.value }); }}
+                    required
+                  />
+                <span className="form-help">{counterpart('userSettings.account.displayNameHelp')}</span>
+                <br />
+                  <label htmlFor="realName">
+                    <span className="form-label">{counterpart('userSettings.account.realName')}</span>
+                  </label>
+                  <br />
+                  <input
+                    type="text"
+                    id="realName"
+                    className="standard-input full"
+                    name="credited_name"
+                    value={this.state.creditedName}
+                    onChange={(e) => { this.setState({ creditedName: e.target.value }); }}
+                  />
+                <span className="form-help">{counterpart('userSettings.account.realNameHelp')}</span>
+              </p>
+              <fieldset>
+                <legend>{counterpart('userSettings.account.interventionsPreferences')}</legend>
+                  <label className="form-label">
+                    <input
+                      type="checkbox"
+                      className="standard-input"
+                      name="intervention_notifications"
+                      checked={this.state.interventionNotifications}
+                      onChange={() => { this.setState({ interventionNotifications: !this.state.interventionNotifications }); }}
+                    />
+                    {counterpart('userSettings.account.interventions')}
+                  </label>
+                <br />
+                <span className="form-help">{counterpart('userSettings.account.interventionsHelp')}</span>
+              </fieldset>
+              <p>
+                <button
+                  type="submit"
+                  disabled={this.submitDisabled()}
+                  className="standard-button"
+                >
+                  {counterpart('userSettings.account.save')}
+                </button>
+                {this.renderStatus()}
+              </p>
+            </form>
+          </div>
+        </div>
+        <hr />
+        <div className="content-container">
+          {<ChangePasswordForm {...this.props} />}
         </div>
       </div>
-      <hr />
-      <div className="content-container">
-        {<ChangePasswordForm {...props} />}
-      </div>
-    </div>
-  );
+    );
+  }
 }


### PR DESCRIPTION
Staging branch URL: https://pr-5479.pfe-preview.zooniverse.org

Fixes # .

Describe your changes.

Removes autosave component from account infromation page.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
