### PR TITLE
Translate `hide previous marks` tool

### DIFF
--- a/app/classifier/tasks/drawing/hide-previous-marks-toggle.jsx
+++ b/app/classifier/tasks/drawing/hide-previous-marks-toggle.jsx
@@ -1,5 +1,6 @@
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
+import Translate from 'react-translate-component';
 
 class HidePreviousMarksToggle extends React.Component {
   constructor() {
@@ -69,7 +70,9 @@ class HidePreviousMarksToggle extends React.Component {
             onChange={this.setPreviousMarks.bind(this, nextValueToSet)}
           />
           {' '}
-          Hide previous marks {marksCount > 0 ? `(${marksCount})` : undefined }
+          <Translate content="tasks.hidePreviousMarks" with={{
+            count: marksCount > 0 ? `(${marksCount})` : undefined
+          }} />
         </label>
       </div>
     );
@@ -87,7 +90,7 @@ HidePreviousMarksToggle.propTypes = {
 HidePreviousMarksToggle.defaultProps = {
   annotations: [],
   workflow: null,
-  onChange() {}
+  onChange() { }
 };
 
 export default HidePreviousMarksToggle;

--- a/app/locales/cs.js
+++ b/app/locales/cs.js
@@ -109,6 +109,7 @@ export default {
     pleaseWait: 'Čekejte prosím...'
   },
   tasks: {
+    hidePreviousMarks: 'Skrýt předchozí značky %(count)s',
     less: 'Méně',
     more: 'Více',
     shortcut: {

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -110,6 +110,7 @@ export default {
     pleaseWait: 'Please wait...'
   },
   tasks: {
+    hidePreviousMarks: 'Hide previous marks %(count)s',
     less: 'Less',
     more: 'More',
     shortcut: {


### PR DESCRIPTION
- Add an EN and CS translation for `hide previous marks`, with count interpolation
- Remove text string from tool and use `Translate` component instead

Fixes #5484
