### PR TITLE
Disable drawing for multi-touch events

### DIFF
--- a/app/lib/draggable.jsx
+++ b/app/lib/draggable.jsx
@@ -15,54 +15,64 @@ function Draggable(props) {
   }
 
   function handleStart(e) {
-    e.preventDefault();
+    const multiTouch = e.touches && e.touches.length > 1;
 
-    switch (e.type) {
-      case 'mousedown':
-        [moveEvent, endEvent] = ['mousemove', 'mouseup'];
-        break;
-      case 'touchstart':
-        [moveEvent, endEvent] = ['touchmove', 'touchend'];
-        break;
-      default:
-        [moveEvent, endEvent] = ['pointermove', 'pointerup'];
-    }
+    if (!multiTouch) {
+      e.preventDefault();
 
-    const eventCoords = (e.touches && e.touches[0]) ? e.touches[0] : e;
-    _rememberCoords(eventCoords);
+      switch (e.type) {
+        case 'mousedown':
+          [moveEvent, endEvent] = ['mousemove', 'mouseup'];
+          break;
+        case 'touchstart':
+          [moveEvent, endEvent] = ['touchmove', 'touchend'];
+          break;
+        default:
+          [moveEvent, endEvent] = ['pointermove', 'pointerup'];
+      }
 
-    // Prefix with this class to switch from `cursor:grab` to `cursor:grabbing`.
-    document.body.classList.add('dragging');
+      const eventCoords = (e.touches && e.touches[0]) ? e.touches[0] : e;
+      _rememberCoords(eventCoords);
 
-    document.body.addEventListener(moveEvent, handleDrag);
-    document.body.addEventListener(endEvent, handleEnd);
+      // Prefix with this class to switch from `cursor:grab` to `cursor:grabbing`.
+      document.body.classList.add('dragging');
 
-    // If there's no `onStart`, `onDrag` will be called on start.
-    const startHandler = props.onStart || handleDrag;
-    if (startHandler) { // You can set it to `false` if you don't want anything to fire.
-      startHandler(eventCoords);
+      document.body.addEventListener(moveEvent, handleDrag);
+      document.body.addEventListener(endEvent, handleEnd);
+
+      // If there's no `onStart`, `onDrag` will be called on start.
+      const startHandler = props.onStart || handleDrag;
+      if (startHandler) { // You can set it to `false` if you don't want anything to fire.
+        startHandler(eventCoords);
+      }
     }
   }
 
   function handleDrag(e) {
-    const eventCoords = (e.touches && e.touches[0]) ? e.touches[0] : e;
-    const d = {
-      x: eventCoords.pageX - _previousEventCoords.x,
-      y: eventCoords.pageY - _previousEventCoords.y
-    };
-    props.onDrag(eventCoords, d);
-    _rememberCoords(eventCoords);
+    const multiTouch = e.touches && e.touches.length > 1;
+    if (!multiTouch) {
+      const eventCoords = (e.touches && e.touches[0]) ? e.touches[0] : e;
+      const d = {
+        x: eventCoords.pageX - _previousEventCoords.x,
+        y: eventCoords.pageY - _previousEventCoords.y
+      };
+      props.onDrag(eventCoords, d);
+      _rememberCoords(eventCoords);
+    }
   }
 
   function handleEnd(e) {
-    const eventCoords = (e.touches && e.touches[0]) ? e.touches[0] : e;
+    const multiTouch = e.touches && e.touches.length > 1;
+    if (!multiTouch) {
+      const eventCoords = (e.touches && e.touches[0]) ? e.touches[0] : e;
 
-    document.body.removeEventListener(moveEvent, handleDrag);
-    document.body.removeEventListener(endEvent, handleEnd);
+      document.body.removeEventListener(moveEvent, handleDrag);
+      document.body.removeEventListener(endEvent, handleEnd);
 
-    props.onEnd(eventCoords);
-    _previousEventCoords = {};
-    document.body.classList.remove('dragging');
+      props.onEnd(eventCoords);
+      _previousEventCoords = {};
+      document.body.classList.remove('dragging');
+    }
   }
 
   const { children, disabled } = props;

--- a/app/lib/draggable.spec.js
+++ b/app/lib/draggable.spec.js
@@ -109,6 +109,11 @@ describe('Draggable', function () {
       });
       wrapper.setProps({ disabled: true });
     });
+
+    after(function () {
+      wrapper.setProps({ disabled: false });
+    });
+
     it('should not respond to mousedown', function () {
       wrapper.find('p').simulate('mousedown');
       expect(document.body.addEventListener.callCount).to.equal(0);
@@ -120,6 +125,53 @@ describe('Draggable', function () {
     it('should not respond to pointerdown', function () {
       wrapper.find('p').simulate('pointerdown');
       expect(document.body.addEventListener.callCount).to.equal(0);
+    });
+  });
+
+  describe('with multitouch gestures', function () {
+    function fakeEvent(type) {
+      return {
+        preventDefault: sinon.stub(),
+        type,
+        touches: [
+          {
+            pageX: 30,
+            pageY: 50
+          },
+          {
+            pageX: 40,
+            pageY: 60
+          }
+        ]
+      }
+    }
+
+    before(function () {
+      document.body.addEventListener = sinon.stub().callsFake((eventType, handler) => {
+        if (eventType === 'touchmove') handleDrag = handler;
+        if (eventType === 'touchend') handleEnd = handler;
+      });
+    });
+
+    it('should not respond to touchstart', function () {
+      wrapper.find('p').simulate('touchstart', fakeEvent('touchstart'));
+      expect(onStart.callCount).to.equal(0);
+    });
+
+    it('should not cancel the default start event', function () {
+      const startEvent = fakeEvent('touchstart');
+      wrapper.find('p').simulate('touchstart', startEvent);
+      expect(startEvent.preventDefault.callCount).to.equal(0);
+    });
+
+    it('should not respond to touchmove', function () {
+      handleDrag(fakeEvent('touchmove'));
+      expect(onDrag.callCount).to.equal(0);
+    });
+
+    it('should not respond to touchend', function () {
+      handleEnd(fakeEvent('touchend'));
+      expect(onEnd.callCount).to.equal(0);
     });
   });
 });


### PR DESCRIPTION
Staging branch URL: https://pr-5489.pfe-preview.zooniverse.org

Fixes #5462.

Adds tests for multitouch gestures to the Draggable component.
Wraps each of Draggable's event handlers inside a test that checks if `event.touches` only contains one touch.

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [x] Can you post a talk comment?

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
