### PR TITLE
Register new locales in one place

### DIFF
--- a/app/locales/index.js
+++ b/app/locales/index.js
@@ -1,0 +1,14 @@
+export default {
+  ar: require('./ar').default,
+  cs: require('./cs').default,
+  de: require('./de').default,
+  en: require('./en').default,
+  es: require('./es').default,
+  fr: require('./fr').default,
+  he: require('./he').default,
+  it: require('./it').default,
+  ja: require('./ja').default,
+  nl: require('./nl').default,
+  pt: require('./pt').default
+};
+

--- a/app/main.cjsx
+++ b/app/main.cjsx
@@ -7,6 +7,14 @@ routes = require './router'
 style = require '../css/main.styl'
 { sugarClient } = require 'panoptes-client/lib/sugar'
 
+# register locales
+`import counterpart from 'counterpart';`
+`import locales from './locales';`
+
+Object.keys(locales).forEach((key) -> counterpart.registerTranslations(key, locales[key]))
+
+counterpart.setFallbackLocale('en')
+
 # Redux
 `import { Provider } from 'react-redux';`
 `import configureStore from './redux/store';`

--- a/app/pages/project/index.jsx
+++ b/app/pages/project/index.jsx
@@ -16,16 +16,11 @@ import * as translationActions from '../../redux/ducks/translations';
 import ProjectPage from './project-page';
 import Translations from '../../classifier/translations';
 import getAllLinked from '../../lib/get-all-linked';
+import locales from '../../locales';
 
-counterpart.registerTranslations('cs', require('../../locales/cs').default);
-counterpart.registerTranslations('en', require('../../locales/en').default);
-counterpart.registerTranslations('it', require('../../locales/it').default);
-counterpart.registerTranslations('es', require('../../locales/es').default);
-counterpart.registerTranslations('nl', require('../../locales/nl').default);
-counterpart.registerTranslations('pt', require('../../locales/pt').default);
-counterpart.registerTranslations('de', require('../../locales/de').default);
-counterpart.registerTranslations('ja', require('../../locales/ja').default);
-counterpart.registerTranslations('fr', require('../../locales/fr').default);
+Object.keys(locales).forEach(function registerLocale(key) {
+  counterpart.registerTranslations(key, locales[key]);
+});
 
 counterpart.setFallbackLocale('en');
 

--- a/app/pages/project/index.jsx
+++ b/app/pages/project/index.jsx
@@ -16,13 +16,6 @@ import * as translationActions from '../../redux/ducks/translations';
 import ProjectPage from './project-page';
 import Translations from '../../classifier/translations';
 import getAllLinked from '../../lib/get-all-linked';
-import locales from '../../locales';
-
-Object.keys(locales).forEach(function registerLocale(key) {
-  counterpart.registerTranslations(key, locales[key]);
-});
-
-counterpart.setFallbackLocale('en');
 
 
 class ProjectPageController extends React.Component {

--- a/app/partials/app.cjsx
+++ b/app/partials/app.cjsx
@@ -47,6 +47,8 @@ PanoptesApp = createReactClass
     @geordiLogger.subscribe(new GALogAdapter(window, 'ga'))
 
   componentDidMount: ->
+    if this.props.location.query?.language
+      counterpart.setLocale(this.props.location.query.language);
     @props.notificationsCounter.listen (unreadNotificationsCount) =>
       @setState {unreadNotificationsCount}
 


### PR DESCRIPTION
Add a locales object which stores all registered locales, then dynamically load this into counterpart. Contributors then don't have to remember to edit the code in two places in order to add a new language.

Check the URL for a language on first load, so that we can display translated pages such as:
https://pr-5493.pfe-preview.zooniverse.org/about/faq?language=cs

Staging branch URL: https://pr-5493.pfe-preview.zooniverse.org

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
