### PR TITLE
Add a default entrypoint for local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,13 @@ everything with Docker and Docker Compose.
 - `docker-compose build` will build a local Docker image and run `npm install`. Run this whenever you
 change dependencies in `package.json`.
 
-- `docker-compose run --rm --service-ports dev npm start` builds and runs the site locally on port 3735.
+- `docker-compose up` starts a development web server that listens on port 3735.
 
-- `docker-compose run --rm dev npm test` runs the tests.
+- `docker-compose down` stops the development server.
 
-- `docker-compose run --rm dev npm run stage` builds and optimizes the site, and then deploys it to <https://current-git-branch-name.pfe-preview.zooniverse.org>.
+- `docker-compose run --rm dev test` runs the tests.
+
+- `docker-compose run --rm dev run stage` builds and optimizes the site, and then deploys it to <https://current-git-branch-name.pfe-preview.zooniverse.org>.
 
 ### With Node.js
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,9 @@ services:
     build:
       context: ./
       dockerfile: Dockerfile
+    entrypoint:
+      - "npm"
+    command: ["start"]
     ports:
       - "3735:3735"
     environment:


### PR DESCRIPTION
Add `npm start` as the default entrypoint for docker-compose. Update the README instructions for local development with docker.

Staging branch URL: https://pr-5502.pfe-preview.zooniverse.org

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
