### PR TITLE
Fix volunteer count via constant offset

### DIFF
--- a/app/pages/home-not-logged-in.jsx
+++ b/app/pages/home-not-logged-in.jsx
@@ -31,7 +31,7 @@ export default class HomePage extends React.Component {
       featuredProject: null,
       promotedProjects: [],
       screenWidth: 0,
-      volunteerCount: 1500000
+      volunteerCount: 0
     };
 
     this.showDialog = this.showDialog.bind(this);

--- a/app/pages/home-not-logged-in/research.jsx
+++ b/app/pages/home-not-logged-in/research.jsx
@@ -41,6 +41,7 @@ counterpart.registerTranslations('en', {
 const GZ123_COUNT = 98989226
 const OUROBOROS_COUNT = 142800311
 const OTHERS_COUNT = 8680290
+const OUROBOROS_USER_COUNT = 124921
 
 
 const HomePageResearch = (({ count, screenWidth, showDialog, volunteerCount }) =>
@@ -49,7 +50,7 @@ const HomePageResearch = (({ count, screenWidth, showDialog, volunteerCount }) =
     <span className="class-counter">{(count + GZ123_COUNT + OUROBOROS_COUNT + OTHERS_COUNT).toLocaleString()}</span>
     <Translate className="main-kicker" component="h3" content="researchHomePage.classifications" />
     <div className="home-research__classification-count">
-      <h3 className="main-kicker">{volunteerCount.toLocaleString()}</h3>{' '}
+      <h3 className="main-kicker">{(volunteerCount + OUROBOROS_USER_COUNT).toLocaleString()}</h3>{' '}
       <Translate className="main-kicker" component="h3" content="researchHomePage.registeredUsers" />
     </div>
 


### PR DESCRIPTION
Staging branch URL: https://pr-5518.pfe-preview.zooniverse.org

Fixes #4043 following style of #4511 solution.

Offset between true DB user count and the current/old displayed value is because the old count excluded Ouroboros users (where `USERS.OUROBOROS_CREATED` is true).  That population is currently 124921, so that is the offset used in this fix.  I'll note that this number appears to fluctuate with time (?): it was 126571 on 17 May 2019 and ~118600 in Sep 2017.

Edit to initialize counter to 0 in app/pages/home-not-logged-in.jsx follows fix in #4526.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
