### PR TITLE
Fix notification project links

### DIFF
--- a/app/pages/notifications/comment.cjsx
+++ b/app/pages/notifications/comment.cjsx
@@ -26,6 +26,7 @@ module.exports = createReactClass
     notification = @props.notification
     comment = @props.data.comment
     commentUser = @props.data.commentUser
+    project = @props.project
 
     if @props.data.comment
       <div className="conversation-message talk-module">
@@ -40,7 +41,7 @@ module.exports = createReactClass
           {comment.discussion_title}
         </Link>
 
-        <Markdown>{comment.body}</Markdown>
+        <Markdown project={project}>{comment.body}</Markdown>
 
         <div className="bottom">
           <Link className="user-profile-link" to="/users/#{commentUser.login}">

--- a/app/pages/notifications/moderation.cjsx
+++ b/app/pages/notifications/moderation.cjsx
@@ -36,7 +36,7 @@ module.exports = createReactClass
           </Link>
         </div>
 
-        <Markdown>{@props.data.comment.body}</Markdown>
+        <Markdown project={@props.project}>{@props.data.comment.body}</Markdown>
 
         <p>Reports:</p>
         <ul>

--- a/app/pages/notifications/notification-section.jsx
+++ b/app/pages/notifications/notification-section.jsx
@@ -20,7 +20,8 @@ export default class NotificationSection extends Component {
       loading: false,
       notificationData: [],
       notificationsMap: { },
-      page: 1
+      page: 1,
+      project: null
     };
     this.markAllRead = this.markAllRead.bind(this);
     this.markAsRead = this.markAsRead.bind(this);
@@ -37,6 +38,7 @@ export default class NotificationSection extends Component {
           this.setState({ error });
         })
         .then((project) => {
+          this.setState({ project })
           if (project.links.avatar) {
             apiClient.type('avatars').get(project.links.avatar.id)
               .then((avatar) => {
@@ -269,6 +271,7 @@ export default class NotificationSection extends Component {
                   key={item.notification.id}
                   markAsRead={this.markAsRead}
                   notification={item.notification}
+                  project={this.state.project}
                   user={this.props.user}
                 />);
             }


### PR DESCRIPTION
Pass a notification section's project down as a prop to children.
Add the project prop to Talk comments and moderation reports, so that link URLs point to the parent project.

Staging branch URL: https://pr-5525.pfe-preview.zooniverse.org

Fixes #5524.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
