### PR TITLE
Fix 5527: prevent double annotations on touchscreen marking tasks

### DIFF
--- a/app/lib/draggable.jsx
+++ b/app/lib/draggable.jsx
@@ -18,8 +18,6 @@ function Draggable(props) {
     const multiTouch = e.touches && e.touches.length > 1;
 
     if (!multiTouch) {
-      e.preventDefault();
-
       switch (e.type) {
         case 'mousedown':
           [moveEvent, endEvent] = ['mousemove', 'mouseup'];
@@ -46,6 +44,8 @@ function Draggable(props) {
         startHandler(eventCoords);
       }
     }
+    
+    e.preventDefault();
   }
 
   function handleDrag(e) {
@@ -76,6 +76,7 @@ function Draggable(props) {
   }
 
   const { children, disabled } = props;
+  const usePointer = !!window.PointerEvent;
   const className = classnames({
     [children.props.className]: true,
     draggable: true
@@ -83,9 +84,9 @@ function Draggable(props) {
   const childProps = {
     className,
     'data-disabled': disabled ? true : undefined,
-    onMouseDown: disabled ? undefined : handleStart,
-    onTouchStart: disabled ? undefined : handleStart,
-    onPointerDown: disabled ? undefined : handleStart
+    onMouseDown: (!disabled && !usePointer) ? handleStart : undefined,
+    onTouchStart: (!disabled && !usePointer) ? handleStart : undefined,
+    onPointerDown: (!disabled && usePointer) ? handleStart : undefined
   };
   return React.cloneElement(children, childProps);
 }

--- a/app/lib/draggable.jsx
+++ b/app/lib/draggable.jsx
@@ -75,8 +75,7 @@ function Draggable(props) {
     }
   }
 
-  const { children, disabled } = props;
-  const usePointer = !!window.PointerEvent;
+  const { children, disabled, usePointer } = props;
   const className = classnames({
     [children.props.className]: true,
     draggable: true
@@ -98,14 +97,16 @@ Draggable.propTypes = {
   ]),
   onDrag: PropTypes.func,
   onEnd: PropTypes.func,
-  disabled: PropTypes.bool
+  disabled: PropTypes.bool,
+  usePointer: PropTypes.bool
 };
 
 Draggable.defaultProps = {
   onStart: false,
   onDrag: () => false,
   onEnd: () => false,
-  disabled: false
+  disabled: false,
+  usePointer: !!window.PointerEvent
 };
 
 export default React.memo(Draggable);

--- a/app/lib/draggable.jsx
+++ b/app/lib/draggable.jsx
@@ -18,6 +18,8 @@ function Draggable(props) {
     const multiTouch = e.touches && e.touches.length > 1;
 
     if (!multiTouch) {
+      e.preventDefault();
+      
       switch (e.type) {
         case 'mousedown':
           [moveEvent, endEvent] = ['mousemove', 'mouseup'];
@@ -44,8 +46,6 @@ function Draggable(props) {
         startHandler(eventCoords);
       }
     }
-    
-    e.preventDefault();
   }
 
   function handleDrag(e) {

--- a/app/lib/draggable.spec.js
+++ b/app/lib/draggable.spec.js
@@ -4,14 +4,20 @@ import { shallow } from 'enzyme';
 import { expect } from 'chai';
 import { Draggable } from './draggable';
 
-describe('Draggable', function () {
+describe('Draggable (basic browser compatibility)', function () {
   let wrapper;
   let handleDrag;
   let handleEnd;
   let onStart;
   let onDrag;
   let onEnd;
+  let windowPointerEvent = undefined;
+  
   before(function () {
+    // mousedown and touchstart won't work if window.PointerEvent exists.
+    windowPointerEvent = global.window.PointerEvent;
+    delete global.window.PointerEvent;
+    
     onStart = sinon.stub();
     onDrag = sinon.stub().callsFake((e, d) => d);
     onEnd = sinon.stub();
@@ -24,6 +30,11 @@ describe('Draggable', function () {
         <p>Hello</p>
       </Draggable>
     );
+  });
+  
+  after(function () {
+    // Restore PointerEvent, if any.
+    if (windowPointerEvent) global.window.PointerEvent = windowPointerEvent;
   });
   
   function testDrag(startEvent, dragEvent, endEvent) {
@@ -99,7 +110,6 @@ describe('Draggable', function () {
   }
   testDrag('mousedown', 'mousemove', 'mouseup');
   testDrag('touchstart', 'touchmove', 'touchend');
-  testDrag('pointerdown', 'pointermove', 'pointerup');
 
   describe('when disabled', function () {
     before(function () {
@@ -174,4 +184,112 @@ describe('Draggable', function () {
       expect(onEnd.callCount).to.equal(0);
     });
   });
+});
+
+
+describe('Draggable (with modern PointerEvent support)', function () {
+  let wrapper;
+  let handleDrag;
+  let handleEnd;
+  let onStart;
+  let onDrag;
+  let onEnd;
+  let windowPointerEvent = undefined;
+  
+  before(function () {
+    // pointerdown won't work if window.PointerEvent doesn't exists.
+    windowPointerEvent = global.window.PointerEvent;
+    if (!windowPointerEvent) global.window.PointerEvent = {};
+    
+    onStart = sinon.stub();
+    onDrag = sinon.stub().callsFake((e, d) => d);
+    onEnd = sinon.stub();
+    wrapper = shallow(
+      <Draggable
+        onStart={onStart}
+        onDrag={onDrag}
+        onEnd={onEnd}
+      >
+        <p>Hello</p>
+      </Draggable>
+    );
+  });
+  
+  after(function () {
+    // If window.PointerEvent didn't originally exist, delete it.
+    if (!windowPointerEvent) delete global.window.PointerEvent;
+  })
+  
+  function testDrag(startEvent, dragEvent, endEvent) {
+    describe('on ' + startEvent, function () {
+      let fakeEvent;
+      before(function () {
+        document.body.addEventListener = sinon.stub().callsFake((eventType, handler) => {
+          if (eventType === dragEvent) handleDrag = handler;
+          if (eventType === endEvent) handleEnd = handler;
+        });
+        document.body.removeEventListener = sinon.stub();
+        fakeEvent = {
+          type: startEvent,
+          preventDefault: sinon.stub(),
+          pageX: 50,
+          pageY: 30
+        };
+        wrapper.find('p').simulate(startEvent, fakeEvent);
+      });
+      after(function () {
+        onStart.resetHistory();
+        onDrag.resetHistory();
+        onEnd.resetHistory();
+      });
+      it('should cancel the default event', function () {
+        expect(fakeEvent.preventDefault.callCount).to.equal(1);
+      });
+      it('should add two event listeners', function () {
+        expect(document.body.addEventListener.callCount).to.equal(2);
+      });
+      it('should add a listener for ' + dragEvent, function () {
+        expect(document.body.addEventListener.calledWith(dragEvent)).to.be.true;
+      });
+      it('should add a listener for ' + endEvent, function () {
+        expect(document.body.addEventListener.calledWith(endEvent)).to.be.true;
+      });
+      it('should call the onStart callback', function () {
+        expect(onStart.callCount).to.equal(1);
+      });
+      describe('on drag', function () {
+        before(function () {
+          const fakeEvent = {
+            pageX: 100,
+            pageY: 100
+          };
+          handleDrag(fakeEvent);
+        });
+        it('should call the onDrag callback', function () {
+          expect(onDrag.callCount).to.equal(1);
+        });
+        it('should pass the change in x', function () {
+          expect(onDrag.returnValues[0].x).to.equal(50);
+        });
+        it('should pass the change in y', function () {
+          expect(onDrag.returnValues[0].y).to.equal(70);
+        });
+      });
+      describe('on drag end', function () {
+        before(function () {
+          handleEnd({});
+        });
+        it('should remove the ' + dragEvent + ' listener', function () {
+          expect(document.body.removeEventListener.calledWith(dragEvent)).to.be.true;
+        });
+        it('should remove the ' + endEvent + ' listener', function () {
+          expect(document.body.removeEventListener.calledWith(endEvent)).to.be.true;
+        });
+        it('should call the onEnd callback', function () {
+          expect(onEnd.callCount).to.equal(1);
+        });
+      });
+    });
+  }
+  testDrag('pointerdown', 'pointermove', 'pointerup');
 });

--- a/app/lib/draggable.spec.js
+++ b/app/lib/draggable.spec.js
@@ -4,40 +4,32 @@ import { shallow } from 'enzyme';
 import { expect } from 'chai';
 import { Draggable } from './draggable';
 
-describe('Draggable (basic browser compatibility)', function () {
-  let wrapper;
-  let handleDrag;
-  let handleEnd;
-  let onStart;
-  let onDrag;
-  let onEnd;
-  let windowPointerEvent = undefined;
+describe('Draggable', function () {
   
-  before(function () {
-    // mousedown and touchstart won't work if window.PointerEvent exists.
-    windowPointerEvent = global.window.PointerEvent;
-    delete global.window.PointerEvent;
-    
-    onStart = sinon.stub();
-    onDrag = sinon.stub().callsFake((e, d) => d);
-    onEnd = sinon.stub();
-    wrapper = shallow(
-      <Draggable
-        onStart={onStart}
-        onDrag={onDrag}
-        onEnd={onEnd}
-      >
-        <p>Hello</p>
-      </Draggable>
-    );
-  });
-  
-  after(function () {
-    // Restore PointerEvent, if any.
-    if (windowPointerEvent) global.window.PointerEvent = windowPointerEvent;
-  });
-  
-  function testDrag(startEvent, dragEvent, endEvent) {
+  function testDragEnabled(startEvent, dragEvent, endEvent, usePointer) {
+    let wrapper;
+    let handleDrag = () => false;
+    let handleEnd = () => false;
+    let onStart;
+    let onDrag;
+    let onEnd;
+
+    before(function () {
+      onStart = sinon.stub();
+      onDrag = sinon.stub().callsFake((e, d) => d);
+      onEnd = sinon.stub();
+      wrapper = shallow(
+        <Draggable
+          onStart={onStart}
+          onDrag={onDrag}
+          onEnd={onEnd}
+          usePointer={usePointer}
+        >
+          <p>Hello</p>
+        </Draggable>
+      );
+    });
+
     describe('on ' + startEvent, function () {
       let fakeEvent;
       before(function () {
@@ -108,20 +100,120 @@ describe('Draggable (basic browser compatibility)', function () {
       });
     });
   }
-  testDrag('mousedown', 'mousemove', 'mouseup');
-  testDrag('touchstart', 'touchmove', 'touchend');
+
+  function testDragDisabled(startEvent, dragEvent, endEvent, usePointer) {
+    let wrapper;
+    let handleDrag = () => false;
+    let handleEnd = () => false;
+    let onStart;
+    let onDrag;
+    let onEnd;
+    before(function () {
+      onStart = sinon.stub();
+      onDrag = sinon.stub().callsFake((e, d) => d);
+      onEnd = sinon.stub();
+      wrapper = shallow(
+        <Draggable
+          onStart={onStart}
+          onDrag={onDrag}
+          onEnd={onEnd}
+          usePointer={usePointer}
+        >
+          <p>Hello</p>
+        </Draggable>
+      );
+    });
+
+    describe('on ' + startEvent, function () {
+      let fakeEvent;
+      before(function () {
+        document.body.addEventListener = sinon.stub().callsFake((eventType, handler) => {
+          if (eventType === dragEvent) handleDrag = handler;
+          if (eventType === endEvent) handleEnd = handler;
+        });
+        document.body.removeEventListener = sinon.stub();
+        fakeEvent = {
+          type: startEvent,
+          preventDefault: sinon.stub(),
+          pageX: 50,
+          pageY: 30
+        };
+        wrapper.find('p').simulate(startEvent, fakeEvent);
+      });
+      after(function () {
+        onStart.resetHistory();
+        onDrag.resetHistory();
+        onEnd.resetHistory();
+      });
+      it('should not cancel the default event', function () {
+        expect(fakeEvent.preventDefault.callCount).to.equal(0);
+      });
+      it('should not add two event listeners', function () {
+        expect(document.body.addEventListener.callCount).to.equal(0);
+      });
+      it('should not add a listener for ' + dragEvent, function () {
+        expect(document.body.addEventListener.calledWith(dragEvent)).to.be.false;
+      });
+      it('should not add a listener for ' + endEvent, function () {
+        expect(document.body.addEventListener.calledWith(endEvent)).to.be.false;
+      });
+      it('should not call the onStart callback', function () {
+        expect(onStart.callCount).to.equal(0);
+      });
+      describe('on drag', function () {
+        before(function () {
+          const fakeEvent = {
+            pageX: 100,
+            pageY: 100
+          };
+          handleDrag(fakeEvent);
+        });
+        it('should not call the onDrag callback', function () {
+          expect(onDrag.callCount).to.equal(0);
+        });
+      });
+      describe('on drag end', function () {
+        before(function () {
+          handleEnd({});
+        });
+        it('should not call the onEnd callback', function () {
+          expect(onEnd.callCount).to.equal(0);
+        });
+      });
+    });
+  }
+
+  describe('with no support for pointer events', function () {
+
+    testDragEnabled('mousedown', 'mousemove', 'mouseup', false);
+    testDragEnabled('touchstart', 'touchmove', 'touchend', false);
+    testDragDisabled('pointerdown', 'pointermove', 'pointerup', false);
+  });
+
+  describe('with support for pointer events', function () {
+    
+    testDragDisabled('mousedown', 'mousemove', 'mouseup', true);
+    testDragDisabled('touchstart', 'touchmove', 'touchend', true);
+    testDragEnabled('pointerdown', 'pointermove', 'pointerup', true);
+  })
 
   describe('when disabled', function () {
+    let wrapper;
     before(function () {
       document.body.addEventListener = sinon.stub().callsFake((eventType, handler) => {
         if (eventType === 'mousemove') handleDrag = handler;
         if (eventType === 'mouseup') handleEnd = handler;
       });
-      wrapper.setProps({ disabled: true });
-    });
-
-    after(function () {
-      wrapper.setProps({ disabled: false });
+      wrapper = shallow(
+        <Draggable
+          disabled
+          onStart={sinon.stub()}
+          onDrag={sinon.stub()}
+          onEnd={sinon.stub()}
+        >
+          <p>Hello</p>
+        </Draggable>
+      );
     });
 
     it('should not respond to mousedown', function () {
@@ -139,6 +231,12 @@ describe('Draggable (basic browser compatibility)', function () {
   });
 
   describe('with multitouch gestures', function () {
+    let wrapper;
+    let handleDrag = () => false;
+    let handleEnd = () => false;
+    let onStart;
+    let onDrag;
+    let onEnd;
     function fakeEvent(type) {
       return {
         preventDefault: sinon.stub(),
@@ -157,6 +255,18 @@ describe('Draggable (basic browser compatibility)', function () {
     }
 
     before(function () {
+      onStart = sinon.stub();
+      onDrag = sinon.stub().callsFake((e, d) => d);
+      onEnd = sinon.stub();
+      wrapper = shallow(
+        <Draggable
+          onStart={onStart}
+          onDrag={onDrag}
+          onEnd={onEnd}
+        >
+          <p>Hello</p>
+        </Draggable>
+      );
       document.body.addEventListener = sinon.stub().callsFake((eventType, handler) => {
         if (eventType === 'touchmove') handleDrag = handler;
         if (eventType === 'touchend') handleEnd = handler;
@@ -184,112 +294,4 @@ describe('Draggable (basic browser compatibility)', function () {
       expect(onEnd.callCount).to.equal(0);
     });
   });
-});
-
-
-describe('Draggable (with modern PointerEvent support)', function () {
-  let wrapper;
-  let handleDrag;
-  let handleEnd;
-  let onStart;
-  let onDrag;
-  let onEnd;
-  let windowPointerEvent = undefined;
-  
-  before(function () {
-    // pointerdown won't work if window.PointerEvent doesn't exists.
-    windowPointerEvent = global.window.PointerEvent;
-    if (!windowPointerEvent) global.window.PointerEvent = {};
-    
-    onStart = sinon.stub();
-    onDrag = sinon.stub().callsFake((e, d) => d);
-    onEnd = sinon.stub();
-    wrapper = shallow(
-      <Draggable
-        onStart={onStart}
-        onDrag={onDrag}
-        onEnd={onEnd}
-      >
-        <p>Hello</p>
-      </Draggable>
-    );
-  });
-  
-  after(function () {
-    // If window.PointerEvent didn't originally exist, delete it.
-    if (!windowPointerEvent) delete global.window.PointerEvent;
-  })
-  
-  function testDrag(startEvent, dragEvent, endEvent) {
-    describe('on ' + startEvent, function () {
-      let fakeEvent;
-      before(function () {
-        document.body.addEventListener = sinon.stub().callsFake((eventType, handler) => {
-          if (eventType === dragEvent) handleDrag = handler;
-          if (eventType === endEvent) handleEnd = handler;
-        });
-        document.body.removeEventListener = sinon.stub();
-        fakeEvent = {
-          type: startEvent,
-          preventDefault: sinon.stub(),
-          pageX: 50,
-          pageY: 30
-        };
-        wrapper.find('p').simulate(startEvent, fakeEvent);
-      });
-      after(function () {
-        onStart.resetHistory();
-        onDrag.resetHistory();
-        onEnd.resetHistory();
-      });
-      it('should cancel the default event', function () {
-        expect(fakeEvent.preventDefault.callCount).to.equal(1);
-      });
-      it('should add two event listeners', function () {
-        expect(document.body.addEventListener.callCount).to.equal(2);
-      });
-      it('should add a listener for ' + dragEvent, function () {
-        expect(document.body.addEventListener.calledWith(dragEvent)).to.be.true;
-      });
-      it('should add a listener for ' + endEvent, function () {
-        expect(document.body.addEventListener.calledWith(endEvent)).to.be.true;
-      });
-      it('should call the onStart callback', function () {
-        expect(onStart.callCount).to.equal(1);
-      });
-      describe('on drag', function () {
-        before(function () {
-          const fakeEvent = {
-            pageX: 100,
-            pageY: 100
-          };
-          handleDrag(fakeEvent);
-        });
-        it('should call the onDrag callback', function () {
-          expect(onDrag.callCount).to.equal(1);
-        });
-        it('should pass the change in x', function () {
-          expect(onDrag.returnValues[0].x).to.equal(50);
-        });
-        it('should pass the change in y', function () {
-          expect(onDrag.returnValues[0].y).to.equal(70);
-        });
-      });
-      describe('on drag end', function () {
-        before(function () {
-          handleEnd({});
-        });
-        it('should remove the ' + dragEvent + ' listener', function () {
-          expect(document.body.removeEventListener.calledWith(dragEvent)).to.be.true;
-        });
-        it('should remove the ' + endEvent + ' listener', function () {
-          expect(document.body.removeEventListener.calledWith(endEvent)).to.be.true;
-        });
-        it('should call the onEnd callback', function () {
-          expect(onEnd.callCount).to.equal(1);
-        });
-      });
-    });
-  }
-  testDrag('pointerdown', 'pointermove', 'pointerup');
 });


### PR DESCRIPTION
## PR Overview

Fixes #5527 

Staging branch URL: https://pr-5528.pfe-preview.zooniverse.org

Currently, if we attempt to perform a marking task on a touchscreen device, _two_ annotation marks are created instead of one. This is caused by the `onPointerDown` and `onTouchStart` handlers (in the `Draggable` class) firing simultaneously when a touchscreen device detects touch input.

This PR fixes that issue by checking if Pointer Events exist on the browser, and if available, using it instead of Mouse Events or Touch Events. This prevents redundant events from firing.

(Note: we shouldn't remove Mouse Events or Touch Events altogether, since they're good fallbacks for less modern browsers.)

### Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

### Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] Are the tests passing locally and on Travis?

### Optional Checks

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [x] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?

### Status

Ready for review, and this might be of interest to @eatyourgreens and @simensta 