### PR TITLE
Expand the allowed subject upload list

### DIFF
--- a/app/pages/lab/subject-set.cjsx
+++ b/app/pages/lab/subject-set.cjsx
@@ -15,7 +15,7 @@ isAdmin = require '../../lib/is-admin'
 
 NOOP = Function.prototype
 
-VALID_SUBJECT_EXTENSIONS = ['.jpg', '.jpeg', '.png', '.gif', '.svg', '.mp3', '.m4a', '.mpeg']
+VALID_SUBJECT_EXTENSIONS = ['.jpg', '.jpeg', '.png', '.gif', '.svg', '.mp3', '.m4a', '.mpeg', '.txt', '.json']
 INVALID_FILENAME_CHARS = ['/', '\\', ':', ',']
 MAX_FILE_SIZE = 1000 * 1024
 
@@ -206,7 +206,7 @@ EditSubjectSetPage = createReactClass
         <p>You've reached your subject upload limit. Please <a href='/about/contact'> contact us</a> to request changes to your allowance.</p>
       else
         <p>
-          <UploadDropTarget accept={"text/csv, text/tab-separated-values, image/*#{if isAdmin() then ', video/*, audio/*' else ''}"} multiple onSelect={@handleFileSelection}>
+          <UploadDropTarget accept={"text/csv, text/tab-separated-values, image/*, video/*, audio/*, text/*, application/json"} multiple onSelect={@handleFileSelection}>
             <strong>Drag-and-drop or click to upload manifests and subject images here (you must select the media files as well as the manifest)</strong><br />
             Manifests must be <code>.csv</code> or <code>.tsv</code>. The first row should define metadata headers. All other rows should include at least one reference to an image filename in the same directory as the manifest.<br />
             Headers that begin with "#" or "//" denote private fields that will not be visible to classifiers in the main classification interface or in the Talk discussion tool.<br />
@@ -271,7 +271,7 @@ EditSubjectSetPage = createReactClass
       if file.type in ['text/csv', 'text/tab-separated-values']
         @_addManifest file
         gotManifest = true
-      else if file.type.indexOf('image/') is 0 or (isAdmin() and (file.type.indexOf('video/') is 0) or (file.type.indexOf('audio/') is 0))
+      else if file.type.indexOf('image/') is 0 or file.type.indexOf('video/') is 0 or file.type.indexOf('audio/') is 0 or file.type.indexOf('text/') is 0 or file.type.indexOf('application/json') is 0
         if file.size < MAX_FILE_SIZE or isAdmin()
           @state.files[file.name] = file
           gotFile = true


### PR DESCRIPTION
Remove the admin restriction for video and audio uploads.
Add `text/*` and `application/json` to the list of allowed MIME types.
Add `.txt` and `.json` to the list of allowed file extensions.

Staging branch URL: https://pr-5532.pfe-preview.zooniverse.org

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
