### PR TITLE
Improve accessibility of survey task example photos

### DIFF
--- a/app/classifier/tasks/survey/choice.jsx
+++ b/app/classifier/tasks/survey/choice.jsx
@@ -117,20 +117,24 @@ class Choice extends React.Component {
               {' '}
               {choice.confusionsOrder.map((otherChoiceID, i) => {
                 const otherChoice = this.props.task.choices[otherChoiceID] || { label: '', images: [] };
+                const currentChoiceTranslation = this.props.translation.choices[this.props.choiceID]
+                const autoFocus = !hasFocus && i === 0;
                 return (
                   <span key={otherChoiceID}>
                     <TriggeredModalForm
                       className="survey-task-confusions-modal"
-                      triggerProps={{ autoFocus: !hasFocus && i === 0 }}
+                      triggerProps={{ autoFocus }}
                       trigger={
                         <span className="survey-task-choice-confusion">
-                          {this.props.translation.choices[otherChoiceID].label}
+                          {currentChoiceTranslation.label}
                         </span>
                       }
                       style={{ maxWidth: '60ch' }}
                     >
                       <ImageFlipper images={otherChoice.images.map(filename => this.props.task.images[filename])} />
-                      <Markdown content={this.props.translation.choices[this.props.choiceID].confusions[otherChoiceID]} />
+                      <Markdown
+                        content={currentChoiceTranslation.confusions[otherChoiceID]}
+                      />
                       <div className="survey-task-choice-confusion-buttons" style={{ textAlign: 'center' }}>
                         <button
                           type="submit"
@@ -165,12 +169,16 @@ class Choice extends React.Component {
               const inputType = question.multiple ? 'checkbox' : 'radio';
               return (
                 <div key={questionId} className="survey-task-choice-question" data-multiple={question.multiple || null}>
-                <div className="survey-task-choice-question-label">{translation.questions[questionId].label}</div>
+                  <div className="survey-task-choice-question-label">
+                    {translation.questions[questionId].label}
+                  </div>
                   <div className="survey-task-choice-answers">
                     {question.answersOrder.map((answerId, i) => {
+                      /* eslint-disable multiline-ternary */
                       const isChecked = question.multiple ?
                         !!this.state.answers[questionId] && this.state.answers[questionId].indexOf(answerId) > -1 :
                         this.state.answers[questionId] === answerId;
+                      /* eslint-enable multiline-ternary */
                       const isFocused = this.state.focusedAnswer === `${questionId}/${answerId}`;
                       return (
                         <span key={answerId}>

--- a/app/classifier/tasks/survey/chooser/Choices.jsx
+++ b/app/classifier/tasks/survey/chooser/Choices.jsx
@@ -95,7 +95,7 @@ class Choices extends React.Component {
     const columnsCount = this.howManyColumns(filteredChoices);
     const sortedFilteredChoices = sortIntoColumns(filteredChoices, columnsCount);
     const thumbnailSize = this.whatSizeThumbnails(sortedFilteredChoices);
-    const choiceNotPresent = this.props.focusedChoice.length === 0 || 
+    const choiceNotPresent = this.props.focusedChoice.length === 0 ||
       filteredChoices.indexOf(this.props.focusedChoice) === -1;
     return (
       <div className="survey-task-chooser-choices" data-thumbnail-size={thumbnailSize} data-columns={columnsCount}>
@@ -118,6 +118,8 @@ class Choices extends React.Component {
             src
           });
           const thumbnail = srcPath || '';
+          const chosenClassName = chosenAlready ? 'survey-task-chooser-choice-button-chosen' : '';
+          const className = `survey-task-chooser-choice-button ${chosenClassName}`;
           return (
             <button
               autoFocus={choiceId === this.props.focusedChoice}
@@ -126,7 +128,7 @@ class Choices extends React.Component {
               ref={button => this.choiceButtons.push(button)}
               tabIndex={tabIndex}
               type="button"
-              className={`survey-task-chooser-choice-button ${chosenAlready ? 'survey-task-chooser-choice-button-chosen' : ''}`}
+              className={className}
               onClick={this.props.onChoose.bind(null, choiceId)}
               onKeyDown={this.handleKeyDown.bind(this, choiceId)}
             >

--- a/app/classifier/tasks/survey/chooser/Chooser.jsx
+++ b/app/classifier/tasks/survey/chooser/Chooser.jsx
@@ -12,7 +12,8 @@ class Chooser extends React.Component {
       let rejected = false;
       Object.keys(this.props.filters).map((characteristicId) => {
         const valueId = this.props.filters[characteristicId];
-        if (choice.characteristics[characteristicId] && choice.characteristics[characteristicId].indexOf(valueId) === -1) {
+        const characteristic = choice.characteristics[characteristicId] || [];
+        if (characteristic.indexOf(valueId) === -1) {
           rejected = true;
         }
       });

--- a/app/classifier/tasks/survey/image-flipper.jsx
+++ b/app/classifier/tasks/survey/image-flipper.jsx
@@ -32,10 +32,13 @@ class ImageFlipper extends React.Component {
 
   render() {
     return (
-      <span className="survey-task-image-flipper">
+      <div
+        className="survey-task-image-flipper"
+      >
         {this.renderPreload()}
         <Thumbnail
-          alt={`Frame ${this.state.frame}`}
+          alt={`Example photo ${this.state.frame + 1}`}
+          aria-live="polite"
           src={this.props.images[this.state.frame]}
           className="survey-task-image-flipper-image"
           width={500}
@@ -49,19 +52,19 @@ class ImageFlipper extends React.Component {
                   className={`survey-task-image-flipper-pip ${index === this.state.frame ? 'active' : ''}`}
                 >
                   <input
+                    aria-label={`Example ${index + 1}`}
                     type="radio"
                     name="image-flipper"
                     autoFocus={index === 0}
                     checked={index === this.state.frame}
                     onChange={this.handleFrameChange.bind(this, index)}
                   />
-                  {index + 1}
                 </label>
               )
             )
           }
         </div>
-      </span>
+      </div>
     );
   }
 }

--- a/app/classifier/tasks/survey/index.jsx
+++ b/app/classifier/tasks/survey/index.jsx
@@ -36,7 +36,8 @@ export default class SurveyTask extends React.Component {
 
   static isAnnotationComplete(task, annotation) {
     const minRequiredAnswers = task.required ? 1 : 0;
-    return annotation.value.length >= minRequiredAnswers && !annotation._choiceInProgress;
+    const { _choiceInProgress } = annotation;
+    return annotation.value.length >= minRequiredAnswers && !_choiceInProgress;
   }
 
   constructor(props) {
@@ -101,7 +102,7 @@ export default class SurveyTask extends React.Component {
     onChange(newAnnotation);
   }
 
-  handleAnnotation(choice, answers, e) {
+  handleAnnotation(choice, answers) {
     const { filters } = this.state;
     const { annotation, onChange } = this.props;
 
@@ -130,10 +131,11 @@ export default class SurveyTask extends React.Component {
     const existingAnnotationValue = annotation.value
       && annotation.value.find(value => value.choice === selectedChoiceID);
 
+/* eslint-disable multiline-ternary */
     return (
       <div className="survey-task">
-        {(selectedChoiceID === '') ? (
-          <Chooser
+        {(selectedChoiceID === '') ?
+          (<Chooser
             task={task}
             filters={filters}
             onFilter={this.handleFilter}
@@ -142,9 +144,8 @@ export default class SurveyTask extends React.Component {
             annotation={annotation}
             focusedChoice={focusedChoice}
             translation={translation}
-          />
-        ) : (
-          <Choice
+          />) :
+          (<Choice
             annotation={annotation}
             annotationValue={existingAnnotationValue}
             task={task}
@@ -153,8 +154,8 @@ export default class SurveyTask extends React.Component {
             onCancel={this.clearSelection}
             onConfirm={this.handleAnnotation}
             translation={translation}
-          />
-        )}
+          />)
+        }
       </div>
     );
   }


### PR DESCRIPTION
Staging branch URL: https://pr-5533.pfe-preview.zooniverse.org

Towards #5531.

Add more descriptive labels to the controls for example images.
Make the example image a live region.
Lint survey task components.

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [x] Can you post a talk comment?

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
