### PR TITLE
Adjust drawing tool drag handle size

### DIFF
--- a/app/classifier/drawing-tools/drag-handle.cjsx
+++ b/app/classifier/drawing-tools/drag-handle.cjsx
@@ -2,8 +2,8 @@ React = require 'react'
 createReactClass = require 'create-react-class'
 Draggable = require('../../lib/draggable').default
 
-RADIUS = 4
-OVERSHOOT = 4
+RADIUS = if screen.width > 900 then 4 else 10
+OVERSHOOT = if screen.width > 900 then 4 else 10
 
 module.exports = createReactClass
   displayName: 'DragHandle'


### PR DESCRIPTION
Multiply the drawing tool drag handle size by 2.5 on screens smaller than 900px.

Staging branch URL: https://pr-5537.pfe-preview.zooniverse.org

Fixes #5536.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
