### PR TITLE
Organization landing page redesign - base

### DIFF
--- a/app/components/ExternalLinksBlock/ExternalLinksBlock.jsx
+++ b/app/components/ExternalLinksBlock/ExternalLinksBlock.jsx
@@ -15,10 +15,12 @@ export const StyledExternalLinksBlock = styled.div`
   })};
   flex: ${props => `1 0 ${props.basis}%`};
   min-width: 400px;
-  padding: 3em 4vw;
+  padding: ${props => props.padding};
 
   ul {
     padding-left: 0;
+    display: ${props => props.ulDisplay};
+    flex-wrap: wrap;
   }
 
     li {
@@ -53,10 +55,24 @@ function isResourceAProject(resource) {
   return Object.keys(resource).includes('workflow_description');
 }
 
-export default function ExternalLinksBlock({ basis, header, links, resource }) {
+export default function ExternalLinksBlock({
+  basis,
+  header,
+  links,
+  resource,
+  padding,
+  ulDisplay,
+  className,
+  socialLabel
+}) {
   return (
     <ThemeProvider theme={{ mode: 'light' }}>
-      <StyledExternalLinksBlock basis={basis} isItAProject={isResourceAProject(resource)}>
+      <StyledExternalLinksBlock
+        basis={basis}
+        isItAProject={isResourceAProject(resource)}
+        padding={padding}
+        ulDisplay={ulDisplay}
+      >
         {header}
         <ul>
           {links.map((link) => {
@@ -64,9 +80,11 @@ export default function ExternalLinksBlock({ basis, header, links, resource }) {
             return (
               <li key={url}>
                 <StyledExternalLink
+                  className={className}
                   isExternalLink={isExternalLink}
                   isSocialLink={isSocialLink}
                   label={label}
+                  socialLabel={socialLabel}
                   path={path}
                   site={site}
                   url={url}
@@ -84,13 +102,20 @@ ExternalLinksBlock.defaultProps = {
   basis: '33.333',
   header: null,
   links: [],
-  resource: null
+  resource: null,
+  padding: '3em 4vw',
+  ulDisplay: 'block',
+  className: '',
+  socialLabel: false
 };
 
 ExternalLinksBlock.propTypes = {
   basis: PropTypes.string,
   header: PropTypes.node,
   links: PropTypes.arrayOf(PropTypes.object),
-  resource: PropTypes.object
+  resource: PropTypes.object,
+  padding: PropTypes.string,
+  ulDisplay: PropTypes.string,
+  className: PropTypes.string,
+  socialLabel: PropTypes.bool
 };
-

--- a/app/components/ExternalLinksBlock/ExternalLinksBlockContainer.jsx
+++ b/app/components/ExternalLinksBlock/ExternalLinksBlockContainer.jsx
@@ -37,12 +37,30 @@ export default class ExternalLinksBlockContainer extends React.Component {
   }
 
   render() {
+    const {
+      basis,
+      className,
+      header,
+      padding,
+      resource,
+      socialLabel,
+      ulDisplay
+    } = this.props;
     const { external, social } = this.getExternalLinks();
     const links = [].concat(external, social);
 
     if (links.length > 0) {
       return (
-        <ExternalLinksBlock header={this.props.header} links={links} basis={this.props.basis} resource={this.props.resource} />
+        <ExternalLinksBlock
+          basis={basis}
+          className={className}
+          header={header}
+          links={links}
+          padding={padding}
+          resource={resource}
+          socialLabel={socialLabel}
+          ulDisplay={ulDisplay}
+        />
       );
     }
 

--- a/app/components/ExternalLinksBlock/components/ExternalLink/ExternalLink.jsx
+++ b/app/components/ExternalLinksBlock/components/ExternalLink/ExternalLink.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Markdown } from 'markdownz';
 import { socialIcons } from '../../../../lib/nav-helpers';
 
-export default function ExternalLink({ className, isExternalLink, isSocialLink, label, path, site, url }) {
+export default function ExternalLink({ className, isExternalLink, isSocialLink, label, path, site, url, socialLabel }) {
   let iconClasses;
   let linkLabel = label;
   const linkProps = {
@@ -39,7 +39,13 @@ export default function ExternalLink({ className, isExternalLink, isSocialLink, 
     if (isValidLink) {
       return (
         <a {...linkProps}>
-          <span className="link-title">{linkLabel}</span>
+          <div>
+            <span className="link-title">
+              {socialLabel ? '@' : ''}
+              {linkLabel}
+            </span>
+            {socialLabel && <span className="social-label">{socialIcons[site].label}</span>}
+          </div>
           {iconClasses && <i className={iconClasses} />}
         </a>
       );
@@ -56,7 +62,8 @@ ExternalLink.defaultProps = {
   label: '',
   path: '',
   site: '',
-  url: ''
+  url: '',
+  socialLabel: false
 };
 
 ExternalLink.propTypes = {
@@ -66,5 +73,6 @@ ExternalLink.propTypes = {
   label: PropTypes.string.isRequired,
   path: PropTypes.string,
   site: PropTypes.string,
-  url: PropTypes.string.isRequired
+  url: PropTypes.string.isRequired,
+  socialLabel: PropTypes.bool
 };

--- a/app/components/ExternalLinksBlock/components/ExternalLink/ExternalLink.spec.jsx
+++ b/app/components/ExternalLinksBlock/components/ExternalLink/ExternalLink.spec.jsx
@@ -89,5 +89,28 @@ describe('ExternalLink', function() {
         wrapper.setProps({ site: 'myh4x0rsite.com/' })
         expect(wrapper.html()).to.be.null
       })
+
+      it('should not include the social media label', function () {
+        const socialLabel = wrapper.find('span.social-label');
+        expect(socialLabel.length).to.equal(0);
+      });
+
+      describe('when the socialLabel property is true', function () {
+        const wrapper = shallow(
+          <ExternalLink
+            isExternalLink={false}
+            isSocialLink={true}
+            path={MOCK_SOCIAL_PATH}
+            site={MOCK_SOCIAL_SITE}
+            socialLabel={true}
+            url={MOCK_SOCIAL_URL}
+          />
+        );
+
+        it('should include the social media label', function () {
+          const socialLabel = wrapper.find('span.social-label');
+          expect(socialLabel.text()).to.equal('Facebook');
+        });
+      });
     });
 });

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -94,7 +94,12 @@ export default {
       learn: 'Learn more about %(title)s',
       links: 'Connect with %(title)s',
       metadata: {
-        projects: 'Projects'
+        complete: 'Percent complete',
+        heading: 'Organization Statistics',
+        numbers: 'By the numbers',
+        projects: 'Projects',
+        subtitle: 'Keep track of the progress you and your fellow volunteers have made on this project.',
+        text: 'Every click counts! Join %(title)s\'s community to complete this project and help researchers produce important results.'
       },
       projects: {
         all: 'All',

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -89,8 +89,10 @@ export default {
   organization: {
     error: 'There was an error retrieving organization',
     home: {
-      introduction: 'Introduction',
-      links: 'Links',
+      about: 'About %(title)s',
+      introduction: '%(title)s Introduction',
+      learn: 'Learn more about %(title)s',
+      links: 'Connect with %(title)s',
       metadata: {
         projects: 'Projects'
       },
@@ -102,11 +104,10 @@ export default {
         loading: 'Loading organization projects...',
         none: 'There are no %(state)s %(category)s projects associated with this organization.',
         paused: 'Paused Projects',
+        projectCategory: 'Project Category',
         showSection: 'Show Section'
       },
-      readLess: 'Read Less',
-      readMore: 'Read More',
-      researcher: 'Words from a researcher',
+      researcher: 'Message from the Researcher',
       viewToggle: 'View As Volunteer'
     },
     loading: 'Loading organization',

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -113,7 +113,7 @@ export default {
         showSection: 'Show Section'
       },
       researcher: 'Message from the Researcher',
-      viewToggle: 'View As Volunteer'
+      viewToggle: 'View as volunteer'
     },
     loading: 'Loading organization',
     notFound: 'organization not found.',

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -102,6 +102,7 @@ export default {
         text: 'Every click counts! Join %(title)s\'s community to complete this project and help researchers produce important results.'
       },
       projects: {
+        active: 'Active Projects',
         all: 'All',
         error: 'There was an error loading organization projects.',
         finished: 'Finished Projects',

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -95,9 +95,14 @@ export default {
         projects: 'Projects'
       },
       projects: {
+        all: 'All',
         error: 'There was an error loading organization projects.',
+        finished: 'Finished Projects',
+        hideSection: 'Hide Section',
         loading: 'Loading organization projects...',
-        none: 'There are no projects associated with this organization.'
+        none: 'There are no %(state)s %(category)s projects associated with this organization.',
+        paused: 'Paused Projects',
+        showSection: 'Show Section'
       },
       readLess: 'Read Less',
       readMore: 'Read More',

--- a/app/pages/organization/organization-container.jsx
+++ b/app/pages/organization/organization-container.jsx
@@ -31,87 +31,108 @@ class OrganizationContainer extends React.Component {
   }
 
   componentDidMount() {
-    if (this.context.initialLoadComplete) {
-      this.fetchOrganization(this.props.params.name, this.props.params.owner);
+    const { initialLoadComplete } = this.context;
+    const { params } = this.props;
+
+    if (initialLoadComplete) {
+      this.fetchOrganization(params.name, params.owner);
     }
   }
 
   componentWillReceiveProps(nextProps, nextContext) {
-    const noOrgAfterLoad = nextContext.initialLoadComplete && this.state.organization === null;
+    const { user } = this.context;
+    const { location, params } = this.props;
+    const { collaboratorView, fetchingOrganization, organization } = this.state;
 
-    if (nextProps.params.name !== this.props.params.name ||
-      nextProps.params.owner !== this.props.params.owner ||
-      nextContext.user !== this.context.user ||
-      noOrgAfterLoad) {
-      if (!this.state.fetchingOrganization) {
+    const noOrgAfterLoad = nextContext.initialLoadComplete && organization === null;
+
+    if (nextProps.params.name !== params.name
+      || nextProps.params.owner !== params.owner
+      || nextContext.user !== user
+      || noOrgAfterLoad) {
+      if (!fetchingOrganization) {
         this.fetchOrganization(nextProps.params.name, nextProps.params.owner);
       }
     }
 
-    if (this.state.organization && (nextProps.location.query !== this.props.location.query)) {
+    if (organization && (nextProps.location.query !== location.query)) {
       this.fetchProjects(
-        this.state.organization,
-        ((isAdmin() || this.isCollaborator()) && this.state.collaboratorView),
+        organization,
+        ((isAdmin() || this.isCollaborator()) && collaboratorView),
         nextProps.location.query
       );
     }
   }
 
   isCollaborator() {
-    if (!this.context.user) {
+    const { user } = this.context;
+    const { organizationRoles } = this.state;
+
+    if (!user) {
       return false;
     }
 
-    const collaboratorRoles = this.state.organizationRoles.filter(role =>
-      role.roles.includes('collaborator') || role.roles.includes('owner'));
-    return collaboratorRoles.some(role => role.links.owner.id === this.context.user.id);
+    const collaboratorRoles = organizationRoles
+      .filter(role => role.roles.includes('collaborator') || role.roles.includes('owner'));
+    return collaboratorRoles.some(role => role.links.owner.id === user.id);
   }
 
   toggleCollaboratorView() {
-    const newView = !this.state.collaboratorView;
+    const { collaboratorView, organization } = this.state;
+
+    const newView = !collaboratorView;
     this.setState({ collaboratorView: newView });
-    this.fetchProjects(this.state.organization, newView);
+    this.fetchProjects(organization, newView);
   }
 
   updateQuery(newParams) {
-    const query = Object.assign({}, this.props.location.query, newParams);
+    const { router } = this.context;
+    const { location } = this.props;
+
+    const query = Object.assign({}, location.query, newParams);
     const results = [];
     Object.keys(query).forEach((key) => {
       if (query[key] === '') {
         results.push(delete query[key]);
       }
     });
-    const newLocation = Object.assign({}, this.props.location, { query });
+    const newLocation = Object.assign({}, location, { query });
     newLocation.search = '';
-    this.context.router.push(newLocation);
+    router.push(newLocation);
   }
 
   fetchResearcherQuote() {
-    const quotableProjects = this.state.organizationProjects
+    const { organizationProjects, projectAvatars } = this.state;
+
+    const quotableProjects = organizationProjects
       .filter(project => project.researcher_quote);
     const project = quotableProjects[Math.floor(Math.random() * quotableProjects.length)];
     if (project && project.configuration && project.configuration.researcherID) {
       if (project.configuration.researcherID === project.display_name) {
-        const projectAvatar = this.state.projectAvatars.find(avatar => avatar.links.linked.id === project.id);
+        const projectAvatar = projectAvatars.find(avatar => avatar.links.linked.id === project.id);
         if (projectAvatar && projectAvatar.src) {
-          this.setState({ quoteObject: {
-            displayName: project.display_name,
-            quote: project.researcher_quote,
-            researcherAvatar: projectAvatar.src,
-            slug: project.slug
-          }});
+          this.setState({
+            quoteObject: {
+              displayName: project.display_name,
+              quote: project.researcher_quote,
+              researcherAvatar: projectAvatar.src,
+              slug: project.slug
+            }
+          });
         }
       } else {
         apiClient.type('users').get(project.configuration.researcherID)
           .then((researcher) => {
             researcher.get('avatar').then(([avatar]) => {
               if (avatar.src) {
-                this.setState({ quoteObject: {
-                  displayName: project.display_name,
-                  quote: project.researcher_quote,
-                  researcherAvatar: avatar.src,
-                  slug: project.slug
-                }});
+                this.setState({
+                  quoteObject: {
+                    displayName: project.display_name,
+                    quote: project.researcher_quote,
+                    researcherAvatar: avatar.src,
+                    slug: project.slug
+                  }
+                });
               }
             });
           })
@@ -236,59 +257,82 @@ class OrganizationContainer extends React.Component {
   }
 
   render() {
-    if (this.state.organization && (this.state.organization.listed || isAdmin() || this.isCollaborator())) {
+    const { location, params } = this.props;
+    const {
+      collaboratorView,
+      error,
+      errorFetchingProjects,
+      fetchingOrganization,
+      fetchingProjects,
+      organization,
+      organizationAvatar,
+      organizationBackground,
+      organizationPages,
+      organizationProjects,
+      projectAvatars,
+      quoteObject
+    } = this.state;
+
+    if (organization && (organization.listed || isAdmin() || this.isCollaborator())) {
       return (
         <OrganizationPage
-          category={this.props.location && this.props.location.query && this.props.location.query.category}
+          category={location && location.query && location.query.category}
           collaborator={isAdmin() || this.isCollaborator()}
-          collaboratorView={this.state.collaboratorView}
-          errorFetchingProjects={this.state.errorFetchingProjects}
-          fetchingProjects={this.state.fetchingProjects}
+          collaboratorView={collaboratorView}
+          errorFetchingProjects={errorFetchingProjects}
+          fetchingProjects={fetchingProjects}
           onChangeQuery={this.updateQuery}
-          organization={this.state.organization}
-          organizationAvatar={this.state.organizationAvatar}
-          organizationBackground={this.state.organizationBackground}
-          organizationPages={this.state.organizationPages}
-          organizationProjects={this.state.organizationProjects}
-          projectAvatars={this.state.projectAvatars}
-          quoteObject={this.state.quoteObject}
+          organization={organization}
+          organizationAvatar={organizationAvatar}
+          organizationBackground={organizationBackground}
+          organizationPages={organizationPages}
+          organizationProjects={organizationProjects}
+          projectAvatars={projectAvatars}
+          quoteObject={quoteObject}
           toggleCollaboratorView={this.toggleCollaboratorView}
-        />);
-    } else if (this.state.fetchingOrganization) {
+        />
+      );
+    } else if (fetchingOrganization) {
       return (
         <div className="content-container">
           <p>
             <Translate content="organization.loading" />
-            <strong>{this.props.params.name}</strong>...
+            <strong>{params.name}</strong>
+            ...
           </p>
-        </div>);
-    } else if (this.state.error) {
+        </div>
+      );
+    } else if (error) {
       return (
         <div className="content-container">
           <p>
             <Translate content="organization.error" />
-            <strong>{this.props.params.name}</strong>.
+            <strong>{params.name}</strong>
+            .
           </p>
           <p>
-            <code>{this.state.error.toString()}</code>
+            <code>{error.toString()}</code>
           </p>
-        </div>);
-    } else if (this.state.organization === undefined || (this.state.organization && !this.state.organization.listed)) {
+        </div>
+      );
+    } else if (organization === undefined || (organization && !organization.listed)) {
       return (
         <div className="content-container">
           <p>
-            <strong>{this.props.params.name} </strong>
-            <Translate content="organization.notFound" with={{ title: this.props.params.name }} />
+            <strong>{params.name}</strong>
+            <Translate content="organization.notFound" with={{ title: params.name }} />
           </p>
           <p>
             <Translate content="organization.notPermission" />
           </p>
-        </div>);
+        </div>
+      );
     } else {
       return (
         <div className="content-container">
           <p><Translate content="organization.pleaseWait" /></p>
-        </div>);
+        </div>
+      );
     }
   }
 }

--- a/app/pages/organization/organization-container.spec.js
+++ b/app/pages/organization/organization-container.spec.js
@@ -59,7 +59,7 @@ describe('OrganizationContainer', function () {
   let wrapper;
 
   beforeEach(function () {
-    wrapper = shallow(<OrganizationContainer params={params} />, { context: { router: {}}});
+    wrapper = shallow(<OrganizationContainer params={params} />);
   });
 
   it('should render without crashing', function () {
@@ -106,7 +106,7 @@ describe('OrganizationContainer', function () {
     });
 
     describe('and request for organization roles', function () {
-      wrapper = mount(<OrganizationContainer params={params} location={{}} />, { context: { router: {}}});
+      wrapper = mount(<OrganizationContainer params={params} location={{}} />);
       const container = wrapper.instance();
       const fetchAllOrganizationRolesSpy = sinon.spy(container, 'fetchAllOrganizationRoles');
 

--- a/app/pages/organization/organization-metadata.jsx
+++ b/app/pages/organization/organization-metadata.jsx
@@ -19,7 +19,7 @@ export const OrganizationMetadata = ({ displayName, projects }) => {
     <div className="organization-details__content">
       <Translate
         className="organization-details__content-heading"
-        component="h4"
+        component="h3"
         content="organization.home.metadata.heading"
       />
       {projects && (projects.length > 0)
@@ -28,7 +28,7 @@ export const OrganizationMetadata = ({ displayName, projects }) => {
             <section className="organization-metadata__completeness-section">
               <Translate
                 className="organization-metadata__subtitle"
-                component="h5"
+                component="h4"
                 content="organization.home.metadata.subtitle"
               />
               <Translate
@@ -53,7 +53,7 @@ export const OrganizationMetadata = ({ displayName, projects }) => {
             <section className="organization-metadata__numbers-section">
               <Translate
                 className="organization-metadata__subtitle"
-                component="h5"
+                component="h4"
                 content="organization.home.metadata.numbers"
               />
               <div className="organization-metadata__numbers-stats-container">

--- a/app/pages/organization/organization-metadata.jsx
+++ b/app/pages/organization/organization-metadata.jsx
@@ -17,45 +17,50 @@ export const OrganizationMetadata = ({ displayName, projects }) => {
     <div className="organization-page__container">
       <div className="project-metadata">
         <span className="organization-details__heading">
-          {displayName}{' '}<Translate content="project.home.metadata.statistics" />
+          {displayName}
+          {' '}
+          <Translate content="project.home.metadata.statistics" />
         </span>
-        {projects && (projects.length > 0) &&
-          <div className="project-metadata-stats">
-            <div className="project-metadata-stat">
-              <div className="project-metadata-stat__value">
-                {projects.length.toLocaleString()}
+        {projects && (projects.length > 0)
+          && (
+            <div className="project-metadata-stats">
+              <div className="project-metadata-stat">
+                <div className="project-metadata-stat__value">
+                  {projects.length.toLocaleString()}
+                </div>
+                <div className="project-metadata-stat__label">
+                  <Translate content="organization.home.metadata.projects" />
+                </div>
               </div>
-              <div className="project-metadata-stat__label">
-                <Translate content="organization.home.metadata.projects" />
+              <div className="project-metadata-stat">
+                <div className="project-metadata-stat__value">
+                  {extractStat('subjects_count').toLocaleString()}
+                </div>
+                <div className="project-metadata-stat__label">
+                  <Translate content="project.home.metadata.subjects" />
+                </div>
+              </div>
+              <div className="project-metadata-stat">
+                <div className="project-metadata-stat__value">
+                  {extractStat('classifications_count').toLocaleString()}
+                </div>
+                <div className="project-metadata-stat__label">
+                  <Translate content="project.home.metadata.classifications" />
+                </div>
+              </div>
+              <div className="project-metadata-stat">
+                <div className="project-metadata-stat__value">
+                  {extractStat('retired_subjects_count').toLocaleString()}
+                </div>
+                <div className="project-metadata-stat__label">
+                  <Translate content="project.home.metadata.completedSubjects" />
+                </div>
               </div>
             </div>
-            <div className="project-metadata-stat">
-              <div className="project-metadata-stat__value">
-                {extractStat('subjects_count').toLocaleString()}
-              </div>
-              <div className="project-metadata-stat__label">
-                <Translate content="project.home.metadata.subjects" />
-              </div>
-            </div>
-            <div className="project-metadata-stat">
-              <div className="project-metadata-stat__value">
-                {extractStat('classifications_count').toLocaleString()}
-              </div>
-              <div className="project-metadata-stat__label">
-                <Translate content="project.home.metadata.classifications" />
-              </div>
-            </div>
-            <div className="project-metadata-stat">
-              <div className="project-metadata-stat__value">
-                {extractStat('retired_subjects_count').toLocaleString()}
-              </div>
-              <div className="project-metadata-stat__label">
-                <Translate content="project.home.metadata.completedSubjects" />
-              </div>
-            </div>
-          </div>}
+          )}
       </div>
-    </div>);
+    </div>
+  );
 };
 
 OrganizationMetadata.propTypes = {
@@ -66,6 +71,11 @@ OrganizationMetadata.propTypes = {
       display_name: PropTypes.string
     })
   )
+};
+
+OrganizationMetadata.defaultProps = {
+  displayName: '',
+  projects: []
 };
 
 export default OrganizationMetadata;

--- a/app/pages/organization/organization-metadata.jsx
+++ b/app/pages/organization/organization-metadata.jsx
@@ -13,52 +13,90 @@ export const OrganizationMetadata = ({ displayName, projects }) => {
     }, 0);
   }
 
+  const percentComplete = Math.round((extractStat('retired_subjects_count') / extractStat('subjects_count') * 100));
+
   return (
-    <div className="organization-page__container">
-      <div className="project-metadata">
-        <span className="organization-details__heading">
-          {displayName}
-          {' '}
-          <Translate content="project.home.metadata.statistics" />
-        </span>
-        {projects && (projects.length > 0)
-          && (
-            <div className="project-metadata-stats">
-              <div className="project-metadata-stat">
-                <div className="project-metadata-stat__value">
-                  {projects.length.toLocaleString()}
+    <div className="organization-details__content">
+      <Translate
+        className="organization-details__content-heading"
+        component="h4"
+        content="organization.home.metadata.heading"
+      />
+      {projects && (projects.length > 0)
+        && (
+          <div className="organization-metadata__container">
+            <section className="organization-metadata__completeness-section">
+              <Translate
+                className="organization-metadata__subtitle"
+                component="h5"
+                content="organization.home.metadata.subtitle"
+              />
+              <Translate
+                className="organization-metadata__completeness-text"
+                component="p"
+                content="organization.home.metadata.text"
+                with={{ title: displayName }}
+              />
+              <div className="organization-metadata__progress-bar">
+                <span
+                  className="organization-metadata__progress-bar-meter"
+                  style={{ width: `${percentComplete}%` }}
+                >
+                  {`${percentComplete}%`}
+                </span>
+              </div>
+              <Translate
+                className="organization-metadata__progress-bar-label"
+                content="organization.home.metadata.complete"
+              />
+            </section>
+            <section className="organization-metadata__numbers-section">
+              <Translate
+                className="organization-metadata__subtitle"
+                component="h5"
+                content="organization.home.metadata.numbers"
+              />
+              <div className="organization-metadata__numbers-stats-container">
+                <div className="organization-metadata__numbers-stat-block">
+                  <span className="organization-metadata__numbers-stat">
+                    {projects.length.toLocaleString()}
+                  </span>
+                  <Translate
+                    className="organization-metadata__numbers-label"
+                    content="organization.home.metadata.projects"
+                  />
                 </div>
-                <div className="project-metadata-stat__label">
-                  <Translate content="organization.home.metadata.projects" />
+                <div className="organization-metadata__numbers-stat-block">
+                  <span className="organization-metadata__numbers-stat">
+                    {extractStat('classifications_count').toLocaleString()}
+                  </span>
+                  <Translate
+                    className="organization-metadata__numbers-label"
+                    content="project.home.metadata.classifications"
+                  />
+                </div>
+                <div className="organization-metadata__numbers-stat-block">
+                  <span className="organization-metadata__numbers-stat">
+                    {extractStat('subjects_count').toLocaleString()}
+                  </span>
+                  <Translate
+                    className="organization-metadata__numbers-label"
+                    content="project.home.metadata.subjects"
+                  />
+                </div>
+                <div className="organization-metadata__numbers-stat-block">
+                  <span className="organization-metadata__numbers-stat">
+                    {extractStat('retired_subjects_count').toLocaleString()}
+                  </span>
+                  <Translate
+                    className="organization-metadata__numbers-label"
+                    content="project.home.metadata.completedSubjects"
+                  />
                 </div>
               </div>
-              <div className="project-metadata-stat">
-                <div className="project-metadata-stat__value">
-                  {extractStat('subjects_count').toLocaleString()}
-                </div>
-                <div className="project-metadata-stat__label">
-                  <Translate content="project.home.metadata.subjects" />
-                </div>
-              </div>
-              <div className="project-metadata-stat">
-                <div className="project-metadata-stat__value">
-                  {extractStat('classifications_count').toLocaleString()}
-                </div>
-                <div className="project-metadata-stat__label">
-                  <Translate content="project.home.metadata.classifications" />
-                </div>
-              </div>
-              <div className="project-metadata-stat">
-                <div className="project-metadata-stat__value">
-                  {extractStat('retired_subjects_count').toLocaleString()}
-                </div>
-                <div className="project-metadata-stat__label">
-                  <Translate content="project.home.metadata.completedSubjects" />
-                </div>
-              </div>
-            </div>
-          )}
-      </div>
+            </section>
+          </div>
+        )}
     </div>
   );
 };

--- a/app/pages/organization/organization-metadata.spec.js
+++ b/app/pages/organization/organization-metadata.spec.js
@@ -18,9 +18,10 @@ describe('OrganizationMetadata', function () {
       <OrganizationMetadata
         displayName={organization.display_name}
         projects={organizationProjects}
-      />);
-    const stats = wrapper.find('.project-metadata-stat');
-    assert.equal(stats.length, 4);
+      />
+    );
+    const stats = wrapper.find('.organization-metadata__container');
+    assert.equal(stats.length, 1);
   });
 
   it('should reduce retired subjects count to 75', function () {
@@ -28,8 +29,9 @@ describe('OrganizationMetadata', function () {
       <OrganizationMetadata
         displayName={organization.display_name}
         projects={organizationProjects}
-      />);
-    const retiredSubjects = wrapper.find('.project-metadata-stat__value').at(3);
+      />
+    );
+    const retiredSubjects = wrapper.find('.organization-metadata__numbers-stat').at(3);
     assert.equal(retiredSubjects.text(), '75');
   });
 });

--- a/app/pages/organization/organization-page.jsx
+++ b/app/pages/organization/organization-page.jsx
@@ -21,8 +21,7 @@ class OrganizationPage extends React.Component {
     this.state = {
       category: '',
       finished: false,
-      paused: false,
-      readMore: false
+      paused: false
     };
   }
 
@@ -34,11 +33,6 @@ class OrganizationPage extends React.Component {
   togglePaused() {
     const { paused } = this.state;
     this.setState({ paused: !paused });
-  }
-
-  toggleReadMore() {
-    const { readMore } = this.state;
-    this.setState({ readMore: !readMore });
   }
 
   handleCategoryChange(category) {
@@ -92,10 +86,6 @@ class OrganizationPage extends React.Component {
     const researcherAvatarSrc = quoteObject.researcherAvatar || '/assets/simple-avatar.png';
 
     const [aboutPage] = organizationPages.filter(page => page.url_key === 'about');
-    const aboutContentClass = classnames(
-      'organization-details__about-content',
-      { 'organization-details__about-content--expanded': readMore }
-    );
 
     return (
       <div className="organization-page">
@@ -131,216 +121,246 @@ class OrganizationPage extends React.Component {
           </div>
         </section>
 
-        <section className="resources-container">
-          {collaborator && (
-            <label className="organization-page__toggle" htmlFor="collaborator view">
-              <input
-                id="collaborator view"
-                onChange={() => toggleCollaboratorView()}
-                type="checkbox"
-                value={!collaboratorView}
-              />
-              <Translate content="organization.home.viewToggle" />
-            </label>
-          )}
-          {organization.categories && organization.categories.length > 0 && (
-            <div className="organization-page__categories" ref={(node) => { this.categories = node; }}>
-              <label
-                className={this.calculateClasses('All')}
-                htmlFor="all"
-              >
-                <input
-                  className="organization-page__category-button--hidden"
-                  id="all"
-                  name="category"
-                  onChange={this.handleCategoryChange.bind(this, '')}
-                  type="radio"
-                />
-                <Translate content="organization.home.projects.all" />
-              </label>
-              {organization.categories.map(buttonCategory => (
-                <label
-                  className={this.calculateClasses(buttonCategory)}
-                  htmlFor={buttonCategory}
-                  key={buttonCategory}
-                >
+        <section className="organization-page__main">
+          <section className="organization-page__projects">
+            {collaborator && (
+              <div className="organization-page__toggle">
+                <label htmlFor="collaborator view">
                   <input
-                    className="organization-page__category-button--hidden"
-                    id={buttonCategory}
-                    name="category"
-                    onChange={this.handleCategoryChange.bind(this, buttonCategory)}
-                    type="radio"
+                    id="collaborator view"
+                    onChange={() => toggleCollaboratorView()}
+                    type="checkbox"
+                    value={!collaboratorView}
                   />
-                  {buttonCategory}
+                  <Translate content="organization.home.viewToggle" />
                 </label>
-              ))}
-            </div>
-          )}
-          <OrganizationProjectCards
-            category={category}
-            errorFetchingProjects={errorFetchingProjects}
-            fetchingProjects={fetchingProjects}
-            projects={activeProjects}
-            projectAvatars={projectAvatars}
-            state="active"
-          />
-
-          <div>
-            <Translate
-              content="organization.home.projects.paused"
-            />
-            <button
-              onClick={() => this.togglePaused()}
-              type="button"
-            >
-              {paused ? (
-                <>
-                  <i className="fa fa-chevron-up fa-lg" />
-                  {' '}
-                  <Translate
-                    content="organization.home.projects.hideSection"
-                  />
-                </>
-              ) : (
-                <>
-                  <i className="fa fa-chevron-down fa-lg" />
-                  {' '}
-                  <Translate
-                    content="organization.home.projects.showSection"
-                  />
-                </>
-              )}
-            </button>
-          </div>
-          {paused && (
-            <OrganizationProjectCards
-              category={category}
-              errorFetchingProjects={errorFetchingProjects}
-              fetchingProjects={fetchingProjects}
-              projects={pausedProjects}
-              projectAvatars={projectAvatars}
-              state="paused"
-            />
-          )}
-
-          <div>
-            <Translate
-              content="organization.home.projects.finished"
-            />
-            <button
-              onClick={() => this.toggleFinished()}
-              type="button"
-            >
-              {finished ? (
-                <>
-                  <i className="fa fa-chevron-up fa-lg" />
-                  {' '}
-                  <Translate
-                    content="organization.home.projects.hideSection"
-                  />
-                </>
-              ) : (
-                <>
-                  <i className="fa fa-chevron-down fa-lg" />
-                  {' '}
-                  <Translate
-                    content="organization.home.projects.showSection"
-                  />
-                </>
-              )}
-            </button>
-          </div>
-          {finished && (
-            <OrganizationProjectCards
-              category={category}
-              errorFetchingProjects={errorFetchingProjects}
-              fetchingProjects={fetchingProjects}
-              projects={finishedProjects}
-              projectAvatars={projectAvatars}
-              state="finished"
-            />
-          )}
-        </section>
-
-        <section className="organization-details">
-          <div className="organization-page__container">
-            {quoteObject && quoteObject.quote && (
-              <div className="organization-researcher-words">
-                <Translate className="organization-details__heading" content="organization.home.researcher" />
-                <div className="organization-researcher-words__container">
-                  <img
-                    className="organization-researcher-words__avatar"
-                    alt="presentation"
-                    src={researcherAvatarSrc}
-                  />
-                  <span
-                    className="organization-researcher-words__quote"
-                  >
-                    &quot;
-                    {quoteObject.quote}
-                    &quot;
-                  </span>
-                </div>
-                <Link
-                  className="organization-researcher-words__attribution"
-                  to={quoteObject.slug}
-                >
-                  {' - '}
-                  {quoteObject.displayName}
-                </Link>
               </div>
             )}
-            <div className="organization-details__content">
-              <h4 className="organization-details__heading">
-                {organization.display_name}
-                <Translate content="organization.home.introduction" />
-              </h4>
-              {organization.introduction && (
-                <Markdown project={organization}>{organization.introduction}</Markdown>
-              )}
-            </div>
-          </div>
-
-          <OrganizationMetadata
-            displayName={organization.display_name}
-            projects={organizationProjects}
-          />
-
-          <div className="organization-page__container">
-            <div className="organization-details__content">
-              <h4 className="organization-details__heading">
-                <Translate content="project.home.about" with={{ title: organization.display_name }} />
-              </h4>
-              {aboutPage && (
-                <div>
-                  <Markdown className={aboutContentClass} project={organization}>
-                    {aboutPage.content}
-                  </Markdown>
-                  <button
-                    className="standard-button organization-details__button"
-                    onClick={() => this.toggleReadMore()}
-                    type="button"
+            {organization.categories && organization.categories.length > 0 && (
+              <>
+                <Translate
+                  className="organization-details__content-heading"
+                  component="h4"
+                  content="organization.home.projects.projectCategory"
+                />
+                <div className="organization-page__categories" ref={(node) => { this.categories = node; }}>
+                  <label
+                    className={this.calculateClasses('All')}
+                    htmlFor="all"
                   >
-                    {readMore
-                      ? <Translate content="organization.home.readLess" />
-                      : <Translate content="organization.home.readMore" />}
-                  </button>
+                    <input
+                      className="organization-page__category-button--hidden"
+                      id="all"
+                      name="category"
+                      onChange={this.handleCategoryChange.bind(this, '')}
+                      type="radio"
+                    />
+                    <Translate content="organization.home.projects.all" />
+                  </label>
+                  {organization.categories.map(buttonCategory => (
+                    <label
+                      className={this.calculateClasses(buttonCategory)}
+                      htmlFor={buttonCategory}
+                      key={buttonCategory}
+                    >
+                      <input
+                        className="organization-page__category-button--hidden"
+                        id={buttonCategory}
+                        name="category"
+                        onChange={this.handleCategoryChange.bind(this, buttonCategory)}
+                        type="radio"
+                      />
+                      {buttonCategory}
+                    </label>
+                  ))}
                 </div>
-              )}
-            </div>
-            {organization.urls && organization.urls.length && (
-              <ExternalLinksBlockContainer
-                header={(
-                  <Translate
-                    className="organization-details__heading"
-                    content="organization.home.links"
-                    component="h4"
-                  />
+              </>
+            )}
+            <OrganizationProjectCards
+              category={category}
+              errorFetchingProjects={errorFetchingProjects}
+              fetchingProjects={fetchingProjects}
+              projects={activeProjects}
+              projectAvatars={projectAvatars}
+              state="active"
+            />
+
+            <div className="organization-page__section-heading">
+              <Translate
+                className="organization-page__section-title"
+                content="organization.home.projects.paused"
+              />
+              <button
+                className="standard-button organization-page__section-button"
+                onClick={() => this.togglePaused()}
+                type="button"
+              >
+                {paused ? (
+                  <>
+                    <i className="fa fa-chevron-up fa-lg" />
+                    {' '}
+                    <Translate
+                      content="organization.home.projects.hideSection"
+                    />
+                  </>
+                ) : (
+                  <>
+                    <i className="fa fa-chevron-down fa-lg" />
+                    {' '}
+                    <Translate
+                      content="organization.home.projects.showSection"
+                    />
+                  </>
                 )}
-                resource={organization}
+              </button>
+            </div>
+            {paused && (
+              <OrganizationProjectCards
+                category={category}
+                errorFetchingProjects={errorFetchingProjects}
+                fetchingProjects={fetchingProjects}
+                projects={pausedProjects}
+                projectAvatars={projectAvatars}
+                state="paused"
               />
             )}
-          </div>
+
+            <div className="organization-page__section-heading">
+              <Translate
+                className="organization-page__section-title"
+                content="organization.home.projects.finished"
+              />
+              <button
+                className="standard-button organization-page__section-button"
+                onClick={() => this.toggleFinished()}
+                type="button"
+              >
+                {finished ? (
+                  <>
+                    <i className="fa fa-chevron-up fa-lg" />
+                    {' '}
+                    <Translate
+                      content="organization.home.projects.hideSection"
+                    />
+                  </>
+                ) : (
+                  <>
+                    <i className="fa fa-chevron-down fa-lg" />
+                    {' '}
+                    <Translate
+                      content="organization.home.projects.showSection"
+                    />
+                  </>
+                )}
+              </button>
+            </div>
+            {finished && (
+              <OrganizationProjectCards
+                category={category}
+                errorFetchingProjects={errorFetchingProjects}
+                fetchingProjects={fetchingProjects}
+                projects={finishedProjects}
+                projectAvatars={projectAvatars}
+                state="finished"
+              />
+            )}
+          </section>
+
+          <hr />
+
+          <section className="organization-details">
+            <Translate
+              className="organization-page__section-title"
+              content="organization.home.learn"
+              with={{
+                title: organization.display_name
+              }}
+            />
+            <div className="organization-details__container">
+              <div className="organization-details__flex-container">
+                {quoteObject && quoteObject.quote && (
+                  <div className="organization-researcher-words">
+                    <Translate
+                      className="organization-details__content-heading"
+                      content="organization.home.researcher"
+                    />
+                    <div className="organization-researcher-words__container">
+                      <img
+                        className="organization-researcher-words__avatar"
+                        alt="presentation"
+                        src={researcherAvatarSrc}
+                      />
+                      <span
+                        className="organization-researcher-words__quote"
+                      >
+                        &quot;
+                        {quoteObject.quote}
+                        &quot;
+                      </span>
+                    </div>
+                    <Link
+                      className="organization-researcher-words__attribution"
+                      to={quoteObject.slug}
+                    >
+                      {' - '}
+                      {quoteObject.displayName}
+                    </Link>
+                  </div>
+                )}
+                <div className="organization-details__flex-content">
+                  <Translate
+                    className="organization-details__content-heading"
+                    component="h4"
+                    content="organization.home.introduction"
+                    with={{ title: organization.display_name }}
+                  />
+                  {organization.introduction && (
+                    <Markdown project={organization}>{organization.introduction}</Markdown>
+                  )}
+                </div>
+              </div>
+            </div>
+
+            <div className="organization-details__container">
+              <OrganizationMetadata
+                displayName={organization.display_name}
+                projects={organizationProjects}
+              />
+            </div>
+
+            <div className="organization-details__container">
+              <div className="organization-details__content">
+                <Translate
+                  className="organization-details__content-heading"
+                  component="h4"
+                  content="organization.home.about"
+                  with={{ title: organization.display_name }}
+                />
+                {aboutPage && (
+                  <Markdown
+                    className="organization-details__about-content"
+                    project={organization}
+                  >
+                    {aboutPage.content}
+                  </Markdown>
+                )}
+              </div>
+            </div>
+            <div className="organization-details__container">
+              {organization.urls && organization.urls.length && (
+                <ExternalLinksBlockContainer
+                  header={(
+                    <Translate
+                      className="organization-details__heading"
+                      content="organization.home.links"
+                      component="h4"
+                    />
+                  )}
+                  resource={organization}
+                />
+              )}
+            </div>
+          </section>
         </section>
       </div>
     );

--- a/app/pages/organization/organization-page.jsx
+++ b/app/pages/organization/organization-page.jsx
@@ -146,7 +146,7 @@ class OrganizationPage extends React.Component {
               <>
                 <Translate
                   className="organization-details__content-heading"
-                  component="h4"
+                  component="h3"
                   content="organization.home.projects.projectCategory"
                 />
                 <div className="organization-page__categories" ref={(node) => { this.categories = node; }}>
@@ -214,19 +214,20 @@ class OrganizationPage extends React.Component {
               </button>
             </div>
             {active && (
-            <OrganizationProjectCards
-              category={category}
-              errorFetchingProjects={errorFetchingProjects}
-              fetchingProjects={fetchingProjects}
-              projects={activeProjects}
-              projectAvatars={projectAvatars}
-              state="active"
-            />
+              <OrganizationProjectCards
+                category={category}
+                errorFetchingProjects={errorFetchingProjects}
+                fetchingProjects={fetchingProjects}
+                projects={activeProjects}
+                projectAvatars={projectAvatars}
+                state="active"
+              />
             )}
 
             <div className="organization-page__section-heading">
               <Translate
                 className="organization-page__section-title"
+                component="h2"
                 content="organization.home.projects.paused"
               />
               <button
@@ -267,6 +268,7 @@ class OrganizationPage extends React.Component {
             <div className="organization-page__section-heading">
               <Translate
                 className="organization-page__section-title"
+                component="h2"
                 content="organization.home.projects.finished"
               />
               <button
@@ -310,6 +312,7 @@ class OrganizationPage extends React.Component {
           <section className="organization-details">
             <Translate
               className="organization-page__section-title"
+              component="h2"
               content="organization.home.learn"
               with={{
                 title: organization.display_name
@@ -320,6 +323,7 @@ class OrganizationPage extends React.Component {
                 {quoteObject && quoteObject.quote && (
                   <div className="organization-researcher-words">
                     <Translate
+                      component="h3"
                       className="organization-details__content-heading"
                       content="organization.home.researcher"
                     />
@@ -349,7 +353,7 @@ class OrganizationPage extends React.Component {
                 <div className="organization-details__flex-content">
                   <Translate
                     className="organization-details__content-heading"
-                    component="h4"
+                    component="h3"
                     content="organization.home.introduction"
                     with={{ title: organization.display_name }}
                   />
@@ -373,7 +377,7 @@ class OrganizationPage extends React.Component {
                   header={(
                     <Translate
                       className="organization-details__content-heading"
-                      component="h4"
+                      component="h3"
                       content="organization.home.links"
                       with={{ title: organization.display_name }}
                     />
@@ -391,7 +395,7 @@ class OrganizationPage extends React.Component {
               <div className="organization-details__content">
                 <Translate
                   className="organization-details__content-heading"
-                  component="h4"
+                  component="h3"
                   content="organization.home.about"
                   with={{ title: organization.display_name }}
                 />

--- a/app/pages/organization/organization-page.jsx
+++ b/app/pages/organization/organization-page.jsx
@@ -329,6 +329,26 @@ class OrganizationPage extends React.Component {
             </div>
 
             <div className="organization-details__container">
+              {organization.urls && organization.urls.length && (
+                <ExternalLinksBlockContainer
+                  header={(
+                    <Translate
+                      className="organization-details__content-heading"
+                      component="h4"
+                      content="organization.home.links"
+                      with={{ title: organization.display_name }}
+                    />
+                  )}
+                  resource={organization}
+                  padding="2em"
+                  ulDisplay="flex"
+                  className="organization-details__link"
+                  socialLabel={true}
+                />
+              )}
+            </div>
+
+            <div className="organization-details__container">
               <div className="organization-details__content">
                 <Translate
                   className="organization-details__content-heading"
@@ -345,20 +365,6 @@ class OrganizationPage extends React.Component {
                   </Markdown>
                 )}
               </div>
-            </div>
-            <div className="organization-details__container">
-              {organization.urls && organization.urls.length && (
-                <ExternalLinksBlockContainer
-                  header={(
-                    <Translate
-                      className="organization-details__heading"
-                      content="organization.home.links"
-                      component="h4"
-                    />
-                  )}
-                  resource={organization}
-                />
-              )}
             </div>
           </section>
         </section>

--- a/app/pages/organization/organization-page.jsx
+++ b/app/pages/organization/organization-page.jsx
@@ -20,9 +20,15 @@ class OrganizationPage extends React.Component {
 
     this.state = {
       category: '',
+      active: true,
       finished: false,
       paused: false
     };
+  }
+
+  toggleActive() {
+    const { active } = this.state;
+    this.setState({ active: !active });
   }
 
   toggleFinished() {
@@ -69,9 +75,9 @@ class OrganizationPage extends React.Component {
     } = this.props;
     const {
       category,
+      active,
       finished,
-      paused,
-      readMore
+      paused
     } = this.state;
 
     let projects = organizationProjects;
@@ -176,6 +182,38 @@ class OrganizationPage extends React.Component {
                 </div>
               </>
             )}
+
+            <div className="organization-page__section-heading">
+              <Translate
+                className="organization-page__section-title"
+                component="h2"
+                content="organization.home.projects.active"
+              />
+              <button
+                className="standard-button organization-page__section-button"
+                onClick={() => this.toggleActive()}
+                type="button"
+              >
+                {active ? (
+                  <>
+                    <i className="fa fa-chevron-up fa-lg" />
+                    {' '}
+                    <Translate
+                      content="organization.home.projects.hideSection"
+                    />
+                  </>
+                ) : (
+                  <>
+                    <i className="fa fa-chevron-down fa-lg" />
+                    {' '}
+                    <Translate
+                      content="organization.home.projects.showSection"
+                    />
+                  </>
+                )}
+              </button>
+            </div>
+            {active && (
             <OrganizationProjectCards
               category={category}
               errorFetchingProjects={errorFetchingProjects}
@@ -184,6 +222,7 @@ class OrganizationPage extends React.Component {
               projectAvatars={projectAvatars}
               state="active"
             />
+            )}
 
             <div className="organization-page__section-heading">
               <Translate

--- a/app/pages/organization/organization-page.jsx
+++ b/app/pages/organization/organization-page.jsx
@@ -24,83 +24,99 @@ class OrganizationPage extends React.Component {
   }
 
   toggleReadMore() {
-    this.setState({ readMore: !this.state.readMore });
+    const { readMore } = this.state;
+    this.setState({ readMore: !readMore });
   }
 
   handleCategoryChange(category) {
-    this.props.onChangeQuery({ category });
+    const { onChangeQuery } = this.props;
+    onChangeQuery({ category });
   }
 
-  calculateClasses(category) {
+  calculateClasses(buttonCategory) {
+    const { category } = this.props;
     const list = classnames(
       'standard-button',
       'organization-page__category-button',
-      { 'organization-page__category-button--active':
-        (category === this.props.category) || (!this.props.category && (category === 'All')) }
+      {
+        'organization-page__category-button--active': (buttonCategory === category)
+          || (!category && (buttonCategory === 'All'))
+      }
     );
     return list;
   }
 
   render() {
-    const researcherAvatarSrc = this.props.quoteObject.researcherAvatar || '/assets/simple-avatar.png';
+    const {
+      collaborator,
+      collaboratorView,
+      errorFetchingProjects,
+      fetchingProjects,
+      organization,
+      organizationAvatar,
+      organizationBackground,
+      organizationPages,
+      organizationProjects,
+      projectAvatars,
+      quoteObject,
+      toggleCollaboratorView
+    } = this.props;
+    const { readMore } = this.state;
 
-    const [aboutPage] = this.props.organizationPages.filter(page => page.url_key === 'about');
+    const researcherAvatarSrc = quoteObject.researcherAvatar || '/assets/simple-avatar.png';
+
+    const [aboutPage] = organizationPages.filter(page => page.url_key === 'about');
     const aboutContentClass = classnames(
       'organization-details__about-content',
-      { 'organization-details__about-content--expanded': this.state.readMore });
-
-    let rearrangedLinks = [];
-    if (this.props.organization.urls) {
-      rearrangedLinks = this.props.organization.urls.sort((a, b) => {
-        if (a.path && !b.path) {
-          return 1;
-        }
-        return 0;
-      });
-    }
+      { 'organization-details__about-content--expanded': readMore }
+    );
 
     return (
       <div className="organization-page">
-        <Helmet title={this.props.organization.display_name} />
+        <Helmet title={organization.display_name} />
         <section
           className="organization-hero"
-          style={{ backgroundImage: `url(${this.props.organizationBackground.src})` }}
+          style={{ backgroundImage: `url(${organizationBackground.src})` }}
         >
           <div className="organization-hero__background-gradient">
-            {this.props.organization.announcement &&
+            {organization.announcement && (
               <Markdown tag="div" className="informational project-announcement-banner">
-                {this.props.organization.announcement}
-              </Markdown>}
+                {organization.announcement}
+              </Markdown>
+            )}
             <div className="organization-hero__container">
-              {this.props.organizationAvatar.src ?
+              {organizationAvatar.src ? (
                 <Thumbnail
-                  alt={`Organization icon for ${this.props.organization.display_name}`}
-                  src={this.props.organizationAvatar.src}
+                  alt={`Organization icon for ${organization.display_name}`}
+                  src={organizationAvatar.src}
                   className="organization-hero__avatar"
                   width={AVATAR_SIZE}
                   height={AVATAR_SIZE}
-                /> : <ZooniverseLogo className="organization-hero__avatar" width={AVATAR_SIZE} height={AVATAR_SIZE} />
-              }
+                />
+              ) : (
+                <ZooniverseLogo className="organization-hero__avatar" width={AVATAR_SIZE} height={AVATAR_SIZE} />
+              )}
               <div className="organization-hero__wrapper">
-                <h1 className="organization-hero__title">{this.props.organization.display_name}</h1>
-                <p className="organization-hero__description">{this.props.organization.description}</p>
+                <h1 className="organization-hero__title">{organization.display_name}</h1>
+                <p className="organization-hero__description">{organization.description}</p>
               </div>
             </div>
           </div>
         </section>
 
         <section className="resources-container">
-          {this.props.collaborator &&
+          {collaborator && (
             <label className="organization-page__toggle" htmlFor="collaborator view">
               <input
                 id="collaborator view"
-                onChange={() => this.props.toggleCollaboratorView()}
+                onChange={() => toggleCollaboratorView()}
                 type="checkbox"
-                value={!this.props.collaboratorView}
+                value={!collaboratorView}
               />
               <Translate content="organization.home.viewToggle" />
-            </label>}
-          {this.props.organization.categories && this.props.organization.categories.length > 0 &&
+            </label>
+          )}
+          {organization.categories && organization.categories.length > 0 && (
             <div className="organization-page__categories" ref={(node) => { this.categories = node; }}>
               <label
                 className={this.calculateClasses('All')}
@@ -115,92 +131,108 @@ class OrganizationPage extends React.Component {
                 />
                 All
               </label>
-              {this.props.organization.categories.map(category =>
+              {organization.categories.map(buttonCategory => (
                 <label
-                  className={this.calculateClasses(category)}
-                  htmlFor={category}
-                  key={category}
+                  className={this.calculateClasses(buttonCategory)}
+                  htmlFor={buttonCategory}
+                  key={buttonCategory}
                 >
                   <input
                     className="organization-page__category-button--hidden"
-                    id={category}
+                    id={buttonCategory}
                     name="category"
-                    onChange={this.handleCategoryChange.bind(this, category)}
+                    onChange={this.handleCategoryChange.bind(this, buttonCategory)}
                     type="radio"
                   />
-                  {category}
-                </label>)}
-            </div>}
+                  {buttonCategory}
+                </label>
+              ))}
+            </div>
+          )}
           <OrganizationProjectCards
-            errorFetchingProjects={this.props.errorFetchingProjects}
-            fetchingProjects={this.props.fetchingProjects}
-            projects={this.props.organizationProjects}
-            projectAvatars={this.props.projectAvatars}
+            errorFetchingProjects={errorFetchingProjects}
+            fetchingProjects={fetchingProjects}
+            projects={organizationProjects}
+            projectAvatars={projectAvatars}
           />
         </section>
 
         <section className="organization-details">
           <div className="organization-page__container">
-            {this.props.quoteObject && this.props.quoteObject.quote &&
+            {quoteObject && quoteObject.quote && (
               <div className="organization-researcher-words">
                 <Translate className="organization-details__heading" content="organization.home.researcher" />
                 <div className="organization-researcher-words__container">
                   <img
                     className="organization-researcher-words__avatar"
-                    role="presentation"
+                    alt="presentation"
                     src={researcherAvatarSrc}
                   />
                   <span
                     className="organization-researcher-words__quote"
                   >
-                    &quot;{this.props.quoteObject.quote}&quot;
+                    &quot;
+                    {quoteObject.quote}
+                    &quot;
                   </span>
                 </div>
                 <Link
                   className="organization-researcher-words__attribution"
-                  to={this.props.quoteObject.slug}
+                  to={quoteObject.slug}
                 >
-                  - {this.props.quoteObject.displayName}
+                  {' - '}
+                  {quoteObject.displayName}
                 </Link>
-              </div>}
+              </div>
+            )}
             <div className="organization-details__content">
               <h4 className="organization-details__heading">
-                {this.props.organization.display_name} <Translate content="organization.home.introduction" />
+                {organization.display_name}
+                <Translate content="organization.home.introduction" />
               </h4>
-              {this.props.organization.introduction &&
-                <Markdown project={this.props.organization}>{this.props.organization.introduction}</Markdown>}
+              {organization.introduction && (
+                <Markdown project={organization}>{organization.introduction}</Markdown>
+              )}
             </div>
           </div>
 
           <OrganizationMetadata
-            displayName={this.props.organization.display_name}
-            projects={this.props.organizationProjects}
+            displayName={organization.display_name}
+            projects={organizationProjects}
           />
 
           <div className="organization-page__container">
             <div className="organization-details__content">
               <h4 className="organization-details__heading">
-                <Translate content="project.home.about" with={{ title: this.props.organization.display_name }} />
+                <Translate content="project.home.about" with={{ title: organization.display_name }} />
               </h4>
-              {aboutPage &&
+              {aboutPage && (
                 <div>
-                  <Markdown className={aboutContentClass} project={this.props.organization}>
+                  <Markdown className={aboutContentClass} project={organization}>
                     {aboutPage.content}
                   </Markdown>
                   <button
                     className="standard-button organization-details__button"
                     onClick={() => this.toggleReadMore()}
+                    type="button"
                   >
-                    {this.state.readMore ?
-                      <Translate content="organization.home.readLess" /> :
-                      <Translate content="organization.home.readMore" />}
+                    {readMore
+                      ? <Translate content="organization.home.readLess" />
+                      : <Translate content="organization.home.readMore" />}
                   </button>
-                </div>}
+                </div>
+              )}
             </div>
-            {this.props.organization.urls && this.props.organization.urls.length && (
+            {organization.urls && organization.urls.length && (
               <ExternalLinksBlockContainer
-                header={<Translate className="organization-details__heading" content="organization.home.links" component="h4" />}
-                resource={this.props.organization}
+                header={(
+                  <Translate
+                    className="organization-details__heading"
+                    content="organization.home.links"
+                    component="h4"
+                  />
+                )}
+                resource={organization}
               />
             )}
           </div>
@@ -217,7 +249,6 @@ OrganizationPage.defaultProps = {
   errorFetchingProjects: {},
   fetchingProjects: false,
   onChangeQuery: () => {},
-  organization: {},
   organizationAvatar: {},
   organizationBackground: {},
   organizationPages: [],

--- a/app/pages/organization/organization-page.spec.js
+++ b/app/pages/organization/organization-page.spec.js
@@ -61,7 +61,7 @@ describe('OrganizationPage', function () {
           organization={organization}
           toggleCollaboratorView={toggle}
         />);
-      label = wrapper.find('label.organization-page__toggle');
+      label = wrapper.find('div.organization-page__toggle');
       checkbox = label.find('input[type="checkbox"]');
     });
 
@@ -76,7 +76,7 @@ describe('OrganizationPage', function () {
 
     it('should have project view toggle checked if collaboratorView is false', function () {
       wrapper.setProps({ collaboratorView: false });
-      label = wrapper.find('label.organization-page__toggle');
+      label = wrapper.find('div.organization-page__toggle');
       checkbox = label.find('input[type="checkbox"]');
       assert.equal(checkbox.prop('value'), true);
     });
@@ -139,26 +139,10 @@ describe('OrganizationPage', function () {
     assert.equal(quote.length, 0);
   });
 
-  describe('with pages about content', function () {
-    let wrapper;
-    let aboutPage;
-
-    beforeEach(function () {
-      wrapper = shallow(<OrganizationPage organization={organization} organizationPages={organizationPages} />);
-      aboutPage = wrapper.find('Markdown.organization-details__about-content');
-    });
-
-    it('should initially show pages about content collapsed', function () {
-      assert.equal(aboutPage.length, 1);
-      assert.equal(aboutPage.contains('test content'), true);
-    });
-
-    it('should show pages about content expanded after clicking Read More', function () {
-      wrapper.find('button.organization-details__button').simulate('click');
-      const aboutPageExpanded = wrapper.find('Markdown.organization-details__about-content--expanded');
-      assert.equal(aboutPageExpanded.length, 1);
-      assert.equal(aboutPageExpanded.contains('test content'), true);
-    });
+  it('should show about page content', function () {
+    const wrapper = shallow(<OrganizationPage organization={organization} organizationPages={organizationPages} />);
+    const aboutPage = wrapper.find('Markdown.organization-details__about-content');
+    assert.equal(aboutPage.contains('test content'), true);
   });
 
   it('should not render ExternalLinks section if no urls', function () {

--- a/app/pages/organization/organization-page.spec.js
+++ b/app/pages/organization/organization-page.spec.js
@@ -144,7 +144,7 @@ describe('OrganizationPage', function () {
     let aboutPage;
 
     beforeEach(function () {
-      wrapper = shallow(<OrganizationPage organizationPages={organizationPages} />);
+      wrapper = shallow(<OrganizationPage organization={organization} organizationPages={organizationPages} />);
       aboutPage = wrapper.find('Markdown.organization-details__about-content');
     });
 

--- a/app/pages/organization/organization-project-cards.jsx
+++ b/app/pages/organization/organization-project-cards.jsx
@@ -25,7 +25,7 @@ export const OrganizationProjectCards = ({
     );
   } else if (projects && projects.length > 0) {
     return (
-      <div className="project-cards-section">
+      <div className="organization-page__project-cards-section">
         {projects.map((project) => {
           let projectAvatar = projectAvatars.find(avatar => avatar.links.linked.id === project.id);
           if (!projectAvatar) {

--- a/app/pages/organization/organization-project-cards.jsx
+++ b/app/pages/organization/organization-project-cards.jsx
@@ -3,17 +3,24 @@ import React from 'react';
 import Translate from 'react-translate-component';
 import ProjectCard from '../../partials/project-card';
 
-export const OrganizationProjectCards = ({ errorFetchingProjects, fetchingProjects, projects, projectAvatars }) => {
+export const OrganizationProjectCards = ({
+  errorFetchingProjects,
+  fetchingProjects,
+  projects,
+  projectAvatars
+}) => {
   if (fetchingProjects) {
     return (
       <div className="organization-page__projects-status">
         <p><Translate content="organization.home.projects.loading" /></p>
-      </div>);
+      </div>
+    );
   } else if (!fetchingProjects && projects && !projects.length) {
     return (
       <div className="organization-page__projects-status">
         <p><Translate content="organization.home.projects.none" /></p>
-      </div>);
+      </div>
+    );
   } else if (projects && projects.length > 0) {
     return (
       <div className="project-card-list">
@@ -25,16 +32,22 @@ export const OrganizationProjectCards = ({ errorFetchingProjects, fetchingProjec
           return (
             <ProjectCard key={project.id} project={project} imageSrc={projectAvatar.src} />);
         })}
-      </div>);
+      </div>
+    );
   } else {
     return (
       <div className="organization-page__projects-status">
         <p><Translate content="organization.home.projects.error" /></p>
-        {errorFetchingProjects &&
-          <p>
-            <code>{errorFetchingProjects.toString()}</code>
-          </p>}
-      </div>);
+        {errorFetchingProjects
+          && (
+            <p>
+              <code>
+                {errorFetchingProjects.toString()}
+              </code>
+            </p>
+          )}
+      </div>
+    );
   }
 };
 

--- a/app/pages/organization/organization-project-cards.jsx
+++ b/app/pages/organization/organization-project-cards.jsx
@@ -13,19 +13,19 @@ export const OrganizationProjectCards = ({
 }) => {
   if (fetchingProjects) {
     return (
-      <div className="organization-page__projects-status">
+      <div className="organization-page__project-cards-message">
         <p><Translate content="organization.home.projects.loading" /></p>
       </div>
     );
   } else if (!fetchingProjects && projects && !projects.length) {
     return (
-      <div className="organization-page__projects-status">
+      <div className="organization-page__project-cards-message">
         <p><Translate content="organization.home.projects.none" with={{ category, state }} /></p>
       </div>
     );
   } else if (projects && projects.length > 0) {
     return (
-      <div className="project-card-list">
+      <div className="project-cards-section">
         {projects.map((project) => {
           let projectAvatar = projectAvatars.find(avatar => avatar.links.linked.id === project.id);
           if (!projectAvatar) {
@@ -38,7 +38,7 @@ export const OrganizationProjectCards = ({
     );
   } else {
     return (
-      <div className="organization-page__projects-status">
+      <div className="organization-page__project-cards-message">
         <p><Translate content="organization.home.projects.error" /></p>
         {errorFetchingProjects
           && (

--- a/app/pages/organization/organization-project-cards.jsx
+++ b/app/pages/organization/organization-project-cards.jsx
@@ -4,10 +4,12 @@ import Translate from 'react-translate-component';
 import ProjectCard from '../../partials/project-card';
 
 export const OrganizationProjectCards = ({
+  category,
   errorFetchingProjects,
   fetchingProjects,
   projects,
-  projectAvatars
+  projectAvatars,
+  state
 }) => {
   if (fetchingProjects) {
     return (
@@ -18,7 +20,7 @@ export const OrganizationProjectCards = ({
   } else if (!fetchingProjects && projects && !projects.length) {
     return (
       <div className="organization-page__projects-status">
-        <p><Translate content="organization.home.projects.none" /></p>
+        <p><Translate content="organization.home.projects.none" with={{ category, state }} /></p>
       </div>
     );
   } else if (projects && projects.length > 0) {
@@ -52,6 +54,7 @@ export const OrganizationProjectCards = ({
 };
 
 OrganizationProjectCards.propTypes = {
+  category: PropTypes.string,
   errorFetchingProjects: PropTypes.shape({
     message: PropTypes.string
   }),
@@ -67,7 +70,8 @@ OrganizationProjectCards.propTypes = {
       id: PropTypes.string,
       src: PropTypes.string
     })
-  )
+  ),
+  state: PropTypes.string
 };
 
 export default OrganizationProjectCards;

--- a/app/pages/organization/organization-project-cards.spec.js
+++ b/app/pages/organization/organization-project-cards.spec.js
@@ -39,11 +39,13 @@ describe('OrganizationProjectCards', function () {
   });
 
   it('should show no projects associated message if fetchingProjects false and no projects', function () {
-    const message = <Translate content="organization.home.projects.none" />;
+    const message = <Translate content="organization.home.projects.none" with={{ category: 'TestCategory', state: 'active' }} />;
     const wrapper = shallow(
       <OrganizationProjectCards
+        category="TestCategory"
         fetchingProjects={false}
         projects={[]}
+        state="active"
       />);
     const status = wrapper.find('.organization-page__projects-status');
     assert.equal(status.length, 1);

--- a/app/pages/organization/organization-project-cards.spec.js
+++ b/app/pages/organization/organization-project-cards.spec.js
@@ -5,7 +5,7 @@ import React from 'react';
 import assert from 'assert';
 import { shallow } from 'enzyme';
 import Translate from 'react-translate-component';
-import OrganizationProjectCards from './organization-project-cards';
+import { OrganizationProjectCards } from './organization-project-cards';
 
 export const organizationProjects = [1, 2, 3].map(i => ({
   id: i.toString(),
@@ -22,9 +22,8 @@ describe('OrganizationProjectCards', function () {
 
   it('should show loading projects message if fetchingProjects', function () {
     const message = <Translate content="organization.home.projects.loading" />;
-    const wrapper = shallow(
-      <OrganizationProjectCards fetchingProjects={true} />);
-    const status = wrapper.find('.organization-page__projects-status');
+    const wrapper = shallow(<OrganizationProjectCards fetchingProjects={true} />);
+    const status = wrapper.find(Translate);
     assert.equal(status.length, 1);
     assert.equal(status.contains(message), true);
   });
@@ -32,8 +31,12 @@ describe('OrganizationProjectCards', function () {
   it('should show projects error message if errorFetchingProjects', function () {
     const message = <Translate content="organization.home.projects.error" />;
     const wrapper = shallow(
-      <OrganizationProjectCards errorFetchingProjects={{ message: 'test error' }} />);
-    const status = wrapper.find('.organization-page__projects-status');
+      <OrganizationProjectCards
+        errorFetchingProjects={{ message: 'test error' }}
+        fetchingProjects={false}
+      />
+    );
+    const status = wrapper.find(Translate);
     assert.equal(status.length, 1);
     assert.equal(status.contains(message), true);
   });
@@ -46,8 +49,9 @@ describe('OrganizationProjectCards', function () {
         fetchingProjects={false}
         projects={[]}
         state="active"
-      />);
-    const status = wrapper.find('.organization-page__projects-status');
+      />
+    );
+    const status = wrapper.find(Translate);
     assert.equal(status.length, 1);
     assert.equal(status.contains(message), true);
   });
@@ -58,7 +62,8 @@ describe('OrganizationProjectCards', function () {
         fetchingProjects={false}
         projects={organizationProjects}
         projectAvatars={[]}
-      />);
+      />
+    );
     const cards = wrapper.find('ProjectCard');
     assert.equal(cards.length, organizationProjects.length);
   });

--- a/css/organization-page.styl
+++ b/css/organization-page.styl
@@ -200,25 +200,32 @@
     flex: 3 1 500px
     margin: 2em 1em 0 1em
 
-  &__links
-    background-color: white
-    color: ZOONIVERSE_NAVY
-    display: flex
-    flex: 2 0 auto
-    flex-direction: column
-    padding: 3em 4vw
-    width: 250px
-
   &__link
-    align-items: center
-    display: flex
-    font-size: 1.2em
-    margin-left: .8em
-    margin-top: 20px
-    text-decoration: none
+    color: #5c5c5c
+    font-size: 1em
+    justify-content: flex-end
+    height: 100%
+    margin-right: 2em
+    min-width: 150px
 
-  &__icon
-    padding-right: .1em
+    div
+      display: flex
+      flex-direction: column
+
+    i
+      font-size: 2em
+      margin-right: 0
+
+    .link-title
+      color: TEAL_DARK
+      text-transform: uppercase
+
+      a
+        color: TEAL_DARK
+        text-transform: uppercase
+
+    .social-label
+      font-weight: bold
 
   &__about-content
     columns: 2 400px

--- a/css/organization-page.styl
+++ b/css/organization-page.styl
@@ -262,3 +262,67 @@
     font-size: 1em
     text-decoration: none
     text-transform: uppercase
+
+.organization-metadata
+  &__container
+    display: flex
+    margin-top: 1em
+
+    @media(max-width: 900px)
+      flex-direction: column
+
+  &__subtitle
+    font-size: 1em
+
+  &__completeness-section
+    border-bottom: none
+    border-right: 1px solid #979797
+    display: flex
+    flex-direction: column
+    margin-right: 2em
+    padding-right: 2em
+
+    @media(max-width: 900px)
+      border-bottom: 1px solid #979797
+      border-right: none
+      margin: 0 0 2em 0
+      padding: 0 0 2em 0
+
+  &__completeness-text
+    margin-top: 0
+
+  &__progress-bar
+    background-color: BACKGROUND_COLOR
+    height: 2.2em
+    margin-bottom: .8em
+
+  &__progress-bar-meter
+    background: linear-gradient(270deg, #D46256 0%, #F0B200 100%)
+    color: white
+    display: block
+    height: 100%
+    line-height: 2.2em
+    padding-right: 1em
+    text-align: right
+
+  &__progress-bar-label
+    color: #5C5C5C
+    font-weight: bold
+
+  &__numbers-section
+    min-width: 200px
+
+  &__numbers-stats-container
+    display: flex
+    flex-flow: row wrap
+
+  &__numbers-stat-block
+    margin: 0 2em 2em 0
+
+  &__numbers-stat
+    display: block
+    font-size: 2em
+
+  &__numbers-label
+    display: block
+    font-weight: bold

--- a/css/organization-page.styl
+++ b/css/organization-page.styl
@@ -1,38 +1,54 @@
 .organization-page
   background-color: BACKGROUND_COLOR
-  color: white
-  display: flex
-  flex: 1 0 auto
-  flex-direction: column
   font-family: 'Karla', sans-serif
 
-  &__container
+  &__main
+    padding: 2em 6em 4em 6em
+
+    hr
+      margin-bottom: 2em
+    
+    @media(max-width: 600px)
+      padding: 2em 0 4em 0 
+
+  &__projects
+    display: flex
+    flex-direction: column
+
+  &__project-cards-section
     display: flex
     flex-flow: row wrap
 
-  &__projects-status
+    @media (max-width: 900px)
+      flex-direction: column
+      padding-left: 0
+      text-align: center
+
+  &__project-cards-message
     align-items: center
     color: TEAL_DARK
     display: flex
-    flex-flow: column
+    flex-direction: column
     margin: 3em
 
   &__toggle
-    color: TEAL_DARK
-    margin-left: 2em
+    color: #5C5C5C
+    text-align: right
 
   &__categories
     display: flex
-    justify-content: center
     flex-wrap: wrap
+    margin-bottom: 2em
+
+    @media (max-width: 900px)
+      justify-content: center
 
   &__category-button
-    background: white
-    border: 1px #EBEBEB
+    background: BACKGROUND_COLOR
+    border: 1px solid TEAL_MID
     border-radius: 0
-    color: TEAL_MID
-    font-weight: bold
-    margin: .8em .5em
+    color: black
+    margin: 1em 1em 0 0
     width: 150px
 
     @media (max-width: 900px)
@@ -40,21 +56,47 @@
 
     &:focus,
     &:hover
-      background: TEAL_DARK
-      border: 1px TEAL_DARK
+      background: TEAL_MID
+      border: 1px solid TEAL_MID
       color: white
 
     &--active
-      background: TEAL_DARK
-      border: 1px TEAL_DARK
+      background: TEAL_MID
+      border: 1px solid TEAL_MID
       color: white
 
     &--hidden
       left: -9999px
       position: absolute
+  
+  &__section-heading
+    display: flex
+    flex-direction: row
+    justify-content: space-between
+    margin-bottom: 2em
+
+  &__section-title
+    color: #5C5C5C
+    font-weight: bold
+    font-size: 1.8em
+    letter-spacing: -.5px
+
+  &__section-button
+    background: BACKGROUND_COLOR
+    color: TEAL_MID
+    margin: 0
+    padding: 0
+    text-transform: uppercase
+
+    &:focus,
+    &:hover
+      background: BACKGROUND_COLOR
+      color: TEAL_MID
+      text-decoration: underline
 
 .organization-hero
   background-size: cover
+  color: white
   min-height: 400px
   position: relative
 
@@ -82,7 +124,10 @@
 
   &__avatar
     border-radius: 50%
+    height: 8em
+    object-fit: cover
     vertical-align: -.3em
+    width: 8em
 
   &__wrapper
     margin-left: 3em
@@ -92,6 +137,7 @@
       display: flex
       flex-direction: column
       margin-left: 0
+      text-align: center
 
   &__title
     font-size: 2.5em
@@ -101,27 +147,35 @@
     font-size: 1em
     font-weight: normal
 
-    @media (max-width: 900px)
-      margin: .8em
-      text-align: center
-
 .organization-details
+  display: flex
+  flex-direction: column
+  
+  &__container
+    margin-top: 2em
 
-  &__heading
+  &__flex-container
+    display: flex
+    flex-wrap: wrap
+    margin: -2em -1em 0 -1em
+
+  &__content-heading
+    color: black
+    font-weight: bold
+    letter-spacing: 1.5px
     text-transform: uppercase
 
   &__content
-    background-color: TEAL_MID
-    flex: 3 1 auto
-    padding: 3em 3em 4em
+    background: white
+    border: 1px solid #E2E5E9
+    padding: 2em
     text-align: left
-    width: 600px
 
     .markdown
       a
         background: none
         border: 0
-        color: BACKGROUND_COLOR
+        color: TEAL_DARK
         font-weight: bold
         margin: 0
         padding: 0
@@ -140,14 +194,11 @@
       p
         line-height: 1.75
 
-  &__button
-    background: TEAL_MID
-    border: white
-    margin-top: 2em
+  &__flex-content
+    @extends .organization-details__content
 
-    &:focus,
-    &:hover
-      background: TEAL_LIGHT
+    flex: 3 1 500px
+    margin: 2em 1em 0 1em
 
   &__links
     background-color: white
@@ -170,24 +221,21 @@
     padding-right: .1em
 
   &__about-content
-    max-height: 300px
-    overflow-y: hidden
-
-    &--expanded
-      max-height: none
+    columns: 2 400px
+    column-gap: 4em
 
 .organization-researcher-words
   background-color: white
-  color: ZOONIVERSE_NAVY
-  display: flex
-  flex: 2 0 auto
-  flex-direction: column
-  padding: 3em 4vw
-  width: 250px
+  border: 1px solid #E2E5E9
+  color: #5c5c5c
+  flex: 2 0 200px
+  height: fit-content
+  margin: 2em 1em 0 1em
+  padding: 2em
 
   &__container
     display: flex
-    margin-top: 1.5em
+    margin: 1.5em 0
 
   &__avatar
     border-radius: 50%
@@ -197,13 +245,13 @@
     min-width: 5em
 
   &__quote
-    font-size: 1.75em
+    font-size: 1.5em
     line-height: 1.2em
     overflow: auto
     word-wrap: break-word
 
   &__attribution
-    color: ZOONIVERSE_NAVY
+    color: TEAL_DARK
     font-size: 1em
-    margin: 1em auto
     text-decoration: none
+    text-transform: uppercase

--- a/css/organization-page.styl
+++ b/css/organization-page.styl
@@ -24,6 +24,12 @@
       padding-left: 0
       text-align: center
 
+    .project-card
+      margin: 0 1em 1em 0
+
+      @media (max-width: 900px)
+        margin-right: 0
+
   &__project-cards-message
     align-items: center
     color: TEAL_DARK
@@ -73,7 +79,7 @@
     display: flex
     flex-direction: row
     justify-content: space-between
-    margin-bottom: 2em
+    margin: 2em 0
 
   &__section-title
     color: #5C5C5C
@@ -163,6 +169,7 @@
     color: black
     font-weight: bold
     letter-spacing: 1.5px
+    line-height: 1.2em
     text-transform: uppercase
 
   &__content


### PR DESCRIPTION
HOLD: until Notes from Nature and Snapshot Safari can update their organization content for new design, most notably about section.

Staging branch URL: https://pr-5554.pfe-preview.zooniverse.org

Helpful links:
- staging test organization: https://pr-5554.pfe-preview.zooniverse.org/organizations/markb-panoptes/urban-wildlife-org-test
- Snapshot Serengeti: https://pr-5554.pfe-preview.zooniverse.org/organizations/meredithspalmer/snapshot-safari?env=production
- Notes from Nature: https://pr-5554.pfe-preview.zooniverse.org/organizations/md68135/notes-from-nature?env=production

[InVision organization landing page redesign](https://projects.invisionapp.com/d/main/default/#/console/12924056/391430827/preview)

I've separated the organization landing page redesign work into several small PRs.
~This PR is primarily linting and is intended to be a base for other related PRs to merge into.~
[EDIT] ^ This is PR now the combined changes.

Recommended order of related PR review and merge:
- [x] 1. #5555 - Add project state sections to organization landing page 
- [x] 2. #5556 - Update organization landing page style
- [x] 3. #5557 - Refactor external links section for organization redesign
- [x] 4. #5577 - Refactor stats section for organization redesign

ToDos:
- [x] review content section headings for proper spacing and content
- [x] add light grey border around content boxes
- [x] project cards are squished to the left of the screen (e.g., iPhone 8 iOS 13.0 | mobile_Safari, Samsung Galaxy S10 Android 9.0 | mobile_Chrome)
- [x] `.organization-page__section-title` should have margin-top: 60px (now has top & bottom of 30px, combined with neighboring elements, I think gets desired result)
- [x] fully left align project cards, currently there's a small margin/padding between first card and left side of container

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [x] Can you post a talk comment?

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
