### PR TITLE
Remove grid tool from list of experimental features

### DIFF
--- a/app/pages/admin/project-status/experimental-features.jsx
+++ b/app/pages/admin/project-status/experimental-features.jsx
@@ -9,7 +9,6 @@ const experimentalFeatures = [
   'fan',
   'mini-course',
   'worldwide telescope',
-  'grid',
   'workflow assignment',
   'Gravity Spy Gold Standard',
   'allow workflow query',


### PR DESCRIPTION
Disables the grid experimental tool by removing it from the list of available experimental features.

I haven't removed the code yet, as there are two projects still using it - the prototype OCR project for Old Weather it was originally built for, and a test project owned by @snblickhan. My plan for this is to:

- Inform the OW team
- Remove the tool from the OCR project workflow
- Delete the code from PFE