### PR TITLE
Remove https and open config options

### DIFF
--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -13,9 +13,7 @@ var config = {
       '.zooniverse.org'
     ],
     historyApiFallback: true,
-    https: true,
     host: process.env.HOST || "localhost",
-    open: true,
     overlay: true,
     port: 3735
   },


### PR DESCRIPTION
Staging branch URL: https://pr-{NUMBER}.pfe-preview.zooniverse.org

I've been seeing https://github.com/webpack/webpack-dev-server/issues/2313, so I'm removing the https dev server config for now until it is fixed. I'm also removing the auto open config because it'll open to `localhost` which is not useful (since you should be using `local.zooniverse.org` or one of the other allowed sub-domains)

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
