### PR TITLE
Refactor media action with getAllLinked

### DIFF
--- a/app/pages/lab/actions/media.js
+++ b/app/pages/lab/actions/media.js
@@ -1,4 +1,5 @@
 const apiClient = require('panoptes-client/lib/api-client');
+const getAllLinked = require('../../../lib/get-all-linked').default;
 const putFile = require('../../../lib/put-file');
 
 // warn on uploads bigger than 500k
@@ -8,7 +9,7 @@ const mediaActions = {
   fetchMedia(props = this.props) {
     this.setState({ media: null });
 
-    return props.resource.get(this.props.link, { page_size: this.props.pageSize })
+    return getAllLinked(props.resource, props.link)
       .then((media) => {
         return media.filter((medium) => {
           return Object.keys(medium.metadata).length > 0;

--- a/app/pages/lab/media-area/index.jsx
+++ b/app/pages/lab/media-area/index.jsx
@@ -65,7 +65,6 @@ MediaAreaController.defaultProps = {
   metadata: {},
   onAdd: () => {},
   onDelete: () => {},
-  pageSize: 200,
   resource: null,
   style: {},
   actions: mediaActions
@@ -92,7 +91,6 @@ MediaAreaController.propTypes = {
   metadata: PropTypes.object,
   onAdd: PropTypes.func,
   onDelete: PropTypes.func,
-  pageSize: PropTypes.number,
   resource: PropTypes.shape({
     _getURL: PropTypes.func,
     get: PropTypes.func


### PR DESCRIPTION
Staging branch URL: https://pr-5591.pfe-preview.zooniverse.org

Fixes lab/media page size issue, as noted in [this Talk post](https://www.zooniverse.org/talk/17/1207000).

Refactors media fetch action to use `getAllLinked` helper.

Comparing https://www.zooniverse.org/lab/5483/media to https://pr-5591.pfe-preview.zooniverse.org/lab/5483/media?env=production, searching for "https://panoptes-uploads", returns 200 results on master as expected compared to 427(!) on this staged branch.

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [x] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
