### PR TITLE
Add "Museum" role to PFE Lab Collaborators (experimental tool)

### DIFF
--- a/app/pages/admin/project-status/experimental-features.jsx
+++ b/app/pages/admin/project-status/experimental-features.jsx
@@ -24,7 +24,8 @@ const experimentalFeatures = [
   'general feedback',
   'slider',
   'highlighter',
-  'translator-role'
+  'translator-role',
+  'museum-role',
 ];
 
 class ExperimentalFeatures extends Component {

--- a/app/pages/lab/collaborators.cjsx
+++ b/app/pages/lab/collaborators.cjsx
@@ -38,6 +38,9 @@ ROLES_INFO =
   translator:
     label: 'Translator'
     description: 'Translators will have access to the translation site.'
+  museum:
+    label: 'Museum'
+    description: 'Museum visitors will experience a different user interface/user experience in the mobile app. This role is designed for curated events, such as a museum exhibit.'
 
 CollaboratorCreator = createReactClass
   displayName: 'CollaboratorCreator'
@@ -51,6 +54,7 @@ CollaboratorCreator = createReactClass
 
   render: ->
     @showTranslatorRole()
+    @showMuseumRole()
 
     style = if @state.creating
       opacity: 0.5
@@ -84,6 +88,10 @@ CollaboratorCreator = createReactClass
   showTranslatorRole: ->
     if (@props.project.experimental_tools?.indexOf('translator-role') > -1) or isAdmin()
       POSSIBLE_ROLES = Object.assign({}, POSSIBLE_ROLES, {translator: 'translator'});
+  
+  showMuseumRole: ->
+    if (@props.project.experimental_tools?.indexOf('museum-role') > -1) or isAdmin()
+      POSSIBLE_ROLES = Object.assign({}, POSSIBLE_ROLES, {museum: 'museum'});
 
   handleSubmit: (e) ->
     e.preventDefault()

--- a/app/pages/lab/collaborators.cjsx
+++ b/app/pages/lab/collaborators.cjsx
@@ -19,6 +19,9 @@ POSSIBLE_ROLES = {
   tester: 'team'
 }
 
+# NOTE: Panoptes API and Talk API keep track of user roles separately; Panoptes can accept arbitrary role values, but Talk API can't.
+# The key-value pairs of POSSIBLE_ROLES maps the roles on Panoptes API (key) to the 'comparable' roles on Talk API.
+
 ROLES_INFO =
   collaborator:
     label: 'Collaborator'
@@ -41,6 +44,10 @@ ROLES_INFO =
   museum:
     label: 'Museum'
     description: 'Enables a custom interface for the project on the Zooniverse iPad app, specifically designed to be used in a museum or exhibit space.'
+    
+ROLES_NOT_IN_TALK_API = [
+  'museum'
+]
 
 CollaboratorCreator = createReactClass
   displayName: 'CollaboratorCreator'
@@ -101,7 +108,7 @@ CollaboratorCreator = createReactClass
     roles = for checkbox in checkboxes when checkbox.checked
       checkbox.value
 
-    talkRoles = for role, talkRole of POSSIBLE_ROLES when role in roles and role isnt 'museum'  # 'museum' role should be added to Panoptes API's project_roles, but NOT Talk API's 
+    talkRoles = for role, talkRole of POSSIBLE_ROLES when role in roles and role not in ROLES_NOT_IN_TALK_API 
       talkRole
 
     talkRoles = talkRoles.reduce(((memo, role) ->
@@ -233,7 +240,7 @@ module.exports = createReactClass
         user_id: parseInt(projectRoleSet.links.owner.id)
         section: @talkSection()
         name: POSSIBLE_ROLES[role]
-      ).save() unless role is 'museum'  # 'museum' role should be added to Panoptes API's project_roles, but NOT Talk API's 
+      ).save() unless role in ROLES_NOT_IN_TALK_API 
     else
       projectRoleSet.roles.splice index, 1
       filteredRoles = projectRoleSet.talk_roles.filter (talkRole) ->

--- a/app/pages/lab/collaborators.cjsx
+++ b/app/pages/lab/collaborators.cjsx
@@ -101,7 +101,7 @@ CollaboratorCreator = createReactClass
     roles = for checkbox in checkboxes when checkbox.checked
       checkbox.value
 
-    talkRoles = for role, talkRole of POSSIBLE_ROLES when role in roles
+    talkRoles = for role, talkRole of POSSIBLE_ROLES when role in roles and role isnt 'museum'  # 'museum' role should be added to Panoptes API's project_roles, but NOT Talk API's 
       talkRole
 
     talkRoles = talkRoles.reduce(((memo, role) ->
@@ -233,7 +233,7 @@ module.exports = createReactClass
         user_id: parseInt(projectRoleSet.links.owner.id)
         section: @talkSection()
         name: POSSIBLE_ROLES[role]
-      ).save()
+      ).save() unless role is 'museum'  # 'museum' role should be added to Panoptes API's project_roles, but NOT Talk API's 
     else
       projectRoleSet.roles.splice index, 1
       filteredRoles = projectRoleSet.talk_roles.filter (talkRole) ->

--- a/app/pages/lab/collaborators.cjsx
+++ b/app/pages/lab/collaborators.cjsx
@@ -40,7 +40,7 @@ ROLES_INFO =
     description: 'Translators will have access to the translation site.'
   museum:
     label: 'Museum'
-    description: 'Enables a custom interface for the project on the Zooniverse iPad app, specifically designed to be used in a museum or exhibit space. Assign a user to this role to turn on.'
+    description: 'Enables a custom interface for the project on the Zooniverse iPad app, specifically designed to be used in a museum or exhibit space.'
 
 CollaboratorCreator = createReactClass
   displayName: 'CollaboratorCreator'

--- a/app/pages/lab/collaborators.cjsx
+++ b/app/pages/lab/collaborators.cjsx
@@ -40,7 +40,7 @@ ROLES_INFO =
     description: 'Translators will have access to the translation site.'
   museum:
     label: 'Museum'
-    description: 'Museum visitors will experience a different user interface/user experience in the mobile app. This role is designed for curated events, such as a museum exhibit.'
+    description: 'Enables a custom interface for the project on the Zooniverse iPad app, specifically designed to be used in a museum or exhibit space. Assign a user to this role to turn on.'
 
 CollaboratorCreator = createReactClass
   displayName: 'CollaboratorCreator'


### PR DESCRIPTION
## PR Overview

Fixes #5607

Staging branch URL: https://pr-5608.pfe-preview.zooniverse.org

This PR adds 'museum' role option, to the PFE Lab's Collaborators page.

- The new `museum` role is designed, presumably, for use with museum exhibits or similar events. (See #5607)
- ❗️ To see the `museum` role on the PFE Lab's Collaborators page, EITHER the `experimental_tools: ['museum-role']` value must be enabled for the project, OR the user viewing the page must be in admin mode.
- ❗️ To actually add/remove museum roles to certain users, the Panoptes API needs to have a `museum` role first.

![Screen Shot 2020-01-08 at 14 16 53](https://user-images.githubusercontent.com/13952701/71985202-fc836300-3221-11ea-90ea-6eec8b87dfc9.png)

### Notes

I'm actually not aware if there was ever any discussion whether there _should_ be a `museum` role or not, but AFAIC that's irrelevant to this PR and the requirements set out by 5607. Any discussion on whether there should be a new role, and what that role needs to perform, etc, should be discussed on #5607 or on the Panoptes API repo.

### Status

⚠️  **DO NOT MERGE** until...
- [ ] The requirements for the `museum` role is confirmed in #5607 
- [x] Panoptes API has the `museum` role

**Required follow up:**
- [ ] Experimental Tools documentation needs to be updated if/when this PR gets merged.

### Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [ ] Can you post a talk comment?

### Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?
