### PR TITLE
Project home page: translate workflows

### DIFF
--- a/app/pages/project/home/home-workflow-button.jsx
+++ b/app/pages/project/home/home-workflow-button.jsx
@@ -56,8 +56,8 @@ class ProjectHomeWorkflowButton extends React.Component {
         onClick={this.handleWorkflowSelection}
       >
         {(this.props.workflowAssignment && !this.props.disabled) ?
-          <Translate content="project.home.workflowAssignment" with={{ workflowDisplayName: this.props.workflow.display_name }} /> :
-          this.props.workflow.display_name}
+          <Translate content="project.home.workflowAssignment" with={{ workflowDisplayName: this.props.translation.display_name }} /> :
+          this.props.translation.display_name}
       </button>
     );
   }

--- a/app/pages/project/home/home-workflow-button.jsx
+++ b/app/pages/project/home/home-workflow-button.jsx
@@ -75,6 +75,7 @@ ProjectHomeWorkflowButton.defaultProps = {
   disabled: false,
   preferences: {},
   project: {},
+  translation: {},
   workflow: {},
   workflowAssignment: false
 };
@@ -95,6 +96,10 @@ ProjectHomeWorkflowButton.propTypes = {
   project: PropTypes.shape({
     slug: PropTypes.string
   }).isRequired,
+  translation: PropTypes.shape({
+    display_name: PropTypes.string,
+    id: PropTypes.string
+  }),
   translations: PropTypes.shape({
     locale: PropTypes.string
   }),

--- a/app/pages/project/home/home-workflow-button.spec.js
+++ b/app/pages/project/home/home-workflow-button.spec.js
@@ -61,6 +61,7 @@ describe('ProjectHomeWorkflowButton', function () {
         disabled={false}
         preferences={preferences}
         project={testProject}
+        translation={testWorkflowWithoutLevel}
         translations={translations}
         user={user}
         workflow={testWorkflowWithoutLevel}
@@ -139,6 +140,7 @@ describe('ProjectHomeWorkflowButton', function () {
           disabled={true}
           preferences={preferences}
           project={testProject}
+          translation={testWorkflowWithoutLevel}
           workflow={testWorkflowWithoutLevel}
           workflowAssignment={false}
         />
@@ -161,6 +163,7 @@ describe('ProjectHomeWorkflowButton', function () {
           disabled={false}
           preferences={preferences}
           project={testProject}
+          translation={testWorkflowWithoutLevel}
           workflow={testWorkflowWithoutLevel}
           workflowAssignment={true}
         />

--- a/app/pages/project/home/home-workflow-buttons.jsx
+++ b/app/pages/project/home/home-workflow-buttons.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import Translate from 'react-translate-component';
 import ProjectHomeWorkflowButton from './home-workflow-button';
 import LoadingIndicator from '../../../components/loading-indicator';
+import Translations from '../../../classifier/translations'
 
 export default class ProjectHomeWorkflowButtons extends React.Component {
   constructor() {
@@ -43,15 +44,21 @@ export default class ProjectHomeWorkflowButtons extends React.Component {
               )}
               {this.props.activeWorkflows.map((workflow) => {
                 return (
-                  <ProjectHomeWorkflowButton
-                    key={workflow.id}
-                    disabled={this.shouldWorkflowBeDisabled(workflow)}
-                    preferences={this.props.preferences}
-                    project={this.props.project}
-                    user={this.props.user}
-                    workflow={workflow}
-                    workflowAssignment={this.props.workflowAssignment}
-                  />);
+                    <Translations
+                      key={workflow.id}
+                      original={workflow}
+                      type="workflow"
+                    >
+                      <ProjectHomeWorkflowButton
+                        disabled={this.shouldWorkflowBeDisabled(workflow)}
+                        preferences={this.props.preferences}
+                        project={this.props.project}
+                        user={this.props.user}
+                        workflow={workflow}
+                        workflowAssignment={this.props.workflowAssignment}
+                      />
+                    </Translations>
+                  );
               })
             }</div>
           </div>)}


### PR DESCRIPTION
Staging branch URL: https://pr-5626.pfe-preview.zooniverse.org

Fixes #5451.

Connect up the project homepage workflow buttons to the redux store. Display translations for the workflow display names.

![Chimp & See with workflow names in English.](https://user-images.githubusercontent.com/59547/72735909-a654df00-3b94-11ea-8915-398a644305e9.png)
https://pr-5626.pfe-preview.zooniverse.org/projects/sassydumbledore/chimp-and-see?env=production

![Chimp & See with workflow names in German.](https://user-images.githubusercontent.com/59547/72735932-b076dd80-3b94-11ea-9030-283766dd64f1.png)
https://pr-5626.pfe-preview.zooniverse.org/projects/sassydumbledore/chimp-and-see?env=production&language=de

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [x] Can you post a talk comment?

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [x] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
