### PR TITLE
Show Background Color Over External Links

### DIFF
--- a/app/components/ExternalLinksBlock/ExternalLinksBlock.jsx
+++ b/app/components/ExternalLinksBlock/ExternalLinksBlock.jsx
@@ -7,7 +7,7 @@ import { zooTheme } from '../../theme';
 
 export const StyledExternalLinksBlock = styled.div`
   background-color: ${({ isItAProject }) => {
-    return (isItAProject) ? zooTheme.colors.background : 'white';
+    return (isItAProject) ? '#eff2f5' : 'white';
   }};
   box-sizing: border-box;
   color: ${theme('mode', {

--- a/app/components/ExternalLinksBlock/ExternalLinksBlock.jsx
+++ b/app/components/ExternalLinksBlock/ExternalLinksBlock.jsx
@@ -7,7 +7,7 @@ import { zooTheme } from '../../theme';
 
 export const StyledExternalLinksBlock = styled.div`
   background-color: ${({ isItAProject }) => {
-    return (isItAProject) ? '#eff2f5' : 'white';
+    return (isItAProject) ? zooTheme.colors.lightTheme.background.default : 'white';
   }};
   box-sizing: border-box;
   color: ${theme('mode', {


### PR DESCRIPTION
Staging branch URL: https://pr-5627.pfe-preview.zooniverse.org

Fixes an issue appearing [on Talk](https://www.zooniverse.org/talk/17/1232948) 

Describe your changes.
Gives a background to an otherwise transparent div that was not receiving styling from the theme. I think this issue was only appearing on Windows in particular browsers? It appears to only appear when images are quite tall. However, I went ahead and made the change as I can see this occurring for any project with tall subjects.

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [x] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
