### PR TITLE
Remove Mobile Check for One Image on Workflow Tasks

### DIFF
--- a/app/pages/lab/mobile/mobile-section-container.jsx
+++ b/app/pages/lab/mobile/mobile-section-container.jsx
@@ -39,16 +39,6 @@ function workflowHasNoMoreThanXShortcuts(shortcutsLimit) {
   };
 }
 
-function workflowQuestionHasOneOrLessImages({ task }) {
-  let validation = convertBooleanToValidation(false);
-  if (task.question) {
-    const matchArray = task.question.match(MARKDOWN_IMAGE);
-    validation = convertBooleanToValidation(matchArray ? matchArray.length < 2 : true, true);
-  }
-
-  return validation;
-}
-
 function drawingToolTypeIsValid({ task }) {
   let validationBool = false;
   if (task.tools[0]) {
@@ -74,15 +64,13 @@ const validatorFns = {
     taskQuestionNotTooLong,
     taskFeedbackDisabled,
     workflowHasSingleTask,
-    workflowNotTooManyShortcuts: workflowHasNoMoreThanXShortcuts(2),
-    workflowQuestionHasOneOrLessImages
+    workflowNotTooManyShortcuts: workflowHasNoMoreThanXShortcuts(2)
   },
   multiple: {
     taskQuestionNotTooLong,
     taskFeedbackDisabled,
     workflowHasSingleTask,
-    workflowNotTooManyShortcuts: workflowHasNoMoreThanXShortcuts(2),
-    workflowQuestionHasOneOrLessImages
+    workflowNotTooManyShortcuts: workflowHasNoMoreThanXShortcuts(2)
   },
   drawing: {
     taskFeedbackDisabled,

--- a/app/pages/lab/mobile/mobile-section-container.spec.js
+++ b/app/pages/lab/mobile/mobile-section-container.spec.js
@@ -129,11 +129,6 @@ describe('<MobileSectionContainer />', function () {
       testValidationProp('drawingTaskHasNoSubtasks', validationFixtures.drawingTaskHasNoSubtasks, true);
       testValidationProp('drawingTaskHasNoSubtasks', validationFixtures.drawingTaskHasSubtasks, false);
     });
-
-    it('should check whether workflow question has one image', function () {
-      testValidationProp('workflowQuestionHasOneOrLessImages', validationFixtures.questionHasOneImage, true, true);
-      testValidationProp('workflowQuestionHasOneOrLessImages', validationFixtures.questionHasTwoImages, false, true);
-    });
   });
 
   describe('enabled prop', function () {

--- a/app/pages/lab/mobile/mobile-section.jsx
+++ b/app/pages/lab/mobile/mobile-section.jsx
@@ -20,7 +20,6 @@ counterpart.registerTranslations('en', {
       workflowNotTooManyShortcuts: 'Has less than three shortcuts',
       workflowDoesNotContainShortcuts: 'Has no shortcuts',
       taskFeedbackDisabled: 'Cannot provide feedback',
-      workflowQuestionHasOneOrLessImages: 'Task question has no more than one image',
       drawingToolTypeIsValid: 'Drawing tool must be a rectangle tool',
       drawingTaskHasOneTool: 'Drawing task must have only 1 tool',
       drawingTaskHasNoSubtasks: 'Drawing tool must not have any subtasks'
@@ -129,10 +128,6 @@ class MobileSection extends Component {
               <Translate content={`mobileSection.${helpTextKey}`} component="small" />
             </p>
 
-            {
-              this.props.validations.workflowQuestionHasOneOrLessImages === ValidationValue.warning ? warningView : null
-            }
-
             <ul>
               {map(this.props.validations, renderValidation)}
             </ul>
@@ -162,9 +157,7 @@ class MobileSection extends Component {
 }
 
 MobileSection.propTypes = {
-  validations: PropTypes.shape({
-    workflowQuestionHasOneOrLessImages: PropTypes.string
-  }),
+  validations: PropTypes.shape(),
   enabled: PropTypes.bool,
   toggleChecked: PropTypes.func,
   checked: PropTypes.bool


### PR DESCRIPTION
Staging branch URL: https://pr-5630.pfe-preview.zooniverse.org

Describe your changes.
A volunteer recently brought up [on Talk](https://www.zooniverse.org/talk/18/1238480) that we still have validations in the lab for a mobile task to only have one image tasks (no multi-image workflow). This was originally a validation in early iterations of the app; however, the drawing tool allowed multi-image workflows. 

The [mobile validations](https://github.com/zooniverse/mobile/blob/a8ca98fa3e567b0ab2e733352d5afe66f9272d07/src/utils/workflow-utils.js#L27) also make no reference to a workflow having one image tasks. The `SwipeClassifier` is also capable of showing the mobile app's [version of the filmstrip viewer](https://github.com/zooniverse/mobile/blob/282603301f9260d956e6771fcb02bf3c7c46d02e/src/components/classifier/SwipeCardSubjectsView.js#L56) when multiple subjects are present.

You can test this out on this PR by navigating to a question workflow with multiple subjects and marking that subject mobile friendly. You should then be able to open the staging version of the app and enter that workflow.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
