### PR TITLE
Fail gracefully when Google Analytics is not available

### DIFF
--- a/app/lib/ga-log-adapter.js
+++ b/app/lib/ga-log-adapter.js
@@ -40,13 +40,15 @@ class GALogAdapter {
 
   initializeGA() {
     // initialize the google analytics object with the tracking code
-    const tracker = this.gaLayer.getAll()[0];
-    const code = tracker.get('trackingId');
-    this.gaLayer('create', code, 'auto');
+    const tracker = this.gaLayer && this.gaLayer.getAll()[0];
+    if (tracker) {
+      const code = tracker.get('trackingId');
+      this.gaLayer('create', code, 'auto');
 
-    // send any analytics messages we'd been waiting to send
-    this.pending.forEach(params => this.gaLayer.apply(null, params));
-    this.pending = [];
+      // send any analytics messages we'd been waiting to send
+      this.pending.forEach(params => this.gaLayer.apply(null, params));
+      this.pending = [];
+    }
   }
 
   enqueue(...args) {

--- a/app/lib/ga-log-adapter.spec.js
+++ b/app/lib/ga-log-adapter.spec.js
@@ -62,6 +62,24 @@ describe('GALogAdapter', () => {
   });
 
   describe('analytics object lifecycle', () => {
+    it('fails gracefully when GA is not available', () => {
+      const fakeGA = () => null;
+      fakeGA.getAll = () => [];
+
+      const fakeWindow = {};
+
+      const adapter = new GALogAdapter(fakeWindow, 'ga');
+
+      adapter.logEvent({ type: 'testMessage' });
+
+      fakeWindow.ga = fakeGA;
+
+      adapter.pending = [];
+      adapter.logEvent({ type: 'testMessage' });
+
+      assert.equal(adapter.pending.length, 0);
+    });
+
     it('initializes the analytics object the first time it sees one', () => {
       const fakeTracker = { get: () => 'UA-AAAA-AA' };
       const fakeGA = () => null;


### PR DESCRIPTION
Staging branch URL: https://pr-5639.pfe-preview.zooniverse.org

Fixes #5638.

Add a test for the case where Google Analytics is not available.
Check for the existence of the Google tracker before getting a code and logging an event.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
