### PR TITLE
Add the transcription line for admins

### DIFF
--- a/app/classifier/drawing-tools/index.coffee
+++ b/app/classifier/drawing-tools/index.coffee
@@ -19,3 +19,4 @@ module.exports =
   rotateRectangle: require('./rotate-rectangle').default
   triangle: require './triangle'
   pointGrid: require('./point-grid').default
+  transcriptionLine: require './line'

--- a/app/classifier/tasks/generic-editor.cjsx
+++ b/app/classifier/tasks/generic-editor.cjsx
@@ -8,6 +8,7 @@ alert = require('../../lib/alert').default
 DrawingTaskDetailsEditor = require './drawing-task-details-editor'
 NextTaskSelector = require './next-task-selector'
 {MarkdownEditor, MarkdownHelp} = require 'markdownz'
+isAdmin = require '../../lib/is-admin'
 
 # `import MinMaxEditor from './drawing/min-max-editor';`
 MinMaxEditor = require('./drawing/min-max-editor').default
@@ -145,7 +146,7 @@ module.exports = createReactClass
                         Type{' '}
                         <select name="#{@props.taskPrefix}.#{choicesKey}.#{index}.type" value={choice.type} onChange={handleChange}>
                           {for toolKey of drawingTools
-                            <option key={toolKey} value={toolKey}>{toolKey}</option> unless toolKey in ["grid", "freehandLine", "freehandShape", "freehandSegmentLine", "freehandSegmentShape", "anchoredEllipse", "fan"]}
+                            <option key={toolKey} value={toolKey}>{toolKey}</option> unless toolKey in ["grid", "freehandLine", "freehandShape", "freehandSegmentLine", "freehandSegmentShape", "anchoredEllipse", "fan", "transcriptionLine"]}
                           {if @canUse("grid")
                             <option key="grid" value="grid">grid</option>}
                           {if @canUse("freehandLine")
@@ -160,6 +161,8 @@ module.exports = createReactClass
                             <option key="anchoredEllipse" value="anchoredEllipse">anchored ellipse</option>}
                           {if @canUse("fan")
                             <option key="fan" value="fan">fan tool</option>}
+                          {if isAdmin()
+                            <option key="transcriptionLine" value="transcriptionLine">transcription line</option>}
                         </select>
                       </AutoSave>
                     </div>


### PR DESCRIPTION
Add transcriptionLine to the list of drawing tools.
Show it in the lab options in admin mode.

Staging branch URL: https://pr-5640.pfe-preview.zooniverse.org

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
