### PR TITLE
Bind video event handlers properly

### DIFF
--- a/app/components/file-viewer/video-player.jsx
+++ b/app/components/file-viewer/video-player.jsx
@@ -7,6 +7,7 @@ class VideoPlayer extends React.Component {
 
     this.player = null;
 
+    this.endVideo = this.endVideo.bind(this);
     this.playVideo = this.playVideo.bind(this);
     this.setPlayRate = this.setPlayRate.bind(this);
 
@@ -28,13 +29,14 @@ class VideoPlayer extends React.Component {
     this.setState({ playbackRate: parseFloat(e.target.value) });
   }
 
-  playVideo(playing) {
+  playVideo() {
     const { player } = this;
+    const { playing } = this.state
     if (!player) return;
 
-    this.setState({ playing });
+    this.setState({ playing: !playing });
 
-    if (playing) {
+    if (!playing) {
       player.play();
     } else {
       player.pause();
@@ -76,7 +78,7 @@ class VideoPlayer extends React.Component {
           type={`${this.props.type}/${this.props.format}`}
           preload="auto"
           onCanPlay={this.props.onLoad}
-          onClick={this.playVideo.bind(this, !this.state.playing)}
+          onClick={this.playVideo}
           onEnded={this.endVideo}
         >
           Your browser does not support the video format. Please upgrade your browser.


### PR DESCRIPTION
Bind the video player event handlers so that `this` is defined. Refactor `playVideo` so that it is only bound once.

Staging branch URL: https://pr-5661.pfe-preview.zooniverse.org

Fixes #5570.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
