### PR TITLE
Add a featured project editor to the Projects page

### DIFF
--- a/app/pages/admin/project-status-list.jsx
+++ b/app/pages/admin/project-status-list.jsx
@@ -7,20 +7,15 @@ import ProjectIcon from '../../components/project-icon';
 import Paginator from '../../talk/lib/paginator';
 import SearchSelector from '../projects/projects-search-selector';
 
-function navigateToProject(option) {
-  const projectUrl = option.value;
-  if (projectUrl.match(/^http.*/)) {
-    window.location.assign(projectUrl);
-  } else {
-    browserHistory.push(['/admin/project_status', projectUrl].join('/'));
-  }
+function navigateToProject(project) {
+  const { slug } = project;
+  browserHistory.push(['/admin/project_status', slug].join('/'));
 }
 
-function renderProjectListItem(project) {
-  const [owner, name] = project.slug.split('/');
+function ProjectListItem({ project }) {
   return (
     <div key={project.id}>
-      <ProjectIcon linkTo={`/admin/project_status/${owner}/${name}`} project={project} />
+      <ProjectIcon linkTo={`/admin/project_status/${project.slug}`} project={project} />
     </div>
   );
 }
@@ -78,7 +73,7 @@ class ProjectStatusList extends Component {
       (
         <div>
           <div className="project-status-list">
-            {projects.map(project => renderProjectListItem(project))}
+            {projects.map(project => <ProjectListItem key={project.id} project={project} />)}
           </div>
           <Paginator page={meta.page} pageCount={meta.page_count} />
         </div>

--- a/app/pages/projects/featured-project-editor.jsx
+++ b/app/pages/projects/featured-project-editor.jsx
@@ -25,10 +25,11 @@ export default class FeaturedProjectEditor extends Component {
   }
 
   selectProject(project) {
-    console.log(project)
-    this.props.project.update({ featured: false }).save();
-    project.update({ featured: true }).save();
-    this.setState({ editing: false, project });
+    if (project.launch_approved) {
+      this.props.project.update({ featured: false }).save();
+      project.update({ featured: true }).save();
+      this.setState({ editing: false, project });
+    }
   }
 
   render() {
@@ -44,7 +45,7 @@ export default class FeaturedProjectEditor extends Component {
             {editing && 
               <>
                 <button autoFocus className="outlined-button" onClick={this.disableEditor}>cancel</button>
-                <ProjectsSearchSelector onChange={this.selectProject} />
+                <ProjectsSearchSelector launchApproved onChange={this.selectProject} />
               </>
             }
           </div>

--- a/app/pages/projects/featured-project-editor.jsx
+++ b/app/pages/projects/featured-project-editor.jsx
@@ -1,0 +1,57 @@
+import apiClient from 'panoptes-client/lib/api-client';
+import React, { cloneElement, Component } from 'react';
+import ProjectsSearchSelector from './projects-search-selector';
+import isAdmin from '../../lib/is-admin';
+
+
+export default class FeaturedProjectEditor extends Component {
+  constructor(props) {
+    super(props)
+    this.disableEditor = this.disableEditor.bind(this);
+    this.enableEditor = this.enableEditor.bind(this);
+    this.selectProject = this.selectProject.bind(this);
+    this.state = {
+      editing: false,
+      project: props.project
+    };
+  }
+
+  disableEditor() {
+    this.setState({ editing: false });
+  }
+
+  enableEditor() {
+    this.setState({ editing: true });
+  }
+
+  selectProject(project) {
+    console.log(project)
+    this.props.project.update({ featured: false }).save();
+    project.update({ featured: true }).save();
+    this.setState({ editing: false, project });
+  }
+
+  render() {
+    const { children } = this.props;
+    const { editing, project } = this.state;
+    const canEdit = isAdmin();
+    if (canEdit) {
+      return (
+        <div className="project-card-editor">
+          {cloneElement(children, { project })}
+          <div className="controls">
+            {!editing && <button className="outlined-button" onClick={this.enableEditor}>edit</button>}
+            {editing && 
+              <>
+                <button autoFocus className="outlined-button" onClick={this.disableEditor}>cancel</button>
+                <ProjectsSearchSelector onChange={this.selectProject} />
+              </>
+            }
+          </div>
+        </div>
+      );
+    } else {
+      return children;
+    }
+  }
+}

--- a/app/pages/projects/featured-project-editor.jsx
+++ b/app/pages/projects/featured-project-editor.jsx
@@ -37,6 +37,10 @@ export default class FeaturedProjectEditor extends Component {
     const { children } = this.props;
     const { editing, project } = this.state;
     const canEdit = isAdmin();
+    const options = {
+      launch_approved: true,
+      featured: false
+    };
     if (canEdit) {
       return (
         <div className="project-card-editor">
@@ -46,7 +50,7 @@ export default class FeaturedProjectEditor extends Component {
             {editing && 
               <>
                 <button autoFocus className="outlined-button" onClick={this.disableEditor}>cancel</button>
-                <ProjectsSearchSelector launchApproved onChange={this.selectProject} />
+                <ProjectsSearchSelector options={options} onChange={this.selectProject} />
               </>
             }
           </div>

--- a/app/pages/projects/featured-project-editor.jsx
+++ b/app/pages/projects/featured-project-editor.jsx
@@ -25,8 +25,9 @@ export default class FeaturedProjectEditor extends Component {
   }
 
   selectProject(project) {
+    const currentProject = this.state.project;
     if (project.launch_approved) {
-      this.props.project.update({ featured: false }).save();
+      currentProject.update({ featured: false }).save();
       project.update({ featured: true }).save();
       this.setState({ editing: false, project });
     }

--- a/app/pages/projects/project-filtering-interface.jsx
+++ b/app/pages/projects/project-filtering-interface.jsx
@@ -138,7 +138,10 @@ class ProjectFilteringInterface extends Component {
 
   render() {
     const { discipline, sort } = this.props;
-    const launchApproved = !apiClient.params.admin ? true : undefined;
+    const launch_approved = !apiClient.params.admin ? true : undefined;
+    const options = {
+      launch_approved
+    }
     return (
       <section className="resources-container">
         <Filmstrip
@@ -147,7 +150,7 @@ class ProjectFilteringInterface extends Component {
           onChange={this.handleDisciplineChange}
         />
         <div className="resource-results-counter">
-          <SearchSelector launchApproved={launchApproved} />
+          <SearchSelector options={options} />
           <SortSelector value={sort} onChange={this.handleSortChange} />
         </div>
         {this.renderCounter()}

--- a/app/pages/projects/project-filtering-interface.jsx
+++ b/app/pages/projects/project-filtering-interface.jsx
@@ -138,6 +138,7 @@ class ProjectFilteringInterface extends Component {
 
   render() {
     const { discipline, sort } = this.props;
+    const launchApproved = !apiClient.params.admin ? true : undefined;
     return (
       <section className="resources-container">
         <Filmstrip
@@ -146,7 +147,7 @@ class ProjectFilteringInterface extends Component {
           onChange={this.handleDisciplineChange}
         />
         <div className="resource-results-counter">
-          <SearchSelector />
+          <SearchSelector launchApproved={launchApproved} />
           <SortSelector value={sort} onChange={this.handleSortChange} />
         </div>
         {this.renderCounter()}

--- a/app/pages/projects/projects-search-selector.jsx
+++ b/app/pages/projects/projects-search-selector.jsx
@@ -12,8 +12,10 @@ class SearchSelector extends Component {
   }
 
   onChange(option) {
-    const onChange = this.props.onChange || this.navigateToProject;
-    onChange(option.value);
+    if (option) {
+      const onChange = this.props.onChange || this.navigateToProject;
+      onChange(option.value);
+    }
   }
 
   navigateToProject(project) {

--- a/app/pages/projects/projects-search-selector.jsx
+++ b/app/pages/projects/projects-search-selector.jsx
@@ -26,10 +26,11 @@ class SearchSelector extends Component {
   }
 
   searchByName(value) {
+    const launch_approved = this.props.launchApproved;
     const query = {
       search: `%${value}%`,
       cards: true,
-      launch_approved: !apiClient.params.admin ? true : undefined
+      launch_approved
     };
     if ((value != null ? value.trim().length : undefined) > 3) {
       return apiClient.type('projects').get(query, {

--- a/app/pages/projects/projects-search-selector.jsx
+++ b/app/pages/projects/projects-search-selector.jsx
@@ -11,6 +11,11 @@ class SearchSelector extends Component {
     this.searchByName = this.searchByName.bind(this);
   }
 
+  onChange(option) {
+    const onChange = this.props.onChange || this.navigateToProject;
+    onChange(option.value);
+  }
+
   navigateToProject(project) {
     const { redirect, slug } = project;
     if (redirect) {
@@ -20,22 +25,17 @@ class SearchSelector extends Component {
     }
   }
 
-  onChange(option) {
-    const onChange = this.props.onChange || this.navigateToProject;
-    onChange(option.value);
-  }
-
   searchByName(value) {
-    const launch_approved = this.props.launchApproved;
+    const { options } = this.props;
     const query = {
       search: `%${value}%`,
       cards: true,
-      launch_approved
+      ...options
     };
     if ((value != null ? value.trim().length : undefined) > 3) {
       return apiClient.type('projects').get(query, {
         page_size: 10
-      }).then(projects => {
+      }).then((projects) => {
         const opts = projects.map(project => ({
           value: project,
           label: project.display_name
@@ -67,12 +67,14 @@ class SearchSelector extends Component {
 
 SearchSelector.propTypes = {
   className: PropTypes.string,
-  onChange: PropTypes.func
+  onChange: PropTypes.func,
+  options: PropTypes.shape({})
 };
 
 SearchSelector.defaultProps = {
   className: '',
-  onChange: null
+  onChange: undefined,
+  options: {}
 };
 
 export default SearchSelector;

--- a/app/pages/projects/projects-search-selector.jsx
+++ b/app/pages/projects/projects-search-selector.jsx
@@ -7,17 +7,22 @@ import Select from 'react-select';
 class SearchSelector extends Component {
   constructor(props) {
     super(props);
-    this.navigateToProject = this.navigateToProject.bind(this);
+    this.onChange = this.onChange.bind(this);
     this.searchByName = this.searchByName.bind(this);
   }
 
-  navigateToProject(option) {
-    const projectUrl = option.value;
-    if (projectUrl.match(/^http.*/)) {
-      window.location.assign(projectUrl);
+  navigateToProject(project) {
+    const { redirect, slug } = project;
+    if (redirect) {
+      window.location.assign(redirect);
     } else {
-      browserHistory.push(['/projects', projectUrl].join('/'));
+      browserHistory.push(['/projects', slug].join('/'));
     }
+  }
+
+  onChange(option) {
+    const onChange = this.props.onChange || this.navigateToProject;
+    onChange(option.value);
   }
 
   searchByName(value) {
@@ -31,7 +36,7 @@ class SearchSelector extends Component {
         page_size: 10
       }).then(projects => {
         const opts = projects.map(project => ({
-          value: project.redirect || project.slug,
+          value: project,
           label: project.display_name
         }));
         return { options: opts };
@@ -42,7 +47,7 @@ class SearchSelector extends Component {
   }
 
   render() {
-    const { className, onChange } = this.props;
+    const { className } = this.props;
 
     return (
       <Select.Async
@@ -52,7 +57,7 @@ class SearchSelector extends Component {
         value=""
         searchPromptText="Search by name"
         loadOptions={this.searchByName}
-        onChange={onChange || this.navigateToProject}
+        onChange={this.onChange}
         className={`search card-search standard-input ${className}`}
       />
     );

--- a/app/pages/projects/projects-welcome.jsx
+++ b/app/pages/projects/projects-welcome.jsx
@@ -19,7 +19,7 @@ class ProjectsWelcome extends Component {
   }
 
   getFeaturedProjects() {
-    const query = { featured: true, launch_approved: true, cards: true };
+    const query = { featured: true, cards: true };
     return apiClient.type('projects').get(query)
       .then((featuredProjects) => {
         this.setState({ featuredProjects });

--- a/app/pages/projects/projects-welcome.jsx
+++ b/app/pages/projects/projects-welcome.jsx
@@ -3,7 +3,8 @@ import { Markdown } from 'markdownz';
 import apiClient from 'panoptes-client/lib/api-client';
 import React, { Component } from 'react';
 import Translate from 'react-translate-component';
-import ProjectCardList from './project-card-list';
+import FeaturedProjectEditor from './featured-project-editor';
+import ProjectCard from '../../partials/project-card';
 
 class ProjectsWelcome extends Component {
   constructor() {
@@ -30,7 +31,13 @@ class ProjectsWelcome extends Component {
         <Translate content="projects.welcome.heading" component="h2" />
         <Translate content="projects.welcome.thanks" component="p" />
         <Markdown>{counterpart('projects.welcome.talk')}</Markdown>
-        <ProjectCardList projects={this.state.featuredProjects} />
+        <div className="project-card-list">
+          {this.state.featuredProjects.map(project =>
+            <FeaturedProjectEditor key={project.id} project={project}>
+              <ProjectCard project={project} />
+            </FeaturedProjectEditor>
+          )}
+        </div>
         <p><Translate content="projects.welcome.scrollDown" component="em" /></p>
       </div>
     );

--- a/css/project-card.styl
+++ b/css/project-card.styl
@@ -27,3 +27,11 @@
 
     .description
       margin: 0.8em 0
+
+.project-card-editor
+  position: relative
+
+  .controls
+    position: absolute
+    top: 5px
+    right: 10px

--- a/css/project-card.styl
+++ b/css/project-card.styl
@@ -30,6 +30,7 @@
 
 .project-card-editor
   position: relative
+  text-align: right
 
   .controls
     position: absolute


### PR DESCRIPTION
 - Adds a FeaturedProjectEditor, which wraps a featured project card and allows admins to edit it with the project search selector.
 - adds an optional onChange prop to the project search selector, so that we can override the default link navigation behaviour.
- adds an options prop to the project search selector, which can be used to pass query options for filtered searches.
- updates the admin project search to use the new search selector.

Staging branch URL: https://pr-5667.pfe-preview.zooniverse.org/projects

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
