### PR TITLE
Allow Admin to Search Project on Status Page

### DIFF
--- a/app/pages/admin/project-status-list.jsx
+++ b/app/pages/admin/project-status-list.jsx
@@ -16,12 +16,20 @@ function navigateToProject(option) {
   }
 }
 
+function renderProjectListItem(project) {
+  const [owner, name] = project.slug.split('/');
+  return (
+    <div key={project.id}>
+      <ProjectIcon linkTo={`/admin/project_status/${owner}/${name}`} project={project} />
+    </div>
+  );
+}
+
 class ProjectStatusList extends Component {
   constructor(props) {
     super(props);
     this.getProjects = this.getProjects.bind(this);
     this.renderProjectList = this.renderProjectList.bind(this);
-    this.renderProjectListItem = this.renderProjectListItem.bind(this);
     this.state = {
       loading: false,
       projects: [],
@@ -66,23 +74,15 @@ class ProjectStatusList extends Component {
       meta = projects[0].getMeta();
     }
 
-    return (projects.length === 0)
-      ? <div className="project-status-list">No projects found for this filter</div>
-      : <div>
+    return (projects.length === 0) ? <div className="project-status-list">No projects found for this filter</div> :
+      (
+        <div>
           <div className="project-status-list">
-            {projects.map(project => this.renderProjectListItem(project))}
+            {projects.map(project => renderProjectListItem(project))}
           </div>
           <Paginator page={meta.page} pageCount={meta.page_count} />
         </div>
-  }
-
-  renderProjectListItem(project) {
-    const [owner, name] = project.slug.split('/');
-    return (
-      <div key={project.id}>
-        <ProjectIcon linkTo={`/admin/project_status/${owner}/${name}`} project={project} />
-      </div>
-    );
+      );
   }
 
   render() {

--- a/app/pages/admin/project-status-list.jsx
+++ b/app/pages/admin/project-status-list.jsx
@@ -1,9 +1,19 @@
 import React, { Component } from 'react';
-import { Link } from 'react-router';
+import { browserHistory, Link } from 'react-router';
 import apiClient from 'panoptes-client/lib/api-client';
 import LoadingIndicator from '../../components/loading-indicator';
 import ProjectIcon from '../../components/project-icon';
 import Paginator from '../../talk/lib/paginator';
+import SearchSelector from '../projects/projects-search-selector';
+
+function navigateToProject(option) {
+  const projectUrl = option.value;
+  if (projectUrl.match(/^http.*/)) {
+    window.location.assign(projectUrl);
+  } else {
+    browserHistory.push(['/admin/project_status', projectUrl].join('/'));
+  }
+}
 
 class ProjectStatusList extends Component {
   constructor(props) {
@@ -76,6 +86,7 @@ class ProjectStatusList extends Component {
   render() {
     return (
       <div className="project-status-page">
+        <SearchSelector onChange={navigateToProject} />
         <nav className="project-status-filters">
           <Link to="/admin/project_status">All</Link>
           <Link to="/admin/project_status?filterBy=launch_approved">Launch Approved</Link>

--- a/app/pages/admin/project-status-list.jsx
+++ b/app/pages/admin/project-status-list.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { browserHistory, Link } from 'react-router';
 import apiClient from 'panoptes-client/lib/api-client';
+import PropTypes from 'prop-types';
 import LoadingIndicator from '../../components/loading-indicator';
 import ProjectIcon from '../../components/project-icon';
 import Paginator from '../../talk/lib/paginator';
@@ -33,7 +34,8 @@ class ProjectStatusList extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    if (prevProps.location.query !== this.props.location.query) {
+    const { query } = this.props.location;
+    if (prevProps.location.query !== query) {
       this.getProjects();
     }
   }
@@ -84,6 +86,8 @@ class ProjectStatusList extends Component {
   }
 
   render() {
+    const { error, loading } = this.state;
+
     return (
       <div className="project-status-page">
         <SearchSelector onChange={navigateToProject} />
@@ -94,11 +98,21 @@ class ProjectStatusList extends Component {
           <Link to="/admin/project_status?filterBy=beta_approved">Beta Approved</Link>
           <Link to="/admin/project_status?filterBy=beta_requested">Beta Requested</Link>
         </nav>
-        {(this.state.error) ? <p>{this.state.error}</p> : null}
-        {(this.state.loading) ? <LoadingIndicator /> : this.renderProjectList()}
+        {(error) ? <p>{error}</p> : null}
+        {(loading) ? <LoadingIndicator /> : this.renderProjectList()}
       </div>
     );
   }
 }
+
+ProjectStatusList.propTypes = {
+  location: PropTypes.shape({
+    query: PropTypes.shape()
+  })
+};
+
+ProjectStatusList.defaultProps = {
+  location: {}
+};
 
 export default ProjectStatusList;

--- a/app/pages/admin/project-status-list.jsx
+++ b/app/pages/admin/project-status-list.jsx
@@ -34,14 +34,14 @@ class ProjectStatusList extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { query } = this.props.location;
+    const { location: { query }} = this.props;
     if (prevProps.location.query !== query) {
       this.getProjects();
     }
   }
 
   getProjects() {
-    const { query } = this.props.location;
+    const { location: { query }} = this.props;
 
     const projectsQuery = {
       include: 'avatar',

--- a/app/pages/admin/project-status-list.jsx
+++ b/app/pages/admin/project-status-list.jsx
@@ -90,7 +90,7 @@ class ProjectStatusList extends Component {
 
     return (
       <div className="project-status-page">
-        <SearchSelector onChange={navigateToProject} />
+        <SearchSelector className="project-status-search" onChange={navigateToProject} />
         <nav className="project-status-filters">
           <Link to="/admin/project_status">All</Link>
           <Link to="/admin/project_status?filterBy=launch_approved">Launch Approved</Link>

--- a/app/pages/projects/projects-search-selector.jsx
+++ b/app/pages/projects/projects-search-selector.jsx
@@ -42,6 +42,8 @@ class SearchSelector extends Component {
   }
 
   render() {
+    const { onChange } = this.props
+
     return (
       <Select.Async
         multi={false}
@@ -50,7 +52,7 @@ class SearchSelector extends Component {
         value=""
         searchPromptText="Search by name"
         loadOptions={this.searchByName}
-        onChange={this.navigateToProject}
+        onChange={onChange || this.navigateToProject}
         className="search card-search standard-input"
       />
     );
@@ -59,6 +61,11 @@ class SearchSelector extends Component {
 
 SearchSelector.propTypes = {
   onChange: PropTypes.func,
+  query: PropTypes.func,
+};
+
+SearchSelector.defaultProps = {
+  onChange: null,
   query: PropTypes.func,
 };
 

--- a/app/pages/projects/projects-search-selector.jsx
+++ b/app/pages/projects/projects-search-selector.jsx
@@ -22,13 +22,13 @@ class SearchSelector extends Component {
 
   searchByName(value) {
     const query = {
-      search: '%' + value + '%',
+      search: `%${value}%`,
       cards: true,
-      launch_approved: !apiClient.params.admin ? true : undefined,
+      launch_approved: !apiClient.params.admin ? true : undefined
     };
     if ((value != null ? value.trim().length : undefined) > 3) {
       return apiClient.type('projects').get(query, {
-        page_size: 10,
+        page_size: 10
       }).then(projects => {
         const opts = projects.map(project => ({
           value: project.redirect || project.slug,
@@ -42,7 +42,7 @@ class SearchSelector extends Component {
   }
 
   render() {
-    const { onChange } = this.props
+    const { onChange } = this.props;
 
     return (
       <Select.Async
@@ -60,13 +60,11 @@ class SearchSelector extends Component {
 }
 
 SearchSelector.propTypes = {
-  onChange: PropTypes.func,
-  query: PropTypes.func,
+  onChange: PropTypes.func
 };
 
 SearchSelector.defaultProps = {
-  onChange: null,
-  query: PropTypes.func,
+  onChange: null
 };
 
 export default SearchSelector;

--- a/app/pages/projects/projects-search-selector.jsx
+++ b/app/pages/projects/projects-search-selector.jsx
@@ -42,7 +42,7 @@ class SearchSelector extends Component {
   }
 
   render() {
-    const { onChange } = this.props;
+    const { className, onChange } = this.props;
 
     return (
       <Select.Async
@@ -53,17 +53,19 @@ class SearchSelector extends Component {
         searchPromptText="Search by name"
         loadOptions={this.searchByName}
         onChange={onChange || this.navigateToProject}
-        className="search card-search standard-input"
+        className={`search card-search standard-input ${className}`}
       />
     );
   }
 }
 
 SearchSelector.propTypes = {
+  className: PropTypes.string,
   onChange: PropTypes.func
 };
 
 SearchSelector.defaultProps = {
+  className: '',
   onChange: null
 };
 

--- a/css/admin-page.styl
+++ b/css/admin-page.styl
@@ -3,6 +3,9 @@
     &__section
       margin: 1em 0
 
+      &-search
+        float: none
+
       &-list
         margin: 0 0 1em 0
 

--- a/css/admin-page.styl
+++ b/css/admin-page.styl
@@ -1,10 +1,11 @@
 .admin-page
+  .project-status-search
+    float: none
+    margin: 2em
+
   .project-status
     &__section
       margin: 1em 0
-
-      &-search
-        float: none
 
       &-list
         margin: 0 0 1em 0


### PR DESCRIPTION
Staging branch URL: https://pr-5669.pfe-preview.zooniverse.org

Describe your changes.
This PR adds a search box to the admin "set project status" page as it's always a bit tricky to find a project on that view. Clicking on a project from the search box navigates directly to the status page.

<img width="730" alt="Screen Shot 2020-04-01 at 1 48 00 PM" src="https://user-images.githubusercontent.com/14099077/78174830-8311a000-741f-11ea-9d1a-9e2cf7bb5d8d.png">

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
