### PR TITLE
Remove duplicates from the upcoming queue on append

### DIFF
--- a/app/redux/ducks/classify.js
+++ b/app/redux/ducks/classify.js
@@ -185,8 +185,10 @@ export default function reducer(state = initialState, action = {}) {
       const { subjects, workflowID } = action.payload;
       const { workflow } = state;
       if (workflow && workflow.id === workflowID) {
-        const upcomingSubjects = state.upcomingSubjects.slice();
-        upcomingSubjects.push(...subjects);
+        const newSubjects = state.upcomingSubjects.slice();
+        newSubjects.push(...subjects);
+        // remove duplicates from the upcoming queue by keeping the first instance of each subject.
+        const upcomingSubjects = newSubjects.filter((subject, index) => index === newSubjects.indexOf(subject));
         return Object.assign({}, state, { upcomingSubjects });
       }
       return state;

--- a/app/redux/ducks/classify.spec.js
+++ b/app/redux/ducks/classify.spec.js
@@ -196,6 +196,14 @@ describe('Classifier actions', function () {
       const newState = reducer(state, action);
       expect(newState.upcomingSubjects).to.deep.equal(action.payload.subjects);
     });
+    it('should not add duplicate subjects to the queue', function () {
+      const state = {
+        workflow: { id: '1'},
+        upcomingSubjects: [subjects[0], subjects[1], subjects[2]]
+      };
+      const newState = reducer(state, action);
+      expect(newState.upcomingSubjects).to.deep.equal([subjects[0], subjects[1], subjects[2], subjects[3]]);
+    });
   });
   describe('prepend subjects', function () {
     const subjects = [


### PR DESCRIPTION
- Add a test to check that existing subjects are not added to the subject queue on append.
- Update the `append` action to pass the test by deduping the upcoming subjects array.

Staging branch URL: https://pr-5671.pfe-preview.zooniverse.org

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
