### PR TITLE
use new router api for history navigation

### DIFF
--- a/app/router.cjsx
+++ b/app/router.cjsx
@@ -65,7 +65,7 @@ ONE_UP_REDIRECT = createReactClass
     givenPathSegments = @props.location.pathname.split '/'
     givenPathSegments.pop()
     pathOneLevelUp = givenPathSegments.join '/'
-    @props.history.replace
+    @props.router.replace
       pathname: pathOneLevelUp,
       query: @props.location.query
 


### PR DESCRIPTION
fix the home redirect route by using the v3 version of router history manipulation, https://github.com/ReactTraining/react-router/blob/v3/docs/API.md#router-1

Staging branch URL: https://pr-5685.pfe-preview.zooniverse.org

Fixes a bug report from twitter https://twitter.com/clmcavaney/status/1250575570850603009.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
