### PR TITLE
Edit project home talk rtl translations

### DIFF
--- a/app/locales/ar.js
+++ b/app/locales/ar.js
@@ -68,9 +68,9 @@ export default {
         subjects: 'Subjects'
       },
       talk: {
-        zero: 'No one is talking about <strong>%(title)s</strong> right now.',
-        one: '<strong>1</strong> person is talking about <strong>%(title)s</strong> right now.',
-        other: '<strong>%(count)s</strong> people are talking about <strong>%(title)s</strong> right now.'
+        zero: 'No one is talking about %(title)s right now',
+        one: '1 person is talking about %(title)s right now',
+        other: '%(count)s people are talking about %(title)s right now'
       },
       joinIn: 'Join in',
       learnMore: 'Learn more',

--- a/app/locales/ar.js
+++ b/app/locales/ar.js
@@ -68,9 +68,9 @@ export default {
         subjects: 'Subjects'
       },
       talk: {
-        zero: 'No one is talking about %(title)s right now',
-        one: '1 person is talking about %(title)s right now',
-        other: '%(count)s people are talking about %(title)s right now'
+        zero: 'No one is talking about **%(title)s** right now.',
+        one: '**1** person is talking about **%(title)s** right now.',
+        other: '**%(count)s** people are talking about **%(title)s** right now.'
       },
       joinIn: 'Join in',
       learnMore: 'Learn more',

--- a/app/locales/he.js
+++ b/app/locales/he.js
@@ -68,9 +68,9 @@ export default {
         subjects: 'Subjects'
       },
       talk: {
-        zero: 'No one is talking about <strong>%(title)s</strong> right now.',
-        one: '<strong>1</strong> person is talking about <strong>%(title)s</strong> right now.',
-        other: '<strong>%(count)s</strong> people are talking about <strong>%(title)s</strong> right now.'
+        zero: 'No one is talking about %(title)s right now',
+        one: '1 person is talking about %(title)s right now',
+        other: '%(count)s people are talking about %(title)s right now'
       },
       joinIn: 'Join in',
       learnMore: 'Learn more',

--- a/app/locales/he.js
+++ b/app/locales/he.js
@@ -68,9 +68,9 @@ export default {
         subjects: 'Subjects'
       },
       talk: {
-        zero: 'No one is talking about %(title)s right now',
-        one: '1 person is talking about %(title)s right now',
-        other: '%(count)s people are talking about %(title)s right now'
+        zero: 'No one is talking about **%(title)s** right now.',
+        one: '**1** person is talking about **%(title)s** right now.',
+        other: '**%(count)s** people are talking about **%(title)s** right now.'
       },
       joinIn: 'Join in',
       learnMore: 'Learn more',


### PR DESCRIPTION
Staging branch URL: https://pr-5702.pfe-preview.zooniverse.org

The project home page talk section (`project.home.talk` strings) has an issue with `<strong>` when translated right-to-left: https://www.zooniverse.org/projects/markbouslog/test-project-mb?language=he

Describe your changes.
- replaced `<strong>` with `**`, see: https://pr-5702.pfe-preview.zooniverse.org/projects/markbouslog/test-project-mb?language=he

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
