### PR TITLE
Add translation for Field Guide toggle

### DIFF
--- a/app/locales/ar.js
+++ b/app/locales/ar.js
@@ -28,6 +28,7 @@ export default {
   project: {
     loading: 'Loading project',
     disclaimer: 'This project has been built using the Zooniverse Project Builder but is not yet an official Zooniverse project. Queries and issues relating to this project directed at the Zooniverse Team may not receive any response.',
+    fieldGuide: 'Field Guide',
     about: {
       header: 'About',
       nav: {

--- a/app/locales/cs.js
+++ b/app/locales/cs.js
@@ -33,6 +33,7 @@ export default {
     language: 'Jazyk',
     loading: 'Projekt se načítá',
     disclaimer: 'Tento projekt byl vybudován za pomoci aplikace Zooniverse Project Builder, ale zatím není oficiálním projektem Zooniverse. Dotazy a připomínky týkající se tohoto projektu směřované na tým Zooniverse se nemusí dočkat odezvy.',
+    fieldGuide: 'Field Guide',
     about: {
       header: 'O projektu',
       nav: {

--- a/app/locales/de.js
+++ b/app/locales/de.js
@@ -30,6 +30,7 @@ export default {
     language: 'Sprache',
     loading: 'Projekt wird geladen',
     disclaimer: 'Dieses Projekt wurde mit dem Zooniverse Project Builder gebaut, ist aber derzeit noch kein offizielles Zooniverse Projekt. Anfragen und Probleme bezüglich dieses Projekts an das Zooniverse Team könnten unbeantwortet bleiben.',
+    fieldGuide: 'Field Guide',
     about: {
       header: 'Über',
       nav: {

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -42,6 +42,7 @@ export default {
     language: 'Language',
     loading: 'Loading project',
     disclaimer: 'This project has been built using the Zooniverse Project Builder but is not yet an official Zooniverse project. Queries and issues relating to this project directed at the Zooniverse Team may not receive any response.',
+    fieldGuide: 'Field Guide',
     about: {
       header: 'About',
       nav: {
@@ -66,7 +67,6 @@ export default {
     },
     classifyPage: {
       dark: 'dark',
-      fieldGuide: 'Field Guide',
       light: 'light',
       title: 'Classify',
       themeToggle: 'Switch to %(theme)s theme'

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -66,6 +66,7 @@ export default {
     },
     classifyPage: {
       dark: 'dark',
+      fieldGuide: 'Field Guide',
       light: 'light',
       title: 'Classify',
       themeToggle: 'Switch to %(theme)s theme'

--- a/app/locales/es.js
+++ b/app/locales/es.js
@@ -30,6 +30,7 @@ export default {
     language: 'Idioma',
     loading: 'Cargando el proyecto',
     disclaimer: 'Este proyecto ha sido construido usando Zooniverse Project Builder, pero todavía no es un proyecto oficial de Zooniverse. Las preguntas y asuntos relacionados con este proyecto dirigidos al equipo de Zooniverse podrían no recibir respuesta.',
+    fieldGuide: 'Field Guide',
     about: {
       header: 'Acerca de',
       nav: {

--- a/app/locales/fr.js
+++ b/app/locales/fr.js
@@ -30,6 +30,7 @@ export default {
     language: 'Langue',
     loading: 'Chargement du projet',
     disclaimer: 'Ce projet a été créé avec le Zooniverse Project Builder mais ce n\'est pas encore un projet officiel de Zooniverse. Les questions et problèmes a propos de ce projet adressés à l\'équipe de Zooniverse peut ne pas recevoir de réponse.',
+    fieldGuide: 'Field Guide',
     about: {
       header: 'À propos',
       nav: {

--- a/app/locales/he.js
+++ b/app/locales/he.js
@@ -52,6 +52,7 @@ export default {
     },
     classifyPage: {
       dark: 'dark',
+      fieldGuide: 'Field Guide',
       light: 'light',
       title: 'Classify',
       themeToggle: 'Switch to %(theme)s theme'

--- a/app/locales/he.js
+++ b/app/locales/he.js
@@ -28,6 +28,7 @@ export default {
   project: {
     loading: 'Loading project',
     disclaimer: 'This project has been built using the Zooniverse Project Builder but is not yet an official Zooniverse project. Queries and issues relating to this project directed at the Zooniverse Team may not receive any response.',
+    fieldGuide: 'Field Guide',
     about: {
       header: 'About',
       nav: {
@@ -52,7 +53,6 @@ export default {
     },
     classifyPage: {
       dark: 'dark',
-      fieldGuide: 'Field Guide',
       light: 'light',
       title: 'Classify',
       themeToggle: 'Switch to %(theme)s theme'

--- a/app/locales/hi.js
+++ b/app/locales/hi.js
@@ -42,6 +42,7 @@ export default {
     language: 'Language',
     loading: 'Loading project',
     disclaimer: 'This project has been built using the Zooniverse Project Builder but is not yet an official Zooniverse project. Queries and issues relating to this project directed at the Zooniverse Team may not receive any response.',
+    fieldGuide: 'Field Guide',
     about: {
       header: 'About',
       nav: {

--- a/app/locales/it.js
+++ b/app/locales/it.js
@@ -33,6 +33,7 @@ export default {
     language: 'Lingua',
     loading: 'Caricamento progetto',
     disclaimer: "Questo progetto è stato creato con il Project Builder di Zooniverse, ma non è ancora un progetto ufficiale. Per questo motivo è possibile che domande su questo progetto dirette al Team Zooniverse non ricevano una risposta.",
+    fieldGuide: 'Field Guide',
     about: {
       header: 'About',
       nav: {

--- a/app/locales/ja.js
+++ b/app/locales/ja.js
@@ -34,6 +34,7 @@ export default {
     language: 'Language',
     loading: 'Loading project',
     disclaimer: 'This project has been built using the Zooniverse Project Builder but is not yet an official Zooniverse project. Queries and issues relating to this project directed at the Zooniverse Team may not receive any response.',
+    fieldGuide: 'Field Guide',
     about: {
       header: 'About',
       nav: {

--- a/app/locales/kn.js
+++ b/app/locales/kn.js
@@ -42,6 +42,7 @@ export default {
     language: 'Language',
     loading: 'Loading project',
     disclaimer: 'This project has been built using the Zooniverse Project Builder but is not yet an official Zooniverse project. Queries and issues relating to this project directed at the Zooniverse Team may not receive any response.',
+    fieldGuide: 'Field Guide',
     about: {
       header: 'About',
       nav: {

--- a/app/locales/ko.js
+++ b/app/locales/ko.js
@@ -42,6 +42,7 @@ export default {
     language: 'Language',
     loading: 'Loading project',
     disclaimer: 'This project has been built using the Zooniverse Project Builder but is not yet an official Zooniverse project. Queries and issues relating to this project directed at the Zooniverse Team may not receive any response.',
+    fieldGuide: 'Field Guide',
     about: {
       header: 'About',
       nav: {

--- a/app/locales/nl.js
+++ b/app/locales/nl.js
@@ -62,6 +62,7 @@ export default {
     language: 'Taal',
     loading: 'Project wordt geladen',
     disclaimer: 'Dit project is gemaakt met de Zooniverse projectbouwer maar nog geen officieel Zooniverse project. Vragen over het project die gestuurd worden aan het Zooniverseteam worden mogelijk niet beantwoord.',
+    fieldGuide: 'Field Guide',
     about: {
       header: 'Over',
       nav: {

--- a/app/locales/pl.js
+++ b/app/locales/pl.js
@@ -34,6 +34,7 @@ export default {
     language: 'Język',
     loading: 'Loading project',
     disclaimer: 'This project has been built using the Zooniverse Project Builder but is not yet an official Zooniverse project. Queries and issues relating to this project directed at the Zooniverse Team may not receive any response.',
+    fieldGuide: 'Field Guide',
     about: {
       header: 'Opis',
       nav: {

--- a/app/locales/pt.js
+++ b/app/locales/pt.js
@@ -33,6 +33,7 @@ export default {
     language: 'Language',
     loading: 'Loading project',
     disclaimer: 'This project has been built using the Zooniverse Project Builder but is not yet an official Zooniverse project. Queries and issues relating to this project directed at the Zooniverse Team may not receive any response.',
+    fieldGuide: 'Field Guide',
     about: {
       header: 'About',
       nav: {

--- a/app/locales/sv.js
+++ b/app/locales/sv.js
@@ -42,6 +42,7 @@ export default {
     language: 'Språk',
     loading: 'Laddar projekt',
     disclaimer: 'Detta projekt har byggs med hjälp av Zooniverse Project Buildermen är ännu något officiellt Zooniverse-project. Frågor och problem som rapporteras till Zooniverse-teamet kanske inte får svar.',
+    fieldGuide: 'Field Guide',
     about: {
       header: 'Om',
       nav: {

--- a/app/locales/zh-cn.js
+++ b/app/locales/zh-cn.js
@@ -34,6 +34,7 @@ export default {
     language: '语言',
     loading: 'Loading project',
     disclaimer: 'This project has been built using the Zooniverse Project Builder but is not yet an official Zooniverse project. Queries and issues relating to this project directed at the Zooniverse Team may not receive any response.',
+    fieldGuide: 'Field Guide',
     about: {
       header: '关于',
       nav: {

--- a/app/locales/zh-tw.js
+++ b/app/locales/zh-tw.js
@@ -34,6 +34,7 @@ export default {
     language: '語言',
     loading: 'Loading project',
     disclaimer: 'This project has been built using the Zooniverse Project Builder but is not yet an official Zooniverse project. Queries and issues relating to this project directed at the Zooniverse Team may not receive any response.',
+    fieldGuide: 'Field Guide',
     about: {
       header: '關於',
       nav: {

--- a/app/pages/project/field-guide-container.jsx
+++ b/app/pages/project/field-guide-container.jsx
@@ -41,7 +41,7 @@ export default class FieldGuideContainer extends React.Component {
         <Pullout className="field-guide-pullout" side="right" open={this.state.revealed}>
           <button type="button" className="field-guide-pullout-toggle" onClick={this.toggleFieldGuide}>
             <strong>
-              <Translate content="project.classifyPage.fieldGuide" />
+              <Translate content="project.fieldGuide" />
             </strong>
           </button>
           <Provider store={this.context.store}>

--- a/app/pages/project/field-guide-container.jsx
+++ b/app/pages/project/field-guide-container.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import Pullout from 'react-pullout';
 import { Provider } from 'react-redux';
 import FieldGuide from './field-guide';
+import Translate from 'react-translate-component';
 import Translations from '../../classifier/translations';
 
 export default class FieldGuideContainer extends React.Component {
@@ -39,7 +40,9 @@ export default class FieldGuideContainer extends React.Component {
       return (
         <Pullout className="field-guide-pullout" side="right" open={this.state.revealed}>
           <button type="button" className="field-guide-pullout-toggle" onClick={this.toggleFieldGuide}>
-            <strong>Field guide</strong>
+            <strong>
+              <Translate content="project.classifyPage.fieldGuide" />
+            </strong>
           </button>
           <Provider store={this.context.store}>
             <Translations original={this.props.guide} type="field_guide" >


### PR DESCRIPTION
Staging branch URL: https://pr-5706.pfe-preview.zooniverse.org
- https://pr-5706.pfe-preview.zooniverse.org/projects/markbouslog/test-project-mb/classify?env=production

Describe your changes.
- update Field Guide toggle button content so translatable

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
