### PR TITLE
Remove zooAPI from Window

### DIFF
--- a/app/main.cjsx
+++ b/app/main.cjsx
@@ -57,7 +57,4 @@ ReactDOM.render <Provider store={store}><Router history={browserHistory} render=
 # Are we connected to the latest back end?
 require('./lib/log-deployed-commit')()
 
-# Just for console access:
-window?.zooAPI = require 'panoptes-client/lib/api-client'
-window?.talkAPI = require 'panoptes-client/lib/talk-client'
 require('./lib/split-config')


### PR DESCRIPTION
Staging branch URL: https://pr-5714.pfe-preview.zooniverse.org

Closes https://github.com/zooniverse/how-to-zooniverse/issues/60

Describe your changes.
This PR remove zooAPI and talkAPI from the global window. More info found on the issue.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
