### PR TITLE
Add user email preference toggle for NASA email list

### DIFF
--- a/app/locales/ar.js
+++ b/app/locales/ar.js
@@ -212,7 +212,9 @@ export default {
       classify: 'Get email updates when you first classify on a project',
       note: 'Note: Unticking the box will not unsubscribe you from any of the projects',
       manual: 'Manage projects individually',
-      beta: 'Get beta project email updates and become a beta tester'
+      beta: 'Get beta project email updates and become a beta tester',
+      partnerPreferences: 'Zooniverse partner email preferences',
+      nasa: 'Get periodic email updates from NASA regarding broader NASA citizen science projects and efforts'
     },
     talk: {
       section: 'Talk email preferences',

--- a/app/locales/cs.js
+++ b/app/locales/cs.js
@@ -218,7 +218,9 @@ export default {
       classify: 'Dostávat emailové aktualizace projektů po Vaší první klasifikaci v projektu.',
       note: 'Poznámka: Odstraněním značky z rámečku se neodhlásíte z žádného projektu.',
       manual: 'Spravovat projekty individuálně',
-      beta: 'Dostávat emailové aktualizace o beta projektech a stát se beta testerem.'
+      beta: 'Dostávat emailové aktualizace o beta projektech a stát se beta testerem.',
+      partnerPreferences: 'Zooniverse partner email preferences',
+      nasa: 'Get periodic email updates from NASA regarding broader NASA citizen science projects and efforts'
     },
     talk: {
       section: 'Emailové předvolby pro Diskuze',

--- a/app/locales/de.js
+++ b/app/locales/de.js
@@ -214,7 +214,9 @@ export default {
       classify: 'Erhalte Projekt-Neuigkeiten per E-Mail, wenn Du beginnst in einem Projekt zu klassifizieren',
       note: 'Beachte: Nicht-Auswählen dieser Box wird keine Auswirkungen auf andere Projekte haben.',
       manual: 'Verwalte Projekte individuell',
-      beta: 'Erhalte E-Mails über Projekte in der Beta-Testung und werde Beta-Tester!'
+      beta: 'Erhalte E-Mails über Projekte in der Beta-Testung und werde Beta-Tester!',
+      partnerPreferences: 'Zooniverse partner email preferences',
+      nasa: 'Get periodic email updates from NASA regarding broader NASA citizen science projects and efforts'
     },
     talk: {
       section: 'E-Mail-Präferenzen für Talk',

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -268,6 +268,7 @@ export default {
       beta: 'Get beta project email updates and become a beta tester',
       partnerPreferences: 'Zooniverse partner email preferences',
       nasa: 'Get periodic email updates from NASA regarding broader NASA citizen science projects and efforts',
+      nasaNote: 'Note: this opt-in email reflects an on-going partnership between NASA and Zooniverse.'
     },
     talk: {
       section: 'Talk email preferences',

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -267,8 +267,7 @@ export default {
       manual: 'Manage projects individually',
       beta: 'Get beta project email updates and become a beta tester',
       partnerPreferences: 'Zooniverse partner email preferences',
-      nasa: 'Get periodic email updates from NASA regarding broader NASA citizen science projects and efforts',
-      nasaNote: 'Note: this opt-in email reflects an on-going partnership between NASA and Zooniverse.'
+      nasa: 'Get periodic email updates from NASA regarding broader NASA citizen science projects and efforts'
     },
     talk: {
       section: 'Talk email preferences',

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -265,7 +265,9 @@ export default {
       classify: 'Get email updates when you first classify on a project',
       note: 'Note: Unticking the box will not unsubscribe you from any of the projects',
       manual: 'Manage projects individually',
-      beta: 'Get beta project email updates and become a beta tester'
+      beta: 'Get beta project email updates and become a beta tester',
+      partnerPreferences: 'Zooniverse partner email preferences',
+      nasa: 'Get periodic email updates from NASA regarding broader NASA citizen science projects and efforts',
     },
     talk: {
       section: 'Talk email preferences',

--- a/app/locales/es.js
+++ b/app/locales/es.js
@@ -195,6 +195,47 @@ export default {
   workflowToggle: {
     label: 'Active'
   },
+  collections: {
+    createForm: {
+      private: 'Private',
+      submit: 'Add Collection'
+    }
+  },
+  emailSettings: {
+    email: 'Email address',
+    general: {
+      section: 'Zooniverse email preferences',
+      updates: 'Get general Zooniverse email updates',
+      classify: 'Get email updates when you first classify on a project',
+      note: 'Note: Unticking the box will not unsubscribe you from any of the projects',
+      manual: 'Manage projects individually',
+      beta: 'Get beta project email updates and become a beta tester',
+      partnerPreferences: 'Zooniverse partner email preferences',
+      nasa: 'Get periodic email updates from NASA regarding broader NASA citizen science projects and efforts'
+    },
+    talk: {
+      section: 'Talk email preferences',
+      header: 'Send me an email',
+      frequency: {
+        immediate: 'Immediately',
+        day: 'Daily',
+        week: 'Weekly',
+        never: 'Never'
+      },
+      options: {
+        participating_discussions: 'When discussions I\'m participating in are updated',
+        followed_discussions: 'When discussions I\'m following are updated',
+        mentions: 'When I\'m mentioned',
+        group_mentions: 'When I\'m mentioned by group (@admins, @team, etc.)',
+        messages: 'When I receive a private message',
+        started_discussions: 'When a discussion is started in a board I\'m following'
+      }
+    },
+    project: {
+      section: 'Project email preferences',
+      header: 'Project',
+    }
+  },
   about: {
     publications: {
       nav: {

--- a/app/locales/fr.js
+++ b/app/locales/fr.js
@@ -214,7 +214,9 @@ export default {
       classify: 'Recevoir un e-mail quand vous avez fait une première classification dans un projet.',
       note: 'Note: Décocher la case ne vas vous désabonner à aucun des projets',
       manual: 'Gérer les projets individuellement',
-      beta: 'Recevoir les nouvelles sur le projet beta et devenir un testeur beta.'
+      beta: 'Recevoir les nouvelles sur le projet beta et devenir un testeur beta.',
+      partnerPreferences: 'Zooniverse partner email preferences',
+      nasa: 'Get periodic email updates from NASA regarding broader NASA citizen science projects and efforts'
     },
     talk: {
       section: 'Préférence pour les e-mails de la section Discussions',

--- a/app/locales/he.js
+++ b/app/locales/he.js
@@ -212,7 +212,9 @@ export default {
       classify: 'Get email updates when you first classify on a project',
       note: 'Note: Unticking the box will not unsubscribe you from any of the projects',
       manual: 'Manage projects individually',
-      beta: 'Get beta project email updates and become a beta tester'
+      beta: 'Get beta project email updates and become a beta tester',
+      partnerPreferences: 'Zooniverse partner email preferences',
+      nasa: 'Get periodic email updates from NASA regarding broader NASA citizen science projects and efforts'
     },
     talk: {
       section: 'Talk email preferences',

--- a/app/locales/hi.js
+++ b/app/locales/hi.js
@@ -265,7 +265,9 @@ export default {
       classify: 'Get email updates when you first classify on a project',
       note: 'Note: Unticking the box will not unsubscribe you from any of the projects',
       manual: 'Manage projects individually',
-      beta: 'Get beta project email updates and become a beta tester'
+      beta: 'Get beta project email updates and become a beta tester',
+      partnerPreferences: 'Zooniverse partner email preferences',
+      nasa: 'Get periodic email updates from NASA regarding broader NASA citizen science projects and efforts'
     },
     talk: {
       section: 'Talk email preferences',

--- a/app/locales/hr.js
+++ b/app/locales/hr.js
@@ -167,6 +167,41 @@ export default {
       submit: 'Dodaj zbirku'
     }
   },
+  emailSettings: {
+    email: 'Email address',
+    general: {
+      section: 'Zooniverse email preferences',
+      updates: 'Get general Zooniverse email updates',
+      classify: 'Get email updates when you first classify on a project',
+      note: 'Note: Unticking the box will not unsubscribe you from any of the projects',
+      manual: 'Manage projects individually',
+      beta: 'Get beta project email updates and become a beta tester',
+      partnerPreferences: 'Zooniverse partner email preferences',
+      nasa: 'Get periodic email updates from NASA regarding broader NASA citizen science projects and efforts'
+    },
+    talk: {
+      section: 'Talk email preferences',
+      header: 'Send me an email',
+      frequency: {
+        immediate: 'Immediately',
+        day: 'Daily',
+        week: 'Weekly',
+        never: 'Never'
+      },
+      options: {
+        participating_discussions: 'When discussions I\'m participating in are updated',
+        followed_discussions: 'When discussions I\'m following are updated',
+        mentions: 'When I\'m mentioned',
+        group_mentions: 'When I\'m mentioned by group (@admins, @team, etc.)',
+        messages: 'When I receive a private message',
+        started_discussions: 'When a discussion is started in a board I\'m following'
+      }
+    },
+    project: {
+      section: 'Project email preferences',
+      header: 'Project',
+    }
+  },
   about: {
     index: {
       header: 'O Zooniversu',

--- a/app/locales/it.js
+++ b/app/locales/it.js
@@ -217,7 +217,9 @@ export default {
       classify: 'Ricevi aggiornamenti sui progetti a cui hai contribuito',
       note: 'Note: Unticking the box will not unsubscribe you from any of the projects',
       manual: 'Manage projects individually',
-      beta: 'Diventa beta-tester e ricevi email sui progetti in beta'
+      beta: 'Diventa beta-tester e ricevi email sui progetti in beta',
+      partnerPreferences: 'Zooniverse partner email preferences',
+      nasa: 'Get periodic email updates from NASA regarding broader NASA citizen science projects and efforts'
     },
     talk: {
       section: 'Preferenze per Talk',

--- a/app/locales/ja.js
+++ b/app/locales/ja.js
@@ -218,7 +218,9 @@ export default {
       classify: 'Get email updates when you first classify on a project',
       note: 'Note: Unticking the box will not unsubscribe you from any of the projects',
       manual: 'Manage projects individually',
-      beta: 'Get beta project email updates and become a beta tester'
+      beta: 'Get beta project email updates and become a beta tester',
+      partnerPreferences: 'Zooniverse partner email preferences',
+      nasa: 'Get periodic email updates from NASA regarding broader NASA citizen science projects and efforts'
     },
     talk: {
       section: 'Talk email preferences',

--- a/app/locales/kn.js
+++ b/app/locales/kn.js
@@ -265,7 +265,9 @@ export default {
       classify: 'Get email updates when you first classify on a project',
       note: 'Note: Unticking the box will not unsubscribe you from any of the projects',
       manual: 'Manage projects individually',
-      beta: 'Get beta project email updates and become a beta tester'
+      beta: 'Get beta project email updates and become a beta tester',
+      partnerPreferences: 'Zooniverse partner email preferences',
+      nasa: 'Get periodic email updates from NASA regarding broader NASA citizen science projects and efforts'
     },
     talk: {
       section: 'Talk email preferences',

--- a/app/locales/ko.js
+++ b/app/locales/ko.js
@@ -265,7 +265,9 @@ export default {
       classify: 'Get email updates when you first classify on a project',
       note: 'Note: Unticking the box will not unsubscribe you from any of the projects',
       manual: 'Manage projects individually',
-      beta: 'Get beta project email updates and become a beta tester'
+      beta: 'Get beta project email updates and become a beta tester',
+      partnerPreferences: 'Zooniverse partner email preferences',
+      nasa: 'Get periodic email updates from NASA regarding broader NASA citizen science projects and efforts'
     },
     talk: {
       section: 'Talk email preferences',

--- a/app/locales/nl.js
+++ b/app/locales/nl.js
@@ -232,6 +232,41 @@ export default {
       submit: 'Maak verzameling'
     }
   },
+  emailSettings: {
+    email: 'Email address',
+    general: {
+      section: 'Zooniverse email preferences',
+      updates: 'Get general Zooniverse email updates',
+      classify: 'Get email updates when you first classify on a project',
+      note: 'Note: Unticking the box will not unsubscribe you from any of the projects',
+      manual: 'Manage projects individually',
+      beta: 'Get beta project email updates and become a beta tester',
+      partnerPreferences: 'Zooniverse partner email preferences',
+      nasa: 'Get periodic email updates from NASA regarding broader NASA citizen science projects and efforts'
+    },
+    talk: {
+      section: 'Talk email preferences',
+      header: 'Send me an email',
+      frequency: {
+        immediate: 'Immediately',
+        day: 'Daily',
+        week: 'Weekly',
+        never: 'Never'
+      },
+      options: {
+        participating_discussions: 'When discussions I\'m participating in are updated',
+        followed_discussions: 'When discussions I\'m following are updated',
+        mentions: 'When I\'m mentioned',
+        group_mentions: 'When I\'m mentioned by group (@admins, @team, etc.)',
+        messages: 'When I receive a private message',
+        started_discussions: 'When a discussion is started in a board I\'m following'
+      }
+    },
+    project: {
+      section: 'Project email preferences',
+      header: 'Project',
+    }
+  },
   about: {
     publications: {
       nav: {

--- a/app/locales/pl.js
+++ b/app/locales/pl.js
@@ -257,7 +257,9 @@ export default {
       classify: 'Get email updates when you first classify on a project',
       note: 'Note: Unticking the box will not unsubscribe you from any of the projects',
       manual: 'Manage projects individually',
-      beta: 'Get beta project email updates and become a beta tester'
+      beta: 'Get beta project email updates and become a beta tester',
+      partnerPreferences: 'Zooniverse partner email preferences',
+      nasa: 'Get periodic email updates from NASA regarding broader NASA citizen science projects and efforts'
     },
     talk: {
       section: 'Talk email preferences',

--- a/app/locales/pt.js
+++ b/app/locales/pt.js
@@ -202,7 +202,9 @@ export default {
       classify: 'Receba actualizações por email quando classificar pela primeira vez num projecto',
       note: 'Nota: Desmarcar a caixa não cancelará a sua inscrição em nenhum dos projectos',
       manual: 'Gerir projectos individualmente',
-      beta: 'Receba actualizações por e-mail do projecto beta e torne-se um testador beta'
+      beta: 'Receba actualizações por e-mail do projecto beta e torne-se um testador beta',
+      partnerPreferences: 'Zooniverse partner email preferences',
+      nasa: 'Get periodic email updates from NASA regarding broader NASA citizen science projects and efforts'
     },
     talk: {
       section: 'Preferências de e-mail para Falar',

--- a/app/locales/sv.js
+++ b/app/locales/sv.js
@@ -265,7 +265,9 @@ export default {
       classify: 'Få uppdateringar med epost när du börjar klassificera för ett projekt',
       note: 'Obs: Om du avbockar här avslutas inte din prenumeration på något av projekten',
       manual: 'Hantera varje projekt för sig',
-      beta: 'Få mejl om betaprojekt och bli en betatestare'
+      beta: 'Få mejl om betaprojekt och bli en betatestare',
+      partnerPreferences: 'Zooniverse partner email preferences',
+      nasa: 'Get periodic email updates from NASA regarding broader NASA citizen science projects and efforts'
     },
     talk: {
       section: 'Epost-preferenser för Prata',

--- a/app/locales/zh-cn.js
+++ b/app/locales/zh-cn.js
@@ -219,7 +219,9 @@ export default {
       classify: 'Get email updates when you first classify on a project',
       note: 'Note: Unticking the box will not unsubscribe you from any of the projects',
       manual: 'Manage projects individually',
-      beta: 'Get beta project email updates and become a beta tester'
+      beta: 'Get beta project email updates and become a beta tester',
+      partnerPreferences: 'Zooniverse partner email preferences',
+      nasa: 'Get periodic email updates from NASA regarding broader NASA citizen science projects and efforts'
     },
     talk: {
       section: 'Talk email preferences',

--- a/app/locales/zh-tw.js
+++ b/app/locales/zh-tw.js
@@ -219,7 +219,9 @@ export default {
       classify: 'Get email updates when you first classify on a project',
       note: 'Note: Unticking the box will not unsubscribe you from any of the projects',
       manual: 'Manage projects individually',
-      beta: 'Get beta project email updates and become a beta tester'
+      beta: 'Get beta project email updates and become a beta tester',
+      partnerPreferences: 'Zooniverse partner email preferences',
+      nasa: 'Get periodic email updates from NASA regarding broader NASA citizen science projects and efforts'
     },
     talk: {
       section: 'Talk email preferences',

--- a/app/pages/settings/email.jsx
+++ b/app/pages/settings/email.jsx
@@ -299,6 +299,9 @@ class EmailSettingsPage extends React.Component {
             </label>
           </AutoSave>
           <br />
+          <span>
+            <Translate className="preference-note" content="emailSettings.general.nasaNote" />
+          </span>
         </p>
 
         <p>

--- a/app/pages/settings/email.jsx
+++ b/app/pages/settings/email.jsx
@@ -281,6 +281,24 @@ class EmailSettingsPage extends React.Component {
               <Translate content="emailSettings.general.beta" />
             </label>
           </AutoSave>
+          <br />
+          <p>
+            <strong>
+              <Translate content="emailSettings.general.partnerPreferences" />
+            </strong>
+          </p>
+          <AutoSave resource={this.props.user}>
+            <label>
+              <input
+                type="checkbox"
+                name="nasa_email_communication"
+                checked={this.props.user.nasa_email_communication}
+                onChange={handleInputChange.bind(this.props.user)}
+              />{' '}
+              <Translate content="emailSettings.general.nasa" />
+            </label>
+          </AutoSave>
+          <br />
         </p>
 
         <p>

--- a/app/pages/settings/email.jsx
+++ b/app/pages/settings/email.jsx
@@ -381,6 +381,7 @@ EmailSettingsPage.propTypes = {
     beta_email_communication: PropTypes.bool,
     project_email_communication: PropTypes.bool,
     global_email_communication: PropTypes.bool,
+    nasa_email_communication: PropTypes.bool,
     get: PropTypes.func
   })
 };

--- a/app/pages/settings/email.jsx
+++ b/app/pages/settings/email.jsx
@@ -299,9 +299,6 @@ class EmailSettingsPage extends React.Component {
             </label>
           </AutoSave>
           <br />
-          <span>
-            <Translate className="preference-note" content="emailSettings.general.nasaNote" />
-          </span>
         </p>
 
         <p>

--- a/app/pages/settings/email.spec.js
+++ b/app/pages/settings/email.spec.js
@@ -90,6 +90,7 @@ const user = {
   email: 'An email address',
   beta_email_communication: false,
   global_email_communication: true,
+  nasa_email_communication: true,
   project_email_communication: true,
   get() {
     return Promise.resolve([]);
@@ -135,6 +136,11 @@ describe('EmailSettings', function () {
   it('shows beta email preference correctly', function () {
     const betaEmail = wrapper.find('input[name="beta_email_communication"]');
     assert.equal(betaEmail.prop('checked'), user.beta_email_communication);
+  });
+  
+  it('shows NASA email preference correctly', function () {
+    const nasaEmail = wrapper.find('input[name="nasa_email_communication"]');
+    assert.equal(nasaEmail.prop('checked'), user.nasa_email_communication);
   });
 
   describe('project listing', function () {

--- a/css/settings.styl
+++ b/css/settings.styl
@@ -54,9 +54,6 @@
           list-style-type: none
           padding: 0
 
-      .preference-note
-        opacity: 0.6
-
       .talk-email-preferences
         th
           padding: 0 5px

--- a/css/settings.styl
+++ b/css/settings.styl
@@ -54,6 +54,9 @@
           list-style-type: none
           padding: 0
 
+      .preference-note
+        opacity: 0.6
+
       .talk-email-preferences
         th
           padding: 0 5px


### PR DESCRIPTION
Staging branch URL: https://pr-5747.pfe-preview.zooniverse.org

Closes #5746.

Why DRAFT:
- [x] holding on backend - https://github.com/zooniverse/panoptes/pull/3421 and deploy
- [x] add new content strings to other language locales

Describe your changes.
- adds user email preference toggle with note

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [x] Can you post a talk comment?

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
