### PR TITLE
Home page: Fix page_size=0 bug for classifications ribbon

### DIFF
--- a/app/pages/home-for-user/index.jsx
+++ b/app/pages/home-for-user/index.jsx
@@ -122,40 +122,42 @@ export default class HomePageForUser extends React.Component {
         return projectPreferences;
       } else {
         let activePreferences = projectPreferences.filter((preference) => { return preference.activity_count > 0; });
-        activePreferences = activePreferences.map((preference, i) => {
-          preference.sort_order = i;
-          return preference;
-        });
-        this.getProjectsForPreferences(activePreferences)
-          .then((projects) => {
-            return projects
-            .sort((a, b) => {
-              return a.sort_order - b.sort_order;
-            })
-            .filter(Boolean)
-            .map((project, i) => {
-              return {
-                avatar_src: projects[i].avatar_src,
-                id: projects[i].id,
-                slug: projects[i].slug,
-                display_name: projects[i].display_name,
-                description: projects[i].description,
-                color: getColorFromString(projects[i].slug),
-                classifications: projects[i].activity_count,
-                updated_at: projects[i].updated_at,
-                redirect: projects[i].redirect
-              };
-            });
-          })
-          .then((projects) => {
-            this.setState((prevState) => {
-              const ribbonData = prevState.ribbonData.concat(projects);
-              const totalClassifications = ribbonData.reduce((total, project) => {
-                return total + project.classifications;
-              }, 0);
-              return { ribbonData, totalClassifications };
-            });
+        if (activePreferences.length > 0) {
+          activePreferences = activePreferences.map((preference, i) => {
+            preference.sort_order = i;
+            return preference;
           });
+          this.getProjectsForPreferences(activePreferences)
+            .then((projects) => {
+              return projects
+              .sort((a, b) => {
+                return a.sort_order - b.sort_order;
+              })
+              .filter(Boolean)
+              .map((project, i) => {
+                return {
+                  avatar_src: projects[i].avatar_src,
+                  id: projects[i].id,
+                  slug: projects[i].slug,
+                  display_name: projects[i].display_name,
+                  description: projects[i].description,
+                  color: getColorFromString(projects[i].slug),
+                  classifications: projects[i].activity_count,
+                  updated_at: projects[i].updated_at,
+                  redirect: projects[i].redirect
+                };
+              });
+            })
+            .then((projects) => {
+              this.setState((prevState) => {
+                const ribbonData = prevState.ribbonData.concat(projects);
+                const totalClassifications = ribbonData.reduce((total, project) => {
+                  return total + project.classifications;
+                }, 0);
+                return { ribbonData, totalClassifications };
+              });
+            });
+        }
         const meta = projectPreferences[0].getMeta();
         if (meta.page !== meta.page_count) {
           getRibbonData(user, meta.page + 1);
@@ -169,26 +171,26 @@ export default class HomePageForUser extends React.Component {
       return projectPreference.links.project;
     });
     return apiClient
-    .type('projects')
-    .get({ id: projectIDs, cards: true, page_size: preferences.length })
-    .catch((error) => {
-      console.log('Something went wrong. Error: ', error);
-    })
-    .then((projects) => {
-      const classifications = preferences.reduce((counts, projectPreference) => {
-        counts[projectPreference.links.project] = projectPreference.activity_count;
-        return counts;
-      }, {});
-      const sortOrders = preferences.reduce((orders, projectPreference) => {
-        orders[projectPreference.links.project] = projectPreference.sort_order;
-        return orders;
-      }, {});
-      return projects.map((project) => {
-        project.activity_count = classifications[project.id];
-        project.sort_order = sortOrders[project.id];
-        return project;
+      .type('projects')
+      .get({ id: projectIDs, cards: true, page_size: preferences.length })
+      .catch((error) => {
+        console.log('Something went wrong. Error: ', error);
+      })
+      .then((projects) => {
+        const classifications = preferences.reduce((counts, projectPreference) => {
+          counts[projectPreference.links.project] = projectPreference.activity_count;
+          return counts;
+        }, {});
+        const sortOrders = preferences.reduce((orders, projectPreference) => {
+          orders[projectPreference.links.project] = projectPreference.sort_order;
+          return orders;
+        }, {});
+        return projects.map((project) => {
+          project.activity_count = classifications[project.id];
+          project.sort_order = sortOrders[project.id];
+          return project;
+        });
       });
-    });
   }
 
   deselectSection() {

--- a/app/pages/home-for-user/index.jsx
+++ b/app/pages/home-for-user/index.jsx
@@ -121,7 +121,14 @@ export default class HomePageForUser extends React.Component {
       if (projectPreferences.length === 0) {
         return projectPreferences;
       } else {
+        // continue paging through preferences until we've got them all.
+        const meta = projectPreferences[0].getMeta();
+        if (meta.page !== meta.page_count) {
+          getRibbonData(user, meta.page + 1);
+        }
+        // filter out projects you haven't classified on.
         let activePreferences = projectPreferences.filter((preference) => { return preference.activity_count > 0; });
+        // get the projects that you have classified on, if any.
         if (activePreferences.length > 0) {
           activePreferences = activePreferences.map((preference, i) => {
             preference.sort_order = i;
@@ -157,10 +164,6 @@ export default class HomePageForUser extends React.Component {
                 return { ribbonData, totalClassifications };
               });
             });
-        }
-        const meta = projectPreferences[0].getMeta();
-        if (meta.page !== meta.page_count) {
-          getRibbonData(user, meta.page + 1);
         }
       }
     });


### PR DESCRIPTION
Check activePreferences before making a request for associated projects. If activePreferences is empty, getProjectsForPreferences would make an API request with page size 0.

Staging branch URL: https://pr-5748.pfe-preview.zooniverse.org

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
