### PR TITLE
Refactor survey questions existence check

### DIFF
--- a/app/classifier/tasks/survey/editor.cjsx
+++ b/app/classifier/tasks/survey/editor.cjsx
@@ -99,7 +99,7 @@ module.exports = createReactClass
                 <span className="filename">{@state.confusionsName}</span>}
             </div>
             <div className="columns-container" style={marginBottom: '0.2em'}>
-              <FileButton className="major-button column" accept=".csv, .tsv" disabled={@checkAdd()} onSelect={@handleFiles.bind this, 'questionsName', @addQuestion, @cleanQuestions}>{if @state.task.questionsOrder.length is 0 then "Add" else "Replace"} questions</FileButton>
+              <FileButton className="major-button column" accept=".csv, .tsv" disabled={@checkAdd()} onSelect={@handleFiles.bind this, 'questionsName', @addQuestion, @cleanQuestions}>{if @state.task.questions.keys?.length is 0 then "Add" else "Replace"} questions</FileButton>
               <TriggeredModalForm trigger={
                 <span className="secret-button">
                 <i className="fa fa-question-circle"></i>
@@ -665,7 +665,7 @@ module.exports = createReactClass
       contentWarnings.push {source: 'confusions', message: 'No confusions added.'}
 
     #questions
-    if @state.task.questionsOrder.length is 0
+    if @state.task.questions.keys?.length is 0
       contentWarnings.push {source: 'questions', message: 'No questions added.'}
 
     #images-choices


### PR DESCRIPTION
Staging branch URL: https://pr-5765.pfe-preview.zooniverse.org

Fixes issue where UI shows there are no survey task questions when there are questions. This issue is because the existence of questions is being determined by `questionsOrder` length, when if no questions are applied to all choices, or if questions have `included` defined with all choices (not suggested usage, but happens), then `questionsOrder` will have no length and the UI (button text, warning) will appear as if there are no questions.

Describe your changes.
- changes questions existence check from `questionsOrder.length` to `questions.keys?.length`

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
