### PR TITLE
Edit Translation: Field Guide + French lang label

### DIFF
--- a/app/constants/languageMenu.js
+++ b/app/constants/languageMenu.js
@@ -5,7 +5,7 @@ export default {
   de: 'Deutsch',
   es: 'Español',
   el: 'Ελληνικά',
-  fr: 'Francais',
+  fr: 'Français',
   he: 'עברית',
   hi: 'हिन्दी',
   hr: 'Hrvatski',

--- a/app/locales/de.js
+++ b/app/locales/de.js
@@ -30,7 +30,7 @@ export default {
     language: 'Sprache',
     loading: 'Projekt wird geladen',
     disclaimer: 'Dieses Projekt wurde mit dem Zooniverse Project Builder gebaut, ist aber derzeit noch kein offizielles Zooniverse Projekt. Anfragen und Probleme bezüglich dieses Projekts an das Zooniverse Team könnten unbeantwortet bleiben.',
-    fieldGuide: 'Field Guide',
+    fieldGuide: 'Benutzerhandbuch',
     about: {
       header: 'Über',
       nav: {

--- a/app/locales/es.js
+++ b/app/locales/es.js
@@ -30,7 +30,7 @@ export default {
     language: 'Idioma',
     loading: 'Cargando el proyecto',
     disclaimer: 'Este proyecto ha sido construido usando Zooniverse Project Builder, pero todavía no es un proyecto oficial de Zooniverse. Las preguntas y asuntos relacionados con este proyecto dirigidos al equipo de Zooniverse podrían no recibir respuesta.',
-    fieldGuide: 'Field Guide',
+    fieldGuide: 'Guía Práctica',
     about: {
       header: 'Acerca de',
       nav: {

--- a/app/locales/fr.js
+++ b/app/locales/fr.js
@@ -30,7 +30,7 @@ export default {
     language: 'Langue',
     loading: 'Chargement du projet',
     disclaimer: 'Ce projet a été créé avec le Zooniverse Project Builder mais ce n\'est pas encore un projet officiel de Zooniverse. Les questions et problèmes a propos de ce projet adressés à l\'équipe de Zooniverse peut ne pas recevoir de réponse.',
-    fieldGuide: 'Field Guide',
+    fieldGuide: 'Guide Pratique',
     about: {
       header: 'À propos',
       nav: {

--- a/app/locales/it.js
+++ b/app/locales/it.js
@@ -33,7 +33,7 @@ export default {
     language: 'Lingua',
     loading: 'Caricamento progetto',
     disclaimer: "Questo progetto è stato creato con il Project Builder di Zooniverse, ma non è ancora un progetto ufficiale. Per questo motivo è possibile che domande su questo progetto dirette al Team Zooniverse non ricevano una risposta.",
-    fieldGuide: 'Field Guide',
+    fieldGuide: 'Guida Pratica',
     about: {
       header: 'About',
       nav: {


### PR DESCRIPTION
Staging branch URL: https://pr-5769.pfe-preview.zooniverse.org

Adds platform translation in Spanish, Italian, French, and German of "Field Guide" UI label.  Also edits French language label in dropdown from "Francais" to "Français".

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [x] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
