### PR TITLE
Add overflow-anchor style to task nav container

### DIFF
--- a/css/classify.styl
+++ b/css/classify.styl
@@ -201,6 +201,7 @@
 
   .task-nav
     display: flex
+    overflow-anchor: none
     padding: 0 2em 0 2em
 
     > :not(:first-child)

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -14,6 +14,7 @@ var config = {
     ],
     historyApiFallback: true,
     host: process.env.HOST || "localhost",
+    https: true,
     overlay: true,
     port: 3735
   },


### PR DESCRIPTION
Staging branch URL: https://pr-5784.pfe-preview.zooniverse.org

Fixes #5781 

The underlying scroll anchor behavior has changed with Chrome since v84. We're disabling scroll anchoring on the task nav container by adding `overflow-anchor: none` style to it. This seems to fix the unusual scroll behavior originally reported on Talk: https://www.zooniverse.org/talk/17/1533848

No changelog report exist for this change, so this is still a guess, but #5781 got us on the right track.

This PR also adds back in `https: true` to the webpack dev server configuration. It was removed a few months ago because of a bug in webpack, but webpack has been updated since then. We need this to be able to run the site locally.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
