### PR TITLE
Text task: fix potential infinite loop

### DIFF
--- a/app/classifier/tasks/text/index.jsx
+++ b/app/classifier/tasks/text/index.jsx
@@ -34,10 +34,6 @@ export default class TextTask extends React.PureComponent {
     });
   }
 
-  componentDidUpdate() {
-    this.handleResize();
-  }
-
   componentWillUnmount() {
     this.debouncedUpdateAnnotation.flush();
     clearTimeout(this.handleMount);
@@ -69,6 +65,7 @@ export default class TextTask extends React.PureComponent {
         this.textInput.current.setSelectionRange((value.length - textAfter.length), (value.length - textAfter.length));
         this.textInput.current.focus();
       }
+      this.handleResize();
     });
 
     this.updateAnnotation(value);
@@ -76,10 +73,12 @@ export default class TextTask extends React.PureComponent {
 
   handleChange() {
     const value = this.textInput.current.value;
-    if (value.length < this.state.value.length) {
-      this.setState({ rows: 1, value });
-    } else {
-      this.setState({ value });
+    if (value !== this.state.value) {
+      if (value.length < this.state.value.length) {
+        this.setState({ rows: 1, value }, this.handleResize);
+      } else {
+        this.setState({ value }, this.handleResize);
+      }
     }
 
     this.debouncedUpdateAnnotation(value);


### PR DESCRIPTION
Remove `componentDidUpdate` and, instead, call `handleResize` only after updates to the text value. This should make it impossible for `handleResize` to invoke itself via `componentDidUpdate`.

Staging branch URL: https://pr-5795.pfe-preview.zooniverse.org

Fixes #5767.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
