### PR TITLE
Talk: require a valid email address

### DIFF
--- a/app/subjects/comment-form.cjsx
+++ b/app/subjects/comment-form.cjsx
@@ -75,9 +75,11 @@ module.exports = createReactClass
       when 1 then @startDiscussion()
 
   render: ->
+    invalidEmail = <p>You must have a <Link to="/settings/email">valid email address</Link> in order to contribute to the conversation.</p>
     return <Loading /> if @state.loading
     return @noDefaultBoardMessage() unless @state.boards
     return @loginPrompt() unless @props.user
+    return invalidEmail unless @props.user?.valid_email
 
     if @state.boards.length < 1
       @renderTab()

--- a/app/talk/discussion-comment.jsx
+++ b/app/talk/discussion-comment.jsx
@@ -56,7 +56,14 @@ class DiscussionComment extends React.Component {
   }
 
   render() {
-    if (this.props.user) {
+    if (this.props.user && !this.props.user.valid_email) {
+      return(
+        <p>
+          You must have a <Link to="/settings/email">valid email address</Link> in order to contribute to the conversation.
+        </p>
+      )
+    }
+    if (this.props.user && this.props.user.valid_email) {
       const baseLink = this.props.project ? `projects/${this.props.project.slug}` : '/';
       return (
         <div>

--- a/app/talk/discussion-comment.spec.js
+++ b/app/talk/discussion-comment.spec.js
@@ -1,5 +1,8 @@
+import apiClient from 'panoptes-client/lib/api-client';
 import React from 'react';
+import { Link } from 'react-router';
 import assert from 'assert';
+import { expect } from 'chai';
 import DiscussionComment from './discussion-comment';
 import { shallow } from 'enzyme';
 
@@ -7,10 +10,23 @@ const discussion = {
   section: 1
 };
 
-const user = {
-  id: 1,
-  display_name: 'Test User'
-};
+const validUser = apiClient.type('users').create({
+  login: 'test-account',
+  display_name: 'Test Account',
+  email: 'test@zooniverse.org',
+  global_email_communication: false,
+  beta_email_communication: true,
+  valid_email: true
+});
+
+const invalidUser = apiClient.type('users').create({
+  login: 'test-account',
+  display_name: 'Test Account',
+  email: 'test@zooniverse',
+  global_email_communication: false,
+  beta_email_communication: true,
+  valid_email: false
+});
 
 describe('DiscussionComment', function() {
   let wrapper;
@@ -33,15 +49,32 @@ describe('DiscussionComment', function() {
 
   describe('logged in', function() {
     beforeEach(function() {
-      wrapper = shallow(<DiscussionComment discussion={discussion} user={user} />);
+      wrapper = shallow(<DiscussionComment discussion={discussion} user={validUser} />);
     });
 
     it('will show a user avatar', function() {
       assert.equal(wrapper.find('.talk-comment-author').length, 1);
     });
-    it('will show a comment box', function() {
-      assert.equal(wrapper.find('Commentbox').props().user, user);
-    });
+
+    describe('with a valid email', function() {
+      it('will show a comment box', function() {
+        assert.equal(wrapper.find('Commentbox').props().user, validUser);
+      });
+    })
+
+    describe('with an invalid email', function() {
+      beforeEach(function () {
+        wrapper.setProps({ user: invalidUser });
+        wrapper.update();
+      });
+
+      it('will not show a comment box', function() {
+        expect(wrapper.find('Commentbox').length).to.equal(0);
+      });
+      it('will show a link to update your email address', function () {
+        expect(wrapper.find(Link).props().to).to.equal('/settings/email');
+      })
+    })
   });
 
   describe('comment validation', function(){


### PR DESCRIPTION
Require a valid email address before showing the Talk comment form. Otherwise, link them to the settings page to update their details.
Require a valid email address for the subject comment form too.

Staging branch URL: https://pr-5799.pfe-preview.zooniverse.org

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
