### PR TITLE
Full-size drawing tools: use subject dimensions

### DIFF
--- a/app/classifier/drawing-tools/full-height-line.cjsx
+++ b/app/classifier/drawing-tools/full-height-line.cjsx
@@ -13,8 +13,9 @@ module.exports = createReactClass
   displayName: 'FullHeightLineTool'
 
   statics:
-    defaultValues: ({x}) ->
+    defaultValues: ({x}, {naturalHeight}) ->
       x: x
+      y: naturalHeight
 
     initMove: ({x}) ->
       x: x
@@ -23,12 +24,12 @@ module.exports = createReactClass
       x >= 0 and x <= naturalWidth
 
   render: ->
-    {x} = @props.mark
+    {x, y} = @props.mark
     points =
       x1: x
-      y1: '0%'
+      y1: 0
       x2: x
-      y2: '100%'
+      y2: y
     {x1, y1, x2, y2} = points
 
     deletePosition =

--- a/app/classifier/drawing-tools/full-width-line.cjsx
+++ b/app/classifier/drawing-tools/full-width-line.cjsx
@@ -13,7 +13,8 @@ module.exports = createReactClass
   displayName: 'FullWidthLineTool'
 
   statics:
-    defaultValues: ({y}) ->
+    defaultValues: ({y}, {naturalWidth}) ->
+      x: naturalWidth
       y: y
 
     initMove: ({y}) ->
@@ -23,11 +24,11 @@ module.exports = createReactClass
       y >= 0 and y <= naturalHeight
 
   render: ->
-    {y} = @props.mark
+    {x, y} = @props.mark
     points =
-      x1: '0%'
+      x1: 0
       y1: y
-      x2: '100%'
+      x2: x
       y2: y
     {x1, y1, x2, y2} = points
 


### PR DESCRIPTION
Use the subject's naturalHeight and naturalWidth to set the dimensions of the full height and full width line tools.

Staging branch URL: https://pr-5801.pfe-preview.zooniverse.org

Fixes #5800.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
