### PR TITLE
Project admin: add workflow.grouped

### DIFF
--- a/app/pages/admin/project-status.jsx
+++ b/app/pages/admin/project-status.jsx
@@ -76,7 +76,7 @@ class ProjectStatus extends Component {
   }
 
   getWorkflows() {
-    const fields = 'display_name,active,configuration,retirement';
+    const fields = 'display_name,active,configuration,grouped,retirement';
     return getWorkflowsInOrder(this.state.project, { fields }).then((workflows) => {
       const usedWorkflowLevels = this.getUsedWorkflowLevels(workflows);
       this.setState({ usedWorkflowLevels, workflows });
@@ -161,6 +161,14 @@ class ProjectStatus extends Component {
     }
     workflow.update({ 'configuration.image_layout': newLayout }).save();
   }
+
+  toggleWorkflowGrouped(event, workflow) {
+    workflow
+      .update({ grouped: event.target.checked })
+      .save()
+      .catch(error => this.setState({ error }));
+  }
+
   renderWorkflows() {
     if (this.state.workflows.length === 0) {
       return <div>No workflows found</div>;
@@ -234,6 +242,15 @@ class ProjectStatus extends Component {
                   no max height
                 </label>
               </fieldset>
+              <label>
+                <input
+                  id="grouped"
+                  type="checkbox"
+                  onChange={event => this.toggleWorkflowGrouped(event, workflow)}
+                  defaultChecked={workflow.grouped}
+                />
+                  Use grouped subject selection
+              </label>
             </li>
           );
         })}


### PR DESCRIPTION
Add workflow.grouped to the project admin, and allow it to be set for project workflows.

Staging branch URL: https://pr-5803.pfe-preview.zooniverse.org

Fixes #5783.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
