### PR TITLE
Updated Field Guide background

### DIFF
--- a/css/field-guide.styl
+++ b/css/field-guide.styl
@@ -1,5 +1,5 @@
 .field-guide-pullout
-  background: rgba(white, 0.95)
+  background: BACKGROUND
   bottom: 3vh !important // Override default
   box-shadow: 0 0 15px rgba(black, 0.3)
   color: black
@@ -14,7 +14,7 @@
 
 .field-guide-pullout-toggle
   @extends $reset-button
-  background: rgba(white, 0.95)
+  background: BACKGROUND
   border: solid thin #ebebeb
   border-radius: 0
   color: inherit
@@ -39,7 +39,7 @@
 
   > header
     background: black
-    color: white
+    color: BACKGROUND
     display: flex
     flex-direction: row
     justify-content: space-between


### PR DESCRIPTION
Fixes #5811 

Fix for transparency issue within the Field Guide. Background color is now using ‘BACKGROUND’ from the `common.styl` file which is white and opacity at 100%.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
