### PR TITLE
Admin interface for subject viewer settings

### DIFF
--- a/app/pages/admin/project-status.jsx
+++ b/app/pages/admin/project-status.jsx
@@ -291,7 +291,7 @@ class ProjectStatus extends Component {
                   >
                     <option value="none">None Selected</option>
                     <option value="dataImage">Data Image</option>
-                    <option value="lightCurve">(D3/TESS) Light Curve</option>
+                    <option value="lightcurve">(D3/TESS) Light Curve</option>
                     <option value="multiFrame">Multi-Frame</option>
                     <option value="singleImage">Single Image</option>
                     <option value="subjectGroup">Subject Group</option>

--- a/app/pages/admin/project-status.jsx
+++ b/app/pages/admin/project-status.jsx
@@ -62,6 +62,18 @@ class ProjectStatus extends Component {
       .catch(error => this.setState({ error }));
   }
 
+  onChangeSubjectViewer(workflow, event) {
+    this.setState({ error: null })
+    let selected = event.target.value
+    selected = selected === 'none' ? undefined : selected;
+    if (!workflow.configuration.classifier_version) {
+      workflow.update({ 'configuration.classifier_version': '2.0' });
+    }
+    return workflow.update({ 'configuration.subject_viewer': selected }).save()
+      .then(() => this.getWorkflows())
+      .catch(error => this.setState({ error }));
+  }
+
   getProject() {
     const { owner, name } = this.props.params;
     const slug = `${owner}/${name}`;
@@ -175,7 +187,7 @@ class ProjectStatus extends Component {
     }
 
     return (
-      <ul className="project-status__section-list">
+      <div>
         {this.state.dialogIsOpen &&
           <WorkflowDefaultDialog
             onCancel={this.handleDialogCancel}
@@ -183,51 +195,63 @@ class ProjectStatus extends Component {
           />}
         {this.state.workflows.map((workflow) => {
           return (
-            <li key={workflow.id} className="section-list__item">
-              {this.state.project.configuration &&
-                this.state.project.configuration.default_workflow === workflow.id ? ' * ' : ''}
-              <WorkflowToggle
-                workflow={workflow}
-                name="active"
-                checked={workflow.active}
-                handleToggle={event => this.handleToggle(event, workflow)}
-              />{' | '}
-              <label>
-                Level:{' '}
-                <select
-                  id='promotionLevels'
-                  onChange={(event) => this.onChangeWorkflowLevel(workflow, event)}
-                  value={workflow.configuration.level && workflow.configuration.level}
-                >
-                  <option value="none">none</option>
-                  {this.state.workflows.map((w, i) => {
-                    const value = i + 1;
-                    return (
-                      <option
-                        key={i + Math.random()}
-                        value={value}
-                        disabled={this.state.usedWorkflowLevels.indexOf(value) > -1}
-                      >
-                        {value}
-                      </option>
-                    );
-                  })}
-                </select>
-              </label>
-              {' | '}
-              <label>
-                Retirement:{' '}
-                <select
-                  id='retirementConfig'
-                  onChange={(event) => this.onChangeWorkflowRetirement(workflow, event)}
-                  value={workflow.retirement.criteria}
-                >
-                  <option value="never_retire">Never Retire</option>
-                  <option value="classification_count">Classification Count - {(workflow.retirement.options && workflow.retirement.options.count) || ''}</option>
-                </select>
-              </label>
-              <fieldset>
-                <legend>Subject image layout</legend>
+            <fieldset key={workflow.id} className="project-status__section-settings">
+              <legend>{`Workflow ${workflow.id}: ${workflow.display_name}`}</legend>
+              <div>
+                <h4>Workflow Activeness</h4>
+                {this.state.project.configuration &&
+                  this.state.project.configuration.default_workflow === workflow.id ? ' * ' : ''}
+                <WorkflowToggle
+                  workflow={workflow}
+                  name="active"
+                  checked={workflow.active}
+                  handleToggle={event => this.handleToggle(event, workflow)}
+                />
+              </div>
+              <hr />
+              <div>
+                <h4>Workflow assignment/promotion settings</h4>
+                <label>
+                  Level:{' '}
+                  <select
+                    id='promotionLevels'
+                    onChange={(event) => this.onChangeWorkflowLevel(workflow, event)}
+                    value={workflow.configuration.level && workflow.configuration.level}
+                  >
+                    <option value="none">none</option>
+                    {this.state.workflows.map((w, i) => {
+                      const value = i + 1;
+                      return (
+                        <option
+                          key={i + Math.random()}
+                          value={value}
+                          disabled={this.state.usedWorkflowLevels.indexOf(value) > -1}
+                        >
+                          {value}
+                        </option>
+                      );
+                    })}
+                  </select>
+                </label>
+              </div>
+              <hr />
+              <div>
+                <h4>Subject retirement settings</h4>
+                <label>
+                  Retirement:{' '}
+                  <select
+                    id='retirementConfig'
+                    onChange={(event) => this.onChangeWorkflowRetirement(workflow, event)}
+                    value={workflow.retirement.criteria}
+                  >
+                    <option value="never_retire">Never Retire</option>
+                    <option value="classification_count">Classification Count - {(workflow.retirement.options && workflow.retirement.options.count) || ''}</option>
+                  </select>
+                </label>
+              </div>
+              <hr />
+              <div>
+                <h4>Subject viewer layout settings</h4>
                 <label>
                   <input
                     type="checkbox"
@@ -241,20 +265,44 @@ class ProjectStatus extends Component {
                   />
                   no max height
                 </label>
-              </fieldset>
-              <label>
-                <input
-                  id="grouped"
-                  type="checkbox"
-                  onChange={event => this.toggleWorkflowGrouped(event, workflow)}
-                  defaultChecked={workflow.grouped}
-                />
+              </div>
+              <hr />
+              <div>
+                <h4>Subject selection settings</h4>
+                <label>
+                  <input
+                    id="grouped"
+                    type="checkbox"
+                    onChange={event => this.toggleWorkflowGrouped(event, workflow)}
+                    defaultChecked={workflow.grouped}
+                  />
                   Use grouped subject selection
-              </label>
-            </li>
+                </label>
+              </div>
+              <hr />
+              <div>
+                <h4>Classifier 2.0 (rewrite) settings</h4>
+                <label>
+                  Subject Viewer:{' '}
+                  <select
+                    id="subject-viewers"
+                    onChange={(event) => this.onChangeSubjectViewer(workflow, event)}
+                    value={workflow.configuration.subject_viewer}
+                  >
+                    <option value="none">None Selected</option>
+                    <option value="dataImage">Data Image</option>
+                    <option value="lightCurve">(D3/TESS) Light Curve</option>
+                    <option value="multiFrame">Multi-Frame</option>
+                    <option value="singleImage">Single Image</option>
+                    <option value="subjectGroup">Subject Group</option>
+                    <option value="variableStar">Variable Star</option>
+                  </select>
+                </label>
+              </div>
+            </fieldset>
           );
         })}
-      </ul>
+      </div>
     );
   }
 
@@ -336,8 +384,7 @@ class ProjectStatus extends Component {
         />
         <ExperimentalFeatures project={project} />
         <div className="project-status__section">
-          <h4>Workflow Settings</h4>
-          <small>The workflow level dropdown is for the workflow assignment experimental feature.</small>
+          <h3>Workflow Settings</h3>
           <br />
           <small>An asterisk (*) denotes a default workflow.</small>
           {this.state.error &&

--- a/app/pages/admin/project-status.spec.js
+++ b/app/pages/admin/project-status.spec.js
@@ -44,6 +44,7 @@ describe('ProjectStatus', function () {
   let loadingIndicator;
   let onChangeWorkflowLevelStub;
   let onChangeWorkflowRetirementStub;
+  let onChangeSubjectViewerStub;
   let wrapper;
 
   before(function () {
@@ -51,6 +52,7 @@ describe('ProjectStatus', function () {
     sinon.stub(ProjectStatus.prototype, 'getWorkflows').callsFake(() => Promise.resolve(workflows));
     onChangeWorkflowLevelStub = sinon.stub(ProjectStatus.prototype, 'onChangeWorkflowLevel');
     onChangeWorkflowRetirementStub = sinon.stub(ProjectStatus.prototype, 'onChangeWorkflowRetirement');
+    onChangeSubjectViewerStub = sinon.stub(ProjectStatus.prototype, 'onChangeSubjectViewer');
     handleDialogCancelStub = sinon.stub(ProjectStatus.prototype, 'handleDialogCancel');
     handleDialogSuccessStub = sinon.stub(ProjectStatus.prototype, 'handleDialogSuccess');
 
@@ -64,79 +66,82 @@ describe('ProjectStatus', function () {
     handleDialogSuccessStub.restore();
     ProjectStatus.prototype.getProject.restore();
     ProjectStatus.prototype.getWorkflows.restore();
+    ProjectStatus.prototype.onChangeSubjectViewer.restore();
   });
 
   it('renders without crashing', function () {
-    assert.equal(wrapper, wrapper);
+    assert.strictEqual(wrapper, wrapper);
   });
 
-  describe('when no project is in component state', function () {
+  describe('when no project is loaded', function () {
     it('renders Loading Indicator component', function () {
       loadingIndicator = wrapper.find('LoadingIndicator');
-      assert.equal(loadingIndicator.length, 1);
+      assert.strictEqual(loadingIndicator.length, 1);
     });
   });
 
-  describe('when project is in component state', function () {
+  describe('when a project is loaded', function () {
     before(function () {
+      wrapper = shallow(<ProjectStatus />);
       wrapper.setState({ project });
     });
 
     it('does not render the LoadingIndicator component', function () {
       loadingIndicator = wrapper.find('LoadingIndicator');
-      assert.equal(loadingIndicator.length, 0);
+      assert.strictEqual(loadingIndicator.length, 0);
     });
 
     it('renders a ProjectIcon component', function () {
       wrapper.setState({ project });
       const projectIconComponent = wrapper.find('ProjectIcon');
-      assert.equal(projectIconComponent.length, 1);
+      assert.strictEqual(projectIconComponent.length, 1);
     });
 
     it('renders a RedirectToggle component', function () {
       const redirectToggleComponent = wrapper.find('RedirectToggle');
-      assert.equal(redirectToggleComponent.length, 1);
+      assert.strictEqual(redirectToggleComponent.length, 1);
     });
 
     it('renders a ExperimentalFeatures component', function () {
       const experimentalFeaturesComponent = wrapper.find('ExperimentalFeatures');
-      assert.equal(experimentalFeaturesComponent.length, 1);
+      assert.strictEqual(experimentalFeaturesComponent.length, 1);
     });
 
     it('renders a FeaturedProjectToggle component', function () {
       const featuredProjectToggle = wrapper.find('FeaturedProjectToggle');
-      assert.equal(featuredProjectToggle.length, 1);
+      assert.strictEqual(featuredProjectToggle.length, 1);
     });
 
     it('renders a VersionList component', function () {
       const versionListComponent = wrapper.find('VersionList');
-      assert.equal(versionListComponent.length, 1);
+      assert.strictEqual(versionListComponent.length, 1);
     });
 
-    it('renders a no workflows found message when no workflow is in component state', function () {
+    it('renders a no workflows found message when no workflow is loaded', function () {
       const noWorkflowsMessage = wrapper.find('.project-status__section').at(2).children().find('div');
-      assert.equal(noWorkflowsMessage.text(), 'No workflows found');
+      assert.strictEqual(noWorkflowsMessage.text(), 'No workflows found');
     });
   });
 
-  describe('when workflow is in component state', function () {
+  describe('when workflow is loaded', function () {
     before(function () {
-      wrapper.setState({ workflows });
+      wrapper = shallow(<ProjectStatus />);
+      wrapper.setState({ project, workflows });
     });
 
     it('displays an asterisk next to the default workflow, if one is set', function () {
-      const defaultWorkflow = wrapper.find('li.section-list__item').first().text();
+      const defaultWorkflow = wrapper.find('fieldset.project-status__section-settings').first().find('div').first().text();
       assert.ok(defaultWorkflow.match(' * '), true);
     });
 
     it('does not display an asterisk next to a workflow that is not the default workflow', function () {
-      const notDefaultWorkflow = wrapper.find('li.section-list__item').last().text();
+      const notDefaultWorkflow = wrapper.find('fieldset.project-status__section-settings').last().find('div').first().text();
       assert.ok(notDefaultWorkflow.match(' * '), false);
     });
 
     it('renders a WorkflowToggle component for each workflow', function () {
       const workflowToggleComponents = wrapper.find('WorkflowToggle');
-      assert.equal(workflowToggleComponents.length, workflows.length);
+      assert.strictEqual(workflowToggleComponents.length, workflows.length);
     });
 
     it('calls #onChangeWorkflowLevel when a user changes a workflow\'s configuration level', function () {
@@ -149,10 +154,15 @@ describe('ProjectStatus', function () {
       sinon.assert.calledOnce(onChangeWorkflowRetirementStub);
     });
 
+    it('calls #onChangeSubjectViewer when a user changes a workflow\'s subject viewer configuration', function () {
+      wrapper.find('select#subject-viewers').first().simulate('change');
+      sinon.assert.calledOnce(onChangeSubjectViewerStub);
+    });
+
     it('renders the WorkflowDefaultDialog component when dialogIsOpen state is true', function () {
       wrapper.setState({ dialogIsOpen: true });
       const workflowDefaultDialog = wrapper.find('WorkflowDefaultDialog');
-      assert.equal(workflowDefaultDialog.length, 1);
+      assert.strictEqual(workflowDefaultDialog.length, 1);
     });
 
     it('calls #handleDialogCancel when a user cancels the WorkflowDefaultDialog modal', function () {

--- a/css/admin-page.styl
+++ b/css/admin-page.styl
@@ -7,7 +7,7 @@
     &__section
       margin: 1em 0
 
-      &-list
+      &-settings
         margin: 0 0 1em 0
 
       &-table


### PR DESCRIPTION
Staging branch URL: https://pr-5830.pfe-preview.zooniverse.org

I added a select dropdown to the admin interface for projects to set the subject viewer to use per workflow. I also reorganized the layout because it was really inconsistent and didn't clearly label what different settings were for.

Here we see the staging Anti-Slavery Test project with its default workflow setup for the new classifier using the `multiFrame` viewer. Most workflows won't have this set yet because they haven't migrated over to the new classifier.
<img width="376" alt="Screen Shot 2020-10-23 at 11 40 53 AM" src="https://user-images.githubusercontent.com/5016731/97052106-06bee580-1546-11eb-8d08-223b971d5202.png">

Specs are updated.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
