### PR TITLE
Revert "Talk: require a valid email address"

### DIFF
--- a/app/subjects/comment-form.cjsx
+++ b/app/subjects/comment-form.cjsx
@@ -75,11 +75,9 @@ module.exports = createReactClass
       when 1 then @startDiscussion()
 
   render: ->
-    invalidEmail = <p>You must have a <Link to="/settings/email">valid email address</Link> in order to contribute to the conversation.</p>
     return <Loading /> if @state.loading
     return @noDefaultBoardMessage() unless @state.boards
     return @loginPrompt() unless @props.user
-    return invalidEmail unless @props.user?.valid_email
 
     if @state.boards.length < 1
       @renderTab()

--- a/app/talk/discussion-comment.jsx
+++ b/app/talk/discussion-comment.jsx
@@ -56,14 +56,7 @@ class DiscussionComment extends React.Component {
   }
 
   render() {
-    if (this.props.user && !this.props.user.valid_email) {
-      return(
-        <p>
-          You must have a <Link to="/settings/email">valid email address</Link> in order to contribute to the conversation.
-        </p>
-      )
-    }
-    if (this.props.user && this.props.user.valid_email) {
+    if (this.props.user) {
       const baseLink = this.props.project ? `projects/${this.props.project.slug}` : '/';
       return (
         <div>

--- a/app/talk/discussion-comment.spec.js
+++ b/app/talk/discussion-comment.spec.js
@@ -1,8 +1,5 @@
-import apiClient from 'panoptes-client/lib/api-client';
 import React from 'react';
-import { Link } from 'react-router';
 import assert from 'assert';
-import { expect } from 'chai';
 import DiscussionComment from './discussion-comment';
 import { shallow } from 'enzyme';
 
@@ -10,23 +7,10 @@ const discussion = {
   section: 1
 };
 
-const validUser = apiClient.type('users').create({
-  login: 'test-account',
-  display_name: 'Test Account',
-  email: 'test@zooniverse.org',
-  global_email_communication: false,
-  beta_email_communication: true,
-  valid_email: true
-});
-
-const invalidUser = apiClient.type('users').create({
-  login: 'test-account',
-  display_name: 'Test Account',
-  email: 'test@zooniverse',
-  global_email_communication: false,
-  beta_email_communication: true,
-  valid_email: false
-});
+const user = {
+  id: 1,
+  display_name: 'Test User'
+};
 
 describe('DiscussionComment', function() {
   let wrapper;
@@ -49,32 +33,15 @@ describe('DiscussionComment', function() {
 
   describe('logged in', function() {
     beforeEach(function() {
-      wrapper = shallow(<DiscussionComment discussion={discussion} user={validUser} />);
+      wrapper = shallow(<DiscussionComment discussion={discussion} user={user} />);
     });
 
     it('will show a user avatar', function() {
       assert.equal(wrapper.find('.talk-comment-author').length, 1);
     });
-
-    describe('with a valid email', function() {
-      it('will show a comment box', function() {
-        assert.equal(wrapper.find('Commentbox').props().user, validUser);
-      });
-    })
-
-    describe('with an invalid email', function() {
-      beforeEach(function () {
-        wrapper.setProps({ user: invalidUser });
-        wrapper.update();
-      });
-
-      it('will not show a comment box', function() {
-        expect(wrapper.find('Commentbox').length).to.equal(0);
-      });
-      it('will show a link to update your email address', function () {
-        expect(wrapper.find(Link).props().to).to.equal('/settings/email');
-      })
-    })
+    it('will show a comment box', function() {
+      assert.equal(wrapper.find('Commentbox').props().user, user);
+    });
   });
 
   describe('comment validation', function(){


### PR DESCRIPTION
Reverts zooniverse/Panoptes-Front-End#5799

Volunteers with real email addresses are flagged as invalid in the `users` table, which has locked them out of Talk.