### PR TITLE
Project Builder: Align workflow completeness radio buttons

### DIFF
--- a/app/pages/lab/workflows-table.jsx
+++ b/app/pages/lab/workflows-table.jsx
@@ -57,8 +57,8 @@ const WorkflowsTable = ({
                   Active
                 </label>
               </td>
-              <td class="stats_completeness_type">
-                <label>
+              <td>
+                <label class="standard-table__label__completeness">
                   <input
                     checked={statsCompletenessType === 'classification'}
                     name={`stats_completeness_type.${workflow.id}`}
@@ -69,7 +69,7 @@ const WorkflowsTable = ({
                   Classification Count
                 </label>
                 {' '}
-                <label>
+                <label class="standard-table__label__completeness">
                   <input
                     checked={statsCompletenessType === 'retirement'}
                     name={`stats_completeness_type.${workflow.id}`}

--- a/app/pages/lab/workflows-table.jsx
+++ b/app/pages/lab/workflows-table.jsx
@@ -57,7 +57,7 @@ const WorkflowsTable = ({
                   Active
                 </label>
               </td>
-              <td>
+              <td class="stats_completeness_type">
                 <label>
                   <input
                     checked={statsCompletenessType === 'classification'}

--- a/css/lab.styl
+++ b/css/lab.styl
@@ -175,3 +175,9 @@
       &:active
         background: MAIN_HIGHLIGHT
         color: white
+
+.standard-table
+  .stats_completeness_type
+    label
+      display: block
+      whitespace: nowrap

--- a/css/lab.styl
+++ b/css/lab.styl
@@ -177,7 +177,6 @@
         color: white
 
 .standard-table
-  .stats_completeness_type
-    label
-      display: block
-      whitespace: nowrap
+  &__label__completeness
+    display: block
+    whitespace: nowrap


### PR DESCRIPTION
Align the workflow completeness radio buttons, in the lab, so that they are above one another.

Staging branch URL: https://pr-5834.pfe-preview.zooniverse.org

**before**
![Screenshot showing the workflows table in the lab. The retirement count radio button is easy to miss because it isn't beneath the classification count radio button.](https://user-images.githubusercontent.com/59547/97889197-f962e180-1d23-11eb-83ff-a2719d5a33ab.png)

**after**
![Screenshot showing the same table, but now the two radio buttons are vertically aligned.](https://user-images.githubusercontent.com/59547/97889314-231c0880-1d24-11eb-9812-736544a64b27.png)

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
