### PR TITLE
Add workflow.prioritized to project admin

### DIFF
--- a/app/pages/admin/project-status.jsx
+++ b/app/pages/admin/project-status.jsx
@@ -181,6 +181,13 @@ class ProjectStatus extends Component {
       .catch(error => this.setState({ error }));
   }
 
+  toggleWorkflowPrioritized(event, workflow) {
+    workflow
+      .update({ prioritized: event.target.checked })
+      .save()
+      .catch(error => this.setState({ error }));
+  }
+
   renderWorkflows() {
     if (this.state.workflows.length === 0) {
       return <div>No workflows found</div>;
@@ -277,6 +284,15 @@ class ProjectStatus extends Component {
                     defaultChecked={workflow.grouped}
                   />
                   Use grouped subject selection
+                </label>
+                <label>
+                  <input
+                    id="prioritized"
+                    type="checkbox"
+                    onChange={event => this.toggleWorkflowPrioritized(event, workflow)}
+                    defaultChecked={workflow.prioritized}
+                  />
+                  Use prioritized (sequential) subject selection
                 </label>
               </div>
               <hr />

--- a/app/pages/admin/project-status.jsx
+++ b/app/pages/admin/project-status.jsx
@@ -88,7 +88,7 @@ class ProjectStatus extends Component {
   }
 
   getWorkflows() {
-    const fields = 'display_name,active,configuration,grouped,retirement';
+    const fields = 'display_name,active,configuration,grouped,prioritized,retirement';
     return getWorkflowsInOrder(this.state.project, { fields }).then((workflows) => {
       const usedWorkflowLevels = this.getUsedWorkflowLevels(workflows);
       this.setState({ usedWorkflowLevels, workflows });

--- a/css/admin-page.styl
+++ b/css/admin-page.styl
@@ -10,6 +10,9 @@
       &-settings
         margin: 0 0 1em 0
 
+        label
+          display: block
+
       &-table
         display: table
 


### PR DESCRIPTION
Staging branch URL: https://pr-5835.pfe-preview.zooniverse.org

Allow admins to enable sequential subject selection for a workflow.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
