### PR TITLE
Lab data export error

### DIFF
--- a/app/pages/lab/project.cjsx
+++ b/app/pages/lab/project.cjsx
@@ -25,6 +25,10 @@ EditProjectPage = createReactClass
   contextTypes:
     router: PropTypes.object.isRequired
 
+  componentDidCatch: (error, info) ->
+    console.log(error, info);
+    this.setState({ error, info });
+
   getDefaultProps: ->
     project: id: '2'
     workflowActions: workflowActions
@@ -36,7 +40,16 @@ EditProjectPage = createReactClass
   labPath: (postFix = '') ->
     "/lab/#{@props.project.id}#{postFix}"
 
+  renderError: ->
+    <div>
+      <h1><code>{this.state.error.message}</code></h1>
+      <p>{!!this.state.info && <pre>{this.state.info.componentStack}</pre>}</p>
+    </div>
+
   render: ->
+    if @state.error
+      return @renderError()
+
     linkParams =
       projectID: @props.project.id
 

--- a/app/partials/data-export-download-link.jsx
+++ b/app/partials/data-export-download-link.jsx
@@ -20,7 +20,7 @@ export default class DataExportDownloadLink extends React.Component {
     }
 
     recentAndReady(exported) {
-        return exported && (exported.metadata.state === 'ready' || !exported.metadata.state);
+        return exported?.metadata && (exported.metadata.state === 'ready' || !exported.metadata.state);
     }
 
     pending(exported) {


### PR DESCRIPTION
Staging branch URL: https://pr-5847.pfe-preview.zooniverse.org

Closes: #5848. 

Fixes an error where the project builder crashes with `exported.metadata is null` if you try to view data exports on a project that has no exports, like I Fancy Cats (staging project 335.)

This PR adds an error boundary to lab projects, which prints out the error message and stack trace for page crashes.
The bug is fixed by adding an existence check to `exported.metadata` in the data download link component.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
