### PR TITLE
Allow admins to edit Training data in Workflow config

### DIFF
--- a/app/pages/admin/project-status.jsx
+++ b/app/pages/admin/project-status.jsx
@@ -333,7 +333,7 @@ class ProjectStatus extends Component {
                     type="text"
                     onBlur={(event) => this.onBlurTrainingSetIds(workflow, event)}
                     onChange={(event) => {
-                      const updatedTrainingSetIds = Object.apply({}, this.state.valTrainingSetIds)
+                      const updatedTrainingSetIds = Object.assign({}, this.state.valTrainingSetIds)
                       updatedTrainingSetIds[workflow.id] = event.target.value
                       this.setState({ valTrainingSetIds: updatedTrainingSetIds })
                     }}
@@ -347,7 +347,7 @@ class ProjectStatus extends Component {
                     type="text"
                     onBlur={(event) => this.onBlurTrainingChances(workflow, event)}
                     onChange={(event) => {
-                      const updatedTrainingChances = Object.apply({}, this.state.valTrainingChances)
+                      const updatedTrainingChances = Object.assign({}, this.state.valTrainingChances)
                       updatedTrainingChances[workflow.id] = event.target.value
                       this.setState({ valTrainingChances: updatedTrainingChances })
                     }}
@@ -361,7 +361,7 @@ class ProjectStatus extends Component {
                     type="text"
                     onBlur={(event) => this.onBlurTrainingDefaultChance(workflow, event)}
                     onChange={(event) => {
-                      const updatedTrainingDefaultChance = Object.apply({}, this.state.valTrainingDefaultChance)
+                      const updatedTrainingDefaultChance = Object.assign({}, this.state.valTrainingDefaultChance)
                       updatedTrainingDefaultChance[workflow.id] = event.target.value
                       this.setState({ valTrainingDefaultChance: updatedTrainingDefaultChance })
                     }}

--- a/app/pages/admin/project-status.jsx
+++ b/app/pages/admin/project-status.jsx
@@ -144,8 +144,9 @@ class ProjectStatus extends Component {
           (wf.configuration.training_chances && wf.configuration.training_chances.join)
           ? wf.configuration.training_chances.join(',')
           : '';
+        // Note: please allow default chance to be 0. This is a valid edge case.
         valTrainingDefaultChance[wf.id] =
-          wf.configuration.training_default_chance
+          (wf.configuration.training_default_chance >= 0 && wf.configuration.training_default_chance !== null)
           ? wf.configuration.training_default_chance
           : '';
       })
@@ -364,7 +365,6 @@ class ProjectStatus extends Component {
                     value={(this.state.valTrainingDefaultChance[workflow.id] || '')}
                   />
                 </label>
-                <label>Debug: {this.state.valTrainingDefaultChance[workflow.id]}</label>
               </div>
               <hr />
               <div>

--- a/app/pages/admin/project-status.jsx
+++ b/app/pages/admin/project-status.jsx
@@ -20,6 +20,8 @@ class ProjectStatus extends Component {
     this.onChangeWorkflowLevel = this.onChangeWorkflowLevel.bind(this);
     this.onChangeWorkflowRetirement = this.onChangeWorkflowRetirement.bind(this);
     this.onChangeTrainingDefaultChance = this.onChangeTrainingDefaultChance.bind(this);
+    this.onChangeTrainingSetIds = this.onChangeTrainingSetIds.bind(this);
+    this.onChangeTrainingChances = this.onChangeTrainingChances.bind(this);
     this.getWorkflows = this.getWorkflows.bind(this);
     this.forceUpdate = this.forceUpdate.bind(this);
     this.renderWorkflows = this.renderWorkflows.bind(this);
@@ -62,13 +64,35 @@ class ProjectStatus extends Component {
       .then(() => this.getWorkflows())
       .catch(error => this.setState({ error }));
   }
-  
+
   onChangeTrainingDefaultChance (workflow, event) {
     this.setState({ error: null });
     const val = parseInt(event.target.value);
     if (isNaN(val)) return;  // Ignore invalid values
     // TODO: if the value is an empty string, the field should be deleted altogether.
     return workflow.update({ 'configuration.training_default_chance': val }).save()
+      .then(() => this.getWorkflows())
+      .catch(error => this.setState({ error }));
+  }
+
+  onChangeTrainingSetIds(workflow, event) {
+    this.setState({ error: null });
+    let val = event.target.value || '';
+    val = val.split(',').map((str) => { return parseInt(str) })
+      .filter((num) => { return !isNaN(num) });
+    // TODO: if the value is an empty string, the field should be deleted altogether.
+    return workflow.update({ 'configuration.training_set_ids': val }).save()
+      .then(() => this.getWorkflows())
+      .catch(error => this.setState({ error }));
+  }
+
+  onChangeTrainingChances(workflow, event) {
+    this.setState({ error: null });
+    let val = event.target.value || '';
+    val = val.split(',').map((str) => { return parseFloat(str) })
+      .filter((num) => { return !isNaN(num) });
+    // TODO: if the value is an empty string, the field should be deleted altogether.
+    return workflow.update({ 'configuration.training_chances': val }).save()
       .then(() => this.getWorkflows())
       .catch(error => this.setState({ error }));
   }
@@ -271,7 +295,23 @@ class ProjectStatus extends Component {
               <div>
                 <h4>Configure Training Data</h4>
                 <label>
-                  training_default_chance:{' '}
+                  Training Set IDs:{' '}
+                  <input
+                    type="text"
+                    onChange={(event) => this.onChangeTrainingSetIds(workflow, event)}
+                    value={(workflow.configuration.training_set_ids || '')}
+                  />
+                </label>
+                <label>
+                  Training Chances:{' '}
+                  <input
+                    type="text"
+                    onChange={(event) => this.onChangeTrainingChances(workflow, event)}
+                    value={(workflow.configuration.training_chances || '')}
+                  />
+                </label>
+                <label>
+                  Training Default Chance:{' '}
                   <input
                     type="text"
                     onChange={(event) => this.onChangeTrainingDefaultChance(workflow, event)}

--- a/app/pages/admin/project-status.jsx
+++ b/app/pages/admin/project-status.jsx
@@ -329,6 +329,7 @@ class ProjectStatus extends Component {
                 <label>
                   Training Set IDs:{' '}
                   <input
+                    id="training-set-ids"
                     type="text"
                     onBlur={(event) => this.onBlurTrainingSetIds(workflow, event)}
                     onChange={(event) => {
@@ -342,6 +343,7 @@ class ProjectStatus extends Component {
                 <label>
                   Training Chances:{' '}
                   <input
+                    id="training-chances"
                     type="text"
                     onBlur={(event) => this.onBlurTrainingChances(workflow, event)}
                     onChange={(event) => {
@@ -355,6 +357,7 @@ class ProjectStatus extends Component {
                 <label>
                   Training Default Chance:{' '}
                   <input
+                    id="training-default-chance"
                     type="text"
                     onBlur={(event) => this.onBlurTrainingDefaultChance(workflow, event)}
                     onChange={(event) => {

--- a/app/pages/admin/project-status.jsx
+++ b/app/pages/admin/project-status.jsx
@@ -19,6 +19,7 @@ class ProjectStatus extends Component {
     super(props);
     this.onChangeWorkflowLevel = this.onChangeWorkflowLevel.bind(this);
     this.onChangeWorkflowRetirement = this.onChangeWorkflowRetirement.bind(this);
+    this.onChangeTrainingDefaultChance = this.onChangeTrainingDefaultChance.bind(this);
     this.getWorkflows = this.getWorkflows.bind(this);
     this.forceUpdate = this.forceUpdate.bind(this);
     this.renderWorkflows = this.renderWorkflows.bind(this);
@@ -58,6 +59,16 @@ class ProjectStatus extends Component {
     this.setState({ error: null });
     let selected = event.target.value;
     return workflow.update({ 'retirement.criteria': selected }).save()
+      .then(() => this.getWorkflows())
+      .catch(error => this.setState({ error }));
+  }
+  
+  onChangeTrainingDefaultChance (workflow, event) {
+    this.setState({ error: null });
+    const val = parseInt(event.target.value);
+    if (isNaN(val)) return;  // Ignore invalid values
+    // TODO: if the value is an empty string, the field should be deleted altogether.
+    return workflow.update({ 'configuration.training_default_chance': val }).save()
       .then(() => this.getWorkflows())
       .catch(error => this.setState({ error }));
   }
@@ -254,6 +265,18 @@ class ProjectStatus extends Component {
                     <option value="never_retire">Never Retire</option>
                     <option value="classification_count">Classification Count - {(workflow.retirement.options && workflow.retirement.options.count) || ''}</option>
                   </select>
+                </label>
+              </div>
+              <hr />
+              <div>
+                <h4>Configure Training Data</h4>
+                <label>
+                  training_default_chance:{' '}
+                  <input
+                    type="text"
+                    onChange={(event) => this.onChangeTrainingDefaultChance(workflow, event)}
+                    value={(workflow.configuration.training_default_chance || '')}
+                  />
                 </label>
               </div>
               <hr />

--- a/app/pages/admin/project-status.spec.js
+++ b/app/pages/admin/project-status.spec.js
@@ -44,6 +44,9 @@ describe('ProjectStatus', function () {
   let loadingIndicator;
   let onChangeWorkflowLevelStub;
   let onChangeWorkflowRetirementStub;
+  let onBlurTrainingDefaultChanceStub;
+  let onBlurTrainingSetIdsStub;
+  let onBlurTrainingChancesStub;
   let onChangeSubjectViewerStub;
   let wrapper;
 
@@ -52,6 +55,9 @@ describe('ProjectStatus', function () {
     sinon.stub(ProjectStatus.prototype, 'getWorkflows').callsFake(() => Promise.resolve(workflows));
     onChangeWorkflowLevelStub = sinon.stub(ProjectStatus.prototype, 'onChangeWorkflowLevel');
     onChangeWorkflowRetirementStub = sinon.stub(ProjectStatus.prototype, 'onChangeWorkflowRetirement');
+    onBlurTrainingDefaultChanceStub = sinon.stub(ProjectStatus.prototype, 'onBlurTrainingDefaultChance');
+    onBlurTrainingSetIdsStub = sinon.stub(ProjectStatus.prototype, 'onBlurTrainingSetIds');
+    onBlurTrainingChancesStub = sinon.stub(ProjectStatus.prototype, 'onBlurTrainingChances');
     onChangeSubjectViewerStub = sinon.stub(ProjectStatus.prototype, 'onChangeSubjectViewer');
     handleDialogCancelStub = sinon.stub(ProjectStatus.prototype, 'handleDialogCancel');
     handleDialogSuccessStub = sinon.stub(ProjectStatus.prototype, 'handleDialogSuccess');
@@ -62,6 +68,9 @@ describe('ProjectStatus', function () {
   after(function () {
     onChangeWorkflowLevelStub.restore();
     onChangeWorkflowRetirementStub.restore();
+    onBlurTrainingDefaultChanceStub.restore();
+    onBlurTrainingSetIdsStub.restore();
+    onBlurTrainingChancesStub.restore();
     handleDialogCancelStub.restore();
     handleDialogSuccessStub.restore();
     ProjectStatus.prototype.getProject.restore();
@@ -153,7 +162,22 @@ describe('ProjectStatus', function () {
       wrapper.find('select#retirementConfig').first().simulate('change');
       sinon.assert.calledOnce(onChangeWorkflowRetirementStub);
     });
-
+    
+    it('calls #onBlurTrainingDefaultChance when a user finishes making changes to a workflow\'s "training -> default chance" configuration', function () {
+      wrapper.find('input#training-default-chance').first().simulate('blur');
+      sinon.assert.calledOnce(onBlurTrainingDefaultChanceStub);
+    });
+    
+    it('calls #onBlurTrainingSetIds when a user finishes making changes to a workflow\'s "training -> set IDs" configuration', function () {
+      wrapper.find('input#training-set-ids').first().simulate('blur');
+      sinon.assert.calledOnce(onBlurTrainingSetIdsStub);
+    });
+    
+    it('calls #onBlurTrainingChances when a user finishes making changes to a workflow\'s "training -> chances" configuration', function () {
+      wrapper.find('input#training-chances').first().simulate('blur');
+      sinon.assert.calledOnce(onBlurTrainingChancesStub);
+    });
+    
     it('calls #onChangeSubjectViewer when a user changes a workflow\'s subject viewer configuration', function () {
       wrapper.find('select#subject-viewers').first().simulate('change');
       sinon.assert.calledOnce(onChangeSubjectViewerStub);


### PR DESCRIPTION
## PR Overview

Context (Why): a Workflow's Training data can currently only be edited by manually editing the Workflow config object, e.g. by the Rails console. It would be much easier to make these minor changes via a UI. As a Hackday project, @nciemniak wants to add such a functionality to the Admin page.

Details (What): This PR allows admins to edit the Training data values in a Workflow's configuration.

- This can be accessed by going to the Admin page, "Set Project Status", selecting a Project, then scrolling down to the individual workflows.
- The Training data fields are: `training_chances`, `training_default_chance`, `training_set_ids`
- Example:
  ```
  workflow.configuration = {
    training_chances: [1, 0.5, 0.3],
    training_default_chance: 5,
    training_set_ids: [4808,4807],
  }
  ```

<img width="787" alt="Screen Shot 2020-12-09 at 3 15 49 PM" src="https://user-images.githubusercontent.com/8762785/101688991-6b6ccb80-3a32-11eb-9c74-511477481e95.png">

_Example of the Configure Training Data section.

### Status

Ready for review!