### PR TITLE
use regexes to detect valid avatar_src urls vs paths

### DIFF
--- a/app/partials/project-card.cjsx
+++ b/app/partials/project-card.cjsx
@@ -25,9 +25,10 @@ ProjectCard = createReactClass
     if !!@props.imageSrc
       conditionalStyle.backgroundImage = "url('#{ @props.imageSrc }')"
     else if !!@props.project.avatar_src
-      try
-        backgroundImageSrc = new URL(@props.project.avatar_src)
-      catch error
+      urlRegex = new RegExp('^https?:\/\/[^\s]+');
+      if urlRegex.test(@props.project.avatar_src)
+        backgroundImageSrc = @props.project.avatar_src
+      else
         backgroundImageSrc = "//#{ @props.project.avatar_src }"
 
       conditionalStyle.backgroundImage = "url('#{ backgroundImageSrc }')"


### PR DESCRIPTION
Linked to #5865 - it appears that #5865 broke the www.zooniverse.org project cards for IE11 users. This PR fixes the issue for all supported browsers.

Another attempt to fix the broken project avatars, this time use regex instead to determine if the `avatar_src` is a full URL or a path suffix. MDN shows support for `new RegExp` and the `test` method in use here, https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp#Browser_compatibility

I think this will work to bridge the difference in API behaviour.

Staging branch URL: https://pr-5866.pfe-preview.zooniverse.org/projects
Prod version branch URL: https://pr-5866.pfe-preview.zooniverse.org/projects?env=production

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
