### PR TITLE
Update static asset URL

### DIFF
--- a/views/index.ejs
+++ b/views/index.ejs
@@ -13,9 +13,9 @@
     <meta property="og:type" content="website" />
     <meta property="og:title" content="Zooniverse" />
     <meta property="og:description" content="The Zooniverse is the world’s largest and most popular platform for people-powered research." />
-    <meta property="og:image" content="https://zooniverse-static.s3.amazonaws.com/assets/zooniverse-icon-web-black.png" />
+    <meta property="og:image" content="https://static.zooniverse.org/assets/zooniverse-icon-web-black.png" />
     <meta name="twitter:card" content="summary" />
-    <meta name="twitter:image" content="https://zooniverse-static.s3.amazonaws.com/assets/zooniverse-icon-web-black.png" />
+    <meta name="twitter:image" content="https://static.zooniverse.org/assets/zooniverse-icon-web-black.png" />
   </head>
 
   <body>


### PR DESCRIPTION
Staging branch URL: https://pr-5877.pfe-preview.zooniverse.org

Minor change to the Zooniverse social header info (Facebook OG and Twitter tags): change logo URL from S3-specific to cloud-agnostic version -- specifically, change domain from zooniverse-static.s3.amazonaws.com to static.zooniverse.org.  This will ensure the logo PNG URL resolves to the correct location once zooniverse-static content starts to be hosted out of Azure.

Note to @srallen: This was the only s3-specific URL I identified in PFE that required a change.  In contrast to what I said during our conversation on Tuesday, the app status messages already use the cloud-agnostic version of the URL, so no PFE changes are needed for that feature.  The only change needed for that feature applies to the Jenkins jobs (I created operations issue for that future update).