### PR TITLE
Add Sentry logging for project errors

### DIFF
--- a/app/lib/init-sentry.js
+++ b/app/lib/init-sentry.js
@@ -1,0 +1,10 @@
+import { init } from '@sentry/browser';
+import { Integrations } from '@sentry/tracing';
+
+export default function initSentry() {
+  init({
+    dsn: 'https://36a5af57df8b426ba710c0accec90544@o274434.ingest.sentry.io/5623615',
+    integrations: [new Integrations.BrowserTracing()],
+    tracesSampleRate: 1.0
+  });
+}

--- a/app/main.cjsx
+++ b/app/main.cjsx
@@ -6,6 +6,7 @@ useScroll = require 'react-router-scroll/lib/useScroll'
 routes = require './router'
 style = require '../css/main.styl'
 { sugarClient } = require 'panoptes-client/lib/sugar'
+initSentry = require('./lib/init-sentry').default
 
 # register locales
 `import counterpart from 'counterpart';`
@@ -50,6 +51,8 @@ shouldUpdateScroll = (prevRouterProps, routerProps) ->
     false
   else
     true
+
+initSentry()
 
 ReactDOM.render <Provider store={store}><Router history={browserHistory} render={applyRouterMiddleware(useScroll(shouldUpdateScroll))}>{routes}</Router></Provider>,
   document.getElementById('panoptes-main-container')

--- a/app/pages/project/index.jsx
+++ b/app/pages/project/index.jsx
@@ -3,6 +3,7 @@
  * DS205: Consider reworking code to avoid use of IIFEs
  * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
  */
+import { captureException, withScope } from '@sentry/browser';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Helmet } from 'react-helmet';
@@ -17,6 +18,17 @@ import ProjectPage from './project-page';
 import Translations from '../../classifier/translations';
 import getAllLinked from '../../lib/get-all-linked';
 
+/**
+  Send exceptions and React error info to Sentry
+*/
+function logToSentry(error, info) {
+  withScope((scope) => {
+    Object.keys(info).forEach((key) => {
+      scope.setExtra(key, info[key]);
+    });
+    captureException(error);
+  });
+}
 
 class ProjectPageController extends React.Component {
   constructor() {
@@ -92,6 +104,7 @@ class ProjectPageController extends React.Component {
 
   componentDidCatch(error, info) {
     console.log(error, info);
+    logToSentry(error, info);
     const loading = false;
     const ready = false;
     this.setState({ error, info, loading, ready });

--- a/package-lock.json
+++ b/package-lock.json
@@ -5252,6 +5252,75 @@
         }
       }
     },
+    "@sentry/browser": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-6.1.0.tgz",
+      "integrity": "sha512-t3y2TLXDWgvfknyH8eKj/9mghJfSEqItFyp74zPu1Src6kOPjkd4Sa7o4+bdkNgA8dIIOrDAhRUbB2sq4sWMCA==",
+      "requires": {
+        "@sentry/core": "6.1.0",
+        "@sentry/types": "6.1.0",
+        "@sentry/utils": "6.1.0",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/core": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.1.0.tgz",
+      "integrity": "sha512-57mXkp3NoyxRycXrL+Ec6bYS6UYJZp9tYX0lUp5Ry2M0FxDZ3Q4drkjr8MIQOhBaQXP2ukSX4QTVLGMPm60zMw==",
+      "requires": {
+        "@sentry/hub": "6.1.0",
+        "@sentry/minimal": "6.1.0",
+        "@sentry/types": "6.1.0",
+        "@sentry/utils": "6.1.0",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/hub": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.1.0.tgz",
+      "integrity": "sha512-JnBSCgNg3VHiMojUl5tCHU8iWPVuE+qqENIzG9A722oJms1kKWBvWl+yQzhWBNdgk5qeAY3F5UzKWJZkbJ6xow==",
+      "requires": {
+        "@sentry/types": "6.1.0",
+        "@sentry/utils": "6.1.0",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/minimal": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.1.0.tgz",
+      "integrity": "sha512-g6sfNKenL7wnsr/tibp8nFiMv/XRH0s0Pt4p151npmNI+SmjuUz3GGYEXk8ChCyaKldYKilkNOFdVXJxUf5gZw==",
+      "requires": {
+        "@sentry/hub": "6.1.0",
+        "@sentry/types": "6.1.0",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/tracing": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.1.0.tgz",
+      "integrity": "sha512-s6a4Ra3hHn4awiNz4fOEK6TCV2w2iLcxdppijcYEB7S/1rJpmqZgHWDicqufbOmVMOLmyKLEQ7w+pZq3TR3WgQ==",
+      "requires": {
+        "@sentry/hub": "6.1.0",
+        "@sentry/minimal": "6.1.0",
+        "@sentry/types": "6.1.0",
+        "@sentry/utils": "6.1.0",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/types": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.1.0.tgz",
+      "integrity": "sha512-kIaN52Fw5K+2mKRaHE2YluJ+F/qMGSUzZXIFDNdC6OUMXQ4TM8gZTrITXs8CLDm7cK8iCqFCtzKOjKK6KyOKAg=="
+    },
+    "@sentry/utils": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.1.0.tgz",
+      "integrity": "sha512-6JAplzUOS6bEwfX0PDRZBbYRvn9EN22kZfcL0qGHtM9L0QQ5ybjbbVwOpbXgRkiZx++dQbzLFtelxnDhsbFG+Q==",
+      "requires": {
+        "@sentry/types": "6.1.0",
+        "tslib": "^1.9.3"
+      }
+    },
     "@sinonjs/commons": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.4.0.tgz",
@@ -19394,8 +19463,7 @@
     "tslib": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
-      "dev": true
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
     },
     "tty-browserify": {
       "version": "0.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,8 @@
 {
   "name": "panoptes-front-end",
   "dependencies": {
+    "@sentry/browser": "~6.1.0",
+    "@sentry/tracing": "~6.1.0",
     "animated-scrollto": "~1.1.0",
     "chart.js": "~2.7.3",
     "chartist": "~0.11.0",


### PR DESCRIPTION
Staging branch URL: https://pr-5885.pfe-preview.zooniverse.org

Install Sentry browser error logging and performance tracing packages. Initialise Sentry before the App component mounts in the browser. Add Sentry logging to the project error boundary.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
