### PR TITLE
Localise the field guide title

### DIFF
--- a/app/pages/project/field-guide.cjsx
+++ b/app/pages/project/field-guide.cjsx
@@ -2,6 +2,7 @@ React = require 'react'
 createReactClass = require 'create-react-class'
 classnames = require 'classnames'
 {Markdown} = require 'markdownz'
+Translate = require('react-translate-component')
 CroppedImage = require('../../components/cropped-image').default
 
 module.exports = createReactClass
@@ -97,7 +98,7 @@ module.exports = createReactClass
         <button type="button" className="field-guide-header-button" disabled={atRoot} onClick={levelUp}>
           <i className="fa fa-chevron-left fa-fw"></i>
         </button>
-        <strong>Field Guide</strong>
+        <Translate component="strong" content="project.fieldGuide" />
         <button type="button" className="field-guide-header-button" onClick={@props.onClickClose}>
           <i className="fa fa-times fa-fw"></i>
         </button>


### PR DESCRIPTION
Use the Translate component to render the field guide title in the current locale.

![Screenshot showing the field guide title in German.](https://user-images.githubusercontent.com/59547/107223902-a8434780-6a0e-11eb-9536-4e3bc2ffa749.png)


Staging branch URL: https://pr-5888.pfe-preview.zooniverse.org

Fixes #5886.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
