### PR TITLE
Maintenance Mode - Feb 2021

### DIFF
--- a/views/index.ejs
+++ b/views/index.ejs
@@ -23,27 +23,11 @@
     <!--Deployed commit: <%= process.env.HEAD_COMMIT %>-->
     <!--Build env: <%= process.env.NODE_ENV %>-->
 
-    <noscript>
-      <p style="text-align: center;">
-        Sorry, it looks like you have JavaScript disabled.
-        <strong><a href="http://enable-javascript.com/">Learn how to enable it.</a></strong>
-      </p>
-    </noscript>
+    <h1>Under Maintenance</h1>
 
-    <script>
-      if (typeof SVGElement === 'undefined' || (new XMLHttpRequest()).withCredentials !== false) {
-        document.write([
-          '<p style="text-align: center;">',
-            'Sorry, it looks like your browser is too old to run this app.',
-            '<strong><a href="http://browsehappy.com/">Check out your upgrade options.</a></strong>',
-            '<small><em><a href="https://www.whatismybrowser.com/guides/why-should-i-update-my-web-browser">Why?</a></em></small>',
-          '</p>',
-        ].join('\n'));
-      }
-    </script>
+    <p>The Zooniverse is currently under maintenance. We'll be up again soon.</p>
 
-    <!-- Talk sticky -->
-    <li id="talk-sticky-placeholder"  class="talk-sticky-placeholder fa fa-bars" style="display: none"></li>
+    <p>You can keep up-to-date with the status of the platform at all times via our page at <a href="https://status.zooniverse.org">status.zooniverse.org</a>, and via our <a href="https://twitter.com/the_zooniverse">Twitter account</a>.</p>
 
     <!-- Google Tag Manager -->
     <noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-WDW6V4"
@@ -55,22 +39,5 @@
     })(window,document,'script','dataLayer','GTM-WDW6V4');</script>
     <!-- End Google Tag Manager -->
 
-    <i id="font-awesome-test" class="fa" style="opacity: 0; pointer-events: none; position: absolute;"></i>
-    <script>
-      addEventListener('DOMContentLoaded', function() {
-        var testIcon = document.getElementById('font-awesome-test');
-        var testIconFontFamily = getComputedStyle(testIcon).fontFamily;
-        if (testIconFontFamily !== 'FontAwesome') {
-          var fallbackLinkTag = '<link rel="stylesheet" href="/font-awesome/css/font-awesome.min.css" />';
-          document.head.insertAdjacentHTML('beforeEnd', fallbackLinkTag);
-        }
-        testIcon.parentNode.removeChild(testIcon);
-      });
-    </script>
-
-    <div id="panoptes-main-container"></div>
-
-    <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=default,es6,Promise,fetch,Array.prototype.includes,Array.prototype.find,Object.entries,Object.values&amp;flags=gated"></script>
-    <script>('assign' in Object) || document.write('<script src="/fallback-polyfills.js"></'+'script>');</script>
   </body>
 </html>


### PR DESCRIPTION
**DO NOT MERGE UNTIL CLEARED BY @nciemniak ON THURSDAY Feb 11!**

Add maintenance page placeholder for Feb 2021 DB upgrade downtime.  Follows example from July 2020 via Apply PR (https://github.com/zooniverse/Panoptes-Front-End/pull/5773) and Revert PR (https://github.com/zooniverse/Panoptes-Front-End/pull/5774).

Staging branch URL: https://pr-5889.pfe-preview.zooniverse.org

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
