### PR TITLE
Add paging for Media lab page

### DIFF
--- a/app/pages/lab/actions/media.js
+++ b/app/pages/lab/actions/media.js
@@ -13,19 +13,18 @@ const mediaActions = {
     return props.resource.get(props.link, { page, page_size })
       .then((media) => {
         const meta = media.length ? media[0].getMeta() : {};  // Derive the paging metadata for all the media, from the first media item.
-        return {
-          meta,
-          filteredMedia: media.filter((medium) => {
-            return Object.keys(medium.metadata).length > 0;
-          }),
-        };
-      })
-      .then((data) => {
+        const filteredMedia = media.filter((medium) => {
+          return Object.keys(medium.metadata).length > 0;
+        })
+        
         this.setState({
-          page_count: data.meta.page_count || 1,
-          media: data.filteredMedia,
+          page_count: meta.page_count || 1,
+          media: filteredMedia,
         });
-      }).catch((error) => { return []; });
+        
+        return filteredMedia;
+        
+      }).catch((error) => { console.error(error); return []; });
   },
 
   handleDrop(event) {

--- a/app/pages/lab/actions/media.js
+++ b/app/pages/lab/actions/media.js
@@ -26,7 +26,7 @@ const mediaActions = {
         console.error(error);
         return {
           page_count: 1,
-          media: filteredMedia,
+          media: [],
         }
         
       }).then((data) => {        

--- a/app/pages/lab/actions/media.js
+++ b/app/pages/lab/actions/media.js
@@ -5,13 +5,12 @@ const putFile = require('../../../lib/put-file');
 const MAX_FILE_SIZE = 500 * 1024;
 
 const mediaActions = {
-  fetchMedia(props = this.props) {
+  fetchMedia(props = this.props, page = 1) {
     this.setState({ media: null });
     
-    const page_size = this.props.pageSize
-    const page = this.state.page 
+    const page_size = props.pageSize;
     
-    return props.resource.get(this.props.link, { page, page_size })
+    return props.resource.get(props.link, { page, page_size })
       .then((media) => {
         const meta = media.length ? media[0].getMeta() : {};  // Derive the paging metadata for all the media, from the first media item.
         return {
@@ -23,6 +22,7 @@ const mediaActions = {
       })
       .then((data) => {
         this.setState({
+          page,
           page_count: data.meta.page_count || 1,
           media: data.filteredMedia,
         });

--- a/app/pages/lab/actions/media.js
+++ b/app/pages/lab/actions/media.js
@@ -6,7 +6,7 @@ const MAX_FILE_SIZE = 500 * 1024;
 
 const mediaActions = {
   fetchMedia(props = this.props, page = 1) {
-    this.setState({ media: null });
+    this.setState({ media: null, page });
     
     const page_size = props.pageSize;
     
@@ -22,7 +22,6 @@ const mediaActions = {
       })
       .then((data) => {
         this.setState({
-          page,
           page_count: data.meta.page_count || 1,
           media: data.filteredMedia,
         });

--- a/app/pages/lab/actions/media.js
+++ b/app/pages/lab/actions/media.js
@@ -17,14 +17,21 @@ const mediaActions = {
           return Object.keys(medium.metadata).length > 0;
         })
         
-        this.setState({
+        return {
           page_count: meta.page_count || 1,
           media: filteredMedia,
-        });
+        }
         
-        return filteredMedia;
+      }).catch((error) => {
+        console.error(error);
+        return {
+          page_count: 1,
+          media: filteredMedia,
+        }
         
-      }).catch((error) => { console.error(error); return []; });
+      }).then((data) => {        
+        this.setState(data);
+      });
   },
 
   handleDrop(event) {

--- a/app/pages/lab/actions/media.js
+++ b/app/pages/lab/actions/media.js
@@ -8,17 +8,24 @@ const mediaActions = {
   fetchMedia(props = this.props) {
     this.setState({ media: null });
     
-    const page_size = this.props.pageSize || 10
-    const page = this.props.page || 1
+    const page_size = this.props.pageSize
+    const page = this.state.page 
     
     return props.resource.get(this.props.link, { page, page_size })
       .then((media) => {
-        return media.filter((medium) => {
-          return Object.keys(medium.metadata).length > 0;
-        });
+        const meta = media.length ? media[0].getMeta() : {};  // Derive the paging metadata for all the media, from the first media item.
+        return {
+          meta,
+          filteredMedia: media.filter((medium) => {
+            return Object.keys(medium.metadata).length > 0;
+          }),
+        };
       })
-      .then((filteredMedia) => {
-        this.setState({ media: filteredMedia });
+      .then((data) => {
+        this.setState({
+          page_count: data.meta.page_count || 1,
+          media: data.filteredMedia,
+        });
       }).catch((error) => { return []; });
   },
 

--- a/app/pages/lab/actions/media.js
+++ b/app/pages/lab/actions/media.js
@@ -7,8 +7,11 @@ const MAX_FILE_SIZE = 500 * 1024;
 const mediaActions = {
   fetchMedia(props = this.props) {
     this.setState({ media: null });
-
-    return props.resource.get(this.props.link, { page_size: this.props.pageSize })
+    
+    const page_size = this.props.pageSize || 10
+    const page = this.props.page || 1
+    
+    return props.resource.get(this.props.link, { page, page_size })
       .then((media) => {
         return media.filter((medium) => {
           return Object.keys(medium.metadata).length > 0;

--- a/app/pages/lab/media-area/index.jsx
+++ b/app/pages/lab/media-area/index.jsx
@@ -51,6 +51,11 @@ export default class MediaAreaController extends React.Component {
   render() {
     return (
       <div>
+        <Paginator
+          page={this.state.page}
+          onPageChange={this.onPageChange.bind(this)}
+          pageCount={this.state.page_count}
+        />
         <MediaAreaView
           className={this.props.className}
           errors={this.state.errors}

--- a/app/pages/lab/media-area/index.jsx
+++ b/app/pages/lab/media-area/index.jsx
@@ -4,6 +4,7 @@ import apiClient from 'panoptes-client/lib/api-client';
 import MediaAreaView from './media-area-view';
 import putFile from '../../../lib/put-file';
 import mediaActions from '../actions/media';
+import Paginator from '../../../talk/lib/paginator';
 
 export default class MediaAreaController extends React.Component {
   constructor(props) {
@@ -37,8 +38,14 @@ export default class MediaAreaController extends React.Component {
 
   componentWillReceiveProps(nextProps) {
     if (this.props.resource !== nextProps.resource) {
-      this.fetchMedia(nextProps);
+      this.fetchMedia(nextProps, 1);
     }
+  }
+  
+  onPageChange (page) {
+    // When user requests the page to change, first fetch the media,
+    // and THEN update the state.page. (This is done in fetchMedia)
+    this.fetchMedia(this.props, page);
   }
 
   render() {
@@ -57,7 +64,11 @@ export default class MediaAreaController extends React.Component {
         >
           {this.props.children}
         </MediaAreaView>
-        <div>Page {this.state.page} of {this.state.page_count}</div>
+        <Paginator
+          page={this.state.page}
+          onPageChange={this.onPageChange.bind(this)}
+          pageCount={this.state.page_count}
+        />
       </div>
     );
   }
@@ -70,7 +81,7 @@ MediaAreaController.defaultProps = {
   metadata: {},
   onAdd: () => {},
   onDelete: () => {},
-  pageSize: 5,  // DEBUG 200,
+  pageSize: 200,
   resource: null,
   style: {},
   actions: mediaActions

--- a/app/pages/lab/media-area/index.jsx
+++ b/app/pages/lab/media-area/index.jsx
@@ -65,6 +65,7 @@ MediaAreaController.defaultProps = {
   metadata: {},
   onAdd: () => {},
   onDelete: () => {},
+  page: 1,
   pageSize: 200,
   resource: null,
   style: {},
@@ -92,6 +93,7 @@ MediaAreaController.propTypes = {
   metadata: PropTypes.object,
   onAdd: PropTypes.func,
   onDelete: PropTypes.func,
+  page: PropTypes.number,
   pageSize: PropTypes.number,
   resource: PropTypes.shape({
     _getURL: PropTypes.func,

--- a/app/pages/lab/media-area/index.jsx
+++ b/app/pages/lab/media-area/index.jsx
@@ -12,6 +12,8 @@ export default class MediaAreaController extends React.Component {
     this.state = {
       errors: [],
       media: null,
+      page: 1,  // Current page. Controlled by the user.
+      page_count: 1,  // Total number of pages. Update when we fetch the from resource's metadata.
       pendingFiles: [],
       pendingMedia: []
     };
@@ -41,19 +43,22 @@ export default class MediaAreaController extends React.Component {
 
   render() {
     return (
-      <MediaAreaView
-        className={this.props.className}
-        errors={this.state.errors}
-        media={this.state.media}
-        onDelete={this.handleDelete}
-        onDrop={this.handleDrop}
-        onSelect={this.handleFileSelection}
-        pendingFiles={this.state.pendingFiles}
-        pendingMedia={this.state.pendingMedia}
-        style={this.props.style}
-      >
-        {this.props.children}
-      </MediaAreaView>
+      <div>
+        <MediaAreaView
+          className={this.props.className}
+          errors={this.state.errors}
+          media={this.state.media}
+          onDelete={this.handleDelete}
+          onDrop={this.handleDrop}
+          onSelect={this.handleFileSelection}
+          pendingFiles={this.state.pendingFiles}
+          pendingMedia={this.state.pendingMedia}
+          style={this.props.style}
+        >
+          {this.props.children}
+        </MediaAreaView>
+        <div>Page {this.state.page} of {this.state.page_count}</div>
+      </div>
     );
   }
 }
@@ -65,8 +70,7 @@ MediaAreaController.defaultProps = {
   metadata: {},
   onAdd: () => {},
   onDelete: () => {},
-  page: 1,
-  pageSize: 200,
+  pageSize: 5,  // DEBUG 200,
   resource: null,
   style: {},
   actions: mediaActions
@@ -93,7 +97,6 @@ MediaAreaController.propTypes = {
   metadata: PropTypes.object,
   onAdd: PropTypes.func,
   onDelete: PropTypes.func,
-  page: PropTypes.number,
   pageSize: PropTypes.number,
   resource: PropTypes.shape({
     _getURL: PropTypes.func,

--- a/app/pages/lab/media-area/index.jsx
+++ b/app/pages/lab/media-area/index.jsx
@@ -43,8 +43,8 @@ export default class MediaAreaController extends React.Component {
   }
   
   onPageChange (page) {
-    // When user requests the page to change, first fetch the media,
-    // and THEN update the state.page. (This is done in fetchMedia)
+    // When user requests the page to change, the media fetch AND the update
+    // of state.page is done in fetchMedia()
     this.fetchMedia(this.props, page);
   }
 


### PR DESCRIPTION
## PR Overview

This PR adds a basic pagination system to the Media page. (e.g. https://www.zooniverse.org/lab/1292/media) This fixes an issue where projects owners with more than 200 media files either 1. think they've "lost" images, or 2. can't see when they've successfully uploaded new images.

Context:
- We had a [Freshdesk report](https://zooniverse.freshdesk.com/a/tickets/7034) from project owners detailing the issue.
- Our investigation uncovered that the Media page in the lab has a hard limit of _showing_ 200 images, but a small number of projects having far, far more than 200 images.
- The backend is fine, this is purely a UI issue causing user confusion.

Staging branch URL: https://pr-{NUMBER}.pfe-preview.zooniverse.org

### Dev Notes

This update consists of 3 parts

- the `<MediaArea>` component now tracks `state.page` and `state.page_count`
- the `fetchMedia()` action now asks for the page it should fetch, and records the page_count from the metadata received.
  - Detailed note: `state.page` and `state.page_count` are only updated in the fetchMedia() function. This may lead to some quirks - e.g. the page indicator won't change until the attached_images resources are fetched - but it's the most sensible option. I originally wanted to pass page and page_count as props to <MediaArea> from the <Media> page, but dangit, that'd split state management across two containers and that made it harder to read and harder to trace the React lifecycle. 
- the common `<Paginator>` component has been added to `<MediaArea>`

### Testing

Proper testing requires a project with a huge amount of media images.

- To view this one a live production project, try `https://local.zooniverse.org:3735/lab/11262/media?env=production`
- To test this on local, on your own project...
  - go to `app/pages/lab/media/index.jsx` and crank the `MediaAreaController.defaultProps.pageSize` down to 3
  - open the Media lab page for your project
  - upload 5 images.
  - observe that you can now browse between 2 pages.
  - delete any number of images
  - observe that your page is reset to 1 after each delete, and images have been correctly deleted.
  - upload additional images
  - Note: if you upload images on page 2+, the page will reset to 1 after each upload, IIRC.

### Status

Ready for review.

This issue is currently affecting at least 1 live project, and if this PR is good, it will go quite a bit to help that project team.