### PR TITLE
Redirect for P4

### DIFF
--- a/app/router.cjsx
+++ b/app/router.cjsx
@@ -86,6 +86,13 @@ RELOAD = createReactClass
   render: ->
     null
 
+ExternalRedirect = createReactClass
+  componentDidMount: ->
+    if @props.newUrl
+      window.location = @props.newUrl
+  render: ->
+    null
+
 module.exports =
   <Route path="/" component={require './partials/app'}>
     <IndexRoute component={HomePageRoot} />
@@ -154,6 +161,8 @@ module.exports =
 
     <Route path="/projects/msalmon/hms-nhs-the-nautical-health-service" component={() => <RELOAD newUrl='https://fe-project.zooniverse.org/projects/msalmon/hms-nhs-the-nautical-health-service' />} />
     <Route path="/projects/msalmon/hms-nhs-the-nautical-health-service/classify" component={() => <RELOAD newUrl='https://fe-project.zooniverse.org/projects/msalmon/hms-nhs-the-nautical-health-service/classify' />} />
+
+    <Route path="/projects/mschwamb/planet-four/authors" component={() => <ExternalRedirect newUrl='https://authors.planetfour.org/' />} />
 
     <Route path="projects/:owner/:name" component={require('./pages/project').default}>
       <IndexRoute component={ProjectHomePage} />


### PR DESCRIPTION
Retrying what I meant to do in #5894. I reused `RELOAD` when I shouldn't have. It does what we expect when the hostname is not `www.zooniverse.org`, but not when it is (aka production) because what its intended behavior is to reload the page to then proxy redirect to the new apps. All we want here is a simple redirect, so I added code to do just that.

Can test with:  https://pr-5897.pfe-preview.zooniverse.org/projects/mschwamb/planet-four/authors?env=production

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
