### PR TITLE
Add scatterPlot to the list in the admin pages

### DIFF
--- a/app/pages/admin/project-status.jsx
+++ b/app/pages/admin/project-status.jsx
@@ -411,6 +411,8 @@ class ProjectStatus extends Component {
               <hr />
               <div>
                 <h4>Classifier 2.0 (rewrite) settings</h4>
+                <p>Note that that Scatter Plot is preferred over TESS Light Curve for that kind of JSON subject data. The TESS light curve viewer is built specifically for their requirements. The code in the viewer assumes the project is using a task like them.</p>
+
                 <label>
                   Subject Viewer:{' '}
                   <select
@@ -422,6 +424,7 @@ class ProjectStatus extends Component {
                     <option value="dataImage">Data Image</option>
                     <option value="lightcurve">(D3/TESS) Light Curve</option>
                     <option value="multiFrame">Multi-Frame</option>
+                    <option value="scatterPlot">Scatter Plot</option>
                     <option value="singleImage">Single Image</option>
                     <option value="subjectGroup">Subject Group</option>
                     <option value="variableStar">Variable Star</option>


### PR DESCRIPTION
Staging branch URL: https://pr-5898.pfe-preview.zooniverse.org

This adds `scatterPlot` as a subject viewer option for the new classifier in the admin tools. 

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [x] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
