### PR TITLE
Add UI button for transcription task to lab

### DIFF
--- a/app/pages/lab/workflow.cjsx
+++ b/app/pages/lab/workflow.cjsx
@@ -62,7 +62,7 @@ EditWorkflowPage = createReactClass
     @props.project.uncacheLink 'workflows'
     @props.project.uncacheLink 'subject_sets' # An "expert" subject set is automatically created with each workflow.
 
-  canUseTask: (project, task)->
+  canUseTask: (project, task) ->
     task in project.experimental_tools
 
   handleTaskChange: (taskKey, taskDescription) ->
@@ -150,7 +150,8 @@ EditWorkflowPage = createReactClass
                             when 'dropdown' then <i className="fa fa-list fa-fw"></i>
                             when 'combo' then <i className="fa fa-cubes fa-fw"></i>
                             when 'slider' then <i className="fa fa-sliders fa-fw"></i>
-                            when 'highlighter' then <i className="fa fa-i-cursor"></i>}
+                            when 'highlighter' then <i className="fa fa-i-cursor"></i>
+                            when 'transcription' then <i className="fa fa-font fa-fw"></i>}
                           {' '}
                           {taskDefinition || 'Task editor is unavailable'}
                           {if key is @props.workflow.first_task
@@ -233,6 +234,14 @@ EditWorkflowPage = createReactClass
                         <i className="fa fa-sliders fa-2x"></i>
                         <br />
                         <small><strong>Slider</strong></small>
+                      </button>
+                    </AutoSave>}{' '}
+                  {if @canUseTask(@props.project, "transcription-task")
+                    <AutoSave resource={@props.workflow}>
+                      <button type="submit" className="minor-button" onClick={() => console.log 'add transcription task'} title="Transcription tasks: the volunteer marks a line under text and transcribes the text into a text box. If caesar is configured, then text suggestions if available from other volunteers are options.">
+                        <i className="fa fa-font fa-2x"></i>
+                        <br />
+                        <small><strong>Transcription</strong></small>
                       </button>
                     </AutoSave>}
                 </TriggeredModalForm>


### PR DESCRIPTION
Staging branch URL: https://pr-5899.pfe-preview.zooniverse.org

This adds a button in the list of tasks when you click "Add Task" for transcription task, if the project has the `transcription-task` experimental tool enabled. This can be setup in the admin pages for a project. Once it is, you'll see it in the list:

<img width="586" alt="Screen Shot 2021-02-17 at 11 25 02 AM" src="https://user-images.githubusercontent.com/5016731/108242895-1379d180-7113-11eb-8883-bebbd9c2944a.png">

For existing projects setup with the transcription task, it also adds the icon to the task in the task list:

<img width="512" alt="Screen Shot 2021-02-17 at 11 25 12 AM" src="https://user-images.githubusercontent.com/5016731/108242958-27bdce80-7113-11eb-8487-72ba2da79fe4.png">

Both of these can be demoed by checking out https://pr-5899.pfe-preview.zooniverse.org/lab/1764/workflows/3392

Right now the button doesn't do anything other than console log. Functionality will come in a future PR.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
