### PR TITLE
Add subtask editor

### DIFF
--- a/app/classifier/tasks/transcription/SubtaskEditor.jsx
+++ b/app/classifier/tasks/transcription/SubtaskEditor.jsx
@@ -1,0 +1,69 @@
+import React from 'react'
+import AutoSave from '../../../components/auto-save';
+
+export default function SubTaskEditor({ subtask, subtaskPrefix, workflow }) {
+  const instructionPath = `${subtaskPrefix}.instruction`
+  const textTagsPath = `${subtaskPrefix}.text_tags`
+  function tagExists(tag) {
+    if (subtask.text_tags) {
+      return subtask.text_tags.indexOf(tag) > -1;
+    }
+
+    return false
+  }
+
+  function updateTags(event) {
+    const changes = {};
+    const { checked, value } = event.target;
+    const text_tags = subtask.text_tags ?? [];
+    if (text_tags.indexOf(value) === -1 && checked) {
+      text_tags.push(value)
+    } else if (!checked) {
+      const removalIndex = text_tags.indexOf(value)
+      text_tags.splice(removalIndex, 1);
+    }
+    changes[textTagsPath] = text_tags
+    workflow.update(changes).save()
+  }
+
+  function handleChange(event) {
+    const { name,  value } = event.target;
+    const changes = {};
+    changes[name] = value;
+    // Don't need to call save here because wrapped by an AutoSave component in render
+    workflow.update(changes);
+  }
+
+  return (
+    <div className="text-editor">
+      <section>
+        <div>
+          <AutoSave resource={workflow}>
+            <span className="form-label">Main text</span>
+            <br />
+            <textarea name={instructionPath} value={subtask.instruction} className="standard-input full" onChange={handleChange} />
+          </AutoSave>
+          <small className="form-help">Describe the task, or ask the question, in a way that is clear to a non-expert. You can use markdown to format this text.</small><br />
+        </div>
+        <br />
+        <span className="form-label">Metadata Tags</span> <br/>
+        <small className="form-help">Volunteers can attach the following tags to highlighted portions of their transcription.</small><br/>
+        <label>
+          <input type="checkbox" value="deletion" checked={tagExists('deletion')} onChange={updateTags} />
+          {"Deletion"}
+        </label>
+        <br/>
+        <label>
+          <input type="checkbox" value="insertion" checked={tagExists('insertion')} onChange={updateTags} />
+          {"Insertion"}
+        </label>
+        <br/>
+        <label>
+          <input type="checkbox" value="unclear" checked={tagExists('unclear')} onChange={updateTags} />
+          {"Unclear"}
+        </label>
+      </section>
+      <hr/>
+    </div>
+  )
+}

--- a/app/classifier/tasks/transcription/editor.jsx
+++ b/app/classifier/tasks/transcription/editor.jsx
@@ -3,12 +3,25 @@ import { MarkdownEditor, MarkdownHelp } from 'markdownz';
 import handleInputChange from '../../../lib/handle-input-change';
 import AutoSave from '../../../components/auto-save';
 import alert from  '../../../lib/alert';
+import SubTaskEditor from './SubtaskEditor';
 
 export default function TranscriptionTaskEditor({ task, taskPrefix, workflow }) {
   const handleChange = handleInputChange.bind(workflow)
 
+  // function handleSubtaskChange (subtaskIndex, path, value) {
+  //   taskKey = (key for key, description of @props.workflow.tasks when description is @props.task)[0]
+  //   changes = {}
+  //   changes["#{@props.toolPath}.details.#{subtaskIndex}.#{path}"] = value
+  //   @props.workflow.update(changes).save()
+  // }
+
+  const toolPath = `${taskPrefix}.tools.0`
+  const subtask = task.tools[0].details[0]
+
   return (
     <div className={`workflow-task-editor ${task.type}`}>
+      <p>The transcription task comprises of a pre-configured drawing task using a two-click line drawing mark, the transcription line tool, and text sub-task.</p>
+      <p>Only the instructions, help text, and text modifiers are editable.</p>
       <div>
         <AutoSave resource={workflow}>
           <span className="form-label">Main text</span>
@@ -25,6 +38,15 @@ export default function TranscriptionTaskEditor({ task, taskPrefix, workflow }) 
           <MarkdownEditor name={`${taskPrefix}.help`} onHelp={() => {alert(<MarkdownHelp/>)}} value={task.help ?? ""} rows="7" className="full" onChange={handleChange} />
         </AutoSave>
         <small className="form-help">Add text and images for a window that pops up when volunteers click “Need some help?” You can use markdown to format this text and add images. The help text can be as long as you need, but you should try to keep it simple and avoid jargon.</small>
+      </div>
+      <br />
+      <div className="drawing-task-details-editor">
+        <p>Text sub-task</p>
+        <SubTaskEditor
+          subtask={subtask}
+          subtaskPrefix={`${toolPath}.details.0`}
+          workflow={workflow}
+        />
       </div>
     </div>
   )


### PR DESCRIPTION
Staging branch URL: https://pr-5904.pfe-preview.zooniverse.org

This adds a basic editor for the text subtask portion of the transcription task. You should be able to edit the instruction and which text tags are allowed for an already existing transcription task. Try it out at: https://pr-5904.pfe-preview.zooniverse.org/lab/1764/workflows/3392

<img width="511" alt="Screen Shot 2021-02-24 at 3 43 47 PM" src="https://user-images.githubusercontent.com/5016731/109069879-6aede380-76b7-11eb-9da2-e023fd015a87.png">

I also added a basic explanatory message about what the transcription task is at the top:
 
<img width="508" alt="Screen Shot 2021-02-24 at 3 43 38 PM" src="https://user-images.githubusercontent.com/5016731/109069862-63c6d580-76b7-11eb-8907-08cff064e460.png">


# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
