### PR TITLE
Add transcription line tool explanation

### DIFF
--- a/app/classifier/tasks/transcription/SubtaskEditor.jsx
+++ b/app/classifier/tasks/transcription/SubtaskEditor.jsx
@@ -63,7 +63,6 @@ export default function SubTaskEditor({ subtask, subtaskPrefix, workflow }) {
           {"Unclear"}
         </label>
       </section>
-      <hr/>
     </div>
   )
 }

--- a/app/classifier/tasks/transcription/editor.jsx
+++ b/app/classifier/tasks/transcription/editor.jsx
@@ -39,7 +39,7 @@ export default function TranscriptionTaskEditor({ task, taskPrefix, workflow }) 
         </AutoSave>
         <small className="form-help">Add text and images for a window that pops up when volunteers click “Need some help?” You can use markdown to format this text and add images. The help text can be as long as you need, but you should try to keep it simple and avoid jargon.</small>
       </div>
-      <br />
+      <hr />
       <div className="drawing-task-details-editor">
         <p>Text sub-task</p>
         <SubTaskEditor
@@ -47,6 +47,23 @@ export default function TranscriptionTaskEditor({ task, taskPrefix, workflow }) 
           subtaskPrefix={`${toolPath}.details.0`}
           workflow={workflow}
         />
+      </div>
+      <hr />
+      <div>
+        <p>Transcription line tool</p>
+        <p>
+          This is a 2-click line mark tool which has pre-set colors. These colors map to the following states:
+          <dl>
+            <dt><img src='https://via.placeholder.com/10x10.png/06FE76?text=+' /> Green</dt>
+            <dd>A transcription line mark currently selected by the volunteer.</dd>
+            <dt><img src='https://via.placeholder.com/10x10.png/235DFF?text=+' /> Blue</dt>
+            <dd>A transcription line mark made by the volunteer.</dd>
+            <dt><img src='https://via.placeholder.com/10x10.png/FF40FF?text=+' /> Purple </dt>
+            <dd>A transcription line mark made previously by another volunteer. This mark can be selected to create a new transcription to submit.</dd>
+            <dt><img src='https://via.placeholder.com/10x10.png/979797?text=+' /> Gray</dt>
+            <dd>A transcription line mark which has reached consensus. The mark and transcriptions are view only.</dd>
+          </dl>
+        </p>
       </div>
     </div>
   )

--- a/app/classifier/tasks/transcription/editor.jsx
+++ b/app/classifier/tasks/transcription/editor.jsx
@@ -20,8 +20,8 @@ export default function TranscriptionTaskEditor({ task, taskPrefix, workflow }) 
 
   return (
     <div className={`workflow-task-editor ${task.type}`}>
-      <p>The transcription task comprises of a pre-configured drawing task using a two-click line drawing mark, the transcription line tool, and text sub-task.</p>
-      <p>Only the instructions, help text, and text modifiers are editable.</p>
+      <p className='form-help'>The transcription task comprises of a pre-configured drawing task using a two-click line drawing mark, the transcription line tool, and text sub-task.</p>
+      <p className='form-help'>Only the instructions, help text, and text modifiers are editable.</p>
       <div>
         <AutoSave resource={workflow}>
           <span className="form-label">Main text</span>
@@ -41,7 +41,7 @@ export default function TranscriptionTaskEditor({ task, taskPrefix, workflow }) 
       </div>
       <hr />
       <div className="drawing-task-details-editor">
-        <p>Text sub-task</p>
+        <p className='form-label'>Text sub-task</p>
         <SubTaskEditor
           subtask={subtask}
           subtaskPrefix={`${toolPath}.details.0`}
@@ -50,8 +50,8 @@ export default function TranscriptionTaskEditor({ task, taskPrefix, workflow }) 
       </div>
       <hr />
       <div>
-        <p>Transcription line tool</p>
-        <p>
+        <p className='form-label'>Transcription line tool</p>
+        <small className="form-help">
           This is a 2-click line mark tool which has pre-set colors. These colors map to the following states:
           <dl>
             <dt><img src='https://via.placeholder.com/10x10.png/06FE76?text=+' /> Green</dt>
@@ -63,7 +63,7 @@ export default function TranscriptionTaskEditor({ task, taskPrefix, workflow }) 
             <dt><img src='https://via.placeholder.com/10x10.png/979797?text=+' /> Gray</dt>
             <dd>A transcription line mark which has reached consensus. The mark and transcriptions are view only.</dd>
           </dl>
-        </p>
+        </small>
       </div>
     </div>
   )

--- a/app/classifier/tasks/transcription/editor.jsx
+++ b/app/classifier/tasks/transcription/editor.jsx
@@ -58,7 +58,7 @@ export default function TranscriptionTaskEditor({ task, taskPrefix, workflow }) 
             <dd>A transcription line mark currently selected by the volunteer.</dd>
             <dt><img src='https://via.placeholder.com/10x10.png/235DFF?text=+' /> Blue</dt>
             <dd>A transcription line mark made by the volunteer.</dd>
-            <dt><img src='https://via.placeholder.com/10x10.png/FF40FF?text=+' /> Purple </dt>
+            <dt><img src='https://via.placeholder.com/10x10.png/FF40FF?text=+' /> Pink </dt>
             <dd>A transcription line mark made previously by another volunteer. This mark can be selected to create a new transcription to submit.</dd>
             <dt><img src='https://via.placeholder.com/10x10.png/979797?text=+' /> Gray</dt>
             <dd>A transcription line mark which has reached consensus. The mark and transcriptions are view only.</dd>


### PR DESCRIPTION
Staging branch URL: https://pr-5905.pfe-preview.zooniverse.org

This add explanatory text a bout the transcription line:

<img width="510" alt="Screen Shot 2021-02-25 at 3 19 15 PM" src="https://user-images.githubusercontent.com/5016731/109219257-fc735900-777c-11eb-88fd-ed5f58af5524.png">

Previewed at: https://pr-5905.pfe-preview.zooniverse.org/lab/1764/workflows/3392

@snblickhan and @beckyrother is this text ok for the editor?

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
