### PR TITLE
remove hidden project prefs from the logged in user ribbon

### DIFF
--- a/app/pages/home-for-user/index.jsx
+++ b/app/pages/home-for-user/index.jsx
@@ -126,8 +126,12 @@ export default class HomePageForUser extends React.Component {
         if (meta.page !== meta.page_count) {
           getRibbonData(user, meta.page + 1);
         }
-        // filter out projects you haven't classified on.
-        let activePreferences = projectPreferences.filter((preference) => { return preference.activity_count > 0; });
+        // filter out projects you haven't classified on AND that are not marked as hidden.
+        let activePreferences = projectPreferences.filter((preference) => {
+          let userHasClassified = preference.activity_count > 0;
+          let isVisiblePreference = !preference.settings['hidden'];
+          return userHasClassified && isVisiblePreference;
+        });
         // get the projects that you have classified on, if any.
         if (activePreferences.length > 0) {
           activePreferences = activePreferences.map((preference, i) => {


### PR DESCRIPTION
filter any user project preferences that have the settings object marked as `preference.hidden=true`

Currently relies on manually setting the value in the API db manually, however changes in https://github.com/zooniverse/panoptes/pull/3583 will expose this `hidden` attribute for update via the API.

I'm happy to modify any testing user project preferences to have this value. 

Staging branch URL: https://pr-5908.pfe-preview.zooniverse.org

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
