### PR TITLE
Use the thumbnail service for collections previews

### DIFF
--- a/app/pages/collections/collection-card.jsx
+++ b/app/pages/collections/collection-card.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import FlexibleLink from '../../components/flexible-link';
+import Thumbnail from '../../components/thumbnail'
 
 export default class CollectionCard extends React.Component {
   constructor(props) {
@@ -16,7 +17,13 @@ export default class CollectionCard extends React.Component {
   setSubjectPreview(src) {
     const splitSrc = src ? src.split('.') : [];
     if (src && splitSrc[splitSrc.length - 1] !== 'mp4') {
-      this.collectionCard.style.backgroundImage = `url('${src}')`;
+      const thumbnailSrc = Thumbnail.getThumbnailSrc({
+        origin: 'https://thumbnails.zooniverse.org',
+        width: 220,
+        height: 270,
+        src
+      })
+      this.collectionCard.style.backgroundImage = `url('${thumbnailSrc}')`;
       this.collectionCard.style.backgroundPosition = 'initial';
       this.collectionCard.style.backgroundRepeat = 'no-repeat';
       this.collectionCard.style.backgroundSize = 'cover';


### PR DESCRIPTION
Staging branch URL: https://pr-5916.pfe-preview.zooniverse.org

For https://zooniverse.freshdesk.com/a/tickets/7356

Let's use the thumbnail service for the collection previews. Hopefully this will make this component a bit faster. The actual subject views use the subject viewer, so unfortunately I don't think we can use the thumbnail service here. Thoughts for a new version of the page in the app:  Maybe default to an optimized preview and let the volunteer view it in the subject viewer only per subject, not on the paginated version.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
