### PR TITLE
Replace Travis CI with GitHub Actions

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:    
       - master
-
+  workflow_dispatch:
 jobs:
   build:
    runs-on: ubuntu-latest

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -1,0 +1,37 @@
+name: CI Tests
+
+on:
+  pull_request:
+  push:
+    branches:    
+      - master
+
+jobs:
+  build:
+   runs-on: ubuntu-latest
+
+   steps:
+    # See: https://help.github.com/en/actions/automating-your-workflow-with-github-actions/configuring-a-workflow#using-the-checkout-action
+    - uses: actions/checkout@v2
+
+    - name: Use Node.js 14
+      uses: actions/setup-node@v1
+      with:
+        node-version: '14.x'
+
+    - name: Cache dependencies
+      uses: actions/cache@v1
+      with:
+        path: ~/.npm
+        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-node-
+
+    - run: npm ci
+    - run: npm run test-ci
+    - run: npm run coverage
+
+    - name: Coveralls
+      uses: coverallsapp/github-action@master
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: node_js
-node_js: "14"
-
-script:
-  - npm run test-travis
-
-after_success:
-  npm run coverage
-

--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
     "coffee-react": "~5.0.1",
     "coffeescript": "~2.3.2",
     "copy-webpack-plugin": "~4.6.0",
-    "coveralls": "~3.0.2",
     "css-loader": "~2.1.0",
     "ejs": "~2.6.1",
     "enzyme": "~3.8.0",
@@ -128,7 +127,7 @@
   },
   "repository": "zooniverse/Panoptes-Front-End",
   "scripts": {
-    "coverage": "nyc report --reporter=text-lcov | coveralls",
+    "coverage": "nyc report --reporter=lcov",
     "start": "export NODE_ENV=development; check-engines && check-dependencies && webpack-dashboard -p 3736 -- webpack-dev-server --config ./webpack.dev.js",
     "_build": "export HEAD_COMMIT=$(git rev-parse --short HEAD); check-engines && check-dependencies && rimraf dist; webpack --config ./webpack.build.js --progress --profile --colors",
     "serve-static": "export NODE_ENV=staging; check-engines && check-dependencies && npm run _build && node ./static-server.js",
@@ -143,7 +142,7 @@
     "test-and-watch": "NODE_ENV=development BABEL_ENV=test mocha --watch --watch-extensions js,jsx,coffee,cjsx test/setup.js test/enzyme-configuration.js $(find app -name *.spec.js*) --reporter nyan || true",
     "test": "NODE_ENV=development BABEL_ENV=test nyc mocha test/setup.js test/enzyme-configuration.js $(find app -name *.spec.js*) --reporter nyan || true",
     "test-one": "NODE_ENV=development BABEL_ENV=test nyc mocha test/setup.js test/enzyme-configuration.js $1",
-    "test-travis": "NODE_ENV=development BABEL_ENV=test nyc mocha test/setup.js test/enzyme-configuration.js $(find app -name *.spec.js*)",
+    "test-ci": "NODE_ENV=development BABEL_ENV=test nyc mocha test/setup.js test/enzyme-configuration.js $(find app -name *.spec.js*)",
     "lint": "eslint ./app --ext .jsx,.js",
     "lint:watch": "esw --watch --color ./app --ext .jsx,.js"
   }


### PR DESCRIPTION
Remove travis.yml. Add a GH workflow which runs the CI tests, generates a coverage report and posts the results to Coveralls.

Staging branch URL: https://pr-5918.pfe-preview.zooniverse.org

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
