### PR TITLE
Use link to fe-project for transcription task workflows

### DIFF
--- a/app/pages/lab/workflow.cjsx
+++ b/app/pages/lab/workflow.cjsx
@@ -45,10 +45,15 @@ EditWorkflowPage = createReactClass
 
   workflowLink: ->
     [owner, name] = @props.project.slug.split('/')
-    viewQuery = workflow: @props.workflow.id, reload: @state.forceReloader
-    @context.router.createHref
-      pathname: "/projects/#{owner}/#{name}/classify"
-      query: viewQuery
+    usingTranscriptionTask = Object.keys(@props.workflow.tasks).some((taskKey) => @props.workflow.tasks[taskKey].type is 'transcription')
+    if @canUseTask(@props.project, "transcription-task") and usingTranscriptionTask
+      env = process.env.NODE_ENV
+      "https://fe-project.zooniverse.org/projects/#{owner}/#{name}/classify/workflow/#{@props.workflow.id}?env=#{env}"
+    else
+      viewQuery = workflow: @props.workflow.id, reload: @state.forceReloader
+      @context.router.createHref
+        pathname: "/projects/#{owner}/#{name}/classify"
+        query: viewQuery
 
   showCreateWorkflow: ->
     @setState workflowCreationInProgress: true


### PR DESCRIPTION
Staging branch URL: https://pr-5919.pfe-preview.zooniverse.org

Another enhancement to make using the transcription task in the lab a little easier. If a project has the transcription task experimental tool enabled and if the workflow being edited is using one, then the "Test Workflow" link goes to `fe-project` rather than PFE. 

Try this out with Anti-Slavery Testing: https://pr-5919.pfe-preview.zooniverse.org/lab/1764/workflows

Workflow 3392 goes to fe-project, but all the others go to staging PFE. 

Note for projects/workflows intending to use this, the workflow must be active and the project public. The new project app isn't setup to support private projects or user roles that can load inactive workflows yet.

It'd be really helpful to have this reviewed and merged before this Friday (NEH workshop). @shaunanoordin let me know if you have time this week to do this since you have context for the transcription task editor most recently. If not, we can request someone else.

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
