### PR TITLE
Transcription Task: add 3 new text tags for subtask

### DIFF
--- a/app/classifier/tasks/transcription/SubtaskEditor.jsx
+++ b/app/classifier/tasks/transcription/SubtaskEditor.jsx
@@ -62,6 +62,21 @@ export default function SubTaskEditor({ subtask, subtaskPrefix, workflow }) {
           <input type="checkbox" value="unclear" checked={tagExists('unclear')} onChange={updateTags} />
           {"Unclear"}
         </label>
+        <br/>
+        <label>
+          <input type="checkbox" value="underline" checked={tagExists('underline')} onChange={updateTags} />
+          {"Underline"}
+        </label>
+        <br/>
+        <label>
+          <input type="checkbox" value="superscript" checked={tagExists('superscript')} onChange={updateTags} />
+          {"Superscript"}
+        </label>
+        <br/>
+        <label>
+          <input type="checkbox" value="&amp;" checked={tagExists('&')} onChange={updateTags} />
+          {"&"}
+        </label>
       </section>
     </div>
   )


### PR DESCRIPTION
## PR Overview

Staging branch URL: https://pr-{NUMBER}.pfe-preview.zooniverse.org

The _Davey Notebooks_ project wants to add three new tags to the Transcription task's Text subtask. This PR makes those tags available to any Transcription-type project.

- Added new tags to the Transcription -> Text subtask: `underline`, `superscript`, `&`
  - These tags are fairly generic ; I see no issue if other transcription projects want to use them.

<img width="702" alt="Screen Shot 2021-03-23 at 13 29 44" src="https://user-images.githubusercontent.com/13952701/112156963-a6100380-8bde-11eb-8fdd-df450871ecf4.png">

### Testing

Go ahead and play with the workflow settings:

- Project builder: https://local.zooniverse.org:3735/lab/1929/workflows/3459
- Classifier: https://fe-project.preview.zooniverse.org/projects/darkeshard/davy-notebooks-2021/classify/workflow/3459?env=staging

### Status

Ready for review