### PR TITLE
Change background-size to contain

### DIFF
--- a/app/pages/collections/collection-card.jsx
+++ b/app/pages/collections/collection-card.jsx
@@ -26,7 +26,7 @@ export default class CollectionCard extends React.Component {
       this.collectionCard.style.backgroundImage = `url('${thumbnailSrc}')`;
       this.collectionCard.style.backgroundPosition = 'initial';
       this.collectionCard.style.backgroundRepeat = 'no-repeat';
-      this.collectionCard.style.backgroundSize = 'cover';
+      this.collectionCard.style.backgroundSize = 'contain';
     }
   }
 


### PR DESCRIPTION
Staging branch URL: https://pr-5921.pfe-preview.zooniverse.org

Follow up to #5916 and in response to https://www.zooniverse.org/talk/17/1904019

Changes the background-size CSS for the collections card to use contain. 

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
