### PR TITLE
Prevent tasks linking to themselves

### DIFF
--- a/app/classifier/tasks/combo/editor.cjsx
+++ b/app/classifier/tasks/combo/editor.cjsx
@@ -77,7 +77,7 @@ ComboTaskEditor = createReactClass
       <p>
         <label>
           Next task:{' '}
-          <NextTaskSelector workflow={@props.workflow} value={@props.task.next} onChange={@setNextTask} />
+          <NextTaskSelector task={@props.task} workflow={@props.workflow} value={@props.task.next} onChange={@setNextTask} />
         </label>
         <br />
         <span className="form-help">This overrides anything set by a sub-task.</span>

--- a/app/classifier/tasks/dropdown/editor.jsx
+++ b/app/classifier/tasks/dropdown/editor.jsx
@@ -216,6 +216,7 @@ export default class DropdownEditor extends React.Component {
           <span className="form-label">Next task</span>
           <br />
           <NextTaskSelector
+            task={this.props.task}
             workflow={this.props.workflow}
             name={`${this.props.taskPrefix}.next`}
             value={this.props.task.next || ''}

--- a/app/classifier/tasks/generic-editor.cjsx
+++ b/app/classifier/tasks/generic-editor.cjsx
@@ -115,7 +115,7 @@ module.exports = createReactClass
                       <div className="workflow-choice-setting">
                         <AutoSave resource={@props.workflow}>
                           Next task{' '}
-                          <NextTaskSelector workflow={@props.workflow} name="#{@props.taskPrefix}.#{choicesKey}.#{index}.next" value={choice.next ? ''} onChange={handleChange} />
+                          <NextTaskSelector task={@props.task} workflow={@props.workflow} name="#{@props.taskPrefix}.#{choicesKey}.#{index}.next" value={choice.next ? ''} onChange={handleChange} />
                         </AutoSave>
                       </div>
 
@@ -266,7 +266,7 @@ module.exports = createReactClass
         <div>
           <AutoSave resource={@props.workflow}>
             Next task{' '}
-            <NextTaskSelector workflow={@props.workflow} name="#{@props.taskPrefix}.next" value={@props.task.next ? ''} onChange={handleChange} />
+            <NextTaskSelector task={@props.task} workflow={@props.workflow} name="#{@props.taskPrefix}.next" value={@props.task.next ? ''} onChange={handleChange} />
           </AutoSave>
         </div>}
     </div>

--- a/app/classifier/tasks/next-task-selector.cjsx
+++ b/app/classifier/tasks/next-task-selector.cjsx
@@ -21,7 +21,7 @@ module.exports = createReactClass
     <select name={@props.name} value={@props.value} onChange={@props.onChange}>
       <option value="">(Submit classification and load next subject)</option>
       {for key, definition of @props.workflow.tasks
-        unless definition.type is 'shortcut'
+        unless definition.type is 'shortcut' or definition is @props.task
           text = tasks[definition.type]?.getTaskText definition
           if text and text.length > MAX_TEXT_LENGTH_IN_MENU
             text = text[0...MAX_TEXT_LENGTH_IN_MENU] + '...'

--- a/app/classifier/tasks/slider/editor.jsx
+++ b/app/classifier/tasks/slider/editor.jsx
@@ -16,6 +16,7 @@ const SliderTaskEditor = (props) => {
         <span className="form-label">Next task</span>
         <br />
         <NextTaskSelector
+          task={props.task}
           workflow={props.workflow}
           name={`${props.taskPrefix}.next`}
           value={props.task.next ? props.task.next : ''}

--- a/app/classifier/tasks/survey/editor.cjsx
+++ b/app/classifier/tasks/survey/editor.cjsx
@@ -202,7 +202,7 @@ module.exports = createReactClass
         <AutoSave resource={@props.workflow}>
           <span className="form-label">Next task</span>
           <br />
-          <NextTaskSelector workflow={@props.workflow} name="#{@props.taskPrefix}.next" value={@props.task.next ? ''} onChange={handleInputChange.bind @props.workflow} />
+          <NextTaskSelector task={@props.task} workflow={@props.workflow} name="#{@props.taskPrefix}.next" value={@props.task.next ? ''} onChange={handleInputChange.bind @props.workflow} />
         </AutoSave>
       </p>
 

--- a/app/classifier/tasks/text/editor.cjsx
+++ b/app/classifier/tasks/text/editor.cjsx
@@ -86,6 +86,6 @@ module.exports = createReactClass
         <AutoSave resource={@props.workflow}>
           <span className="form-label">Next task</span>
           <br />
-          <NextTaskSelector workflow={@props.workflow} name="#{@props.taskPrefix}.next" value={@props.task.next ? ''} onChange={handleInputChange.bind @props.workflow} />
+          <NextTaskSelector task={@props.task} workflow={@props.workflow} name="#{@props.taskPrefix}.next" value={@props.task.next ? ''} onChange={handleInputChange.bind @props.workflow} />
         </AutoSave>}
     </div>


### PR DESCRIPTION
Add a task prop to the `NextTaskSelector` in the lab and pass down the current task. Filter the current task out of the list of next task options.

This turned out to be more complicated than I thought because each task (`app/classifier/tasks`) implements its own 'Next task' menu in its editor component. I think I got them all. You can check it by editing tasks in the project builder. You shouldn't be able to link any task back to itself any more.

Staging branch URL: https://pr-5925.pfe-preview.zooniverse.org

Fixes #2512.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
