### PR TITLE
Add 'wildcam classroom' to Experimental Tools admin

### DIFF
--- a/app/pages/admin/project-status/experimental-features.jsx
+++ b/app/pages/admin/project-status/experimental-features.jsx
@@ -26,7 +26,8 @@ const experimentalFeatures = [
   'highlighter',
   'translator-role',
   'museum-role',
-  'transcription-task'
+  'transcription-task',
+  'wildcam classroom'  // Indicates a Project is linked to a "WildCam Lab"-type Zooniverse Classroom. Allows the classifier to select a workflow (i.e. "classroom assignment") directly via ID.
 ];
 
 class ExperimentalFeatures extends Component {


### PR DESCRIPTION
## PR Overview

Staging branch URL: https://pr-{NUMBER}.pfe-preview.zooniverse.org
Related to: classroom.zooniverse.org

This PR adds the `wildcam classroom` to the list of available Experimental Tools at the project admin. (e.g. https://www.zooniverse.org/admin/project_status/sandiegozooglobal/wildwatch-kenya)

- The 'wildcam classroom' flag indicates that a Project is part of "WildCam Lab"-type Zooniverse Classroom. This in turn means that the PFE classifier allows the user to select specific workflows (i.e. Classroom assignments) by their ID. 
- The 'wildcam classroom' flag has already been extant in WildCam Gorongosa and WildCam Darién's configuration since 2019, but we never noticed there wasn't a way to easily add this flag for new projects. (e.g. for the upcoming Wildwatch Kenya Lab)

### Status

Ready for review.