### PR TITLE
Add Davy Notebooks project to list of FEM routes

### DIFF
--- a/app/router.cjsx
+++ b/app/router.cjsx
@@ -165,6 +165,9 @@ module.exports =
     <Route path="/projects/blicksam/transcription-task-testing" component={() => <RELOAD newUrl='https://fe-project.zooniverse.org/projects/blicksam/transcription-task-testing' />} />
     <Route path="/projects/blicksam/transcription-task-testing/classify" component={() => <RELOAD newUrl='https://fe-project.zooniverse.org/projects/blicksam/transcription-task-testing/classify' />} />
 
+    <Route path="/projects/humphrydavy/davy-notebooks-project" component={() => <RELOAD newUrl='https://fe-project.zooniverse.org/projects/humphrydavy/davy-notebooks-project' />} />
+    <Route path="/projects/humphrydavy/davy-notebooks-project/classify" component={() => <RELOAD newUrl='https://fe-project.zooniverse.org/projects/humphrydavy/davy-notebooks-project/classify' />} />
+
     <Route path="/projects/mschwamb/planet-four/authors" component={() => <ExternalRedirect newUrl='https://authors.planetfour.org/' />} />
 
     <Route path="projects/:owner/:name" component={require('./pages/project').default}>


### PR DESCRIPTION
## PR Overview

This PR adds a new Front End Monorepo project (re-)route for the Davy Notebooks, which is going into Beta on Thu 29 Apr 2021.

- The URL https://www.zooniverse.org/projects/humphrydavy/davy-notebooks-project will functionally take users to the FEM equivalent, https://fe-project.zooniverse.org/projects/humphrydavy/davy-notebooks-project
- Ditto for the /classify page and its child pages.

### Status

Ready for review. Next up: Front Door modifications.