### PR TITLE
Revert "Upgrade Panoptes API client to 3.3.1"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15335,13 +15335,24 @@
       "dev": true
     },
     "panoptes-client": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-3.3.1.tgz",
-      "integrity": "sha512-N/8xUjl/mhBqSgNpq4q5ZUFp/Evw/iVqDVWcIedfkSIt3kuSZR7dVb7x7PjALkRPCHGA24LsSgGje5mEHkB7gg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-3.0.0.tgz",
+      "integrity": "sha512-LEeFBveR37HBbu8keWuTWaFkCMr2gvnoQ93M2O1o4wGF2BVQIb2lJlx5BxFMiCD33xwRBYVtMxijHwAaR159mg==",
       "requires": {
         "json-api-client": "~5.0.0",
         "local-storage": "^1.4.2",
         "sugar-client": "^1.0.1"
+      },
+      "dependencies": {
+        "json-api-client": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/json-api-client/-/json-api-client-5.0.0.tgz",
+          "integrity": "sha512-HFXao3PkvgNQOlD1iAwKbR+tuT+lYiyyu6Q/FxPoTRai1DAv7c6pha0gvOFxe/FrkaUu1/v6btr2OdkzFVGX0A==",
+          "requires": {
+            "normalizeurl": "~0.1.3",
+            "superagent": "^3.8.3"
+          }
+        }
       }
     },
     "papaparse": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "mocha": "~5.2.0",
     "modal-form": "~2.9",
     "moment": "~2.24.0",
-    "panoptes-client": "~3.3.1",
+    "panoptes-client": "~3.0.0-rc.0",
     "papaparse": "^5.2.0",
     "polished": "~2.3.3",
     "prop-types": "~15.7.1",


### PR DESCRIPTION
Reverts zooniverse/Panoptes-Front-End#5936 - sugar integration is broken with this version 

