### PR TITLE
[Security] Upgrade panoptes-client to 3.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14869,7 +14869,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
           "dev": true
         },
@@ -15335,24 +15335,13 @@
       "dev": true
     },
     "panoptes-client": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-3.0.0.tgz",
-      "integrity": "sha512-LEeFBveR37HBbu8keWuTWaFkCMr2gvnoQ93M2O1o4wGF2BVQIb2lJlx5BxFMiCD33xwRBYVtMxijHwAaR159mg==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-3.3.2.tgz",
+      "integrity": "sha512-fb6Tah+M8QTZ/cSU6BE8/1+hatS1AVmj29iZj7hAdprvhenfcJcyj/C4eLEbbEmzXS7ZeOVJ3ESUY5KngAfivg==",
       "requires": {
         "json-api-client": "~5.0.0",
         "local-storage": "^1.4.2",
         "sugar-client": "^1.0.1"
-      },
-      "dependencies": {
-        "json-api-client": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/json-api-client/-/json-api-client-5.0.0.tgz",
-          "integrity": "sha512-HFXao3PkvgNQOlD1iAwKbR+tuT+lYiyyu6Q/FxPoTRai1DAv7c6pha0gvOFxe/FrkaUu1/v6btr2OdkzFVGX0A==",
-          "requires": {
-            "normalizeurl": "~0.1.3",
-            "superagent": "^3.8.3"
-          }
-        }
       }
     },
     "papaparse": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "mocha": "~5.2.0",
     "modal-form": "~2.9",
     "moment": "~2.24.0",
-    "panoptes-client": "~3.0.0-rc.0",
+    "panoptes-client": "~3.3.2",
     "papaparse": "^5.2.0",
     "polished": "~2.3.3",
     "prop-types": "~15.7.1",


### PR DESCRIPTION
This fixes a Sugar problem that was introduced in 3.3.0, and installs a security patch for lodash. The window for refreshing expired tokens is increased to 5 minutes, which might help resolve issues where classifications from logged-in volunteers are being recorded as anonymous. 3.3 also included changes to store  the auth bearer token more securely in the client.

Staging branch URL: https://pr-5939.pfe-preview.zooniverse.org

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
