### PR TITLE
[Security] Upgrade chart.js to version 3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7101,49 +7101,14 @@
       "dev": true
     },
     "chart.js": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-2.7.3.tgz",
-      "integrity": "sha512-3+7k/DbR92m6BsMUYP6M0dMsMVZpMnwkUyNSAbqolHKsbIzH2Q4LWVEHHYq7v0fmEV8whXE0DrjANulw9j2K5g==",
-      "requires": {
-        "chartjs-color": "^2.1.0",
-        "moment": "^2.10.2"
-      },
-      "dependencies": {
-        "moment": {
-          "version": "2.23.0",
-          "resolved": "https://registry.npmjs.org/moment/-/moment-2.23.0.tgz",
-          "integrity": "sha512-3IE39bHVqFbWWaPOMHZF98Q9c3LDKGTmypMiTM2QygGXXElkFWIH7GxfmlwmY2vwa+wmNsoYZmG2iusf1ZjJoA=="
-        }
-      }
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-3.2.1.tgz",
+      "integrity": "sha512-XsNDf3854RGZkLCt+5vWAXGAtUdKP2nhfikLGZqud6G4CvRE2ts64TIxTTfspOin2kEZvPgomE29E6oU02dYjQ=="
     },
     "chartist": {
       "version": "0.11.4",
       "resolved": "https://registry.npmjs.org/chartist/-/chartist-0.11.4.tgz",
       "integrity": "sha512-H4AimxaUD738/u9Mq8t27J4lh6STsLi4BQHt65nOtpLk3xyrBPaLiLMrHw7/WV9CmsjGA02WihjuL5qpSagLYw=="
-    },
-    "chartjs-color": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/chartjs-color/-/chartjs-color-2.2.0.tgz",
-      "integrity": "sha1-hKL7dVeH7YXDndbdjHsdiEKbrq4=",
-      "requires": {
-        "chartjs-color-string": "^0.5.0",
-        "color-convert": "^0.5.3"
-      },
-      "dependencies": {
-        "color-convert": {
-          "version": "0.5.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
-          "integrity": "sha1-vbbGnOZg+t/+CwAHzER+G59ygr0="
-        }
-      }
-    },
-    "chartjs-color-string": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/chartjs-color-string/-/chartjs-color-string-0.5.0.tgz",
-      "integrity": "sha512-amWNvCOXlOUYxZVDSa0YOab5K/lmEhbFNKI55PWc4mlv28BDzA7zaoQTGxSBgJMHIW+hGX8YUrvw/FH4LyhwSQ==",
-      "requires": {
-        "color-name": "^1.0.0"
-      }
     },
     "check-dependencies": {
       "version": "1.1.0",
@@ -7502,7 +7467,8 @@
     "color-name": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.2.tgz",
-      "integrity": "sha1-XIq3K2S9IhXWF66VWeuxSEdc+Y0="
+      "integrity": "sha1-XIq3K2S9IhXWF66VWeuxSEdc+Y0=",
+      "dev": true
     },
     "colors": {
       "version": "0.5.1",
@@ -14824,7 +14790,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
           "dev": true
         },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "@sentry/browser": "~6.1.0",
     "@sentry/tracing": "~6.1.0",
     "animated-scrollto": "~1.1.0",
-    "chart.js": "~2.7.3",
+    "chart.js": "~3.2.1",
     "chartist": "~0.11.0",
     "classnames": "~2.2.6",
     "counterpart": "~0.18.6",


### PR DESCRIPTION
Upgrade `chart.js` to fix a security vulnerability in version 2.7.

Staging branch URL: https://pr-5943.pfe-preview.zooniverse.org

I think `chart.js` is only used on project stats pages
eg. https://pr-5943.pfe-preview.zooniverse.org/projects/stephenresearch/beluga-bits/stats?env=production

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
