### PR TITLE
Subject Group project builder controls

### DIFF
--- a/app/classifier/tasks/generic-editor.cjsx
+++ b/app/classifier/tasks/generic-editor.cjsx
@@ -32,8 +32,9 @@ module.exports = createReactClass
       when 'text' then ['instruction']
       when 'slider' then ['instruction']
       when 'highlighter' then ['instruction', 'highlighterLabels']
+      when 'subjectGroupComparison' then ['question']
 
-    isAQuestion = @props.task.type in ['single', 'multiple']
+    isAQuestion = @props.task.type in ['single', 'multiple', 'subjectGroupComparison']
     canBeRequired = @props.task.type in ['single', 'multiple', 'text']
 
     <div className="workflow-task-editor #{@props.task.type}">

--- a/app/classifier/tasks/generic-editor.cjsx
+++ b/app/classifier/tasks/generic-editor.cjsx
@@ -32,9 +32,8 @@ module.exports = createReactClass
       when 'text' then ['instruction']
       when 'slider' then ['instruction']
       when 'highlighter' then ['instruction', 'highlighterLabels']
-      when 'subjectGroupComparison' then ['question']
 
-    isAQuestion = @props.task.type in ['single', 'multiple', 'subjectGroupComparison']
+    isAQuestion = @props.task.type in ['single', 'multiple']
     canBeRequired = @props.task.type in ['single', 'multiple', 'text']
 
     <div className="workflow-task-editor #{@props.task.type}">

--- a/app/classifier/tasks/index.jsx
+++ b/app/classifier/tasks/index.jsx
@@ -10,6 +10,7 @@ import DropdownTask from './dropdown/';
 import ShortcutTask from './shortcut/';
 import Highlighter from './highlighter/';
 import TranscriptionTask from './transcription'
+import SubjectGroupComparisonTask from './subjectGroupComparison';
 
 const tasks = {
   combo: ComboTask,
@@ -23,7 +24,8 @@ const tasks = {
   dropdown: DropdownTask,
   shortcut: ShortcutTask,
   highlighter: Highlighter,
-  transcription: TranscriptionTask
+  transcription: TranscriptionTask,
+  subjectGroupComparison: SubjectGroupComparisonTask,
 };
 
 export default tasks;

--- a/app/classifier/tasks/subjectGroupComparison/README.md
+++ b/app/classifier/tasks/subjectGroupComparison/README.md
@@ -1,0 +1,7 @@
+# Subject Group Comparison Task
+
+The Subject Group Comparison Task in PFE is an ADMIN-ONLY component. The code in this folder exists only to allow admins to edit SGC Tasks.
+
+When a volunter views an SGC Task on the PFE Classifier, the task is purely a placeholder.
+
+For a volunteer to properly view an SGC Task, they have to do so on the [FEM](https://github.com/zooniverse/front-end-monorepo) Classifier.

--- a/app/classifier/tasks/subjectGroupComparison/editor.jsx
+++ b/app/classifier/tasks/subjectGroupComparison/editor.jsx
@@ -1,0 +1,50 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import AutoSave from '../../../components/auto-save';
+import handleInputChange from '../../../lib/handle-input-change';
+
+export default class SubjectGroupComparisonEditor extends React.Component {
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    const props = this.props;
+    const handleChange = handleInputChange.bind(props.workflow);
+    
+    return (
+      <div className={`workflow-task-editor ${props.task.type}`}>
+        <div>
+          <AutoSave resource={props.workflow}>
+            <span className="form-label">Main text</span>
+            <br />
+            <textarea name={`${props.taskPrefix}.question`} value={props.task['question']} className="standard-input full" onChange={handleChange} />
+          </AutoSave>
+          <small className="form-help">Describe the task, or ask the question, in a way that is clear to a non-expert. You can use markdown to format this text.</small><br />
+        </div>
+      </div>
+    );
+  }
+
+}
+
+SubjectGroupComparisonEditor.propTypes = {
+  children: PropTypes.node,
+  task: PropTypes.shape(
+    {
+      question: PropTypes.string,
+      unlinkedTask: PropTypes.string
+    }
+  ),
+  workflow: PropTypes.shape(
+    {
+      tasks: PropTypes.object,
+      update: PropTypes.func
+    }
+  )
+};
+
+SubjectGroupComparisonEditor.defaultProps = {
+  task: { },
+  workflow: { }
+};

--- a/app/classifier/tasks/subjectGroupComparison/editor.jsx
+++ b/app/classifier/tasks/subjectGroupComparison/editor.jsx
@@ -14,6 +14,7 @@ export default class SubjectGroupComparisonEditor extends React.Component {
     
     return (
       <div className={`workflow-task-editor ${props.task.type}`}>
+        <div><b>Subject Group Comparison Task</b></div>
         <div>
           <AutoSave resource={props.workflow}>
             <span className="form-label">Main text</span>

--- a/app/classifier/tasks/subjectGroupComparison/index.jsx
+++ b/app/classifier/tasks/subjectGroupComparison/index.jsx
@@ -2,7 +2,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import GenericTask from '../generic';
-import GenericTaskEditor from '../generic-editor';
+// import GenericTaskEditor from '../generic-editor';
+import SubjectGroupComparisonEditor from './editor';
 import SubjectGroupComparisonSummary from './summary';
 import TaskInputField from '../components/TaskInputField';
 
@@ -31,7 +32,7 @@ export default class SubjectGroupComparisonTask extends React.Component {
 }
 
 // Define the static methods and values
-SubjectGroupComparisonTask.Editor = GenericTaskEditor;
+SubjectGroupComparisonTask.Editor = SubjectGroupComparisonEditor;
 SubjectGroupComparisonTask.Summary = SubjectGroupComparisonSummary;
 SubjectGroupComparisonTask.getDefaultTask = () => {
   return {

--- a/app/classifier/tasks/subjectGroupComparison/index.jsx
+++ b/app/classifier/tasks/subjectGroupComparison/index.jsx
@@ -13,13 +13,6 @@ export default class SubjectGroupComparisonTask extends React.Component {
     super(props);
   }
 
-  handleChange(index, e) {
-    if (e.target.checked) {
-      const newAnnotation = Object.assign({}, this.props.annotation, { value: index });
-      this.props.onChange(newAnnotation);
-    }
-  }
-
   render() {
     const { annotation, autoFocus, task, translation } = this.props;
     if (!task._key) {

--- a/app/classifier/tasks/subjectGroupComparison/index.jsx
+++ b/app/classifier/tasks/subjectGroupComparison/index.jsx
@@ -1,0 +1,95 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import GenericTask from '../generic';
+import GenericTaskEditor from '../generic-editor';
+import SubjectGroupComparisonSummary from './summary';
+import TaskInputField from '../components/TaskInputField';
+
+const NOOP = Function.prototype;
+
+export default class SubjectGroupComparisonTask extends React.Component {
+  constructor(props) {
+    super(props);
+  }
+
+  handleChange(index, e) {
+    if (e.target.checked) {
+      const newAnnotation = Object.assign({}, this.props.annotation, { value: index });
+      this.props.onChange(newAnnotation);
+    }
+  }
+
+  render() {
+    const { annotation, autoFocus, task, translation } = this.props;
+    if (!task._key) {
+      task._key = Math.random();
+    }
+    return (
+      <GenericTask
+        autoFocus={autoFocus && annotation.value === null}
+        question={translation.question}
+        help={translation.help}
+        required={task.required}
+        showRequiredNotice={this.props.showRequiredNotice}
+      />
+    );
+  }
+}
+
+// Define the static methods and values
+SubjectGroupComparisonTask.Editor = GenericTaskEditor;
+SubjectGroupComparisonTask.Summary = SubjectGroupComparisonSummary;
+SubjectGroupComparisonTask.getDefaultTask = () => {
+  return {
+    type: 'subjectGroupComparison',
+    question: 'Enter a question.',
+    help: '',
+  };
+};
+SubjectGroupComparisonTask.getTaskText = (task) => {
+  return task.question;
+};
+SubjectGroupComparisonTask.getDefaultAnnotation = () => {
+  return { value: null };
+};
+SubjectGroupComparisonTask.isAnnotationComplete = (task, annotation) => {
+  return (!task.required || annotation.value !== null);
+};
+
+SubjectGroupComparisonTask.propTypes = {
+  task: PropTypes.shape(
+    {
+      question: PropTypes.string,
+      help: PropTypes.string,
+      required: PropTypes.bool
+    }
+  ),
+  translation: PropTypes.shape({
+    characteristics: PropTypes.object,
+    choices: PropTypes.object,
+    questions: PropTypes.object
+  }).isRequired,
+  annotation: PropTypes.shape(
+    { value: PropTypes.number }
+  ),
+  autoFocus: PropTypes.bool,
+  onChange: PropTypes.func,
+  showRequiredNotice: PropTypes.bool
+};
+
+SubjectGroupComparisonTask.defaultProps = {
+  task: {
+    question: '',
+    help: '',
+    required: false
+  },
+  translation: {
+    question: '',
+    help: ''
+  },
+  annotation: { value: null },
+  autoFocus: false,
+  onChange: NOOP,
+  showRequiredNotice: false
+};

--- a/app/classifier/tasks/subjectGroupComparison/index.spec.js
+++ b/app/classifier/tasks/subjectGroupComparison/index.spec.js
@@ -1,0 +1,226 @@
+/* eslint prefer-arrow-callback: 0, func-names: 0, 'react/jsx-boolean-value': ['error', 'always'], 'react/jsx-filename-extension': 0 */
+/* global describe, it, beforeEach */
+import { shallow } from 'enzyme';
+import React from 'react';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import SingleTask from './';
+import GenericTask from '../generic';
+import { mockReduxStore, radioTypeAnnotation, radioTypeTask } from '../testHelpers';
+
+const annotation = Object.assign({}, radioTypeAnnotation, {
+  value: 1
+});
+
+describe('SingleChoiceTask', function () {
+  describe('when it renders', function() {
+    let wrapper;
+
+    beforeEach(function () {
+      wrapper = shallow(<SingleTask task={radioTypeTask} annotation={annotation} translation={radioTypeTask} />, mockReduxStore);
+    });
+
+    it('should render without crashing', function () {
+      expect(wrapper).to.be.ok;
+    });
+
+    it('should have a question', function () {
+      const question = wrapper.find(GenericTask).prop('question');
+      expect(question).to.equal(radioTypeTask.question);
+    });
+
+    it('should have answers', function () {
+      expect(wrapper.find(GenericTask).prop('answers')).to.have.lengthOf(radioTypeTask.answers.length);
+    });
+  });
+
+  describe('with an empty annotation', function () {
+    const annotation = Object.assign({}, radioTypeAnnotation, { value: null });
+    [true, false].forEach(function testAutofocus(autofocus) {
+      const wrapper = shallow(
+        <SingleTask
+          autoFocus={autofocus}
+          task={radioTypeTask}
+          annotation={annotation}
+          translation={radioTypeTask}
+        />,
+        mockReduxStore
+      );
+      const genericTask = wrapper.dive();
+      it(`should pass autofocus ${autofocus} to its children`, function () {
+        expect(genericTask.prop('autoFocus')).to.equal(autofocus);
+      })
+    });
+  });
+
+  describe('with an annotation', function () {
+    const annotation = Object.assign({}, radioTypeAnnotation, { value: 1 });
+    [true, false].forEach(function testAutofocus(autofocus) {
+      const wrapper = shallow(
+        <SingleTask
+          autoFocus={autofocus}
+          task={radioTypeTask}
+          annotation={annotation}
+          translation={radioTypeTask}
+        />,
+        mockReduxStore
+      );
+      const answers = wrapper.dive().prop('answers');
+      answers.forEach(function (answer) {
+        it(`should pass autofocus ${autofocus} for answer ${answer.props.index}`, function () {
+          const hasFocus = autofocus && answer.props.index === annotation.value;
+          expect(answer.props.autoFocus).to.equal(hasFocus);
+        })
+      })
+    });
+  });
+
+  describe('input onChange event handler', function() {
+    let handleChangeSpy;
+    let onChangeSpy;
+    let setStateSpy;
+    let wrapper;
+    before(function () {
+      handleChangeSpy = sinon.spy(SingleTask.prototype, 'handleChange');
+      onChangeSpy = sinon.spy();
+      setStateSpy = sinon.spy(SingleTask.prototype, 'setState');
+    });
+
+    beforeEach(function() {
+      wrapper = shallow(
+        <SingleTask
+          task={radioTypeTask}
+          translation={radioTypeTask}
+          onChange={onChangeSpy}
+        />,
+        mockReduxStore
+      );
+    });
+
+    afterEach(function () {
+      handleChangeSpy.resetHistory();
+      onChangeSpy.resetHistory();
+      setStateSpy.resetHistory();
+    });
+
+    after(function () {
+      handleChangeSpy.restore();
+      setStateSpy.restore();
+    });
+
+    it('should call handleChange with the answer array index', function () {
+      const firstAnswer = wrapper.find(GenericTask).prop('answers')[0];
+      firstAnswer.props.onChange({ target: { checked: true } });
+      expect(handleChangeSpy).to.have.been.calledWith(0);
+    });
+
+    it('should call props.onChange when an answer changes and the target is checked', function () {
+      const firstAnswer = wrapper.find(GenericTask).prop('answers')[0];
+      firstAnswer.props.onChange({ target: { checked: true } });
+      expect(onChangeSpy).to.have.been.calledOnce;
+    });
+  });
+
+  describe('static methods', function () {
+    it('should be complete', function () {
+      expect(SingleTask.isAnnotationComplete(radioTypeTask, annotation)).to.be.true;
+    });
+
+    it('should be complete when value is 0 (i.e. falsy)', function () {
+      expect(SingleTask.isAnnotationComplete(radioTypeTask, { value: 0 })).to.be.true;
+    });
+
+    it('should not be complete when value is null', function () {
+      expect(SingleTask.isAnnotationComplete(radioTypeTask, { value: null })).to.be.false;
+    });
+
+    it('should be complete when task is not required', function () {
+      expect(SingleTask.isAnnotationComplete(Object.assign({}, radioTypeTask, { required: false }), { value: null })).to.be.true;
+    });
+
+    it('should have the correct question text', function () {
+      expect(SingleTask.getTaskText(radioTypeTask)).to.equal(radioTypeTask.question);
+    });
+
+    it('the default annotation should be null', function () {
+      expect(SingleTask.getDefaultAnnotation().value).to.be.null;
+    });
+  });
+});
+
+describe('SingleChoiceSummary', function () {
+  let summary;
+
+  beforeEach(function () {
+    summary = shallow(<SingleTask.Summary task={radioTypeTask} annotation={annotation} translation={radioTypeTask} />);
+  });
+
+  it('should render without crashing', function () {
+  });
+
+  it('should have a question', function () {
+    const question = summary.find('.question');
+    expect(question).to.have.lengthOf(1)
+  });
+
+  it('the default expanded state should be false', function () {
+    expect(summary.state().expanded).to.be.false;
+  });
+
+  it('should have one answer when collapsed', function () {
+    const answers = summary.find('.answer');
+    expect(answers).to.have.lengthOf(1)
+  });
+
+  it('should have the correct answer label when the value if falsy (i.e. 0)', function () {
+    summary = shallow(<SingleTask.Summary task={radioTypeTask} annotation={{ value: 0 }} translation={radioTypeTask} />);
+    const answers = summary.find('.answer');
+    expect(answers.text()).to.not.equal('No answer');
+  });
+
+  it('should return "No answer" when annotation is null', function () {
+    summary = shallow(<SingleTask.Summary task={radioTypeTask} annotation={{ value: null }} translation={radioTypeTask} />);
+    const answers = summary.find('.answer');
+    expect(answers.text()).to.equal('No answer');
+  });
+
+  it('button should read "More" when not expanded', function () {
+    const button = summary.find('button');
+    expect(button.text()).to.equal('More');
+  });
+
+  describe('when summary is expanded', function () {
+    beforeEach(function () {
+      summary.find('button').simulate('click');
+    });
+
+    it('should set expanded to true in state', function () {
+      expect(summary.state().expanded).to.be.true;
+    });
+
+    it('should show all answers', function () {
+      const answers = summary.find('.answer');
+      expect(answers).to.have.lengthOf(radioTypeTask.answers.length);
+    });
+
+    it('should have one answer selected', function () {
+      const checks = summary.find('.fa-check-circle-o');
+      expect(checks).to.have.lengthOf(1);
+    });
+
+    it('should have the correct number of non-selected answers', function () {
+      const unchecks = summary.find('.fa-circle-o');
+      expect(unchecks).to.have.lengthOf(radioTypeTask.answers.length - 1);
+    });
+
+    it('button should read "Less"', function () {
+      const button = summary.find('button');
+      expect(button.text()).to.equal('Less');
+    });
+
+    it('clicking the button should set expanded to false in state', function () {
+      summary.find('button').simulate('click');
+      expect(summary.state().expanded).to.be.false;
+    });
+  });
+});

--- a/app/classifier/tasks/subjectGroupComparison/index.spec.js
+++ b/app/classifier/tasks/subjectGroupComparison/index.spec.js
@@ -4,7 +4,7 @@ import { shallow } from 'enzyme';
 import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import SingleTask from './';
+import SubjectGroupComparisonTask from './';
 import GenericTask from '../generic';
 import { mockReduxStore, radioTypeAnnotation, radioTypeTask } from '../testHelpers';
 
@@ -12,12 +12,12 @@ const annotation = Object.assign({}, radioTypeAnnotation, {
   value: 1
 });
 
-describe('SingleChoiceTask', function () {
+describe('SubjectGroupComparisonTask', function () {
   describe('when it renders', function() {
     let wrapper;
 
     beforeEach(function () {
-      wrapper = shallow(<SingleTask task={radioTypeTask} annotation={annotation} translation={radioTypeTask} />, mockReduxStore);
+      wrapper = shallow(<SubjectGroupComparisonTask task={radioTypeTask} annotation={annotation} translation={radioTypeTask} />, mockReduxStore);
     });
 
     it('should render without crashing', function () {
@@ -28,131 +28,40 @@ describe('SingleChoiceTask', function () {
       const question = wrapper.find(GenericTask).prop('question');
       expect(question).to.equal(radioTypeTask.question);
     });
-
-    it('should have answers', function () {
-      expect(wrapper.find(GenericTask).prop('answers')).to.have.lengthOf(radioTypeTask.answers.length);
-    });
-  });
-
-  describe('with an empty annotation', function () {
-    const annotation = Object.assign({}, radioTypeAnnotation, { value: null });
-    [true, false].forEach(function testAutofocus(autofocus) {
-      const wrapper = shallow(
-        <SingleTask
-          autoFocus={autofocus}
-          task={radioTypeTask}
-          annotation={annotation}
-          translation={radioTypeTask}
-        />,
-        mockReduxStore
-      );
-      const genericTask = wrapper.dive();
-      it(`should pass autofocus ${autofocus} to its children`, function () {
-        expect(genericTask.prop('autoFocus')).to.equal(autofocus);
-      })
-    });
-  });
-
-  describe('with an annotation', function () {
-    const annotation = Object.assign({}, radioTypeAnnotation, { value: 1 });
-    [true, false].forEach(function testAutofocus(autofocus) {
-      const wrapper = shallow(
-        <SingleTask
-          autoFocus={autofocus}
-          task={radioTypeTask}
-          annotation={annotation}
-          translation={radioTypeTask}
-        />,
-        mockReduxStore
-      );
-      const answers = wrapper.dive().prop('answers');
-      answers.forEach(function (answer) {
-        it(`should pass autofocus ${autofocus} for answer ${answer.props.index}`, function () {
-          const hasFocus = autofocus && answer.props.index === annotation.value;
-          expect(answer.props.autoFocus).to.equal(hasFocus);
-        })
-      })
-    });
-  });
-
-  describe('input onChange event handler', function() {
-    let handleChangeSpy;
-    let onChangeSpy;
-    let setStateSpy;
-    let wrapper;
-    before(function () {
-      handleChangeSpy = sinon.spy(SingleTask.prototype, 'handleChange');
-      onChangeSpy = sinon.spy();
-      setStateSpy = sinon.spy(SingleTask.prototype, 'setState');
-    });
-
-    beforeEach(function() {
-      wrapper = shallow(
-        <SingleTask
-          task={radioTypeTask}
-          translation={radioTypeTask}
-          onChange={onChangeSpy}
-        />,
-        mockReduxStore
-      );
-    });
-
-    afterEach(function () {
-      handleChangeSpy.resetHistory();
-      onChangeSpy.resetHistory();
-      setStateSpy.resetHistory();
-    });
-
-    after(function () {
-      handleChangeSpy.restore();
-      setStateSpy.restore();
-    });
-
-    it('should call handleChange with the answer array index', function () {
-      const firstAnswer = wrapper.find(GenericTask).prop('answers')[0];
-      firstAnswer.props.onChange({ target: { checked: true } });
-      expect(handleChangeSpy).to.have.been.calledWith(0);
-    });
-
-    it('should call props.onChange when an answer changes and the target is checked', function () {
-      const firstAnswer = wrapper.find(GenericTask).prop('answers')[0];
-      firstAnswer.props.onChange({ target: { checked: true } });
-      expect(onChangeSpy).to.have.been.calledOnce;
-    });
   });
 
   describe('static methods', function () {
     it('should be complete', function () {
-      expect(SingleTask.isAnnotationComplete(radioTypeTask, annotation)).to.be.true;
+      expect(SubjectGroupComparisonTask.isAnnotationComplete(radioTypeTask, annotation)).to.be.true;
     });
 
     it('should be complete when value is 0 (i.e. falsy)', function () {
-      expect(SingleTask.isAnnotationComplete(radioTypeTask, { value: 0 })).to.be.true;
+      expect(SubjectGroupComparisonTask.isAnnotationComplete(radioTypeTask, { value: 0 })).to.be.true;
     });
 
     it('should not be complete when value is null', function () {
-      expect(SingleTask.isAnnotationComplete(radioTypeTask, { value: null })).to.be.false;
+      expect(SubjectGroupComparisonTask.isAnnotationComplete(radioTypeTask, { value: null })).to.be.false;
     });
 
     it('should be complete when task is not required', function () {
-      expect(SingleTask.isAnnotationComplete(Object.assign({}, radioTypeTask, { required: false }), { value: null })).to.be.true;
+      expect(SubjectGroupComparisonTask.isAnnotationComplete(Object.assign({}, radioTypeTask, { required: false }), { value: null })).to.be.true;
     });
 
     it('should have the correct question text', function () {
-      expect(SingleTask.getTaskText(radioTypeTask)).to.equal(radioTypeTask.question);
+      expect(SubjectGroupComparisonTask.getTaskText(radioTypeTask)).to.equal(radioTypeTask.question);
     });
 
     it('the default annotation should be null', function () {
-      expect(SingleTask.getDefaultAnnotation().value).to.be.null;
+      expect(SubjectGroupComparisonTask.getDefaultAnnotation().value).to.be.null;
     });
   });
 });
 
-describe('SingleChoiceSummary', function () {
+describe('SubjectGroupComparison', function () {
   let summary;
 
   beforeEach(function () {
-    summary = shallow(<SingleTask.Summary task={radioTypeTask} annotation={annotation} translation={radioTypeTask} />);
+    summary = shallow(<SubjectGroupComparisonTask.Summary task={radioTypeTask} annotation={annotation} translation={radioTypeTask} />);
   });
 
   it('should render without crashing', function () {
@@ -161,66 +70,5 @@ describe('SingleChoiceSummary', function () {
   it('should have a question', function () {
     const question = summary.find('.question');
     expect(question).to.have.lengthOf(1)
-  });
-
-  it('the default expanded state should be false', function () {
-    expect(summary.state().expanded).to.be.false;
-  });
-
-  it('should have one answer when collapsed', function () {
-    const answers = summary.find('.answer');
-    expect(answers).to.have.lengthOf(1)
-  });
-
-  it('should have the correct answer label when the value if falsy (i.e. 0)', function () {
-    summary = shallow(<SingleTask.Summary task={radioTypeTask} annotation={{ value: 0 }} translation={radioTypeTask} />);
-    const answers = summary.find('.answer');
-    expect(answers.text()).to.not.equal('No answer');
-  });
-
-  it('should return "No answer" when annotation is null', function () {
-    summary = shallow(<SingleTask.Summary task={radioTypeTask} annotation={{ value: null }} translation={radioTypeTask} />);
-    const answers = summary.find('.answer');
-    expect(answers.text()).to.equal('No answer');
-  });
-
-  it('button should read "More" when not expanded', function () {
-    const button = summary.find('button');
-    expect(button.text()).to.equal('More');
-  });
-
-  describe('when summary is expanded', function () {
-    beforeEach(function () {
-      summary.find('button').simulate('click');
-    });
-
-    it('should set expanded to true in state', function () {
-      expect(summary.state().expanded).to.be.true;
-    });
-
-    it('should show all answers', function () {
-      const answers = summary.find('.answer');
-      expect(answers).to.have.lengthOf(radioTypeTask.answers.length);
-    });
-
-    it('should have one answer selected', function () {
-      const checks = summary.find('.fa-check-circle-o');
-      expect(checks).to.have.lengthOf(1);
-    });
-
-    it('should have the correct number of non-selected answers', function () {
-      const unchecks = summary.find('.fa-circle-o');
-      expect(unchecks).to.have.lengthOf(radioTypeTask.answers.length - 1);
-    });
-
-    it('button should read "Less"', function () {
-      const button = summary.find('button');
-      expect(button.text()).to.equal('Less');
-    });
-
-    it('clicking the button should set expanded to false in state', function () {
-      summary.find('button').simulate('click');
-      expect(summary.state().expanded).to.be.false;
-    });
   });
 });

--- a/app/classifier/tasks/subjectGroupComparison/summary.jsx
+++ b/app/classifier/tasks/subjectGroupComparison/summary.jsx
@@ -1,0 +1,63 @@
+import { Markdown } from 'markdownz';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+class SubjectGroupComparisonSummary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.expand = this.expand.bind(this);
+    this.collapse = this.collapse.bind(this);
+    this.state = {
+      expanded: this.props.expanded
+    };
+  }
+
+  expand() {
+    this.setState({ expanded: true });
+  }
+
+  collapse() {
+    this.setState({ expanded: false });
+  }
+
+  render() {
+    // TODO
+    return (
+      <div>
+        <div className="question">
+          <Markdown>
+            {this.props.task.question}
+          </Markdown>
+        </div>
+      </div>
+    );
+  }
+}
+
+SubjectGroupComparisonSummary.propTypes = {
+  task: PropTypes.shape(
+    {
+      question: PropTypes.string
+    }
+  ),
+  translation: PropTypes.shape({
+    questions: PropTypes.object
+  }).isRequired,
+  annotation: PropTypes.shape(
+    { value: PropTypes.number }
+  ).isRequired,
+  expanded: PropTypes.bool
+};
+
+SubjectGroupComparisonSummary.defaultProps = {
+  task: {
+    question: ''
+  },
+  translation: {
+    question: '',
+    help: ''
+  },
+  expanded: false
+};
+
+export default SubjectGroupComparisonSummary;

--- a/app/pages/admin/project-status/experimental-features.jsx
+++ b/app/pages/admin/project-status/experimental-features.jsx
@@ -27,7 +27,8 @@ const experimentalFeatures = [
   'translator-role',
   'museum-role',
   'transcription-task',
-  'wildcam classroom'  // Indicates a Project is linked to a "WildCam Lab"-type Zooniverse Classroom. Allows the classifier to select a workflow (i.e. "classroom assignment") directly via ID.
+  'wildcam classroom',  // Indicates a Project is linked to a "WildCam Lab"-type Zooniverse Classroom. Allows the classifier to select a workflow (i.e. "classroom assignment") directly via ID.
+  'subjectGroupViewer',  // Enables Subject Group Viewer and Subject Group Comparison Task, used for grid-like cell selection tasks. SGV and SGCT can be edited in PFE, but only works on the FEM classifier.
 ];
 
 class ExperimentalFeatures extends Component {

--- a/app/pages/lab/workflow-components/subject-group-viewer-editor.jsx
+++ b/app/pages/lab/workflow-components/subject-group-viewer-editor.jsx
@@ -50,6 +50,7 @@ export default class SubjectGroupViewerEditor extends React.Component {
   updateViewerConfig (event) {
     if (!event.target) return
     this.setState({
+      stateChanged: true,
       [event.target.dataset.configkey]: event.target.value,
     })
   }
@@ -76,7 +77,13 @@ export default class SubjectGroupViewerEditor extends React.Component {
     this.props.workflow.update({
       'configuration.subject_viewer_config': subject_viewer_config,
       'configuration.subject_group': subject_group,
-    }).save()
+    })
+    .save()
+    .then(() => {
+      this.setState({
+        stateChanged: false,
+      })
+    })
   }
   
   /*
@@ -169,8 +176,9 @@ export default class SubjectGroupViewerEditor extends React.Component {
                 </tr>
               </tbody>
             </table>
+            <small class="form-help">Note: as of May 2021, the maximum grid size is 25 cells.</small>
             <br/>
-            <button onClick={this.saveViewerConfig.bind(this)}>Save viewer config</button>
+            <button onClick={this.saveViewerConfig.bind(this)} disabled={!this.state.stateChanged}>Save viewer config</button>
           </div>
         )}
       </div>

--- a/app/pages/lab/workflow-components/subject-group-viewer-editor.jsx
+++ b/app/pages/lab/workflow-components/subject-group-viewer-editor.jsx
@@ -145,7 +145,10 @@ export default class SubjectGroupViewerEditor extends React.Component {
       <div>
         <span class="form-label">Subject Group Viewer Configuration</span>
         <br />
-        <small class="form-help">Note: the Subject Group Viewer (aka "grid drawing tool") can only be used on the FEM classifier, not the PFE classifier.</small>
+        <small class="form-help">
+          The Subject Group Viewer (aka "grid drawing tool") can only be used on the FEM classifier, not the PFE classifier.
+          If you enable the SGViewer, be sure to add a Subject Group Comparison Task.
+        </small>
         <br />
         <label>
           <input type="checkbox" checked={enableSGViewer} onChange={this.toggleSubjectViewer.bind(this)} />

--- a/app/pages/lab/workflow-components/subject-group-viewer-editor.jsx
+++ b/app/pages/lab/workflow-components/subject-group-viewer-editor.jsx
@@ -1,0 +1,106 @@
+/*
+Subject Group Viewer Editor
+---------------------------
+
+Used by lab/workflow.cjsx, on Workflows with the experimental tool
+"subjectGroupViewer" enabled.
+
+Example: if a workflow is configured to use the SubjectGroupViewer with a
+5x5 grid (of 200px by 200px cells), its configuration should look like...
+
+workflow.configuration: {
+  subject_viewer: "subjectGroup",
+  subject_viewer_config: {
+    cell_height: 200,
+    cell_width: 200,
+    grid_columns: 5,
+    grid_rows: 5,
+  }
+}
+ */
+
+import PropTypes from 'prop-types';
+import React from 'react';
+import AutoSave from '../../../components/auto-save.coffee';
+
+export default class SubjectGroupViewerEditor extends React.Component {
+  constructor (props) {
+    super(props)
+    
+    this.state = {}
+  }
+  
+  saveViewerConfig () {
+    console.log('hello')
+  }
+  
+  toggleSubjectViewer (event) {
+    if (!event.target) return
+    const enableSGViewer = event.target.checked
+    
+    if (enableSGViewer) {
+      
+      const oldConfig = this.props.workflow.configuration || {}
+      const newConfig = {
+        ...oldConfig,
+        subject_viewer: 'subjectGroup',
+        subject_viewer_config: {
+          cell_height: 200,
+          cell_width: 200,
+          grid_columns: 5,
+          grid_rows: 5,
+        }
+      }
+      
+      this.props.workflow.update({ configuration: newConfig }).save()
+      
+    } else {
+      const oldConfig = this.props.workflow.configuration || {}
+      const newConfig = { ...oldConfig }
+      
+      delete newConfig.subject_viewer
+      delete newConfig.subject_viewer_config
+      
+      this.props.workflow.update({ configuration: newConfig }).save()
+    }
+  }
+
+  render () {
+    const props = this.props
+    const configuration = props.workflow && props.workflow.configuration || {}
+    const enableSGViewer = configuration.subject_viewer === 'subjectGroup'
+    
+    return (
+      <div>
+        <span class="form-label">Subject Group Viewer Configuration</span>
+        <br />
+        <small class="form-help">Note: the Subject Group Viewer (aka "grid drawing tool") can only be used on the FEM classifier, not the PFE classifier.</small>
+        <br />
+        <label>
+          <input type="checkbox" checked={enableSGViewer} onChange={this.toggleSubjectViewer.bind(this)} />
+          Enable Subject Group Viewer for this workflow
+        </label>
+        
+        {enableSGViewer && (
+          <div>
+            <b>Viewer Configuration</b>
+            <br/>
+            TODO
+            <br/>
+            <button onClick={this.saveViewerConfig.bind(this)}>Save viewer config</button>
+          </div>
+        )}
+      </div>
+    );
+  }
+}
+
+SubjectGroupViewerEditor.defaultProps = {
+  workflow: {}
+};
+
+SubjectGroupViewerEditor.propTypes = {
+  workflow: PropTypes.shape({
+    configuration: PropTypes.object
+  })
+};

--- a/app/pages/lab/workflow-components/subject-group-viewer-editor.jsx
+++ b/app/pages/lab/workflow-components/subject-group-viewer-editor.jsx
@@ -10,11 +10,15 @@ Example: if a workflow is configured to use the SubjectGroupViewer with a
 
 workflow.configuration: {
   subject_viewer: "subjectGroup",
-  subject_viewer_config: {
+  subject_viewer_config: {  // Used by the frontend classifier
     cell_height: 200,
     cell_width: 200,
     grid_columns: 5,
     grid_rows: 5,
+  },
+  subject_group: {   // Used by the backend "/subjects/grouped" endpoint
+    num_columns: 5,  // this must match grid_columns
+    num_rows: 5,     // this must match grid_rows
   }
 }
  */
@@ -27,19 +31,65 @@ export default class SubjectGroupViewerEditor extends React.Component {
   constructor (props) {
     super(props)
     
-    this.state = {}
+    const subjectViewerConfig = props.workflow && props.workflow.configuration && props.workflow.configuration.subject_viewer_config || {}
+    
+    this.state = {
+      stateChanged: false,
+      cell_height: subjectViewerConfig.cell_height || '',
+      cell_width: subjectViewerConfig.cell_width || '',
+      grid_columns: subjectViewerConfig.grid_columns || '',
+      grid_rows: subjectViewerConfig.grid_rows || '',
+    }
   }
   
+  /*
+  Changes to the subject viewer config are saved to the state as a buffer.
+  We're not using autosave here since a user might change a large number of
+  subject viewer config items before being satisfied.
+   */
+  updateViewerConfig (event) {
+    if (!event.target) return
+    this.setState({
+      [event.target.dataset.configkey]: event.target.value,
+    })
+  }
+  
+  /*
+  Manually saves the subject viewer config changes to the Workflow resource.
+   */
   saveViewerConfig () {
-    console.log('hello')
+    const state = this.state
+    const subject_viewer_config = {
+      cell_height: parseInt(state.cell_height),
+      cell_width: parseInt(state.cell_width),
+      grid_columns: parseInt(state.grid_columns),
+      grid_rows: parseInt(state.grid_rows),
+    }
+    
+    const subject_group = {
+      num_columns: parseInt(state.grid_columns),
+      num_rows: parseInt(state.grid_rows),
+    }
+    
+    // TODO: some items are optional. Setting a blank string for their values should REMOVE those items from the config.
+    
+    this.props.workflow.update({
+      'configuration.subject_viewer_config': subject_viewer_config,
+      'configuration.subject_group': subject_group,
+    }).save()
   }
   
+  /*
+  Enables/disables the Subject Group Viewer system for this workflow.
+  When enabling, a DEFAULT set of configuration values is generated as a guideline.
+   */
   toggleSubjectViewer (event) {
     if (!event.target) return
     const enableSGViewer = event.target.checked
     
     if (enableSGViewer) {
       
+      // Submit the changes to the database
       const oldConfig = this.props.workflow.configuration || {}
       const newConfig = {
         ...oldConfig,
@@ -49,10 +99,22 @@ export default class SubjectGroupViewerEditor extends React.Component {
           cell_width: 200,
           grid_columns: 5,
           grid_rows: 5,
-        }
+        },
+        subject_group: {
+          num_columns: 5,
+          num_rows: 5, 
+        },
       }
-      
       this.props.workflow.update({ configuration: newConfig }).save()
+      
+      // Sync the React component
+      this.setState({
+        stateChanged: false,
+        cell_height: newConfig.subject_viewer_config.cell_height,
+        cell_width: newConfig.subject_viewer_config.cell_width,
+        grid_columns: newConfig.subject_viewer_config.grid_columns,
+        grid_rows: newConfig.subject_viewer_config.grid_rows,
+      })
       
     } else {
       const oldConfig = this.props.workflow.configuration || {}
@@ -60,8 +122,10 @@ export default class SubjectGroupViewerEditor extends React.Component {
       
       delete newConfig.subject_viewer
       delete newConfig.subject_viewer_config
+      delete newConfig.subject_group
       
       this.props.workflow.update({ configuration: newConfig }).save()
+      // Note: no need to setState() here; it's redundant.
     }
   }
 
@@ -83,9 +147,28 @@ export default class SubjectGroupViewerEditor extends React.Component {
         
         {enableSGViewer && (
           <div>
-            <b>Viewer Configuration</b>
+            <small>Viewer Configuration</small>
             <br/>
-            TODO
+            <table>
+              <tbody>
+                <tr>
+                  <td>cell_width</td>
+                  <td><input data-configkey="cell_width" value={this.state.cell_width} onChange={this.updateViewerConfig.bind(this)} /> pixels</td>
+                </tr>
+                <tr>
+                  <td>cell_height</td>
+                  <td><input data-configkey="cell_height" value={this.state.cell_height} onChange={this.updateViewerConfig.bind(this)} /> pixels</td>
+                </tr>
+                <tr>
+                  <td>grid_columns</td>
+                  <td><input data-configkey="grid_columns" value={this.state.grid_columns} onChange={this.updateViewerConfig.bind(this)} /> cells</td>
+                </tr>
+                <tr>
+                  <td>grid_rows</td>
+                  <td><input data-configkey="grid_rows" value={this.state.grid_rows} onChange={this.updateViewerConfig.bind(this)} /> cells</td>
+                </tr>
+              </tbody>
+            </table>
             <br/>
             <button onClick={this.saveViewerConfig.bind(this)}>Save viewer config</button>
           </div>

--- a/app/pages/lab/workflow.cjsx
+++ b/app/pages/lab/workflow.cjsx
@@ -19,6 +19,7 @@ classnames = require 'classnames'
 ShortcutEditor = require('../../classifier/tasks/shortcut/editor').default
 FeedbackSection = require('../../features/feedback/lab').default
 MobileSection = require('./mobile').default
+SubjectGroupViewerEditor = require('./workflow-components/subject-group-viewer-editor').default
 
 DEMO_SUBJECT_SET_ID = if process.env.NODE_ENV is 'production'
   '6' # Cats
@@ -380,6 +381,14 @@ EditWorkflowPage = createReactClass
 
               <hr />
 
+            </div>}
+
+          {if 'subjectGroupViewer' in @props.project.experimental_tools
+            <div>
+              <SubjectGroupViewerEditor
+                workflow={@props.workflow}
+              />
+              <hr />
             </div>}
 
           <div>

--- a/app/pages/lab/workflow.cjsx
+++ b/app/pages/lab/workflow.cjsx
@@ -253,7 +253,15 @@ EditWorkflowPage = createReactClass
                           <br />
                           <small><strong>Transcription</strong></small>
                         </button>
-                      </AutoSave>}
+                      </AutoSave>}{' '}
+                    {if @canUseTask(@props.project, "subjectGroupViewer")
+                      <AutoSave resource={@props.workflow}>
+                        <button type="button" className="minor-button" onClick={@addNewTask.bind this, 'subjectGroupComparison'} title="Subject Group Comparison Task: the volunteer looks at a grid of images, and selects the cells that look different. Be sure to enable the 'Subject Group Viewer' configuration for the workflow">
+                          <i className="fa fa-th fa-2x"></i>
+                          <br />
+                          <small><strong>Subject Group Comparison (aka "Grid")</strong></small>
+                        </button>
+                      </AutoSave>}{' '}
                     </div>}
               </div>
 


### PR DESCRIPTION
## PR Overview

This PR allows the "Subject Group" set of viewers and tasks to be edited on the PFE project builder. The "Subject Group" set refers to the Subject Group _Viewer_ (a grid-like subject viewer + "drawing" interface) and the Subject Group Comparison _Task_ (similar to a multi-answer task, except instead of checkboxes in the Task area, the 'selectable checkboxes' are cells on the grid. The Task Area itself just has a single question) that's built for the Front End Monorepo.

Please see the [FEM](https://github.com/zooniverse/front-end-monorepo) for the SubjectGroupViewer and SubjectGroupComparisonTask components.

Intended features of this PR:
- [x] Admins should be able to toggle the "subject group viewer" experimental tools task.
- [x] Project owners with said experimental tool should be able to EDIT existing Subject Group Comparison Tasks. (i.e. change the question. That's it.)
  - [x] Project owners should be able to ADD new Subject Group Comparison Tasks?
- [x] Project owners with said experimental tool should be able to EDIT configuration values for the Subject Group Viewer

Staging branch URL: https://pr-5946.pfe-preview.zooniverse.org/

### Testing

View the SURVOS Testing 2020 project from the user's perspective on the FEM Classifier:
https://frontend.preview.zooniverse.org/projects/darkeshard/survos-testing-2020/classify/workflow/3412?env=staging
- Expect to see a Task Area with one question
- Expect to see a Subject Viewer with a 5x5 grid of Subject images. Each image (cell) can be selected

View the SURVOS Testing 2020 project admin from the project owner's perspective on the PFE Project Builder page: https://pr-5946.pfe-preview.zooniverse.org/lab/1900/workflows/3412

### Status

Hackday WIP