### PR TITLE
Survey task: localise the AnnotationsView component

### DIFF
--- a/app/classifier/tasks/survey/annotation-view.jsx
+++ b/app/classifier/tasks/survey/annotation-view.jsx
@@ -1,6 +1,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
+import TaskTranslations fom '../translations'
+
 function AnnotationView({
   annotation = null,
   onChange,
@@ -40,7 +42,7 @@ function AnnotationView({
               {' '}
               <button
                 className="survey-identification-remove"
-                onClick={handleRemove.bind(this, i)}
+                onClick={i => handleRemove(i)}
                 title="Remove"
                 type="button"
               >

--- a/app/classifier/tasks/survey/annotation-view.jsx
+++ b/app/classifier/tasks/survey/annotation-view.jsx
@@ -1,13 +1,13 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import TaskTranslations fom '../translations'
+import TaskTranslations from '../translations'
 
-function AnnotationView({
+export function AnnotationView({
   annotation = null,
   onChange,
   task = null,
-  workflow = null
+  translation = null,
 }) {
   function handleRemove(index) {
     annotation.value.splice(index, 1);
@@ -20,7 +20,7 @@ function AnnotationView({
 
       if (answerKeys.indexOf(questionID) >= 0) {
         const answerLabels = [].concat(identification.answers[questionID]).map((answerID) => {
-          return task.questions[questionID].answers[answerID].label;
+          return translation.questions[questionID].answers[answerID].label;
         });
         return answerLabels.join(', ');
       }
@@ -30,7 +30,7 @@ function AnnotationView({
   if (!annotation.value) return null;
 
   return (
-    <div>
+    <>
       {annotation.value.map((identification, i) => {
         identification._key = `IDENTIFICATION_KEY_${i}`;
         const answersList = answerByQuestion(identification).filter(Boolean).join('; ');
@@ -38,7 +38,7 @@ function AnnotationView({
         return (
           <span key={identification._key}>
             <span className="survey-identification-proxy" title={answersList}>
-              {task.choices[identification.choice].label}
+              {translation.choices[identification.choice].label}
               {' '}
               <button
                 className="survey-identification-remove"
@@ -52,7 +52,7 @@ function AnnotationView({
           </span>
         );
       })}
-    </div>
+    </>
   );
 }
 
@@ -68,4 +68,23 @@ AnnotationView.propTypes = {
   })
 };
 
-export default AnnotationView;
+export default function LocalisedAnnotationView({
+  annotation = null,
+  onChange,
+  task = null,
+  workflow = null
+}) {
+  return (
+    <TaskTranslations
+      taskKey={annotation.task}
+      task={task}
+      workflowID={workflow.id}
+    >
+      <AnnotationView
+        annotation={annotation}
+        onChange={onChange}
+        task={task}
+      />
+    </TaskTranslations>
+  )
+};

--- a/app/classifier/tasks/survey/annotation-view.jsx
+++ b/app/classifier/tasks/survey/annotation-view.jsx
@@ -33,17 +33,18 @@ export function AnnotationView({
     <>
       {annotation.value.map((identification, i) => {
         identification._key = `IDENTIFICATION_KEY_${i}`;
-        const answersList = answerByQuestion(identification).filter(Boolean).join('; ');
+        const answersList = answerByQuestion(identification).filter(Boolean).join('; ').trim();
+        const answersLabel = answersList ? `(${answersList})` : ''
 
         return (
           <span key={identification._key}>
-            <span className="survey-identification-proxy" title={answersList}>
-              {translation.choices[identification.choice].label}
+            <span className="survey-identification-proxy">
+              {translation.choices[identification.choice].label} {answersLabel}
               {' '}
               <button
                 className="survey-identification-remove"
                 onClick={i => handleRemove(i)}
-                title="Remove"
+                aria-label="Remove"
                 type="button"
               >
                 &times;

--- a/app/classifier/tasks/survey/annotation-view.jsx
+++ b/app/classifier/tasks/survey/annotation-view.jsx
@@ -1,15 +1,18 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-function AnnotationView(props) {
+function AnnotationView({
+  annotation = null,
+  onChange,
+  task = null,
+  workflow = null
+}) {
   function handleRemove(index) {
-    const { annotation, onChange } = props;
     annotation.value.splice(index, 1);
     onChange(annotation);
   }
 
   function answerByQuestion(identification) {
-    const { task } = props;
     return task.questionsOrder.map((questionID) => {
       const answerKeys = Object.keys(identification.answers);
 
@@ -22,7 +25,6 @@ function AnnotationView(props) {
     });
   }
 
-  const { annotation, task } = props;
   if (!annotation.value) return null;
 
   return (
@@ -62,11 +64,6 @@ AnnotationView.propTypes = {
     questions: PropTypes.object,
     questionsOrder: PropTypes.array
   })
-};
-
-AnnotationView.defaultProps = {
-  annotation: null,
-  task: null
 };
 
 export default AnnotationView;

--- a/app/classifier/tasks/survey/annotation-view.spec.jsx
+++ b/app/classifier/tasks/survey/annotation-view.spec.jsx
@@ -2,7 +2,7 @@ import { shallow } from 'enzyme';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import React from 'react';
-import AnnotationView from './annotation-view';
+import { AnnotationView } from './annotation-view';
 
 const annotationValue = {
   answers: {
@@ -43,6 +43,7 @@ describe('AnnotationView', function() {
       annotation={annotation}
       onChange={onChange}
       task={task}
+      translation={task}
     />
   );
 


### PR DESCRIPTION
Staging branch URL: https://pr-5950.pfe-preview.zooniverse.org

Fixes #5949.

I've refactored the `AnnotationView` component to wrap it in `TaskTranslations`, which passes a `translation` object containing localised strings for the current task.

I've also removed the `title` attribute, which isn't accessible to volunteers who use screen readers or who rely on the keyboard or voice control. Buttons are labelled with `aria-label` and I've added answers to the displayed text.

https://localhost.pfe-preview.zooniverse.org:3735/projects/aicensusuhu/iberian-camera-trap-project/classify?env=production&language=cs
![Screenshot of the Iberian Camera Trap project showing annotations displayed in Czech.](https://user-images.githubusercontent.com/59547/118464250-8be33500-b6f8-11eb-9abd-c538a2db3412.png)


# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
