### PR TITLE
Publish commit_id.txt on deploy

### DIFF
--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -12,6 +12,8 @@ on:
 jobs:
   deploy_production:
     runs-on: ubuntu-latest
+    env:
+      HEAD_COMMIT: ${{ github.sha }}
     steps:
     - uses: actions/checkout@v2
     - uses: azure/login@v1
@@ -25,6 +27,9 @@ jobs:
         node-version: '14.x'
     - run: npm install
     - run: npm run _build-production
+
+    - name: Write commit_id.txt
+      run: echo ${HEAD_COMMIT} > ./dist/commit_id.txt
 
     - name: Upload to blob storage
       id: upload
@@ -43,6 +48,12 @@ jobs:
               --container-name '$web' \
               --name 'www.zooniverse.org/index.html' \
               --file ./dist/index.html
+            az storage blob upload \
+              --account-name zooniversestatic \
+              --content-cache-control 'public, max-age=60' \
+              --container-name '$web' \
+              --name 'www.zooniverse.org/commit_id.txt' \
+              --file ./dist/commit_id.txt
 
     - name: Slack notification
       uses: 8398a7/action-slack@v3

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   deploy_staging:
     runs-on: ubuntu-latest
+    env:
+      HEAD_COMMIT: ${{ github.sha }}
     steps:
     - uses: actions/checkout@v2
     - uses: azure/login@v1
@@ -22,6 +24,9 @@ jobs:
         node-version: '14.x'
     - run: npm install
     - run: npm run _build-staging
+
+    - name: Write commit_id.txt
+      run: echo ${HEAD_COMMIT} > ./dist/commit_id.txt
 
     - name: Upload to blob storage
       id: upload
@@ -40,6 +45,12 @@ jobs:
               --container-name '$web' \
               --name 'preview.zooniverse.org/panoptes-front-end/master/index.html' \
               --file ./dist/index.html
+            az storage blob upload \
+              --account-name zooniversestatic \
+              --content-cache-control 'public, max-age=60' \
+              --container-name '$web' \
+              --name 'preview.zooniverse.org/panoptes-front-end/master/commit_id.txt' \
+              --file ./dist/commit_id.txt
 
     - name: Slack notification
       uses: 8398a7/action-slack@v3


### PR DESCRIPTION
Add HEAD_COMMIT to the build environment (it's referenced in `package.json` in a couple of places.) Publish HEAD_COMMIT as `dist/commit_id.txt` and upload that to Azure with a cache lifetime of 60s.

Staging branch URL: https://pr-5951.pfe-preview.zooniverse.org/commit_id.txt

This is https://github.com/zooniverse/pandora/pull/189 adapted for PFE.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
