### PR TITLE
Bugfix: Update the Copy Workflow button

### DIFF
--- a/app/pages/lab/workflow-create-form.cjsx
+++ b/app/pages/lab/workflow-create-form.cjsx
@@ -26,12 +26,15 @@ WorkflowCreateForm = createReactClass
 
     newWorkflow =
       display_name: @refs.newDisplayName.value
-      primary_language: counterpart.getLocale()
+      primary_language: workflowToClone?.primary_language
+      steps: workflowToClone?.steps ? undefined
       tasks: workflowToClone?.tasks ? {}
       first_task: workflowToClone?.first_task ? ''
       configuration: workflowToClone?.configuration ? {}
       retirement: workflowToClone?.retirement ? {}
       active: @props.workflowActiveStatus ? false
+      grouped: workflowToClone?.grouped ? false
+      prioritized: workflowToClone?.prioritized ? false
 
     awaitSubmission = @props.onSubmit(@props.projectID, newWorkflow)
 


### PR DESCRIPTION
Copy workflow steps, prioritized and grouped (if defined) when cloning a workflow. Set the new workflow's primary language to the same language as the original.

This is a quick patch so that we can continue to copy workflows for transcription projects and for Engaging Crowds.

Staging branch URL: https://pr-5961.pfe-preview.zooniverse.org

Fixes #5960.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
