### PR TITLE
ensure the workflow has a pimary language set

### DIFF
--- a/app/pages/lab/workflow-create-form.cjsx
+++ b/app/pages/lab/workflow-create-form.cjsx
@@ -7,7 +7,7 @@ WorkflowCreateForm = createReactClass
     onCancel: ->
     onSubmit: ->
     onSuccess: ->
-    projectID: ''
+    project: null
     workflowToClone: null
     workflowActiveStatus: false
 
@@ -26,7 +26,7 @@ WorkflowCreateForm = createReactClass
 
     newWorkflow =
       display_name: @refs.newDisplayName.value
-      primary_language: workflowToClone?.primary_language || counterpart.getLocale()
+      primary_language: workflowToClone?.primary_language || @props.project.primary_language
       steps: workflowToClone?.steps ? undefined
       tasks: workflowToClone?.tasks ? {}
       first_task: workflowToClone?.first_task ? ''
@@ -36,7 +36,7 @@ WorkflowCreateForm = createReactClass
       grouped: workflowToClone?.grouped ? false
       prioritized: workflowToClone?.prioritized ? false
 
-    awaitSubmission = @props.onSubmit(@props.projectID, newWorkflow)
+    awaitSubmission = @props.onSubmit(@props.project.id, newWorkflow)
 
     Promise.resolve(awaitSubmission)
       .then (result) =>

--- a/app/pages/lab/workflow-create-form.cjsx
+++ b/app/pages/lab/workflow-create-form.cjsx
@@ -26,7 +26,7 @@ WorkflowCreateForm = createReactClass
 
     newWorkflow =
       display_name: @refs.newDisplayName.value
-      primary_language: workflowToClone?.primary_language
+      primary_language: workflowToClone?.primary_language || counterpart.getLocale()
       steps: workflowToClone?.steps ? undefined
       tasks: workflowToClone?.tasks ? {}
       first_task: workflowToClone?.first_task ? ''

--- a/app/pages/lab/workflow.cjsx
+++ b/app/pages/lab/workflow.cjsx
@@ -105,7 +105,7 @@ EditWorkflowPage = createReactClass
       </h3>
       {if @state.workflowCreationInProgress
         <ModalFormDialog tag="div">
-          <WorkflowCreateForm onSubmit={@props.workflowActions.createWorkflowForProject} onCancel={@hideCreateWorkflow} onSuccess={@handleWorkflowCreation}  projectID={@props.project.id} workflowToClone={@props.workflow} workflowActiveStatus={not @props.project.live} />
+          <WorkflowCreateForm onSubmit={@props.workflowActions.createWorkflowForProject} onCancel={@hideCreateWorkflow} onSuccess={@handleWorkflowCreation}  project={@props.project} workflowToClone={@props.workflow} workflowActiveStatus={not @props.project.live} />
         </ModalFormDialog>}
       <p className="form-help">A workflow is the sequence of tasks that you’re asking volunteers to perform. For example, you might want to ask volunteers to answer questions about your images, or to mark features in your images, or both.</p>
       {if @props.project.live and @props.workflow.active
@@ -533,7 +533,7 @@ EditWorkflowPage = createReactClass
                   project={@props.project}
                   onChange={@handleTaskChange.bind this, @state.selectedTaskKey}
                 />
-              else 
+              else
                 <div>Editor is not available.</div>}
               <hr />
               <br />
@@ -673,7 +673,7 @@ EditWorkflowPage = createReactClass
   addNewTask: (type) ->
     changes = {}
     { nextTaskID } = @getNextTaskID()
-  
+
     if @canUseTask(@props.project, "transcription-task")
       nextStepID = @getNextStepID()
       newStep = [nextStepID, { taskKeys: [nextTaskID] }]
@@ -720,7 +720,7 @@ EditWorkflowPage = createReactClass
       required: "true",
       type: "single"
     }
-    
+
     tasks
 
   addNewTranscriptionTask: () ->
@@ -902,7 +902,7 @@ EditWorkflowPage = createReactClass
     if changes.steps?.length is 0
       # If no more steps, remove the classifier version 2.0 designation
       changes["configuration.classifier_version"] = undefined
-    
+
     @props.workflow.update changes
 
   handleTaskDelete: (taskKey, e) ->
@@ -910,7 +910,7 @@ EditWorkflowPage = createReactClass
     if e.shiftKey or confirm 'Really delete this task?'
       if @canUseTask(@props.project, "transcription-task")
         @deleteStepAndTask(taskKey)
-      else 
+      else
         changes = {}
         if shortcut
           changes["tasks.#{shortcut}"] = undefined

--- a/app/pages/lab/workflows.jsx
+++ b/app/pages/lab/workflows.jsx
@@ -79,7 +79,7 @@ const WorkflowsPage = (props) => {
             onSubmit={props.workflowActions.createWorkflowForProject}
             onCancel={props.hideCreateWorkflow}
             onSuccess={props.handleWorkflowCreation}
-            projectID={props.project.id}
+            project={props.project}
             workflowActiveStatus={!props.project.live}
           />
         </ModalFormDialog>


### PR DESCRIPTION
Staging branch URL: https://pr-5962.pfe-preview.zooniverse.org

Ensure we have a primary language specified on workflow creation. Use the workflow to clone by default and fallback to the current locale.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
