### PR TITLE
Subject Group project builder controls pt 2

### DIFF
--- a/app/pages/lab/workflow-components/subject-group-viewer-editor.jsx
+++ b/app/pages/lab/workflow-components/subject-group-viewer-editor.jsx
@@ -170,28 +170,28 @@ export default class SubjectGroupViewerEditor extends React.Component {
             <table>
               <tbody>
                 <tr>
-                  <td>cell_width</td>
-                  <td><input title="cell_width" data-configkey="cell_width" value={this.state.cell_width} onChange={this.updateViewerConfig.bind(this)} /> pixels</td>
+                  <td><label for="sgv-config-cell_width">cell_width</label></td>
+                  <td><input id="sgv-config-cell_width" data-configkey="cell_width" value={this.state.cell_width} onChange={this.updateViewerConfig.bind(this)} /> pixels</td>
                 </tr>
                 <tr>
-                  <td>cell_height</td>
-                  <td><input title="cell_height" data-configkey="cell_height" value={this.state.cell_height} onChange={this.updateViewerConfig.bind(this)} /> pixels</td>
+                  <td><label for="sgv-config-cell_height">cell_height</label></td>
+                  <td><input id="sgv-config-cell_height" data-configkey="cell_height" value={this.state.cell_height} onChange={this.updateViewerConfig.bind(this)} /> pixels</td>
                 </tr>
                 <tr>
-                  <td>grid_columns</td>
-                  <td><input title="grid_columns" data-configkey="grid_columns" value={this.state.grid_columns} onChange={this.updateViewerConfig.bind(this)} /> cells</td>
+                  <td><label for="sgv-config-grid_columns">grid_columns</label></td>
+                  <td><input id="sgv-config-grid_columns" data-configkey="grid_columns" value={this.state.grid_columns} onChange={this.updateViewerConfig.bind(this)} /> cells</td>
                 </tr>
                 <tr>
-                  <td>grid_rows</td>
-                  <td><input title="grid_rows" data-configkey="grid_rows" value={this.state.grid_rows} onChange={this.updateViewerConfig.bind(this)} /> cells</td>
+                  <td><label for="sgv-config-grid_rows">grid_rows</label></td>
+                  <td><input id="sgv-config-grid_rows" data-configkey="grid_rows" value={this.state.grid_rows} onChange={this.updateViewerConfig.bind(this)} /> cells</td>
                 </tr>
                 <tr>
-                  <td>grid_max_width</td>
-                  <td><input title="grid_max_width" data-configkey="grid_max_width" value={this.state.grid_max_width} onChange={this.updateViewerConfig.bind(this)} placeholder="Optional" /> CSS units</td>
+                  <td><label for="sgv-config-grid_max_width">grid_max_width</label></td>
+                  <td><input id="sgv-config-grid_max_width" data-configkey="grid_max_width" value={this.state.grid_max_width} onChange={this.updateViewerConfig.bind(this)} placeholder="Optional" /> CSS units</td>
                 </tr>
                 <tr>
-                  <td>grid_max_height</td>
-                  <td><input title="grid_max_height" data-configkey="grid_max_height" value={this.state.grid_max_height} onChange={this.updateViewerConfig.bind(this)} placeholder="Optional" /> CSS units</td>
+                  <td><label for="sgv-config-grid_max_height">grid_max_height</label></td>
+                  <td><input id="sgv-config-grid_max_height" data-configkey="grid_max_height" value={this.state.grid_max_height} onChange={this.updateViewerConfig.bind(this)} placeholder="Optional" /> CSS units</td>
                 </tr>
               </tbody>
             </table>

--- a/app/pages/lab/workflow-components/subject-group-viewer-editor.jsx
+++ b/app/pages/lab/workflow-components/subject-group-viewer-editor.jsx
@@ -112,8 +112,6 @@ export default class SubjectGroupViewerEditor extends React.Component {
           cell_width: 200,
           grid_columns: 5,
           grid_rows: 5,
-          // grid_max_width: '',  // Optional, do not define
-          // grid_max_height: '',  // Optional, do not define
         },
         subject_group: {
           num_columns: 5,

--- a/app/pages/lab/workflow-components/subject-group-viewer-editor.jsx
+++ b/app/pages/lab/workflow-components/subject-group-viewer-editor.jsx
@@ -189,15 +189,16 @@ export default class SubjectGroupViewerEditor extends React.Component {
                 </tr>
                 <tr>
                   <td>grid_max_width</td>
-                  <td><input data-configkey="grid_max_width" value={this.state.grid_max_width} onChange={this.updateViewerConfig.bind(this)} /> CSS units (e.g. 1000px or 50vw)</td>
+                  <td><input data-configkey="grid_max_width" value={this.state.grid_max_width} onChange={this.updateViewerConfig.bind(this)} placeholder="Optional" /> CSS units</td>
                 </tr>
                 <tr>
                   <td>grid_max_height</td>
-                  <td><input data-configkey="grid_max_height" value={this.state.grid_max_height} onChange={this.updateViewerConfig.bind(this)} /> CSS units</td>
+                  <td><input data-configkey="grid_max_height" value={this.state.grid_max_height} onChange={this.updateViewerConfig.bind(this)} placeholder="Optional" /> CSS units</td>
                 </tr>
               </tbody>
             </table>
-            <small class="form-help">Note: as of May 2021, the maximum grid size is 25 cells.</small>
+            <small class="form-help">Note: as of May 2021, the maximum grid size is 25 cells.</small><br />
+            <small class="form-help">Note: grid_max_width and grid_max height are fully optional and used only if users say the grid is "exceeding the visible browser space". (Usually happens with really wide screens.) Either leave blank, or use CSS units, e.g. 1000px or 50vw.</small>
             <br/>
             <button onClick={this.saveViewerConfig.bind(this)} disabled={!this.state.stateChanged}>Save viewer config</button>
           </div>

--- a/app/pages/lab/workflow-components/subject-group-viewer-editor.jsx
+++ b/app/pages/lab/workflow-components/subject-group-viewer-editor.jsx
@@ -171,27 +171,27 @@ export default class SubjectGroupViewerEditor extends React.Component {
               <tbody>
                 <tr>
                   <td>cell_width</td>
-                  <td><input data-configkey="cell_width" value={this.state.cell_width} onChange={this.updateViewerConfig.bind(this)} /> pixels</td>
+                  <td><input title="cell_width" data-configkey="cell_width" value={this.state.cell_width} onChange={this.updateViewerConfig.bind(this)} /> pixels</td>
                 </tr>
                 <tr>
                   <td>cell_height</td>
-                  <td><input data-configkey="cell_height" value={this.state.cell_height} onChange={this.updateViewerConfig.bind(this)} /> pixels</td>
+                  <td><input title="cell_height" data-configkey="cell_height" value={this.state.cell_height} onChange={this.updateViewerConfig.bind(this)} /> pixels</td>
                 </tr>
                 <tr>
                   <td>grid_columns</td>
-                  <td><input data-configkey="grid_columns" value={this.state.grid_columns} onChange={this.updateViewerConfig.bind(this)} /> cells</td>
+                  <td><input title="grid_columns" data-configkey="grid_columns" value={this.state.grid_columns} onChange={this.updateViewerConfig.bind(this)} /> cells</td>
                 </tr>
                 <tr>
                   <td>grid_rows</td>
-                  <td><input data-configkey="grid_rows" value={this.state.grid_rows} onChange={this.updateViewerConfig.bind(this)} /> cells</td>
+                  <td><input title="grid_rows" data-configkey="grid_rows" value={this.state.grid_rows} onChange={this.updateViewerConfig.bind(this)} /> cells</td>
                 </tr>
                 <tr>
                   <td>grid_max_width</td>
-                  <td><input data-configkey="grid_max_width" value={this.state.grid_max_width} onChange={this.updateViewerConfig.bind(this)} placeholder="Optional" /> CSS units</td>
+                  <td><input title="grid_max_width" data-configkey="grid_max_width" value={this.state.grid_max_width} onChange={this.updateViewerConfig.bind(this)} placeholder="Optional" /> CSS units</td>
                 </tr>
                 <tr>
                   <td>grid_max_height</td>
-                  <td><input data-configkey="grid_max_height" value={this.state.grid_max_height} onChange={this.updateViewerConfig.bind(this)} placeholder="Optional" /> CSS units</td>
+                  <td><input title="grid_max_height" data-configkey="grid_max_height" value={this.state.grid_max_height} onChange={this.updateViewerConfig.bind(this)} placeholder="Optional" /> CSS units</td>
                 </tr>
               </tbody>
             </table>

--- a/app/pages/lab/workflow-components/subject-group-viewer-editor.jsx
+++ b/app/pages/lab/workflow-components/subject-group-viewer-editor.jsx
@@ -15,6 +15,8 @@ workflow.configuration: {
     cell_width: 200,
     grid_columns: 5,
     grid_rows: 5,
+    grid_max_width: '',  // CSS value, string, optional
+    grid_max_height: '70vh',  // CSS value, string, optional
   },
   subject_group: {   // Used by the backend "/subjects/grouped" endpoint
     num_columns: 5,  // this must match grid_columns
@@ -39,6 +41,8 @@ export default class SubjectGroupViewerEditor extends React.Component {
       cell_width: subjectViewerConfig.cell_width || '',
       grid_columns: subjectViewerConfig.grid_columns || '',
       grid_rows: subjectViewerConfig.grid_rows || '',
+      grid_max_width: subjectViewerConfig.grid_max_width || '',
+      grid_max_height: subjectViewerConfig.grid_max_height || '',
     }
   }
   
@@ -65,6 +69,8 @@ export default class SubjectGroupViewerEditor extends React.Component {
       cell_width: parseInt(state.cell_width),
       grid_columns: parseInt(state.grid_columns),
       grid_rows: parseInt(state.grid_rows),
+      grid_max_width: state.grid_max_width,
+      grid_max_height: state.grid_max_height,
     }
     
     const subject_group = {
@@ -106,6 +112,8 @@ export default class SubjectGroupViewerEditor extends React.Component {
           cell_width: 200,
           grid_columns: 5,
           grid_rows: 5,
+          // grid_max_width: '',  // Optional, do not define
+          // grid_max_height: '',  // Optional, do not define
         },
         subject_group: {
           num_columns: 5,
@@ -121,6 +129,8 @@ export default class SubjectGroupViewerEditor extends React.Component {
         cell_width: newConfig.subject_viewer_config.cell_width,
         grid_columns: newConfig.subject_viewer_config.grid_columns,
         grid_rows: newConfig.subject_viewer_config.grid_rows,
+        grid_max_width: '',
+        grid_max_height: '',
       })
       
     } else {
@@ -176,6 +186,14 @@ export default class SubjectGroupViewerEditor extends React.Component {
                 <tr>
                   <td>grid_rows</td>
                   <td><input data-configkey="grid_rows" value={this.state.grid_rows} onChange={this.updateViewerConfig.bind(this)} /> cells</td>
+                </tr>
+                <tr>
+                  <td>grid_max_width</td>
+                  <td><input data-configkey="grid_max_width" value={this.state.grid_max_width} onChange={this.updateViewerConfig.bind(this)} /> CSS units (e.g. 1000px or 50vw)</td>
+                </tr>
+                <tr>
+                  <td>grid_max_height</td>
+                  <td><input data-configkey="grid_max_height" value={this.state.grid_max_height} onChange={this.updateViewerConfig.bind(this)} /> CSS units</td>
                 </tr>
               </tbody>
             </table>


### PR DESCRIPTION
## PR Overview

Extension of: #5946 (adds ability to change workflow configuration values for Subject Group Viewer.)
Related PR: https://github.com/zooniverse/front-end-monorepo/pull/2231 (allows Subject Group Viewer to have an optional maximum grid height/width)

This PR allows project owners to edit the optional `grid_max_width` and `grid_max_height` workflow configuration values, for their workflows that use the Subject Group Viewer. These optional values are useful to restrict the the grid component to only appear on the visible browser space, instead of, e.g. growing so tall (due to "fit-to-width" behaviour) that the grid's bottom half gets cut off.

- Please note that this functionality is only relevant to Projects that 1. have the "subject group viewer" experimental tool enabled, and 2. have the corresponding "Enable Subject Group Viewer for this workflow" option on the workflow page checked.
- The functionality otherwise is a very very simple addition to the value editor for a basic Workflow resource.
- Expected values are either an empty string, or a CSS value, e.g. `1000px` or `50vh`. ⚠️ NO TYPE CHECKING is involved for this optional, experimental values.

### Testing

Test URL: https://local.zooniverse.org:3735/lab/1900/workflows/3412

Testing steps:
- Choose a workflow, e.g. workflow 3412 (linked above) which already as the SGV option enabled.
- Edit either grid_max_width or grid_max_height values, then save.
- Confirm all changes are registered on the Workflow resource.
- Disable the "Enable Subject Group Viewer for this workflow" option
- Re-enable the "Enable Subject Group Viewer for this workflow" option
- Expect the grid_max_height and grid_max_width values to be initialised with empty strings
- Confirm all changes are registered on the Workflow resource.
- Optional: confirm all changes are visible on the Classifier (see related PR on the FEM)

### Status

Ready for review