### PR TITLE
[Security] Update striptags to 3.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "regl": "~1.3.11",
         "shortid": "~2.2.14",
         "sort-into-columns": "~1.0.0",
-        "striptags": "~3.1.1",
+        "striptags": "~3.2.0",
         "styled-components": "~4.1.3",
         "styled-theming": "~2.2.0",
         "sugar-client": "~1.0.1",
@@ -17973,9 +17973,9 @@
       }
     },
     "node_modules/striptags": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/striptags/-/striptags-3.1.1.tgz",
-      "integrity": "sha1-yMPn/db7S7OjKjt1LltePjgJPr0="
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/striptags/-/striptags-3.2.0.tgz",
+      "integrity": "sha512-g45ZOGzHDMe2bdYMdIvdAfCQkCTDMGBazSw1ypMowwGIee7ZQ5dU0rBJ8Jqgl+jAKIv4dbeE1jscZq9wid1Tkw=="
     },
     "node_modules/style-loader": {
       "version": "1.3.0",
@@ -36339,9 +36339,9 @@
       "dev": true
     },
     "striptags": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/striptags/-/striptags-3.1.1.tgz",
-      "integrity": "sha1-yMPn/db7S7OjKjt1LltePjgJPr0="
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/striptags/-/striptags-3.2.0.tgz",
+      "integrity": "sha512-g45ZOGzHDMe2bdYMdIvdAfCQkCTDMGBazSw1ypMowwGIee7ZQ5dU0rBJ8Jqgl+jAKIv4dbeE1jscZq9wid1Tkw=="
     },
     "style-loader": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "regl": "~1.3.11",
     "shortid": "~2.2.14",
     "sort-into-columns": "~1.0.0",
-    "striptags": "~3.1.1",
+    "striptags": "~3.2.0",
     "styled-components": "~4.1.3",
     "styled-theming": "~2.2.0",
     "sugar-client": "~1.0.1",


### PR DESCRIPTION
Staging branch URL: https://pr-5976.pfe-preview.zooniverse.org/

Fixes security alert: https://github.com/zooniverse/how-to-zooniverse/issues/160.

Describe your changes.
Manually update `striptags` package to 3.2.0.  I found this package used in only one location on the website (on the homepage):
![socials](https://user-images.githubusercontent.com/23665803/123317882-27d03f80-d4f4-11eb-8290-eea66d2e2f25.jpg)


# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
