### PR TITLE
Subtasks: merge translations into the original task

### DIFF
--- a/app/classifier/drawing-tools/components/DetailsSubTaskForm/DetailsSubTaskForm.jsx
+++ b/app/classifier/drawing-tools/components/DetailsSubTaskForm/DetailsSubTaskForm.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import merge from 'lodash/merge';
 import PropTypes from 'prop-types';
 import StickyModalForm from 'modal-form/sticky';
 import { connect, Provider } from 'react-redux';
@@ -132,9 +133,10 @@ export class DetailsSubTaskForm extends React.Component {
                 if (!detailTask._key) detailTask._key = Math.random();
                 const TaskComponent = tasks[detailTask.type];
                 const workflowTranslation = translations.strings.workflow[workflow.id]
-                const detailTranslation = workflowTranslation ?
+                const detailTranslationStrings = workflowTranslation ?
                   workflowTranslation.strings.tasks[toolProps.taskKey].tools[toolProps.mark.tool].details[i] :
                   detailTask;
+                const detailTranslation = merge({}, detailTask, detailTranslationStrings);
                 
                 return (
                   <TaskComponent

--- a/app/talk/active-users.jsx
+++ b/app/talk/active-users.jsx
@@ -20,6 +20,7 @@ export default class ActiveUsers extends React.Component {
     };
 
     this.onPageChange = this.onPageChange.bind(this);
+    this.restartTimer = this.restartTimer.bind(this);
   }
 
   componentDidMount() {


### PR DESCRIPTION
Merge subtask translation strings into the original task, so that the passed translation has the same shape as the task, including option values.

Staging branch URL: https://pr-5980.pfe-preview.zooniverse.org

Fixes #5979.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
