### PR TITLE
ActiveUsers: explicitly bind this.restartTimer

### DIFF
--- a/app/talk/active-users.jsx
+++ b/app/talk/active-users.jsx
@@ -20,6 +20,7 @@ export default class ActiveUsers extends React.Component {
     };
 
     this.onPageChange = this.onPageChange.bind(this);
+    this.restartTimer = this.restartTimer.bind(this);
   }
 
   componentDidMount() {

--- a/app/talk/active-users.jsx
+++ b/app/talk/active-users.jsx
@@ -20,7 +20,8 @@ export default class ActiveUsers extends React.Component {
     };
 
     this.onPageChange = this.onPageChange.bind(this);
-    this.restartTimer = this.restartTimer.bind(this);
+    // ensure this is bound correctly for setTimeout calling context
+    this.update = this.update.bind(this);
   }
 
   componentDidMount() {

--- a/app/talk/active-users.spec.js
+++ b/app/talk/active-users.spec.js
@@ -15,6 +15,7 @@ describe('ActiveUsers', function () {
   let fetchUsersSpy;
   let pageCountSpy;
   let boundedPageSpy;
+  let restartStub;
   let userIdSpy;
   let wrapper;
 
@@ -24,6 +25,7 @@ describe('ActiveUsers', function () {
     pageCountSpy = sinon.spy(ActiveUsers.prototype, 'pageCount');
     boundedPageSpy = sinon.spy(ActiveUsers.prototype, 'boundedPage');
     userIdSpy = sinon.spy(ActiveUsers.prototype, 'userIdsOnPage');
+    restartStub = sinon.stub(ActiveUsers.prototype, 'restartTimer')
     wrapper = shallow(<ActiveUsers />);
     wrapper.setState({ users });
   });
@@ -34,7 +36,8 @@ describe('ActiveUsers', function () {
       fetchUsersSpy,
       pageCountSpy,
       boundedPageSpy,
-      userIdSpy
+      userIdSpy,
+      restartStub
     ];
     spies.forEach(spy => spy.restore());
   });
@@ -53,5 +56,6 @@ describe('ActiveUsers', function () {
     sinon.assert.calledOnce(userIdSpy);
     sinon.assert.calledWith(fetchUsersSpy, activeIds);
     sinon.assert.calledWith(pageCountSpy, activeIds);
+    sinon.assert.calledOnce(restartStub);
   });
 });

--- a/app/talk/active-users.spec.js
+++ b/app/talk/active-users.spec.js
@@ -4,7 +4,7 @@ import { shallow } from 'enzyme';
 import sinon from 'sinon';
 import ActiveUsers from './active-users';
 
-const activeIds = ['1234', '5678'];
+const activeIds = ['1', '2'];
 const users = [
   { id: '1', display_name: 'Test_User_1', login: 'testUser1' },
   { id: '2', display_name: 'Test_User_2', login: 'testUser2' }
@@ -15,31 +15,29 @@ describe('ActiveUsers', function () {
   let fetchUsersSpy;
   let pageCountSpy;
   let boundedPageSpy;
-  let restartStub;
   let userIdSpy;
   let wrapper;
 
   before(function () {
     getActiveIdsStub = sinon.stub(ActiveUsers.prototype, 'getActiveUserIds').callsFake(() => Promise.resolve(activeIds));
-    fetchUsersSpy = sinon.spy(ActiveUsers.prototype, 'fetchUncachedUsers');
     pageCountSpy = sinon.spy(ActiveUsers.prototype, 'pageCount');
     boundedPageSpy = sinon.spy(ActiveUsers.prototype, 'boundedPage');
     userIdSpy = sinon.spy(ActiveUsers.prototype, 'userIdsOnPage');
-    restartStub = sinon.stub(ActiveUsers.prototype, 'restartTimer')
+    fetchUsersSpy = sinon.stub(ActiveUsers.prototype, 'fetchUncachedUsers').callsFake(() => Promise.resolve(users));
     wrapper = shallow(<ActiveUsers />);
-    wrapper.setState({ users });
   });
 
   after(function () {
-    const spies = [
+    const spiesandStubs = [
       getActiveIdsStub,
       fetchUsersSpy,
       pageCountSpy,
       boundedPageSpy,
-      userIdSpy,
-      restartStub
+      userIdSpy
     ];
-    spies.forEach(spy => spy.restore());
+    spiesandStubs.forEach(spy => spy.restore());
+    // ensure we unmount to unset the saved timers
+    wrapper.unmount();
   });
 
   it('should render without crashing', function() {
@@ -56,6 +54,5 @@ describe('ActiveUsers', function () {
     sinon.assert.calledOnce(userIdSpy);
     sinon.assert.calledWith(fetchUsersSpy, activeIds);
     sinon.assert.calledWith(pageCountSpy, activeIds);
-    sinon.assert.calledOnce(restartStub);
   });
 });

--- a/app/talk/active-users.spec.js
+++ b/app/talk/active-users.spec.js
@@ -12,10 +12,10 @@ const users = [
 
 describe('ActiveUsers', function () {
   let getActiveIdsStub;
-  let fetchUsersSpy;
   let pageCountSpy;
   let boundedPageSpy;
   let userIdSpy;
+  let fetchUsersStub;
   let wrapper;
 
   before(function () {
@@ -23,17 +23,17 @@ describe('ActiveUsers', function () {
     pageCountSpy = sinon.spy(ActiveUsers.prototype, 'pageCount');
     boundedPageSpy = sinon.spy(ActiveUsers.prototype, 'boundedPage');
     userIdSpy = sinon.spy(ActiveUsers.prototype, 'userIdsOnPage');
-    fetchUsersSpy = sinon.stub(ActiveUsers.prototype, 'fetchUncachedUsers').callsFake(() => Promise.resolve(users));
+    fetchUsersStub = sinon.stub(ActiveUsers.prototype, 'fetchUncachedUsers').callsFake(() => Promise.resolve(users));
     wrapper = shallow(<ActiveUsers />);
   });
 
   after(function () {
     const spiesandStubs = [
       getActiveIdsStub,
-      fetchUsersSpy,
       pageCountSpy,
       boundedPageSpy,
-      userIdSpy
+      userIdSpy,
+      fetchUsersStub
     ];
     spiesandStubs.forEach(spy => spy.restore());
     // ensure we unmount to unset the saved timers
@@ -52,7 +52,7 @@ describe('ActiveUsers', function () {
     sinon.assert.calledOnce(getActiveIdsStub);
     sinon.assert.calledOnce(boundedPageSpy);
     sinon.assert.calledOnce(userIdSpy);
-    sinon.assert.calledWith(fetchUsersSpy, activeIds);
+    sinon.assert.calledWith(fetchUsersStub, activeIds);
     sinon.assert.calledWith(pageCountSpy, activeIds);
   });
 });


### PR DESCRIPTION
Staging branch URL: https://pr-5981.pfe-preview.zooniverse.org

CI tests are failing with `this.restartTimer is not a function` so this explicitly binds `restartTimer` in the `ActiveUsers` component and stubs it in tests.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
