### PR TITLE
Talk: turn off flipbook mode for group subjects

### DIFF
--- a/app/components/subject-viewer.cjsx
+++ b/app/components/subject-viewer.cjsx
@@ -114,6 +114,7 @@ module.exports = createReactClass
       'subject-viewer--flipbook': @state.inFlipbookMode
       'subject-viewer--invert': @state.invert
       "subject-viewer--layout-#{@props.workflow?.configuration?.multi_image_layout}": @props.workflow?.configuration?.multi_image_layout
+      'subject-viewer--layout-grid4': @props.subject?.metadata['#subject_group_id']
     })
 
     isIE = 'ActiveXObject' of window

--- a/app/components/subject-viewer.cjsx
+++ b/app/components/subject-viewer.cjsx
@@ -85,6 +85,11 @@ module.exports = createReactClass
       initialFrame = default_frame - 1
     initialFrame
 
+  componentDidMount: () ->
+    if @props.subject?.metadata['#subject_group_id']?
+      @setState
+        inFlipbookMode: false
+
   componentWillReceiveProps: (nextProps) ->
     unless nextProps.subject is @props.subject
       clearTimeout @signInAttentionTimeout

--- a/css/subject-viewer.styl
+++ b/css/subject-viewer.styl
@@ -128,6 +128,9 @@
     &.subject-viewer--layout-grid3
       .subject-container > *
         width: 33%
+    &.subject-viewer--layout-grid4
+      .subject-container > *
+        max-width: 100px
 
 .subject
   .subject-tools


### PR DESCRIPTION
When the subject viewer mounts, check subjects for `subject.metadata.#subject_group_id`. If that's present, turn off flipbook mode so that all the subject images are shown in a grid. Also set a new viewer class, `subject-viewer--layout-grid4`, when that metadata key is present.

Staging branch URL: https://pr-5983.pfe-preview.zooniverse.org/projects/zookeeper/galaxy-zoo-weird-and-wonderful/talk/subjects/63395872?env=production

![Screenshot of a Galaxy Zoo: Weird and Wonderful subject, displayed as a grid in Talk.](https://user-images.githubusercontent.com/59547/124931236-ebbfd300-dff9-11eb-9739-83b546a30245.png)

I've styled images with `max-width: 100px` so they fill the available width without appearing too large.
https://pr-5983.pfe-preview.zooniverse.org/projects/darkeshard/survos-testing-2020-subject-group-viewer/talk/228/345
![Screenshot of a test subject displayed with five images per row in a Talk discussion thread.](https://user-images.githubusercontent.com/59547/125060222-0babd100-e0a4-11eb-8a79-fc11e6e21e18.png)

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
