### PR TITLE
Talk: support special Subject Group metadata on Subject discussion pages

### DIFF
--- a/app/subjects/subject-metadata.jsx
+++ b/app/subjects/subject-metadata.jsx
@@ -1,0 +1,74 @@
+/*
+Subject Metadata Component
+--------------------------
+
+The more accurate name for this component would be the "SELECTIVE subject
+metadata display component".
+
+- This component is meant to display certain additional information to the user,
+  based on the TYPE of Subject.
+- The earliest context for the feature comes with the Survos project (2021)
+  which introduces "Subject Groups". In this case, we want to expose the
+  individual Subjects that make the Subject Group.
+- This does NOT replace the "Subject Metadata" button built into the
+  Subject Viewer.
+
+(shaun 20210709)
+ */
+
+import PropTypes from 'prop-types';
+import React from 'react';
+import Loading from '../components/loading-indicator';
+
+const SubjectMetadata = (props) => {
+  if (props.subject) {
+    const metadata = props.subject.metadata || {};
+    
+    // A "Subject Group" is a Subject that's a collection of other Subjects.
+    const isSubjectGroup = metadata.['#group_subject_ids'] && metadata.['#subject_group_id'];
+    let subjectGroupHtml = null;
+    
+    if (isSubjectGroup) {
+      const subjects = (typeof metadata.['#group_subject_ids'] === 'string')
+        ? metadata.['#group_subject_ids'].split('-')
+        : [];
+      
+      subjectGroupHtml = (
+        <div>
+          <p>This Subject is a group of subjects, with a Subject Group ID of <b>{metadata.['#subject_group_id']}</b> and consisting of...</p>
+          <ul>
+            {(subjects.length === 0) && (
+              <li>...no subjects, strangely enough. (This is likely an error)</li>
+            )}
+            {subjects.map(sbj => {
+              return (<li>Subject {sbj}</li>)
+            })}
+          </ul>
+        </div>
+      )
+    }
+    
+
+    console.log('+++ Subject: ', props.subject)
+    return (
+      <div className="subject-metadata">
+        <h2>Additional Subject information</h2>
+        {subjectGroupHtml}
+      </div>
+    );
+  }
+
+  return (<Loading />);
+};
+
+SubjectMetadata.defaultProps = {
+  subject: null
+};
+
+SubjectMetadata.propTypes = {
+  subject: PropTypes.shape({
+    id: PropTypes.string
+  }),
+};
+
+export default SubjectMetadata;

--- a/app/subjects/subject-metadata.jsx
+++ b/app/subjects/subject-metadata.jsx
@@ -21,7 +21,7 @@ import React from 'react';
 import Loading from '../components/loading-indicator';
 
 const SubjectMetadata = (props) => {
-  if (props.subject) {
+  if (props.project && props.subject) {
     const metadata = props.subject.metadata || {};
     
     // A "Subject Group" is a Subject that's a collection of other Subjects.
@@ -29,6 +29,7 @@ const SubjectMetadata = (props) => {
     let subjectGroupHtml = null;
     
     if (isSubjectGroup) {
+      const projectSlug = props.project.slug || ''
       const subjects = (typeof metadata['#group_subject_ids'] === 'string')
         ? metadata['#group_subject_ids'].split('-')
         : [];
@@ -40,16 +41,22 @@ const SubjectMetadata = (props) => {
             {(subjects.length === 0) && (
               <li>...no subjects, strangely enough. (This is likely an error)</li>
             )}
-            {subjects.map(sbj => {
-              return (<li>Subject {sbj}</li>)
+            {subjects.map(subjectId => {
+              return (
+                <li>
+                  <a
+                    href={`/projects/${projectSlug}/talk/subjects/${subjectId}`}
+                  >
+                    Subject {subjectId}
+                  </a>
+                </li>
+              )
             })}
           </ul>
         </div>
       )
     }
     
-
-    console.log('+++ Subject: ', props.subject)
     return (
       <div className="subject-metadata">
         <h2>Additional Subject information</h2>
@@ -62,10 +69,14 @@ const SubjectMetadata = (props) => {
 };
 
 SubjectMetadata.defaultProps = {
-  subject: null
+  project: null,
+  subject: null,
 };
 
 SubjectMetadata.propTypes = {
+  project: PropTypes.shape({
+    id: PropTypes.string
+  }),
   subject: PropTypes.shape({
     id: PropTypes.string
   }),

--- a/app/subjects/subject-metadata.jsx
+++ b/app/subjects/subject-metadata.jsx
@@ -21,7 +21,7 @@ import React, { useState } from 'react';
 import Loading from '../components/loading-indicator';
 
 const SubjectMetadata = (props) => {
-  const [expandSubjectGroup, setExpandSubjectGroup] = useState(false);
+  const [expandSubjectGroup, setExpandSubjectGroup] = useState(props.expandSubjectGroup);
   
   if (props.project && props.subject) {
     const metadata = props.subject.metadata || {};
@@ -39,7 +39,7 @@ const SubjectMetadata = (props) => {
       subjectGroupHtml = (
         <div>
           <p>
-            This Subject is a group of subjects, with a Subject Group ID of <b>{metadata['#subject_group_id']}</b> and consisting of {subjects.length} subject(s).
+            This Subject is a group of subjects, with a Subject Group ID of <b>{metadata['#subject_group_id']}</b> and consisting of <b>{subjects.length}</b> subject(s).
             &nbsp;
             <button onClick={()=>{ setExpandSubjectGroup(!expandSubjectGroup) }}>
               {expandSubjectGroup ? 'hide' : 'show'}
@@ -49,7 +49,7 @@ const SubjectMetadata = (props) => {
           <ul>
             {subjects.map(subjectId => {
               return (
-                <li>
+                <li key={`subjectGroup-subject-${subjectId}`}>
                   <a
                     href={`/projects/${projectSlug}/talk/subjects/${subjectId}`}
                   >
@@ -81,11 +81,13 @@ const SubjectMetadata = (props) => {
 };
 
 SubjectMetadata.defaultProps = {
+  expandSubjectGroup: false,
   project: null,
   subject: null,
 };
 
 SubjectMetadata.propTypes = {
+  expandSubjectGroup: PropTypes.bool,
   project: PropTypes.shape({
     id: PropTypes.string
   }),

--- a/app/subjects/subject-metadata.jsx
+++ b/app/subjects/subject-metadata.jsx
@@ -17,10 +17,12 @@ metadata display component".
  */
 
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useState } from 'react';
 import Loading from '../components/loading-indicator';
 
 const SubjectMetadata = (props) => {
+  const [expandSubjectGroup, setExpandSubjectGroup] = useState(false);
+  
   if (props.project && props.subject) {
     const metadata = props.subject.metadata || {};
     
@@ -36,11 +38,15 @@ const SubjectMetadata = (props) => {
       
       subjectGroupHtml = (
         <div>
-          <p>This Subject is a group of subjects, with a Subject Group ID of <b>{metadata['#subject_group_id']}</b> and consisting of...</p>
+          <p>
+            This Subject is a group of subjects, with a Subject Group ID of <b>{metadata['#subject_group_id']}</b> and consisting of {subjects.length} subject(s).
+            &nbsp;
+            <button onClick={()=>{ setExpandSubjectGroup(!expandSubjectGroup) }}>
+              {expandSubjectGroup ? 'hide' : 'show'}
+            </button>
+          </p>
+          {expandSubjectGroup && (
           <ul>
-            {(subjects.length === 0) && (
-              <li>...no subjects, strangely enough. (This is likely an error)</li>
-            )}
             {subjects.map(subjectId => {
               return (
                 <li>
@@ -53,13 +59,14 @@ const SubjectMetadata = (props) => {
               )
             })}
           </ul>
+          )}
         </div>
       )
     }
     
     return (
       <div className="subject-metadata">
-        <h2>Additional Subject information</h2>
+        <h3>Additional Subject information</h3>
         {subjectGroupHtml}
       </div>
     );

--- a/app/subjects/subject-metadata.jsx
+++ b/app/subjects/subject-metadata.jsx
@@ -25,17 +25,17 @@ const SubjectMetadata = (props) => {
     const metadata = props.subject.metadata || {};
     
     // A "Subject Group" is a Subject that's a collection of other Subjects.
-    const isSubjectGroup = metadata.['#group_subject_ids'] && metadata.['#subject_group_id'];
+    const isSubjectGroup = metadata['#group_subject_ids'] && metadata['#subject_group_id'];
     let subjectGroupHtml = null;
     
     if (isSubjectGroup) {
-      const subjects = (typeof metadata.['#group_subject_ids'] === 'string')
-        ? metadata.['#group_subject_ids'].split('-')
+      const subjects = (typeof metadata['#group_subject_ids'] === 'string')
+        ? metadata['#group_subject_ids'].split('-')
         : [];
       
       subjectGroupHtml = (
         <div>
-          <p>This Subject is a group of subjects, with a Subject Group ID of <b>{metadata.['#subject_group_id']}</b> and consisting of...</p>
+          <p>This Subject is a group of subjects, with a Subject Group ID of <b>{metadata['#subject_group_id']}</b> and consisting of...</p>
           <ul>
             {(subjects.length === 0) && (
               <li>...no subjects, strangely enough. (This is likely an error)</li>

--- a/app/subjects/subject-metadata.jsx
+++ b/app/subjects/subject-metadata.jsx
@@ -64,12 +64,17 @@ const SubjectMetadata = (props) => {
       )
     }
     
-    return (
-      <div className="subject-metadata">
-        <h3>Additional Subject information</h3>
-        {subjectGroupHtml}
-      </div>
-    );
+    // Only display if the Subject has something interesting to say
+    if (subjectGroupHtml) {
+      return (
+        <div className="subject-metadata">
+          <h3>Additional Subject information</h3>
+          {subjectGroupHtml}
+        </div>
+      );
+    }
+    
+    return null;
   }
 
   return (<Loading />);

--- a/app/subjects/subject-metadata.spec.js
+++ b/app/subjects/subject-metadata.spec.js
@@ -36,15 +36,21 @@ describe('SubjectMetadata', function () {
         <SubjectMetadata subject={subject_ofType_subjectGroup} project={project} />
       );
       expect(wrapper).to.be.ok
-    })
-  })
-  
+    });
+    
+    it('should list the correct number of component Subjects (when expanded)', function () {
+      const wrapper = shallow(
+        <SubjectMetadata subject={subject_ofType_subjectGroup} project={project} expandSubjectGroup={true} />
+      );
+      expect(wrapper.find('li')).to.have.lengthOf(4);
+    });
+  });
   describe('with single image Subject', function () {
     it('should not render', function () {
       const wrapper = shallow(
         <SubjectMetadata subject={subject_ofType_subjectGroup} project={project} />
       );
       expect(wrapper).to.be.empty
-    })
-  })
+    });
+  });
 });

--- a/app/subjects/subject-metadata.spec.js
+++ b/app/subjects/subject-metadata.spec.js
@@ -17,16 +17,34 @@ const subject_ofType_subjectGroup = {
   }
 }
 
+const subject_ofType_singleImage = {
+  id: '8000',
+  locations: [
+    { 'image/png': 'https://placekitten.com/200/200'},
+  ],
+}
+
 const project = {
   id: '1',
   slug: 'zooniverse/survos-testing'
 }
 
 describe('SubjectMetadata', function () {
-  it('should render without crashing', function () {
-    const wrapper = shallow(
-      <SubjectMetadata subject={subject_ofType_subjectGroup} project={project} />
-    );
-    expect(wrapper).to.be.ok
+  describe('with Subject Group type of Subject', function () {
+    it('should render without crashing', function () {
+      const wrapper = shallow(
+        <SubjectMetadata subject={subject_ofType_subjectGroup} project={project} />
+      );
+      expect(wrapper).to.be.ok
+    })
+  })
+  
+  describe('with single image Subject', function () {
+    it('should not render', function () {
+      const wrapper = shallow(
+        <SubjectMetadata subject={subject_ofType_subjectGroup} project={project} />
+      );
+      expect(wrapper).to.be.empty
+    })
   })
 });

--- a/app/subjects/subject-metadata.spec.js
+++ b/app/subjects/subject-metadata.spec.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import SubjectMetadata from './subject-metadata';
+
+const subject_ofType_subjectGroup = {
+  id: '9000',
+  locations: [
+    { 'image/png': 'https://placekitten.com/200/200'},
+    { 'image/png': 'https://placekitten.com/200/200'},
+    { 'image/png': 'https://placekitten.com/200/200'},
+    { 'image/png': 'https://placekitten.com/200/200'},
+  ],
+  metadata: {
+    '#group_subject_ids': '9001-9002-9003-9004',
+    '#subject_group_id': 100,
+  }
+}
+
+const project = {
+  id: '1',
+  slug: 'zooniverse/survos-testing'
+}
+
+describe('SubjectMetadata', function () {
+  it('should render without crashing', function () {
+    const wrapper = shallow(
+      <SubjectMetadata subject={subject_ofType_subjectGroup} project={project} />
+    );
+    expect(wrapper).to.be.ok
+  })
+});

--- a/app/subjects/subject-page.jsx
+++ b/app/subjects/subject-page.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import SubjectViewer from '../components/subject-viewer';
 import ActiveUsers from '../talk/active-users';
 import ProjectLinker from '../talk/lib/project-linker';
+import SubjectMetadata from './subject-metadata';
 import SubjectCommentForm from './comment-form';
 import SubjectCommentList from './comment-list';
 import SubjectDiscussionList from './discussion-list';
@@ -28,6 +29,7 @@ const SubjectPage = (props) => {
                 isFavorite={props.isFavorite}
               />
 
+              <SubjectMetadata subject={props.subject} />
               <SubjectCommentList subject={props.subject} {...props} />
               <SubjectCollectionList collections={props.collections} {...props} />
               <SubjectDiscussionList subject={props.subject} {...props} />

--- a/app/subjects/subject-page.jsx
+++ b/app/subjects/subject-page.jsx
@@ -29,7 +29,7 @@ const SubjectPage = (props) => {
                 isFavorite={props.isFavorite}
               />
 
-              <SubjectMetadata subject={props.subject} />
+              <SubjectMetadata subject={props.subject} project={props.project} />
               <SubjectCommentList subject={props.subject} {...props} />
               <SubjectCollectionList collections={props.collections} {...props} />
               <SubjectDiscussionList subject={props.subject} {...props} />


### PR DESCRIPTION
## PR Overview

Context: for projects using the new "Subject Group" subject type (e.g. Galaxy Zoo: Weird and Wonderful, 2021), we want users on Talk to see + interact with a lot more of the (hitherto) hidden metadata.

This PR adds an additional data display for "Subject Groups" type of Subjects, in Talk's single Subject discussion pages.

- Talk's single Subject discussion pages will now have the `SubjectMetadata` sub-component.
  - This sub-component is responsible for surfacing certain kinds of data for certain kinds of Subject types.
  - For now, it only applies to the the "Subject Group" subject type. This sub-component will display all the _constituent Subjects_ of the group, in a list.
  - For every other Subject type, this component should render null. (i.e. no functional changes when discussing non-Subject Groups.)

Note: Subject Groups are identified by the presence of two metadata fields: `metadata.['#group_subject_ids']` and `metadata.['#subject_group_id']`. The former is a _string_ of the constituent _subjects' IDs,_ delineated by dash `-`. The latter is the a unique number ID.

### Status

WIP

- Current progress: POC is complete.
  ![image](https://user-images.githubusercontent.com/13952701/125144207-0dfa4380-e115-11eb-8c2d-b16768ef53c8.png)
- [x] need to add styling.
- [x] items in list should link to respective Subject pages on Talk.

Local testing URL: https://local.zooniverse.org:3735/projects/zookeeper/galaxy-zoo-weird-and-wonderful/talk/subjects/63395872?env=production

Staging test URL 1: https://pr-5984.pfe-preview.zooniverse.org/projects/zookeeper/galaxy-zoo-weird-and-wonderful/talk/subjects/63395872?env=production (Galaxy Zoo: Weird & Wonderful)
- ⚠️ NOTE: when clicking on the individual Subject links, the page might not load properly because the ?env=production isn't carried over. To test that more smoothly, try using the next URL instead...

Staging test URL 2: https://pr-5984.pfe-preview.zooniverse.org/projects/darkeshard/survos-testing-2020-subject-group-viewer/talk/subjects/136083 (Shaun's SURVOS Testing 2020)