### PR TITLE
Talk: Add invert filter for multiple images

### DIFF
--- a/css/subject-viewer.styl
+++ b/css/subject-viewer.styl
@@ -110,7 +110,7 @@
   &.subject-viewer--invert
     // Talk
     .subject-container
-      .subject-image-frame:only-child
+      .subject-image-frame
         img
           filter: invert(100%)
       .subject-video-frame:only-child


### PR DESCRIPTION
Remove the `:only-child` selector so that the invert filter can be applied to multiple images in the subject viewer. Enables the 'invert' button in Talk for group subjects.

Staging branch URL: https://pr-5985.pfe-preview.zooniverse.org/projects/zookeeper/galaxy-zoo-weird-and-wonderful/talk/subjects/63395872?env=production

![A Galaxy Zoo: Weird and Wonderful subject with all its images inverted.](https://user-images.githubusercontent.com/59547/125270781-eb794d80-e301-11eb-9fed-bf3282b4ba52.png)



# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
