### PR TITLE
Subject viewer: add isGroupSubject

### DIFF
--- a/app/components/subject-viewer.cjsx
+++ b/app/components/subject-viewer.cjsx
@@ -73,6 +73,7 @@ module.exports = createReactClass
     frameDurationIntervalId: null
     inFlipbookMode: @props.allowFlipbook
     invert: false
+    isGroupSubject: false
     promptingToSignIn: false
 
   getInitialFrame: ->
@@ -86,9 +87,10 @@ module.exports = createReactClass
     initialFrame
 
   componentDidMount: () ->
-    if @props.subject?.metadata['#subject_group_id']?
+    if @props.subject?.metadata?['#subject_group_id']?
       @setState
         inFlipbookMode: false
+        isGroupSubject: true
 
   componentWillReceiveProps: (nextProps) ->
     unless nextProps.subject is @props.subject
@@ -99,10 +101,14 @@ module.exports = createReactClass
         frame: 0
 
   componentDidUpdate: (prevProps) ->
+    isGroupSubject = @props.subject?.metadata?['#subject_group_id']?
     if @props.subject isnt prevProps.subject
       # turn off the slideshow player and reset any counters
       @setPlaying false
-      @setState frame: @getInitialFrame()
+      @setState
+        frame: @getInitialFrame()
+        inFlipbookMode: !isGroupSubject
+        isGroupSubject: isGroupSubject
 
   logSubjClick: (logType) ->
     @context.geordi?.logEvent
@@ -114,7 +120,7 @@ module.exports = createReactClass
       'subject-viewer--flipbook': @state.inFlipbookMode
       'subject-viewer--invert': @state.invert
       "subject-viewer--layout-#{@props.workflow?.configuration?.multi_image_layout}": @props.workflow?.configuration?.multi_image_layout
-      'subject-viewer--layout-grid4': @props.subject?.metadata['#subject_group_id']
+      'subject-viewer--layout-grid4': @state.isGroupSubject
     })
 
     isIE = 'ActiveXObject' of window


### PR DESCRIPTION
Add `isGroupSubject` to the subject viewer, which checks for undefined subject metadata and only displays group subjects if `subject.metadata` exists.

Staging branch URL: https://pr-5987.pfe-preview.zooniverse.org

Fixes #5986.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
