### PR TITLE
Talk + SubjectViewer: make Subject Group's images link to component Subjects

### DIFF
--- a/app/components/frame-viewer.jsx
+++ b/app/components/frame-viewer.jsx
@@ -104,9 +104,13 @@ export default class FrameViewer extends React.Component {
           </FrameWrapper>
         </PanZoom>
       );
-    } else if (this.props.isGroupSubject && this.props.linkToSubject) {
+    } else if (this.props.isGroupSubject) {
       return (
-        <a href={this.props.linkToSubject} style={{ display: 'block', border: '1px solid cyan'}}>
+        <a
+          href={this.props.groupSubjectLink}
+          title={`Subject ${this.props.groupSubjectId}`}
+          style={{ display: 'block', border: '1px solid cyan'}}
+        >
           <FileViewer
             src={src}
             type={type}
@@ -143,8 +147,9 @@ FrameViewer.propTypes = {
   annotations: PropTypes.arrayOf(PropTypes.object),
   frame: PropTypes.number,
   frameWrapper: PropTypes.func,
+  groupSubjectId: PropTypes.string,
+  groupSubjectLink: PropTypes.string,
   isGroupSubject: PropTypes.bool,
-  linkToSubject: PropTypes.string,
   modification: PropTypes.object,
   onChange: PropTypes.func,
   onLoad: PropTypes.func,
@@ -163,8 +168,9 @@ FrameViewer.propTypes = {
 FrameViewer.defaultProps = {
   annotations: [],
   frame: 0,
+  groupSubjectId: undefined,
+  groupSubjectLink: undefined,  // If a Subject is a "Subject Group", each frame can link to its constituent Subject's Talk page.
   isGroupSubject: false,  // A "Subject Group" is a type of Subject that's composed of many (single image) Subjects
-  linkToSubject: undefined,  // If a Subject is a "Subject Group", each frame can link to its constituent Subject's Talk page.
   onChange: () => {},
   preferences: { },
   subject: {

--- a/app/components/frame-viewer.jsx
+++ b/app/components/frame-viewer.jsx
@@ -108,9 +108,9 @@ export default class FrameViewer extends React.Component {
     } else if (this.props.isGroupSubject) {
       return (
         <Link
-          to={this.props.groupSubjectLink}
+          className="linked-image"
           title={`Subject ${this.props.groupSubjectId}`}
-          style={{ display: 'block', border: '1px solid cyan'}}
+          to={this.props.groupSubjectLink}
         >
           <FileViewer
             src={src}

--- a/app/components/frame-viewer.jsx
+++ b/app/components/frame-viewer.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import { Link } from 'react-router';
 import getSubjectLocation from '../lib/get-subject-location';
 import getSubjectLocations from '../lib/get-subject-locations';
 import PanZoom from './pan-zoom';
@@ -106,8 +107,8 @@ export default class FrameViewer extends React.Component {
       );
     } else if (this.props.isGroupSubject) {
       return (
-        <a
-          href={this.props.groupSubjectLink}
+        <Link
+          to={this.props.groupSubjectLink}
           title={`Subject ${this.props.groupSubjectId}`}
           style={{ display: 'block', border: '1px solid cyan'}}
         >
@@ -121,7 +122,7 @@ export default class FrameViewer extends React.Component {
             registerProgressObject={this.props.registerProgressObject}
             {...modellingProps}
           />
-        </a>
+        </Link>
       )
     } else {
       return (

--- a/app/components/frame-viewer.jsx
+++ b/app/components/frame-viewer.jsx
@@ -104,6 +104,21 @@ export default class FrameViewer extends React.Component {
           </FrameWrapper>
         </PanZoom>
       );
+    } else if (this.props.isGroupSubject && this.props.linkToSubject) {
+      return (
+        <a href={this.props.linkToSubject} style={{ display: 'block', border: '1px solid cyan'}}>
+          <FileViewer
+            src={src}
+            type={type}
+            format={format}
+            frame={this.props.frame}
+            onLoad={this.handleLoad}
+            progressListener={this.props.progressListener}
+            registerProgressObject={this.props.registerProgressObject}
+            {...modellingProps}
+          />
+        </a>
+      )
     } else {
       return (
         <FileViewer
@@ -128,6 +143,8 @@ FrameViewer.propTypes = {
   annotations: PropTypes.arrayOf(PropTypes.object),
   frame: PropTypes.number,
   frameWrapper: PropTypes.func,
+  isGroupSubject: PropTypes.bool,
+  linkToSubject: PropTypes.string,
   modification: PropTypes.object,
   onChange: PropTypes.func,
   onLoad: PropTypes.func,
@@ -146,6 +163,8 @@ FrameViewer.propTypes = {
 FrameViewer.defaultProps = {
   annotations: [],
   frame: 0,
+  isGroupSubject: false,  // A "Subject Group" is a type of Subject that's composed of many (single image) Subjects
+  linkToSubject: undefined,  // If a Subject is a "Subject Group", each frame can link to its constituent Subject's Talk page.
   onChange: () => {},
   preferences: { },
   subject: {

--- a/app/components/subject-viewer.cjsx
+++ b/app/components/subject-viewer.cjsx
@@ -137,8 +137,9 @@ module.exports = createReactClass
     else if @state.isGroupSubject
       componentSubjectIds = @props.subject?.metadata?['#group_subject_ids']?.split('-') || []
       mainDisplay = @props.subject.locations.map (frame, index) =>
-        linkToSubject = "/projects/#{@props.project?.slug}/talk/subjects/#{componentSubjectIds[index]}"      
-        @renderFrame index, {key: "frame-#{index}", isGroupSubject: true, linkToSubject}
+        groupSubjectId = componentSubjectIds[index]
+        groupSubjectLink = "/projects/#{@props.project?.slug}/talk/subjects/#{componentSubjectIds[index]}"      
+        @renderFrame index, {key: "frame-#{index}", isGroupSubject: true, groupSubjectId, groupSubjectLink}
     else
       mainDisplay = @props.subject.locations.map (frame, index) =>
         @renderFrame index, {key: "frame-#{index}"}

--- a/app/components/subject-viewer.cjsx
+++ b/app/components/subject-viewer.cjsx
@@ -131,9 +131,14 @@ module.exports = createReactClass
     {type, format, src} = getSubjectLocation @props.subject, @state.frame
     subjectLocations = getSubjectLocations @props.subject
     if subjectIsLikelyAudioPlusImage @props.subject
-          mainDisplay = @renderFrame @state.frame, {subjectLocations : subjectLocations, isAudioPlusImage : true}
+      mainDisplay = @renderFrame @state.frame, {subjectLocations : subjectLocations, isAudioPlusImage : true}
     else if @state.inFlipbookMode
       mainDisplay = @renderFrame @state.frame
+    else if @state.isGroupSubject
+      componentSubjectIds = @props.subject?.metadata?['#group_subject_ids']?.split('-') || []
+      mainDisplay = @props.subject.locations.map (frame, index) =>
+        linkToSubject = "/projects/#{@props.project?.slug}/talk/subjects/#{componentSubjectIds[index]}"      
+        @renderFrame index, {key: "frame-#{index}", isGroupSubject: true, linkToSubject}
     else
       mainDisplay = @props.subject.locations.map (frame, index) =>
         @renderFrame index, {key: "frame-#{index}"}

--- a/app/subjects/index.jsx
+++ b/app/subjects/index.jsx
@@ -21,13 +21,13 @@ export default class SubjectPageContainer extends React.Component {
     this.setSubject();
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (this.props.params && nextProps.params && nextProps.params.id !== this.props.params.id) {
-      this.setSubject(nextProps);
+  componentDidUpdate(prevProps) {
+    if (prevProps.params && this.props.params && this.props.params.id !== prevProps.params.id) {
+      this.setSubject();
     }
 
-    if (nextProps.location.query.collections_page !== this.props.location.query.collections_page) {
-      this.getCollections(this.state.subject, nextProps.location.query.collections_page);
+    if (this.props.location.query.collections_page !== prevProps.location.query.collections_page) {
+      this.getCollections(this.state.subject, this.props.location.query.collections_page);
     }
   }
 

--- a/app/subjects/index.jsx
+++ b/app/subjects/index.jsx
@@ -23,7 +23,7 @@ export default class SubjectPageContainer extends React.Component {
 
   componentWillReceiveProps(nextProps) {
     if (this.props.params && nextProps.params && nextProps.params.id !== this.props.params.id) {
-      this.setSubject();
+      this.setSubject(nextProps);
     }
 
     if (nextProps.location.query.collections_page !== this.props.location.query.collections_page) {
@@ -35,8 +35,8 @@ export default class SubjectPageContainer extends React.Component {
     this.getCollections(this.state.subject, page);
   }
 
-  setSubject() {
-    const subjectId = this.props.params.id.toString();
+  setSubject(props = this.props) {
+    const subjectId = props.params.id.toString();
     apiClient.type('subjects').get(subjectId, { include: 'project' })
       .then((subject) => {
         this.setState({ subject });

--- a/app/subjects/index.jsx
+++ b/app/subjects/index.jsx
@@ -40,7 +40,7 @@ export default class SubjectPageContainer extends React.Component {
     apiClient.type('subjects').get(subjectId, { include: 'project' })
       .then((subject) => {
         this.setState({ subject });
-        this.getCollections(subject, this.props.location.query.collections_page);
+        this.getCollections(subject, props.location.query.collections_page);
       });
   }
 

--- a/css/subject-viewer.styl
+++ b/css/subject-viewer.styl
@@ -122,6 +122,19 @@
     .subject-container
       align-items: center
       justify-content: space-between
+      
+      // For certain Subject types, e.g. Subject Groups, individual images are linked to individual subjects
+      > a.linked-image
+        outline: 1px solid TEAL_MID
+        display: block
+        margin-bottom: 0.2em
+        
+        img
+          display: block
+
+        &:focus, &:hover
+          outline: 1px solid MAIN_HIGHLIGHT
+      
     &.subject-viewer--layout-grid2
       .subject-container > *
         width: 49%


### PR DESCRIPTION
## PR Overview

Alternative to: #5984 
Follows #5983 (allows Subject Talk pages to display SubjectGroup images) and #5987

Context: for projects using the new "Subject Group" subject type (e.g. Galaxy Zoo: Weird and Wonderful, 2021), we want users on Talk to be able to go to the the individual Subjects that form the group.

This PR makes individual "frames" (i.e. component Subjects) of a SubjectGroup-type subject clickable, and link to their respective component subject's Talk pages.

- ⚠️ This adds new behaviour to the very widely used `subject-viewer.cjsx` component
  - While this behaviour is exclusive to only a specific type of subject (i.e. SubjectGroups), we need to confirm the functionality of the SubjectViewer component in multiple cases.
  - Known use cases: Subject Talk page, a project's Recents list, a user's Collections.
  - Cases that can be safely ignored: a project's Classify page (SubjectGroups are only classified on FEM)

### Status

WIP

- Functionality done
- [x] Tweaking styles. Need to communicate that these images (component Subjects) are clickable in a less obnoxious way.
- Check use cases for SubjectViewer + SubjectGroup subjects:
  - [x] Subject Talk page
  - [x] a project's Recents list
  - [x] a user's collections
