### PR TITLE
Add Talk invert filters for group subjects

### DIFF
--- a/css/subject-viewer.styl
+++ b/css/subject-viewer.styl
@@ -109,8 +109,13 @@
 
   &.subject-viewer--invert
     // Talk
+    &.subject-viewer--layout-grid4
+      .subject-container
+        .subject-image-frame
+          img
+            filter: invert(100%)
     .subject-container
-      .subject-image-frame
+      .subject-image-frame:only-child
         img
           filter: invert(100%)
       .subject-video-frame:only-child


### PR DESCRIPTION
#5985 has broken the invert filter for the classifier on projects like Plankton Portal. This redoes the CSS change, but scopes it only to group subjects (`subject-viewer--layout-grid4`.) Images in the classifier shouldn't be accidentally styled by this change, like they were in the previous PR.

Staging branch URL: https://pr-5990.pfe-preview.zooniverse.org

Test URLs:
Plankton Portal
https://pr-5990.pfe-preview.zooniverse.org:3735/projects/kelseyswieca/plankton-portal/classify?env=production

GZ: Weird and Wonderful
https://pr-5990.pfe-preview.zooniverse.org:3735/projects/zookeeper/galaxy-zoo-weird-and-wonderful/talk/subjects/63395872?env=production

Fixes #5813.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
