### PR TITLE
Subject Viewer: fix inFlipbookMode

### DIFF
--- a/app/components/subject-viewer.cjsx
+++ b/app/components/subject-viewer.cjsx
@@ -102,12 +102,13 @@ module.exports = createReactClass
 
   componentDidUpdate: (prevProps) ->
     isGroupSubject = @props.subject?.metadata?['#subject_group_id']?
+    allowFlipbook = @props.allowFlipbook || isGroupSubject
     if @props.subject isnt prevProps.subject
       # turn off the slideshow player and reset any counters
       @setPlaying false
       @setState
         frame: @getInitialFrame()
-        inFlipbookMode: !isGroupSubject
+        inFlipbookMode: allowFlipbook
         isGroupSubject: isGroupSubject
 
   logSubjClick: (logType) ->


### PR DESCRIPTION
Check `props.allowFlipbook` and `isGroupSubject` before enabling flipbook mode in the subject viewer.

Staging branch URL: 
https://pr-5993.pfe-preview.zooniverse.org/projects/zookeeper/galaxy-zoo-weird-and-wonderful/talk/subjects/63395872?env=production
https://pr-5993.pfe-preview.zooniverse.org/projects/dwright04/supernova-hunters/classify?env=production

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
