### PR TITLE
Add redirects for Black Hole Hunters

### DIFF
--- a/app/router.cjsx
+++ b/app/router.cjsx
@@ -176,6 +176,9 @@ module.exports =
     <Route path="/projects/zookeeper/galaxy-zoo-weird-and-wonderful" component={() => <RELOAD newUrl='https://fe-project.zooniverse.org/projects/zookeeper/galaxy-zoo-weird-and-wonderful' />} />
     <Route path="/projects/zookeeper/galaxy-zoo-weird-and-wonderful/classify" component={() => <RELOAD newUrl='https://fe-project.zooniverse.org/zookeeper/galaxy-zoo-weird-and-wonderful/classify' />} />
 
+    <Route path="/projects/hughdickinson/superwasp-black-hole-hunters" component={() => <RELOAD newUrl='https://fe-project.zooniverse.org/projects/hughdickinson/superwasp-black-hole-hunters' />} />
+    <Route path="/projects/hughdickinson/superwasp-black-hole-hunters/classify" component={() => <RELOAD newUrl='https://fe-project.zooniverse.org/hughdickinson/superwasp-black-hole-hunters/classify' />} />
+    
     <Route path="projects/:owner/:name" component={require('./pages/project').default}>
       <IndexRoute component={ProjectHomePage} />
       <Route path="home" component={ONE_UP_REDIRECT} />


### PR DESCRIPTION
Redirect `hughdickinson/superwasp-black-hole-hunters` so that it's served from fe-project.zooniverse.org

Staging branch URL: https://pr-5997.pfe-preview.zooniverse.org/projects/hughdickinson/superwasp-black-hole-hunters/talk?env=production

Fixes #5996.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
