### PR TITLE
Allow the text viewer to render json

### DIFF
--- a/app/components/file-viewer/index.jsx
+++ b/app/components/file-viewer/index.jsx
@@ -32,7 +32,9 @@ function subjectViewerSelector(props) {
     if (props.type.includes('audio')) {
       return VIEWERS.audio;
     }
-    // ... add other here if neccessary
+    // ... add other here if necessary
+  } else if (props.format === 'json') {
+    return VIEWERS.text;
   }
   return VIEWERS[props.type] || DefaultViewer;
 }

--- a/app/components/file-viewer/text-viewer.jsx
+++ b/app/components/file-viewer/text-viewer.jsx
@@ -2,8 +2,8 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classnames from 'classnames';
 
-const SUPPORTED_TYPES = ['text'];
-const SUPPORTED_FORMATS = ['plain'];
+const SUPPORTED_TYPES = ['text', 'application'];
+const SUPPORTED_FORMATS = ['plain', 'json'];
 
 const cache = {};
 


### PR DESCRIPTION
Staging branch URL: https://pr-5999.pfe-preview.zooniverse.org

Fixes #5995 

Use the text viewer as a fallback for subject locations that are json to render something. This can be previewed at https://pr-5999.pfe-preview.zooniverse.org/projects/adamamiller/zwickys-stellar-sleuths/talk/subjects/50787258?env=production

The second frame is the JSON, so should just display it now rather not anything at all.

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [x] Can you post a talk comment?

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
