### PR TITLE
Redirect Scarlets and Blues to fe-project

### DIFF
--- a/app/router.cjsx
+++ b/app/router.cjsx
@@ -180,7 +180,7 @@ module.exports =
     <Route path="/projects/hughdickinson/superwasp-black-hole-hunters/classify" component={() => <RELOAD newUrl='https://fe-project.zooniverse.org/hughdickinson/superwasp-black-hole-hunters/classify' />} />
 
     <Route path="/projects/bogden/scarlets-and-blues" component={() => <RELOAD newUrl='https://fe-project.zooniverse.org/projects/bogden/scarlets-and-blues' />} />
-    <Route path="/projects/bogden/scarlets-and-blues/classify" component={() => <RELOAD newUrl='https://fe-project.zooniverse.org/bogden/scarlets-and-blues/classify' />} />
+    <Route path="/projects/bogden/scarlets-and-blues/classify" component={() => <RELOAD newUrl='https://fe-project.zooniverse.org/projects/bogden/scarlets-and-blues/classify' />} />
 
     <Route path="projects/:owner/:name" component={require('./pages/project').default}>
       <IndexRoute component={ProjectHomePage} />

--- a/app/router.cjsx
+++ b/app/router.cjsx
@@ -178,7 +178,10 @@ module.exports =
 
     <Route path="/projects/hughdickinson/superwasp-black-hole-hunters" component={() => <RELOAD newUrl='https://fe-project.zooniverse.org/projects/hughdickinson/superwasp-black-hole-hunters' />} />
     <Route path="/projects/hughdickinson/superwasp-black-hole-hunters/classify" component={() => <RELOAD newUrl='https://fe-project.zooniverse.org/hughdickinson/superwasp-black-hole-hunters/classify' />} />
-    
+
+    <Route path="/projects/bogden/scarlets-and-blues" component={() => <RELOAD newUrl='https://fe-project.zooniverse.org/projects/bogden/scarlets-and-blues' />} />
+    <Route path="/projects/bogden/scarlets-and-blues/classify" component={() => <RELOAD newUrl='https://fe-project.zooniverse.org/bogden/scarlets-and-blues/classify' />} />
+
     <Route path="projects/:owner/:name" component={require('./pages/project').default}>
       <IndexRoute component={ProjectHomePage} />
       <Route path="home" component={ONE_UP_REDIRECT} />


### PR DESCRIPTION
Redirect `bogden/scarlets-and-blues` to fe-project.zooniverse.org.

Staging branch URL: https://pr-6001.pfe-preview.zooniverse.org

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
