### PR TITLE
Add drawing task instruction validations for mobile

### DIFF
--- a/app/pages/lab/mobile/mobile-section-container.fixtures.js
+++ b/app/pages/lab/mobile/mobile-section-container.fixtures.js
@@ -71,6 +71,30 @@ const validationFixtures = {
       question: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla ut dui erat. Vivamus est nisl, accumsan non urna at, elementum tempor urna. Sed eget pulvinar eros. Nunc placerat metus bibendum lacus elementum, vitae sagittis mi tincidunt.'
     }
   },
+  taskInstructionNotTooLong: {
+    task: {
+      instruction: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+      tools: [
+        {
+          type: 'rectangle',
+          details: []
+        }
+      ],
+      type: 'drawing'
+    }
+  },
+  taskInstructionTooLong: {
+    task: {
+      instruction: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla ut dui erat. Vivamus est nisl, accumsan non urna at, elementum tempor urna. Sed eget pulvinar eros. Nunc placerat metus bibendum lacus elementum, vitae sagittis mi tincidunt.',
+      tools: [
+        {
+          type: 'rectangle',
+          details: []
+        }
+      ],
+      type: 'drawing'
+    }
+  },
   taskFeedbackEnabled: {
     task: {
       feedback: {
@@ -189,6 +213,30 @@ const validationFixtures = {
   questionHasTwoImages: {
     task: {
       question: '![image.jpg](https://panoptes-uploads.zooniverse.org/staging/location.jpeg) ![image.jpg](https://panoptes-uploads.zooniverse.org/staging/location.jpeg)'
+    }
+  },
+  instructionHasOneImage: {
+    task: {
+      instruction: '![image.jpg](https://panoptes-uploads.zooniverse.org/staging/location.jpeg)',
+      tools: [
+        {
+          type: 'rectangle',
+          details: []
+        }
+      ],
+      type: 'drawing'
+    }
+  },
+  instructionHasTwoImages: {
+    task: {
+      instruction: '![image.jpg](https://panoptes-uploads.zooniverse.org/staging/location.jpeg) ![image.jpg](https://panoptes-uploads.zooniverse.org/staging/location.jpeg)',
+      tools: [
+        {
+          type: 'rectangle',
+          details: []
+        }
+      ],
+      type: 'drawing'
     }
   }
 };

--- a/app/pages/lab/mobile/mobile-section-container.jsx
+++ b/app/pages/lab/mobile/mobile-section-container.jsx
@@ -24,6 +24,21 @@ function taskQuestionNotTooLong({ task }) {
   return convertBooleanToValidation(question ? question.length < VALID_QUESTION_LENGTH : false);
 }
 
+// A drawing task has task.instruction, instead of task.question, as the property edited in the "Main Text" input in the drawing task editor
+function taskInstructionNotTooLong({ task }) {
+  const { instruction } = task;
+  // TODO: Code to remove markdown images from character count. Change must be made in mobile app checks before addition.
+  // if (instruction) {
+  //   const matchArray = instruction.match(MARKDOWN_IMAGE);
+  //   if (matchArray) {
+  //     matchArray.map((imageLink) => {
+  //       instruction = instruction.replace(imageLink, '');
+  //     });
+  //   }
+  // }
+  return convertBooleanToValidation(instruction ? instruction.length < VALID_QUESTION_LENGTH : false);
+}
+
 function taskFeedbackDisabled({ task }) {
   return convertBooleanToValidation(!task.feedback || !task.feedback.enabled);
 }
@@ -43,6 +58,16 @@ function workflowQuestionHasOneOrLessImages({ task }) {
   let validation = convertBooleanToValidation(false);
   if (task.question) {
     const matchArray = task.question.match(MARKDOWN_IMAGE);
+    validation = convertBooleanToValidation(matchArray ? matchArray.length < 2 : true, true);
+  }
+
+  return validation;
+}
+
+function workflowInstructionHasOneOrLessImages({ task }) {
+  let validation = convertBooleanToValidation(false);
+  if (task.instruction) {
+    const matchArray = task.instruction.match(MARKDOWN_IMAGE);
     validation = convertBooleanToValidation(matchArray ? matchArray.length < 2 : true, true);
   }
 
@@ -85,12 +110,14 @@ const validatorFns = {
     workflowQuestionHasOneOrLessImages
   },
   drawing: {
+    taskInstructionNotTooLong,
     taskFeedbackDisabled,
     workflowHasSingleTask,
     drawingToolTypeIsValid,
     drawingTaskHasOneTool,
     drawingTaskHasNoSubtasks,
-    workflowDoesNotContainShortcuts: workflowHasNoMoreThanXShortcuts(0)
+    workflowDoesNotContainShortcuts: workflowHasNoMoreThanXShortcuts(0),
+    workflowInstructionHasOneOrLessImages
   }
 };
 
@@ -194,6 +221,7 @@ MobileSectionContainer.propTypes = {
   task: PropTypes.shape({
     answers: PropTypes.array,
     feedback: PropTypes.object,
+    instruction: PropTypes.string,
     question: PropTypes.string,
     type: PropTypes.string,
     unlinkedTask: PropTypes.string
@@ -212,6 +240,7 @@ MobileSectionContainer.propTypes = {
 MobileSectionContainer.defaultProps = {
   task: {
     type: '',
+    instruction: '',
     question: '',
     answers: [],
     feedback: {

--- a/app/pages/lab/mobile/mobile-section-container.spec.js
+++ b/app/pages/lab/mobile/mobile-section-container.spec.js
@@ -57,7 +57,20 @@ describe('<MobileSectionContainer />', function () {
       const mobileSection = wrapper.find('MobileSection').first();
       assert.strictEqual(mobileSection.length, 1);
     });
-
+    
+    it('should render the <MobileSection /> component if the task type is drawing', function () {
+      const task = fixtures.task({
+        tools: [{
+          details: [],
+          type: 'rectangle'
+        }],
+        type: 'drawing'
+      });
+      wrapper = shallow(<MobileSectionContainer task={task} workflow={fixtures.workflow()} project={fixtures.project()} />);
+      const mobileSection = wrapper.find('MobileSection').first();
+      assert.strictEqual(mobileSection.length, 1);
+    });
+  
     it('should render nothing if the task type isn\'t single or multiple or drawing', function () {
       const task = fixtures.task({ type: 'survey' });
       wrapper = shallow(<MobileSectionContainer task={task} workflow={fixtures.workflow()} project={fixtures.project()} />);
@@ -100,6 +113,11 @@ describe('<MobileSectionContainer />', function () {
       testValidationProp('taskQuestionNotTooLong', validationFixtures.taskQuestionTooLong, false);
     });
 
+    it('should check whether the task instruction text is too long', function () {
+      testValidationProp('taskInstructionNotTooLong', validationFixtures.taskInstructionNotTooLong, true);
+      testValidationProp('taskInstructionNotTooLong', validationFixtures.taskInstructionTooLong, false);
+    });
+
     it('should check whether the task uses feedback', function () {
       testValidationProp('taskFeedbackDisabled');
       testValidationProp('taskFeedbackDisabled', validationFixtures.taskFeedbackEnabled, false);
@@ -120,19 +138,24 @@ describe('<MobileSectionContainer />', function () {
       testValidationProp('drawingToolTypeIsValid', validationFixtures.workflowHasInvalidDrawingTask, false);
     });
 
-    it('should check whether workflow has only one tool', function () {
+    it('should check whether drawing task has only one tool', function () {
       testValidationProp('drawingTaskHasOneTool', validationFixtures.drawingTaskHasOneTool, true);
       testValidationProp('drawingTaskHasOneTool', validationFixtures.drawingTaskHasTwoTools, false);
     });
 
-    it('should check whether workflow has no subtasks', function () {
+    it('should check whether drawing task has no subtasks', function () {
       testValidationProp('drawingTaskHasNoSubtasks', validationFixtures.drawingTaskHasNoSubtasks, true);
       testValidationProp('drawingTaskHasNoSubtasks', validationFixtures.drawingTaskHasSubtasks, false);
     });
 
-    it('should check whether workflow question has one image', function () {
+    it('should check whether task question has one image', function () {
       testValidationProp('workflowQuestionHasOneOrLessImages', validationFixtures.questionHasOneImage, true, true);
       testValidationProp('workflowQuestionHasOneOrLessImages', validationFixtures.questionHasTwoImages, false, true);
+    });
+
+    it('should check whether task instruction has one image', function () {
+      testValidationProp('workflowInstructionHasOneOrLessImages', validationFixtures.instructionHasOneImage, true, true);
+      testValidationProp('workflowInstructionHasOneOrLessImages', validationFixtures.instructionHasTwoImages, false, true);
     });
   });
 

--- a/app/pages/lab/mobile/mobile-section.jsx
+++ b/app/pages/lab/mobile/mobile-section.jsx
@@ -17,10 +17,12 @@ counterpart.registerTranslations('en', {
     validations: {
       workflowHasSingleTask: 'Has one Task',
       taskQuestionNotTooLong: 'Question has less than 200 characters',
+      taskInstructionNotTooLong: 'Instruction has less than 200 characters',
       workflowNotTooManyShortcuts: 'Has less than three shortcuts',
       workflowDoesNotContainShortcuts: 'Has no shortcuts',
       taskFeedbackDisabled: 'Cannot provide feedback',
       workflowQuestionHasOneOrLessImages: 'Task question has no more than one image',
+      workflowInstructionHasOneOrLessImages: 'Task instruction has no more than one image',
       drawingToolTypeIsValid: 'Drawing tool must be a rectangle tool',
       drawingTaskHasOneTool: 'Drawing task must have only 1 tool',
       drawingTaskHasNoSubtasks: 'Drawing tool must not have any subtasks'


### PR DESCRIPTION
Staging branch URL: https://pr-{NUMBER}.pfe-preview.zooniverse.org

Staging project: https://pr-{NUMBER}.pfe-preview.zooniverse.org/lab/1930/workflows

Relates to zooniverse/mobile/pull/363. The issue occurred recently when a drawing task failed validation within the mobile app because the drawing task instructions were too long. These changes won't prevent the general issue linked in the mobile app, but will prevent at least one underlying cause of the issue.

Describe your changes.
- add mobile validation of less than 200 characters for the drawing task instruction
- add mobile validation of only 1 image for the drawing task instruction

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
