### PR TITLE
Add about pages for FEM redirect routes.

### DIFF
--- a/app/router.cjsx
+++ b/app/router.cjsx
@@ -155,32 +155,45 @@ module.exports =
 
     <Route path="/projects/nora-dot-eisner/planet-hunters-tess" component={() => <RELOAD newUrl='https://fe-project.zooniverse.org/projects/nora-dot-eisner/planet-hunters-tess' />} />
     <Route path="/projects/nora-dot-eisner/planet-hunters-tess/classify" component={() => <RELOAD newUrl='https://fe-project.zooniverse.org/projects/nora-dot-eisner/planet-hunters-tess/classify' />} />
+    <Route path="/projects/nora-dot-eisner/planet-hunters-tess/about" component={() => <RELOAD newUrl='https://fe-project.zooniverse.org/projects/nora-dot-eisner/planet-hunters-tess/about' />} />
 
     <Route path="/projects/adamamiller/zwickys-stellar-sleuths" component={() => <RELOAD newUrl='https://fe-project.zooniverse.org/projects/adamamiller/zwickys-stellar-sleuths' />} />
     <Route path="/projects/adamamiller/zwickys-stellar-sleuths/classify" component={() => <RELOAD newUrl='https://fe-project.zooniverse.org/projects/adamamiller/zwickys-stellar-sleuths/classify' />} />
+    <Route path="/projects/adamamiller/zwickys-stellar-sleuths/about" component={() => <RELOAD newUrl='https://fe-project.zooniverse.org/projects/adamamiller/zwickys-stellar-sleuths/about' />} />
 
     <Route path="/projects/msalmon/hms-nhs-the-nautical-health-service" component={() => <RELOAD newUrl='https://fe-project.zooniverse.org/projects/msalmon/hms-nhs-the-nautical-health-service' />} />
     <Route path="/projects/msalmon/hms-nhs-the-nautical-health-service/classify" component={() => <RELOAD newUrl='https://fe-project.zooniverse.org/projects/msalmon/hms-nhs-the-nautical-health-service/classify' />} />
+    <Route path="/projects/msalmon/hms-nhs-the-nautical-health-service/about" component={() => <RELOAD newUrl='https://fe-project.zooniverse.org/projects/msalmon/hms-nhs-the-nautical-health-service/about' />} />
 
     <Route path="/projects/blicksam/transcription-task-testing" component={() => <RELOAD newUrl='https://fe-project.zooniverse.org/projects/blicksam/transcription-task-testing' />} />
     <Route path="/projects/blicksam/transcription-task-testing/classify" component={() => <RELOAD newUrl='https://fe-project.zooniverse.org/projects/blicksam/transcription-task-testing/classify' />} />
+    <Route path="/projects/blicksam/transcription-task-testing/about" component={() => <RELOAD newUrl='https://fe-project.zooniverse.org/projects/blicksam/transcription-task-testing/about' />} />
 
     <Route path="/projects/humphrydavy/davy-notebooks-project" component={() => <RELOAD newUrl='https://fe-project.zooniverse.org/projects/humphrydavy/davy-notebooks-project' />} />
     <Route path="/projects/humphrydavy/davy-notebooks-project/classify" component={() => <RELOAD newUrl='https://fe-project.zooniverse.org/projects/humphrydavy/davy-notebooks-project/classify' />} />
+    <Route path="/projects/humphrydavy/davy-notebooks-project/about" component={() => <RELOAD newUrl='https://fe-project.zooniverse.org/projects/humphrydavy/davy-notebooks-project/about' />} />
 
-    <Route path="/projects/mschwamb/planet-four/authors" component={() => <ExternalRedirect newUrl='https://authors.planetfour.org/' />} />
+    <Route path="/projects/kmc35/peoples-contest-digital-archive" component={() => <RELOAD newUrl='https://fe-project.zooniverse.org/projects/kmc35/peoples-contest-digital-archive' />} />
+    <Route path="/projects/kmc35/peoples-contest-digital-archive/classify" component={() => <RELOAD newUrl='https://fe-project.zooniverse.org/projects/kmc35/peoples-contest-digital-archive/classify' />} />
+    <Route path="/projects/kmc35/peoples-contest-digital-archive/about" component={() => <RELOAD newUrl='https://fe-project.zooniverse.org/projects/kmc35/peoples-contest-digital-archive/about' />} />
 
     <Route path="/projects/mainehistory/beyond-borders-transcribing-historic-maine-land-documents" component={() => <RELOAD newUrl='https://fe-project.zooniverse.org/projects/mainehistory/beyond-borders-transcribing-historic-maine-land-documents' />} />
     <Route path="/projects/mainehistory/beyond-borders-transcribing-historic-maine-land-documents/classify" component={() => <RELOAD newUrl='https://fe-project.zooniverse.org/projects/mainehistory/beyond-borders-transcribing-historic-maine-land-documents/classify' />} />
+    <Route path="/projects/mainehistory/beyond-borders-transcribing-historic-maine-land-documents/about" component={() => <RELOAD newUrl='https://fe-project.zooniverse.org/projects/mainehistory/beyond-borders-transcribing-historic-maine-land-documents/about' />} />
 
     <Route path="/projects/zookeeper/galaxy-zoo-weird-and-wonderful" component={() => <RELOAD newUrl='https://fe-project.zooniverse.org/projects/zookeeper/galaxy-zoo-weird-and-wonderful' />} />
     <Route path="/projects/zookeeper/galaxy-zoo-weird-and-wonderful/classify" component={() => <RELOAD newUrl='https://fe-project.zooniverse.org/zookeeper/galaxy-zoo-weird-and-wonderful/classify' />} />
+    <Route path="/projects/zookeeper/galaxy-zoo-weird-and-wonderful/about" component={() => <RELOAD newUrl='https://fe-project.zooniverse.org/zookeeper/galaxy-zoo-weird-and-wonderful/about' />} />
 
     <Route path="/projects/hughdickinson/superwasp-black-hole-hunters" component={() => <RELOAD newUrl='https://fe-project.zooniverse.org/projects/hughdickinson/superwasp-black-hole-hunters' />} />
     <Route path="/projects/hughdickinson/superwasp-black-hole-hunters/classify" component={() => <RELOAD newUrl='https://fe-project.zooniverse.org/hughdickinson/superwasp-black-hole-hunters/classify' />} />
+    <Route path="/projects/hughdickinson/superwasp-black-hole-hunters/about" component={() => <RELOAD newUrl='https://fe-project.zooniverse.org/hughdickinson/superwasp-black-hole-hunters/about' />} />
 
     <Route path="/projects/bogden/scarlets-and-blues" component={() => <RELOAD newUrl='https://fe-project.zooniverse.org/projects/bogden/scarlets-and-blues' />} />
     <Route path="/projects/bogden/scarlets-and-blues/classify" component={() => <RELOAD newUrl='https://fe-project.zooniverse.org/projects/bogden/scarlets-and-blues/classify' />} />
+    <Route path="/projects/bogden/scarlets-and-blues/about" component={() => <RELOAD newUrl='https://fe-project.zooniverse.org/projects/bogden/scarlets-and-blues/about' />} />
+
+    <Route path="/projects/mschwamb/planet-four/authors" component={() => <ExternalRedirect newUrl='https://authors.planetfour.org/' />} />
 
     <Route path="projects/:owner/:name" component={require('./pages/project').default}>
       <IndexRoute component={ProjectHomePage} />


### PR DESCRIPTION
Staging branch URL: https://pr-6014.pfe-preview.zooniverse.org

Also adds Peoples Contest Digital Archive project to the set of FEM projects with redirect. 

**This should not merge until zooniverse/operations#523, zooniverse/operations#528, and zooniverse/operations#529 are done and the about pages are included there for each project. Then this should merge shortly after we confirm the existing routes work with the NGINX http frontend and the about page routes are added**

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
