### PR TITLE
Fix FEM redirects

### DIFF
--- a/app/MonorepoRoute.jsx
+++ b/app/MonorepoRoute.jsx
@@ -8,18 +8,18 @@ import { createRoutesFromReactChildren } from 'react-router/lib//RouteUtils';
 
  Usage: <Route path="path/to/location" component={RELOAD} />
 */
-function RELOAD({ newUrl }) {
+function RELOAD({ path }) {
+  let newUrl = `https://fe-project.zooniverse.org${path}`;
   if (window.location.hostname === 'www.zooniverse.org') {
-    window.location.reload();
-  } else {
-    window.location = newUrl;
+    newUrl = `https://www.zooniverse.org${path}`;
   }
+  window.location.replace(newUrl)
 
   return null;
 }
 
-function withReload(newUrl) {
-  return () => <RELOAD newUrl={newUrl} />;
+function withReload(path) {
+  return () => <RELOAD path={path} />;
 }
 
 /*
@@ -40,9 +40,9 @@ MonorepoRoute.createRouteFromReactElement = (element, parentRoute) => {
 
   const monorepoRoute = createRoutesFromReactChildren(
     <Route path={path}>
-      <IndexRoute component={withReload(`https://fe-project.zooniverse.org${path}`)} />
-      <Route path="classify" component={withReload(`https://fe-project.zooniverse.org${path}/classify`)} />
-      <Route path="about" component={withReload(`https://fe-project.zooniverse.org${path}/about`)} />
+      <IndexRoute component={withReload(path)} />
+      <Route path="classify" component={withReload(`${path}/classify`)} />
+      <Route path="about" component={withReload(`${path}/about`)} />
     </Route>,
     parentRoute
   )[0];

--- a/app/router.cjsx
+++ b/app/router.cjsx
@@ -80,10 +80,12 @@ ONE_UP_REDIRECT = createReactClass
 # Usage: <Route path="path/to/location" component={RELOAD} />
 RELOAD = createReactClass
   componentDidMount: ->
+    { path } = @props
+    newUrl = "https://fe-content-pages.zooniverse.org/#{path}"
     if window.location.hostname is 'www.zooniverse.org'
-      window.location.reload()
-    else
-      window.location = @props.newUrl
+      newUrl = "https://www.zooniverse.org/#{path}"
+    window.location.replace(newUrl)
+
   render: ->
     null
 
@@ -102,8 +104,8 @@ module.exports =
 
     <Route path="about" component={AboutPage} ignoreScrollBehavior>
       <IndexRoute component={AboutHome} />
-      <Route path="team" component={() => <RELOAD newUrl='https://fe-content-pages.zooniverse.org/about/team' />} />
-      <Route path="publications" component={() => <RELOAD newUrl='https://fe-content-pages.zooniverse.org/about/publications' />} />
+      <Route path="team" component={() => <RELOAD path='about/team' />} />
+      <Route path="publications" component={() => <RELOAD path='about/publications' />} />
       <Route path="acknowledgements" component={Acknowledgements} />
       <Route path="resources" component={Resources} />
       <Route path="contact" component={Contact} />


### PR DESCRIPTION
Redirects to the NextJS apps should use `location.replace(url)`, so that the redirected PFE route is not remembered in browser history. This PR uses `location.replace` for pages hosted on both the `fe-project` and `fe-content-pages` apps.

Staging branch URL: https://pr-6027.pfe-preview.zooniverse.org/projects/nora-dot-eisner/planet-hunters-tess/talk?env=production
 - Go to any of the project pages that are served from NextJS, then back with the Back button.
 - Go to the Projects page, then through to HMS NHS, then back with the Back button.
 - Go to the About page, then Publications or Our Team, then back with the Back button.

Fixes #6026.
Fixes https://github.com/zooniverse/front-end-monorepo/issues/1054.

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
