### PR TITLE
Restore CanvasViewer for JSON subjects

### DIFF
--- a/app/components/file-viewer/index.jsx
+++ b/app/components/file-viewer/index.jsx
@@ -33,8 +33,6 @@ function subjectViewerSelector(props) {
       return VIEWERS.audio;
     }
     // ... add other here if necessary
-  } else if (props.format === 'json') {
-    return VIEWERS.text;
   }
   return VIEWERS[props.type] || DefaultViewer;
 }

--- a/app/components/file-viewer/text-viewer.jsx
+++ b/app/components/file-viewer/text-viewer.jsx
@@ -2,8 +2,8 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classnames from 'classnames';
 
-const SUPPORTED_TYPES = ['text', 'application'];
-const SUPPORTED_FORMATS = ['plain', 'json'];
+const SUPPORTED_TYPES = ['text'];
+const SUPPORTED_FORMATS = ['plain'];
 
 const cache = {};
 


### PR DESCRIPTION
Remove the text viewer for JSON subjects, so that they are rendered with `CanvasViewer`. This fixes subjects in the classifier and in Talk for Galaxy Builder.

Staging branch URL: 
https://pr-6033.pfe-preview.zooniverse.org/projects/tingard/galaxy-builder/classify?env=production
https://pr-6033.pfe-preview.zooniverse.org/projects/tingard/galaxy-builder/talk/1222/1266104?env=production

<img width="1062" alt="Screenshot of the Galaxy Builder classifier, showing a model galaxy rendered from JSON data." src="https://user-images.githubusercontent.com/59547/137506546-2099ef81-6ca3-4c3c-859a-d46d337e2a83.png">


# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
