### PR TITLE
Use HTML links for external About pages

### DIFF
--- a/app/pages/about/index.jsx
+++ b/app/pages/about/index.jsx
@@ -5,118 +5,102 @@ import Translate from 'react-translate-component';
 import { Helmet } from 'react-helmet';
 import { Link, IndexLink } from 'react-router';
 
-class AboutPage extends React.Component {
-  componentWillReceiveProps(nextProps, nextContext) {
-    this.logClick = !!nextContext &&
-      !!nextContext.geordi &&
-      !!nextContext.geordi.makeHandler &&
-      nextContext.geordi.makeHandler('about-menu');
+function AboutPage({ children }) {
+  let host = 'https://frontend.preview.zooniverse.org';
+  if (window.location.hostname === 'www.zooniverse.org') {
+    host = 'https://www.zooniverse.org';
   }
 
-  render() {
-    return (
-      <div className="secondary-page about-page">
-        <Helmet title={counterpart('about.index.header')} />
-        <section className="hero">
-          <div className="hero-container">
-            <Translate content="about.index.title" component="h1" />
-            <nav className="hero-nav">
-              <ul>
-                <li>
-                  <IndexLink
-                    to="/about"
-                    activeClassName="active"
-                  >
-                    <Translate content="about.index.nav.about" />
-                  </IndexLink>
-                </li>
-                <li>
-                  <Link
-                    to="/about/publications"
-                    activeClassName="active"
-                    onClick={this.logClick ? this.logClick.bind(this, 'about.index.nav.publications') : null}
-                  >
-                    <Translate content="about.index.nav.publications" />
-                  </Link>
-                </li>
-                <li>
-                  <Link
-                    to="/about/team"
-                    activeClassName="active"
-                    onClick={this.logClick ? this.logClick.bind(this, 'about.index.nav.team') : null}
-                  >
-                    <Translate content="about.index.nav.ourTeam" />
-                  </Link>
-                </li>
-                <li>
-                  <Link
-                    to="/about/acknowledgements"
-                    activeClassName="active"
-                    onClick={this.logClick ? this.logClick.bind(this, 'about.index.nav.acknowledgements') : null}
-                  >
-                    <Translate content="about.index.nav.acknowledgements" />
-                  </Link>
-                </li>
-                <li>
-                  <Link
-                    to="/about/resources"
-                    activeClassName="active"
-                    onClick={this.logClick ? this.logClick.bind(this, 'about.index.nav.resources') : null}
-                  >
-                    <Translate content="about.index.nav.resources" />
-                  </Link>
-                </li>
-                <li>
-                  <Link
-                    to="/about/contact"
-                    activeClassName="active"
-                    onClick={this.logClick ? this.logClick.bind(this, 'about.index.nav.contact') : null}
-                  >
-                    <Translate content="about.index.nav.contact" />
-                  </Link>
-                </li>
-                <li>
-                  <Link
-                    to="/about/faq"
-                    activeClassName="active"
-                    onClick={this.logClick ? this.logClick.bind(this, 'about.index.nav.faq') : null}
-                  >
-                    <Translate content="about.index.nav.faq" />
-                  </Link>
-                </li>
-                <li>
-                  <Link
-                    to="/about/highlights"
-                    activeClassName="active"
-                    onClick={this.logClick ? this.logClick.bind(this, 'about.index.nav.highlights') : null}
-                  >
-                    <Translate content="about.index.nav.highlights" />
-                  </Link>
-                </li>
-                <li>
-                  <Link
-                    to="/about/donate"
-                    activeClassName="active"
-                    onClick={this.logClick ? this.logClick.bind(this, 'about.index.nav.donate') : null}
-                  >
-                    <Translate content="about.index.nav.donate" />
-                  </Link>
-                </li>
-              </ul>
-            </nav>
-          </div>
-        </section>
-        <section className="about-page-content content-container">
-          {this.props.children}
-        </section>
-      </div>
-    );
-  }
+  return (
+    <div className="secondary-page about-page">
+      <Helmet title={counterpart('about.index.header')} />
+      <section className="hero">
+        <div className="hero-container">
+          <Translate content="about.index.title" component="h1" />
+          <nav className="hero-nav">
+            <ul>
+              <li>
+                <IndexLink
+                  to="/about"
+                  activeClassName="active"
+                >
+                  <Translate content="about.index.nav.about" />
+                </IndexLink>
+              </li>
+              <li>
+                <a
+                  href={`${host}/about/publications`}
+                  activeClassName="active"
+                >
+                  <Translate content="about.index.nav.publications" />
+                </a>
+              </li>
+              <li>
+                <a
+                  href={`${host}/about/team`}
+                  activeClassName="active"
+                >
+                  <Translate content="about.index.nav.ourTeam" />
+                </a>
+              </li>
+              <li>
+                <Link
+                  to="/about/acknowledgements"
+                  activeClassName="active"
+                >
+                  <Translate content="about.index.nav.acknowledgements" />
+                </Link>
+              </li>
+              <li>
+                <Link
+                  to="/about/resources"
+                  activeClassName="active"
+                >
+                  <Translate content="about.index.nav.resources" />
+                </Link>
+              </li>
+              <li>
+                <Link
+                  to="/about/contact"
+                  activeClassName="active"
+                >
+                  <Translate content="about.index.nav.contact" />
+                </Link>
+              </li>
+              <li>
+                <Link
+                  to="/about/faq"
+                  activeClassName="active"
+                >
+                  <Translate content="about.index.nav.faq" />
+                </Link>
+              </li>
+              <li>
+                <Link
+                  to="/about/highlights"
+                  activeClassName="active"
+                >
+                  <Translate content="about.index.nav.highlights" />
+                </Link>
+              </li>
+              <li>
+                <Link
+                  to="/about/donate"
+                  activeClassName="active"
+                >
+                  <Translate content="about.index.nav.donate" />
+                </Link>
+              </li>
+            </ul>
+          </nav>
+        </div>
+      </section>
+      <section className="about-page-content content-container">
+        {children}
+      </section>
+    </div>
+  );
 }
-
-AboutPage.contextTypes = {
-  geordi: PropTypes.object
-};
 
 AboutPage.propTypes = {
   children: PropTypes.node


### PR DESCRIPTION
Use plain links for the Publications and Team pages, which are served by NextJS.

Staging branch URL: https://pr-6039.pfe-preview.zooniverse.org

Fixes #6026.
Closes https://github.com/zooniverse/front-end-monorepo/issues/1054.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
