### PR TITLE
Lab: Refactor workflow subject sets

### DIFF
--- a/app/pages/lab/workflow-components/subject-set-linker.jsx
+++ b/app/pages/lab/workflow-components/subject-set-linker.jsx
@@ -1,0 +1,95 @@
+import PropTypes from 'prop-types';
+import React, { useEffect, useState } from 'react';
+
+// 6 is Cats on staging, 1166 is Ghosts on production.
+const DEMO_SUBJECT_SET_ID = process.env.NODE_ENV === 'production' ? '6' : '1166';
+
+function fetchSubjectSets(project) {
+  return project.get('subject_sets', { sort: 'display_name', page_size: 250 });
+}
+
+/**
+  List checkboxes for available subject sets. Linked subject sets are checked.
+*/
+export default function SubjectSetLinker({
+  /** The active project. */
+  project,
+  /** The active workflow. Subject sets will be linked to this. */
+  workflow
+}) {
+  const [projectSets, setProjectSets] = useState([]);
+  const [workflowSets, setWorkflowSets] = useState(workflow.links.subject_sets);
+
+  function fetchData() {
+    fetchSubjectSets(project)
+      .then(setProjectSets);
+  }
+
+  function onProjectChange() {
+    fetchData();
+  }
+  useEffect(onProjectChange, [project]);
+
+  const hasNoSets = projectSets.length === 0;
+
+  function updateLink(checked, subjectSet) {
+    if (checked) {
+      setWorkflowSets([...workflowSets, subjectSet.id]);
+      workflow.addLink('subject_sets', [subjectSet.id]);
+    } else {
+      const removeIndex = workflowSets.indexOf(subjectSet.id);
+      workflowSets.splice(removeIndex, 1);
+      setWorkflowSets(workflowSets);
+      workflow.removeLink('subject_sets', [subjectSet.id]);
+    }
+  }
+
+  function addDemoSet() {
+    project.uncacheLink('subject_sets');
+    workflow.addLink('subject_sets', [DEMO_SUBJECT_SET_ID]);
+  }
+
+  function handleToggle(subjectSet, event) {
+    if (workflow.hasUnsavedChanges()) {
+      workflow.save()
+      .then(() => updateLink(event.target.checked, subjectSet));
+    } else {
+      updateLink(event.target.checked, subjectSet);
+    }
+  }
+
+  if (hasNoSets) {
+    return (
+      <p>
+        This project has no subject sets.{' '}
+        <button type="button" onClick={addDemoSet}>Add an example subject set</button>
+      </p>
+    );
+  }
+  return (
+    <ul>
+      {projectSets.map(subjectSet => (
+        <li key={subjectSet.id}>
+          <input
+            id={`subjectSet${subjectSet.id}`}
+            type="checkbox"
+            checked={workflowSets.includes(subjectSet.id)}
+            onChange={event => handleToggle(subjectSet, event)}
+          />
+          <label htmlFor={`subjectSet${subjectSet.id}`}>
+            {subjectSet.display_name} (#{subjectSet.id})
+          </label>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+SubjectSetLinker.propTypes = {
+  project: PropTypes.shape({
+    get: PropTypes.func
+  }).isRequired,
+  workflow: PropTypes.shape({
+    get: PropTypes.func
+  }).isRequired
+};

--- a/app/pages/lab/workflow-components/subject-set-linker.jsx
+++ b/app/pages/lab/workflow-components/subject-set-linker.jsx
@@ -4,8 +4,22 @@ import React, { useEffect, useState } from 'react';
 // 6 is Cats on staging, 1166 is Ghosts on production.
 const DEMO_SUBJECT_SET_ID = process.env.NODE_ENV === 'production' ? '6' : '1166';
 
+function compareNames(setA, setB) {
+  if (setA.display_name < setB.display_name) {
+    return -1;
+  }
+  if (setA.display_name > setB.display_name) {
+    return 1;
+  }
+  return 0;
+}
+
 function fetchSubjectSets(project) {
   return project.get('subject_sets', { sort: '-id', page_size: 250 });
+}
+
+function sortSubjectSets(subjectSets) {
+  return subjectSets.sort(compareNames);
 }
 
 /**
@@ -22,6 +36,7 @@ export default function SubjectSetLinker({
 
   function fetchData() {
     fetchSubjectSets(project)
+      .then(sortSubjectSets)
       .then(setProjectSets);
   }
 

--- a/app/pages/lab/workflow-components/subject-set-linker.jsx
+++ b/app/pages/lab/workflow-components/subject-set-linker.jsx
@@ -61,7 +61,8 @@ export default function SubjectSetLinker({
 
   function addDemoSet() {
     project.uncacheLink('subject_sets');
-    workflow.addLink('subject_sets', [DEMO_SUBJECT_SET_ID]);
+    workflow.addLink('subject_sets', [DEMO_SUBJECT_SET_ID])
+      .then(() => fetchData());
   }
 
   function handleToggle(subjectSet, event) {

--- a/app/pages/lab/workflow-components/subject-set-linker.jsx
+++ b/app/pages/lab/workflow-components/subject-set-linker.jsx
@@ -5,7 +5,7 @@ import React, { useEffect, useState } from 'react';
 const DEMO_SUBJECT_SET_ID = process.env.NODE_ENV === 'production' ? '6' : '1166';
 
 function fetchSubjectSets(project) {
-  return project.get('subject_sets', { sort: 'display_name', page_size: 250 });
+  return project.get('subject_sets', { sort: '-id', page_size: 250 });
 }
 
 /**

--- a/app/pages/lab/workflow.cjsx
+++ b/app/pages/lab/workflow.cjsx
@@ -20,6 +20,7 @@ ShortcutEditor = require('../../classifier/tasks/shortcut/editor').default
 FeedbackSection = require('../../features/feedback/lab').default
 MobileSection = require('./mobile').default
 SubjectGroupViewerEditor = require('./workflow-components/subject-group-viewer-editor').default
+SubjectSetLinker = require('./workflow-components/subject-set-linker').default
 
 DEMO_SUBJECT_SET_ID = if process.env.NODE_ENV is 'production'
   '6' # Cats
@@ -294,7 +295,10 @@ EditWorkflowPage = createReactClass
           <div>
             <span className="form-label">Associated subject sets</span><br />
             <small className="form-help">Choose the set of subjects you want to use for this workflow.</small>
-            {@renderSubjectSets()}
+            <SubjectSetLinker
+              project={@props.project}
+              workflow={@props.workflow}
+            />
           </div>
 
           <hr />
@@ -566,44 +570,6 @@ EditWorkflowPage = createReactClass
       </div>
     </div>
 
-  renderSubjectSets: ->
-    projectAndWorkflowSubjectSets = Promise.all [
-      @props.project.get 'subject_sets', sort: 'display_name', page_size: 250
-      @props.workflow.get 'subject_sets', sort: 'display_name', page_size: 250
-    ]
-
-    <PromiseRenderer promise={projectAndWorkflowSubjectSets}>{([projectSubjectSets, workflowSubjectSets]) =>
-      <div>
-        <table role="presentation">
-          <tbody>
-            {for subjectSet in projectSubjectSets
-              assigned = subjectSet in workflowSubjectSets
-              toggle = @handleSubjectSetToggle.bind this, subjectSet
-              <tr key={subjectSet.id}>
-                <td>
-                  <input
-                    id={"subjectSet#{subjectSet.id}"}
-                    type="checkbox"
-                    checked={assigned}
-                    onChange={toggle}
-                  />
-                </td>
-                <td>
-                  <label for={"subjectSet#{subjectSet.id}"}>
-                    {subjectSet.display_name} (#{subjectSet.id})
-                  </label>
-                </td>
-              </tr>}
-          </tbody>
-        </table>
-        {if projectSubjectSets.length is 0
-          <p>
-            This project has no subject sets.{' '}
-            <button type="button" onClick={@addDemoSubjectSet}>Add an example subject set</button>
-          </p>}
-      </div>
-    }</PromiseRenderer>
-
   renderTutorials: ->
     projectAndWorkflowTutorials = Promise.all [
       apiClient.type('tutorials').get project_id: @props.project.id, page_size: 100
@@ -807,20 +773,6 @@ EditWorkflowPage = createReactClass
     if @props.workflow.configuration.custom_summary
       'world_wide_telescope' in @props.workflow.configuration.custom_summary
 
-  handleSubjectSetToggle: (subjectSet, e) ->
-    shouldAdd = e.target.checked
-
-    ensureSaved = if @props.workflow.hasUnsavedChanges()
-      @props.workflow.save()
-    else
-      Promise.resolve()
-
-    ensureSaved.then =>
-      if shouldAdd
-        @props.workflow.addLink 'subject_sets', [subjectSet.id]
-      else
-        @props.workflow.removeLink 'subject_sets', subjectSet.id
-
   handleDefaultWorkflowToggle: (e) ->
     shouldSet = e.target.checked
 
@@ -854,10 +806,6 @@ EditWorkflowPage = createReactClass
 
   removeTutorial: (tutorial, workflowTutorials, e) ->
     @props.workflow.removeLink 'tutorials', tutorial.id
-
-  addDemoSubjectSet: ->
-    @props.project.uncacheLink 'subject_sets'
-    @props.workflow.addLink 'subject_sets', [DEMO_SUBJECT_SET_ID]
 
   handleDelete: ->
     @setState deletionError: null


### PR DESCRIPTION
TODO:
- [x] Move all workflow subject set logic into a `SubjectSetLinker` component.
- [x] Change the sort order of requested sets from `display_name` to `-id`, so that newer sets are received first.
- [x] display sets in alphabetical order, by  `display_name`. 

UPDATE: Alphabetical sorting, by name, is preserved while still showing the 2021 sets for Radio Meteor Zoo.
<img width="654" alt="Screenshot of Radio Meteor Zoo subjects, listed alphabetically for recent years." src="https://user-images.githubusercontent.com/59547/139870449-e69b817b-046c-4137-84bb-192568f0074e.png">

The motivation for this is that [Radio Meteor Zoo](https://www.zooniverse.org/lab/2471) has hit a hard limit for the number of sets displayed for a workflow, so can't link up new sets to new workflows.

Try it out on Radio Meteor Zoo, where you should see the latest 2021 subject sets listed for a workflow:
https://pr-6042.pfe-preview.zooniverse.org/lab/2471/workflows/19930?env=production


Staging branch URL: https://pr-6042.pfe-preview.zooniverse.org

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
