### PR TITLE
Remove creds from azure/CLI

### DIFF
--- a/.github/workflows/deploy_branch.yml
+++ b/.github/workflows/deploy_branch.yml
@@ -33,7 +33,6 @@ jobs:
       id: upload
       uses: azure/CLI@v1
       with:
-        creds: ${{ secrets.AZURE_STATIC_SITES }}
         inlineScript: |
             az storage blob upload \
               --account-name zooniversestatic \

--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -43,7 +43,6 @@ jobs:
       id: upload
       uses: azure/CLI@v1
       with:
-        creds: ${{ secrets.AZURE_STATIC_SITES }}
         inlineScript: |
             az storage blob upload \
               --account-name zooniversestatic \

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -40,7 +40,6 @@ jobs:
       id: upload
       uses: azure/CLI@v1
       with:
-        creds: ${{ secrets.AZURE_STATIC_SITES }}
         inlineScript: |
             az storage blob upload \
               --account-name zooniversestatic \


### PR DESCRIPTION
Remove the invalid `creds` argument from [`azure/CLI`](https://github.com/marketplace/actions/azure-cli-action) commands.

Builds have been warning about this for a while, but I think it's an annoyance rather than fatal:
```
Warning: Unexpected input(s) 'creds', valid inputs are ['inlineScript', 'azcliversion']
```

Staging branch URL: https://pr-6043.pfe-preview.zooniverse.org

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
