### PR TITLE
Fix styling for video subject controls and survey task identifications

### DIFF
--- a/css/subject-viewer.styl
+++ b/css/subject-viewer.styl
@@ -35,8 +35,6 @@
 
   .subject-video-controls
     display: inline-block
-    position: absolute
-    bottom: -1.4em
     left: 0
     width: 30vw
 


### PR DESCRIPTION
Staging branch URL: https://pr-6046.pfe-preview.zooniverse.org

Closes #5041 

Fixes issue with video subjects and survey task identifications, where video speed controls are overlapped by survey task identifications.

See - https://www.zooniverse.org/projects/victorav/spyfish-aotearoa/talk/4189/2148047?comment=3586444

Testing
- WARNING production project, video subjects, survey task - https://pr-6046.pfe-preview.zooniverse.org/projects/victorav/spyfish-aotearoa/classify?env=production
- staging project, image subjects, survey task - https://pr-6046.pfe-preview.zooniverse.org/projects/markb-panoptes/survey-task-test-project/classify (for reference)

Issue #3765 and PR #3781 fixed an IE bug, but added the styling issue noted above. We no longer support IE, so I think it's ok to remove this styling to fix a bug with currently supported browsers.

Describe your changes.
- remove absolute and bottom position styling for video controls

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
