### PR TITLE
Update survey task editor link to templates

### DIFF
--- a/app/classifier/tasks/survey/editor.cjsx
+++ b/app/classifier/tasks/survey/editor.cjsx
@@ -46,7 +46,7 @@ module.exports = createReactClass
       <span className="form-label">INSTRUCTIONS</span>
       <p><small>The survey task is ideal for asking volunteers to identify wildlife species in camera trap photos, but can be used anytime you have a lot of choices you need volunteers to filter from.</small></p>
       <p><small><a href="https://www.zooniverse.org/projects/aliburchard/cameratraptest/about/faq">See here</a> for detailed instructions.</small></p>
-      <p><small><a href="http://bit.ly/1QSpevJ">Click here</a> to download Choices, Characteristics, Confusions and Questions templates.</small></p>
+      <p><small><a href="https://bit.ly/survey-task-templates">Click here</a> to download Choices, Characteristics, Confusions and Questions templates.</small></p>
       <p><small>You can Apply changes after adding an individual csv file or many csv files.</small></p>
       <hr />
 


### PR DESCRIPTION
Staging branch URL: https://pr-6052.pfe-preview.zooniverse.org

Fixes currently broken link to Google Docs folder with survey task templates.

Describe your changes.
- created new bitly link

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
