### PR TITLE
Update monorepoUtils for staging

### DIFF
--- a/app/monorepoUtils.js
+++ b/app/monorepoUtils.js
@@ -16,6 +16,9 @@ export const SLUGS = [
 ];
 
 export function usesMonorepo(slug) {
+  if (window.location.hostname === 'frontend.preview.zooniverse.org') {
+    return true;
+  }
   return SLUGS.includes(slug);
 }
 


### PR DESCRIPTION
Use the new project app for all projects on frontend.preview.zooniverse.org.

Related to #6053, this ensures that all projects link to the correct Home, About and Classify pages when previewed on `frontend.preview.zooniverse.org`.

Staging branch URL: https://pr-6054.pfe-preview.zooniverse.org

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
