### PR TITLE
add opt in API feature toggles for project admin attributes

### DIFF
--- a/app/pages/admin/project-status.jsx
+++ b/app/pages/admin/project-status.jsx
@@ -507,6 +507,10 @@ class ProjectStatus extends Component {
             <li>Launch Requested: <Toggle project={project} field="launch_requested" /></li>
             <li>Launch Approved: <Toggle project={project} field="launch_approved" /></li>
           </ul>
+          <h4>Opt-In API Features</h4>
+          <ul className="project-status__section-list">
+            <li>Run SubjectSet Completion Events: <Toggle project={project} field="run_subject_set_completion_events" /></li>
+          </ul>
         </div>
         <RedirectToggle project={project} />
         <FeaturedProjectToggle


### PR DESCRIPTION
Staging branch URL: https://pr-6063.pfe-preview.zooniverse.org

Linked to https://github.com/zooniverse/panoptes/pull/3737 - this PR adds the ability for admins to opt into API features like the "Run SubjectSet completion events" as outlined the the linked PR. 

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
