### PR TITLE
Fix deploy scripts

### DIFF
--- a/.github/workflows/deploy_branch.yml
+++ b/.github/workflows/deploy_branch.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   deploy_staging_branch:
     name: Deploy staging branch
-    uses: zooniverse/Panoptes-Front-End/.github/workflows/azure_deploy.yml@reusable-workflows
+    uses: zooniverse/Panoptes-Front-End/.github/workflows/azure_deploy.yml@production-release
     with:
       commit_id: ${{ github.sha }}
       deploy_url: 'https://pr-${{ github.event.number }}.pfe-preview.zooniverse.org'

--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   deploy_production:
     name: Deploy production
-    uses: zooniverse/Panoptes-Front-End/.github/workflows/azure_deploy.yml@reusable-workflows
+    uses: zooniverse/Panoptes-Front-End/.github/workflows/azure_deploy.yml@production-release
     with:
       commit_id: ${{ github.sha }}
       deploy_url: 'https://www.zooniverse.org'

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   deploy_staging:
     name: Deploy staging
-    uses: zooniverse/Panoptes-Front-End/.github/workflows/azure_deploy.yml@reusable-workflows
+    uses: zooniverse/Panoptes-Front-End/.github/workflows/azure_deploy.yml@production-release
     with:
       commit_id: ${{ github.sha }}
       deploy_url: 'https://master.pfe-preview.zooniverse.org'


### PR DESCRIPTION
Staging branch URL: https://pr-6065.pfe-preview.zooniverse.org

The deployment scripts are still pointing to the `reusable-workflows` branch. This points them to the `production-release` tag. 

In the meantime, I’ve restored the `reusable-workflows` branch so that actions still run. 

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
