### PR TITLE
Throw a meaningful error when workflow.first_task is missing

### DIFF
--- a/app/classifier/classifier.jsx
+++ b/app/classifier/classifier.jsx
@@ -315,7 +315,7 @@ class Classifier extends React.Component {
   }
 
   render() {
-    const { actions, goldStandardMode, intervention, user } = this.props;
+    const { actions, goldStandardMode, intervention, user, workflow } = this.props;
     const { showIntervention, showSummary, workflowHistory } = this.state;
     const currentTaskKey = workflowHistory.length > 0 ? workflowHistory[workflowHistory.length - 1] : null;
     const taskAreaVariant = goldStandardMode ? 'goldStandardMode' : 'default';
@@ -325,6 +325,17 @@ class Classifier extends React.Component {
       'large-image': largeFormatImage,
       [this.props.className]: !!this.props.className
     });
+
+    /*
+      Throw an error if the workflow has tasks but a first task isn't set,
+      otherwise the classifier will crash deeper down the component tree.
+    */
+    if (!workflow.first_task) {
+      const hasTasks = Object.keys(workflow.tasks).length
+      if (hasTasks) {
+        throw new Error('First task has not been set for workflow.')
+      }
+    }
 
     let currentClassification;
     let currentTask;

--- a/app/classifier/classifier.spec.js
+++ b/app/classifier/classifier.spec.js
@@ -53,6 +53,7 @@ const workflow = mockPanoptesResource('workflow', {
   configuration: {
     hide_classification_summaries: false
   },
+  first_task: 'T0',
   tasks: {
     T0: {},
     T1: {}


### PR DESCRIPTION
Throw `First task has not been set for workflow`, when `workflow.first_task` is undefined or empty.

<img width="807" alt="I Fancy Cats showing 'First task has not been set for workflow' instead of the Classify page." src="https://user-images.githubusercontent.com/59547/145011936-cfcf1bd6-4098-436d-9652-64e5dde5ba9e.png">

There's a project that's broken because `workflow.first_task` is an empty string. This PR would show them a meaningful error, although it's not clear how they created a workflow with no first task.
https://www.zooniverse.org/projects/matildagrahn/korrekturlas-svenska-skillingtryck/classify?reload=0&workflow=20341

See also this Talk post:
https://www.zooniverse.org/talk/17/2244862?comment=3681061&page=1

TODO: is there a bug in the project builder that allows you to create invalid workflows?

Staging branch URL: https://pr-6067.pfe-preview.zooniverse.org/projects/matildagrahn/korrekturlas-svenska-skillingtryck/classify?reload=0&workflow=20341&env=production

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
