### PR TITLE
Fix broken delete for survey annotations

### DIFF
--- a/app/classifier/tasks/survey/annotation-view.jsx
+++ b/app/classifier/tasks/survey/annotation-view.jsx
@@ -14,6 +14,12 @@ export function AnnotationView({
     onChange(annotation);
   }
 
+  function onClick(event) {
+    const { target } = event
+    const { index } = target.dataset
+    handleRemove(index)
+  }
+
   function answerByQuestion(identification) {
     return task.questionsOrder.map((questionID) => {
       const answerKeys = Object.keys(identification.answers);
@@ -43,7 +49,8 @@ export function AnnotationView({
               {' '}
               <button
                 className="survey-identification-remove"
-                onClick={i => handleRemove(i)}
+                data-index={i}
+                onClick={onClick}
                 aria-label="Remove"
                 type="button"
               >

--- a/app/classifier/tasks/survey/annotation-view.spec.jsx
+++ b/app/classifier/tasks/survey/annotation-view.spec.jsx
@@ -68,7 +68,13 @@ describe('AnnotationView', function() {
   describe('The delete button', function() {
     it('should call the onChange callback', function() {
       const deleteButton = wrapper.find('.survey-identification-remove');
-      deleteButton.simulate('click');
+      deleteButton.simulate('click', {
+        target: {
+          dataset: {
+            index: 0
+          }
+        }
+      });
       expect(onChange.calledOnce).to.be.true;
     });
 


### PR DESCRIPTION
The delete button for survey task annotations is passing the click event as the annotation index, `i`. This PR stores the index on each tag as `data-index` then uses that to get the selected annotation from the click event target.

See this Talk thread for a description of the bug:
https://www.zooniverse.org/talk/17/2251137?comment=3691589

Staging branch URL: https://pr-6068.pfe-preview.zooniverse.org/projects/zooniverse/snapshot-serengeti/classify?env=production

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
