### PR TITLE
Use production-release for deploys

### DIFF
--- a/.github/workflows/deploy_branch.yml
+++ b/.github/workflows/deploy_branch.yml
@@ -7,14 +7,14 @@ on:
 jobs:
   build:
     name: Build staging branch
-    uses: zooniverse/Panoptes-Front-End/.github/workflows/npm_build.yml@reusable-workflows
+    uses: zooniverse/Panoptes-Front-End/.github/workflows/npm_build.yml@production-release
     with:
       commit_id: ${{ github.sha }}
       output: 'dist'
       script: '_build-staging'
   deploy_staging_branch:
     name: Deploy staging branch
-    uses: zooniverse/Panoptes-Front-End/.github/workflows/azure_deploy.yml@reusable-workflows
+    uses: zooniverse/Panoptes-Front-End/.github/workflows/azure_deploy.yml@production-release
     needs: build
     with:
       source: 'dist'
@@ -23,7 +23,7 @@ jobs:
       creds: ${{ secrets.AZURE_STATIC_SITES }}
   slack_notification:
     name: Send Slack notification
-    uses: zooniverse/Panoptes-Front-End/.github/workflows/slack_notification.yml@reusable-workflows
+    uses: zooniverse/Panoptes-Front-End/.github/workflows/slack_notification.yml@production-release
     needs: deploy_staging_branch
     if: always()
     with:

--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -12,14 +12,14 @@ on:
 jobs:
   build:
     name: Build production
-    uses: zooniverse/Panoptes-Front-End/.github/workflows/npm_build.yml@reusable-workflows
+    uses: zooniverse/Panoptes-Front-End/.github/workflows/npm_build.yml@production-release
     with:
       commit_id: ${{ github.sha }}
       output: 'dist'
       script: '_build-production'
   deploy_production:
     name: Deploy production
-    uses: zooniverse/Panoptes-Front-End/.github/workflows/azure_deploy.yml@reusable-workflows
+    uses: zooniverse/Panoptes-Front-End/.github/workflows/azure_deploy.yml@production-release
     needs: build
     with:
       source: 'dist'
@@ -28,7 +28,7 @@ jobs:
       creds: ${{ secrets.AZURE_STATIC_SITES }}
   slack_notification:
     name: Send Slack notification
-    uses: zooniverse/Panoptes-Front-End/.github/workflows/slack_notification.yml@reusable-workflows
+    uses: zooniverse/Panoptes-Front-End/.github/workflows/slack_notification.yml@production-release
     needs: deploy_production
     if: always()
     with:

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: Build staging
-    uses: zooniverse/Panoptes-Front-End/.github/workflows/npm_build.yml@reusable-workflows
+    uses: zooniverse/Panoptes-Front-End/.github/workflows/npm_build.yml@production-release
     with:
       commit_id: ${{ github.sha }}
       output: 'dist'
@@ -26,7 +26,7 @@ jobs:
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
   slack_notification:
     name: Send Slack notification
-    uses: zooniverse/Panoptes-Front-End/.github/workflows/slack_notification.yml@reusable-workflows
+    uses: zooniverse/Panoptes-Front-End/.github/workflows/slack_notification.yml@production-release
     needs: deploy_staging
     if: always()
     with:


### PR DESCRIPTION
Switch the deploy workflows from the `reusable-workflows` branch to the `production-release` tag.

Once this is merged, `reusable-workflows` can be deleted.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
