### PR TITLE
CI: use built-in package caching

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -15,17 +15,10 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Use Node.js 14
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2
       with:
         node-version: '14.x'
-
-    - name: Cache dependencies
-      uses: actions/cache@v1
-      with:
-        path: ~/.npm
-        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-node-
+        cache: 'npm'
 
     - run: npm ci
     - run: npm run test-ci

--- a/.github/workflows/deploy_branch.yml
+++ b/.github/workflows/deploy_branch.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
     name: Build staging branch
-    uses: zooniverse/Panoptes-Front-End/.github/workflows/npm_build.yml@production-release
+    uses: zooniverse/Panoptes-Front-End/.github/workflows/npm_build.yml@clean-up-npm-caching
     with:
       commit_id: ${{ github.sha }}
       output: 'dist'

--- a/.github/workflows/deploy_branch.yml
+++ b/.github/workflows/deploy_branch.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
     name: Build staging branch
-    uses: zooniverse/Panoptes-Front-End/.github/workflows/npm_build.yml@clean-up-npm-caching
+    uses: zooniverse/Panoptes-Front-End/.github/workflows/npm_build.yml@production-release
     with:
       commit_id: ${{ github.sha }}
       output: 'dist'

--- a/.github/workflows/npm_build.yml
+++ b/.github/workflows/npm_build.yml
@@ -30,19 +30,12 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Cache dependencies
-      uses: actions/cache@v1
-      with:
-        path: ~/.npm
-        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-node-
-
     - name: Node.js build
       id: build
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2
       with:
         node-version: ${{ inputs.node_version }}
+        cache: 'npm'
     - run: npm ci
     - run: npm run ${{ inputs.script }}
 


### PR DESCRIPTION
Bump `actions/setup-node` and use [built-in package caching](https://github.com/actions/setup-node#caching-packages-dependencies) instead of `actions/cache`.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
