### PR TITLE
Trim translation strings

### DIFF
--- a/app/redux/ducks/translations.js
+++ b/app/redux/ducks/translations.js
@@ -64,7 +64,8 @@ export default function reducer(state = initialState, action = {}) {
       const resourceTranslations = {};
       translations.forEach((translation, i) => {
         Object.keys(translation.strings).map((translationKey) => {
-          const newTranslation = explodeTranslationKey(translationKey, translation.strings[translationKey]);
+          const translationValue = translation.strings[translationKey] || '';
+          const newTranslation = explodeTranslationKey(translationKey, translationValue.trim());
           translation.strings = merge(translation.strings, newTranslation);
           resourceTranslations[translation.translated_id] = translation;
         });


### PR DESCRIPTION
Translations can be accidentally saved, from the project builder, with extra whitespace, which then causes display bugs. This trims all language strings after loading them from Panoptes.

Staging branch URL: https://pr-6075.pfe-preview.zooniverse.org/projects/eatyourgreens/text-highlighter-demo

Test project with the whitespace bug: https://master.pfe-preview.zooniverse.org/projects/eatyourgreens/text-highlighter-demo

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
