### PR TITLE
Admin pages: show recent user classification history

### DIFF
--- a/app/pages/admin/user-settings.jsx
+++ b/app/pages/admin/user-settings.jsx
@@ -7,7 +7,8 @@ import UserProperties from './user-settings/properties';
 import UserResources from './user-settings/resources';
 import UserLimitToggle from './user-settings/limit-toggle';
 import DeleteUser from './user-settings/delete-user';
-import { getUserProjects } from './user-settings/stats';
+import { getUserClassifications, getUserProjects } from './user-settings/stats';
+import ClassificationData from './user-settings/ClassificationData';
 
 class UserSettings extends Component {
   constructor(props) {
@@ -17,6 +18,7 @@ class UserSettings extends Component {
     this.updateUserProjects = this.updateUserProjects.bind(this);
 
     this.state = {
+      classifications: [],
       editUser: null,
       ribbonData: [],
       totalClassifications: 0
@@ -30,6 +32,8 @@ class UserSettings extends Component {
   componentDidUpdate(prevProps, prevState) {
     if (this.state.editUser?.id !== prevState.editUser?.id) {
       getUserProjects(this.state.editUser, this.updateUserProjects)
+      getUserClassifications(this.state.editUser)
+        .then(classifications => this.setState({ classifications }))
     }
   }
 
@@ -97,6 +101,16 @@ class UserSettings extends Component {
             </li>
           ))}
           </ul>
+        </details>
+        <details>
+          <summary>Recent classifications {this.state.classifications.length}</summary>
+          <ol>
+          {this.state.classifications.map(classification => (
+            <li key={classification.id}>
+              <ClassificationData classification={classification} />
+            </li>
+          ))}
+          </ol>
         </details>
       </div>
     );

--- a/app/pages/admin/user-settings.jsx
+++ b/app/pages/admin/user-settings.jsx
@@ -86,16 +86,18 @@ class UserSettings extends Component {
         <UserResources type="projects" user={this.state.editUser} />
         <UserResources type="organizations" user={this.state.editUser} />
         <h4>Classification history</h4>
-        <p>Total classifications: {this.state.totalClassifications}</p>
-        <ul>
-        {this.state.ribbonData.map(project => (
-          <li key={project.id}>
-            <p><b>{project.display_name}</b><br/>
-              Classifications: {project.classifications}
-            </p>
-          </li>
-        ))}
-        </ul>
+        <details>
+          <summary>Total classifications: {this.state.totalClassifications}</summary>
+          <ul>
+          {this.state.ribbonData.map(project => (
+            <li key={project.id}>
+              <p><b>{project.display_name}</b><br/>
+                Classifications: {project.classifications}
+              </p>
+            </li>
+          ))}
+          </ul>
+        </details>
       </div>
     );
   }

--- a/app/pages/admin/user-settings/ClassificationData.jsx
+++ b/app/pages/admin/user-settings/ClassificationData.jsx
@@ -1,0 +1,23 @@
+import React from 'react'
+
+function ClassificationEntry({
+  name,
+  value
+}) {
+  return (
+    <>
+      <b>{name}:</b> {JSON.stringify(value)}<br/>
+    </>
+  )
+}
+
+export default function Classification({
+  classification = {}
+}) {
+  const entries = Object.entries(classification).filter(([key, value]) => !key.startsWith('_'))
+  return (
+    <code>
+      {entries.map(([key, value]) => <ClassificationEntry key={key} name={key} value={value} />)}
+    </code>
+  )
+}

--- a/app/pages/admin/user-settings/ClassificationData.jsx
+++ b/app/pages/admin/user-settings/ClassificationData.jsx
@@ -4,6 +4,27 @@ function ClassificationEntry({
   name,
   value
 }) {
+  if (name === 'annotations') {
+    return (
+      <>
+        <b>annotations:</b>
+        <ol>
+          {value.map(annotation => <li>{JSON.stringify(annotation)}<br/></li>)}
+        </ol>
+      </>
+    )
+  }
+  if (name === 'metadata') {
+    const entries = Object.entries(value)
+    return (
+      <>
+        <b>metadata:</b>
+        <ul>
+          {entries.map(([key, value]) => <li><b>{key}:</b>{JSON.stringify(value)}<br/></li>)}
+        </ul>
+      </>
+    )
+  }
   return (
     <>
       <b>{name}:</b> {JSON.stringify(value)}<br/>

--- a/app/pages/admin/user-settings/stats.js
+++ b/app/pages/admin/user-settings/stats.js
@@ -80,3 +80,10 @@ export function getUserProjects(user, callback, _page = 1) {
     }
   });
 }
+
+export function getUserClassifications(user, _page = 1) {
+  return user.get('classifications', {
+    sort: '-created_at',
+    page: _page
+  })
+}


### PR DESCRIPTION
Add the 20 most recent classifications to the admin page for a user account.
Tidy up the mark-up to use summary/details for classification history.

Staging branch URL: https://pr-6077.pfe-preview.zooniverse.org

<img width="1197" alt="Screenshot of a user account showing one of their most recent classifications, with the classification keys in bold." src="https://user-images.githubusercontent.com/59547/148537215-5cd9e604-c523-46bd-a3ab-ddf475bb59fe.png">

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
