### PR TITLE
Temporary workaround: Bursts from Space redirect

### DIFF
--- a/app/router.jsx
+++ b/app/router.jsx
@@ -168,6 +168,14 @@ export const routes = (
 
     <Route path="/projects/mschwamb/planet-four/authors" component={() => <ExternalRedirect newUrl='https://authors.planetfour.org/' />} />
 
+    /*
+    2022 Feb Temporary fix: a recent issue of "Sky and Telescope" misprinted the
+    URL for the Bursts from Space project. This is a workaround.
+    See https://zooniverse.slack.com/archives/C14TTCLNN/p1643655013402769
+    Please remove in 6 months time.
+    */
+    <Redirect from="projects/mike-walmsley/bursts-from-space" to="projects/mikewalmsley/bursts-from-space"/>
+
     <Route path="projects/:owner/:name" component={require('./pages/project').default}>
       <IndexRoute component={ProjectHomePage} />
       <Route path="home" component={ONE_UP_REDIRECT} />


### PR DESCRIPTION
## PR Overview

This PR adds a redirect for a misprinted Bursts from Space URL

- A recent publication of "Sky and Telescope" misprinted the URL for @mwalmsley 's Bursts from Space project
- Incorrect URL: https://www.zooniverse.org/projects/mike-walmsley/bursts-from-space
- Correct URL: https://www.zooniverse.org/projects/mikewalmsley/bursts-from-space

Test URL: https://pr-6088.pfe-preview.zooniverse.org/projects/mike-walmsley/bursts-from-space?env=production

### Status

Ready for review

This workaround should be deleted after, say, _6 months_ to keep the code clean.