### PR TITLE
UI/UX: change keyboard focus colour for Survey Task options

### DIFF
--- a/css/survey-task.styl
+++ b/css/survey-task.styl
@@ -340,6 +340,10 @@ $survey-task-pill-button
 
   &[data-focused]
     border: 1px MAIN_HIGHLIGHT solid
+    color: MAIN_HIGHLIGHT
+
+  &[data-focused][data-checked]
+    border: 1px MAIN_HIGHLIGHT solid
     color: white
 
   span


### PR DESCRIPTION
## PR Overview

Fixes #6089 

This PR changes the UI colours of Survey Task answers/options, so they have more high contrast.

Currently:

<img width="218" alt="Screenshot 2022-02-02 at 14 53 06" src="https://user-images.githubusercontent.com/13952701/152180360-4eabaf6a-3dfc-4ac3-8f99-1b9ed433c9dd.png">

With this PR:

<img width="217" alt="Screenshot 2022-02-02 at 14 53 20" src="https://user-images.githubusercontent.com/13952701/152181193-d02df689-486c-45a6-9ac5-12e8b52e3a53.png">

- Left: option is _not selected_ and _doesn't have focus._
- Middle: option is _not selected_ and has **focus.**
- Right: option is **selected** and _doesn't have focus_ - OR - option is **selected** and and has **focus**

### Dev Notes

Tagging @seanmiller26 in this for design review. Please let me know if what I have here is good enough to roll or if you have better ideas.

- Sean, my proposal is to change the "if option is not selected and has focus" scenario so that the text colour is blue (matching the HIGHLIGHT_COLOUR of the border)
- One **quirk** of the current colour scheme though is that you can never tell when a selected option ALSO has focus, because they look the same. Like, which one of the options below has keyboard focus, right?
    ![image](https://user-images.githubusercontent.com/13952701/152182595-cb312e4f-bb85-4a10-a58b-3d10c9b1eeca.png)
  (Answer: the left-most one.) This might be a separate design/UI issue, though.

### Testing

Baseline: https://www.zooniverse.org/projects/sassydumbledore/chimp-and-see/classify
Test URL: https://pr-6090.pfe-preview.zooniverse.org/projects/sassydumbledore/chimp-and-see/classify?env=production

Testing steps:
- Choose a species, then use keyboard tab navigation to gain focus on different answers/options.
- Observe the colour of the elements

### Status

Ready for review