### PR TITLE
Survey task translations: fallback to showing keys

### DIFF
--- a/app/classifier/tasks/survey/choice.jsx
+++ b/app/classifier/tasks/survey/choice.jsx
@@ -127,14 +127,14 @@ class Choice extends React.Component {
                       triggerProps={{ autoFocus }}
                       trigger={
                         <span className="survey-task-choice-confusion">
-                          {otherChoiceTranslation.label}
+                          {otherChoiceTranslation?.label || `translation.choices.${otherChoiceID}`}
                         </span>
                       }
                       style={{ maxWidth: '60ch' }}
                     >
                       <ImageFlipper images={otherChoice.images.map(filename => this.props.task.images[filename])} />
                       <Markdown
-                        content={currentChoiceTranslation.confusions[otherChoiceID]}
+                        content={currentChoiceTranslation.confusions[otherChoiceID] || `translation.confusions.${otherChoiceID}`}
                       />
                       <div className="survey-task-choice-confusion-buttons" style={{ textAlign: 'center' }}>
                         <button
@@ -171,7 +171,7 @@ class Choice extends React.Component {
               return (
                 <div key={questionId} className="survey-task-choice-question" data-multiple={question.multiple || null}>
                   <div className="survey-task-choice-question-label">
-                    {translation.questions[questionId].label}
+                    {translation.questions[questionId]?.label || `translation.questions.${questionId}.label`}
                   </div>
                   <div className="survey-task-choice-answers">
                     {question.answersOrder.map((answerId, i) => {
@@ -200,7 +200,7 @@ class Choice extends React.Component {
                               onFocus={this.handleFocus.bind(this, questionId, answerId)}
                               onBlur={this.handleFocus.bind(this, null, null)}
                             />
-                            {translation.questions[questionId].answers[answerId].label}
+                            {translation.questions[questionId]?.answers[answerId]?.label || `translation.questions.${questionId}.answers.${answerId}.label`}
                           </label>
                           {' '}
                           {hasFocus = true}


### PR DESCRIPTION
Survey task translations crash the project page if a choice is missing. This updates the survey task to fall back to show the original dictionary key for missing choices, questions and answers.

Staging branch URL: https://pr-6102.pfe-preview.zooniverse.org/projects/shuebner729/snapshot-tswalu/classify?env=production
(select honey badger, black-footed cat or meerkat to trigger the original bug.)

<img width="356" alt="Screenshot showing a button label replaced with the missing translation key: 'translations.choices.MONGOOSE'" src="https://user-images.githubusercontent.com/59547/155288202-e2bc3fb5-9f3f-4fc0-bc0e-be8a7a345243.png">


Fixes #6101.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
