### PR TITLE
test updated PJC with sugar client v2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9459,13 +9459,12 @@
       "dev": true
     },
     "panoptes-client": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-3.3.4.tgz",
-      "integrity": "sha512-37ZxdLBUkTBmo/eoCyVYijvsnvnCXt9lzKfwbVKFmYlMCSujlDBmHIb4lKSiaKd3Jg3r19NqGiqTQF1ZO4U5pg==",
+      "version": "git+https://github.com/zooniverse/panoptes-javascript-client.git#4056b1118c41a6c9d16cc9ad16aeef05cfac68c1",
+      "from": "git+https://github.com/zooniverse/panoptes-javascript-client.git#4056b1118c41a6c9d16cc9ad16aeef05cfac68c1",
       "requires": {
         "json-api-client": "~5.0.0",
         "local-storage": "^1.4.2",
-        "sugar-client": "^1.1.0"
+        "sugar-client": "^2.0.0"
       }
     },
     "papaparse": {
@@ -11908,9 +11907,9 @@
       }
     },
     "sugar-client": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/sugar-client/-/sugar-client-1.1.0.tgz",
-      "integrity": "sha512-/1fgJcTUQPUw4hrT/AXpI4iVdsoXIIgVrbj3mPGMJWD00JHtWna5KmKyeoqNKSCO672UK+5Cc9/B53UfzthbwA=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/sugar-client/-/sugar-client-2.0.0.tgz",
+      "integrity": "sha512-87RfgwzyiQrA77lsBGYFPjHbDVzkcSl5aiubz3n7qPOwf9LLNKe+PvtlNf0bnFS63+gGWe6r8A18iaKLBthw1w=="
     },
     "superagent": {
       "version": "3.8.3",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "markdownz": "~7.8.1",
     "modal-form": "~2.9",
     "moment": "~2.24.0",
-    "panoptes-client": "~3.3.2",
+    "panoptes-client": "git+https://github.com/zooniverse/panoptes-javascript-client#4056b1118c41a6c9d16cc9ad16aeef05cfac68c1",
     "papaparse": "^5.2.0",
     "polished": "~2.3.3",
     "prop-types": "~15.7.1",


### PR DESCRIPTION
Staging branch URL: https://pr-6103.pfe-preview.zooniverse.org

Test the updates to sugar client (v2.0.0) and the PJC via github URL

linked to https://github.com/zooniverse/panoptes-javascript-client/pull/151

Once this is tested and declared working we can close this and bump the https://github.com/zooniverse/panoptes-javascript-client package to v3.3.5 for automatic inclusion of rebuilds / deploys of this PFE system

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
