### PR TITLE
update panoptes-client to v3.3.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11554,12 +11554,13 @@
       "license": "(MIT AND Zlib)"
     },
     "node_modules/panoptes-client": {
-      "version": "3.3.4",
-      "license": "Apache-2.0",
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-3.3.5.tgz",
+      "integrity": "sha512-G4TC/1Xma/7LvVABsFJGL1BfPm5CVKlCG/e7ZAKGyljrFl9CcUphU2AcoOsAWm6G7n2npMaGdeznzmElD8oETw==",
       "dependencies": {
         "json-api-client": "~5.0.0",
         "local-storage": "^1.4.2",
-        "sugar-client": "^1.1.0"
+        "sugar-client": "^2.0.0"
       }
     },
     "node_modules/papaparse": {
@@ -14260,7 +14261,9 @@
       }
     },
     "node_modules/sugar-client": {
-      "version": "1.1.0",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/sugar-client/-/sugar-client-2.0.0.tgz",
+      "integrity": "sha512-87RfgwzyiQrA77lsBGYFPjHbDVzkcSl5aiubz3n7qPOwf9LLNKe+PvtlNf0bnFS63+gGWe6r8A18iaKLBthw1w==",
       "engines": {
         "node": ">=14"
       }
@@ -24122,11 +24125,13 @@
       "dev": true
     },
     "panoptes-client": {
-      "version": "3.3.4",
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-3.3.5.tgz",
+      "integrity": "sha512-G4TC/1Xma/7LvVABsFJGL1BfPm5CVKlCG/e7ZAKGyljrFl9CcUphU2AcoOsAWm6G7n2npMaGdeznzmElD8oETw==",
       "requires": {
         "json-api-client": "~5.0.0",
         "local-storage": "^1.4.2",
-        "sugar-client": "^1.1.0"
+        "sugar-client": "^2.0.0"
       }
     },
     "papaparse": {
@@ -26015,7 +26020,9 @@
       }
     },
     "sugar-client": {
-      "version": "1.1.0"
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/sugar-client/-/sugar-client-2.0.0.tgz",
+      "integrity": "sha512-87RfgwzyiQrA77lsBGYFPjHbDVzkcSl5aiubz3n7qPOwf9LLNKe+PvtlNf0bnFS63+gGWe6r8A18iaKLBthw1w=="
     },
     "superagent": {
       "version": "3.8.3",


### PR DESCRIPTION
update the PJC to v3.3.5 which includes the sugar client v2.0.0 update (primus client updates)

Staging branch URL: https://pr-6107.pfe-preview.zooniverse.org

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `rm -rf node_modules/ && npm install` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on Travis?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
