### PR TITLE
Project Builder: Improved IIIF manifest parser

### DIFF
--- a/app/pages/lab/iiif/components/IIIFSubjectSet.jsx
+++ b/app/pages/lab/iiif/components/IIIFSubjectSet.jsx
@@ -1,4 +1,4 @@
-import { useRef, useMemo, useState } from 'react'
+import { useEffect, useRef, useMemo, useState } from 'react'
 
 import { parseManifestV2 } from './helpers'
 import { useManifest } from './hooks'
@@ -19,18 +19,39 @@ function IIIFThumbnail({ subject }) {
   )
 }
 
-export default function IIIFSubjectSet({ project }) {
-  const manifestUrl = useRef()
-  const [metadata, setMetadata] = useState(null)
-  const [url, setUrl] = useState('')
-  const { manifest, error } = useManifest(url)
-  const { label, metadata: newMetadata, subjects, thumb } = useMemo(() => (manifest ? parseManifestV2(manifest) : {}), [manifest])
+function parseManifest(manifest) {
+  // Right now, only v2 manifests are supported
+  if (manifest?.['@context'] === 'http://iiif.io/api/presentation/2/context.json') {
+    return parseManifestV2(manifest)
+  }
+  const error = new Error('Only version 2 manifests are supported at present.')
+  return { error }
+}
 
-  if(newMetadata && !metadata) {
+export default function IIIFSubjectSet({ project }) {
+  let error
+
+  const [metadata, setMetadata] = useState(null)
+  const manifestUrl = useRef()
+  const [url, setUrl] = useState('')
+  const manifestData = useManifest(url)
+  const { manifest } = manifestData
+  const parsedManifest = useMemo(() => manifest ? parseManifest(manifest) : {}, [manifest])
+  const { label, metadata : newMetadata, subjects, thumb } = parsedManifest
+  useEffect(() => {
     setMetadata(newMetadata)
+  }, [newMetadata])
+
+  if (parsedManifest.error) {
+    error = parsedManifest.error
   }
 
-  function onClick() {
+  if (manifestData.error) {
+    error = manifestData.error
+  }
+
+  function fetchManifest(event) {
+    event?.preventDefault()
     const { value } = manifestUrl?.current
     if (value) {
       setUrl(value)
@@ -40,11 +61,13 @@ export default function IIIFSubjectSet({ project }) {
   return (
     <>
       <h1>Create a new subject set</h1>
-      <label className="form-label" htmlFor="iiifUrl">Enter a manifest URL</label>
-      <input className="standard-input full" id="iiifUrl" ref={manifestUrl} size="100" type="text" defaultValue="https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100022589096.0x000002/manifest.json" />
-      <button className="standard-button" onClick={onClick}>Fetch manifest</button>
+      <form onSubmit={fetchManifest}>
+        <label className="form-label" htmlFor="iiifUrl">Enter a manifest URL</label>
+        <input className="standard-input full" id="iiifUrl" ref={manifestUrl} size="100" type="search" defaultValue="https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100022589096.0x000002/manifest.json" />
+        <button type="submit" className="standard-button">Fetch manifest</button>
+      </form>
       {error && <p><b>{error.status}: {error.message}</b></p>}
-      {manifest && <MetadataEditor caption={manifest.label} metadata={metadata} onChange={setMetadata} />}
+      {manifest && metadata && <MetadataEditor caption={manifest.label} metadata={metadata} onChange={setMetadata} />}
       {subjects && <p>{subjects.slice(0,10).map(subject => <IIIFThumbnail key={subject.id} subject={subject} />)}</p>}
       {subjects && <UploadButton manifest={manifest} metadata={metadata} project={project} subjects={subjects} />}
     </>

--- a/app/pages/lab/iiif/components/helpers/parseManifestV2.js
+++ b/app/pages/lab/iiif/components/helpers/parseManifestV2.js
@@ -3,6 +3,8 @@ import TurndownService from 'turndown';
 export const MAX_WIDTH = 1400
 export const MAX_HEIGHT = 2000
 
+const turndownService = new TurndownService();
+
 function parseCanvasImage(image) {
   const { resource } = image;
   const id = resource.service['@id'];
@@ -21,8 +23,44 @@ function parseCanvas(canvas, index) {
   return { thumb, locations, metadata };
 }
 
+function parseValue({ label, value }) {
+  if (value[`@language`]) {
+    const language = value[`@language`];
+    label = `${label}:${language}`;
+  }
+
+  if (value[`@value`]) {
+    value = value['@value'];
+  }
+
+  return {
+    label,
+    value: turndownService.turndown(value.toString())
+  };
+}
+
+function parseMetadataItem({ label, value }) {
+  if (Array.isArray(value)) {
+    return value.map(v => parseValue({ label, value: v }));
+  }
+
+  return [
+    parseValue({ label, value })
+  ];
+}
+
+function parseMetadata(manifest) {
+  const metadata = {};
+  manifest.metadata.forEach(({ label, value }) => {
+    const items = parseMetadataItem({ label, value });
+    items.forEach(({ label, value }) => {
+      metadata[label] = value;
+    })
+  });
+  return metadata;
+}
+
 export default function parseManifestV2(manifest) {
-  const turndownService = new TurndownService();
   const { sequences, structures } = manifest;
   const [sequence] = sequences;
   const subjects = sequence.canvases.map((canvas, index) => {
@@ -31,12 +69,10 @@ export default function parseManifestV2(manifest) {
     return { alt, locations, metadata, thumb };
   });
   const metadata = {
-    "iiif:manifest": manifest['@id']
+    "iiif:manifest": manifest['@id'],
+    ...parseMetadata(manifest)
   };
-  manifest.metadata.forEach(({ label, value }) => {
-    metadata[label] = turndownService.turndown(value);
-  });
-  const thumb = subjects[0].thumb;
-  const label = subjects[0].alt;
+  const thumb = subjects[0]?.thumb;
+  const label = subjects[0]?.alt;
   return { label, metadata, subjects, thumb };
 }

--- a/app/pages/lab/iiif/components/helpers/parseManifestV2.spec.js
+++ b/app/pages/lab/iiif/components/helpers/parseManifestV2.spec.js
@@ -17,13 +17,6 @@ describe('parseManifestV2', function () {
       expect(data.metadata['iiif:manifest']).to.equal(manifest['@id']);
   })
 
-  it('should convert manifest metadata to Markdown', function () {
-    manifest.metadata.forEach(({ label, value }) => {
-      const markdownValue = turndownService.turndown(value);
-      expect(data.metadata[label]).to.equal(markdownValue);
-    })
-  })
-
   it('should generate subjects from the default sequence', function () {
     expect(data.subjects.length).to.equal(sequence.canvases.length)
   })
@@ -53,6 +46,35 @@ describe('parseManifestV2', function () {
     sequence.canvases.forEach((canvas, index) => {
       const subject = data.subjects[index];
       expect(subject.metadata['iiif:canvas']).to.equal(canvas['@id']);
+    })
+  })
+
+  describe('metadata', function () {
+    it('should convert manifest metadata to Markdown', function () {
+      manifest.metadata.forEach(({ label, value }) => {
+        const markdownValue = turndownService.turndown(value);
+        expect(data.metadata[label]).to.equal(markdownValue);
+      })
+    })
+
+    it('should parse metadata items in multiple languages', function () {
+      const mockManifest = {
+        metadata: [
+          {
+            label: "Published",
+            value: [
+              { '@language': 'en', '@value': 'in Paris, 1790' },
+              { '@language': 'fr', '@value': 'en Paris, 1790' }
+            ]
+          }
+        ],
+        sequences: [
+          { canvases: [] }
+        ]
+      };
+      const { metadata } = parseManifestV2(mockManifest);
+      expect(metadata['Published:en']).to.equal('in Paris, 1790');
+      expect(metadata['Published:fr']).to.equal('en Paris, 1790');
     })
   })
 })


### PR DESCRIPTION
- show an error when the manifest context does not match IIIF Presentation version 2.
- Update metadata when the manifest URL changes (bug fix.)
- Submit the manifest URL by pressing Enter.
- Improved metadata parsing: handle complex metadata values, including arrays of items in multiple languages.

Some manifests that should work with this version:
- BL Siberian Photographs: https://eap.bl.uk/archive-file/EAP016-1-1/manifest
- BL In The Spotlight playbills: https://api.bl.uk/metadata/iiif/ark:/81055/vdc_100022589176.0x000002/manifest.json
- Getty images: https://media.getty.edu/iiif/manifest/db379bba-801c-4650-bc31-3ff2f712eb21

Staging branch URL: https://pr-6117.pfe-preview.zooniverse.org

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
