### PR TITLE
Project builder: Add a readme for IIIF manifests

### DIFF
--- a/app/pages/lab/iiif/Readme.md
+++ b/app/pages/lab/iiif/Readme.md
@@ -1,0 +1,15 @@
+# IIIF manifests
+
+Tools to create Panoptes subject sets from [IIIF](https://iiif.io) manifests, rather than CSV files.
+
+At the moment (28th March 2022) we only support [version 2 manifests](https://iiif.io/api/presentation/2.0/#manifest) (in `iiif/components/helpers/parseManifestV2.js`). 
+
+A manifest is represented in Panoptes as a single subject set. Each canvas in the manifest's default sequence (`manifest.sequences[0]`) is converted into a Panoptes subject with one image location. Manifest metadata is copied to the new subject set's metadata, and also to each subject, so that it can be displayed in the subject viewer.
+
+Each subject is assigned a `#priority` metadata key, in manifest sequence order and starting at 1, so that ordered subject selection can be used with workflows that have `workflow.prioritized` set.
+
+Subject images are externally hosted, using the [IIIF Image API](https://iiif.io/api/image/2.0/) service specified in the manifest for each canvas, eg.
+```js
+  import { MAX_WIDTH, MAX_HEIGHT } from `./parseManifestV2.js`;
+  const href = `https://api.bl.uk/image/iiif/ark:/81055/vdc_100022589175.0x000028/full/!${MAX_WIDTH},${MAX_HEIGHT_}/0/default.jpg`;
+``` 


### PR DESCRIPTION
A short Readme for IIIF manifests in the project builder.

Staging branch URL: https://pr-6118.pfe-preview.zooniverse.org

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
