### PR TITLE
Project Builder: IIIF: fix React errors

### DIFF
--- a/app/pages/lab/iiif/components/IIIFSubjectSet.jsx
+++ b/app/pages/lab/iiif/components/IIIFSubjectSet.jsx
@@ -45,7 +45,7 @@ export default function IIIFSubjectSet({ project }) {
       <button className="standard-button" onClick={onClick}>Fetch manifest</button>
       {error && <p><b>{error.status}: {error.message}</b></p>}
       {manifest && <MetadataEditor caption={manifest.label} metadata={metadata} onChange={setMetadata} />}
-      {subjects && <p>{subjects.slice(0,10).map(subject => <IIIFThumbnail key={subject.id} subject={subject} />)}</p>}
+      {subjects && <p>{subjects.slice(0,10).map(subject => <IIIFThumbnail key={subject.canvasID} subject={subject} />)}</p>}
       {subjects && <UploadButton manifest={manifest} metadata={metadata} project={project} subjects={subjects} />}
     </>
   )

--- a/app/pages/lab/iiif/components/MetadataEditor.jsx
+++ b/app/pages/lab/iiif/components/MetadataEditor.jsx
@@ -35,13 +35,15 @@ export default function MetadataEditor({
           <th>Hidden</th>
         </tr>
       </thead>
-    {Object.entries(metadata).map(([key, value]) => (
-      <tr key={key}>
-        <td><strong>{key}</strong></td>
-        <Markdown tag="td" content={value} inline />
-        <td><input type="checkbox" checked={key.startsWith('#')} name={key} value={value} onChange={onMetadataChange} /></td>
-      </tr>
-    ))}
+      <tbody>
+      {Object.entries(metadata).map(([key, value]) => (
+        <tr key={key}>
+          <td><strong>{key}</strong></td>
+          <Markdown tag="td" content={value} inline />
+          <td><input type="checkbox" checked={key.startsWith('#')} name={key} value={value} onChange={onMetadataChange} /></td>
+        </tr>
+      ))}
+      </tbody>
     </table>
   );
 }

--- a/app/pages/lab/iiif/components/helpers/parseManifestV2.js
+++ b/app/pages/lab/iiif/components/helpers/parseManifestV2.js
@@ -27,8 +27,9 @@ export default function parseManifestV2(manifest) {
   const [sequence] = sequences;
   const subjects = sequence.canvases.map((canvas, index) => {
     const alt = structures?.[index].label;
+    const canvasID = canvas['@id'];
     const { thumb, locations, metadata } = parseCanvas(canvas, index);
-    return { alt, locations, metadata, thumb };
+    return { alt, canvasID, locations, metadata, thumb };
   });
   const metadata = {
     "iiif:manifest": manifest['@id']


### PR DESCRIPTION
Fix a couple of small errors in the `IIIFSubjectSet` component and its children.
- Fix invalid DOM nesting in the metadata table by wrapping the table body in `<tbody>`.
- Fix missing keys for preview thumbnails by using the canvas identifier as a key for each image.

Staging branch URL: https://pr-6119.pfe-preview.zooniverse.org

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
