### PR TITLE
Project Builder: IIIF: improved language support

### DIFF
--- a/app/pages/lab/iiif/components/helpers/parseManifestV2.js
+++ b/app/pages/lab/iiif/components/helpers/parseManifestV2.js
@@ -24,12 +24,22 @@ function parseCanvas(canvas, index) {
 }
 
 function parseValue({ label, value }) {
-  if (value[`@language`]) {
-    const language = value[`@language`];
+  let language
+
+  if (value['@language']) {
+    language = value['@language'];
     label = `${label}:${language}`;
   }
 
-  if (value[`@value`]) {
+  if (label['@language']) {
+    language = label['@language'];
+    label = `${label['@value']}:${language}`;
+    if (Array.isArray(value)) {
+      value = value.find(v => v['@language'] === language)
+    }
+  }
+
+  if (value['@value']) {
     value = value['@value'];
   }
 
@@ -40,6 +50,10 @@ function parseValue({ label, value }) {
 }
 
 function parseMetadataItem({ label, value }) {
+  if (Array.isArray(label)) {
+    return label.map(l => parseValue({ label: l, value }))
+  }
+
   if (Array.isArray(value)) {
     return value.map(v => parseValue({ label, value: v }));
   }

--- a/app/pages/lab/iiif/components/helpers/parseManifestV2.spec.js
+++ b/app/pages/lab/iiif/components/helpers/parseManifestV2.spec.js
@@ -76,5 +76,37 @@ describe('parseManifestV2', function () {
       expect(metadata['Published:en']).to.equal('in Paris, 1790');
       expect(metadata['Published:fr']).to.equal('en Paris, 1790');
     })
+
+    it('should parse metadata labels in multiple languages', function () {
+      const mockManifest = {
+        metadata: [
+          {
+            label: [
+              { "@value":"Author", "@language": "en" },
+              { "@value":"Awdur", "@language": "cy-GB" }
+            ],
+            value:"Cardiganshire Constabulary"
+          },
+          {
+            label: [
+              { "@value":"Repository", "@language": "en" },
+              { "@value":"Ystorfa", "@language": "cy-GB" }
+            ],
+            value: [
+              { "@value":"This content has been digitised by The National Library of Wales", "@language": "en" },
+              { "@value":"Digidwyd y cynnwys hwn gan Lyfrgell Genedlaethol Cymru", "@language": "cy-GB" }
+            ]
+          }
+        ],
+        sequences: [
+          { canvases: [] }
+        ]
+      };
+      const { metadata } = parseManifestV2(mockManifest);
+      expect(metadata['Author:en']).to.equal('Cardiganshire Constabulary');
+      expect(metadata['Awdur:cy-GB']).to.equal('Cardiganshire Constabulary');
+      expect(metadata['Repository:en']).to.equal('This content has been digitised by The National Library of Wales');
+      expect(metadata['Ystorfa:cy-GB']).to.equal('Digidwyd y cynnwys hwn gan Lyfrgell Genedlaethol Cymru');
+    })
   })
 })


### PR DESCRIPTION
Support for bi-lingual IIIF manifests, as published by the National Library of Wales.

Try it out with this manifest:
https://damsssl.llgc.org.uk/iiif/2.0/4389767/manifest.json

Staging branch URL: https://pr-6120.pfe-preview.zooniverse.org

<img width="976" alt="Screenshot of the metadata from a Cardiganshire Constabulary register of criminals, with labels and values in both English and Welsh." src="https://user-images.githubusercontent.com/59547/160501708-f1b82c5c-a887-4054-9fe9-43e08d38a606.png">

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
