### PR TITLE
Project Builder: IIIF: handle subject upload errors

### DIFF
--- a/app/pages/lab/iiif/components/UploadButton.jsx
+++ b/app/pages/lab/iiif/components/UploadButton.jsx
@@ -39,13 +39,17 @@ export default function UploadButton({
   const [subjectSet, setSubjectSet] = useState(null);
   const [uploading, setUploading] = useState(false);
   const [uploadQueue, setUploadQueue] = useState([]);
-  const { loaded, uploadCount } = useSubjectUploads(uploadQueue, subjectSet);
+  const { error: uploadError, loaded, uploadCount } = useSubjectUploads(uploadQueue, subjectSet);
 
   useEffect(() => {
     if (loaded) {
       onLoad()
     }
   }, [loaded])
+
+  useEffect(() => {
+    setError(uploadError)
+  }, [uploadError])
 
   async function createSet() {
     try {
@@ -63,7 +67,7 @@ export default function UploadButton({
     <>
       {subjects && !uploading && <button className="standard-button" onClick={createSet}>Create a subject set</button>}
       {uploading && <p>Uploading {uploadCount}/{subjects.length} subjects.</p>}
-      {error && <p><strong>{error.message}</strong></p>}
+      {error && <p><strong>{error.status}: {error.message}</strong></p>}
       {loaded && <Link to={`/lab/${project.id}/subject-sets/${subjectSet.id}`}>{subjectSet.display_name}</Link>}
     </>
   )

--- a/app/pages/lab/iiif/components/hooks/useSubjectUploads.js
+++ b/app/pages/lab/iiif/components/hooks/useSubjectUploads.js
@@ -4,6 +4,7 @@ import { createSubject } from '../helpers'
 
 export default function useSubjectUploads(snapshots = [], subjectSet) {
   const [uploaded, setUploaded] = useState([])
+  const [error, setError] = useState(null)
   const [failed, setFailed] = useState([])
   const [finished, setFinished] = useState(false)
   const [loaded, setLoaded] = useState(false)
@@ -15,8 +16,11 @@ export default function useSubjectUploads(snapshots = [], subjectSet) {
       setUploaded(subjects => [...subjects, panoptesSubject])
       setUploadCount(count => count + 1)
     } catch (error) {
-      console.error(error)
-      setFailed(subjects => [...subjects, snapshot])
+      if (error.status) {
+        setError(error)
+      } else {
+        setFailed(subjects => [...subjects, snapshot])
+      }
     }
   }
 
@@ -46,5 +50,5 @@ export default function useSubjectUploads(snapshots = [], subjectSet) {
     }
   }, [failed, finished, uploaded])
 
-  return { loaded, uploadCount }
+  return { error, loaded, uploadCount }
 }


### PR DESCRIPTION
Improved error handling for subject uploads from an IIIF manifest.
- add an error state to the `useSubjectUploads` hook.
- report error status when `UploadButton` fails.
- don't retry if the API error has a status code. A status code either indicates that you aren't authorised to upload, or something is wrong with the API. In either case, retrying probably won't help.

Staging branch URL: https://pr-6121.pfe-preview.zooniverse.org

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
