### PR TITLE
Project Builder: IIIF: update project subject sets

### DIFF
--- a/app/pages/lab/iiif/components/IIIFSubjectSet.jsx
+++ b/app/pages/lab/iiif/components/IIIFSubjectSet.jsx
@@ -28,9 +28,8 @@ function parseManifest(manifest) {
   return { error }
 }
 
-export default function IIIFSubjectSet({ project }) {
+export default function IIIFSubjectSet({ project, onSubjectSetChange }) {
   let error
-
   const [metadata, setMetadata] = useState(null)
   const manifestUrl = useRef()
   const [url, setUrl] = useState('')
@@ -69,7 +68,13 @@ export default function IIIFSubjectSet({ project }) {
       {error && <p><b>{error.status}: {error.message}</b></p>}
       {manifest && metadata && <MetadataEditor caption={manifest.label} metadata={metadata} onChange={setMetadata} />}
       {subjects && <p>{subjects.slice(0,10).map(subject => <IIIFThumbnail key={subject.canvasID} subject={subject} />)}</p>}
-      {subjects && <UploadButton manifest={manifest} metadata={metadata} project={project} subjects={subjects} />}
+      {subjects && <UploadButton
+        manifest={manifest}
+        metadata={metadata}
+        project={project}
+        subjects={subjects}
+        onLoad={onSubjectSetChange}
+      />}
     </>
   )
 }

--- a/app/pages/lab/iiif/components/UploadButton.jsx
+++ b/app/pages/lab/iiif/components/UploadButton.jsx
@@ -55,6 +55,7 @@ export default function UploadButton({
     try {
       setUploading(true);
       const _subjectSet = await createSubjectSet(subjectSetSnapshot(manifest, metadata, project));
+      project.uncacheLink('subject_sets');
       setSubjectSet(_subjectSet);
       const _uploadQueue = subjects.map(subject => subjectSnapshot(metadata, project, subject));
       setUploadQueue(_uploadQueue);

--- a/app/pages/lab/iiif/components/UploadButton.spec.jsx
+++ b/app/pages/lab/iiif/components/UploadButton.spec.jsx
@@ -10,7 +10,7 @@ import manifest from './helpers/mockManifest.json';
 describe('IIIF > UploadButton', function () {
   let wrapper;
   const { metadata, subjects } = parseManifestV2(manifest);
-  const project = { id: 'testProject' };
+  const project = { id: 'testProject', uncacheLink: sinon.stub() };
 
   beforeEach(function () {
     wrapper = mount(<UploadButton manifest={manifest} metadata={metadata} project={project} subjects={subjects} />);

--- a/app/pages/lab/subject-sets-container.jsx
+++ b/app/pages/lab/subject-sets-container.jsx
@@ -17,6 +17,7 @@ export default class SubjectSetsContainer extends React.Component {
     this.onPageChange = this.onPageChange.bind(this);
     this.labPath = this.labPath.bind(this);
     this.createNewSubjectSet = this.createNewSubjectSet.bind(this);
+    this.getSubjectSets = this.getSubjectSets.bind(this);
   }
 
   componentDidMount() {
@@ -80,7 +81,8 @@ export default class SubjectSetsContainer extends React.Component {
       createNewSubjectSet: this.createNewSubjectSet,
       defaultSubjectSetName: DEFAULT_SUBJECT_SET_NAME,
       labPath: this.labPath,
-      onPageChange: this.onPageChange
+      onPageChange: this.onPageChange,
+      onSubjectSetChange: this.getSubjectSets
     };
 
     const allProps = Object.assign({}, this.state, this.props, hookProps);


### PR DESCRIPTION
- add an `onSubjectSetChange` hook to lab subject set pages, which can be run after we create a new set.
- pass down `getSubjectSets` to the upload button, so that the list of project subject sets is refreshed after uploading a new set.

Staging branch URL: https://pr-6122.pfe-preview.zooniverse.org

Fixes this issue, from https://github.com/zooniverse/Panoptes-Front-End/pull/6095#pullrequestreview-922206590

>[minor][UI/UX][quirk] if the user then clicks on the Subject Sets link in the Project Builder from the IIIF Uploader page or the created Subject Set page, then the newly created SSet will NOT be listed. This is because the "fetch list of SSets" doesn't trigger when you move from the /subject-sets/iiif (or /subject-sets/1234) route to /subject-sets. Just a quirk worth noting in case users are confused.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
