### PR TITLE
Project Builder: Add indexed subject sets

### DIFF
--- a/app/pages/lab/subject-set.cjsx
+++ b/app/pages/lab/subject-set.cjsx
@@ -13,6 +13,7 @@ UploadDropTarget = require '../../components/upload-drop-target'
 ManifestView = require '../../components/manifest-view'
 isAdmin = require '../../lib/is-admin'
 { addIndexFields, cleanSubjectData } = require './helpers/subject-sets'
+{ default: IndexedSubjectSet } = require './subject-sets/IndexedSubjectSet'
 
 NOOP = Function.prototype
 
@@ -196,6 +197,9 @@ EditSubjectSetPage = createReactClass
         </p>
       </form>
 
+      {if @props.subjectSet.metadata.indexFields
+        <IndexedSubjectSet subjectSet={@props.subjectSet} />
+      }
       <hr />
 
       This set contains {@props.subjectSet.set_member_subjects_count} subjects:<br />

--- a/app/pages/lab/subject-sets/IndexedSubjectSet.jsx
+++ b/app/pages/lab/subject-sets/IndexedSubjectSet.jsx
@@ -1,0 +1,32 @@
+import isAdmin from '../../../lib/is-admin';
+
+export default function IndexedSubjectSet({ subjectSet }) {
+  function updateMetadata(event) {
+    const data = new FormData(event.target);
+    const indexFields = data.get('indexFields');
+    subjectSet.update({ 'metadata.indexFields': indexFields });
+    subjectSet.save();
+    event.preventDefault();
+  }
+
+  const readOnly = !isAdmin()
+  return (
+    <>
+      <h4>Index settings</h4>
+      <p>Subjects in this set are indexed and searchable.</p>
+      <p><a href={`https://subject-set-search-api.zooniverse.org/subjects/${subjectSet.id}`}>View the index.</a></p>
+      <form onSubmit={updateMetadata}>
+        <label className="form-label" htmlFor="indexFields">Indexed metadata fields</label>
+        <input
+          id="indexFields"
+          name="indexFields"
+          className="standard-input full"
+          type="text"
+          disabled={readOnly}
+          defaultValue={subjectSet.metadata.indexFields}
+        />
+        {!readOnly && <button className="standard-button" type="submit">Save</button>}
+      </form>
+    </>
+  )
+}


### PR DESCRIPTION
Add a form to indexed subject sets, which lists the indexed subject metadata fields, and a link to the index in Datasette. Indexed fields are read-only for project owners, but can be edited by Zooniverse admins.

<img width="725" alt="Screenshot of the indexed subject set form, showing a disabled text input for the index fields and a link to the index in Datasette." src="https://user-images.githubusercontent.com/59547/160804996-842abf49-1ad2-434a-a2e4-7a9933675f0c.png">

Try it out on the RBGE Engaging crowds project
Staging branch URL: https://pr-{NUMBER}.pfe-preview.zooniverse.org/lab/12561?env=production

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
