### PR TITLE
Experiment: Free Rotation for Subject Viewer

### DIFF
--- a/app/components/frame-viewer.jsx
+++ b/app/components/frame-viewer.jsx
@@ -75,6 +75,7 @@ export default class FrameViewer extends React.Component {
         <PanZoom
           ref={(c) => { this.panZoom = c; }}
           enabled={this.props.zoomControls && zoomEnabled}
+          experimental_tools={this.props.project?.experimental_tools}
           frameDimensions={this.state.frameDimensions}
           subject={this.props.subject}
         >

--- a/app/components/pan-zoom.jsx
+++ b/app/components/pan-zoom.jsx
@@ -346,7 +346,7 @@ class PanZoom extends Component {
               <button title="rotate" className={'rotate fa fa-repeat'} onClick={this.rotateClockwise} />
             </div>
             {canUseFreeRotation && (
-              <div class="experimental-free-rotation">
+              <div className="experimental-free-rotation">
                 <input type="range" min={0} max={360} value={this.state.rotation % 360} onChange={this.rotateFreely} />
               </div>
             )}

--- a/app/components/pan-zoom.jsx
+++ b/app/components/pan-zoom.jsx
@@ -346,8 +346,8 @@ class PanZoom extends Component {
               <button title="rotate" className={'rotate fa fa-repeat'} onClick={this.rotateClockwise} />
             </div>
             {canUseFreeRotation && (
-              <div style={{ display: 'flex', height: '80px' }}>
-                <input style={{ width: '60px', transform: 'rotate(270deg)' }} type="range" min={0} max={360} value={this.state.rotation % 360} onChange={this.rotateFreely} />
+              <div class="experimental-free-rotation">
+                <input type="range" min={0} max={360} value={this.state.rotation % 360} onChange={this.rotateFreely} />
               </div>
             )}
             <div>

--- a/app/components/pan-zoom.jsx
+++ b/app/components/pan-zoom.jsx
@@ -9,6 +9,7 @@ class PanZoom extends Component {
     this.frameKeyPan = this.frameKeyPan.bind(this);
     this.panByDrag = this.panByDrag.bind(this);
     this.rotateClockwise = this.rotateClockwise.bind(this);
+    this.rotateFreely = this.rotateFreely.bind(this);
     this.stopZoom = this.stopZoom.bind(this);
     this.togglePanOn = this.togglePanOn.bind(this);
     this.togglePanOff = this.togglePanOff.bind(this);
@@ -261,11 +262,24 @@ class PanZoom extends Component {
   }
 
   rotateClockwise() {
-    const newRotation = this.state.rotation + 90;
+    const newRotation = (this.state.rotation + 90) % 360;
     this.setState({
       rotation: newRotation,
       transform: `rotate(${newRotation} ${this.props.frameDimensions.width / 2} ${this.props.frameDimensions.height / 2})`
     });
+  }
+
+  /*
+  TODO: hide this behind an experimental flag
+   */
+  rotateFreely(event) {
+    if (!event?.target) return
+    const newRotation = event.target.value % 360
+    console.log(newRotation)
+    this.setState({
+      rotation: newRotation,
+      transform: `rotate(${newRotation} ${this.props.frameDimensions.width / 2} ${this.props.frameDimensions.height / 2})`
+    })
   }
 
   render() {
@@ -330,6 +344,9 @@ class PanZoom extends Component {
             </div>
             <div>
               <button title="rotate" className={'rotate fa fa-repeat'} onClick={this.rotateClockwise} />
+            </div>
+            <div style={{ display: 'flex', height: '80px' }}>
+              <input style={{ width: '60px', transform: 'rotate(270deg)' }} type="range" min={0} max={360} value={this.state.rotation % 360} onChange={this.rotateFreely} />
             </div>
             <div>
               <button

--- a/app/components/pan-zoom.jsx
+++ b/app/components/pan-zoom.jsx
@@ -281,7 +281,7 @@ class PanZoom extends Component {
   }
 
   render() {
-    console.log('+++ experimental_tools: ', this.props.experimental_tools)
+    const canUseFreeRotation = this.props.experimental_tools?.indexOf?.('subjectViewer-freeRotation') > -1
 
     const children = React.Children.map(this.props.children, child =>
       React.cloneElement(child, {
@@ -345,9 +345,11 @@ class PanZoom extends Component {
             <div>
               <button title="rotate" className={'rotate fa fa-repeat'} onClick={this.rotateClockwise} />
             </div>
-            <div style={{ display: 'flex', height: '80px' }}>
-              <input style={{ width: '60px', transform: 'rotate(270deg)' }} type="range" min={0} max={360} value={this.state.rotation % 360} onChange={this.rotateFreely} />
-            </div>
+            {canUseFreeRotation && (
+              <div style={{ display: 'flex', height: '80px' }}>
+                <input style={{ width: '60px', transform: 'rotate(270deg)' }} type="range" min={0} max={360} value={this.state.rotation % 360} onChange={this.rotateFreely} />
+              </div>
+            )}
             <div>
               <button
                 title="reset zoom levels"

--- a/app/components/pan-zoom.jsx
+++ b/app/components/pan-zoom.jsx
@@ -347,7 +347,7 @@ class PanZoom extends Component {
             </div>
             {canUseFreeRotation && (
               <div className="experimental-free-rotation">
-                <input type="range" min={0} max={360} value={this.state.rotation % 360} onChange={this.rotateFreely} />
+                <input type="range" min={0} max={359} value={this.state.rotation % 360} onChange={this.rotateFreely} />
               </div>
             )}
             <div>

--- a/app/components/pan-zoom.jsx
+++ b/app/components/pan-zoom.jsx
@@ -268,9 +268,6 @@ class PanZoom extends Component {
     });
   }
 
-  /*
-  TODO: hide this behind an experimental flag
-   */
   rotateFreely(event) {
     if (!event?.target) return
     const newRotation = event.target.value % 360

--- a/app/components/pan-zoom.jsx
+++ b/app/components/pan-zoom.jsx
@@ -30,7 +30,6 @@ class PanZoom extends Component {
     };
   }
 
-
   componentDidMount() {
     // these events enable a user to navigate an image using arrows, +, and - keys,
     // while the user is in pan and zoom mode.
@@ -275,7 +274,6 @@ class PanZoom extends Component {
   rotateFreely(event) {
     if (!event?.target) return
     const newRotation = event.target.value % 360
-    console.log(newRotation)
     this.setState({
       rotation: newRotation,
       transform: `rotate(${newRotation} ${this.props.frameDimensions.width / 2} ${this.props.frameDimensions.height / 2})`
@@ -283,6 +281,8 @@ class PanZoom extends Component {
   }
 
   render() {
+    console.log('+++ experimental_tools: ', this.props.experimental_tools)
+
     const children = React.Children.map(this.props.children, child =>
       React.cloneElement(child, {
         viewBoxDimensions: this.state.viewBoxDimensions,
@@ -366,6 +366,7 @@ class PanZoom extends Component {
 PanZoom.propTypes = {
   children: PropTypes.node,
   enabled: PropTypes.bool,
+  experimental_tools: PropTypes.array,  // Taken from project.experimental_tools
   frameDimensions: PropTypes.shape({
     height: PropTypes.number,
     width: PropTypes.number
@@ -378,6 +379,7 @@ PanZoom.propTypes = {
 PanZoom.defaultProps = {
   children: null,
   enabled: false,
+  experimental_tools: [],
   frameDimensions: {
     height: 0,
     width: 0

--- a/app/components/pan-zoom.spec.js
+++ b/app/components/pan-zoom.spec.js
@@ -23,6 +23,10 @@ describe('PanZoom', function () {
       assert.equal(wrapper.find('button.reset').length, 1);
     });
 
+    it('should NOT, by default, render experimental free rotation slider', function () {
+      assert.equal(wrapper.find('.experimental-free-rotation').length, 0);
+    });
+
     it('if this.state.panEnabled is false, PanZoom should render a pointer button', function () {
       assert.equal(wrapper.find('button.fa-mouse-pointer').length, 1);
     });
@@ -453,6 +457,30 @@ describe('PanZoom', function () {
         const updatedTransformation = `rotate(90 ${wrapper.props().frameDimensions.width / 2} ${wrapper.props().frameDimensions.height / 2})`;
 
         assert.equal(wrapper.state('transform'), updatedTransformation);
+      });
+    });
+
+    describe('#rotateFreely() (Experimental)', function () {
+      let originalFrameDimensions;
+      let wrapper;
+
+      beforeEach(function () {
+        originalFrameDimensions = { width: 100, height: 100, x: 0, y: 0 };
+        wrapper = mount(<PanZoom enabled={true} frameDimensions={originalFrameDimensions} experimental_tools={['subjectViewer-freeRotation']} />);
+      });
+
+      it('should render experimental free rotation slider when specified', function () {
+        assert.equal(wrapper.find('.experimental-free-rotation').length, 1);
+      });
+
+      it('should set this.state.rotation to the free rotation slider\'s value', function () {
+        const sliderEvent = {
+          target: {
+            value: 69
+          }
+        }
+        wrapper.instance().rotateFreely(sliderEvent);
+        assert.equal(wrapper.state('rotation'), 69);
       });
     });
   });

--- a/app/pages/admin/project-status/experimental-features.jsx
+++ b/app/pages/admin/project-status/experimental-features.jsx
@@ -27,6 +27,7 @@ const experimentalFeatures = [
   'sim notification',
   'slider',
   'subjectGroupViewer', // Enables Subject Group Viewer and Subject Group Comparison Task, used for grid-like cell selection tasks. SGV and SGCT can be edited in PFE, but only works on the FEM classifier.
+  'subjectViewer-freeRotation',  // Allows PFE Subject Viewer to rotate freely instead of in 90 degree increments
   'temporalPoint', // temporal tools only works in FEM!
   'temporalRotateRectangle', // temporal tools only works in FEM!
   'transcription-task',

--- a/css/subject-viewer.styl
+++ b/css/subject-viewer.styl
@@ -107,6 +107,8 @@
 
       .experimental-free-rotation
         display: flex
+        justify-content: center
+        width: 2em
         height: 5.5em
 
         input[type=range]

--- a/css/subject-viewer.styl
+++ b/css/subject-viewer.styl
@@ -105,6 +105,14 @@
           background-color: #bbc0c0
           color: #575959
 
+      .experimental-free-rotation
+        display: flex
+        height: 5.5em
+
+        input[type=range]
+          width: 5em
+          transform: rotate(270deg)
+
   &.subject-viewer--invert
     // Talk
     &.subject-viewer--layout-grid4
@@ -125,19 +133,19 @@
     .subject-container
       align-items: center
       justify-content: space-between
-      
+
       // For certain Subject types, e.g. Subject Groups, individual images are linked to individual subjects
       > a.linked-image
         outline: 1px solid TEAL_MID
         display: block
         margin-bottom: 0.2em
-        
+
         img
           display: block
 
         &:focus, &:hover
           outline: 1px solid MAIN_HIGHLIGHT
-      
+
     &.subject-viewer--layout-grid2
       .subject-container > *
         width: 49%


### PR DESCRIPTION
## PR Overview - EXPERIMENTAL

Affects: Subject Viewer

This PR adds an experimental feature to the Subject Viewer, which allows the Subject image to be rotated freely (instead of being locked into 90-degree rotations).

<img width="569" alt="image" src="https://user-images.githubusercontent.com/13952701/161785396-27b55323-dc1e-4902-a7aa-abd10248c46c.png">

_In the image above, there's a new vertical slider/range input (below the old "Rotate" button and above the "Reset" button) on the image toolbar, which allows users to set an arbitrary rotation for the Subject images._

Preview: https://pr-6127.pfe-preview.zooniverse.org/projects/ellenjj/rosetta-zoo/classify?env=production

### Status

Experimental.
- To be properly reviewed on a hackday.
- Feature needs to be hidden behind an experimental flag