### PR TITLE
Add TextFromSubject task to FEM lab

### DIFF
--- a/app/classifier/tasks/index.jsx
+++ b/app/classifier/tasks/index.jsx
@@ -1,15 +1,16 @@
-import ComboTask from './combo/';
+import ComboTask from './combo';
 import SingleTask from './single';
 import MultipleTask from './multiple';
-import DrawingTask from './drawing/';
-import SurveyTask from './survey/';
-import CropTask from './crop/';
-import SliderTask from './slider/';
-import TextTask from './text/';
-import DropdownTask from './dropdown/';
-import ShortcutTask from './shortcut/';
-import Highlighter from './highlighter/';
-import TranscriptionTask from './transcription'
+import DrawingTask from './drawing';
+import SurveyTask from './survey';
+import CropTask from './crop';
+import SliderTask from './slider';
+import TextTask from './text';
+import TextFromSubjectTask from './textFromSubject';
+import DropdownTask from './dropdown';
+import ShortcutTask from './shortcut';
+import Highlighter from './highlighter';
+import TranscriptionTask from './transcription';
 import SubjectGroupComparisonTask from './subjectGroupComparison';
 
 const tasks = {
@@ -21,11 +22,12 @@ const tasks = {
   crop: CropTask,
   slider: SliderTask,
   text: TextTask,
+  textFromSubject: TextFromSubjectTask,
   dropdown: DropdownTask,
   shortcut: ShortcutTask,
   highlighter: Highlighter,
   transcription: TranscriptionTask,
-  subjectGroupComparison: SubjectGroupComparisonTask,
+  subjectGroupComparison: SubjectGroupComparisonTask
 };
 
 export default tasks;

--- a/app/classifier/tasks/textFromSubject/editor.jsx
+++ b/app/classifier/tasks/textFromSubject/editor.jsx
@@ -1,0 +1,100 @@
+import { MarkdownEditor, MarkdownHelp } from 'markdownz';
+import PropTypes from 'prop-types';
+import React from 'react';
+import AutoSave from '../../../components/auto-save';
+import alert from '../../../lib/alert';
+import handleInputChange from '../../../lib/handle-input-change';
+import NextTaskSelector from '../next-task-selector';
+
+export default class TextFromSubjectEditor extends React.Component {
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    const props = this.props;
+    const handleChange = handleInputChange.bind(props.workflow);
+
+    return (
+      <div className="text-editor">
+        <section>
+          <div>
+            <AutoSave resource={props.workflow}>
+              <span className="form-label">Main text</span>
+              <br />
+              <textarea
+                name={`${props.taskPrefix}.instruction`}
+                value={props.task.instruction}
+                className="standard-input full"
+                onChange={handleChange}
+              />
+            </AutoSave>
+            <small className="form-help">
+              Describe the task, or ask the question, in a way that is clear to a non-expert. You can use markdown to format this text.
+            </small>
+            <br />
+          </div>
+          <br />
+          <div>
+            <AutoSave resource={props.workflow}>
+              <span className="form-label">Help text</span>
+              <br />
+              <MarkdownEditor
+                name={`${props.taskPrefix}.help`}
+                value={props.task.help}
+                rows="4"
+                className="full"
+                onChange={handleChange}
+                onHelp={() => alert(<MarkdownHelp />)}
+              />
+            </AutoSave>
+            <small className="form-help">
+              Add text and images for a help window.
+            </small>
+          </div>
+        </section>
+        <hr />
+        <AutoSave resource={props.workflow}>
+          <span className="form-label">
+            Next task
+          </span>
+          <br />
+          <NextTaskSelector
+            task={props.task}
+            workflow={props.workflow}
+            name={`${props.taskPrefix}.next`}
+            value={props.task.next}
+            onChange={handleInputChange.bind(props.workflow)}
+          />
+        </AutoSave>
+      </div>
+    );
+  }
+}
+
+TextFromSubjectEditor.propTypes = {
+  taskPrefix: PropTypes.string,
+  task: PropTypes.shape(
+    {
+      help: PropTypes.string,
+      instruction: PropTypes.string,
+      next: PropTypes.string
+    }
+  ),
+  workflow: PropTypes.shape(
+    {
+      tasks: PropTypes.object,
+      update: PropTypes.func
+    }
+  )
+};
+
+TextFromSubjectEditor.defaultProps = {
+  taskPrefix: 'T0',
+  task: {
+    help: '',
+    instruction: '',
+    next: ''
+  },
+  workflow: { }
+};

--- a/app/classifier/tasks/textFromSubject/editor.jsx
+++ b/app/classifier/tasks/textFromSubject/editor.jsx
@@ -18,9 +18,15 @@ export default function TextFromSubjectEditor({
       <section>
         <div>
           <AutoSave resource={workflow}>
-            <span className="form-label">Main text</span>
+            <label
+              className="form-label"
+              htmlFor={`${taskPrefix}-instruction`}
+            >
+              Main text
+            </label>
             <br />
             <textarea
+              id={`${taskPrefix}-instruction`}
               name={`${taskPrefix}.instruction`}
               value={task.instruction}
               className="standard-input full"

--- a/app/classifier/tasks/textFromSubject/editor.jsx
+++ b/app/classifier/tasks/textFromSubject/editor.jsx
@@ -6,74 +6,70 @@ import alert from '../../../lib/alert';
 import handleInputChange from '../../../lib/handle-input-change';
 import NextTaskSelector from '../next-task-selector';
 
-export default class TextFromSubjectEditor extends React.Component {
-  constructor(props) {
-    super(props);
-  }
+export default function TextFromSubjectEditor({
+  task,
+  taskPrefix,
+  workflow
+}) {
+  const handleChange = handleInputChange.bind(workflow);
 
-  render() {
-    const props = this.props;
-    const handleChange = handleInputChange.bind(props.workflow);
-
-    return (
-      <div className="text-editor">
-        <section>
-          <div>
-            <AutoSave resource={props.workflow}>
-              <span className="form-label">Main text</span>
-              <br />
-              <textarea
-                name={`${props.taskPrefix}.instruction`}
-                value={props.task.instruction}
-                className="standard-input full"
-                onChange={handleChange}
-              />
-            </AutoSave>
-            <small className="form-help">
-              Describe the task, or ask the question, in a way that is clear to a non-expert. You can use markdown to format this text.
-            </small>
+  return (
+    <div className="text-editor">
+      <section>
+        <div>
+          <AutoSave resource={workflow}>
+            <span className="form-label">Main text</span>
             <br />
-          </div>
+            <textarea
+              name={`${taskPrefix}.instruction`}
+              value={task.instruction}
+              className="standard-input full"
+              onChange={handleChange}
+            />
+          </AutoSave>
+          <small className="form-help">
+            Describe the task, or ask the question, in a way that is clear to a non-expert. You can use markdown to format this text.
+          </small>
           <br />
-          <div>
-            <AutoSave resource={props.workflow}>
-              <span className="form-label">Help text</span>
-              <br />
-              <MarkdownEditor
-                name={`${props.taskPrefix}.help`}
-                value={props.task.help}
-                rows="4"
-                className="full"
-                onChange={handleChange}
-                onHelp={() => alert(<MarkdownHelp />)}
-              />
-            </AutoSave>
-            <small className="form-help">
-              Add text and images for a help window.
-            </small>
-          </div>
-        </section>
-        <hr />
-        <AutoSave resource={props.workflow}>
-          <span className="form-label">
-            Next task
-          </span>
-          <br />
-          <NextTaskSelector
-            task={props.task}
-            workflow={props.workflow}
-            name={`${props.taskPrefix}.next`}
-            value={props.task.next}
-            onChange={handleInputChange.bind(props.workflow)}
-          />
-        </AutoSave>
-      </div>
-    );
-  }
+        </div>
+        <br />
+        <div>
+          <AutoSave resource={workflow}>
+            <span className="form-label">Help text</span>
+            <br />
+            <MarkdownEditor
+              name={`${taskPrefix}.help`}
+              value={task.help}
+              rows="4"
+              className="full"
+              onChange={handleChange}
+              onHelp={() => alert(<MarkdownHelp />)}
+            />
+          </AutoSave>
+          <small className="form-help">
+            Add text and images for a help window.
+          </small>
+        </div>
+      </section>
+      <hr />
+      <AutoSave resource={workflow}>
+        <span className="form-label">
+          Next task
+        </span>
+        <br />
+        <NextTaskSelector
+          task={task}
+          workflow={workflow}
+          name={`${taskPrefix}.next`}
+          value={task.next}
+          onChange={handleInputChange.bind(workflow)}
+        />
+      </AutoSave>
+    </div>
+  );
 }
 
 TextFromSubjectEditor.propTypes = {
-  taskPrefix: PropTypes.string,
   task: PropTypes.shape(
     {
       help: PropTypes.string,
@@ -81,6 +77,7 @@ TextFromSubjectEditor.propTypes = {
       next: PropTypes.string
     }
   ),
+  taskPrefix: PropTypes.string,
   workflow: PropTypes.shape(
     {
       tasks: PropTypes.object,
@@ -90,11 +87,11 @@ TextFromSubjectEditor.propTypes = {
 };
 
 TextFromSubjectEditor.defaultProps = {
-  taskPrefix: 'T0',
   task: {
     help: '',
     instruction: '',
     next: ''
   },
+  taskPrefix: '',
   workflow: { }
 };

--- a/app/classifier/tasks/textFromSubject/editor.spec.js
+++ b/app/classifier/tasks/textFromSubject/editor.spec.js
@@ -1,0 +1,54 @@
+/* eslint prefer-arrow-callback: 0, func-names: 0, 'react/jsx-boolean-value': ['error', 'always'], 'react/jsx-filename-extension': 0 */
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import React from 'react';
+import sinon from 'sinon';
+
+import mockPanoptesResource from '../../../../test/mock-panoptes-resource';
+
+import TextFromSubjectEditor from './editor';
+
+const mockTextFromSubjectTask = {
+  help: '',
+  instruction: 'Correct the text',
+  type: 'textFromSubject'
+};
+
+describe('TextFromSubjectEditor', function () {
+  let mockWorkflow;
+  let wrapper;
+  let workflowUpdateSpy;
+
+  beforeEach(function () {
+    workflowUpdateSpy = sinon.spy();
+    mockWorkflow = mockPanoptesResource('workflows', {});
+    mockWorkflow.update = workflowUpdateSpy;
+    wrapper = shallow(
+      <TextFromSubjectEditor
+        task={mockTextFromSubjectTask}
+        taskPrefix="T0"
+        workflow={mockWorkflow}
+      />
+    );
+  });
+
+  it('should render without crashing', function () {
+    expect(wrapper).to.be.ok;
+  });
+
+  it('should update the instructions when changed', function () {
+    const mainTextTextarea = wrapper.find('textarea');
+    mainTextTextarea.simulate('change', { target: { name: 'tasks.T0.instruction', value: 'Correct the OCR' }});
+    expect(workflowUpdateSpy).to.have.been.calledWith({ 'tasks.T0.instruction': 'Correct the OCR' });
+  });
+
+  it('should update the help when changed', function () {
+    const helpInput = wrapper.find('MarkdownEditor');
+    helpInput.simulate('change', { target: { name: 'tasks.T0.help', value: 'new help text' }});
+    expect(workflowUpdateSpy).to.have.been.calledWith({ 'tasks.T0.help': 'new help text' });
+  });
+
+  it('should render the NextTaskSelector component', function () {
+    expect(wrapper.find('NextTaskSelector')).to.have.lengthOf(1);
+  });
+});

--- a/app/classifier/tasks/textFromSubject/index.jsx
+++ b/app/classifier/tasks/textFromSubject/index.jsx
@@ -1,0 +1,18 @@
+import TextFromSubjectTaskEditor from './editor';
+
+const TextFromSubjectTask = {};
+
+// Define the static methods and values
+
+TextFromSubjectTask.Editor = TextFromSubjectTaskEditor;
+TextFromSubjectTask.getDefaultAnnotation = () => ({
+  value: ''
+});
+TextFromSubjectTask.getDefaultTask = () => ({
+  help: '',
+  instruction: 'Correct the text',
+  type: 'textFromSubject'
+});
+TextFromSubjectTask.getTaskText = task => (task.instruction);
+
+export default TextFromSubjectTask;

--- a/app/classifier/tasks/textFromSubject/index.jsx
+++ b/app/classifier/tasks/textFromSubject/index.jsx
@@ -1,6 +1,27 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
 import TextFromSubjectTaskEditor from './editor';
 
-const TextFromSubjectTask = {};
+// The TextFromSubject task is an experimental FEM task.
+// The TextFromSubject task is a text task that initializes the annotation value from a text subject's content.
+
+export default class TextFromSubjectTask extends React.Component {
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    return (
+      <div>
+        <p>
+          The TextFromSubject task is designed exclusively for the front-end-monorepo.
+          It is not intended to be used in Panoptes-Front-End.
+        </p>
+      </div>
+    );
+  }
+}
 
 // Define the static methods and values
 
@@ -14,5 +35,5 @@ TextFromSubjectTask.getDefaultTask = () => ({
   type: 'textFromSubject'
 });
 TextFromSubjectTask.getTaskText = task => (task.instruction);
-
-export default TextFromSubjectTask;
+// isAnnotationComplete will return false within PFE to prevent classifications from being submitted within PFE, as the TextFromSubject task is exclusively for the front-end-monorepo.
+TextFromSubjectTask.isAnnotationComplete = () => false;

--- a/app/classifier/tasks/textFromSubject/index.jsx
+++ b/app/classifier/tasks/textFromSubject/index.jsx
@@ -1,4 +1,3 @@
-import PropTypes from 'prop-types';
 import React from 'react';
 
 import TextFromSubjectTaskEditor from './editor';
@@ -6,21 +5,15 @@ import TextFromSubjectTaskEditor from './editor';
 // The TextFromSubject task is an experimental FEM task.
 // The TextFromSubject task is a text task that initializes the annotation value from a text subject's content.
 
-export default class TextFromSubjectTask extends React.Component {
-  constructor(props) {
-    super(props);
-  }
-
-  render() {
-    return (
-      <div>
-        <p>
-          The TextFromSubject task is designed exclusively for the front-end-monorepo.
-          It is not intended to be used in Panoptes-Front-End.
-        </p>
-      </div>
-    );
-  }
+export default function TextFromSubjectTask() {
+  return (
+    <div>
+      <p>
+        The TextFromSubject task is designed exclusively for the front-end-monorepo.
+        It is not intended to be used in Panoptes-Front-End.
+      </p>
+    </div>
+  );
 }
 
 // Define the static methods and values

--- a/app/classifier/tasks/textFromSubject/index.spec.js
+++ b/app/classifier/tasks/textFromSubject/index.spec.js
@@ -1,0 +1,23 @@
+/* eslint prefer-arrow-callback: 0, func-names: 0, 'react/jsx-boolean-value': ['error', 'always'], 'react/jsx-filename-extension': 0 */
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import TextFromSubjectTask from '.';
+
+describe('TextFromSubjectTask', function () {
+  it('should render without crashing', function () {
+    const wrapper = shallow(<TextFromSubjectTask />);
+    expect(wrapper).to.be.ok;
+  });
+
+  describe('static methods', function () {
+    it('should be incomplete', function () {
+      expect(TextFromSubjectTask.isAnnotationComplete()).to.be.false;
+    });
+
+    it('should have the correct instruction text', function () {
+      expect(TextFromSubjectTask.getTaskText({ instruction: 'Correct the OCR text' })).to.equal('Correct the OCR text');
+    });
+  });
+});

--- a/app/pages/admin/project-status/experimental-features.jsx
+++ b/app/pages/admin/project-status/experimental-features.jsx
@@ -30,6 +30,7 @@ const experimentalFeatures = [
   'subjectViewer-freeRotation',  // Allows PFE Subject Viewer to rotate freely instead of in 90 degree increments
   'temporalPoint', // temporal tools only works in FEM!
   'temporalRotateRectangle', // temporal tools only works in FEM!
+  'textFromSubject', // textFromSubject task only works in FEM!
   'transcription-task',
   'translator-role',
   'wildcam classroom', // Indicates a Project is linked to a "WildCam Lab"-type Zooniverse Classroom. Allows the classifier to select a workflow (i.e. "classroom assignment") directly via ID.

--- a/app/pages/lab-fem/workflow.cjsx
+++ b/app/pages/lab-fem/workflow.cjsx
@@ -174,6 +174,7 @@ EditWorkflowPage = createReactClass
                             when 'flexibleSurvey' then <i className="fa fa-binoculars fa-fw"></i>
                             when 'crop' then <i className="fa fa-crop fa-fw"></i>
                             when 'text' then <i className="fa fa-file-text-o fa-fw"></i>
+                            when 'textFromSubject' then <i className="fa fa-file-text-o fa-fw"></i>
                             when 'dropdown' then <i className="fa fa-list fa-fw"></i>
                             when 'combo' then <i className="fa fa-cubes fa-fw"></i>
                             when 'slider' then <i className="fa fa-sliders fa-fw"></i>
@@ -216,6 +217,14 @@ EditWorkflowPage = createReactClass
                         <small><strong>Text</strong></small>
                       </button>
                     </AutoSave>{' '}
+                    {if @canUseTask(@props.project, "textFromSubject")
+                      <AutoSave resource={@props.workflow}>
+                        <button type="button" className="minor-button" onClick={@addNewTask.bind this, 'textFromSubject'} title="Text from subject tasks: the volunteer corrects text provided by subject text location.">
+                          <i className="fa fa-file-text-o fa-2x"></i>
+                          <br />
+                          <small><strong>Text from Subject</strong></small>
+                        </button>
+                      </AutoSave>}{' '}
                     <AutoSave resource={@props.workflow}>
                       <button type="button" className="minor-button" onClick={@addNewTask.bind this, 'survey'} title="Survey tasks: the volunteer identifies objects (usually animals) in the image(s) by filtering by their visible charactaristics, then answers questions about them.">
                         <i className="fa fa-binoculars fa-2x"></i>


### PR DESCRIPTION
Staging branch URL: https://pr-6131.pfe-preview.zooniverse.org
- https://pr-6131.pfe-preview.zooniverse.org/lab/1952/workflows/3602

See related [FEM DigiLeap project](https://github.com/zooniverse/front-end-monorepo/projects/17) and specifically documentation related https://github.com/zooniverse/front-end-monorepo/pull/3008.

Describe your changes.
- add `textFromSubject` task to admin project experimental features
- add `Text from Subject` option to FEM lab task options
- add `textFromSubject` task with placeholder component
- add `textFromSubject` task editor

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
