### PR TITLE
[Security] bump moment to 2.29.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "lodash": "~4.17.11",
         "markdownz": "~7.8.1",
         "modal-form": "~2.9",
-        "moment": "~2.24.0",
+        "moment": "~2.29.0",
         "panoptes-client": "~3.3.2",
         "papaparse": "^5.2.0",
         "polished": "~2.3.3",
@@ -10627,8 +10627,9 @@
       }
     },
     "node_modules/moment": {
-      "version": "2.24.0",
-      "license": "MIT",
+      "version": "2.29.3",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.3.tgz",
+      "integrity": "sha512-c6YRvhEo//6T2Jz/vVtYzqBzwvPT95JBQ+smCytzf7c50oMZRsR/a4w88aD34I+/QVSfnoAnSBFPJHItlOMJVw==",
       "engines": {
         "node": "*"
       }
@@ -23651,7 +23652,9 @@
       }
     },
     "moment": {
-      "version": "2.24.0"
+      "version": "2.29.3",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.3.tgz",
+      "integrity": "sha512-c6YRvhEo//6T2Jz/vVtYzqBzwvPT95JBQ+smCytzf7c50oMZRsR/a4w88aD34I+/QVSfnoAnSBFPJHItlOMJVw=="
     },
     "moo": {
       "version": "0.5.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lodash": "~4.17.11",
     "markdownz": "~7.8.1",
     "modal-form": "~2.9",
-    "moment": "~2.24.0",
+    "moment": "~2.29.0",
     "panoptes-client": "~3.3.2",
     "papaparse": "^5.2.0",
     "polished": "~2.3.3",


### PR DESCRIPTION
Upgrade `moment` to the latest version.

Staging branch URL: https://pr-6134.pfe-preview.zooniverse.org

Closes https://github.com/zooniverse/how-to-zooniverse/issues/274

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
