### PR TITLE
Make rotate slider use all remaining space in the pan/zoom controls area

### DIFF
--- a/app/components/pan-zoom.jsx
+++ b/app/components/pan-zoom.jsx
@@ -344,7 +344,7 @@ class PanZoom extends Component {
             </div>
             {canUseFreeRotation && (
               <div className="experimental-free-rotation">
-                <input type="range" min={0} max={359} value={this.state.rotation % 360} onChange={this.rotateFreely} />
+                <input type="range" min={0} max={359} value={this.state.rotation % 360} onChange={this.rotateFreely} orient="vertical" />
               </div>
             )}
             <div>

--- a/css/subject-viewer.styl
+++ b/css/subject-viewer.styl
@@ -81,6 +81,9 @@
       text-align: center
       background: grey;
       border-radius: .1em;
+      display: flex
+      flex-direction: column
+
       .draw-pan-toggle
         background-color: #F9F9F9
         border: solid 1px #989898
@@ -106,14 +109,18 @@
           color: #575959
 
       .experimental-free-rotation
+        flex-grow: 1
         display: flex
+        flex-direction: column
         justify-content: center
+        align-items: center
         width: 2em
-        height: 5.5em
+        padding-top: 0.5em
+        padding-bottom: 0.5em
 
         input[type=range]
-          width: 5em
-          transform: rotate(270deg)
+          flex-grow: 1
+          -webkit-appearance: slider-vertical
 
   &.subject-viewer--invert
     // Talk


### PR DESCRIPTION
Staging branch URL: https://pr-6140.pfe-preview.zooniverse.org

The experimental rotation slider in use at https://www.zooniverse.org/projects/ellenjj/rosetta-zoo/classify was quite short. This was also a frequent item mentioned in the beta review comments: due to it's small size, it was harder to set the angle than it needed to be.

I've switched the CSS over to use vendor prefixes rather than the commonly used rotation trick, because setting an element to full but dynamic "height" after rotation cannot really be done with CSS alone. I hope that this is okay, especially for a tool that's behind an experimental flag. If it cannot be accepted because of this, let me know and I'll rework it to just make it a bit bigger but still statically sized.

Manually tested in Chrome, EdgeChrome, Firefox, iOS Safari and the combination of `webkit` prefix and `orient` attribute for Firefox seems to cover all supported browsers. I don't have access to an Android device for testing.

<img width="1413" alt="image" src="https://user-images.githubusercontent.com/277/166459257-557a45cf-8f5d-4c0e-bb2e-2fcaaa8843df.png">


# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
