### PR TITLE
Add description for survey task alwaysShowThumbnails

### DIFF
--- a/app/classifier/tasks/survey/editor.cjsx
+++ b/app/classifier/tasks/survey/editor.cjsx
@@ -283,12 +283,19 @@ module.exports = createReactClass
 
       <hr />
 
-      <label>
-        <AutoSave resource={@props.workflow}>
-          <input type="checkbox" name="#{@props.taskPrefix}.alwaysShowThumbnails" checked={@props.task.alwaysShowThumbnails} onChange={handleInputChange.bind @props.workflow} />{' '}
-          Always show thumbnails
-        </AutoSave>
-      </label>
+      <div>
+        <label>
+          <AutoSave resource={@props.workflow}>
+            <input type="checkbox" name="#{@props.taskPrefix}.alwaysShowThumbnails" checked={@props.task.alwaysShowThumbnails} onChange={handleInputChange.bind @props.workflow} />{' '}
+            Always show thumbnails
+          </AutoSave>
+        </label>
+        <p>
+          <small>
+            If checked then thumbnails will always show as small. If unchecked then thumbnails will show as small, medium, large, or not at all (choices > 30) based on the number of choices shown. The number of choices shown will change based on filters.
+          </small>
+        </p>
+      </div>
     </div>
 
   handleImportTabs: (tab) ->

--- a/app/classifier/tasks/survey/editor.cjsx
+++ b/app/classifier/tasks/survey/editor.cjsx
@@ -292,7 +292,7 @@ module.exports = createReactClass
         </label>
         <p>
           <small>
-            If checked then thumbnails will always show as small. If unchecked then thumbnails will show as small, medium, large, or not at all (choices > 30) based on the number of choices shown. The number of choices shown will change based on filters.
+            If checked, then thumbnails will always show as small. If unchecked, then thumbnails will show as small, medium, large, or not at all (when choices > 30) based on the number of choices shown. The number of choices shown will change based on filters.
           </small>
         </p>
       </div>


### PR DESCRIPTION
Staging branch URL: https://pr-6143.pfe-preview.zooniverse.org

- review here: https://pr-6143.pfe-preview.zooniverse.org/lab/4312/workflows/20254?env=production

Clarifies survey task setting `alwaysShowThumbnails` consequences.

Describe your changes.
- add description for `alwaysShowThumbnails` setting, noting fluctuating choices thumbnails sizing

# Required Manual Testing

- [x] Can you load project home pages?
- [x] Does the lab / Project Builder load correctly?