### PR TITLE
Add an optional locale to project page routes

### DIFF
--- a/app/MonorepoRoutes.jsx
+++ b/app/MonorepoRoutes.jsx
@@ -21,6 +21,9 @@ MonorepoRoutes.createRouteFromReactElement = (element, parentRoute) => {
   const monorepoRoutes = createRoutesFromReactChildren(
     <Route path='projects'>
       {SLUGS.map(slug => <MonorepoRoute path={slug} />)}
+      <Route path=':locale'>
+        {SLUGS.map(slug => <MonorepoRoute path={slug} />)}
+      </Route>
     </Route>,
     parentRoute
   )[0];

--- a/app/pages/project/index.jsx
+++ b/app/pages/project/index.jsx
@@ -135,7 +135,7 @@ class ProjectPageController extends React.Component {
   }
 
   fetchProjectData(ownerName, projectName, user) {
-    const { actions, location } = this.props
+    const { actions, location, params } = this.props
     this.setState({
       error: null,
       loading: true,
@@ -150,6 +150,9 @@ class ProjectPageController extends React.Component {
 
         if (project) {
           let locale = project.primary_language
+          if (params.locale) {
+            locale = params.locale
+          }
           if (location.query.language) {
             locale = location.query.language;
           }

--- a/app/router.jsx
+++ b/app/router.jsx
@@ -232,6 +232,46 @@ export const routes = (
       <Route path="recents" component={Recents} />
     </Route>
 
+    <Route path="projects/:locale/:owner/:name" component={require('./pages/project').default}>
+      <Route path="notifications" component={NotificationsPage} />
+      <Route path="talk" component={require('./pages/project/talk')}>
+        <IndexRoute component={require('./talk/init')} />
+        <Route path="recents" component={require('./talk/recents')} />
+        <Route path="not-found" component={NotFoundPage} />
+        <Route path="search" component={require('./talk/search')} />
+        <Route path="moderations" component={require('./talk/moderations')} />
+        <Route path="subjects/:id" component={SubjectPageController} />
+        <Route path="recents/:board" component={require('./talk/recents')} />
+        <Route path="tags/:tag" component={TalkTags} />
+        <Route path=":board" component={require('./talk/board')} />
+        <Route path=":board/:discussion" component={require('./talk/discussion')} />
+      </Route>
+      <Route path="stats" component={require('./pages/project/stats')} />
+      <Route path="favorites" component={require('./pages/collections/index')}>
+        <IndexRoute component={require('./pages/collections/favorites-list')} />
+        <Route path=":collection_owner" component={require('./pages/collections/favorites-list')} />
+      </Route>
+
+      <Route path="collections" component={require('./pages/collections/index')}>
+         <IndexRoute component={require('./pages/collections/collections-list')} />
+         <Route path=":collection_owner" component={require('./pages/collections/collections-list')} />
+      </Route>
+
+      <Route path="collections/:collection_owner/:collection_name" component={CollectionPageWrapper}>
+        <IndexRoute component={require('./collections/show-list')} />
+        <Route path="settings" component={CollectionSettings} />
+        <Route path="collaborators" component={CollectionCollaborators} />
+        <Route path="talk" component={require('./collections/show-list')} />
+      </Route>
+      <Route path="users/:profile_name" component={UserProfilePage}>
+        <IndexRoute component={require('./pages/profile/feed')} />
+        <Route path="favorites" component={require('./pages/collections/favorites-list')} />
+        <Route path="collections" component={require('./pages/collections/collections-list')} />
+        <Route path="message" component={require('./pages/profile/private-message')} />
+      </Route>
+      <Route path="recents" component={Recents} />
+    </Route>
+
     <Route path="organizations/:owner/:name" component={(require('./pages/organization/organization-container').default)}>
       <IndexRoute component={(require('./pages/organization/organization-page').default)} />
       <Route path="home" component={ONE_UP_REDIRECT} />


### PR DESCRIPTION
Add support for routes like `/projects/:locale/:owner/:name/talk`, which will allow us to support links to PFE project pages from FEM projects.

Try it out with Planet Hunters TESS:
- Talk in Spanish: https://pr-6145.pfe-preview.zooniverse.org/projects/es/nora-dot-eisner/planet-hunters-tess/talk?env=production
- The home page in the test locale:  https://pr-6145.pfe-preview.zooniverse.org/projects/test/nora-dot-eisner/planet-hunters-tess?env=production

Staging branch URL: https://pr-6145.pfe-preview.zooniverse.org

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
