### PR TITLE
Preserve language codes in project navigation

### DIFF
--- a/app/lib/nav-helpers/getProjectLinks.js
+++ b/app/lib/nav-helpers/getProjectLinks.js
@@ -1,3 +1,4 @@
+import counterpart from 'counterpart';
 import _ from 'lodash';
 
 import isAdmin from '../is-admin';
@@ -6,41 +7,49 @@ import { monorepoURL, usesMonorepo } from '../../monorepoUtils';
 
 function getProjectLinks({ project, projectRoles, user }) {
   const { id, redirect, slug } = project;
+  const searchParams = new URLSearchParams(window.location.search);
+  const env = searchParams.get('env');
+  const locale = counterpart.getLocale();
+  const navSearchParams = new URLSearchParams({ env });
+  if (locale !== project.primary_language) {
+    navSearchParams.set('language', locale);
+  }
+  const query = `${navSearchParams}` ? `?${navSearchParams}` : '';
 
   const links = {
     about: {
       order: 0,
-      url: `/projects/${slug}/about`,
+      url: `/projects/${slug}/about${query}`,
       translationPath: 'project.nav.about'
     },
     classify: {
       order: 1,
-      url: `/projects/${slug}/classify`,
+      url: `/projects/${slug}/classify${query}`,
       translationPath: 'project.nav.classify'
     },
     talk: {
       order: 2,
-      url: `/projects/${slug}/talk`,
+      url: `/projects/${slug}/talk${query}`,
       translationPath: 'project.nav.talk'
     },
     collections: {
       order: 3,
-      url: `/projects/${slug}/collections`,
+      url: `/projects/${slug}/collections${query}`,
       translationPath: 'project.nav.collections'
     },
     recents: {
       order: 4,
-      url: `/projects/${slug}/recents`,
+      url: `/projects/${slug}/recents${query}`,
       translationPath: 'project.nav.recents'
     },
     admin: {
       order: 5,
-      url: `/admin/project_status/${slug}`,
+      url: `/admin/project_status/${slug}${query}`,
       translationPath: 'project.nav.adminPage'
     },
     lab: {
       order: 6,
-      url: `/lab/${id}`,
+      url: `/lab/${id}${query}`,
       translationPath: 'project.nav.lab'
     }
   };
@@ -48,9 +57,11 @@ function getProjectLinks({ project, projectRoles, user }) {
   const canClassify = project.links.active_workflows && project.links.active_workflows.length > 0;
 
   if (usesMonorepo(slug)) {
-    links.about.url = `${monorepoURL(slug)}/about`;
+    const i18nSlug = locale === 'en' ? slug : `${locale}/${slug}`;
+    const query = env === 'staging' ? '?env=staging' : '';
+    links.about.url = `${monorepoURL(i18nSlug)}/about${query}`;
     links.about.isMonorepoLink = true;
-    links.classify.url = `${monorepoURL(slug)}/classify`;
+    links.classify.url = `${monorepoURL(i18nSlug)}/classify${query}`;
     links.classify.isMonorepoLink = true;
   }
 

--- a/app/pages/project/components/ProjectNavbar/ProjectNavbarContainer.jsx
+++ b/app/pages/project/components/ProjectNavbar/ProjectNavbarContainer.jsx
@@ -73,16 +73,28 @@ class ProjectNavbarContainer extends Component {
   }
 
   render() {
+    const searchParams = new URLSearchParams(window.location.search);
+    const env = searchParams.get('env');
+    const locale = counterpart.getLocale();
+    const newSearchParams = new URLSearchParams({ env });
+    if (locale !== this.props.project.primary_language) {
+      newSearchParams.set('language', locale);
+    }
+    const query = `${newSearchParams}` ? `?${newSearchParams}` : '';
     const avatarSrc = _.get(this.props.projectAvatar, 'src', undefined);
     const backgroundSrc = _.get(this.props.background, 'src', undefined);
     const launched = this.props.project.launch_approved || this.props.project.listed;
     const navLinks = isResourceAProject(this.props.project) ? this.getNavLinks() : [];
     const projectTitle = _.get(this.props.translation, 'display_name', undefined);
-    const projectLink = isResourceAProject(this.props.project) ? `/projects/${this.props.project.slug}` : `/organizations/${this.props.project.slug}`;
+    const projectLink = isResourceAProject(this.props.project) ?
+      `/projects/${this.props.project.slug}${query}` :
+      `/organizations/${this.props.project.slug}${query}`;
     let redirect = this.props.project.redirect ? this.props.project.redirect : '';
     const underReview = this.props.project.beta_approved;
     if (usesMonorepo(this.props.project.slug)) {
-      redirect = monorepoURL(this.props.project.slug)
+      const i18nSlug = locale === 'en' ? this.props.project.slug : `${locale}/${this.props.project.slug}`;
+      const query = env === 'staging' ? '?env=staging' : '';
+      redirect = `${monorepoURL(i18nSlug)}${query}`;
     }
 
     return (


### PR DESCRIPTION
Add the current location's `env` and `language` query parameters to project navigation links, so that query parameters are preserved when you change pages, or reload a page.

Prepend the locale to page URLs when we're linking to pages in the NextJS project app.

Try it out on:
- PH TESS in Spanish: https://pr-6146.pfe-preview.zooniverse.org/projects/nora-dot-eisner/planet-hunters-tess/talk?language=es
- PH-TESS in Spanish, without query parameters: https://pr-6146.pfe-preview.zooniverse.org/projects/es/nora-dot-eisner/planet-hunters-tess/talk
- or with the test locale: https://pr-6146.pfe-preview.zooniverse.org/projects/nora-dot-eisner/planet-hunters-tess/talk?language=test
- I Fancy Cats without any query parameters: https://pr-6146.pfe-preview.zooniverse.org/projects/brooke/i-fancy-cats?env=staging
- Every Name Counts in German: https://pr-6146.pfe-preview.zooniverse.org/projects/arolsen-archives/every-name-counts?language=de

Staging branch URL: https://pr-6146.pfe-preview.zooniverse.org

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
