### PR TITLE
Update page URL after changing language

### DIFF
--- a/app/pages/project/components/LanguagePicker/LanguagePicker.jsx
+++ b/app/pages/project/components/LanguagePicker/LanguagePicker.jsx
@@ -23,6 +23,9 @@ function LanguagePicker(props) {
 
   function onChange(e) {
     actions.translations.setLocale(e.target.value);
+    const searchParams = new URLSearchParams(window.location.search);
+    searchParams.set('language', e.target.value);
+    window.history.pushState({}, '', `${window.location.pathname}?${searchParams}`);
   }
 
   return (

--- a/app/pages/project/components/LanguagePicker/LanguagePicker.spec.js
+++ b/app/pages/project/components/LanguagePicker/LanguagePicker.spec.js
@@ -47,5 +47,10 @@ describe('LanguagePicker', function () {
     it('should pass the new language to setLocale', function () {
       expect(changeSpy.calledWith('nl')).to.be.true;
     });
+
+    it('should add the new language to the page URL', function () {
+      const searchParams = new URLSearchParams(window.location.search)
+      expect(searchParams.get('language')).to.equal('nl')
+    });
   });
 });


### PR DESCRIPTION
Set the `language` query parameter and update the page URL after selecting a new language.

Try it out on a project that's available in multiple languages:
https://pr-6147.pfe-preview.zooniverse.org/projects/arolsen-archives/every-name-counts?env=production

Staging branch URL: https://pr-6147.pfe-preview.zooniverse.org

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
