### PR TITLE
Create a canary deploy for team testing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "markdownz": "~7.8.1",
         "modal-form": "~2.9",
         "moment": "~2.29.0",
-        "panoptes-client": "~3.4.1",
+        "panoptes-client": "zooniverse/panoptes-javascript-client#app-panoptes-api-canary-headers",
         "papaparse": "^5.2.0",
         "polished": "~2.3.3",
         "prop-types": "~15.7.1",
@@ -113,6 +113,21 @@
       "engines": {
         "node": ">=16",
         "npm": ">=8"
+      }
+    },
+    "../panoptes-javascript-client": {
+      "name": "panoptes-client",
+      "version": "3.4.1",
+      "extraneous": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-api-client": "~5.1.0",
+        "local-storage": "^2.0.0",
+        "sugar-client": "^2.0.0"
+      },
+      "devDependencies": {
+        "blue-tape": "~1.0.0",
+        "tap-spec": "^5.0.0"
       }
     },
     "node_modules/@babel/cli": {
@@ -2932,7 +2947,7 @@
     "node_modules/asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
     },
     "node_modules/asn1.js": {
       "version": "5.4.1",
@@ -5476,7 +5491,7 @@
     "node_modules/dezalgo": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
-      "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
+      "integrity": "sha512-K7i4zNfT2kgQz3GylDw40ot9GAE47sFZ9EXHFSPP6zONLgH6kWXE0KWJchkbQJLBkRazq4APwZ4OwiFFlT95OQ==",
       "dependencies": {
         "asap": "^2.0.0",
         "wrappy": "1"
@@ -11034,7 +11049,7 @@
     "node_modules/normalizeurl": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/normalizeurl/-/normalizeurl-1.0.0.tgz",
-      "integrity": "sha1-SxpFjNDH0IVkNvaca1EEeraFUxc="
+      "integrity": "sha512-GyndB0rq1FmO49Vwy88c3jzp5G3OnjEbwVlm+vst+P5ANKQVtm+2682qgRptcZeZvU1I2E5RgCeZirqLuUQQEw=="
     },
     "node_modules/npm-run-path": {
       "version": "4.0.1",
@@ -11739,8 +11754,8 @@
     },
     "node_modules/panoptes-client": {
       "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-3.4.1.tgz",
-      "integrity": "sha512-jBTN754730Zd7XdAA409B7TiLAPIkuzfe0hZhK5EpTzqUgII+dP+5TzhqVHPzUZngIqTkTxx1neL0vSrygNHmA==",
+      "resolved": "git+ssh://git@github.com/zooniverse/panoptes-javascript-client.git#e32592bd6dbdf0c302c536cacce16800a0bf2023",
+      "license": "Apache-2.0",
       "dependencies": {
         "json-api-client": "~5.1.0",
         "local-storage": "^2.0.0",
@@ -14459,9 +14474,9 @@
       }
     },
     "node_modules/superagent": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-7.1.3.tgz",
-      "integrity": "sha512-WA6et4nAvgBCS73lJvv1D0ssI5uk5Gh+TGN/kNe+B608EtcVs/yzfl+OLXTzDs7tOBDIpvgh/WUs1K2OK1zTeQ==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-7.1.5.tgz",
+      "integrity": "sha512-HQYyGuDRFGmZ6GNC4hq2f37KnsY9Lr0/R1marNZTgMweVDQLTLJJ6DGQ9Tj/xVVs5HEnop9EMmTbywb5P30aqw==",
       "dependencies": {
         "component-emitter": "^1.3.0",
         "cookiejar": "^2.1.3",
@@ -14502,9 +14517,9 @@
       }
     },
     "node_modules/superagent/node_modules/qs": {
-      "version": "6.10.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
-      "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
       "dependencies": {
         "side-channel": "^1.0.4"
       },
@@ -18520,7 +18535,7 @@
     "asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
     },
     "asn1.js": {
       "version": "5.4.1",
@@ -20345,7 +20360,7 @@
     "dezalgo": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
-      "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
+      "integrity": "sha512-K7i4zNfT2kgQz3GylDw40ot9GAE47sFZ9EXHFSPP6zONLgH6kWXE0KWJchkbQJLBkRazq4APwZ4OwiFFlT95OQ==",
       "requires": {
         "asap": "^2.0.0",
         "wrappy": "1"
@@ -24115,7 +24130,7 @@
     "normalizeurl": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/normalizeurl/-/normalizeurl-1.0.0.tgz",
-      "integrity": "sha1-SxpFjNDH0IVkNvaca1EEeraFUxc="
+      "integrity": "sha512-GyndB0rq1FmO49Vwy88c3jzp5G3OnjEbwVlm+vst+P5ANKQVtm+2682qgRptcZeZvU1I2E5RgCeZirqLuUQQEw=="
     },
     "npm-run-path": {
       "version": "4.0.1",
@@ -24575,9 +24590,8 @@
       "dev": true
     },
     "panoptes-client": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-3.4.1.tgz",
-      "integrity": "sha512-jBTN754730Zd7XdAA409B7TiLAPIkuzfe0hZhK5EpTzqUgII+dP+5TzhqVHPzUZngIqTkTxx1neL0vSrygNHmA==",
+      "version": "git+ssh://git@github.com/zooniverse/panoptes-javascript-client.git#e32592bd6dbdf0c302c536cacce16800a0bf2023",
+      "from": "panoptes-client@zooniverse/panoptes-javascript-client#app-panoptes-api-canary-headers",
       "requires": {
         "json-api-client": "~5.1.0",
         "local-storage": "^2.0.0",
@@ -26486,9 +26500,9 @@
       "integrity": "sha512-87RfgwzyiQrA77lsBGYFPjHbDVzkcSl5aiubz3n7qPOwf9LLNKe+PvtlNf0bnFS63+gGWe6r8A18iaKLBthw1w=="
     },
     "superagent": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-7.1.3.tgz",
-      "integrity": "sha512-WA6et4nAvgBCS73lJvv1D0ssI5uk5Gh+TGN/kNe+B608EtcVs/yzfl+OLXTzDs7tOBDIpvgh/WUs1K2OK1zTeQ==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-7.1.5.tgz",
+      "integrity": "sha512-HQYyGuDRFGmZ6GNC4hq2f37KnsY9Lr0/R1marNZTgMweVDQLTLJJ6DGQ9Tj/xVVs5HEnop9EMmTbywb5P30aqw==",
       "requires": {
         "component-emitter": "^1.3.0",
         "cookiejar": "^2.1.3",
@@ -26517,9 +26531,9 @@
           "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg=="
         },
         "qs": {
-          "version": "6.10.3",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
-          "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
+          "version": "6.11.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+          "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
           "requires": {
             "side-channel": "^1.0.4"
           }

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "coverage": "nyc report --reporter=lcov",
     "start": "export NODE_ENV=development; check-engines && check-dependencies && webpack-dashboard -p 3736 -- webpack-dev-server --config ./webpack.dev.js",
     "_build": "export HEAD_COMMIT=$(git rev-parse --short HEAD); check-engines && check-dependencies && rimraf dist; webpack --config ./webpack.build.js --progress --color",
-    "build-production": "export NODE_ENV=production; npm run _build",
+    "build-production": "export NODE_ENV=staging; npm run _build",
     "serve-static": "export NODE_ENV=staging; check-engines && check-dependencies && npm run _build && node ./static-server.js",
     "test-and-watch": "NODE_ENV=development BABEL_ENV=test mocha --watch --watch-extensions js,jsx,coffee,cjsx test/setup.js test/enzyme-configuration.js $(find app -name *.spec.js*) --reporter nyan || true",
     "test": "NODE_ENV=development BABEL_ENV=test nyc mocha --exit test/setup.js test/enzyme-configuration.js $(find app -name *.spec.js*) --reporter nyan || true",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "markdownz": "~7.8.1",
     "modal-form": "~2.9",
     "moment": "~2.29.0",
-    "panoptes-client": "~3.4.1",
+    "panoptes-client": "zooniverse/panoptes-javascript-client#app-panoptes-api-canary-headers",
     "papaparse": "^5.2.0",
     "polished": "~2.3.3",
     "prop-types": "~15.7.1",


### PR DESCRIPTION
Create a version of PFE that opts into the canary testing on all API requests and auto deploys via the PR build system. This depends on the canary client headers setup in a custom version of the PJC https://github.com/zooniverse/panoptes-javascript-client/tree/app-panoptes-api-canary-headers 

Staging branch URL: https://pr-6157.pfe-preview.zooniverse.org/?env=staging

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
