### PR TITLE
Revert "Preserve language codes in project navigation"

### DIFF
--- a/app/lib/nav-helpers/getProjectLinks.js
+++ b/app/lib/nav-helpers/getProjectLinks.js
@@ -1,4 +1,3 @@
-import counterpart from 'counterpart';
 import _ from 'lodash';
 
 import isAdmin from '../is-admin';
@@ -7,49 +6,41 @@ import { monorepoURL, usesMonorepo } from '../../monorepoUtils';
 
 function getProjectLinks({ project, projectRoles, user }) {
   const { id, redirect, slug } = project;
-  const searchParams = new URLSearchParams(window.location.search);
-  const env = searchParams.get('env');
-  const locale = counterpart.getLocale();
-  const navSearchParams = new URLSearchParams({ env });
-  if (locale !== project.primary_language) {
-    navSearchParams.set('language', locale);
-  }
-  const query = `${navSearchParams}` ? `?${navSearchParams}` : '';
 
   const links = {
     about: {
       order: 0,
-      url: `/projects/${slug}/about${query}`,
+      url: `/projects/${slug}/about`,
       translationPath: 'project.nav.about'
     },
     classify: {
       order: 1,
-      url: `/projects/${slug}/classify${query}`,
+      url: `/projects/${slug}/classify`,
       translationPath: 'project.nav.classify'
     },
     talk: {
       order: 2,
-      url: `/projects/${slug}/talk${query}`,
+      url: `/projects/${slug}/talk`,
       translationPath: 'project.nav.talk'
     },
     collections: {
       order: 3,
-      url: `/projects/${slug}/collections${query}`,
+      url: `/projects/${slug}/collections`,
       translationPath: 'project.nav.collections'
     },
     recents: {
       order: 4,
-      url: `/projects/${slug}/recents${query}`,
+      url: `/projects/${slug}/recents`,
       translationPath: 'project.nav.recents'
     },
     admin: {
       order: 5,
-      url: `/admin/project_status/${slug}${query}`,
+      url: `/admin/project_status/${slug}`,
       translationPath: 'project.nav.adminPage'
     },
     lab: {
       order: 6,
-      url: `/lab/${id}${query}`,
+      url: `/lab/${id}`,
       translationPath: 'project.nav.lab'
     }
   };
@@ -57,11 +48,9 @@ function getProjectLinks({ project, projectRoles, user }) {
   const canClassify = project.links.active_workflows && project.links.active_workflows.length > 0;
 
   if (usesMonorepo(slug)) {
-    const i18nSlug = locale === 'en' ? slug : `${locale}/${slug}`;
-    const query = env === 'staging' ? '?env=staging' : '';
-    links.about.url = `${monorepoURL(i18nSlug)}/about${query}`;
+    links.about.url = `${monorepoURL(slug)}/about`;
     links.about.isMonorepoLink = true;
-    links.classify.url = `${monorepoURL(i18nSlug)}/classify${query}`;
+    links.classify.url = `${monorepoURL(slug)}/classify`;
     links.classify.isMonorepoLink = true;
   }
 

--- a/app/pages/project/components/ProjectNavbar/ProjectNavbarContainer.jsx
+++ b/app/pages/project/components/ProjectNavbar/ProjectNavbarContainer.jsx
@@ -73,28 +73,16 @@ class ProjectNavbarContainer extends Component {
   }
 
   render() {
-    const searchParams = new URLSearchParams(window.location.search);
-    const env = searchParams.get('env');
-    const locale = counterpart.getLocale();
-    const newSearchParams = new URLSearchParams({ env });
-    if (locale !== this.props.project.primary_language) {
-      newSearchParams.set('language', locale);
-    }
-    const query = `${newSearchParams}` ? `?${newSearchParams}` : '';
     const avatarSrc = _.get(this.props.projectAvatar, 'src', undefined);
     const backgroundSrc = _.get(this.props.background, 'src', undefined);
     const launched = this.props.project.launch_approved || this.props.project.listed;
     const navLinks = isResourceAProject(this.props.project) ? this.getNavLinks() : [];
     const projectTitle = _.get(this.props.translation, 'display_name', undefined);
-    const projectLink = isResourceAProject(this.props.project) ?
-      `/projects/${this.props.project.slug}${query}` :
-      `/organizations/${this.props.project.slug}${query}`;
+    const projectLink = isResourceAProject(this.props.project) ? `/projects/${this.props.project.slug}` : `/organizations/${this.props.project.slug}`;
     let redirect = this.props.project.redirect ? this.props.project.redirect : '';
     const underReview = this.props.project.beta_approved;
     if (usesMonorepo(this.props.project.slug)) {
-      const i18nSlug = locale === 'en' ? this.props.project.slug : `${locale}/${this.props.project.slug}`;
-      const query = env === 'staging' ? '?env=staging' : '';
-      redirect = `${monorepoURL(i18nSlug)}${query}`;
+      redirect = monorepoURL(this.props.project.slug)
     }
 
     return (


### PR DESCRIPTION
Reverts zooniverse/Panoptes-Front-End#6146

Seeing some odd behavior due to this PR: an env=null query param is getting appended in cases where no param was originally included.

Example:
- Visit https://www.zooniverse.org/projects/reinforce/deep-sea-explorers
- Click link to visit stats page
- Click banner to return to project landing page
landing page URL is now https://www.zooniverse.org/projects/reinforce/deep-sea-explorers?env=null

Reloading the page (i.e., explicitly loading the URL with query param included) causes an error and page fails to load: `Uncaught Error: Panoptes Javascript Client Error: Invalid Environment; try setting NODE_ENV to "staging" instead of "production".`

The other failure mode: right click to "open in new tab" of any link with env=null will fail to load