### PR TITLE
Handle locale in nav query parameters

### DIFF
--- a/app/lib/nav-helpers/getProjectLinks.js
+++ b/app/lib/nav-helpers/getProjectLinks.js
@@ -1,3 +1,4 @@
+import counterpart from 'counterpart';
 import _ from 'lodash';
 
 import isAdmin from '../is-admin';
@@ -6,41 +7,49 @@ import { monorepoURL, usesMonorepo } from '../../monorepoUtils';
 
 function getProjectLinks({ project, projectRoles, user }) {
   const { id, redirect, slug } = project;
+  const searchParams = new URLSearchParams(window.location.search);
+  const env = searchParams.get('env');
+  const locale = counterpart.getLocale();
+  const navSearchParams = new URLSearchParams({ env });
+  if (locale !== project.primary_language) {
+    navSearchParams.set('language', locale);
+  }
+  const query = `${navSearchParams}` ? `?${navSearchParams}` : '';
 
   const links = {
     about: {
       order: 0,
-      url: `/projects/${slug}/about`,
+      url: `/projects/${slug}/about${query}`,
       translationPath: 'project.nav.about'
     },
     classify: {
       order: 1,
-      url: `/projects/${slug}/classify`,
+      url: `/projects/${slug}/classify${query}`,
       translationPath: 'project.nav.classify'
     },
     talk: {
       order: 2,
-      url: `/projects/${slug}/talk`,
+      url: `/projects/${slug}/talk${query}`,
       translationPath: 'project.nav.talk'
     },
     collections: {
       order: 3,
-      url: `/projects/${slug}/collections`,
+      url: `/projects/${slug}/collections${query}`,
       translationPath: 'project.nav.collections'
     },
     recents: {
       order: 4,
-      url: `/projects/${slug}/recents`,
+      url: `/projects/${slug}/recents${query}`,
       translationPath: 'project.nav.recents'
     },
     admin: {
       order: 5,
-      url: `/admin/project_status/${slug}`,
+      url: `/admin/project_status/${slug}${query}`,
       translationPath: 'project.nav.adminPage'
     },
     lab: {
       order: 6,
-      url: `/lab/${id}`,
+      url: `/lab/${id}${query}`,
       translationPath: 'project.nav.lab'
     }
   };
@@ -48,9 +57,11 @@ function getProjectLinks({ project, projectRoles, user }) {
   const canClassify = project.links.active_workflows && project.links.active_workflows.length > 0;
 
   if (usesMonorepo(slug)) {
-    links.about.url = `${monorepoURL(slug)}/about`;
+    const i18nSlug = locale === 'en' ? slug : `${locale}/${slug}`;
+    const query = env === 'staging' ? '?env=staging' : '';
+    links.about.url = `${monorepoURL(i18nSlug)}/about${query}`;
     links.about.isMonorepoLink = true;
-    links.classify.url = `${monorepoURL(slug)}/classify`;
+    links.classify.url = `${monorepoURL(i18nSlug)}/classify${query}`;
     links.classify.isMonorepoLink = true;
   }
 

--- a/app/lib/nav-helpers/getProjectLinks.js
+++ b/app/lib/nav-helpers/getProjectLinks.js
@@ -10,11 +10,18 @@ function getProjectLinks({ project, projectRoles, user }) {
   const searchParams = new URLSearchParams(window.location.search);
   const env = searchParams.get('env');
   const locale = counterpart.getLocale();
-  const navSearchParams = new URLSearchParams({ env });
+  const newSearchParams = new URLSearchParams();
+
+  // For most projects, primary_language is en
   if (locale !== project.primary_language) {
-    navSearchParams.set('language', locale);
+    newSearchParams.set('language', locale);
   }
-  const query = `${navSearchParams}` ? `?${navSearchParams}` : '';
+
+  if (env) {
+    newSearchParams.set('env', env);
+  }
+
+  const query = `${newSearchParams}` ? `?${newSearchParams}` : '';
 
   const links = {
     about: {
@@ -58,10 +65,10 @@ function getProjectLinks({ project, projectRoles, user }) {
 
   if (usesMonorepo(slug)) {
     const i18nSlug = locale === 'en' ? slug : `${locale}/${slug}`;
-    const query = env === 'staging' ? '?env=staging' : '';
-    links.about.url = `${monorepoURL(i18nSlug)}/about${query}`;
+    const envQuery = env === 'staging' ? '?env=staging' : '';
+    links.about.url = `${monorepoURL(i18nSlug)}/about${envQuery}`;
     links.about.isMonorepoLink = true;
-    links.classify.url = `${monorepoURL(i18nSlug)}/classify${query}`;
+    links.classify.url = `${monorepoURL(i18nSlug)}/classify${envQuery}`;
     links.classify.isMonorepoLink = true;
   }
 

--- a/app/pages/project/components/ProjectNavbar/ProjectNavbarContainer.jsx
+++ b/app/pages/project/components/ProjectNavbar/ProjectNavbarContainer.jsx
@@ -73,16 +73,28 @@ class ProjectNavbarContainer extends Component {
   }
 
   render() {
+    const searchParams = new URLSearchParams(window.location.search);
+    const env = searchParams.get('env');
+    const locale = counterpart.getLocale();
+    const newSearchParams = new URLSearchParams({ env });
+    if (locale !== this.props.project.primary_language) {
+      newSearchParams.set('language', locale);
+    }
+    const query = `${newSearchParams}` ? `?${newSearchParams}` : '';
     const avatarSrc = _.get(this.props.projectAvatar, 'src', undefined);
     const backgroundSrc = _.get(this.props.background, 'src', undefined);
     const launched = this.props.project.launch_approved || this.props.project.listed;
     const navLinks = isResourceAProject(this.props.project) ? this.getNavLinks() : [];
     const projectTitle = _.get(this.props.translation, 'display_name', undefined);
-    const projectLink = isResourceAProject(this.props.project) ? `/projects/${this.props.project.slug}` : `/organizations/${this.props.project.slug}`;
+    const projectLink = isResourceAProject(this.props.project) ?
+      `/projects/${this.props.project.slug}${query}` :
+      `/organizations/${this.props.project.slug}${query}`;
     let redirect = this.props.project.redirect ? this.props.project.redirect : '';
     const underReview = this.props.project.beta_approved;
     if (usesMonorepo(this.props.project.slug)) {
-      redirect = monorepoURL(this.props.project.slug)
+      const i18nSlug = locale === 'en' ? this.props.project.slug : `${locale}/${this.props.project.slug}`;
+      const query = env === 'staging' ? '?env=staging' : '';
+      redirect = `${monorepoURL(i18nSlug)}${query}`;
     }
 
     return (

--- a/app/pages/project/components/ProjectNavbar/ProjectNavbarContainer.jsx
+++ b/app/pages/project/components/ProjectNavbar/ProjectNavbarContainer.jsx
@@ -76,25 +76,30 @@ class ProjectNavbarContainer extends Component {
     const searchParams = new URLSearchParams(window.location.search);
     const env = searchParams.get('env');
     const locale = counterpart.getLocale();
-    const newSearchParams = new URLSearchParams({ env });
+    const newSearchParams = new URLSearchParams();
+
+    // For most projects, primary_language is en
     if (locale !== this.props.project.primary_language) {
       newSearchParams.set('language', locale);
     }
+
+    if (env) {
+      newSearchParams.set('env', env);
+    }
+
     const query = `${newSearchParams}` ? `?${newSearchParams}` : '';
     const avatarSrc = _.get(this.props.projectAvatar, 'src', undefined);
     const backgroundSrc = _.get(this.props.background, 'src', undefined);
     const launched = this.props.project.launch_approved || this.props.project.listed;
     const navLinks = isResourceAProject(this.props.project) ? this.getNavLinks() : [];
     const projectTitle = _.get(this.props.translation, 'display_name', undefined);
-    const projectLink = isResourceAProject(this.props.project) ?
-      `/projects/${this.props.project.slug}${query}` :
-      `/organizations/${this.props.project.slug}${query}`;
+    const projectLink = isResourceAProject(this.props.project) ? `/projects/${this.props.project.slug}${query}` : `/organizations/${this.props.project.slug}${query}`;
     let redirect = this.props.project.redirect ? this.props.project.redirect : '';
     const underReview = this.props.project.beta_approved;
     if (usesMonorepo(this.props.project.slug)) {
       const i18nSlug = locale === 'en' ? this.props.project.slug : `${locale}/${this.props.project.slug}`;
-      const query = env === 'staging' ? '?env=staging' : '';
-      redirect = `${monorepoURL(i18nSlug)}${query}`;
+      const envQuery = env === 'staging' ? '?env=staging' : '';
+      redirect = `${monorepoURL(i18nSlug)}${envQuery}`;
     }
 
     return (


### PR DESCRIPTION
Staging branch URL: https://pr-6164.pfe-preview.zooniverse.org

Fixes previous PR revert: https://github.com/zooniverse/Panoptes-Front-End/pull/6163

Adds the current location's `env` and `language` query parameters to project navigation links, so that query parameters are preserved when you change pages, or reload a page.

Prepends the locale prefix to URLs when we link to pages in the FEM project app.

## How To Review
PFE Project
- Visit this branch URL and go to a PFE project such as [Galaxy Zoo](https://pr-6164.pfe-preview.zooniverse.org/projects/zookeeper/galaxy-zoo).
- If an env query param such as `?env=production` is added to the url, it will be preserved while using the project header navigation links.
- Use the language dropdown to choose a language other than English.
- The dropdown should add `language` as a query param, and navigating via the project header links will preserve that param and display the page in the desired language.
- Selecting English from the language dropdown will change the language query param to `en`, and then clicking on a different project page in the header will remove the `language` param from the url. This is expected.

FEM Project
- Visit this branch URL and go to a FEM project such as[ TESS's Talk](https://pr-6164.pfe-preview.zooniverse.org/projects/nora-dot-eisner/planet-hunters-tess/talk) page.
- When one of TESS's PFE pages is displayed in English, whether or not the `language` param is present, links to Home, About, and Classify should be to frontend.preview _without_ a language prefix subpath.
- When one of TESS's PFE pages is displayed in a language other than English, whether or not the `language` param is present, links to Home, About, and Classify should be to frontend.preview _with_ the current language's prefix subpath.


Other Notes
- This PR is focused on preserving the currently displayed language when navigating project pages for an FEM project who's Talk, Collections, and Recents still use PFE.
- Visiting a staging project on this branch, such as [i-fancy-cats](https://pr-6164.pfe-preview.zooniverse.org/projects/brooke/i-fancy-cats?env=staging), and using the call-to-action buttons on its homepage will not preserve `?env=staging` or a `language` param. General navigation in PFE is not designed to preserve the env variable, so further refactoring of those home page buttons would be needed if that behavior is desired.
- A `language` param is not necessary to display another language in PFE. Current language is stored internally in the app, and that internal variable is what this PR references when forming links to FEM pages.

## Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] Are the tests passing locally and on GitHub Actions?