### PR TITLE
Add redirect url for Notes from Nature - Labs

### DIFF
--- a/app/monorepoUtils.js
+++ b/app/monorepoUtils.js
@@ -27,7 +27,8 @@ export const SLUGS = [
   'printmigrationnetwork/print',
   'profdrrogerlouismartinez-davila/deciphering-secrets-unlocking-the-manuscripts-of-medieval-spain',
   'skirmizi/ottoman-turkish-crowdsourcing',
-  'bldigital/in-the-spotlight'
+  'bldigital/in-the-spotlight',
+  'md68135/notes-from-nature-labs'
 ];
 
 export function usesMonorepo(slug) {


### PR DESCRIPTION
Related to https://github.com/zooniverse/static/pull/315 

Staging branch URL:  https://pr-6174.pfe-preview.zooniverse.org/


# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
