### PR TITLE
Home page: Fix ‘Show all publications link’

### DIFF
--- a/app/pages/home-common/social.jsx
+++ b/app/pages/home-common/social.jsx
@@ -127,7 +127,7 @@ export default class HomePageSocial extends React.Component {
             <Translate className="tertiary-kicker" component="h3" content="socialHomePage.recentPublications" />
             <Translate className="regular-body" component="span" content="socialHomePage.recentPublicationsBlurb" />
             <br/>
-            <Link to="/about/publications" className="primary-button primary-button--light">See All Publications</Link>
+            <a href="/about/publications" className="primary-button primary-button--light">See All Publications</a>
           </div>
 
           <div className="home-social__content--vertical-line"></div>


### PR DESCRIPTION
Publications is an external page now, so link to it with a HTML link, not React Router.

Staging branch URL: https://pr-6195.pfe-preview.zooniverse.org

Fixes #6187. 

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
