### PR TITLE
Allow admins to view linked project organisations

### DIFF
--- a/app/pages/project/index.jsx
+++ b/app/pages/project/index.jsx
@@ -16,6 +16,7 @@ import * as translationActions from '../../redux/ducks/translations';
 import ProjectPage from './project-page';
 import Translations from '../../classifier/translations';
 import getAllLinked from '../../lib/get-all-linked';
+import isAdmin from '../../lib/is-admin';
 
 /**
   Send exceptions and React error info to Sentry
@@ -164,10 +165,10 @@ class ProjectPageController extends React.Component {
             if (error.status === 404) { return { src: '' }; } else { return console.error(error); }
           });
 
-          if (project.links && project.links.organization) {
-            awaitOrganization = project.get('organization', { listed: true })
-              .catch(error => [])
-              .then(response => (response && response.display_name) ? response : null);
+          if (project.links?.organization) {
+            const query = isAdmin() ? null : { listed: true }
+            awaitOrganization = project.get('organization', query)
+              .catch(error => null);
           } else {
             awaitOrganization = Promise.resolve(null);
           }


### PR DESCRIPTION
Remove `{ listed: true }` from the project organisation query in admin mode, so that admins can always see a project's linked organisation.

Staging branch URL: https://pr-{NUMBER}.pfe-preview.zooniverse.org

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
