### PR TITLE
Update LinePlotModel (for canvas viewer) to use Chart.js v3

### DIFF
--- a/app/features/modelling/line-plot/index.js
+++ b/app/features/modelling/line-plot/index.js
@@ -1,4 +1,4 @@
-import { Chart } from 'chart.js';
+import Chart from 'chart.js/auto';
 
 // Help at http://www.chartjs.org/docs/latest
 class LinePlotModel {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@sentry/browser": "~6.1.0",
         "@sentry/tracing": "~6.1.0",
         "animated-scrollto": "~1.1.0",
-        "chart.js": "~3.2.1",
+        "chart.js": "~3.9.1",
         "chartist": "~0.11.0",
         "classnames": "~2.2.6",
         "counterpart": "~0.18.6",
@@ -2147,28 +2147,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/linkify-it": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.2.tgz",
-      "integrity": "sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA==",
-      "peer": true
-    },
-    "node_modules/@types/markdown-it": {
-      "version": "12.2.3",
-      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-12.2.3.tgz",
-      "integrity": "sha512-GKMHFfv3458yYy+v/N8gjufHO6MSZKCOXpZc5GXIWWy8uldwfmPn98vp81gZ5f9SVw8YYBctgfJ22a2d7AOMeQ==",
-      "peer": true,
-      "dependencies": {
-        "@types/linkify-it": "*",
-        "@types/mdurl": "*"
-      }
-    },
-    "node_modules/@types/mdurl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.2.tgz",
-      "integrity": "sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA==",
-      "peer": true
-    },
     "node_modules/@types/mime": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
@@ -4000,8 +3978,9 @@
       "license": "MIT"
     },
     "node_modules/chart.js": {
-      "version": "3.2.1",
-      "license": "MIT"
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-3.9.1.tgz",
+      "integrity": "sha512-Ro2JbLmvg83gXF5F4sniaQ+lTbSv18E+TIf2cOeiH1Iqd2PGFOtem+DUufMZsCJwFE7ywPOpfXFBwRTGq7dh6w=="
     },
     "node_modules/chartist": {
       "version": "0.11.4",
@@ -18025,28 +18004,6 @@
       "version": "7.0.9",
       "dev": true
     },
-    "@types/linkify-it": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.2.tgz",
-      "integrity": "sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA==",
-      "peer": true
-    },
-    "@types/markdown-it": {
-      "version": "12.2.3",
-      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-12.2.3.tgz",
-      "integrity": "sha512-GKMHFfv3458yYy+v/N8gjufHO6MSZKCOXpZc5GXIWWy8uldwfmPn98vp81gZ5f9SVw8YYBctgfJ22a2d7AOMeQ==",
-      "peer": true,
-      "requires": {
-        "@types/linkify-it": "*",
-        "@types/mdurl": "*"
-      }
-    },
-    "@types/mdurl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.2.tgz",
-      "integrity": "sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA==",
-      "peer": true
-    },
     "@types/mime": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
@@ -18346,8 +18303,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.1.1.tgz",
       "integrity": "sha512-1FBc1f9G4P/AxMqIgfZgeOTuRnwZMten8E7zap5zgpPInnCrP8D4Q81+4CWIch8i/Nf7nXjP0v6CjjbHOrXhKg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@webpack-cli/info": {
       "version": "1.4.1",
@@ -18362,8 +18318,7 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.6.1.tgz",
       "integrity": "sha512-gNGTiTrjEVQ0OcVnzsRSqTxaBSr+dmTfm+qJsCDluky8uhdLWep7Gcr62QsAKHTMxjCS/8nEITsmFAhfIx+QSw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@wojtekmaj/enzyme-adapter-react-17": {
       "version": "0.6.7",
@@ -18437,8 +18392,7 @@
     },
     "acorn-jsx": {
       "version": "5.3.2",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -18477,8 +18431,7 @@
     },
     "ajv-errors": {
       "version": "1.0.1",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ajv-formats": {
       "version": "2.1.1",
@@ -18511,8 +18464,7 @@
     },
     "ajv-keywords": {
       "version": "3.5.2",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "amdefine": {
       "version": "1.0.1",
@@ -19429,7 +19381,9 @@
       "dev": true
     },
     "chart.js": {
-      "version": "3.2.1"
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-3.9.1.tgz",
+      "integrity": "sha512-Ro2JbLmvg83gXF5F4sniaQ+lTbSv18E+TIf2cOeiH1Iqd2PGFOtem+DUufMZsCJwFE7ywPOpfXFBwRTGq7dh6w=="
     },
     "chartist": {
       "version": "0.11.4"
@@ -20760,8 +20714,7 @@
           "version": "8.2.3",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
           "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         }
       }
     },
@@ -22522,8 +22475,7 @@
     },
     "icss-utils": {
       "version": "5.1.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ieee754": {
       "version": "1.2.1",
@@ -22743,13 +22695,11 @@
     },
     "io-ts": {
       "version": "2.2.16",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "io-ts-reporters": {
       "version": "1.2.2",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ip": {
       "version": "1.1.5",
@@ -23501,8 +23451,7 @@
       }
     },
     "markdown-it-anchor": {
-      "version": "8.4.1",
-      "requires": {}
+      "version": "8.4.1"
     },
     "markdown-it-container": {
       "version": "3.0.0"
@@ -24978,8 +24927,7 @@
     },
     "postcss-modules-extract-imports": {
       "version": "3.0.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-modules-local-by-default": {
       "version": "4.0.0",
@@ -25540,8 +25488,7 @@
     "redux-thunk": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.1.tgz",
-      "integrity": "sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q==",
-      "requires": {}
+      "integrity": "sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q=="
     },
     "regenerate": {
       "version": "1.4.2",
@@ -26027,8 +25974,7 @@
     },
     "sinon-chai": {
       "version": "3.3.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "slash": {
       "version": "2.0.0",
@@ -26209,8 +26155,7 @@
         },
         "ws": {
           "version": "8.2.3",
-          "dev": true,
-          "requires": {}
+          "dev": true
         }
       }
     },
@@ -26565,8 +26510,7 @@
       "version": "3.5.4"
     },
     "stylis-rule-sheet": {
-      "version": "0.0.10",
-      "requires": {}
+      "version": "0.0.10"
     },
     "stylus": {
       "version": "0.54.8",
@@ -27203,8 +27147,7 @@
     "use-sync-external-store": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.0.0.tgz",
-      "integrity": "sha512-AFVsxg5GkFg8GDcxnl+Z0lMAz9rE8DGJCc28qnBuQF7lac57B5smLcT37aXpXIIPz75rW4g3eXHPjhHwdGskOw==",
-      "requires": {}
+      "integrity": "sha512-AFVsxg5GkFg8GDcxnl+Z0lMAz9rE8DGJCc28qnBuQF7lac57B5smLcT37aXpXIIPz75rW4g3eXHPjhHwdGskOw=="
     },
     "util": {
       "version": "0.11.1",
@@ -27860,8 +27803,7 @@
           "version": "8.5.0",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
           "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         }
       }
     },
@@ -28068,8 +28010,7 @@
     },
     "ws": {
       "version": "7.4.6",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "@sentry/browser": "~6.1.0",
     "@sentry/tracing": "~6.1.0",
     "animated-scrollto": "~1.1.0",
-    "chart.js": "~3.2.1",
+    "chart.js": "~3.9.1",
     "chartist": "~0.11.0",
     "classnames": "~2.2.6",
     "counterpart": "~0.18.6",


### PR DESCRIPTION
## PR Overview

Follows #5943
❗ Affects experimental / no-longer-supported feature

This PR updates the LinePlotModel (for the canvas viewer, and it's actually a _scatter plot model,_ because why not) to properly use Chart.js v3

- Previously, the scatter plots on the LinePlotModel wouldn't render, since PR 5943 bumped the `chart.js` dependency to v3
- This is because chart.js v3 introduces tree-shaking, so the way the library is imported has to change. (See: [migration guide](https://www.chartjs.org/docs/latest/getting-started/v3-migration.html), [v3 integration guide](https://www.chartjs.org/docs/3.9.1/getting-started/integration.html))

### Dev Notes

For info on how the data should look like, see https://www.chartjs.org/docs/3.9.1/charts/scatter.html

Example [JSON](https://panoptes-uploads.zooniverse.org/subject_location/3abacdd5-d872-4045-b2d8-29ed7ee68e27.json?=):
```
{
   "datasets":[
      {
         "label":"Scatte Data!",
         "data":[
            {
               "x":-10,
               "y":0
            },
            {
               "x":0,
               "y":10
            },
            {
               "x":10,
               "y":5
            },
            {
               "x":0.5,
               "y":5.5
            }
         ],
         "backgroundColor":"rgb(255,99,132)"
      }
   ]
}
```

Associated Subject: [80709319](https://www.zooniverse.org/projects/camallen/talk-test-project/talk/subjects/80709319)

### Testing:

- Open https://pr-6198.pfe-preview.zooniverse.org/projects/camallen/talk-test-project/talk/subjects/80709319
- You should see a scatter plot chart rendered on your browser

<img width="313" alt="Screenshot 2022-09-27 at 15 15 15" src="https://user-images.githubusercontent.com/13952701/192551085-ba865ae7-d5b4-40ef-a4d7-797f1ab0be2b.png">

### Status

Ready for review. However, do note some _operational_ caveats:

- As discussed [on 5943](https://github.com/zooniverse/Panoptes-Front-End/pull/5943#issuecomment-843021367) and on [Slack](https://zooniverse.slack.com/archives/C06LHUC6R/p1664262051229589), **the canvas viewer is no longer supported.**
- Future project teams should be using FEM's [Scatter Plot Viewer](https://github.com/zooniverse/front-end-monorepo/tree/master/packages/lib-classifier/src/components/Classifier/components/SubjectViewer/components/ScatterPlotViewer#json-file) instead.
  - The only thing to note here is that the FEM Scatter Plot Viewer and its Subjects/data won't display properly on Talk, as that feature still needs to be integrated.

Long term, we may want to consider simply removing canvas-viewer from our code, since it's no longer officially supported on any project. Short term, this might still have some use for displaying data on Talk.