### PR TITLE
Catch missing researcher avatars

### DIFF
--- a/app/pages/project/home/index.jsx
+++ b/app/pages/project/home/index.jsx
@@ -84,20 +84,20 @@ class ProjectHomeContainer extends React.Component {
   }
 
   fetchResearcherAvatar(props) {
-    if (props.project.configuration && props.project.configuration.researcherID) {
+    if (props.project.configuration?.researcherID) {
       if (props.project.configuration.researcherID === props.project.display_name) {
-        if (props.projectAvatar && props.projectAvatar.src) {
+        if (props.projectAvatar?.src) {
           this.setState({ researcherAvatar: props.projectAvatar.src });
         }
       } else {
         apiClient.type('users').get(this.props.project.configuration.researcherID)
+          .catch(() => null)
           .then((researcher) => {
-            researcher.get('avatar').then(([avatar]) => {
-              if (avatar.src) {
-                this.setState({ researcherAvatar: avatar.src });
-              }
-            });
-          }).catch(error => console.error(error));
+            if (researcher?.avatar_src) {
+              this.setState({ researcherAvatar: researcher.avatar_src });
+            }
+          })
+          .catch(error => console.error(error));
       }
     }
   }


### PR DESCRIPTION
Catch errors when fetching the researcher for a project home page. Use `researcher?.avatar_src` as the researcher avatar.

Staging branch URL: https://pr-6199.pfe-preview.zooniverse.org/projects/zooniverse/astronomy-rewind?env=production

Should fix #6189.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
