### PR TITLE
Fix expert classification data

### DIFF
--- a/app/classifier/classifier.jsx
+++ b/app/classifier/classifier.jsx
@@ -111,7 +111,7 @@ class Classifier extends React.Component {
     );
 
     awaitExpertClassification.then((expertClassification) => {
-      expertClassification = expertClassification || subject.expert_classification_data[workflow.id];
+      expertClassification = expertClassification || subject.expert_classification_data?.[workflow.id];
       if (this.props.workflow === workflow && this.props.subject === subject) {
         window.expertClassification = expertClassification;
         this.setState({ expertClassification });


### PR DESCRIPTION
Check that `subject.expert_classification_data` exists before reading an expert classification.

Staging branch URL: https://pr-6200.pfe-preview.zooniverse.org/projects/povich/milky-way-project/classify

Should fix #6194.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
