### PR TITLE
Bump Panoptes client to v4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "markdownz": "~7.8.1",
         "modal-form": "~2.9",
         "moment": "~2.29.0",
-        "panoptes-client": "~4.0.0",
+        "panoptes-client": "~4.1",
         "papaparse": "^5.2.0",
         "polished": "~2.3.3",
         "prop-types": "~15.7.1",
@@ -11779,9 +11779,9 @@
       "license": "(MIT AND Zlib)"
     },
     "node_modules/panoptes-client": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-4.0.0.tgz",
-      "integrity": "sha512-hPdWcQGAQl8atDMcDTfV5IrwZz7I4uFxXNNmU4H7KnfBGm+LUGxCFshOuZjHe8OghDIiGXyirDrba2vP9N050g==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-4.1.0.tgz",
+      "integrity": "sha512-Fg/CpqToxv45bVeiOQWBlmnBefp6KNzxbmVxhavVtfy2Pej/gPSZPtlTgeYNSkqOk8HgUFhBNgDyiQAm7I8wUg==",
       "dependencies": {
         "json-api-client": "~6.0.0",
         "local-storage": "^2.0.0",
@@ -18303,7 +18303,8 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.1.1.tgz",
       "integrity": "sha512-1FBc1f9G4P/AxMqIgfZgeOTuRnwZMten8E7zap5zgpPInnCrP8D4Q81+4CWIch8i/Nf7nXjP0v6CjjbHOrXhKg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@webpack-cli/info": {
       "version": "1.4.1",
@@ -18318,7 +18319,8 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.6.1.tgz",
       "integrity": "sha512-gNGTiTrjEVQ0OcVnzsRSqTxaBSr+dmTfm+qJsCDluky8uhdLWep7Gcr62QsAKHTMxjCS/8nEITsmFAhfIx+QSw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@wojtekmaj/enzyme-adapter-react-17": {
       "version": "0.6.7",
@@ -18392,7 +18394,8 @@
     },
     "acorn-jsx": {
       "version": "5.3.2",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -18431,7 +18434,8 @@
     },
     "ajv-errors": {
       "version": "1.0.1",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ajv-formats": {
       "version": "2.1.1",
@@ -18464,7 +18468,8 @@
     },
     "ajv-keywords": {
       "version": "3.5.2",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "amdefine": {
       "version": "1.0.1",
@@ -20714,7 +20719,8 @@
           "version": "8.2.3",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
           "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         }
       }
     },
@@ -22475,7 +22481,8 @@
     },
     "icss-utils": {
       "version": "5.1.0",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ieee754": {
       "version": "1.2.1",
@@ -22695,11 +22702,13 @@
     },
     "io-ts": {
       "version": "2.2.16",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "io-ts-reporters": {
       "version": "1.2.2",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ip": {
       "version": "1.1.5",
@@ -23451,7 +23460,8 @@
       }
     },
     "markdown-it-anchor": {
-      "version": "8.4.1"
+      "version": "8.4.1",
+      "requires": {}
     },
     "markdown-it-container": {
       "version": "3.0.0"
@@ -24681,9 +24691,9 @@
       "dev": true
     },
     "panoptes-client": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-4.0.0.tgz",
-      "integrity": "sha512-hPdWcQGAQl8atDMcDTfV5IrwZz7I4uFxXNNmU4H7KnfBGm+LUGxCFshOuZjHe8OghDIiGXyirDrba2vP9N050g==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-4.1.0.tgz",
+      "integrity": "sha512-Fg/CpqToxv45bVeiOQWBlmnBefp6KNzxbmVxhavVtfy2Pej/gPSZPtlTgeYNSkqOk8HgUFhBNgDyiQAm7I8wUg==",
       "requires": {
         "json-api-client": "~6.0.0",
         "local-storage": "^2.0.0",
@@ -24927,7 +24937,8 @@
     },
     "postcss-modules-extract-imports": {
       "version": "3.0.0",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-modules-local-by-default": {
       "version": "4.0.0",
@@ -25488,7 +25499,8 @@
     "redux-thunk": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.1.tgz",
-      "integrity": "sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q=="
+      "integrity": "sha512-OOYGNY5Jy2TWvTL1KgAlVy6dcx3siPJ1wTq741EPyUKfn6W6nChdICjZwCd0p8AZBs5kWpZlbkXW2nE/zjUa+Q==",
+      "requires": {}
     },
     "regenerate": {
       "version": "1.4.2",
@@ -25974,7 +25986,8 @@
     },
     "sinon-chai": {
       "version": "3.3.0",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "slash": {
       "version": "2.0.0",
@@ -26155,7 +26168,8 @@
         },
         "ws": {
           "version": "8.2.3",
-          "dev": true
+          "dev": true,
+          "requires": {}
         }
       }
     },
@@ -26510,7 +26524,8 @@
       "version": "3.5.4"
     },
     "stylis-rule-sheet": {
-      "version": "0.0.10"
+      "version": "0.0.10",
+      "requires": {}
     },
     "stylus": {
       "version": "0.54.8",
@@ -27147,7 +27162,8 @@
     "use-sync-external-store": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.0.0.tgz",
-      "integrity": "sha512-AFVsxg5GkFg8GDcxnl+Z0lMAz9rE8DGJCc28qnBuQF7lac57B5smLcT37aXpXIIPz75rW4g3eXHPjhHwdGskOw=="
+      "integrity": "sha512-AFVsxg5GkFg8GDcxnl+Z0lMAz9rE8DGJCc28qnBuQF7lac57B5smLcT37aXpXIIPz75rW4g3eXHPjhHwdGskOw==",
+      "requires": {}
     },
     "util": {
       "version": "0.11.1",
@@ -27803,7 +27819,8 @@
           "version": "8.5.0",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
           "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         }
       }
     },
@@ -28010,7 +28027,8 @@
     },
     "ws": {
       "version": "7.4.6",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "markdownz": "~7.8.1",
         "modal-form": "~2.9",
         "moment": "~2.29.0",
-        "panoptes-client": "~3.4.1",
+        "panoptes-client": "~4.0.0",
         "papaparse": "^5.2.0",
         "polished": "~2.3.3",
         "prop-types": "~15.7.1",
@@ -2966,7 +2966,7 @@
     "node_modules/asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
     },
     "node_modules/asn1.js": {
       "version": "5.4.1",
@@ -5516,7 +5516,7 @@
     "node_modules/dezalgo": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
-      "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
+      "integrity": "sha512-K7i4zNfT2kgQz3GylDw40ot9GAE47sFZ9EXHFSPP6zONLgH6kWXE0KWJchkbQJLBkRazq4APwZ4OwiFFlT95OQ==",
       "dependencies": {
         "asap": "^2.0.0",
         "wrappy": "1"
@@ -9565,12 +9565,12 @@
       }
     },
     "node_modules/json-api-client": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/json-api-client/-/json-api-client-5.1.1.tgz",
-      "integrity": "sha512-uvqHHh/bZcFEsZbytikxieiPurz6jM+kEqjnpbeeh7Deq06p5ns5+S6fzi7uw+7aBlUJEkdVMM6NrIppiGqrsA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/json-api-client/-/json-api-client-6.0.0.tgz",
+      "integrity": "sha512-rAC5Zhswdxuv2wxmN/gcliAHykz8Sv8ARtbZEkAhevLEWbxitoYMrPEElFFWB5w/QA3cyUSglJbsUlTb9n9Lnw==",
       "dependencies": {
         "normalizeurl": "~1.0.0",
-        "superagent": "^7.1.3"
+        "superagent": "^8.0.0"
       }
     },
     "node_modules/json-parse-better-errors": {
@@ -11075,7 +11075,7 @@
     "node_modules/normalizeurl": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/normalizeurl/-/normalizeurl-1.0.0.tgz",
-      "integrity": "sha1-SxpFjNDH0IVkNvaca1EEeraFUxc="
+      "integrity": "sha512-GyndB0rq1FmO49Vwy88c3jzp5G3OnjEbwVlm+vst+P5ANKQVtm+2682qgRptcZeZvU1I2E5RgCeZirqLuUQQEw=="
     },
     "node_modules/npm-run-path": {
       "version": "4.0.1",
@@ -11779,11 +11779,11 @@
       "license": "(MIT AND Zlib)"
     },
     "node_modules/panoptes-client": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-3.4.1.tgz",
-      "integrity": "sha512-jBTN754730Zd7XdAA409B7TiLAPIkuzfe0hZhK5EpTzqUgII+dP+5TzhqVHPzUZngIqTkTxx1neL0vSrygNHmA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-4.0.0.tgz",
+      "integrity": "sha512-hPdWcQGAQl8atDMcDTfV5IrwZz7I4uFxXNNmU4H7KnfBGm+LUGxCFshOuZjHe8OghDIiGXyirDrba2vP9N050g==",
       "dependencies": {
-        "json-api-client": "~5.1.0",
+        "json-api-client": "~6.0.0",
         "local-storage": "^2.0.0",
         "sugar-client": "^2.0.0"
       }
@@ -14530,9 +14530,9 @@
       }
     },
     "node_modules/superagent": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-7.1.3.tgz",
-      "integrity": "sha512-WA6et4nAvgBCS73lJvv1D0ssI5uk5Gh+TGN/kNe+B608EtcVs/yzfl+OLXTzDs7tOBDIpvgh/WUs1K2OK1zTeQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.0.0.tgz",
+      "integrity": "sha512-iudipXEel+SzlP9y29UBWGDjB+Zzag+eeA1iLosaR2YHBRr1Q1kC29iBrF2zIVD9fqVbpZnXkN/VJmwFMVyNWg==",
       "dependencies": {
         "component-emitter": "^1.3.0",
         "cookiejar": "^2.1.3",
@@ -14541,7 +14541,7 @@
         "form-data": "^4.0.0",
         "formidable": "^2.0.1",
         "methods": "^1.1.2",
-        "mime": "^2.5.0",
+        "mime": "2.6.0",
         "qs": "^6.10.3",
         "readable-stream": "^3.6.0",
         "semver": "^7.3.7"
@@ -14573,9 +14573,9 @@
       }
     },
     "node_modules/superagent/node_modules/qs": {
-      "version": "6.10.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
-      "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
       "dependencies": {
         "side-channel": "^1.0.4"
       },
@@ -18622,7 +18622,7 @@
     "asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
     },
     "asn1.js": {
       "version": "5.4.1",
@@ -20454,7 +20454,7 @@
     "dezalgo": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
-      "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
+      "integrity": "sha512-K7i4zNfT2kgQz3GylDw40ot9GAE47sFZ9EXHFSPP6zONLgH6kWXE0KWJchkbQJLBkRazq4APwZ4OwiFFlT95OQ==",
       "requires": {
         "asap": "^2.0.0",
         "wrappy": "1"
@@ -23176,12 +23176,12 @@
       "dev": true
     },
     "json-api-client": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/json-api-client/-/json-api-client-5.1.1.tgz",
-      "integrity": "sha512-uvqHHh/bZcFEsZbytikxieiPurz6jM+kEqjnpbeeh7Deq06p5ns5+S6fzi7uw+7aBlUJEkdVMM6NrIppiGqrsA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/json-api-client/-/json-api-client-6.0.0.tgz",
+      "integrity": "sha512-rAC5Zhswdxuv2wxmN/gcliAHykz8Sv8ARtbZEkAhevLEWbxitoYMrPEElFFWB5w/QA3cyUSglJbsUlTb9n9Lnw==",
       "requires": {
         "normalizeurl": "~1.0.0",
-        "superagent": "^7.1.3"
+        "superagent": "^8.0.0"
       }
     },
     "json-parse-better-errors": {
@@ -24221,7 +24221,7 @@
     "normalizeurl": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/normalizeurl/-/normalizeurl-1.0.0.tgz",
-      "integrity": "sha1-SxpFjNDH0IVkNvaca1EEeraFUxc="
+      "integrity": "sha512-GyndB0rq1FmO49Vwy88c3jzp5G3OnjEbwVlm+vst+P5ANKQVtm+2682qgRptcZeZvU1I2E5RgCeZirqLuUQQEw=="
     },
     "npm-run-path": {
       "version": "4.0.1",
@@ -24681,11 +24681,11 @@
       "dev": true
     },
     "panoptes-client": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-3.4.1.tgz",
-      "integrity": "sha512-jBTN754730Zd7XdAA409B7TiLAPIkuzfe0hZhK5EpTzqUgII+dP+5TzhqVHPzUZngIqTkTxx1neL0vSrygNHmA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-4.0.0.tgz",
+      "integrity": "sha512-hPdWcQGAQl8atDMcDTfV5IrwZz7I4uFxXNNmU4H7KnfBGm+LUGxCFshOuZjHe8OghDIiGXyirDrba2vP9N050g==",
       "requires": {
-        "json-api-client": "~5.1.0",
+        "json-api-client": "~6.0.0",
         "local-storage": "^2.0.0",
         "sugar-client": "^2.0.0"
       }
@@ -26599,9 +26599,9 @@
       "integrity": "sha512-87RfgwzyiQrA77lsBGYFPjHbDVzkcSl5aiubz3n7qPOwf9LLNKe+PvtlNf0bnFS63+gGWe6r8A18iaKLBthw1w=="
     },
     "superagent": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-7.1.3.tgz",
-      "integrity": "sha512-WA6et4nAvgBCS73lJvv1D0ssI5uk5Gh+TGN/kNe+B608EtcVs/yzfl+OLXTzDs7tOBDIpvgh/WUs1K2OK1zTeQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.0.0.tgz",
+      "integrity": "sha512-iudipXEel+SzlP9y29UBWGDjB+Zzag+eeA1iLosaR2YHBRr1Q1kC29iBrF2zIVD9fqVbpZnXkN/VJmwFMVyNWg==",
       "requires": {
         "component-emitter": "^1.3.0",
         "cookiejar": "^2.1.3",
@@ -26610,7 +26610,7 @@
         "form-data": "^4.0.0",
         "formidable": "^2.0.1",
         "methods": "^1.1.2",
-        "mime": "^2.5.0",
+        "mime": "2.6.0",
         "qs": "^6.10.3",
         "readable-stream": "^3.6.0",
         "semver": "^7.3.7"
@@ -26630,9 +26630,9 @@
           "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg=="
         },
         "qs": {
-          "version": "6.10.3",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
-          "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
+          "version": "6.11.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+          "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
           "requires": {
             "side-channel": "^1.0.4"
           }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "markdownz": "~7.8.1",
     "modal-form": "~2.9",
     "moment": "~2.29.0",
-    "panoptes-client": "~4.0.0",
+    "panoptes-client": "~4.1",
     "papaparse": "^5.2.0",
     "polished": "~2.3.3",
     "prop-types": "~15.7.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "markdownz": "~7.8.1",
     "modal-form": "~2.9",
     "moment": "~2.29.0",
-    "panoptes-client": "~3.4.1",
+    "panoptes-client": "~4.0.0",
     "papaparse": "^5.2.0",
     "polished": "~2.3.3",
     "prop-types": "~15.7.1",


### PR DESCRIPTION
Upgrade `panoptes-client` to the latest version, which upgrades Superagent to 8.

Staging branch URL: https://pr-6201.pfe-preview.zooniverse.org

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [x] Can you post a talk comment?

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
