### PR TITLE
collate logged in home page total classifications count from user's project preferences

### DIFF
--- a/app/pages/home-for-user/index.jsx
+++ b/app/pages/home-for-user/index.jsx
@@ -135,6 +135,13 @@ export default class HomePageForUser extends React.Component {
         // get the projects that you have classified on, if any.
         if (activePreferences.length > 0) {
           activePreferences = activePreferences.map((preference, i) => {
+            // add the classification counts to the total
+            // this will include all classifications a user has contributed
+            // regardless of the project's visibility setting, i.e. private or public.
+            this.setState((prevState) => {
+              const totalClassifications = prevState.totalClassifications + preference.activity_count;
+              return { totalClassifications };
+            });
             preference.sort_order = i;
             return preference;
           });
@@ -162,10 +169,7 @@ export default class HomePageForUser extends React.Component {
             .then((projects) => {
               this.setState((prevState) => {
                 const ribbonData = prevState.ribbonData.concat(projects);
-                const totalClassifications = ribbonData.reduce((total, project) => {
-                  return total + project.classifications;
-                }, 0);
-                return { ribbonData, totalClassifications };
+                return { ribbonData };
               });
             });
         }


### PR DESCRIPTION
This PR change uses the user's project preferences activity counts to calculate their total classification contributions. It  avoids the situation where a project set's their previously accessible project to 'private' and the user's total classification count decreases as it won't include the private projects. 

This change means all classifications contributions a user makes will count in their total. However this change won't impact the ribbon wheel image as that is created by accessing only public projects, hence there can be discrepancies between the total count displayed and the values in the ribbon wheel. 

Staging branch URL: https://pr-6208.pfe-preview.zooniverse.org

Fixes bug reports where users 'lose' classifications on their logged in home page. 

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
