### PR TITLE
Copy workflows via the Panoptes API

### DIFF
--- a/app/pages/lab/actions/workflow.js
+++ b/app/pages/lab/actions/workflow.js
@@ -1,14 +1,27 @@
 var apiClient = require('panoptes-client/lib/api-client');
 
+var projects = apiClient.type('projects');
 var workflows = apiClient.type('workflows');
 
 var workflowActions = {
-  createWorkflowForProject: function(projectID, workflowData) {
+  createWorkflowForProject: function(project, workflowData) {
     var allWorkflowData = Object.assign({
-      links: {project: projectID}
+      links: {project: project.id}
     }, workflowData);
 
     return workflows.create(allWorkflowData).save();
+  },
+  copyWorkflowForProject: async function(project, workflowData) {
+    const oldLinks = new Set(project.links.workflows);
+    const [newProject] = await project.addLink('workflows', [workflowData.id]);
+    const newLinks = newProject?.links
+    const newWorkflowID = newLinks?.workflows.find(workflowID => !oldLinks.has(workflowID));
+    if (!newWorkflowID) {
+      return Promise.reject(new Error('no new workflow links on project.'))
+    }
+    const newWorkflow = await workflows.get(newWorkflowID)
+    await newWorkflow.update({ display_name: workflowData.display_name }).save();
+    return newWorkflow;
   }
 }
 

--- a/app/pages/lab/actions/workflow.js
+++ b/app/pages/lab/actions/workflow.js
@@ -14,8 +14,8 @@ var workflowActions = {
   copyWorkflowForProject: async function(project, workflowData) {
     const oldLinks = new Set(project.links.workflows);
     const [newProject] = await project.addLink('workflows', [workflowData.id]);
-    const newLinks = newProject?.links
-    const newWorkflowID = newLinks?.workflows.find(workflowID => !oldLinks.has(workflowID));
+    const newLinks = newProject?.links.workflows
+    const newWorkflowID = newLinks?.find(workflowID => !oldLinks.has(workflowID));
     if (!newWorkflowID) {
       return Promise.reject(new Error('no new workflow links on project.'))
     }

--- a/app/pages/lab/workflow-create-form.cjsx
+++ b/app/pages/lab/workflow-create-form.cjsx
@@ -25,18 +25,10 @@ WorkflowCreateForm = createReactClass
     workflowToClone = @props.workflowToClone
 
     newWorkflow =
+      id: workflowToClone?.id
       display_name: @refs.newDisplayName.value
-      primary_language: workflowToClone?.primary_language || @props.project.primary_language
-      steps: workflowToClone?.steps ? undefined
-      tasks: workflowToClone?.tasks ? {}
-      first_task: workflowToClone?.first_task ? ''
-      configuration: workflowToClone?.configuration ? {}
-      retirement: workflowToClone?.retirement ? {}
-      active: @props.workflowActiveStatus ? false
-      grouped: workflowToClone?.grouped ? false
-      prioritized: workflowToClone?.prioritized ? false
 
-    awaitSubmission = @props.onSubmit(@props.project.id, newWorkflow)
+    awaitSubmission = @props.onSubmit(@props.project, newWorkflow)
 
     Promise.resolve(awaitSubmission)
       .then (result) =>

--- a/app/pages/lab/workflow.cjsx
+++ b/app/pages/lab/workflow.cjsx
@@ -106,7 +106,7 @@ EditWorkflowPage = createReactClass
       </h3>
       {if @state.workflowCreationInProgress
         <ModalFormDialog tag="div">
-          <WorkflowCreateForm onSubmit={@props.workflowActions.createWorkflowForProject} onCancel={@hideCreateWorkflow} onSuccess={@handleWorkflowCreation}  project={@props.project} workflowToClone={@props.workflow} workflowActiveStatus={not @props.project.live} />
+          <WorkflowCreateForm onSubmit={@props.workflowActions.copyWorkflowForProject} onCancel={@hideCreateWorkflow} onSuccess={@handleWorkflowCreation}  project={@props.project} workflowToClone={@props.workflow} workflowActiveStatus={not @props.project.live} />
         </ModalFormDialog>}
       <p className="form-help">A workflow is the sequence of tasks that you’re asking volunteers to perform. For example, you might want to ask volunteers to answer questions about your images, or to mark features in your images, or both.</p>
       {if @props.project.live and @props.workflow.active


### PR DESCRIPTION
- Copy workflows via the [`/project/{projectID}/links/workflows`](https://panoptes.docs.apiary.io/#reference/projects/project-create-links/add-a-link) API endpoint.
- Get the new workflow ID from the updated project links.
- Update the new workflow with the new title, then redirect.

Staging branch URL: https://pr-6212.pfe-preview.zooniverse.org

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
