### PR TITLE
Bump panoptes-client from 4.1.1 to 4.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "markdownz": "~7.8.1",
         "modal-form": "~2.9",
         "moment": "~2.29.0",
-        "panoptes-client": "~4.1",
+        "panoptes-client": "~4.2",
         "papaparse": "^5.2.0",
         "polished": "~2.3.3",
         "prop-types": "~15.7.1",
@@ -11779,9 +11779,9 @@
       "license": "(MIT AND Zlib)"
     },
     "node_modules/panoptes-client": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-4.1.1.tgz",
-      "integrity": "sha512-d1+fS98XR+Y/JKLnrR/lbUFGGHiZxiBiOFyzhlzXOStt8e/xFU5AJWwS1tDYrqVf5lomK/PPlFI3+NU4TR4ikQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-4.2.0.tgz",
+      "integrity": "sha512-qN8LyFjIkWVZIGlKO21Y+3wk6qRoCUrwtQR845xFy6W6wj8ygtZoF26dRYiFVqLxYZepEFCA51usNkek5T3gLA==",
       "dependencies": {
         "json-api-client": "~6.0.0",
         "local-storage": "^2.0.0",
@@ -24681,9 +24681,9 @@
       "dev": true
     },
     "panoptes-client": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-4.1.1.tgz",
-      "integrity": "sha512-d1+fS98XR+Y/JKLnrR/lbUFGGHiZxiBiOFyzhlzXOStt8e/xFU5AJWwS1tDYrqVf5lomK/PPlFI3+NU4TR4ikQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-4.2.0.tgz",
+      "integrity": "sha512-qN8LyFjIkWVZIGlKO21Y+3wk6qRoCUrwtQR845xFy6W6wj8ygtZoF26dRYiFVqLxYZepEFCA51usNkek5T3gLA==",
       "requires": {
         "json-api-client": "~6.0.0",
         "local-storage": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "markdownz": "~7.8.1",
     "modal-form": "~2.9",
     "moment": "~2.29.0",
-    "panoptes-client": "~4.1",
+    "panoptes-client": "~4.2",
     "papaparse": "^5.2.0",
     "polished": "~2.3.3",
     "prop-types": "~15.7.1",


### PR DESCRIPTION
4.2.0 includes improved error handling for response errors.

Staging branch URL: https://pr-6213.pfe-preview.zooniverse.org

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [x] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
