### PR TITLE
Project builder: Fix undefined required tasks

### DIFF
--- a/app/classifier/tasks/dropdown/index.jsx
+++ b/app/classifier/tasks/dropdown/index.jsx
@@ -263,6 +263,7 @@ DropdownTask.getDefaultTask = () => ({
   type: 'dropdown',
   instruction: 'Select or type an option',
   help: '',
+  required: false,
   selects: [
     {
       id: Math.random().toString(16).split('.')[1],

--- a/app/classifier/tasks/multiple/index.jsx
+++ b/app/classifier/tasks/multiple/index.jsx
@@ -66,6 +66,7 @@ MultipleChoiceTask.getDefaultTask = () => {
     type: 'multiple',
     question: 'Enter a question.',
     help: '',
+    required: false,
     answers: []
   };
 };

--- a/app/classifier/tasks/single/index.jsx
+++ b/app/classifier/tasks/single/index.jsx
@@ -67,6 +67,7 @@ SingleChoiceTask.getDefaultTask = () => {
     type: 'single',
     question: 'Enter a question.',
     help: '',
+    required: false,
     answers: []
   };
 };

--- a/app/classifier/tasks/subjectGroupComparison/index.jsx
+++ b/app/classifier/tasks/subjectGroupComparison/index.jsx
@@ -39,6 +39,7 @@ SubjectGroupComparisonTask.getDefaultTask = () => {
     type: 'subjectGroupComparison',
     question: 'Enter a question.',
     help: '',
+    required: false
   };
 };
 SubjectGroupComparisonTask.getTaskText = (task) => {

--- a/app/classifier/tasks/survey/index.jsx
+++ b/app/classifier/tasks/survey/index.jsx
@@ -16,6 +16,7 @@ export default class SurveyTask extends React.Component {
   static getDefaultTask() {
     return {
       type: 'survey',
+      required: false,
       characteristicsOrder: [],
       characteristics: {},
       choicesOrder: [],

--- a/app/classifier/tasks/textFromSubject/index.jsx
+++ b/app/classifier/tasks/textFromSubject/index.jsx
@@ -25,7 +25,8 @@ TextFromSubjectTask.getDefaultAnnotation = () => ({
 TextFromSubjectTask.getDefaultTask = () => ({
   help: '',
   instruction: 'Correct the text',
-  type: 'textFromSubject'
+  type: 'textFromSubject',
+  required: false
 });
 TextFromSubjectTask.getTaskText = task => (task.instruction);
 // isAnnotationComplete will return false within PFE to prevent classifications from being submitted within PFE, as the TextFromSubject task is exclusively for the front-end-monorepo.

--- a/app/pages/lab/workflow.cjsx
+++ b/app/pages/lab/workflow.cjsx
@@ -517,13 +517,22 @@ EditWorkflowPage = createReactClass
 
         <div className={taskEditorClasses}>
           {if @state.selectedTaskKey? and @props.workflow.tasks[@state.selectedTaskKey]?
-            TaskEditorComponent = taskComponents[@props.workflow.tasks[@state.selectedTaskKey].type]?.Editor
+            task = @props.workflow.tasks[@state.selectedTaskKey]
+            if task.required is 'true'
+              task.required = true
+            if task.required is 'false'
+              task.required = false
+            TaskEditorComponent = taskComponents[task.type]?.Editor
+            taskWithDefaults = {
+              required: false,
+              ...task
+            }
             <div>
               {if 'shortcut' in @props.project.experimental_tools
-                <ShortcutEditor workflow={@props.workflow} task={@props.workflow.tasks[@state.selectedTaskKey]}>
+                <ShortcutEditor workflow={@props.workflow} task={taskWithDefaults}>
                   <TaskEditorComponent
                     workflow={@props.workflow}
-                    task={@props.workflow.tasks[@state.selectedTaskKey]}
+                    task={taskWithDefaults}
                     taskPrefix="tasks.#{@state.selectedTaskKey}"
                     project={@props.project}
                     onChange={@handleTaskChange.bind this, @state.selectedTaskKey}
@@ -532,13 +541,14 @@ EditWorkflowPage = createReactClass
               else if TaskEditorComponent
                 <TaskEditorComponent
                   workflow={@props.workflow}
-                  task={@props.workflow.tasks[@state.selectedTaskKey]}
+                  task={taskWithDefaults}
                   taskPrefix="tasks.#{@state.selectedTaskKey}"
                   project={@props.project}
                   onChange={@handleTaskChange.bind this, @state.selectedTaskKey}
                 />
               else
-                <div>Editor is not available.</div>}
+                <div>Editor is not available.</div>
+              }
               <hr />
               <br />
 
@@ -565,7 +575,8 @@ EditWorkflowPage = createReactClass
           else
             <div className="form-help">
               <p>Choose a task to edit. The configuration for that task will appear here.</p>
-            </div>}
+            </div>
+          }
         </div>
       </div>
     </div>


### PR DESCRIPTION
- Set a default for `task.required` in the workflow editor.
- Convert string values to booleans in the workflow editor.
- Add `required: false` to default tasks when new tasks are created.

Staging branch URL: https://pr-6215.pfe-preview.zooniverse.org
SquirrelMapper workflow from the original bug report: https://pr-6215.pfe-preview.zooniverse.org/lab/8149/workflows/20808

- Fixes #6214.
- This should fix the project builder showing tasks as required when `task.required` is undefined ~~but won't fix any tasks with `required: 'false'`, since it doesn't overwrite existing values~~. I'll add a couple of lines to convert string values to booleans.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
