### PR TITLE
Add required or not null properties for new workflow creation

### DIFF
--- a/app/pages/lab/workflow-create-form.cjsx
+++ b/app/pages/lab/workflow-create-form.cjsx
@@ -27,7 +27,9 @@ WorkflowCreateForm = createReactClass
     newWorkflow =
       id: workflowToClone?.id
       display_name: @refs.newDisplayName.value
+      first_task: ''
       primary_language: @props.project.primary_language
+      tasks: {}
 
     awaitSubmission = @props.onSubmit(@props.project, newWorkflow)
 

--- a/app/pages/lab/workflow-create-form.cjsx
+++ b/app/pages/lab/workflow-create-form.cjsx
@@ -27,6 +27,7 @@ WorkflowCreateForm = createReactClass
     newWorkflow =
       id: workflowToClone?.id
       display_name: @refs.newDisplayName.value
+      primary_language: @props.project.primary_language
 
     awaitSubmission = @props.onSubmit(@props.project, newWorkflow)
 


### PR DESCRIPTION
Staging branch URL: https://pr-6217.pfe-preview.zooniverse.org

Iteration on #6212 .

Local project for testing - https://local.zooniverse.org:3735/lab/1779/workflows
Production test project on preview for testing - https://pr-6217.pfe-preview.zooniverse.org/lab/4312/workflows

Describe your changes.
- per [panoptes create workflow schema](https://github.com/zooniverse/panoptes/blob/master/app/schemas/workflow_create_schema.rb#L5) adds `primary_language` to new workflow creation object
- per workflow_versions not null violations add `first_task` empty string and `tasks` empty object

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
