### PR TITLE
Fix broken survey task editor

### DIFF
--- a/app/classifier/tasks/survey/editor.cjsx
+++ b/app/classifier/tasks/survey/editor.cjsx
@@ -310,7 +310,7 @@ module.exports = createReactClass
     @props.task.questionsMap = newTask.questionsMap
     @props.task.questionsOrder = newTask.questionsOrder
 
-    @props.workflow.update('tasks').save()
+    @props.onChange @props.task
       .then =>
         @clearState()
 
@@ -544,14 +544,14 @@ module.exports = createReactClass
   handleImageAdd: (media) ->
     @setState resettingFiles: true
     @props.task.images[media.metadata.filename] = media.src
-    @props.workflow.update('tasks').save()
+    @props.onChange @props.task
       .then =>
         @setState resettingFiles: false
 
   handleImageDelete: (media) ->
     @setState resettingFiles: true
     delete @props.task.images[media.metadata.filename]
-    @props.workflow.update('tasks').save()
+    @props.onChange @props.task
       .then =>
         @setState resettingFiles: false
 
@@ -595,7 +595,7 @@ module.exports = createReactClass
         questionsOrder: []
         questions: {}
         questionsMap: {}
-      @props.workflow.update 'tasks'
+      @props.onChange @props.task
       @clearState()
 
   resetMedia: (e) ->


### PR DESCRIPTION
Replace `workflow.update('tasks').save()` with `@props.onChange(@props.task)` throughout.

Since #6215, the `task` prop that is passed into task editors is a shallow copy of the original task, so the workflow won't be updated when the editor makes changes to the task. A consequence of this is that survey tasks no longer update when you edit them in the project builder.

This PR changes the survey task editor to call `@props.onChange(task)` which is a wrapper for 
```js
  workflow.update({ [`tasks.${taskKey}`]: task }).save()
```

Staging branch URL: https://pr-6221.pfe-preview.zooniverse.org

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [x] Can you post a talk comment?

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
