### PR TITLE
Workflow Editor: fetch data with hooks

### DIFF
--- a/app/pages/lab-fem/workflow.jsx
+++ b/app/pages/lab-fem/workflow.jsx
@@ -1,4 +1,4 @@
-import { Component } from 'react';
+import { Component, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import handleInputChange from '../../lib/handle-input-change.js';
 import PromiseRenderer from '../../components/promise-renderer.cjsx';
@@ -1042,16 +1042,31 @@ EditWorkflowPage.defaultProps = {
   workflowActions: workflowActions
 };
 
-export default function EditWorkflowPageWrapper (props) {
-  const params = props.params || {
-    workflowID: ''
-  }
+const defaultParams = {
+  workflowID: ''
+}
+export default function EditWorkflowPageWrapper({
+  params = defaultParams,
+  ...props
+}) {
+  const [workflow, setWorkflow] = useState(null);
+  const [error, setError] = useState(null);
 
-  return <PromiseRenderer promise={apiClient.type('workflows').get(params.workflowID, {})}>{workflow => {
-    return <ChangeListener target={workflow}>{() => {
-      return <EditWorkflowPage {...props} workflow={workflow} />;
-    }
-    }</ChangeListener>;
+  useEffect(function loadWorkflow() {
+    apiClient.type('workflows')
+      .get(params.workflowID, {})
+      .catch(error => {
+        setError(error);
+        return null;
+      })
+      .then(setWorkflow);
+  }, [params.workflowID]);
+  
+  if (workflow) {
+    return <EditWorkflowPage {...props} params={params} workflow={workflow} />;
   }
-  }</PromiseRenderer>;
+  if (error) {
+    return <p>{error.message}</p>
+  }
+  return <p>Loading…</p>;
 }


### PR DESCRIPTION
Replace `PromiseRenderer` with a data-fetching hook, when the workflow editor loads.

Staging branch URL: https://pr-6226.pfe-preview.zooniverse.org

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
