### PR TITLE
Project Builder: fix missing Translations link

### DIFF
--- a/app/pages/lab/project.jsx
+++ b/app/pages/lab/project.jsx
@@ -219,7 +219,7 @@ function EditProjectPage({
                 Subject Sets
               </Link>
             </li>
-            {(project.experimental_tools?.indexOf('translator-role') > -1) || isAdmin() &&
+            {((project.experimental_tools?.indexOf('translator-role') > -1) || isAdmin()) &&
               <li>
                 <Link
                   aria-current={pathname === labPath('/translations') ? 'page' : undefined}


### PR DESCRIPTION
## PR Overview

Affects: Project Builder
Fixes #6249

This PR fixes an issue where the "Translations" link (on the left-side menu) _should_ appear when either (1) the translator-role experimental tool is enabled for the project, or (2) the user is in admin mode, but doesn't.

### Dev Notes

We've determined that the issue stems from the way JS evaluates the conditions for rendering the Translations link. The `||` basically meant the first true-ish condition was rendered (as `true`) instead of the intended component.

### Testing

Testing steps:
- Scenario 1: as a Zooniverse admin (admin mode enabled), go to the Project Builder page of any project _without the translator-role_ . [(example)](https://local.zooniverse.org:3735/lab/1873) You should see the Translations link.
- Scenario 2: as a normal user, go to the PB page of any project _with the translator-role._ You should see the link.
- Scenario 2: as a normal user, go to the PB page of any project _without the translator-role._ You should NOT see the link.

### Status

Fix in place, but please wait while I compile some recent suggestions from Slack into this PR before reviewing.