### PR TITLE
Workflow editor: refactor task editor

### DIFF
--- a/app/pages/lab/workflow-components/task-editor.jsx
+++ b/app/pages/lab/workflow-components/task-editor.jsx
@@ -1,0 +1,86 @@
+import ShortcutEditor from '../../../classifier/tasks/shortcut/editor.jsx';
+import FeedbackSection from '../../../features/feedback/lab';
+import MobileSection from '../mobile/index.js';
+import AutoSave from '../../../components/auto-save.coffee';
+import taskComponents from '../../../classifier/tasks/index.js';
+
+export default function TaskEditor({ onDelete, project, selectedTaskKey, workflow }) {
+  const task = workflow.tasks[selectedTaskKey];
+
+  function onChange(taskDescription) {
+    const changes = {
+      [`tasks.${selectedTaskKey}`]: taskDescription
+    };
+    return workflow.update(changes).save();
+  }
+
+  function handleTaskDelete(event) {
+    onDelete(selectedTaskKey, event);
+  }
+
+  if (!!selectedTaskKey && !!task) {
+    if (task.required === 'true') {
+      task.required = true;
+    }
+    if (task.required === 'false') {
+      task.required = false;
+    }
+    const TaskEditorComponent = taskComponents[task.type]?.Editor;
+    const taskWithDefaults = {
+      required: false,
+      ...task
+    };
+
+    return <div>
+      {project.experimental_tools?.includes('shortcut') ?
+        <ShortcutEditor workflow={workflow} task={taskWithDefaults}>
+          <TaskEditorComponent
+            workflow={workflow}
+            task={taskWithDefaults}
+            taskPrefix={`tasks.${selectedTaskKey}`}
+            project={project}
+            onChange={onChange}
+          />
+        </ShortcutEditor>
+      : TaskEditorComponent ?
+        <TaskEditorComponent
+          workflow={workflow}
+          task={taskWithDefaults}
+          taskPrefix={`tasks.${selectedTaskKey}`}
+          project={project}
+          onChange={onChange}
+        />
+      :
+        <div>Editor is not available.</div>
+      }
+      <hr />
+      <br />
+
+      {project.experimental_tools?.includes('general feedback') ?
+        <FeedbackSection
+          task={task}
+          saveFn={onChange}
+        /> :
+          null
+      }
+      <hr />
+      <br />
+
+      <MobileSection
+        project={project}
+        workflow={workflow}
+        task={task}
+      />
+
+      <AutoSave resource={workflow}>
+        <button type="button" className="minor-button" onClick={handleTaskDelete}>
+          <small>Delete this task</small>
+        </button>
+      </AutoSave>
+    </div>;
+  } else {
+    return <div className="form-help">
+      <p>Choose a task to edit. The configuration for that task will appear here.</p>
+    </div>;
+  }
+}

--- a/app/pages/lab/workflow.jsx
+++ b/app/pages/lab/workflow.jsx
@@ -14,14 +14,12 @@ import FileButton from '../../components/file-button.cjsx';
 import WorkflowCreateForm from './workflow-create-form.cjsx';
 import workflowActions from './actions/workflow.js';
 import classnames from 'classnames';
-import ShortcutEditor from '../../classifier/tasks/shortcut/editor.jsx';
-import FeedbackSection from '../../features/feedback/lab';
-import MobileSection from './mobile';
 import SubjectGroupViewerEditor from './workflow-components/subject-group-viewer-editor.jsx';
 import SubjectSetLinker from './workflow-components/subject-set-linker.jsx';
 import MiniCourses from './workflow-components/mini-courses.jsx';
 import Tutorials from './workflow-components/tutorials.jsx';
 import TaskOptions from './workflow-components/task-options.jsx';
+import TaskEditor from './workflow-components/task-editor.jsx';
 
 const DEMO_SUBJECT_SET_ID = process.env.NODE_ENV === 'production'
 ? '6' // Cats
@@ -49,7 +47,8 @@ class EditWorkflowPage extends Component {
     this.handleWorkflowCreation = this.handleWorkflowCreation.bind(this);
     this.hideCreateWorkflow = this.hideCreateWorkflow.bind(this);
     this.showCreateWorkflow = this.showCreateWorkflow.bind(this);
-    this.showTaskAddButtons = this.showTaskAddButtons.bind(this)
+    this.showTaskAddButtons = this.showTaskAddButtons.bind(this);
+    this.handleTaskDelete = this.handleTaskDelete.bind(this);
 
     this.state = {
       selectedTaskKey: props.workflow.first_task,
@@ -94,12 +93,6 @@ class EditWorkflowPage extends Component {
 
   canUseTask(project, task) {
     return Array.from(project.experimental_tools).includes(task);
-  }
-
-  handleTaskChange(taskKey, taskDescription) {
-    const changes = {};
-    changes[`tasks.${taskKey}`] = taskDescription;
-    return this.props.workflow.update(changes).save();
   }
 
   isThereNotADefinedTask() {
@@ -557,72 +550,12 @@ class EditWorkflowPage extends Component {
           </div>
 
           <div className={taskEditorClasses}>
-            {(() => {
-            if ((this.state.selectedTaskKey != null) && (this.props.workflow.tasks[this.state.selectedTaskKey] != null)) {
-              const task = this.props.workflow.tasks[this.state.selectedTaskKey];
-              if (task.required === 'true') {
-                task.required = true;
-              }
-              if (task.required === 'false') {
-                task.required = false;
-              }
-              const TaskEditorComponent = taskComponents[task.type]?.Editor;
-              const taskWithDefaults = {
-                required: false,
-                ...task
-              };
-              return <div>
-                {Array.from(this.props.project.experimental_tools).includes('shortcut') ?
-                  <ShortcutEditor workflow={this.props.workflow} task={taskWithDefaults}>
-                    <TaskEditorComponent
-                      workflow={this.props.workflow}
-                      task={taskWithDefaults}
-                      taskPrefix={`tasks.${this.state.selectedTaskKey}`}
-                      project={this.props.project}
-                      onChange={this.handleTaskChange.bind(this, this.state.selectedTaskKey)}
-                    />
-                  </ShortcutEditor>
-                : TaskEditorComponent ?
-                  <TaskEditorComponent
-                    workflow={this.props.workflow}
-                    task={taskWithDefaults}
-                    taskPrefix={`tasks.${this.state.selectedTaskKey}`}
-                    project={this.props.project}
-                    onChange={this.handleTaskChange.bind(this, this.state.selectedTaskKey)}
-                  />
-                :
-                  <div>Editor is not available.</div>
-                }
-                <hr />
-                <br />
-
-                {Array.from(this.props.project.experimental_tools).includes('general feedback') ?
-                  <FeedbackSection
-                    task={this.props.workflow.tasks[this.state.selectedTaskKey]}
-                    saveFn={this.handleTaskChange.bind(this, this.state.selectedTaskKey)}
-                  /> : undefined}
-                <hr />
-                <br />
-
-                <MobileSection
-                  project={this.props.project}
-                  workflow={this.props.workflow}
-                  task={this.props.workflow.tasks[this.state.selectedTaskKey]}
-                />
-
-                <AutoSave resource={this.props.workflow}>
-                  <small>
-                    <button type="button" className="minor-button" onClick={this.handleTaskDelete.bind(this, this.state.selectedTaskKey)}>Delete this task</button>
-                  </small>
-                </AutoSave>
-              </div>;
-            } else {
-              return <div className="form-help">
-                <p>Choose a task to edit. The configuration for that task will appear here.</p>
-              </div>;
-            }
-          })()
-            }
+            <TaskEditor
+              onDelete={this.handleTaskDelete}
+              project={this.props.project}
+              selectedTaskKey={this.state.selectedTaskKey}
+              workflow={this.props.workflow}
+            />
           </div>
         </div>
       </div>


### PR DESCRIPTION
Replace another auto-running anonymous closure, generated by decaffeinate, with functional React components:
- `TaskEditor` handles all the logic associated with finding and displaying the editor for the selected workflow task.

Staging branch URL: https://pr-6251.pfe-preview.zooniverse.org

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
