### PR TITLE
Minor refactor: improve Project Editor with ternaries

### DIFF
--- a/app/pages/lab/project.jsx
+++ b/app/pages/lab/project.jsx
@@ -26,7 +26,9 @@ function RenderError({
   return (
     <div>
       <h1><code>{error.message}</code></h1>
-      <p>{info?.componentStack && <pre>{info.componentStack}</pre>}</p>
+      <p>
+        {info?.componentStack ? <pre>{info.componentStack}</pre> : null}
+      </p>
     </div>
   )
 }
@@ -147,7 +149,7 @@ function EditProjectPage({
                 Tutorial
               </Link>
             </li>
-            {(project.experimental_tools.includes('mini-course')) &&
+            {(project.experimental_tools.includes('mini-course')) ?
               <li>
                 <Link
                   aria-current={pathname === labPath('/mini-course') ? 'page' : undefined}
@@ -158,7 +160,7 @@ function EditProjectPage({
                   Mini-course
                 </Link>
               </li>
-            }
+            : null}
             <li>
               <Link
                 aria-current={pathname === labPath('/media') ? 'page' : undefined}
@@ -259,9 +261,9 @@ function EditProjectPage({
               <LoadingIndicator off={!deleteState.deletionInProgress} />
             </button>
           </p>
-          {deleteState.deletionError &&
+          {deleteState.deletionError ?
             <p className="form-help error">{deleteState.deletionError.message}</p>
-          }
+          : null}
         </nav>
 
         <hr />


### PR DESCRIPTION
## PR Overview

Affects: Project Editor
Small follow up to #6250

This PR is a minor code refactor. We now use ternary operators when deciding to render React components in the Project Editor, instead of `&&` shortcuts. No behaviour change expected.

Running some quick tests before flagging this ready for review.