### PR TITLE
Preserve session ID on page load

### DIFF
--- a/app/partials/app.cjsx
+++ b/app/partials/app.cjsx
@@ -7,7 +7,7 @@ counterpart = require 'counterpart'
 `import AppStatus from './app-status';`
 IOStatus = require './io-status'
 AppLayout = require('../layout').default
-{generateSessionID} = require '../lib/session'
+{getSessionID} = require '../lib/session'
 NotificationsCounter = require('../lib/notifications-counter').default
 apiClient = require 'panoptes-client/lib/api-client'
 
@@ -54,7 +54,7 @@ PanoptesApp = createReactClass
 
     auth.listen 'change', @handleAuthChange
     @handleAuthChange()
-    generateSessionID()
+    getSessionID()
   
   componentDidUpdate: (prevProps) ->
     if prevProps.params isnt @props.params 


### PR DESCRIPTION
Use `getSessionID()`, instead of `generateSessionID()`, to preserve any existing session ID when the page first loads.

Staging branch URL: https://pr-6254.pfe-preview.zooniverse.org

Fixes #6253.

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
