### PR TITLE
[Security] Replace outdated cjsx-loader

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -74,7 +74,6 @@
         "chai": "~4.2.0",
         "check-dependencies": "~1.1.0",
         "check-engines": "~1.5.0",
-        "cjsx-loader": "~3.0.0",
         "coffee-loader": "~0.9.0",
         "coffee-react": "~5.0.1",
         "coffeescript": "~2.3.2",
@@ -2029,9 +2028,10 @@
       }
     },
     "node_modules/@socket.io/component-emitter": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT"
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
+      "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==",
+      "dev": true
     },
     "node_modules/@tootallnate/once": {
       "version": "1.1.2",
@@ -3347,11 +3347,6 @@
         "babylon": "bin/babylon.js"
       }
     },
-    "node_modules/backo2": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "dev": true,
@@ -3591,9 +3586,13 @@
       }
     },
     "node_modules/bower-config/node_modules/minimist": {
-      "version": "0.2.1",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.2.tgz",
+      "integrity": "sha512-g92kDfAOAszDRtHNagjZPPI/9lfOFaRBL/Ud6Z0RKZua/x+49awTydZLh5Gkhb80Xy5hmcvZNLGzscW5n5yd0g==",
       "dev": true,
-      "license": "MIT"
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -4215,50 +4214,6 @@
       "version": "0.3.3",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/cjsx-loader": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "coffee-react-transform": "^4.0.0",
-        "loader-utils": "0.2.x"
-      }
-    },
-    "node_modules/cjsx-loader/node_modules/big.js": {
-      "version": "3.2.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/cjsx-loader/node_modules/emojis-list": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "node_modules/cjsx-loader/node_modules/json5": {
-      "version": "0.5.1",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "json5": "lib/cli.js"
-      }
-    },
-    "node_modules/cjsx-loader/node_modules/loader-utils": {
-      "version": "0.2.17",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "big.js": "^3.1.3",
-        "emojis-list": "^2.0.0",
-        "json5": "^0.5.0",
-        "object-assign": "^4.0.1"
-      }
     },
     "node_modules/class-utils": {
       "version": "0.3.6",
@@ -4984,9 +4939,10 @@
       }
     },
     "node_modules/css-loader/node_modules/loader-utils": {
-      "version": "2.0.1",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+      "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "big.js": "^5.2.2",
         "emojis-list": "^3.0.0",
@@ -7204,9 +7160,10 @@
       }
     },
     "node_modules/file-loader/node_modules/loader-utils": {
-      "version": "2.0.1",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+      "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "big.js": "^5.2.2",
         "emojis-list": "^3.0.0",
@@ -9719,9 +9676,10 @@
       }
     },
     "node_modules/loader-utils": {
-      "version": "1.4.0",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
+      "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "big.js": "^5.2.2",
         "emojis-list": "^3.0.0",
@@ -10244,9 +10202,10 @@
       }
     },
     "node_modules/mini-css-extract-plugin/node_modules/loader-utils": {
-      "version": "2.0.1",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+      "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "big.js": "^5.2.2",
         "emojis-list": "^3.0.0",
@@ -10540,6 +10499,18 @@
         "node": ">= 6"
       }
     },
+    "node_modules/mocha/node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/mocha/node_modules/has-flag": {
       "version": "4.0.0",
       "dev": true,
@@ -10738,9 +10709,10 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/mout": {
-      "version": "1.2.3",
-      "dev": true,
-      "license": "MIT"
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/mout/-/mout-1.2.4.tgz",
+      "integrity": "sha512-mZb9uOruMWgn/fw28DG4/yE3Kehfk1zKCLhuDU2O3vlKdnBBr4XaOCqVTflJ5aODavGUPqFHZgrFX3NJVuxGhQ==",
+      "dev": true
     },
     "node_modules/move-concurrently": {
       "version": "1.0.1",
@@ -13812,62 +13784,49 @@
       "dev": true
     },
     "node_modules/socket.io-client": {
-      "version": "4.3.2",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.5.3.tgz",
+      "integrity": "sha512-I/hqDYpQ6JKwtJOf5ikM+Qz+YujZPMEl6qBLhxiP0nX+TfXKhW4KZZG8lamrD6Y5ngjmYHreESVasVCgi5Kl3A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@socket.io/component-emitter": "~3.0.0",
-        "backo2": "~1.0.2",
+        "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.2",
-        "engine.io-client": "~6.0.1",
-        "parseuri": "0.0.6",
-        "socket.io-parser": "~4.1.1"
+        "engine.io-client": "~6.2.3",
+        "socket.io-parser": "~4.2.0"
       },
       "engines": {
         "node": ">=10.0.0"
       }
     },
-    "node_modules/socket.io-client/node_modules/base64-arraybuffer": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6.0"
-      }
-    },
     "node_modules/socket.io-client/node_modules/engine.io-client": {
-      "version": "6.0.2",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.2.3.tgz",
+      "integrity": "sha512-aXPtgF1JS3RuuKcpSrBtimSjYvrbhKW9froICH4s0F3XQWLxsKNxqzG39nnvQZQnva4CMvUK63T7shevxRyYHw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@socket.io/component-emitter": "~3.0.0",
+        "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.1",
-        "engine.io-parser": "~5.0.0",
-        "has-cors": "1.1.0",
-        "parseqs": "0.0.6",
-        "parseuri": "0.0.6",
+        "engine.io-parser": "~5.0.3",
         "ws": "~8.2.3",
-        "xmlhttprequest-ssl": "~2.0.0",
-        "yeast": "0.1.2"
+        "xmlhttprequest-ssl": "~2.0.0"
       }
     },
     "node_modules/socket.io-client/node_modules/engine.io-parser": {
-      "version": "5.0.1",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.4.tgz",
+      "integrity": "sha512-+nVFp+5z1E3HcToEnO7ZIj3g+3k9389DvWtvJZz0T6/eOCPIyyxehFcedoYrZQrp0LgQbD9pPXhpMBKMd5QURg==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "base64-arraybuffer": "~1.0.1"
-      },
       "engines": {
         "node": ">=10.0.0"
       }
     },
     "node_modules/socket.io-client/node_modules/socket.io-parser": {
-      "version": "4.1.1",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.1.tgz",
+      "integrity": "sha512-V4GrkLy+HeF1F/en3SpUaM+7XxYXpuMUWLGde1kSSh5nQMN4hLrbPIkD+otwh6q9R6NOQBN4AMaOZ2zVjui82g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@socket.io/component-emitter": "~3.0.0",
+        "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.1"
       },
       "engines": {
@@ -13876,8 +13835,9 @@
     },
     "node_modules/socket.io-client/node_modules/ws": {
       "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
+      "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -13895,9 +13855,10 @@
       }
     },
     "node_modules/socket.io-parser": {
-      "version": "4.0.4",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.0.5.tgz",
+      "integrity": "sha512-sNjbT9dX63nqUFIOv95tTVm6elyIU4RvB1m8dOeZt+IgWwcWklFDOdmGcfo3zSiRsnR/3pJkjY5lfoGqEe4Eig==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/component-emitter": "^1.2.10",
         "component-emitter": "~1.3.0",
@@ -14345,9 +14306,10 @@
       }
     },
     "node_modules/style-loader/node_modules/loader-utils": {
-      "version": "2.0.1",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+      "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "big.js": "^5.2.2",
         "emojis-list": "^3.0.0",
@@ -14439,9 +14401,10 @@
       }
     },
     "node_modules/stylus-loader/node_modules/loader-utils": {
-      "version": "2.0.1",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+      "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "big.js": "^5.2.2",
         "emojis-list": "^3.0.0",
@@ -16548,6 +16511,8 @@
     },
     "node_modules/xmlhttprequest-ssl": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.0.0.tgz",
+      "integrity": "sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A==",
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
@@ -17894,7 +17859,9 @@
       "dev": true
     },
     "@socket.io/component-emitter": {
-      "version": "3.0.0",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
+      "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==",
       "dev": true
     },
     "@tootallnate/once": {
@@ -18919,10 +18886,6 @@
       "version": "6.18.0",
       "dev": true
     },
-    "backo2": {
-      "version": "1.0.2",
-      "dev": true
-    },
     "balanced-match": {
       "version": "1.0.2",
       "dev": true
@@ -19092,7 +19055,9 @@
       },
       "dependencies": {
         "minimist": {
-          "version": "0.2.1",
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.2.tgz",
+          "integrity": "sha512-g92kDfAOAszDRtHNagjZPPI/9lfOFaRBL/Ud6Z0RKZua/x+49awTydZLh5Gkhb80Xy5hmcvZNLGzscW5n5yd0g==",
           "dev": true
         }
       }
@@ -19537,38 +19502,6 @@
     "circular-json": {
       "version": "0.3.3",
       "dev": true
-    },
-    "cjsx-loader": {
-      "version": "3.0.0",
-      "dev": true,
-      "requires": {
-        "coffee-react-transform": "^4.0.0",
-        "loader-utils": "0.2.x"
-      },
-      "dependencies": {
-        "big.js": {
-          "version": "3.2.0",
-          "dev": true
-        },
-        "emojis-list": {
-          "version": "2.1.0",
-          "dev": true
-        },
-        "json5": {
-          "version": "0.5.1",
-          "dev": true
-        },
-        "loader-utils": {
-          "version": "0.2.17",
-          "dev": true,
-          "requires": {
-            "big.js": "^3.1.3",
-            "emojis-list": "^2.0.0",
-            "json5": "^0.5.0",
-            "object-assign": "^4.0.1"
-          }
-        }
-      }
     },
     "class-utils": {
       "version": "0.3.6",
@@ -20099,7 +20032,9 @@
       },
       "dependencies": {
         "loader-utils": {
-          "version": "2.0.1",
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+          "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
           "dev": true,
           "requires": {
             "big.js": "^5.2.2",
@@ -21663,7 +21598,9 @@
       },
       "dependencies": {
         "loader-utils": {
-          "version": "2.0.1",
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+          "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
           "dev": true,
           "requires": {
             "big.js": "^5.2.2",
@@ -23280,7 +23217,9 @@
       "dev": true
     },
     "loader-utils": {
-      "version": "1.4.0",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
+      "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
       "dev": true,
       "requires": {
         "big.js": "^5.2.2",
@@ -23647,7 +23586,9 @@
       },
       "dependencies": {
         "loader-utils": {
-          "version": "2.0.1",
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+          "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
           "dev": true,
           "requires": {
             "big.js": "^5.2.2",
@@ -23836,6 +23777,17 @@
             "minimatch": "^3.0.4",
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
+          },
+          "dependencies": {
+            "minimatch": {
+              "version": "3.1.2",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+              "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+              "dev": true,
+              "requires": {
+                "brace-expansion": "^1.1.7"
+              }
+            }
           }
         },
         "glob-parent": {
@@ -23958,7 +23910,9 @@
       "dev": true
     },
     "mout": {
-      "version": "1.2.3",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/mout/-/mout-1.2.4.tgz",
+      "integrity": "sha512-mZb9uOruMWgn/fw28DG4/yE3Kehfk1zKCLhuDU2O3vlKdnBBr4XaOCqVTflJ5aODavGUPqFHZgrFX3NJVuxGhQ==",
       "dev": true
     },
     "move-concurrently": {
@@ -26108,59 +26062,58 @@
       "dev": true
     },
     "socket.io-client": {
-      "version": "4.3.2",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.5.3.tgz",
+      "integrity": "sha512-I/hqDYpQ6JKwtJOf5ikM+Qz+YujZPMEl6qBLhxiP0nX+TfXKhW4KZZG8lamrD6Y5ngjmYHreESVasVCgi5Kl3A==",
       "dev": true,
       "requires": {
-        "@socket.io/component-emitter": "~3.0.0",
-        "backo2": "~1.0.2",
+        "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.2",
-        "engine.io-client": "~6.0.1",
-        "parseuri": "0.0.6",
-        "socket.io-parser": "~4.1.1"
+        "engine.io-client": "~6.2.3",
+        "socket.io-parser": "~4.2.0"
       },
       "dependencies": {
-        "base64-arraybuffer": {
-          "version": "1.0.1",
-          "dev": true
-        },
         "engine.io-client": {
-          "version": "6.0.2",
+          "version": "6.2.3",
+          "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.2.3.tgz",
+          "integrity": "sha512-aXPtgF1JS3RuuKcpSrBtimSjYvrbhKW9froICH4s0F3XQWLxsKNxqzG39nnvQZQnva4CMvUK63T7shevxRyYHw==",
           "dev": true,
           "requires": {
-            "@socket.io/component-emitter": "~3.0.0",
+            "@socket.io/component-emitter": "~3.1.0",
             "debug": "~4.3.1",
-            "engine.io-parser": "~5.0.0",
-            "has-cors": "1.1.0",
-            "parseqs": "0.0.6",
-            "parseuri": "0.0.6",
+            "engine.io-parser": "~5.0.3",
             "ws": "~8.2.3",
-            "xmlhttprequest-ssl": "~2.0.0",
-            "yeast": "0.1.2"
+            "xmlhttprequest-ssl": "~2.0.0"
           }
         },
         "engine.io-parser": {
-          "version": "5.0.1",
-          "dev": true,
-          "requires": {
-            "base64-arraybuffer": "~1.0.1"
-          }
+          "version": "5.0.4",
+          "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.4.tgz",
+          "integrity": "sha512-+nVFp+5z1E3HcToEnO7ZIj3g+3k9389DvWtvJZz0T6/eOCPIyyxehFcedoYrZQrp0LgQbD9pPXhpMBKMd5QURg==",
+          "dev": true
         },
         "socket.io-parser": {
-          "version": "4.1.1",
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.1.tgz",
+          "integrity": "sha512-V4GrkLy+HeF1F/en3SpUaM+7XxYXpuMUWLGde1kSSh5nQMN4hLrbPIkD+otwh6q9R6NOQBN4AMaOZ2zVjui82g==",
           "dev": true,
           "requires": {
-            "@socket.io/component-emitter": "~3.0.0",
+            "@socket.io/component-emitter": "~3.1.0",
             "debug": "~4.3.1"
           }
         },
         "ws": {
           "version": "8.2.3",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
+          "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
           "dev": true
         }
       }
     },
     "socket.io-parser": {
-      "version": "4.0.4",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.0.5.tgz",
+      "integrity": "sha512-sNjbT9dX63nqUFIOv95tTVm6elyIU4RvB1m8dOeZt+IgWwcWklFDOdmGcfo3zSiRsnR/3pJkjY5lfoGqEe4Eig==",
       "dev": true,
       "requires": {
         "@types/component-emitter": "^1.2.10",
@@ -26477,7 +26430,9 @@
       },
       "dependencies": {
         "loader-utils": {
-          "version": "2.0.1",
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+          "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
           "dev": true,
           "requires": {
             "big.js": "^5.2.2",
@@ -26574,7 +26529,9 @@
       },
       "dependencies": {
         "loader-utils": {
-          "version": "2.0.1",
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+          "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
           "dev": true,
           "requires": {
             "big.js": "^5.2.2",
@@ -28022,6 +27979,8 @@
     },
     "xmlhttprequest-ssl": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.0.0.tgz",
+      "integrity": "sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A==",
       "dev": true
     },
     "xtend": {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
     "chai": "~4.2.0",
     "check-dependencies": "~1.1.0",
     "check-engines": "~1.5.0",
-    "cjsx-loader": "~3.0.0",
     "coffee-loader": "~0.9.0",
     "coffee-react": "~5.0.1",
     "coffeescript": "~2.3.2",

--- a/webpack.build.js
+++ b/webpack.build.js
@@ -73,7 +73,7 @@ module.exports = {
       }, {
         loader: 'coffee-loader'
       }, {
-        loader: 'cjsx-loader'
+        loader: path.resolve('./webpack/cjsx-loader.js')
       }],
     }, {
       test: /\.coffee$/,

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -69,7 +69,7 @@ var config = {
       }, {
         loader: 'coffee-loader'
       }, {
-        loader: 'cjsx-loader'
+        loader: path.resolve('./webpack/cjsx-loader.js')
       }]
     }, {
       test: /\.coffee$/,

--- a/webpack/cjsx-loader.js
+++ b/webpack/cjsx-loader.js
@@ -1,0 +1,6 @@
+var transform = require('coffee-react-transform');
+
+module.exports = function(cjsx) {
+  this.cacheable && this.cacheable();
+  return transform(cjsx);
+};


### PR DESCRIPTION
Replace cjsx-loader with a custom loader that doesn't depend on `loader-utils@0.2`.

Run `npm audit fix` to bump outdated packages, including `loader-utils`.

Staging branch URL: https://pr-6262.pfe-preview.zooniverse.org

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
