### PR TITLE
Bump markdownz to 7.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "hash.js": "~1.1.7",
         "history": "~3.3.0",
         "lodash": "~4.17.11",
-        "markdownz": "~7.8.1",
+        "markdownz": "~7.9.0",
         "modal-form": "~2.9",
         "moment": "~2.29.0",
         "panoptes-client": "~4.2",
@@ -5882,8 +5882,12 @@
       }
     },
     "node_modules/entities": {
-      "version": "2.1.0",
-      "license": "BSD-2-Clause",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
+      "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
+      "engines": {
+        "node": ">=0.12"
+      },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
@@ -9639,8 +9643,9 @@
       }
     },
     "node_modules/linkify-it": {
-      "version": "3.0.3",
-      "license": "MIT",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-4.0.1.tgz",
+      "integrity": "sha512-C7bfi1UZmoj8+PQx22XyeXCuBlokoyWQL5pWSP+EI6nzRylyThouddufc2c1NDIcP9k5agmN9fLpA7VNJfIiqw==",
       "dependencies": {
         "uc.micro": "^1.0.1"
       }
@@ -9898,12 +9903,13 @@
       }
     },
     "node_modules/markdown-it": {
-      "version": "12.3.2",
-      "license": "MIT",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-13.0.1.tgz",
+      "integrity": "sha512-lTlxriVoy2criHP0JKRhO2VDG9c2ypWCsT237eDiLqi09rmbKoUetyGHq2uOIRoRS//kfoJckS0eUzzkDR+k2Q==",
       "dependencies": {
         "argparse": "^2.0.1",
-        "entities": "~2.1.0",
-        "linkify-it": "^3.0.1",
+        "entities": "~3.0.1",
+        "linkify-it": "^4.0.1",
         "mdurl": "^1.0.1",
         "uc.micro": "^1.0.5"
       },
@@ -9989,14 +9995,15 @@
     },
     "node_modules/markdown-it/node_modules/argparse": {
       "version": "2.0.1",
-      "license": "Python-2.0"
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/markdownz": {
-      "version": "7.8.6",
-      "resolved": "https://registry.npmjs.org/markdownz/-/markdownz-7.8.6.tgz",
-      "integrity": "sha512-Tg6NxPMBQcny56lD1jSYSUn5Bv55IiY5VTFCqItRjHB1yl3GCYx9GO33rww6ooDnteeXKt7Hg196OZuBeOV2Sw==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/markdownz/-/markdownz-7.9.0.tgz",
+      "integrity": "sha512-+3jD3tdgpdtQc04GXoMTU0TRd1DayMZ2A9sJ3xGhgqq85kg8ZRfnlxTokiy3miS5gaeuuP5Sncb39VaJku7wOw==",
       "dependencies": {
-        "markdown-it": "~12.3.2",
+        "markdown-it": "~13.0.1",
         "markdown-it-anchor": "~8.4.1",
         "markdown-it-container": "~3.0.0",
         "markdown-it-emoji": "~2.0.0",
@@ -20695,7 +20702,9 @@
       }
     },
     "entities": {
-      "version": "2.1.0"
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
+      "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q=="
     },
     "envinfo": {
       "version": "7.8.1",
@@ -23191,7 +23200,9 @@
       }
     },
     "linkify-it": {
-      "version": "3.0.3",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-4.0.1.tgz",
+      "integrity": "sha512-C7bfi1UZmoj8+PQx22XyeXCuBlokoyWQL5pWSP+EI6nzRylyThouddufc2c1NDIcP9k5agmN9fLpA7VNJfIiqw==",
       "requires": {
         "uc.micro": "^1.0.1"
       }
@@ -23375,17 +23386,21 @@
       }
     },
     "markdown-it": {
-      "version": "12.3.2",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-13.0.1.tgz",
+      "integrity": "sha512-lTlxriVoy2criHP0JKRhO2VDG9c2ypWCsT237eDiLqi09rmbKoUetyGHq2uOIRoRS//kfoJckS0eUzzkDR+k2Q==",
       "requires": {
         "argparse": "^2.0.1",
-        "entities": "~2.1.0",
-        "linkify-it": "^3.0.1",
+        "entities": "~3.0.1",
+        "linkify-it": "^4.0.1",
         "mdurl": "^1.0.1",
         "uc.micro": "^1.0.5"
       },
       "dependencies": {
         "argparse": {
-          "version": "2.0.1"
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
         }
       }
     },
@@ -23445,11 +23460,11 @@
       "version": "0.6.3"
     },
     "markdownz": {
-      "version": "7.8.6",
-      "resolved": "https://registry.npmjs.org/markdownz/-/markdownz-7.8.6.tgz",
-      "integrity": "sha512-Tg6NxPMBQcny56lD1jSYSUn5Bv55IiY5VTFCqItRjHB1yl3GCYx9GO33rww6ooDnteeXKt7Hg196OZuBeOV2Sw==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/markdownz/-/markdownz-7.9.0.tgz",
+      "integrity": "sha512-+3jD3tdgpdtQc04GXoMTU0TRd1DayMZ2A9sJ3xGhgqq85kg8ZRfnlxTokiy3miS5gaeuuP5Sncb39VaJku7wOw==",
       "requires": {
-        "markdown-it": "~12.3.2",
+        "markdown-it": "~13.0.1",
         "markdown-it-anchor": "~8.4.1",
         "markdown-it-container": "~3.0.0",
         "markdown-it-emoji": "~2.0.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "hash.js": "~1.1.7",
     "history": "~3.3.0",
     "lodash": "~4.17.11",
-    "markdownz": "~7.8.1",
+    "markdownz": "~7.9.0",
     "modal-form": "~2.9",
     "moment": "~2.29.0",
     "panoptes-client": "~4.2",


### PR DESCRIPTION
Bump `markdownz` from 7.8.6 to [7.9.0](https://github.com/zooniverse/markdownz/releases/tag/v7.9.0).

Staging branch URL: https://pr-6266.pfe-preview.zooniverse.org

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
