### PR TITLE
FEM Lab: follow 6248

### DIFF
--- a/app/pages/lab-fem/workflow.jsx
+++ b/app/pages/lab-fem/workflow.jsx
@@ -8,7 +8,7 @@ import ChangeListener from '../../components/change-listener.cjsx';
 import RetirementRulesEditor from '../../components/retirement-rules-editor.cjsx';
 import {Link} from 'react-router';
 import MultiImageSubjectOptionsEditor from '../../components/multi-image-subject-options-editor.cjsx';
-import taskComponents from '../../classifier/tasks';
+import taskComponents from '../../classifier/tasks/index.js';
 import AutoSave from '../../components/auto-save.coffee';
 import FileButton from '../../components/file-button.cjsx';
 import WorkflowCreateForm from '../lab/workflow-create-form.cjsx';
@@ -20,6 +20,7 @@ import SubjectGroupViewerEditor from '../lab/workflow-components/subject-group-v
 import SubjectSetLinker from '../lab/workflow-components/subject-set-linker.jsx';
 import MiniCourses from '../lab/workflow-components/mini-courses.jsx';
 import Tutorials from '../lab/workflow-components/tutorials.jsx';
+import TaskOptions from './workflow-components/task-options.jsx';
 import { isThisProjectUsingFEMLab, FEM_LAB_PREVIEW_HOST } from './fem-lab-utilities.js';
 
 const DEMO_SUBJECT_SET_ID = process.env.NODE_ENV === 'production'
@@ -30,7 +31,7 @@ class EditWorkflowPage extends Component {
   constructor (props) {
     super(props);
 
-    /* 
+    /*
       React doesn't automatically bind event handlers to the component so do that here.
     */
     this.addNewTranscriptionTask = this.addNewTranscriptionTask.bind(this);
@@ -126,6 +127,7 @@ class EditWorkflowPage extends Component {
     window.editingWorkflow = this.props.workflow;
 
     const noTasksDefined = Object.keys(this.props.workflow.tasks).length === 0;
+    const handleWorkflowChange = handleInputChange.bind(this.props.workflow);
 
     const stats_completeness_type = this.props.workflow.configuration.stats_completeness_type != null ? this.props.workflow.configuration.stats_completeness_type : 'retirement';
 
@@ -172,7 +174,7 @@ class EditWorkflowPage extends Component {
               <AutoSave tag="label" resource={this.props.workflow}>
                 <label className="form-label" for="displayName">Workflow title</label>
                 <br />
-                <input type="text" id="displayName" name="display_name" value={this.props.workflow.display_name} className="standard-input full" onChange={handleInputChange.bind(this.props.workflow)} />
+                <input type="text" id="displayName" name="display_name" value={this.props.workflow.display_name} className="standard-input full" onChange={handleWorkflowChange} />
               </AutoSave>
               <small className="form-help">If you let your volunteers choose which workflow to attempt, this text will appear as an option on the project front page.</small>
 
@@ -328,23 +330,13 @@ class EditWorkflowPage extends Component {
                 </div>
 
                 <AutoSave tag="div" resource={this.props.workflow}>
-                  <small>First task</small>{' '}
-                  <select name="first_task" value={this.props.workflow.first_task} disabled={noTasksDefined} onChange={handleInputChange.bind(this.props.workflow)}>
+                  <label className='form-label' htmlFor='first_task'>First task</label>{' '}
+                  <select id='first_task' name="first_task" value={this.props.workflow.first_task} disabled={noTasksDefined} onChange={handleWorkflowChange}>
                     {noTasksDefined ?
                       <option>(No tasks yet)</option>
                     :
-                      (() => {
-                        const result1 = [];
-                        for (let taskKey in this.props.workflow.tasks) {
-                          definition = this.props.workflow.tasks[taskKey];
-                          if (definition.type !== 'shortcut') {
-                            result1.push(<option key={taskKey} value={taskKey}>{taskComponents[definition.type]?.getTaskText(definition)}</option>);
-                          } else {
-                            result1.push(undefined);
-                          }
-                        }
-                        return result1;
-                      })()}
+                      <TaskOptions tasks={this.props.workflow.tasks} />
+                    }
                   </select>
                 </AutoSave>
               </div>

--- a/app/pages/lab-fem/workflow.jsx
+++ b/app/pages/lab-fem/workflow.jsx
@@ -20,7 +20,7 @@ import SubjectGroupViewerEditor from '../lab/workflow-components/subject-group-v
 import SubjectSetLinker from '../lab/workflow-components/subject-set-linker.jsx';
 import MiniCourses from '../lab/workflow-components/mini-courses.jsx';
 import Tutorials from '../lab/workflow-components/tutorials.jsx';
-import TaskOptions from './workflow-components/task-options.jsx';
+import TaskOptions from '../lab/workflow-components/task-options.jsx';
 import { isThisProjectUsingFEMLab, FEM_LAB_PREVIEW_HOST } from './fem-lab-utilities.js';
 
 const DEMO_SUBJECT_SET_ID = process.env.NODE_ENV === 'production'


### PR DESCRIPTION
## PR Overview

Follows #6248
Affects: **FEM Lab's** Workflow Editor -> First Task

PR 6248 refactored the First Task feature of the WF Editor for _PFE Lab's) `workflow.jsx`. This PR copies those changes to _FEM Lab's_ `workflow.jsx`, to keep both Workflow Editor pages in sync. No behaviour changes expected.

Testing:
- Staging branch URL: https://pr-{NUMBER}.pfe-preview.zooniverse.org/lab/1986/workflows/3723?femLab=true&env=staging
- Please see 6248 for testing notes.

Shaun's note: when reviewing 6248, I actually tested for `?femLab=true`, but failed to catch that `fem-lab/workflow.jsx` wasn't modified as well. Derp!

Ready for review 👌 