### PR TITLE
Addendum for #6247

### DIFF
--- a/app/pages/lab-fem/workflow.jsx
+++ b/app/pages/lab-fem/workflow.jsx
@@ -21,6 +21,7 @@ import SubjectSetLinker from '../lab/workflow-components/subject-set-linker.jsx'
 import MiniCourses from '../lab/workflow-components/mini-courses.jsx';
 import Tutorials from '../lab/workflow-components/tutorials.jsx';
 import TaskOptions from '../lab/workflow-components/task-options.jsx';
+import TaskPicker from '../lab/workflow-components/task-picker.jsx';
 import { isThisProjectUsingFEMLab, FEM_LAB_PREVIEW_HOST } from './fem-lab-utilities.js';
 
 const DEMO_SUBJECT_SET_ID = process.env.NODE_ENV === 'production'
@@ -189,50 +190,12 @@ class EditWorkflowPage extends Component {
                       <small className="form-help">(No tasks yet)</small>
                     </div>
                   :
-                    (() => {
-                      const result = [];
-                      for (let key in this.props.workflow.tasks) {
-                        definition = this.props.workflow.tasks[key];
-                        if (definition.type !== 'shortcut') {
-                          const classNames = ['secret-button', 'nav-list-item'];
-                          const taskDefinition = taskComponents[definition.type]?.getTaskText(definition);
-                          if (key === this.state.selectedTaskKey) {
-                            classNames.push('active');
-                          }
-                          result.push(<div key={key}>
-                            <button
-                              type="button"
-                              className={classNames.join(' ')}
-                              onClick={this.setState.bind(this, {selectedTaskKey: key}, null)}
-                            >
-                              {(() => { switch (definition.type) {
-                                case 'single': return <i className="fa fa-dot-circle-o fa-fw"></i>;
-                                case 'multiple': return <i className="fa fa-check-square-o fa-fw"></i>;
-                                case 'drawing': return <i className="fa fa-pencil fa-fw"></i>;
-                                case 'survey': return <i className="fa fa-binoculars fa-fw"></i>;
-                                case 'flexibleSurvey': return <i className="fa fa-binoculars fa-fw"></i>;
-                                case 'crop': return <i className="fa fa-crop fa-fw"></i>;
-                                case 'text': return <i className="fa fa-file-text-o fa-fw"></i>;
-                                case 'textFromSubject': return <i className="fa fa-file-text-o fa-fw"></i>;
-                                case 'dropdown': return <i className="fa fa-list fa-fw"></i>;
-                                case 'combo': return <i className="fa fa-cubes fa-fw"></i>;
-                                case 'slider': return <i className="fa fa-sliders fa-fw"></i>;
-                                case 'highlighter': return <i className="fa fa-i-cursor"></i>;
-                                case 'transcription': return <i className="fa fa-font fa-fw"></i>;
-                              } })()}
-                              {' '}
-                              {taskDefinition || 'Task editor is unavailable'}
-                              {key === this.props.workflow.first_task ?
-                                <small> <em>(first)</em></small> : undefined}
-                              <small style={{float: 'right'}}>{key}</small>
-                            </button>
-                          </div>);
-                        } else {
-                          result.push(undefined);
-                        }
-                      }
-                      return result;
-                    })()}
+                    <TaskPicker
+                      onClick={(taskKey) => this.setState({ selectedTaskKey: taskKey })}
+                      selectedTaskKey={this.state.selectedTaskKey}
+                      workflow={this.props.workflow}
+                    />
+                  }
                 </div>
 
                 <div className="edit-workflow-page__section">

--- a/app/pages/lab/workflow-components/task-icon.jsx
+++ b/app/pages/lab/workflow-components/task-icon.jsx
@@ -13,4 +13,5 @@ export default function TaskIcon({ type }) {
     case 'highlighter': return <i className="fa fa-i-cursor"></i>;
     case 'transcription': return <i className="fa fa-font fa-fw"></i>;
   }
+  return null
 }


### PR DESCRIPTION
## PR Overview

Targets and follows #6247 
Affects: Project Builder -> Workflow Editor (PFE Lab & FEM Lab versions)

This PR fixes two issues:
- TaskIcon now has default `return null`, to ensure it doesn't crash the page when an _unaccounted-for Task_ (i.e. Light Curve Task) is rendered.
- The changes to `lab/workflow.jsx` in 6247 is now copied to `lab-fem/workflow.jsx`

**Testing:**
- You can test that _unaccounted-for Tasks_ work properly by taking a look at Planet Hunters TESSting: https://local.zooniverse.org:3735/lab/18190/workflows/20991?env=production&pfeLab=true
- You can test FEM Lab by appending `?femLab=true` to any Workflow Editor URL.

Ready for review.