### PR TITLE
Update Zooniverse Logo title with more context

### DIFF
--- a/app/pages/notifications/notification-section.jsx
+++ b/app/pages/notifications/notification-section.jsx
@@ -171,7 +171,7 @@ export default class NotificationSection extends Component {
     if (this.state.unread > 0) return this.unreadCircle();
 
     if (this.state.name === 'Zooniverse') {
-      avatar = <ZooniverseLogo width="40" height="40" />;
+      avatar = <ZooniverseLogo title="Zooniverse Logo" width="40" height="40" />;
     } else {
       avatar = <img src={src} className="notification-section__img" alt="Project Avatar" />;
     }

--- a/app/pages/organization/organization-page.jsx
+++ b/app/pages/organization/organization-page.jsx
@@ -117,7 +117,11 @@ class OrganizationPage extends React.Component {
                   height={AVATAR_SIZE}
                 />
               ) : (
-                <ZooniverseLogo className="organization-hero__avatar" width={AVATAR_SIZE} height={AVATAR_SIZE} />
+                <ZooniverseLogo
+                  title={`Default organization icon for ${organization.display_name}`}
+                  className="organization-hero__avatar"
+                  width={AVATAR_SIZE}
+                  height={AVATAR_SIZE} />
               )}
               <div className="organization-hero__wrapper">
                 <h1 className="organization-hero__title">{organization.display_name}</h1>

--- a/app/partials/zooniverse-logo.cjsx
+++ b/app/partials/zooniverse-logo.cjsx
@@ -9,7 +9,7 @@ module.exports = createReactClass
   getDefaultProps: ->
     width: '1em'
     height: '1em'
-    title: 'Zooniverse Logo'
+    title: 'Zooniverse'
 
   getInitialState: ->
     nextID += 1


### PR DESCRIPTION
## PR Overview

Affects: header site nav, Notifications page, Organizations page

This PR changes the SVG `title` for the Zooniverse Logo component.

At the moment, the Zooniverse Logo has "Zooniverse Logo" has a generic title ("alt text") describing _what the SVG is._ This PR changes that title on a few pages, so we have context for _what the SVG is used for._

Staging branch URL: https://pr-{NUMBER}.pfe-preview.zooniverse.org

### Use Cases / Contexts

**Case 0:** by default, the Zooniverse Logo SVG has title="Zooniverse"

**Case 1:** the **header site nav**'s Zooniverse Logo SVG now has title="Zooniverse", indicating the logo is a link to the Zooniverse home page.

<img width="400" alt="image" src="https://user-images.githubusercontent.com/13952701/207892577-a916b0df-3310-4ebd-8d85-20381ac7de3c.png">

**Case 2:** on the **Notifications** page, for all official notifications from the Zooniverse, the Zooniverse's avatar will have title="Zooniverse Logo"

<img width="400" alt="Screenshot 2022-12-15 at 22 40 46" src="https://user-images.githubusercontent.com/13952701/207892837-ed84e4e8-b6af-450b-b335-bf36e2472cd7.png">

**Case 3:** on the **Organizations** page, if an org doesn't have its own avatar, the default avatar will have title="Default organization icon for ORG_NAME" [[example]](https://local.zooniverse.org:3735/organizations/md68135/notes-from-nature?env=production)

<img width="400" alt="Screenshot 2022-12-15 at 22 34 26" src="https://user-images.githubusercontent.com/13952701/207893726-60129127-3033-4748-84f1-588ae0103514.png">

### Status

Ready for review. Let me know if there's a more accessible label for these logos in their respective use cases/contexts.