### PR TITLE
Bump markdownz to v7.10.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "hash.js": "~1.1.7",
         "history": "~3.3.0",
         "lodash": "~4.17.11",
-        "markdownz": "~7.9.0",
+        "markdownz": "~7.10.1",
         "modal-form": "~2.9",
         "moment": "~2.29.0",
         "panoptes-client": "~4.2",
@@ -7705,7 +7705,8 @@
     },
     "node_modules/fs-extra": {
       "version": "8.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^4.0.0",
@@ -7717,7 +7718,8 @@
     },
     "node_modules/fs-extra/node_modules/jsonfile": {
       "version": "4.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -9733,7 +9735,8 @@
     },
     "node_modules/jsonfile": {
       "version": "5.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-5.0.0.tgz",
+      "integrity": "sha512-NQRZ5CRo74MhMMC3/3r5g2k4fjodJ/wh8MxjFbCViWKFjxrnudWSY5vomh+23ZaXzAS7J3fBZIR2dV6WbmfM0w==",
       "dependencies": {
         "universalify": "^0.1.2"
       },
@@ -10086,8 +10089,9 @@
       }
     },
     "node_modules/markdown-it-anchor": {
-      "version": "8.4.1",
-      "license": "Unlicense",
+      "version": "8.6.5",
+      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.6.5.tgz",
+      "integrity": "sha512-PI1qEHHkTNWT+X6Ip9w+paonfIQ+QZP9sCeMYi47oqhH+EsW8CrJ8J7CzV19QVOj6il8ATGbK2nTECj22ZHGvQ==",
       "peerDependencies": {
         "@types/markdown-it": "*",
         "markdown-it": "*"
@@ -10167,12 +10171,12 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/markdownz": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/markdownz/-/markdownz-7.9.0.tgz",
-      "integrity": "sha512-+3jD3tdgpdtQc04GXoMTU0TRd1DayMZ2A9sJ3xGhgqq85kg8ZRfnlxTokiy3miS5gaeuuP5Sncb39VaJku7wOw==",
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/markdownz/-/markdownz-7.10.1.tgz",
+      "integrity": "sha512-ik7eUksGV6cv+dIa4TaTCOB+0daTvw0Co/wxBx0woRiirq/jbbG+FREesKyCq+b8RlWcKurQbiU+OUnUoEBsqg==",
       "dependencies": {
         "markdown-it": "~13.0.1",
-        "markdown-it-anchor": "~8.4.1",
+        "markdown-it-anchor": "~8.6.5",
         "markdown-it-container": "~3.0.0",
         "markdown-it-emoji": "~2.0.0",
         "markdown-it-footnote": "~3.0.3",
@@ -10182,7 +10186,7 @@
         "markdown-it-sup": "~1.0.0",
         "markdown-it-table-of-contents": "~0.6.0",
         "markdown-it-video": "~0.6.3",
-        "twemoji": "~13.1.0"
+        "twemoji": "~14.0.2"
       },
       "peerDependencies": {
         "react": ">= 15.6",
@@ -15227,21 +15231,20 @@
       }
     },
     "node_modules/twemoji": {
-      "version": "13.1.0",
-      "license": [
-        "MIT",
-        "CC-BY-4.0"
-      ],
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/twemoji/-/twemoji-14.0.2.tgz",
+      "integrity": "sha512-BzOoXIe1QVdmsUmZ54xbEH+8AgtOKUiG53zO5vVP2iUu6h5u9lN15NcuS6te4OY96qx0H7JK9vjjl9WQbkTRuA==",
       "dependencies": {
         "fs-extra": "^8.0.1",
         "jsonfile": "^5.0.0",
-        "twemoji-parser": "13.1.0",
+        "twemoji-parser": "14.0.0",
         "universalify": "^0.1.2"
       }
     },
     "node_modules/twemoji-parser": {
-      "version": "13.1.0",
-      "license": "MIT"
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/twemoji-parser/-/twemoji-parser-14.0.0.tgz",
+      "integrity": "sha512-9DUOTGLOWs0pFWnh1p6NF+C3CkQ96PWmEFwhOVmT3WbecRC+68AIqpsnJXygfkFcp4aXbOp8Dwbhh/HQgvoRxA=="
     },
     "node_modules/type-check": {
       "version": "0.3.2",
@@ -21979,6 +21982,8 @@
     },
     "fs-extra": {
       "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
       "requires": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^4.0.0",
@@ -21987,6 +21992,8 @@
       "dependencies": {
         "jsonfile": {
           "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
           "requires": {
             "graceful-fs": "^4.1.6"
           }
@@ -23279,6 +23286,8 @@
     },
     "jsonfile": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-5.0.0.tgz",
+      "integrity": "sha512-NQRZ5CRo74MhMMC3/3r5g2k4fjodJ/wh8MxjFbCViWKFjxrnudWSY5vomh+23ZaXzAS7J3fBZIR2dV6WbmfM0w==",
       "requires": {
         "graceful-fs": "^4.1.6",
         "universalify": "^0.1.2"
@@ -23533,7 +23542,9 @@
       }
     },
     "markdown-it-anchor": {
-      "version": "8.4.1"
+      "version": "8.6.5",
+      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.6.5.tgz",
+      "integrity": "sha512-PI1qEHHkTNWT+X6Ip9w+paonfIQ+QZP9sCeMYi47oqhH+EsW8CrJ8J7CzV19QVOj6il8ATGbK2nTECj22ZHGvQ=="
     },
     "markdown-it-container": {
       "version": "3.0.0"
@@ -23588,12 +23599,12 @@
       "version": "0.6.3"
     },
     "markdownz": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/markdownz/-/markdownz-7.9.0.tgz",
-      "integrity": "sha512-+3jD3tdgpdtQc04GXoMTU0TRd1DayMZ2A9sJ3xGhgqq85kg8ZRfnlxTokiy3miS5gaeuuP5Sncb39VaJku7wOw==",
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/markdownz/-/markdownz-7.10.1.tgz",
+      "integrity": "sha512-ik7eUksGV6cv+dIa4TaTCOB+0daTvw0Co/wxBx0woRiirq/jbbG+FREesKyCq+b8RlWcKurQbiU+OUnUoEBsqg==",
       "requires": {
         "markdown-it": "~13.0.1",
-        "markdown-it-anchor": "~8.4.1",
+        "markdown-it-anchor": "~8.6.5",
         "markdown-it-container": "~3.0.0",
         "markdown-it-emoji": "~2.0.0",
         "markdown-it-footnote": "~3.0.3",
@@ -23603,7 +23614,7 @@
         "markdown-it-sup": "~1.0.0",
         "markdown-it-table-of-contents": "~0.6.0",
         "markdown-it-video": "~0.6.3",
-        "twemoji": "~13.1.0"
+        "twemoji": "~14.0.2"
       }
     },
     "marked": {
@@ -27132,16 +27143,20 @@
       }
     },
     "twemoji": {
-      "version": "13.1.0",
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/twemoji/-/twemoji-14.0.2.tgz",
+      "integrity": "sha512-BzOoXIe1QVdmsUmZ54xbEH+8AgtOKUiG53zO5vVP2iUu6h5u9lN15NcuS6te4OY96qx0H7JK9vjjl9WQbkTRuA==",
       "requires": {
         "fs-extra": "^8.0.1",
         "jsonfile": "^5.0.0",
-        "twemoji-parser": "13.1.0",
+        "twemoji-parser": "14.0.0",
         "universalify": "^0.1.2"
       }
     },
     "twemoji-parser": {
-      "version": "13.1.0"
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/twemoji-parser/-/twemoji-parser-14.0.0.tgz",
+      "integrity": "sha512-9DUOTGLOWs0pFWnh1p6NF+C3CkQ96PWmEFwhOVmT3WbecRC+68AIqpsnJXygfkFcp4aXbOp8Dwbhh/HQgvoRxA=="
     },
     "type-check": {
       "version": "0.3.2",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "hash.js": "~1.1.7",
     "history": "~3.3.0",
     "lodash": "~4.17.11",
-    "markdownz": "~7.9.0",
+    "markdownz": "~7.10.1",
     "modal-form": "~2.9",
     "moment": "~2.29.0",
     "panoptes-client": "~4.2",


### PR DESCRIPTION
Bump markdownz from v7.9.0 to v7.10.1
    - Release notes [7.10.0](https://github.com/zooniverse/markdownz/releases/tag/v7.10.0)
    - Release notes [7.10.1](https://github.com/zooniverse/markdownz/releases/tag/v7.10.1)

Staging branch URL: https://pr-6276.pfe-preview.zooniverse.org

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [x] Can you post a talk comment?

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
