### PR TITLE
Bump markdownz from 7.10.2 to 8.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "hash.js": "~1.1.7",
         "history": "~3.3.0",
         "lodash": "~4.17.11",
-        "markdownz": "~7.10.1",
+        "markdownz": "~8.0.0",
         "modal-form": "~2.9",
         "moment": "~2.29.0",
         "panoptes-client": "~4.2",
@@ -10240,9 +10240,9 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/markdownz": {
-      "version": "7.10.2",
-      "resolved": "https://registry.npmjs.org/markdownz/-/markdownz-7.10.2.tgz",
-      "integrity": "sha512-gwym099RAzEQwb1qQUTol/nE8D61fMJorjGZgghANl44Tx57mXcegVw4M44vuOqD9xsxw4aohxqCRQNULufBsA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/markdownz/-/markdownz-8.0.0.tgz",
+      "integrity": "sha512-38YGjRzpubUVYE6OhKfVZ1Tve8zs51M4Jpnp+c4WeeGRO9SgnSjpTUb5OfgJf4dJtVhCiH3no2sQLH7wLlxBSQ==",
       "dependencies": {
         "markdown-it": "~13.0.1",
         "markdown-it-anchor": "~8.6.5",
@@ -10258,8 +10258,8 @@
         "twemoji": "~14.0.2"
       },
       "peerDependencies": {
-        "react": ">= 15.6",
-        "react-dom": ">= 15.6"
+        "react": ">= 16.14",
+        "react-dom": ">= 16.14"
       }
     },
     "node_modules/marked": {
@@ -23611,9 +23611,9 @@
       "version": "0.6.3"
     },
     "markdownz": {
-      "version": "7.10.2",
-      "resolved": "https://registry.npmjs.org/markdownz/-/markdownz-7.10.2.tgz",
-      "integrity": "sha512-gwym099RAzEQwb1qQUTol/nE8D61fMJorjGZgghANl44Tx57mXcegVw4M44vuOqD9xsxw4aohxqCRQNULufBsA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/markdownz/-/markdownz-8.0.0.tgz",
+      "integrity": "sha512-38YGjRzpubUVYE6OhKfVZ1Tve8zs51M4Jpnp+c4WeeGRO9SgnSjpTUb5OfgJf4dJtVhCiH3no2sQLH7wLlxBSQ==",
       "requires": {
         "markdown-it": "~13.0.1",
         "markdown-it-anchor": "~8.6.5",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "hash.js": "~1.1.7",
     "history": "~3.3.0",
     "lodash": "~4.17.11",
-    "markdownz": "~7.10.1",
+    "markdownz": "~8.0.0",
     "modal-form": "~2.9",
     "moment": "~2.29.0",
     "panoptes-client": "~4.2",


### PR DESCRIPTION
Staging branch URL: https://pr-6283.pfe-preview.zooniverse.org

[Release notes](https://github.com/zooniverse/markdownz/releases/tag/v8.0.0).

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
