### PR TITLE
Bump copy-webpack-plugin from 4.6.0 to 11.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -77,7 +77,7 @@
         "coffee-loader": "~0.9.0",
         "coffee-react": "~5.0.1",
         "coffeescript": "~2.3.2",
-        "copy-webpack-plugin": "~4.6.0",
+        "copy-webpack-plugin": "~11.0.0",
         "css-loader": "~6.7.3",
         "ejs": "~2.6.1",
         "engine.io-client": "~5.1.0",
@@ -3134,11 +3134,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/aproba": {
-      "version": "1.2.0",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/archy": {
       "version": "1.0.0",
       "dev": true,
@@ -3219,25 +3214,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/array-union": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-uniq": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/array-uniq": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/array-unique": {
@@ -4115,26 +4091,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/cacache": {
-      "version": "10.0.4",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "bluebird": "^3.5.1",
-        "chownr": "^1.0.1",
-        "glob": "^7.1.2",
-        "graceful-fs": "^4.1.11",
-        "lru-cache": "^4.1.1",
-        "mississippi": "^2.0.0",
-        "mkdirp": "^0.5.1",
-        "move-concurrently": "^1.0.1",
-        "promise-inflight": "^1.0.1",
-        "rimraf": "^2.6.2",
-        "ssri": "^5.2.4",
-        "unique-filename": "^1.1.0",
-        "y18n": "^4.0.0"
-      }
-    },
     "node_modules/cache-base": {
       "version": "1.0.1",
       "dev": true,
@@ -4500,11 +4456,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/chownr": {
-      "version": "1.1.4",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/chrome-trace-event": {
       "version": "1.0.3",
       "dev": true,
@@ -4833,20 +4784,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/concat-stream": {
-      "version": "1.6.2",
-      "dev": true,
-      "engines": [
-        "node >= 0.8"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
-      }
-    },
     "node_modules/confusing-browser-globals": {
       "version": "1.0.10",
       "dev": true,
@@ -4935,19 +4872,6 @@
       "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.3.tgz",
       "integrity": "sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ=="
     },
-    "node_modules/copy-concurrently": {
-      "version": "1.0.5",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "aproba": "^1.1.1",
-        "fs-write-stream-atomic": "^1.0.8",
-        "iferr": "^0.1.5",
-        "mkdirp": "^0.5.1",
-        "rimraf": "^2.5.4",
-        "run-queue": "^1.0.0"
-      }
-    },
     "node_modules/copy-descriptor": {
       "version": "0.1.1",
       "dev": true,
@@ -4957,117 +4881,39 @@
       }
     },
     "node_modules/copy-webpack-plugin": {
-      "version": "4.6.0",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-11.0.0.tgz",
+      "integrity": "sha512-fX2MWpamkW0hZxMEg0+mYnA40LTosOSa5TqZ9GYIBzyJa9C3QUaMPSE2xAi/buNr8u89SfD9wHSQVBzrRa/SOQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "cacache": "^10.0.4",
-        "find-cache-dir": "^1.0.0",
-        "globby": "^7.1.1",
-        "is-glob": "^4.0.0",
-        "loader-utils": "^1.1.0",
-        "minimatch": "^3.0.4",
-        "p-limit": "^1.0.0",
-        "serialize-javascript": "^1.4.0"
+        "fast-glob": "^3.2.11",
+        "glob-parent": "^6.0.1",
+        "globby": "^13.1.1",
+        "normalize-path": "^3.0.0",
+        "schema-utils": "^4.0.0",
+        "serialize-javascript": "^6.0.0"
       },
       "engines": {
-        "node": ">= 4"
+        "node": ">= 14.15.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.1.0"
       }
     },
-    "node_modules/copy-webpack-plugin/node_modules/find-cache-dir": {
-      "version": "1.0.0",
+    "node_modules/copy-webpack-plugin/node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "commondir": "^1.0.1",
-        "make-dir": "^1.0.0",
-        "pkg-dir": "^2.0.0"
+        "is-glob": "^4.0.3"
       },
       "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/copy-webpack-plugin/node_modules/find-up": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/copy-webpack-plugin/node_modules/locate-path": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^2.0.0",
-        "path-exists": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/copy-webpack-plugin/node_modules/make-dir": {
-      "version": "1.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pify": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/copy-webpack-plugin/node_modules/p-limit": {
-      "version": "1.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-try": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/copy-webpack-plugin/node_modules/p-locate": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/copy-webpack-plugin/node_modules/p-try": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/copy-webpack-plugin/node_modules/pify": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/copy-webpack-plugin/node_modules/pkg-dir": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "find-up": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=4"
+        "node": ">=10.13.0"
       }
     },
     "node_modules/core-js": {
@@ -5310,11 +5156,6 @@
       "version": "3.0.11",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.11.tgz",
       "integrity": "sha512-sa6P2wJ+CAbgyy4KFssIb/JNMLxFvKF1pCYCSXS8ZMuqZnMsrxqI2E5sPyoTpxoPU/gVZMzr2zjOfg8GIZOMsw=="
-    },
-    "node_modules/cyclist": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.7",
@@ -5561,18 +5402,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/del/node_modules/dir-glob": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-      "dev": true,
-      "dependencies": {
-        "path-type": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/del/node_modules/globby": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
@@ -5593,15 +5422,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/del/node_modules/ignore": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
-      "dev": true,
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/del/node_modules/p-map": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
@@ -5615,15 +5435,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/del/node_modules/path-type": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/del/node_modules/rimraf": {
@@ -5706,14 +5517,15 @@
       }
     },
     "node_modules/dir-glob": {
-      "version": "2.2.2",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "path-type": "^3.0.0"
+        "path-type": "^4.0.0"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=8"
       }
     },
     "node_modules/discontinuous-range": {
@@ -5877,17 +5689,6 @@
     "node_modules/drag-reorderable": {
       "version": "0.2.0"
     },
-    "node_modules/duplexify": {
-      "version": "3.7.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "end-of-stream": "^1.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.0",
-        "stream-shift": "^1.0.0"
-      }
-    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -5934,14 +5735,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/end-of-stream": {
-      "version": "1.4.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "once": "^1.4.0"
       }
     },
     "node_modules/engine.io": {
@@ -7574,15 +7367,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/flush-write-stream": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.3.6"
-      }
-    },
     "node_modules/follow-redirects": {
       "version": "1.14.9",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
@@ -7759,15 +7543,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/from2": {
-      "version": "2.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.0"
-      }
-    },
     "node_modules/fromentries": {
       "version": "1.3.2",
       "dev": true,
@@ -7818,17 +7593,6 @@
       "version": "1.1.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/fs-write-stream-atomic": {
-      "version": "1.0.10",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "iferr": "^0.1.5",
-        "imurmurhash": "^0.1.4",
-        "readable-stream": "1 || 2"
-      }
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -8043,35 +7807,34 @@
       }
     },
     "node_modules/globby": {
-      "version": "7.1.1",
+      "version": "13.1.3",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-13.1.3.tgz",
+      "integrity": "sha512-8krCNHXvlCgHDpegPzleMq07yMYTO2sXKASmZmquEYWEmCx6J5UTRbp5RwMJkTJGtcQ44YpiUYUiN0b9mzy8Bw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "array-union": "^1.0.1",
-        "dir-glob": "^2.0.0",
-        "glob": "^7.1.2",
-        "ignore": "^3.3.5",
-        "pify": "^3.0.0",
-        "slash": "^1.0.0"
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.11",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^4.0.0"
       },
       "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/globby/node_modules/pify": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/globby/node_modules/slash": {
-      "version": "1.0.0",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+      "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
       "dev": true,
-      "license": "MIT",
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/gopd": {
@@ -8618,15 +8381,14 @@
         "postcss": "^8.1.0"
       }
     },
-    "node_modules/iferr": {
-      "version": "0.1.5",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/ignore": {
-      "version": "3.3.10",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
+      "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
       "dev": true,
-      "license": "MIT"
+      "engines": {
+        "node": ">= 4"
+      }
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
@@ -10468,26 +10230,6 @@
       "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
-    "node_modules/mississippi": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "concat-stream": "^1.5.0",
-        "duplexify": "^3.4.2",
-        "end-of-stream": "^1.1.0",
-        "flush-write-stream": "^1.0.0",
-        "from2": "^2.1.0",
-        "parallel-transform": "^1.1.0",
-        "pump": "^2.0.1",
-        "pumpify": "^1.3.3",
-        "stream-each": "^1.1.0",
-        "through2": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
     "node_modules/mixin-deep": {
       "version": "1.3.2",
       "dev": true,
@@ -10923,19 +10665,6 @@
       "resolved": "https://registry.npmjs.org/mout/-/mout-1.2.4.tgz",
       "integrity": "sha512-mZb9uOruMWgn/fw28DG4/yE3Kehfk1zKCLhuDU2O3vlKdnBBr4XaOCqVTflJ5aODavGUPqFHZgrFX3NJVuxGhQ==",
       "dev": true
-    },
-    "node_modules/move-concurrently": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "aproba": "^1.1.1",
-        "copy-concurrently": "^1.0.0",
-        "fs-write-stream-atomic": "^1.0.8",
-        "mkdirp": "^0.5.1",
-        "rimraf": "^2.5.4",
-        "run-queue": "^1.0.3"
-      }
     },
     "node_modules/ms": {
       "version": "2.1.2",
@@ -11925,16 +11654,6 @@
       "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.3.2.tgz",
       "integrity": "sha512-6dNZu0Ki+gyV0eBsFKJhYr+MdQYAzFUGlBMNj3GNrmHxmz1lfRa24CjFObPXtjcetlOv5Ad299MhIK0znp3afw=="
     },
-    "node_modules/parallel-transform": {
-      "version": "1.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cyclist": "^1.0.1",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.1.5"
-      }
-    },
     "node_modules/param-case": {
       "version": "3.0.4",
       "dev": true,
@@ -12083,22 +11802,12 @@
       "license": "MIT"
     },
     "node_modules/path-type": {
-      "version": "3.0.0",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pify": "^3.0.0"
-      },
       "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/path-type/node_modules/pify": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
+        "node": ">=8"
       }
     },
     "node_modules/pathval": {
@@ -12358,11 +12067,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/promise-inflight": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/prop-types": {
       "version": "15.7.2",
       "license": "MIT",
@@ -12393,25 +12097,6 @@
       "version": "1.8.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/pump": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
-      }
-    },
-    "node_modules/pumpify": {
-      "version": "1.5.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "duplexify": "^3.6.0",
-        "inherits": "^2.0.3",
-        "pump": "^2.0.0"
-      }
     },
     "node_modules/punycode": {
       "version": "2.1.1",
@@ -13395,14 +13080,6 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "node_modules/run-queue": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "aproba": "^1.1.1"
-      }
-    },
     "node_modules/rxjs": {
       "version": "6.6.7",
       "dev": true,
@@ -13633,9 +13310,13 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "1.9.1",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
+      "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "dependencies": {
+        "randombytes": "^2.1.0"
+      }
     },
     "node_modules/serve-index": {
       "version": "1.9.1",
@@ -14289,14 +13970,6 @@
       "version": "1.1.2",
       "license": "BSD-3-Clause"
     },
-    "node_modules/ssri": {
-      "version": "5.3.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "safe-buffer": "^5.1.1"
-      }
-    },
     "node_modules/static-extend": {
       "version": "0.1.2",
       "dev": true,
@@ -14327,20 +14000,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/stream-each": {
-      "version": "1.2.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "end-of-stream": "^1.1.0",
-        "stream-shift": "^1.0.0"
-      }
-    },
-    "node_modules/stream-shift": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/strict-uri-encode": {
       "version": "1.1.0",
@@ -14862,15 +14521,6 @@
         "url": "https://opencollective.com/webpack"
       }
     },
-    "node_modules/terser-webpack-plugin/node_modules/serialize-javascript": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
-      "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
-      "dev": true,
-      "dependencies": {
-        "randombytes": "^2.1.0"
-      }
-    },
     "node_modules/terser-webpack-plugin/node_modules/terser": {
       "version": "5.16.1",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.1.tgz",
@@ -14924,15 +14574,6 @@
       "version": "2.3.8",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/through2": {
-      "version": "2.0.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "readable-stream": "~2.3.6",
-        "xtend": "~4.0.1"
-      }
     },
     "node_modules/thunky": {
       "version": "1.1.0",
@@ -15105,11 +14746,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/typedarray": {
-      "version": "0.0.6",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/typedarray-to-buffer": {
       "version": "3.1.5",
       "dev": true,
@@ -15205,22 +14841,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/unique-filename": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "unique-slug": "^2.0.0"
-      }
-    },
-    "node_modules/unique-slug": {
-      "version": "2.0.2",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "imurmurhash": "^0.1.4"
       }
     },
     "node_modules/universalify": {
@@ -16339,14 +15959,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/xtend": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4"
       }
     },
     "node_modules/y18n": {
@@ -18669,10 +18281,6 @@
         "default-require-extensions": "^3.0.0"
       }
     },
-    "aproba": {
-      "version": "1.2.0",
-      "dev": true
-    },
     "archy": {
       "version": "1.0.0",
       "dev": true
@@ -18732,17 +18340,6 @@
         "get-intrinsic": "^1.1.1",
         "is-string": "^1.0.7"
       }
-    },
-    "array-union": {
-      "version": "1.0.2",
-      "dev": true,
-      "requires": {
-        "array-uniq": "^1.0.1"
-      }
-    },
-    "array-uniq": {
-      "version": "1.0.3",
-      "dev": true
     },
     "array-unique": {
       "version": "0.3.2",
@@ -19408,25 +19005,6 @@
       "version": "3.0.0",
       "dev": true
     },
-    "cacache": {
-      "version": "10.0.4",
-      "dev": true,
-      "requires": {
-        "bluebird": "^3.5.1",
-        "chownr": "^1.0.1",
-        "glob": "^7.1.2",
-        "graceful-fs": "^4.1.11",
-        "lru-cache": "^4.1.1",
-        "mississippi": "^2.0.0",
-        "mkdirp": "^0.5.1",
-        "move-concurrently": "^1.0.1",
-        "promise-inflight": "^1.0.1",
-        "rimraf": "^2.6.2",
-        "ssri": "^5.2.4",
-        "unique-filename": "^1.1.0",
-        "y18n": "^4.0.0"
-      }
-    },
     "cache-base": {
       "version": "1.0.1",
       "dev": true,
@@ -19666,10 +19244,6 @@
         }
       }
     },
-    "chownr": {
-      "version": "1.1.4",
-      "dev": true
-    },
     "chrome-trace-event": {
       "version": "1.0.3",
       "dev": true
@@ -19901,16 +19475,6 @@
       "version": "0.0.1",
       "dev": true
     },
-    "concat-stream": {
-      "version": "1.6.2",
-      "dev": true,
-      "requires": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
-      }
-    },
     "confusing-browser-globals": {
       "version": "1.0.10",
       "dev": true
@@ -19966,94 +19530,31 @@
       "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.3.tgz",
       "integrity": "sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ=="
     },
-    "copy-concurrently": {
-      "version": "1.0.5",
-      "dev": true,
-      "requires": {
-        "aproba": "^1.1.1",
-        "fs-write-stream-atomic": "^1.0.8",
-        "iferr": "^0.1.5",
-        "mkdirp": "^0.5.1",
-        "rimraf": "^2.5.4",
-        "run-queue": "^1.0.0"
-      }
-    },
     "copy-descriptor": {
       "version": "0.1.1",
       "dev": true
     },
     "copy-webpack-plugin": {
-      "version": "4.6.0",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-11.0.0.tgz",
+      "integrity": "sha512-fX2MWpamkW0hZxMEg0+mYnA40LTosOSa5TqZ9GYIBzyJa9C3QUaMPSE2xAi/buNr8u89SfD9wHSQVBzrRa/SOQ==",
       "dev": true,
       "requires": {
-        "cacache": "^10.0.4",
-        "find-cache-dir": "^1.0.0",
-        "globby": "^7.1.1",
-        "is-glob": "^4.0.0",
-        "loader-utils": "^1.1.0",
-        "minimatch": "^3.0.4",
-        "p-limit": "^1.0.0",
-        "serialize-javascript": "^1.4.0"
+        "fast-glob": "^3.2.11",
+        "glob-parent": "^6.0.1",
+        "globby": "^13.1.1",
+        "normalize-path": "^3.0.0",
+        "schema-utils": "^4.0.0",
+        "serialize-javascript": "^6.0.0"
       },
       "dependencies": {
-        "find-cache-dir": {
-          "version": "1.0.0",
+        "glob-parent": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+          "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
           "dev": true,
           "requires": {
-            "commondir": "^1.0.1",
-            "make-dir": "^1.0.0",
-            "pkg-dir": "^2.0.0"
-          }
-        },
-        "find-up": {
-          "version": "2.1.0",
-          "dev": true,
-          "requires": {
-            "locate-path": "^2.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "2.0.0",
-          "dev": true,
-          "requires": {
-            "p-locate": "^2.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "make-dir": {
-          "version": "1.3.0",
-          "dev": true,
-          "requires": {
-            "pify": "^3.0.0"
-          }
-        },
-        "p-limit": {
-          "version": "1.3.0",
-          "dev": true,
-          "requires": {
-            "p-try": "^1.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "2.0.0",
-          "dev": true,
-          "requires": {
-            "p-limit": "^1.1.0"
-          }
-        },
-        "p-try": {
-          "version": "1.0.0",
-          "dev": true
-        },
-        "pify": {
-          "version": "3.0.0",
-          "dev": true
-        },
-        "pkg-dir": {
-          "version": "2.0.0",
-          "dev": true,
-          "requires": {
-            "find-up": "^2.1.0"
+            "is-glob": "^4.0.3"
           }
         }
       }
@@ -20237,10 +19738,6 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.11.tgz",
       "integrity": "sha512-sa6P2wJ+CAbgyy4KFssIb/JNMLxFvKF1pCYCSXS8ZMuqZnMsrxqI2E5sPyoTpxoPU/gVZMzr2zjOfg8GIZOMsw=="
     },
-    "cyclist": {
-      "version": "1.0.1",
-      "dev": true
-    },
     "damerau-levenshtein": {
       "version": "1.0.7",
       "dev": true
@@ -20409,15 +19906,6 @@
           "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
           "dev": true
         },
-        "dir-glob": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-          "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-          "dev": true,
-          "requires": {
-            "path-type": "^4.0.0"
-          }
-        },
         "globby": {
           "version": "11.1.0",
           "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
@@ -20432,12 +19920,6 @@
             "slash": "^3.0.0"
           }
         },
-        "ignore": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-          "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
-          "dev": true
-        },
         "p-map": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
@@ -20446,12 +19928,6 @@
           "requires": {
             "aggregate-error": "^3.0.0"
           }
-        },
-        "path-type": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-          "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-          "dev": true
         },
         "rimraf": {
           "version": "3.0.2",
@@ -20505,10 +19981,12 @@
       "dev": true
     },
     "dir-glob": {
-      "version": "2.2.2",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
       "dev": true,
       "requires": {
-        "path-type": "^3.0.0"
+        "path-type": "^4.0.0"
       }
     },
     "discontinuous-range": {
@@ -20630,16 +20108,6 @@
     "drag-reorderable": {
       "version": "0.2.0"
     },
-    "duplexify": {
-      "version": "3.7.1",
-      "dev": true,
-      "requires": {
-        "end-of-stream": "^1.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.0",
-        "stream-shift": "^1.0.0"
-      }
-    },
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -20673,13 +20141,6 @@
     "encodeurl": {
       "version": "1.0.2",
       "dev": true
-    },
-    "end-of-stream": {
-      "version": "1.4.4",
-      "dev": true,
-      "requires": {
-        "once": "^1.4.0"
-      }
     },
     "engine.io": {
       "version": "6.2.1",
@@ -21842,14 +21303,6 @@
         "write": "^0.2.1"
       }
     },
-    "flush-write-stream": {
-      "version": "1.1.1",
-      "dev": true,
-      "requires": {
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.3.6"
-      }
-    },
     "follow-redirects": {
       "version": "1.14.9",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
@@ -21960,14 +21413,6 @@
       "version": "0.5.2",
       "dev": true
     },
-    "from2": {
-      "version": "2.3.0",
-      "dev": true,
-      "requires": {
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.0"
-      }
-    },
     "fromentries": {
       "version": "1.3.2",
       "dev": true
@@ -22001,16 +21446,6 @@
     "fs-readdir-recursive": {
       "version": "1.1.0",
       "dev": true
-    },
-    "fs-write-stream-atomic": {
-      "version": "1.0.10",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "iferr": "^0.1.5",
-        "imurmurhash": "^0.1.4",
-        "readable-stream": "1 || 2"
-      }
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -22146,23 +21581,22 @@
       "dev": true
     },
     "globby": {
-      "version": "7.1.1",
+      "version": "13.1.3",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-13.1.3.tgz",
+      "integrity": "sha512-8krCNHXvlCgHDpegPzleMq07yMYTO2sXKASmZmquEYWEmCx6J5UTRbp5RwMJkTJGtcQ44YpiUYUiN0b9mzy8Bw==",
       "dev": true,
       "requires": {
-        "array-union": "^1.0.1",
-        "dir-glob": "^2.0.0",
-        "glob": "^7.1.2",
-        "ignore": "^3.3.5",
-        "pify": "^3.0.0",
-        "slash": "^1.0.0"
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.11",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^4.0.0"
       },
       "dependencies": {
-        "pify": {
-          "version": "3.0.0",
-          "dev": true
-        },
         "slash": {
-          "version": "1.0.0",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+          "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
           "dev": true
         }
       }
@@ -22536,12 +21970,10 @@
       "version": "5.1.0",
       "dev": true
     },
-    "iferr": {
-      "version": "0.1.5",
-      "dev": true
-    },
     "ignore": {
-      "version": "3.3.10",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
+      "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
       "dev": true
     },
     "import-fresh": {
@@ -23764,22 +23196,6 @@
       "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
-    "mississippi": {
-      "version": "2.0.0",
-      "dev": true,
-      "requires": {
-        "concat-stream": "^1.5.0",
-        "duplexify": "^3.4.2",
-        "end-of-stream": "^1.1.0",
-        "flush-write-stream": "^1.0.0",
-        "from2": "^2.1.0",
-        "parallel-transform": "^1.1.0",
-        "pump": "^2.0.1",
-        "pumpify": "^1.3.3",
-        "stream-each": "^1.1.0",
-        "through2": "^2.0.0"
-      }
-    },
     "mixin-deep": {
       "version": "1.3.2",
       "dev": true,
@@ -24051,18 +23467,6 @@
       "resolved": "https://registry.npmjs.org/mout/-/mout-1.2.4.tgz",
       "integrity": "sha512-mZb9uOruMWgn/fw28DG4/yE3Kehfk1zKCLhuDU2O3vlKdnBBr4XaOCqVTflJ5aODavGUPqFHZgrFX3NJVuxGhQ==",
       "dev": true
-    },
-    "move-concurrently": {
-      "version": "1.0.1",
-      "dev": true,
-      "requires": {
-        "aproba": "^1.1.1",
-        "copy-concurrently": "^1.0.0",
-        "fs-write-stream-atomic": "^1.0.8",
-        "mkdirp": "^0.5.1",
-        "rimraf": "^2.5.4",
-        "run-queue": "^1.0.3"
-      }
     },
     "ms": {
       "version": "2.1.2"
@@ -24745,15 +24149,6 @@
       "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.3.2.tgz",
       "integrity": "sha512-6dNZu0Ki+gyV0eBsFKJhYr+MdQYAzFUGlBMNj3GNrmHxmz1lfRa24CjFObPXtjcetlOv5Ad299MhIK0znp3afw=="
     },
-    "parallel-transform": {
-      "version": "1.2.0",
-      "dev": true,
-      "requires": {
-        "cyclist": "^1.0.1",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.1.5"
-      }
-    },
     "param-case": {
       "version": "3.0.4",
       "dev": true,
@@ -24862,17 +24257,10 @@
       "dev": true
     },
     "path-type": {
-      "version": "3.0.0",
-      "dev": true,
-      "requires": {
-        "pify": "^3.0.0"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "3.0.0",
-          "dev": true
-        }
-      }
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true
     },
     "pathval": {
       "version": "1.1.1",
@@ -25033,10 +24421,6 @@
       "version": "2.0.3",
       "dev": true
     },
-    "promise-inflight": {
-      "version": "1.0.1",
-      "dev": true
-    },
     "prop-types": {
       "version": "15.7.2",
       "requires": {
@@ -25060,23 +24444,6 @@
     "psl": {
       "version": "1.8.0",
       "dev": true
-    },
-    "pump": {
-      "version": "2.0.1",
-      "dev": true,
-      "requires": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
-      }
-    },
-    "pumpify": {
-      "version": "1.5.1",
-      "dev": true,
-      "requires": {
-        "duplexify": "^3.6.0",
-        "inherits": "^2.0.3",
-        "pump": "^2.0.0"
-      }
     },
     "punycode": {
       "version": "2.1.1",
@@ -25753,13 +25120,6 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "run-queue": {
-      "version": "1.0.3",
-      "dev": true,
-      "requires": {
-        "aproba": "^1.1.1"
-      }
-    },
     "rxjs": {
       "version": "6.6.7",
       "dev": true,
@@ -25947,8 +25307,13 @@
       }
     },
     "serialize-javascript": {
-      "version": "1.9.1",
-      "dev": true
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
+      "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+      "dev": true,
+      "requires": {
+        "randombytes": "^2.1.0"
+      }
     },
     "serve-index": {
       "version": "1.9.1",
@@ -26432,13 +25797,6 @@
     "sprintf-js": {
       "version": "1.1.2"
     },
-    "ssri": {
-      "version": "5.3.0",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "^5.1.1"
-      }
-    },
     "static-extend": {
       "version": "0.1.2",
       "dev": true,
@@ -26458,18 +25816,6 @@
     },
     "statuses": {
       "version": "1.4.0",
-      "dev": true
-    },
-    "stream-each": {
-      "version": "1.2.3",
-      "dev": true,
-      "requires": {
-        "end-of-stream": "^1.1.0",
-        "stream-shift": "^1.0.0"
-      }
-    },
-    "stream-shift": {
-      "version": "1.0.1",
       "dev": true
     },
     "strict-uri-encode": {
@@ -26812,15 +26158,6 @@
             "ajv-keywords": "^3.5.2"
           }
         },
-        "serialize-javascript": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
-          "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
-          "dev": true,
-          "requires": {
-            "randombytes": "^2.1.0"
-          }
-        },
         "terser": {
           "version": "5.16.1",
           "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.1.tgz",
@@ -26851,14 +26188,6 @@
     "through": {
       "version": "2.3.8",
       "dev": true
-    },
-    "through2": {
-      "version": "2.0.5",
-      "dev": true,
-      "requires": {
-        "readable-stream": "~2.3.6",
-        "xtend": "~4.0.1"
-      }
     },
     "thunky": {
       "version": "1.1.0",
@@ -26980,10 +26309,6 @@
         "mime-types": "~2.1.24"
       }
     },
-    "typedarray": {
-      "version": "0.0.6",
-      "dev": true
-    },
     "typedarray-to-buffer": {
       "version": "3.1.5",
       "dev": true,
@@ -27049,20 +26374,6 @@
         "get-value": "^2.0.6",
         "is-extendable": "^0.1.1",
         "set-value": "^2.0.1"
-      }
-    },
-    "unique-filename": {
-      "version": "1.1.1",
-      "dev": true,
-      "requires": {
-        "unique-slug": "^2.0.0"
-      }
-    },
-    "unique-slug": {
-      "version": "2.0.2",
-      "dev": true,
-      "requires": {
-        "imurmurhash": "^0.1.4"
       }
     },
     "universalify": {
@@ -27799,10 +27110,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.0.0.tgz",
       "integrity": "sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A==",
-      "dev": true
-    },
-    "xtend": {
-      "version": "4.0.2",
       "dev": true
     },
     "y18n": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "coffee-loader": "~0.9.0",
     "coffee-react": "~5.0.1",
     "coffeescript": "~2.3.2",
-    "copy-webpack-plugin": "~4.6.0",
+    "copy-webpack-plugin": "~11.0.0",
     "css-loader": "~6.7.3",
     "ejs": "~2.6.1",
     "engine.io-client": "~5.1.0",

--- a/webpack.build.js
+++ b/webpack.build.js
@@ -46,9 +46,11 @@ module.exports = {
       'SUGAR_HOST': null,
       'TALK_HOST': null
     }),
-    new CopyWebpackPlugin([
-      { from: 'public', to: '.' },
-    ]),
+    new CopyWebpackPlugin({
+      patterns: [
+        { from: 'public', to: '.' }
+      ]
+    }),
     new HtmlWebpackPlugin({
       template: 'views/index.ejs',
       inject: 'body',

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -43,9 +43,11 @@ var config = {
       'SUGAR_HOST': null,
       'TALK_HOST': null
     }),
-    new CopyWebpackPlugin([
-      { from: 'public', to: '.' }
-    ]),
+    new CopyWebpackPlugin({
+      patterns: [
+        { from: 'public', to: '.' }
+      ]
+    }),
     new HtmlWebpackPlugin({
       useBasePath: false,
       template: 'views/index.ejs',


### PR DESCRIPTION
Staging branch URL: https://pr-6285.pfe-preview.zooniverse.org

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
