### PR TITLE
Thumbnails: make height and width optional

### DIFF
--- a/app/classifier/tasks/survey/chooser/Choices.jsx
+++ b/app/classifier/tasks/survey/chooser/Choices.jsx
@@ -114,7 +114,6 @@ class Choices extends React.Component {
           const srcPath = Thumbnail.getThumbnailSrc({
             origin: 'https://thumbnails.zooniverse.org',
             width: 500,
-            height: 500,
             src
           });
           const thumbnail = srcPath || '';

--- a/app/components/thumbnail.jsx
+++ b/app/components/thumbnail.jsx
@@ -1,8 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-const MAX_THUMBNAIL_DIMENSION = 999;
-
 export default class Thumbnail extends React.Component {
   constructor(props) {
     super(props);
@@ -38,8 +36,8 @@ export default class Thumbnail extends React.Component {
     };
 
     const style = {
-      maxWidth: this.props.width,
-      maxHeight: this.props.height
+      maxWidth: this.props.width ? `${this.props.width}px` : undefined,
+      maxHeight: this.props.height ? `${this.props.height}px` : undefined
     };
 
     if (this.props.type === 'video') {
@@ -70,7 +68,7 @@ export default class Thumbnail extends React.Component {
   }
 }
 
-Thumbnail.getThumbnailSrc = function getThumbnailSrc({ origin, width, height, src }) {
+Thumbnail.getThumbnailSrc = function getThumbnailSrc({ origin, width = '', height = '', src }) {
   if (!src) {
     return undefined;
   }
@@ -83,11 +81,11 @@ Thumbnail.getThumbnailSrc = function getThumbnailSrc({ origin, width, height, sr
 Thumbnail.defaultProps = {
   controls: true,
   format: '',
-  height: MAX_THUMBNAIL_DIMENSION,
+  height: '',
   origin: 'https://thumbnails.zooniverse.org',
   src: '',
   type: 'image',
-  width: MAX_THUMBNAIL_DIMENSION
+  width: ''
 };
 
 Thumbnail.propTypes = {

--- a/app/pages/project/home/project-home.jsx
+++ b/app/pages/project/home/project-home.jsx
@@ -115,7 +115,7 @@ const ProjectHomePage = (props) => {
                     type={type}
                     format={format}
                     src={src}
-                    width={400}
+                    width={600}
                   />
                 </Link>
               </div>

--- a/app/pages/project/home/project-home.jsx
+++ b/app/pages/project/home/project-home.jsx
@@ -114,9 +114,8 @@ const ProjectHomePage = (props) => {
                     controls={false}
                     type={type}
                     format={format}
-                    height={240}
                     src={src}
-                    width={600}
+                    width={400}
                   />
                 </Link>
               </div>


### PR DESCRIPTION
- Make height and width optional for thumbnails.
- Remove the maximum height from thumbnails where they should be resized to a fixed width.
- Fix CSS dimensions for thumbnail sizing.

Fixes an issue where tall portrait images are stretched to match the required width, resulting in pixelated or blurred previews.

Staging branch URL: https://pr-6351.pfe-preview.zooniverse.org

Talk thumbnails for Living With Machines:
- [Blurred on www.zooniverse.org](https://www.zooniverse.org/projects/bldigital/living-with-machines)  
<img width="1064" alt="Talk subject thumbnails, blurred where they have been stretched to fit the available width." src="https://user-images.githubusercontent.com/59547/212087017-48a5b870-0fb4-4bce-9f4b-3ae215d0f3aa.png">

- [Fixed on this branch](https://pr-6351.pfe-preview.zooniverse.org/projects/bldigital/living-with-machines)  <img width="1064" alt="Talk subject thumbnails, crisp and sharp and legible." src="https://user-images.githubusercontent.com/59547/212086437-ad142756-4eae-4349-929b-f61fae8b8e67.png">


# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
