### PR TITLE
Bump panoptes-client to 5.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "markdownz": "~8.0.2",
         "modal-form": "~2.9",
         "moment": "~2.29.0",
-        "panoptes-client": "~4.2",
+        "panoptes-client": "~5.1.0",
         "papaparse": "^5.2.0",
         "polished": "~4.2.2",
         "prop-types": "~15.8.1",
@@ -9848,9 +9848,9 @@
       }
     },
     "node_modules/json-api-client": {
-      "version": "6.0.7",
-      "resolved": "https://registry.npmjs.org/json-api-client/-/json-api-client-6.0.7.tgz",
-      "integrity": "sha512-qS75DUjX6yE0TzrKWN0mIwf+VX8jt+TtOhw7W2hCuIikQjiiVvl7ayu5vddP1Fryd5xRiM0n5rAszGP63gvaCw==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/json-api-client/-/json-api-client-7.0.2.tgz",
+      "integrity": "sha512-spgq6esXJwUFMFRgVixIoDSCRamdJ4Om/ujJUoq4x+k5nAw4qYERCq4yx8dJ0iPYk4uAV2sxb6Lj8WqmIaEZgQ==",
       "dependencies": {
         "normalizeurl": "~1.0.0",
         "superagent": "^8.0.8"
@@ -11664,13 +11664,12 @@
       }
     },
     "node_modules/panoptes-client": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-4.2.8.tgz",
-      "integrity": "sha512-CnP7XJ/m6LOtEdMj86RkE7+zALL18ZMI1ht35dMyjI8aCPcUiWRnCpfCACvVk5dAKA9A+2ZrKeCzlMURp1qy/Q==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-5.1.0.tgz",
+      "integrity": "sha512-zD1kr8eWmMPq0vRGVUHbCCvJf7cko8pqrjDC05n+f8w2NYJ9NBnpmxvWh+G3cYESzR+scAIM2QRL5cHhs8oYiA==",
       "dependencies": {
-        "json-api-client": "^6.0.7",
-        "local-storage": "^2.0.0",
-        "sugar-client": "^2.0.0"
+        "json-api-client": "^7.0.2",
+        "local-storage": "^2.0.0"
       }
     },
     "node_modules/papaparse": {
@@ -14071,14 +14070,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/sugar-client": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/sugar-client/-/sugar-client-2.0.0.tgz",
-      "integrity": "sha512-87RfgwzyiQrA77lsBGYFPjHbDVzkcSl5aiubz3n7qPOwf9LLNKe+PvtlNf0bnFS63+gGWe6r8A18iaKLBthw1w==",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/superagent": {
@@ -22714,9 +22705,9 @@
       "dev": true
     },
     "json-api-client": {
-      "version": "6.0.7",
-      "resolved": "https://registry.npmjs.org/json-api-client/-/json-api-client-6.0.7.tgz",
-      "integrity": "sha512-qS75DUjX6yE0TzrKWN0mIwf+VX8jt+TtOhw7W2hCuIikQjiiVvl7ayu5vddP1Fryd5xRiM0n5rAszGP63gvaCw==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/json-api-client/-/json-api-client-7.0.2.tgz",
+      "integrity": "sha512-spgq6esXJwUFMFRgVixIoDSCRamdJ4Om/ujJUoq4x+k5nAw4qYERCq4yx8dJ0iPYk4uAV2sxb6Lj8WqmIaEZgQ==",
       "requires": {
         "normalizeurl": "~1.0.0",
         "superagent": "^8.0.8"
@@ -24006,13 +23997,12 @@
       }
     },
     "panoptes-client": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-4.2.8.tgz",
-      "integrity": "sha512-CnP7XJ/m6LOtEdMj86RkE7+zALL18ZMI1ht35dMyjI8aCPcUiWRnCpfCACvVk5dAKA9A+2ZrKeCzlMURp1qy/Q==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-5.1.0.tgz",
+      "integrity": "sha512-zD1kr8eWmMPq0vRGVUHbCCvJf7cko8pqrjDC05n+f8w2NYJ9NBnpmxvWh+G3cYESzR+scAIM2QRL5cHhs8oYiA==",
       "requires": {
-        "json-api-client": "^6.0.7",
-        "local-storage": "^2.0.0",
-        "sugar-client": "^2.0.0"
+        "json-api-client": "^7.0.2",
+        "local-storage": "^2.0.0"
       }
     },
     "papaparse": {
@@ -25740,11 +25730,6 @@
         "klona": "^2.0.5",
         "normalize-path": "^3.0.0"
       }
-    },
-    "sugar-client": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/sugar-client/-/sugar-client-2.0.0.tgz",
-      "integrity": "sha512-87RfgwzyiQrA77lsBGYFPjHbDVzkcSl5aiubz3n7qPOwf9LLNKe+PvtlNf0bnFS63+gGWe6r8A18iaKLBthw1w=="
     },
     "superagent": {
       "version": "8.0.8",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "markdownz": "~8.0.2",
     "modal-form": "~2.9",
     "moment": "~2.29.0",
-    "panoptes-client": "~4.2",
+    "panoptes-client": "~5.1.0",
     "papaparse": "^5.2.0",
     "polished": "~4.2.2",
     "prop-types": "~15.8.1",


### PR DESCRIPTION
- Bumps `json-api-client` to 7.0.2.
- Upgrades the Sugar client to Primus 8.

Staging branch URL: https://pr-6368.pfe-preview.zooniverse.org?env=staging

You can test it out by using the staging API, watching the Sugar websocket connection in browser dev tools.