### PR TITLE
Remove json-api-client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "markdownz": "~8.0.2",
         "modal-form": "~2.9",
         "moment": "~2.29.0",
-        "panoptes-client": "~4.2",
+        "panoptes-client": "github:zooniverse/panoptes-javascript-client#json-api-client",
         "papaparse": "^5.2.0",
         "polished": "~4.2.2",
         "prop-types": "~15.8.1",
@@ -9847,15 +9847,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/json-api-client": {
-      "version": "6.0.7",
-      "resolved": "https://registry.npmjs.org/json-api-client/-/json-api-client-6.0.7.tgz",
-      "integrity": "sha512-qS75DUjX6yE0TzrKWN0mIwf+VX8jt+TtOhw7W2hCuIikQjiiVvl7ayu5vddP1Fryd5xRiM0n5rAszGP63gvaCw==",
-      "dependencies": {
-        "normalizeurl": "~1.0.0",
-        "superagent": "^8.0.8"
-      }
-    },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -11664,13 +11655,14 @@
       }
     },
     "node_modules/panoptes-client": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-4.2.8.tgz",
-      "integrity": "sha512-CnP7XJ/m6LOtEdMj86RkE7+zALL18ZMI1ht35dMyjI8aCPcUiWRnCpfCACvVk5dAKA9A+2ZrKeCzlMURp1qy/Q==",
+      "version": "5.1.0",
+      "resolved": "git+ssh://git@github.com/zooniverse/panoptes-javascript-client.git#710567ee42d4a14a3995b3bf41defb8bad2888a8",
+      "license": "Apache-2.0",
       "dependencies": {
-        "json-api-client": "^6.0.7",
         "local-storage": "^2.0.0",
-        "sugar-client": "^2.0.0"
+        "normalizeurl": "~1.0.0",
+        "sugar-client": "^2.0.0",
+        "superagent": "^8.0.8"
       }
     },
     "node_modules/papaparse": {
@@ -14077,6 +14069,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/sugar-client/-/sugar-client-2.0.0.tgz",
       "integrity": "sha512-87RfgwzyiQrA77lsBGYFPjHbDVzkcSl5aiubz3n7qPOwf9LLNKe+PvtlNf0bnFS63+gGWe6r8A18iaKLBthw1w==",
+      "deprecated": "The latest Zooniverse Sugar client has moved to the panoptes-client package.",
       "engines": {
         "node": ">=14"
       }
@@ -22713,15 +22706,6 @@
       "version": "2.5.2",
       "dev": true
     },
-    "json-api-client": {
-      "version": "6.0.7",
-      "resolved": "https://registry.npmjs.org/json-api-client/-/json-api-client-6.0.7.tgz",
-      "integrity": "sha512-qS75DUjX6yE0TzrKWN0mIwf+VX8jt+TtOhw7W2hCuIikQjiiVvl7ayu5vddP1Fryd5xRiM0n5rAszGP63gvaCw==",
-      "requires": {
-        "normalizeurl": "~1.0.0",
-        "superagent": "^8.0.8"
-      }
-    },
     "json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -24006,13 +23990,13 @@
       }
     },
     "panoptes-client": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-4.2.8.tgz",
-      "integrity": "sha512-CnP7XJ/m6LOtEdMj86RkE7+zALL18ZMI1ht35dMyjI8aCPcUiWRnCpfCACvVk5dAKA9A+2ZrKeCzlMURp1qy/Q==",
+      "version": "git+ssh://git@github.com/zooniverse/panoptes-javascript-client.git#710567ee42d4a14a3995b3bf41defb8bad2888a8",
+      "from": "panoptes-client@github:zooniverse/panoptes-javascript-client#json-api-client",
       "requires": {
-        "json-api-client": "^6.0.7",
         "local-storage": "^2.0.0",
-        "sugar-client": "^2.0.0"
+        "normalizeurl": "~1.0.0",
+        "sugar-client": "^2.0.0",
+        "superagent": "^8.0.8"
       }
     },
     "papaparse": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "markdownz": "~8.0.2",
     "modal-form": "~2.9",
     "moment": "~2.29.0",
-    "panoptes-client": "~4.2",
+    "panoptes-client": "github:zooniverse/panoptes-javascript-client#json-api-client",
     "papaparse": "^5.2.0",
     "polished": "~4.2.2",
     "prop-types": "~15.8.1",


### PR DESCRIPTION
This is a test branch, with `json-api-client` included in the `panoptes-client` library.

See https://github.com/zooniverse/panoptes-javascript-client/pull/186

Staging branch URL: https://pr-6369.pfe-preview.zooniverse.org
