### PR TITLE
Workflow editor: refactor task editor (FEM Lab version)

### DIFF
--- a/app/pages/lab-fem/workflow.jsx
+++ b/app/pages/lab-fem/workflow.jsx
@@ -14,13 +14,12 @@ import FileButton from '../../components/file-button.cjsx';
 import WorkflowCreateForm from '../lab/workflow-create-form.cjsx';
 import workflowActions from '../lab/actions/workflow.js';
 import classnames from 'classnames';
-import FeedbackSection from '../../features/feedback/lab';
-import MobileSection from '../lab/mobile';
 import SubjectGroupViewerEditor from '../lab/workflow-components/subject-group-viewer-editor.jsx';
 import SubjectSetLinker from '../lab/workflow-components/subject-set-linker.jsx';
 import MiniCourses from '../lab/workflow-components/mini-courses.jsx';
 import Tutorials from '../lab/workflow-components/tutorials.jsx';
 import TaskOptions from '../lab/workflow-components/task-options.jsx';
+import TaskEditor from '../lab/workflow-components/task-editor.jsx';
 import TaskPicker from '../lab/workflow-components/task-picker.jsx';
 import { isThisProjectUsingFEMLab, FEM_LAB_PREVIEW_HOST } from './fem-lab-utilities.js';
 
@@ -50,7 +49,8 @@ class EditWorkflowPage extends Component {
     this.handleWorkflowCreation = this.handleWorkflowCreation.bind(this);
     this.hideCreateWorkflow = this.hideCreateWorkflow.bind(this);
     this.showCreateWorkflow = this.showCreateWorkflow.bind(this);
-    this.showTaskAddButtons = this.showTaskAddButtons.bind(this)
+    this.showTaskAddButtons = this.showTaskAddButtons.bind(this);
+    this.handleTaskDelete = this.handleTaskDelete.bind(this);
 
     this.state = {
       selectedTaskKey: props.workflow.first_task,
@@ -106,12 +106,6 @@ class EditWorkflowPage extends Component {
 
   canUseTask(project, task) {
     return Array.from(project.experimental_tools).includes(task);
-  }
-
-  handleTaskChange(taskKey, taskDescription) {
-    const changes = {};
-    changes[`tasks.${taskKey}`] = taskDescription;
-    return this.props.workflow.update(changes).save();
   }
 
   isThereNotADefinedTask() {
@@ -545,62 +539,13 @@ class EditWorkflowPage extends Component {
           </div>
 
           <div className={taskEditorClasses}>
-            {(() => {
-            if ((this.state.selectedTaskKey != null) && (this.props.workflow.tasks[this.state.selectedTaskKey] != null)) {
-              const task = this.props.workflow.tasks[this.state.selectedTaskKey];
-              if (task.required === 'true') {
-                task.required = true;
-              }
-              if (task.required === 'false') {
-                task.required = false;
-              }
-              const TaskEditorComponent = taskComponents[task.type]?.Editor;
-              const taskWithDefaults = {
-                required: false,
-                ...task
-              };
-              return <div>
-                {TaskEditorComponent ?  // Note: ShortcutEditor deprecated (and removed entirely) for FEM-lab
-                  <TaskEditorComponent
-                    workflow={this.props.workflow}
-                    task={taskWithDefaults}
-                    taskPrefix={`tasks.${this.state.selectedTaskKey}`}
-                    project={this.props.project}
-                    onChange={this.handleTaskChange.bind(this, this.state.selectedTaskKey)}
-                  />
-                :
-                  <div>Editor is not available.</div>
-                }
-                <hr />
-                <br />
-
-                {Array.from(this.props.project.experimental_tools).includes('general feedback') ?
-                  <FeedbackSection
-                    task={this.props.workflow.tasks[this.state.selectedTaskKey]}
-                    saveFn={this.handleTaskChange.bind(this, this.state.selectedTaskKey)}
-                  /> : undefined}
-                <hr />
-                <br />
-
-                <MobileSection
-                  project={this.props.project}
-                  workflow={this.props.workflow}
-                  task={this.props.workflow.tasks[this.state.selectedTaskKey]}
-                />
-
-                <AutoSave resource={this.props.workflow}>
-                  <small>
-                    <button type="button" className="minor-button" onClick={this.handleTaskDelete.bind(this, this.state.selectedTaskKey)}>Delete this task</button>
-                  </small>
-                </AutoSave>
-              </div>;
-            } else {
-              return <div className="form-help">
-                <p>Choose a task to edit. The configuration for that task will appear here.</p>
-              </div>;
-            }
-          })()
-            }
+            <TaskEditor
+              pfeLab={false}
+              onDelete={this.handleTaskDelete}
+              project={this.props.project}
+              selectedTaskKey={this.state.selectedTaskKey}
+              workflow={this.props.workflow}
+            />
           </div>
         </div>
       </div>

--- a/app/pages/lab/workflow-components/task-editor.jsx
+++ b/app/pages/lab/workflow-components/task-editor.jsx
@@ -4,7 +4,7 @@ import MobileSection from '../mobile/index.js';
 import AutoSave from '../../../components/auto-save.coffee';
 import taskComponents from '../../../classifier/tasks/index.js';
 
-export default function TaskEditor({ pfeLab = false,onDelete, project, selectedTaskKey, workflow }) {
+export default function TaskEditor({ pfeLab = false, onDelete, project, selectedTaskKey, workflow }) {
   const task = workflow.tasks[selectedTaskKey];
 
   function onChange(taskDescription) {

--- a/app/pages/lab/workflow-components/task-editor.jsx
+++ b/app/pages/lab/workflow-components/task-editor.jsx
@@ -32,7 +32,7 @@ export default function TaskEditor({ pfeLab = false,onDelete, project, selectedT
     };
 
     return <div>
-      {project.experimental_tools?.includes('shortcut' && pfeLab) ?
+      {(project.experimental_tools?.includes('shortcut') && pfeLab) ?
         <ShortcutEditor workflow={workflow} task={taskWithDefaults}>
           <TaskEditorComponent
             workflow={workflow}

--- a/app/pages/lab/workflow-components/task-editor.jsx
+++ b/app/pages/lab/workflow-components/task-editor.jsx
@@ -4,7 +4,7 @@ import MobileSection from '../mobile/index.js';
 import AutoSave from '../../../components/auto-save.coffee';
 import taskComponents from '../../../classifier/tasks/index.js';
 
-export default function TaskEditor({ onDelete, project, selectedTaskKey, workflow }) {
+export default function TaskEditor({ pfeLab = false,onDelete, project, selectedTaskKey, workflow }) {
   const task = workflow.tasks[selectedTaskKey];
 
   function onChange(taskDescription) {
@@ -32,7 +32,7 @@ export default function TaskEditor({ onDelete, project, selectedTaskKey, workflo
     };
 
     return <div>
-      {project.experimental_tools?.includes('shortcut') ?
+      {project.experimental_tools?.includes('shortcut' && pfeLab) ?
         <ShortcutEditor workflow={workflow} task={taskWithDefaults}>
           <TaskEditorComponent
             workflow={workflow}

--- a/app/pages/lab/workflow.jsx
+++ b/app/pages/lab/workflow.jsx
@@ -515,6 +515,7 @@ class EditWorkflowPage extends Component {
 
           <div className={taskEditorClasses}>
             <TaskEditor
+              pfeLab={true}
               onDelete={this.handleTaskDelete}
               project={this.props.project}
               selectedTaskKey={this.state.selectedTaskKey}


### PR DESCRIPTION
## PR Overview

Follows #6251, which applies similar changes for PFE Lab's Workflow Editor.

This PR updates the FEM Lab's Workflow Editor so the "Edit Task" portion of the Workflow Editor uses the new Task Editor component.

- Task Editor component has also been updated to accept a `pfeLab=true|false` value. This is due to FEM Lab not supporting the experimental Shortcuts feature any more.

Please see #6251 for testing procedures.
- Test project in PFE Lab (Shortcuts are enabled, and Shortcut Editor should be visible): [(local)](https://local.zooniverse.org:3735/lab/1966/workflows/3731?pfeLab=true)
- Test project in FEM Lab (Shortcut Editor should NOT be visible): [(local)](https://local.zooniverse.org:3735/lab/1966/workflows/3731?femLab=true)

Ready for review.