### PR TITLE
Set panoptes-client to 4.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "markdownz": "~8.0.1",
         "modal-form": "~2.9",
         "moment": "~2.29.0",
-        "panoptes-client": "~5.0",
+        "panoptes-client": "~4.2",
         "papaparse": "^5.2.0",
         "polished": "~4.2.2",
         "prop-types": "~15.8.1",
@@ -9837,9 +9837,9 @@
       }
     },
     "node_modules/json-api-client": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/json-api-client/-/json-api-client-7.0.1.tgz",
-      "integrity": "sha512-gg+VtMYsjoO7Zhn3RaN4njgObbsNSOFomDjedmzRu529DUz5fSlC5d7rQKGKb8GoMU27AQXDuUr874V+YIkgYQ==",
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/json-api-client/-/json-api-client-6.0.7.tgz",
+      "integrity": "sha512-qS75DUjX6yE0TzrKWN0mIwf+VX8jt+TtOhw7W2hCuIikQjiiVvl7ayu5vddP1Fryd5xRiM0n5rAszGP63gvaCw==",
       "dependencies": {
         "normalizeurl": "~1.0.0",
         "superagent": "^8.0.8"
@@ -11653,11 +11653,11 @@
       }
     },
     "node_modules/panoptes-client": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-5.0.1.tgz",
-      "integrity": "sha512-Iey1lnBZunndCHvUocsf0+asR60EXhU+IB8uC/dGLI+VWk/CGRUDzGqNTjmmb6/gGk1uWA6rr+Ol240nti5JCA==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-4.2.8.tgz",
+      "integrity": "sha512-CnP7XJ/m6LOtEdMj86RkE7+zALL18ZMI1ht35dMyjI8aCPcUiWRnCpfCACvVk5dAKA9A+2ZrKeCzlMURp1qy/Q==",
       "dependencies": {
-        "json-api-client": "^7.0.1",
+        "json-api-client": "^6.0.7",
         "local-storage": "^2.0.0",
         "sugar-client": "^2.0.0"
       }
@@ -22702,9 +22702,9 @@
       "dev": true
     },
     "json-api-client": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/json-api-client/-/json-api-client-7.0.1.tgz",
-      "integrity": "sha512-gg+VtMYsjoO7Zhn3RaN4njgObbsNSOFomDjedmzRu529DUz5fSlC5d7rQKGKb8GoMU27AQXDuUr874V+YIkgYQ==",
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/json-api-client/-/json-api-client-6.0.7.tgz",
+      "integrity": "sha512-qS75DUjX6yE0TzrKWN0mIwf+VX8jt+TtOhw7W2hCuIikQjiiVvl7ayu5vddP1Fryd5xRiM0n5rAszGP63gvaCw==",
       "requires": {
         "normalizeurl": "~1.0.0",
         "superagent": "^8.0.8"
@@ -23994,11 +23994,11 @@
       }
     },
     "panoptes-client": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-5.0.1.tgz",
-      "integrity": "sha512-Iey1lnBZunndCHvUocsf0+asR60EXhU+IB8uC/dGLI+VWk/CGRUDzGqNTjmmb6/gGk1uWA6rr+Ol240nti5JCA==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-4.2.8.tgz",
+      "integrity": "sha512-CnP7XJ/m6LOtEdMj86RkE7+zALL18ZMI1ht35dMyjI8aCPcUiWRnCpfCACvVk5dAKA9A+2ZrKeCzlMURp1qy/Q==",
       "requires": {
-        "json-api-client": "^7.0.1",
+        "json-api-client": "^6.0.7",
         "local-storage": "^2.0.0",
         "sugar-client": "^2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "markdownz": "~8.0.1",
     "modal-form": "~2.9",
     "moment": "~2.29.0",
-    "panoptes-client": "~5.0",
+    "panoptes-client": "~4.2",
     "papaparse": "^5.2.0",
     "polished": "~4.2.2",
     "prop-types": "~15.8.1",


### PR DESCRIPTION
Staging branch URL: https://pr-6382.pfe-preview.zooniverse.org

Related to #6381

Describe your changes.
- reverts PFE to use panoptes-client (aka PJC) to v4.2.8
- PJC v5.0.0 introduced breaking change as noted in #6381 

fix:
- my test project on staging - https://local.zooniverse.org:3735/lab/1779/subject-sets
- ^ click any subject set and it should load

bug:
- same project as ^, with bug - https://master.pfe-preview.zooniverse.org/lab/1779/subject-sets?env=staging

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?