### PR TITLE
Fix moderator discussion board menu

### DIFF
--- a/app/talk/discussion.cjsx
+++ b/app/talk/discussion.cjsx
@@ -310,6 +310,7 @@ module.exports = createReactClass
 
   render: ->
     {discussion} = @state
+    boardID = @props.params.board
 
     <div className="talk-discussion">
       <Helmet title="#{discussion?.title} » #{counterpart 'projectTalk.title'}" />
@@ -353,7 +354,7 @@ module.exports = createReactClass
 
                   <div>
                     <p><strong>Board:</strong></p>
-                    <select defaultValue={discussion.board_id}>
+                    <select defaultValue={boardID}>
                       {@state.boards.map (board, i) =>
                         <option key={board.id} value={board.id}>{board.title}</option>
                         }


### PR DESCRIPTION
Set the default board ID from the page URL, so that it isn’t undefined when the page loads.

Staging branch URL: https://pr-6388.pfe-preview.zooniverse.org

Fixes #6278. 

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
