### PR TITLE
Bump panoptes-client to 5.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "markdownz": "~8.0.2",
         "modal-form": "~2.9",
         "moment": "~2.29.0",
-        "panoptes-client": "~5.1.0",
+        "panoptes-client": "~5.2.0",
         "papaparse": "^5.2.0",
         "polished": "~4.2.2",
         "prop-types": "~15.8.1",
@@ -9847,15 +9847,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/json-api-client": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/json-api-client/-/json-api-client-7.0.2.tgz",
-      "integrity": "sha512-spgq6esXJwUFMFRgVixIoDSCRamdJ4Om/ujJUoq4x+k5nAw4qYERCq4yx8dJ0iPYk4uAV2sxb6Lj8WqmIaEZgQ==",
-      "dependencies": {
-        "normalizeurl": "~1.0.0",
-        "superagent": "^8.0.8"
-      }
-    },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -11664,12 +11655,13 @@
       }
     },
     "node_modules/panoptes-client": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-5.1.0.tgz",
-      "integrity": "sha512-zD1kr8eWmMPq0vRGVUHbCCvJf7cko8pqrjDC05n+f8w2NYJ9NBnpmxvWh+G3cYESzR+scAIM2QRL5cHhs8oYiA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-5.2.0.tgz",
+      "integrity": "sha512-kxOqT2J0WdOPXCbaQbF0K+6B/gYad2IIvRA+KizTF62k5nUbea7crsopo0lUJCs9UGkEcSG9WYiZO8JWTx8vQQ==",
       "dependencies": {
-        "json-api-client": "^7.0.2",
-        "local-storage": "^2.0.0"
+        "local-storage": "^2.0.0",
+        "normalizeurl": "~1.0.0",
+        "superagent": "^8.0.8"
       }
     },
     "node_modules/papaparse": {
@@ -22704,15 +22696,6 @@
       "version": "2.5.2",
       "dev": true
     },
-    "json-api-client": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/json-api-client/-/json-api-client-7.0.2.tgz",
-      "integrity": "sha512-spgq6esXJwUFMFRgVixIoDSCRamdJ4Om/ujJUoq4x+k5nAw4qYERCq4yx8dJ0iPYk4uAV2sxb6Lj8WqmIaEZgQ==",
-      "requires": {
-        "normalizeurl": "~1.0.0",
-        "superagent": "^8.0.8"
-      }
-    },
     "json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -23997,12 +23980,13 @@
       }
     },
     "panoptes-client": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-5.1.0.tgz",
-      "integrity": "sha512-zD1kr8eWmMPq0vRGVUHbCCvJf7cko8pqrjDC05n+f8w2NYJ9NBnpmxvWh+G3cYESzR+scAIM2QRL5cHhs8oYiA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-5.2.0.tgz",
+      "integrity": "sha512-kxOqT2J0WdOPXCbaQbF0K+6B/gYad2IIvRA+KizTF62k5nUbea7crsopo0lUJCs9UGkEcSG9WYiZO8JWTx8vQQ==",
       "requires": {
-        "json-api-client": "^7.0.2",
-        "local-storage": "^2.0.0"
+        "local-storage": "^2.0.0",
+        "normalizeurl": "~1.0.0",
+        "superagent": "^8.0.8"
       }
     },
     "papaparse": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "markdownz": "~8.0.2",
     "modal-form": "~2.9",
     "moment": "~2.29.0",
-    "panoptes-client": "~5.1.0",
+    "panoptes-client": "~5.2.0",
     "papaparse": "^5.2.0",
     "polished": "~4.2.2",
     "prop-types": "~15.8.1",


### PR DESCRIPTION
This is a test branch, to stage the code with `json-api-client` included in the `panoptes-client` library.

Staging branch URL: https://pr-6393.pfe-preview.zooniverse.org

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
