### PR TITLE
Lab: more robust workflow-tutorial links

### DIFF
--- a/app/pages/lab/workflow-components/tutorials.jsx
+++ b/app/pages/lab/workflow-components/tutorials.jsx
@@ -3,31 +3,37 @@ import apiClient from 'panoptes-client/lib/api-client';
 
 export default function Tutorials({ project, workflow }) {
   const [tutorials, setTutorials] = useState([]);
-  const [workflowTutorial, setWorkflowTutorial] = useState(null);
+  const [linkedTutorials, setLinkedTutorials] = useState([]);
 
   useEffect(function loadTutorials() {
-    Promise.all([
-      apiClient.type('tutorials')
-        .get({ project_id: project.id, page_size: 100 })
-        .catch(() => []),
-      apiClient.type('tutorials')
-        .get({ workflow_id: workflow.id, page_size: 100 })
-        .catch(() => [])
-    ])
-    .then(([projectTutorials, workflowTutorials]) => {
-      const tutorials = projectTutorials.filter(value => value.kind === 'tutorial' || value.kind === null);
-      const [workflowTutorial] = tutorials.filter(value => workflowTutorials.includes(value));
-      setTutorials(tutorials);
-      setWorkflowTutorial(workflowTutorial);
-    });
+    apiClient.type('tutorials')
+      .get({ project_id: project.id, page_size: 100 })
+      .catch(() => [])
+      .then(tutorials => {
+        setTutorials(tutorials.filter(value => value.kind === 'tutorial' || value.kind === null));
+      });
+    apiClient.type('tutorials')
+      .get({ workflow_id: workflow.id, page_size: 100 })
+      .catch(() => [])
+      .then(tutorials => {
+        setLinkedTutorials(tutorials.filter(value => value.kind === 'tutorial' || value.kind === null));
+      });
   }, [project?.id, workflow?.id]);
 
-  function removeTutorial() {
-    setWorkflowTutorial(null)
-    return workflow.removeLink('tutorials', workflowTutorial?.id);
+  function updateTutorialLinks(linkedTutorial) {
+    linkedTutorials
+      .filter(tutorial => tutorial.id !== linkedTutorial?.id)
+      .forEach(tutorial => workflow.removeLink('tutorials', tutorial?.id));
+    if (linkedTutorial) {
+      workflow.addLink('tutorials', [linkedTutorial.id]);
+      setLinkedTutorials([linkedTutorial]);
+    } else {
+      setLinkedTutorials([]);
+    }
   }
 
   function onChange(event) {
+    // TODO: radio groups only fire change events for the checked input, so what does this line do?
     const shouldAdd = event.target.checked;
     const tutorialID = event.target.value;
     const tutorial = tutorials.find(tutorial => tutorial.id === tutorialID);
@@ -37,11 +43,7 @@ export default function Tutorials({ project, workflow }) {
     return ensureSaved
       .then(() => {
         if (shouldAdd) {
-          workflow.addLink('tutorials', [tutorial.id]);
-          if (workflowTutorial?.id) {
-            workflow.removeLink('tutorials', workflowTutorial.id);
-          }
-          setWorkflowTutorial(tutorial)
+          updateTutorialLinks(tutorial);
         }
     });
   }
@@ -56,13 +58,13 @@ export default function Tutorials({ project, workflow }) {
                 name="tutorial"
                 type="radio"
                 value=""
-                checked={!workflowTutorial}
-                onChange={removeTutorial}
+                checked={!linkedTutorials.length}
+                onChange={onChange}
               />
               No tutorial
             </label>
             {tutorials.map(tutorial => {
-              const assignedTutorial = tutorial === workflowTutorial;
+              const assignedTutorial = linkedTutorials.includes(tutorial);
               return (
                 <label key={tutorial.id}>
                   <input

--- a/app/pages/lab/workflow-components/tutorials.jsx
+++ b/app/pages/lab/workflow-components/tutorials.jsx
@@ -32,20 +32,14 @@ export default function Tutorials({ project, workflow }) {
     }
   }
 
-  function onChange(event) {
-    // TODO: radio groups only fire change events for the checked input, so what does this line do?
-    const shouldAdd = event.target.checked;
-    const tutorialID = event.target.value;
+  async function onChange({ target }) {
+    const tutorialID = target?.value;
     const tutorial = tutorials.find(tutorial => tutorial.id === tutorialID);
 
     const ensureSaved = workflow.hasUnsavedChanges() ? workflow.save() : Promise.resolve();
 
-    return ensureSaved
-      .then(() => {
-        if (shouldAdd) {
-          updateTutorialLinks(tutorial);
-        }
-    });
+    await ensureSaved;
+    updateTutorialLinks(tutorial);
   }
 
   if (tutorials.length > 0) {


### PR DESCRIPTION
Update the workflow tutorials widget to allow for a case where Panoptes might erroneously link more than one tutorial of the same type to a single workflow.

Staging branch URL: https://pr-6405.pfe-preview.zooniverse.org/lab

Fixes #6400.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
