### PR TITLE
Handle errors on the Zooniverse social feed

### DIFF
--- a/app/lib/get-social-data.js
+++ b/app/lib/get-social-data.js
@@ -15,14 +15,18 @@ function getNewestProject() {
     });
 }
 
-function getBlogPosts(returnPosts) {
-  const request = new XMLHttpRequest();
-  request.open('GET', `${talkClient.root}/social`, true);
-  request.onload = () => {
-    const data = JSON.parse(request.responseText);
-    returnPosts(data.posts);
-  };
-  request.send();
+async function getBlogPosts() {
+  let posts = []
+  try {
+    const response = await fetch(`${talkClient.root}/social`);
+    if (response.ok) {
+      const data = await response.json();
+      posts = data.posts;
+    }
+  } catch (error) {
+    console.error(error);
+  }
+  return posts;
 }
 
 function getRecentProjects() {

--- a/app/pages/home-common/social.jsx
+++ b/app/pages/home-common/social.jsx
@@ -34,18 +34,13 @@ export default class HomePageSocial extends React.Component {
     this.getSocial();
   }
 
-  getSocial() {
-    getNewestProject().then((newestProject) => {
-      this.setState({
-        newestProject
-      });
-    });
-    getRecentProjects().then((recentProjects) => {
-      this.setState({ recentProjects });
-    });
-    getBlogPosts((blogPosts) => {
-      this.setState({ blogPosts });
-    });
+  async getSocial() {
+    const newestProject = await getNewestProject();
+    this.setState({ newestProject });
+    const recentProjects = await getRecentProjects();
+    this.setState({ recentProjects });
+    const blogPosts = await getBlogPosts(blogPosts);
+    this.setState({ blogPosts });
   }
 
   renderUpdatedProject(project) {


### PR DESCRIPTION
- Replace XHR with `fetch`.
- Refactor with `async/await`.
- Catch response errors and return an empty feed by default.

Staging branch URL: https://pr-6413.pfe-preview.zooniverse.org

Fixes #6412.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
