### PR TITLE
Debug volunteer classifications by subjectID

### DIFF
--- a/app/pages/admin/user-settings.jsx
+++ b/app/pages/admin/user-settings.jsx
@@ -116,7 +116,7 @@ class UserSettings extends Component {
           <form onSubmit={this.updateSubjectID}>
             <label for="subjectId">
               Filter by subject ID:
-              <input id="subjectID" name="subjectID" type="text" defaultValue='' />
+              <input id="subjectId" name="subjectID" type="text" defaultValue='' />
             </label>
           </form>
           <ol>

--- a/app/pages/admin/user-settings.jsx
+++ b/app/pages/admin/user-settings.jsx
@@ -16,6 +16,7 @@ class UserSettings extends Component {
     this.boundForceUpdate = this.forceUpdate.bind(this);
     this.getUser = this.getUser.bind(this);
     this.updateUserProjects = this.updateUserProjects.bind(this);
+    this.updateSubjectID = this.updateSubjectID.bind(this);
 
     this.state = {
       classifications: [],
@@ -57,6 +58,14 @@ class UserSettings extends Component {
       }, 0);
       return { ribbonData, totalClassifications };
     });
+  }
+
+  async updateSubjectID(event) {
+    event.preventDefault();
+    const data = new FormData(event.target);
+    const subjectID = data.get('subjectID');
+    const classifications = await getUserClassifications(this.state.editUser, subjectID);
+    this.setState({ classifications });
   }
 
   render() {
@@ -104,6 +113,12 @@ class UserSettings extends Component {
         </details>
         <details>
           <summary>Recent classifications {this.state.classifications.length}</summary>
+          <form onSubmit={this.updateSubjectID}>
+            <label for="subjectId">
+              Filter by subject ID:
+              <input id="subjectID" name="subjectID" type="text" defaultValue='' />
+            </label>
+          </form>
           <ol>
           {this.state.classifications.map(classification => (
             <li key={classification.id}>

--- a/app/pages/admin/user-settings.jsx
+++ b/app/pages/admin/user-settings.jsx
@@ -114,10 +114,9 @@ class UserSettings extends Component {
         <details>
           <summary>Recent classifications {this.state.classifications.length}</summary>
           <form onSubmit={this.updateSubjectID}>
-            <label for="subjectId">
-              Filter by subject ID:
-              <input id="subjectId" name="subjectID" type="text" defaultValue='' />
-            </label>
+            <label for="subjectId">Filter by subject ID: </label>
+            <input id="subjectId" name="subjectID" type="text" defaultValue='' pattern='\d+' />
+            <input type="submit" value="Go" />
           </form>
           <ol>
           {this.state.classifications.map(classification => (

--- a/app/pages/admin/user-settings/stats.js
+++ b/app/pages/admin/user-settings/stats.js
@@ -81,8 +81,9 @@ export function getUserProjects(user, callback, _page = 1) {
   });
 }
 
-export function getUserClassifications(user, _page = 1) {
+export function getUserClassifications(user, subject_id, _page = 1) {
   return user.get('classifications', {
+    subject_id: subject_id ? subject_id : undefined,
     sort: '-created_at',
     page: _page
   })


### PR DESCRIPTION
Add a form to the user admin page, which filters their classifications by classified subject ID. Handy if you want to debug reports of duplicate subjects for a volunteer.

<img width="1109" alt="Screenshot of the user account admin form, with a text input that can be used to filter the classifications history by subject ID." src="https://user-images.githubusercontent.com/59547/219675250-31ea327f-13ce-4503-8eab-7599ce16114e.png">


Staging branch URL: https://pr-6426.pfe-preview.zooniverse.org

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
