### PR TITLE
Log subject image errors to Sentry

### DIFF
--- a/app/components/file-viewer/image-viewer.jsx
+++ b/app/components/file-viewer/image-viewer.jsx
@@ -1,11 +1,13 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import { captureException } from '@sentry/browser';
 import LoadingIndicator from '../loading-indicator';
 
 class ImageViewer extends React.Component {
   constructor(props) {
     super(props);
     this.onLoad = this.onLoad.bind(this);
+    this.onError = this.onError.bind(this);
     this.state = {
       loading: true
     };
@@ -17,10 +19,14 @@ class ImageViewer extends React.Component {
     this.props.onLoad(e);
   }
 
+  onError(error) {
+    captureException(error);
+  }
+
   render() {
     return (
       <div className="subject-image-frame" >
-        <img className="subject pan-active" alt="" src={this.props.src} style={this.props.style} onLoad={this.onLoad} tabIndex={0} onFocus={this.props.onFocus} onBlur={this.props.onBlur} />
+        <img className="subject pan-active" alt="" src={this.props.src} style={this.props.style} onLoad={this.onLoad} onError={this.onError} tabIndex={0} onFocus={this.props.onFocus} onBlur={this.props.onBlur} />
 
         {this.state.loading &&
           <div className="loading-cover" style={this.props.overlayStyle} >

--- a/app/main.cjsx
+++ b/app/main.cjsx
@@ -45,7 +45,7 @@ shouldUpdateScroll = (prevRouterProps, routerProps) ->
   else
     true
 
-# initSentry()
+initSentry()
 store = initStore()
 
 ReactDOM.render <Provider store={store}><Router history={browserHistory} render={applyRouterMiddleware(useScroll(shouldUpdateScroll))}>{routes}</Router></Provider>,


### PR DESCRIPTION
Capture image loading errors so that we can log any problems with timeouts from `panoptes-uploads`.

Staging branch URL: https://pr-6427.pfe-preview.zooniverse.org

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
