### PR TITLE
Sanitise SVG file uploads

### DIFF
--- a/app/lib/put-file.js
+++ b/app/lib/put-file.js
@@ -1,3 +1,6 @@
+import createDOMPurify from 'dompurify';
+
+const DOMPurify = createDOMPurify(window);
 const ALLOWED_MEDIA_TYPES = ['image', 'audio', 'video'];
 const ALLOWED_FILE_TYPES = ['text/plain', 'application/json', 'application/pdf'];
 
@@ -7,13 +10,18 @@ export default async function putFile(url, file, headers = {}) {
     ALLOWED_MEDIA_TYPES.includes(type) ||
     ALLOWED_FILE_TYPES.includes(file.type);
   if (allowedUpload) {
+    let sanitisedFile = file
+    if (file.type === 'image/svg+xml') {
+      sanitisedFile = await file.text();
+      sanitisedFile = DOMPurify.sanitize(sanitisedFile)
+    }
     const options = {
       method: 'PUT',
       headers: {
         ...headers,
         'x-ms-blob-type': 'BlockBlob'
       },
-      body: file
+      body: sanitisedFile
     };
     const response = await fetch(url, options);
     if (response.ok) {

--- a/app/lib/put-file.js
+++ b/app/lib/put-file.js
@@ -1,6 +1,20 @@
 import createDOMPurify from 'dompurify';
 
 const DOMPurify = createDOMPurify(window);
+const sanitiseOptions = {
+  USE_PROFILES: {
+    svg: true,
+    svgFilters: true
+  },
+  ADD_TAGS: [
+    'animate',
+    'use'
+  ],
+  ADD_ATTR: [
+    'calcmode'
+  ]
+}
+
 const ALLOWED_MEDIA_TYPES = ['image', 'audio', 'video'];
 const ALLOWED_FILE_TYPES = ['text/plain', 'application/json', 'application/pdf'];
 
@@ -13,7 +27,7 @@ export default async function putFile(url, file, headers = {}) {
     let sanitisedFile = file
     if (file.type === 'image/svg+xml') {
       sanitisedFile = await file.text();
-      sanitisedFile = DOMPurify.sanitize(sanitisedFile)
+      sanitisedFile = DOMPurify.sanitize(sanitisedFile, sanitiseOptions);
     }
     const options = {
       method: 'PUT',


### PR DESCRIPTION
Update the `putFile` helper to sanitise SVG files and remove unsafe tags, such as `script`.

Towards https://github.com/zooniverse/panoptes/security/advisories/GHSA-85fr-5pvp-fmjm

You can test this out by uploading an SVG file, containing malicious content, via any of the components that use `putFile`:
- project media uploads.
- project subject uploads.
- project avatars.
- user avatars.
- field guide icons.

Any scripts etc. in the original SVG should be stripped out before it is uploaded.

https://pr-6479.pfe-preview.zooniverse.org

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
