### PR TITLE
Add JSON data subjects to recents

### DIFF
--- a/app/components/file-viewer/canvas-viewer.jsx
+++ b/app/components/file-viewer/canvas-viewer.jsx
@@ -153,6 +153,7 @@ class CanvasViewer extends React.Component {
     return (
       <div className="subject-canvas-frame" >
         <canvas
+          key={this.props.src}
           className="subject pan-active"
           width={this.state.canvasSize.width}
           height={this.state.canvasSize.height}

--- a/app/components/thumbnail.jsx
+++ b/app/components/thumbnail.jsx
@@ -60,6 +60,10 @@ export default class Thumbnail extends React.Component {
       );
     }
 
+    if (this.props.type === 'application') {
+      return null;
+    }
+
     return (
       <div  style={style}>
         <img alt="" {...this.props} src={src} {...dimensions} onError={this.handleError} />

--- a/app/features/modelling/line-plot/index.js
+++ b/app/features/modelling/line-plot/index.js
@@ -1,4 +1,4 @@
-import Chart from 'chart.js/auto';
+import { Chart } from 'chart.js/auto';
 
 // Help at http://www.chartjs.org/docs/latest
 class LinePlotModel {
@@ -71,9 +71,9 @@ class LinePlotModel {
         const { height, width } = canvas.getBoundingClientRect()
         onLoad({ height, width })
       })
-      .catch((e) => {
+      .catch((error) => {
         modelDidError({ modelErrorMessage: error.message })
-        console.warn(e);
+        console.warn(error);
       });
   }
   update() {

--- a/app/pages/profile/recents.jsx
+++ b/app/pages/profile/recents.jsx
@@ -1,84 +1,81 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import { useEffect, useState } from 'react';
 import { Link } from 'react-router';
 import Translate from 'react-translate-component';
 import SubjectViewer from '../../components/subject-viewer';
 import Thumbnail from '../../components/thumbnail';
 import getSubjectLocations from '../../lib/getSubjectLocations';
 
-class Recents extends React.Component {
-  constructor() {
-    super();
-    this.state = {
-      recents: []
-    };
-  }
+function Recents({ project, user }) {
+  const [recents, setRecents] = useState([]);
 
-  componentDidMount() {
-    const { user } = this.props;
-    if (user && user.get) {
-      user.get('recents', { project_id: this.props.project.id, sort: '-created_at' })
-        .then(recents => this.setState({ recents }));
+  useEffect(function loadRecents() {
+    if (user?.get && project?.id) {
+      user.get('recents', { project_id: project.id, sort: '-created_at' })
+        .then(recents => setRecents(recents));
     }
-  }
+  }, [project?.id, user]);
 
-  render() {
-    const { user, project } = this.props;
-    return (
-      <div className="collections-page secondary-page has-project-context">
-        <div className="hero collections-hero">
-          <div className="hero-container">
-            <Translate content="classifier.recents" component="h1" />
-          </div>
+  return (
+    <div className="collections-page secondary-page has-project-context">
+      <div className="hero collections-hero">
+        <div className="hero-container">
+          <Translate content="classifier.recents" component="h1" />
         </div>
-        {(this.state.recents.length > 0) &&
-          <div className="content-container collection-page-with-project-context">
-            <ul className="collections-show">
-              {this.state.recents.map((recent) => {
-                const locations = getSubjectLocations(recent);
-                let type = '';
-                let format = '';
-                let src = '';
-                if (locations.image) {
-                  type = 'image';
-                  [format, src] = locations.image;
-                } else if (locations.video) {
-                  type = 'video';
-                  [format, src] = locations.video;
-                }
-                const fakeSubject = {
-                  id: recent.links.subject,
-                  locations: [{ [`${type}/${format}`]: src }]
-                };
-                return (
-                  <li key={recent.id} className="collection-subject-viewer">
-                    <SubjectViewer
-                      project={project}
-                      subject={fakeSubject}
-                      user={user}
-                    >
-                      <Link
-                        className="subject-link"
-                        to={`/projects/${project.slug}/talk/subjects/${recent.links.subject}`}
-                      >
-                        <Thumbnail
-                          alt={`Subject ${recent.links.subject}`}
-                          src={src}
-                          type={type}
-                          format={format}
-                          height={250}
-                        />
-                      </Link>
-                    </SubjectViewer>
-                  </li>
-                );
-              })}
-            </ul>
-          </div>
-        }
       </div>
-    );
-  }
+      {(recents.length > 0) &&
+        <div className="content-container collection-page-with-project-context">
+          <ul className="collections-show">
+            {recents.map((recent) => {
+              const locations = getSubjectLocations(recent);
+              let type = '';
+              let format = '';
+              let src = '';
+              if (locations.image) {
+                type = 'image';
+                [format, src] = locations.image;
+              } else if (locations.video) {
+                type = 'video';
+                [format, src] = locations.video;
+              } else if (locations.application) {
+                type = 'application';
+                [format, src] = locations.application;
+              }
+
+              const fakeSubject = {
+                id: recent.links.subject,
+                locations: [{ [`${type}/${format}`]: src }],
+                metadata: {}
+              };
+
+              return (
+                <li key={recent.id} className="collection-subject-viewer">
+                  <SubjectViewer
+                    project={project}
+                    subject={fakeSubject}
+                    user={user}
+                  >
+                    <Link
+                      className="subject-link"
+                      to={`/projects/${project.slug}/talk/subjects/${recent.links.subject}`}
+                    >
+                      <Thumbnail
+                        alt={`Subject ${recent.links.subject}`}
+                        src={src}
+                        type={type}
+                        format={format}
+                        height={250}
+                      />
+                    </Link>
+                  </SubjectViewer>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      }
+    </div>
+  );
 }
 
 Recents.propTypes = {


### PR DESCRIPTION
- Refactor `Recents` as a functional component.
- add a fake subject and viewer for `application/json` URLs.
- fix a small bug where the canvas viewer crashes if you try to use it when it's already in use.

Staging branch URL: https://pr-6491.pfe-preview.zooniverse.org

Classify a few supernova candidates on this workflow, then go to Recents. Your recent classifications should show up as scatterplot charts, each of them linked through to the Talk page for that subject. There are only 6 subjects, so you should be able to get through them all very quickly.
https://pr-6491.pfe-preview.zooniverse.org/projects/eatyourgreens/-project-testing-ground/classify?reload=0&workflow=3742&env=staging

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
