### PR TITLE
Test Panoptes client async sign out

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "markdownz": "~8.0.3",
         "modal-form": "~2.9",
         "moment": "~2.29.0",
-        "panoptes-client": "~5.2.4",
+        "panoptes-client": "zooniverse/panoptes-javascript-client#async-sign-out",
         "papaparse": "^5.4.1",
         "polished": "~4.2.2",
         "prop-types": "~15.8.1",
@@ -11731,8 +11731,8 @@
     },
     "node_modules/panoptes-client": {
       "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-5.2.4.tgz",
-      "integrity": "sha512-PtWIfwuaGm7u7y2eOm+uli1kCJk/FyRjUWEVtd/kPpR+JhCz3MJa+5VzzoPZyR2AKmEm/rp3F2j4oo+My4vRnA==",
+      "resolved": "git+ssh://git@github.com/zooniverse/panoptes-javascript-client.git#11ec518c4372311fb7c2ee11179c1dbff6c16324",
+      "license": "Apache-2.0",
       "dependencies": {
         "local-storage": "^2.0.0",
         "normalizeurl": "~1.0.0",
@@ -24247,9 +24247,8 @@
       }
     },
     "panoptes-client": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-5.2.4.tgz",
-      "integrity": "sha512-PtWIfwuaGm7u7y2eOm+uli1kCJk/FyRjUWEVtd/kPpR+JhCz3MJa+5VzzoPZyR2AKmEm/rp3F2j4oo+My4vRnA==",
+      "version": "git+ssh://git@github.com/zooniverse/panoptes-javascript-client.git#11ec518c4372311fb7c2ee11179c1dbff6c16324",
+      "from": "panoptes-client@zooniverse/panoptes-javascript-client#async-sign-out",
       "requires": {
         "local-storage": "^2.0.0",
         "normalizeurl": "~1.0.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "markdownz": "~8.0.3",
     "modal-form": "~2.9",
     "moment": "~2.29.0",
-    "panoptes-client": "~5.2.4",
+    "panoptes-client": "zooniverse/panoptes-javascript-client#async-sign-out",
     "papaparse": "^5.4.1",
     "polished": "~4.2.2",
     "prop-types": "~15.8.1",


### PR DESCRIPTION
Test the `async-sign-out` branch of PJC.

Staging branch URL: https://pr-6510.pfe-preview.zooniverse.org?env=production

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
