### PR TITLE
Remove slack notifications from deploy actions

### DIFF
--- a/.github/workflows/deploy_branch.yml
+++ b/.github/workflows/deploy_branch.yml
@@ -22,16 +22,3 @@ jobs:
       target: 'preview.zooniverse.org/panoptes-front-end/pr-${{ github.event.number }}'
     secrets:
       creds: ${{ secrets.AZURE_STATIC_SITES }}
-  slack_notification:
-    name: Send Slack notification
-    uses: zooniverse/ci-cd/.github/workflows/slack_notification.yaml@main
-    needs: deploy_staging_branch
-    if: always()
-    with:
-      commit_id: ${{ github.sha }}
-      job_name: Build staging branch / build
-      status: ${{ needs.deploy_staging_branch.result }}
-      title: 'Deploy https://pr-${{ github.event.number }}.pfe-preview.zooniverse.org'
-      title_link: 'https://pr-${{ github.event.number }}.pfe-preview.zooniverse.org'
-    secrets:
-      slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -27,16 +27,3 @@ jobs:
       target: 'www.zooniverse.org'
     secrets:
       creds: ${{ secrets.AZURE_STATIC_SITES }}
-  slack_notification:
-    name: Send Slack notification
-    uses: zooniverse/ci-cd/.github/workflows/slack_notification.yaml@main
-    needs: deploy_production
-    if: always()
-    with:
-      commit_id: ${{ github.sha }}
-      job_name: Build production / build
-      status: ${{ needs.deploy_production.result }}
-      title: 'PFE Production deploy complete'
-      title_link: 'https://www.zooniverse.org'
-    secrets:
-      slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -24,16 +24,3 @@ jobs:
       target: 'preview.zooniverse.org/panoptes-front-end/master'
     secrets:
       creds: ${{ secrets.AZURE_STATIC_SITES }}
-  slack_notification:
-    name: Send Slack notification
-    uses: zooniverse/ci-cd/.github/workflows/slack_notification.yaml@main
-    needs: deploy_staging
-    if: always()
-    with:
-      commit_id: ${{ github.sha }}
-      job_name: Build staging / build
-      status: ${{ needs.deploy_staging.result }}
-      title: 'PFE Staging deploy complete'
-      title_link: 'https://master.pfe-preview.zooniverse.org'
-    secrets:
-      slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
Deploy notifications for this repo are now handled by the github slack app, where the #deploys channel is subscribed to the repo's workflow events.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
