### PR TITLE
FEM lab: Add separate frames layout options

### DIFF
--- a/app/pages/lab-fem/components/fem-multi-image-subject-options-editor.jsx
+++ b/app/pages/lab-fem/components/fem-multi-image-subject-options-editor.jsx
@@ -79,7 +79,7 @@ export default function FemMultiImageSubjectLayoutEditor ({
             checked={layout === "col"}
             onChange={handleSelectLayout}
           />
-          Single column (all frames stacked vertically)
+          Single column - <small>all frames stacked vertically (recommended for landscape subjects, and this is the default for mobile devices)</small>
         </label>
         <br />
         <label>
@@ -90,7 +90,7 @@ export default function FemMultiImageSubjectLayoutEditor ({
             checked={layout === "row"}
             onChange={handleSelectLayout}
           />
-          Single row (all frames side by side horizontally)
+          Single row - <small>all frames side by side horizontally (recommended only for portrait subjects)</small>
         </label>
         <br />
         <label>

--- a/app/pages/lab-fem/components/fem-multi-image-subject-options-editor.jsx
+++ b/app/pages/lab-fem/components/fem-multi-image-subject-options-editor.jsx
@@ -44,7 +44,8 @@ export default function FemMultiImageSubjectLayoutEditor ({
           <option value={3}>3</option>
           <option value={5}>5</option>
         </select>
-        <label htmlFor='flipbook-play-iterations'>{' '}Play Iterations - <small>choose how many times the images loop</small></label>
+        <label htmlFor='flipbook-play-iterations'>{' '}Play Iterations</label>
+        <small> - choose how many times the images loop</small>
       </div>
       <div>
         <label>
@@ -53,8 +54,9 @@ export default function FemMultiImageSubjectLayoutEditor ({
             checked={enableAutoplayChecked}
             onChange={toggleFlipbookAutoplay}
             />
-          Autoplay - <small>automatically loop through a subject's images when the page loads</small>
+          Autoplay
         </label>
+        <small> - automatically loop through a subject's images when the page loads</small>
       </div>
       <div>
         <label>

--- a/app/pages/lab-fem/components/fem-multi-image-subject-options-editor.jsx
+++ b/app/pages/lab-fem/components/fem-multi-image-subject-options-editor.jsx
@@ -79,8 +79,9 @@ export default function FemMultiImageSubjectLayoutEditor ({
             checked={layout === "col"}
             onChange={handleSelectLayout}
           />
-          Single column - <small>all frames stacked vertically (recommended for landscape subjects, and this is the default for mobile devices)</small>
+          Single column
         </label>
+        <small> - all frames stacked vertically (recommended for landscape subjects; default for mobile devices)</small>
         <br />
         <label>
           <input
@@ -90,8 +91,9 @@ export default function FemMultiImageSubjectLayoutEditor ({
             checked={layout === "row"}
             onChange={handleSelectLayout}
           />
-          Single row - <small>all frames side by side horizontally (recommended only for portrait subjects)</small>
+          Single row
         </label>
+        <small> - all frames side by side horizontally (recommended only for portrait subjects)</small>
         <br />
         <label>
           <input
@@ -101,8 +103,9 @@ export default function FemMultiImageSubjectLayoutEditor ({
             checked={layout === "grid2"}
             onChange={handleSelectLayout}
           />
-          Grid (frames distributed evenly over 2 columns)
+          Grid
         </label>
+        <small> - frames distributed evenly over 2 columns</small>
         <br />
         <label>
           <input
@@ -112,8 +115,9 @@ export default function FemMultiImageSubjectLayoutEditor ({
             checked={layout === "grid3"}
             onChange={handleSelectLayout}
           />
-          Grid (frames distributed evenly over 3 columns)
+          Grid
         </label>
+        <small> - frames distributed evenly over 3 columns</small>
       </div>}
     </div>
   )

--- a/app/pages/lab-fem/components/fem-multi-image-subject-options-editor.jsx
+++ b/app/pages/lab-fem/components/fem-multi-image-subject-options-editor.jsx
@@ -15,6 +15,13 @@ export default function FemMultiImageSubjectLayoutEditor ({
     })
   }
 
+  function handleSelectLayout (e) {
+    const layout = e.target.value
+    return workflow.update({
+      'configuration.multi_image_layout': layout
+    })
+  }
+
   function handleSelectPlayIterations (e) {
     const iterations = e.target.value;
     return workflow.update({
@@ -24,7 +31,8 @@ export default function FemMultiImageSubjectLayoutEditor ({
 
   const enableSwitchingChecked = !!workflow?.configuration?.enable_switching_flipbook_and_separate
   const enableAutoplayChecked = !!workflow?.configuration?.flipbook_autoplay
-  const iterations = (workflow?.configuration?.playIterations >= 0) ? workflow.configuration.playIterations : 3
+  const iterations = workflow?.configuration?.playIterations >= 0 ? workflow.configuration.playIterations : 3
+  const layout = workflow?.configuration?.multi_image_layout || 'col'
 
   return (
     <div className='multi-image-subject-layout-editor'>
@@ -55,9 +63,58 @@ export default function FemMultiImageSubjectLayoutEditor ({
             checked={enableSwitchingChecked}
             onChange={toggleEnableSwitching}
           />
-          Allow Separate Frames View - <small>volunteers can choose flipbook or a one-column separate frames view</small>
+          Allow Separate Frames View - <small>volunteers can choose flipbook or a separate frames view</small>
         </label>
       </div>
+
+      {enableSwitchingChecked && <div>
+        <br />
+        <span>Show separate frames as:</span>
+        <br />
+        <label>
+          <input
+            type="radio"
+            name="multi_image_layout"
+            value="col"
+            checked={layout === "col"}
+            onChange={handleSelectLayout}
+          />
+          Single column (all frames stacked vertically)
+        </label>
+        <br />
+        <label>
+          <input
+            type="radio"
+            name="multi_image_layout"
+            value="row"
+            checked={layout === "row"}
+            onChange={handleSelectLayout}
+          />
+          Single row (all frames side by side horizontally)
+        </label>
+        <br />
+        <label>
+          <input
+            type="radio"
+            name="multi_image_layout"
+            value="grid2"
+            checked={layout === "grid2"}
+            onChange={handleSelectLayout}
+          />
+          Grid (frames distributed evenly over 2 columns)
+        </label>
+        <br />
+        <label>
+          <input
+            type="radio"
+            name="multi_image_layout"
+            value="grid3"
+            checked={layout === "grid3"}
+            onChange={handleSelectLayout}
+          />
+          Grid (frames distributed evenly over 3 columns)
+        </label>
+      </div>}
     </div>
   )
 }


### PR DESCRIPTION
Staging branch URL: https://pr-6536.pfe-preview.zooniverse.org

I added four options to the FEM lab's multi-image subject options section: "row", "grid2", and "grid3" are already established as layout options in PFE. In this PR I also added the option of "col". The layout options only appear when a workflow has "allow volunteers to switch between flipbook and separate frames" enabled:

<img width="478" alt="Screenshot 2023-04-17 at 5 02 45 PM" src="https://user-images.githubusercontent.com/23665803/232620636-a7d3ba11-b9f9-4300-be97-a2cfe4b9cb83.png">

Below are the four layouts rendered in a workflow with a subject that has five frames. The subject image becomes tiny in a "row" or "3-col grid", but we can trust project teams will choose the layout that best suits their subject type. This is just an example.

Column
<img width="500" alt="col" src="https://user-images.githubusercontent.com/23665803/232867652-f160192b-8c59-4383-95c7-bd88f128aa8a.png">

Row
<img width="500" alt="row" src="https://user-images.githubusercontent.com/23665803/232867839-f2b62fa6-7145-4d23-a3b2-270df4fc8f36.png">

Grid With 2 Columns
<img width="500" alt="grid2" src="https://user-images.githubusercontent.com/23665803/232868030-58a0e82d-67d0-4100-b1af-c7baf17f4cd1.png">

Grid With 3 Columns
<img width="500" alt="grid3" src="https://user-images.githubusercontent.com/23665803/232868137-d0457058-27a9-4b47-bf49-cd75308a0233.png">

@seanmiller26 for your review in addition to the screenshots above:
    - Should I add text to the lab section explaining that the layout will always be one column when volunteers use a small screen such as a mobile device?


# Review
To review you can visit my flipbook test project's workflow in the FEM lab: https://local.zooniverse.org:3735/lab/19645/workflows/22532?env=production&femLab=true

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?