### PR TITLE
Fix subject delete buttons in collections

### DIFF
--- a/app/collections/show-list.jsx
+++ b/app/collections/show-list.jsx
@@ -222,11 +222,11 @@ function CollectionShowList({
     />);
   }
 
-  function handleDeleteSubject(subject) {
-    const index = subjects.indexOf(subject);
-    setSubjects(subjects.splice(index, 1));
+  function handleDeleteSubject(subjectToDelete) {
+    const newSubjects = subjects.filter(subject => subject !== subjectToDelete)
+    setSubjects(newSubjects);
 
-    collection.removeLink('subjects', [subject.id.toString()])
+    collection.removeLink('subjects', [subjectToDelete.id.toString()])
       .then(() => {
         collection.uncacheLink('subjects');
     });


### PR DESCRIPTION
Filter deleted subjects out of the displayed subjects, then display the filtered list.

Staging branch URL: https://pr-6541.pfe-preview.zooniverse.org

Fixes #6539.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
