### PR TITLE
Refactor highlighter annotation end calculation

### DIFF
--- a/app/classifier/tasks/highlighter/index.jsx
+++ b/app/classifier/tasks/highlighter/index.jsx
@@ -33,17 +33,6 @@ export default class Highlighter extends React.Component {
     const isSelectable = !spansNodes && !noAreaSelected && subjectSelection;
     return isSelectable;
   }
-  // in Edge and IE, when highlighting a word at the end of a line
-  // sometimes an extra character is added to the range.endOffset value
-  static extraNewLineCharacter(range) {
-    const content = range.startContainer.textContent;
-    const selectedText = range.toString();
-    let { endOffset } = range;
-    if (content[range.endOffset - 1] !== selectedText[-1] && content[range.endOffset - 1] === '\n') {
-      endOffset = range.endOffset - 1;
-    }
-    return endOffset;
-  }
   constructor(props) {
     super(props);
     this.handleChange = this.handleChange.bind(this);
@@ -55,8 +44,7 @@ export default class Highlighter extends React.Component {
     const range = selection.getRangeAt(0);
     const offset = this.constructor.getOffset(selection);
     const start = offset + range.startOffset;
-    const endOffset = this.constructor.extraNewLineCharacter(range);
-    const end = offset + endOffset;
+    const end = offset + range.endOffset - 1;
     const task = this.props.workflow.tasks[this.props.annotation.task];
     const labelInformation = task.highlighterLabels[toolIndex];
     const selectable = this.constructor.selectableArea(selection, range, offset, start, end);

--- a/app/classifier/tasks/highlighter/label-renderer.jsx
+++ b/app/classifier/tasks/highlighter/label-renderer.jsx
@@ -35,7 +35,7 @@ export default class LabelRenderer extends React.Component {
             const newLabel = <Selection key={a} annotation={currentAnnotation} disabled={this.props.disabled} />;
             newContent.push(newLabel);
             // 3. re-set last focusIndex with annotation index
-            lastFocusIndex = currentAnnotation.end;
+            lastFocusIndex = currentAnnotation.end + 1;
           }
         }
       }


### PR DESCRIPTION
Staging branch URL: https://pr-6548.pfe-preview.zooniverse.org

Fixes #6537 .

Describe your changes.
- adjust highlighter annotation `end` calculation to subtract 1 from range endOffset, see issue for detailed comparison
- adjust label renderer calculation per adjustment to end calculation
- remove `extraNewLineCharacter` which is no longer applicable for IE 11 (not supported) and Edge (no longer issue with current versions of Edge), added in #3954

local testing - https://local.zooniverse.org:3735/projects/markb-panoptes/digileap-testing-staging/classify?reload=0&workflow=3538
branch testing - https://pr-6548.pfe-preview.zooniverse.org/projects/markb-panoptes/digileap-testing-staging/classify?reload=0&workflow=3538&env=staging

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
