### PR TITLE
Fix home page social feeds

### DIFF
--- a/app/lib/get-social-data.js
+++ b/app/lib/get-social-data.js
@@ -8,16 +8,9 @@ const BLOG_FEEDS = [
 ]
 
 function removeEntities(htmlString) {
-  return htmlString
-    .replaceAll('&#8217;', '\'')
-    .replaceAll('&#8220;', '"')
-    .replaceAll('&#8221;', '"')
-    .replaceAll('&#38;', '&')
-    .replaceAll('&nbsp;', '')
-    .replaceAll('[&hellip;]', '')
-    .replaceAll('<p>', '')
-    .replaceAll('</p>', '')
-    .trim();
+  const container = document.createElement('div');
+  container.innerHTML = htmlString;
+  return container.textContent;
 }
 
 function parseFeedPost(post) {
@@ -35,7 +28,7 @@ async function fetchBlogFeed(url) {
     const response = await fetch(url);
     if (response.ok) {
       const feed = await response.json();
-      return feed.posts.map(parseFeedPost);
+      return feed.posts;
     }
     return [];
   } catch (error) {
@@ -64,7 +57,7 @@ async function getBlogPosts() {
     feeds.forEach(feed => {
       posts = posts.concat(feed).slice(0,4)
     });
-    return posts;
+    return posts.map(parseFeedPost);
   } catch (error) {
     console.error(error);
   }

--- a/app/lib/get-social-data.js
+++ b/app/lib/get-social-data.js
@@ -2,6 +2,48 @@ import apiClient from 'panoptes-client/lib/api-client';
 import talkClient from 'panoptes-client/lib/talk-client';
 import Publications from './publications';
 
+const BLOG_FEEDS = [
+  'https://public-api.wordpress.com/rest/v1.1/sites/36711287/posts',
+  'https://public-api.wordpress.com/rest/v1.1/sites/57182749/posts'
+]
+
+function removeEntities(htmlString) {
+  return htmlString
+    .replaceAll('&#8217;', '\'')
+    .replaceAll('&#8220;', '"')
+    .replaceAll('&#8221;', '"')
+    .replaceAll('&#38;', '&')
+    .replaceAll('&nbsp;', '')
+    .replaceAll('[&hellip;]', '')
+    .replaceAll('<p>', '')
+    .replaceAll('</p>', '')
+    .trim();
+}
+
+function parseFeedPost(post) {
+  return {
+    id: post.ID,
+    title: removeEntities(post.title),
+    excerpt: removeEntities(post.excerpt),
+    created_at: post.date,
+    link: post.URL,
+    image: post.featured_image
+  };
+}
+async function fetchBlogFeed(url) {
+  try {
+    const response = await fetch(url);
+    if (response.ok) {
+      const feed = await response.json();
+      return feed.posts.map(parseFeedPost);
+    }
+    return [];
+  } catch (error) {
+    console.error(error);
+    return [];
+  }
+}
+
 function getNewestProject() {
   return apiClient.type('projects').get({
     cards: true,
@@ -18,11 +60,11 @@ function getNewestProject() {
 async function getBlogPosts() {
   let posts = []
   try {
-    const response = await fetch(`${talkClient.root}/social`);
-    if (response.ok) {
-      const data = await response.json();
-      posts = data.posts;
-    }
+    const feeds = await Promise.all(BLOG_FEEDS.map(fetchBlogFeed));
+    feeds.forEach(feed => {
+      posts = posts.concat(feed).slice(0,4)
+    });
+    return posts;
   } catch (error) {
     console.error(error);
   }

--- a/app/lib/get-social-data.js
+++ b/app/lib/get-social-data.js
@@ -3,8 +3,10 @@ import talkClient from 'panoptes-client/lib/talk-client';
 import Publications from './publications';
 
 const BLOG_FEEDS = [
-  'https://public-api.wordpress.com/rest/v1.1/sites/36711287/posts',
-  'https://public-api.wordpress.com/rest/v1.1/sites/57182749/posts'
+  // daily.zooniverse.org
+  'https://public-api.wordpress.com/rest/v1.1/sites/57182749/posts',
+  // blog.zooniverse.org
+  'https://public-api.wordpress.com/rest/v1.1/sites/36711287/posts'
 ]
 
 function removeEntities(htmlString) {
@@ -55,7 +57,7 @@ async function getBlogPosts() {
   try {
     const feeds = await Promise.all(BLOG_FEEDS.map(fetchBlogFeed));
     feeds.forEach(feed => {
-      posts = posts.concat(feed).slice(0,4)
+      posts = posts.concat(feed.slice(0,3))
     });
     return posts.map(parseFeedPost);
   } catch (error) {

--- a/app/pages/home-common/social.jsx
+++ b/app/pages/home-common/social.jsx
@@ -70,7 +70,7 @@ export default class HomePageSocial extends React.Component {
       <div key={i} className={classes}>
         {i !== 0 && (<hr />)}
         <h4 className="timestamp-label">{timestamp}</h4>
-        <h5 className="tertiary-headline">{post.title} </h5>
+        <h5 className="tertiary-headline"><a href={post.link}>{post.title}</a></h5>
         <div className="home-social__blog-post">
           <div style={background}></div>
           <div>


### PR DESCRIPTION
Fetch the home page blog feeds direct from `wordpress.com`.

<img width="500" alt="Previews of posts from blog.zooniverse.org on the Zooniverse home page, including a lovely cartoon of Shaun A. Noordin." src="https://github.com/zooniverse/Panoptes-Front-End/assets/59547/3cec9192-22e4-4005-960a-6bf70d3cac54">


Staging branch URL: https://pr-6629.pfe-preview.zooniverse.org

Fixes #6613.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
