### PR TITLE
Experiment: remove session caching

### DIFF
--- a/app/partials/app.cjsx
+++ b/app/partials/app.cjsx
@@ -67,6 +67,7 @@ PanoptesApp = createReactClass
 
   handleAuthChange: ->
     @geordiLogger.forget ['userID']
+    console.log('AUTH CHANGE EVENT')
     auth.checkCurrent().then (user) =>
       @setState
         initialLoadComplete: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "markdownz": "~8.0.5",
         "modal-form": "~2.9",
         "moment": "~2.29.0",
-        "panoptes-client": "~5.3.0",
+        "panoptes-client": "zooniverse/panoptes-javascript-client#remove-session-caching",
         "papaparse": "^5.4.1",
         "polished": "~4.2.2",
         "prop-types": "~15.8.1",
@@ -13153,8 +13153,8 @@
     },
     "node_modules/panoptes-client": {
       "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-5.3.0.tgz",
-      "integrity": "sha512-1XemHMGtMB4adyyewOkn962v2rcx/8eQ7IJkDUK+48L3tadibOlWJvkeRqWxul5L8pvVODjktDfvksYyIwxlWA==",
+      "resolved": "git+ssh://git@github.com/zooniverse/panoptes-javascript-client.git#c903c7e0b7e1b2e7100872305b422c358d5e86cc",
+      "license": "Apache-2.0",
       "dependencies": {
         "local-storage": "^2.0.0",
         "normalizeurl": "~1.0.0",
@@ -16408,9 +16408,9 @@
       }
     },
     "node_modules/superagent/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
+      "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -27853,9 +27853,8 @@
       }
     },
     "panoptes-client": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-5.3.0.tgz",
-      "integrity": "sha512-1XemHMGtMB4adyyewOkn962v2rcx/8eQ7IJkDUK+48L3tadibOlWJvkeRqWxul5L8pvVODjktDfvksYyIwxlWA==",
+      "version": "git+ssh://git@github.com/zooniverse/panoptes-javascript-client.git#c903c7e0b7e1b2e7100872305b422c358d5e86cc",
+      "from": "panoptes-client@zooniverse/panoptes-javascript-client#remove-session-caching",
       "requires": {
         "local-storage": "^2.0.0",
         "normalizeurl": "~1.0.0",
@@ -30219,9 +30218,9 @@
           "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg=="
         },
         "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "version": "7.5.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
+          "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
           "requires": {
             "lru-cache": "^6.0.0"
           }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "markdownz": "~8.0.5",
     "modal-form": "~2.9",
     "moment": "~2.29.0",
-    "panoptes-client": "~5.3.0",
+    "panoptes-client": "zooniverse/panoptes-javascript-client#remove-session-caching",
     "papaparse": "^5.4.1",
     "polished": "~4.2.2",
     "prop-types": "~15.8.1",


### PR DESCRIPTION
This is an experimental build, using an API client that doesn't cache Panoptes user sessions.

- See https://github.com/zooniverse/panoptes-javascript-client/pull/208.

Staging branch URL: https://pr-6677.pfe-preview.zooniverse.org

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
