### PR TITLE
Add Indonesian to language menu

### DIFF
--- a/app/constants/languageMenu.js
+++ b/app/constants/languageMenu.js
@@ -12,6 +12,7 @@ export default {
   hr: 'Hrvatski',
   xh: 'isiXhosa',
   zu: 'isiZulu',
+  id: 'Bahasa Indonesia',
   it: 'Italiano',
   ja: '日本語',
   kn: 'ಕನ್ನಡ',


### PR DESCRIPTION
Staging branch URL: https://pr-6753.pfe-preview.zooniverse.org

To address this freshdesk [ticket](https://zooniverse.freshdesk.com/a/tickets/17617) request to enable Indonesian translations.

Should this be alphabetized into the language menu by locale code or the first letter of the label?

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
