### PR TITLE
Lab: Add instructions in Translations tab for new language

### DIFF
--- a/app/pages/lab/translations/index.jsx
+++ b/app/pages/lab/translations/index.jsx
@@ -58,7 +58,7 @@ class TranslationsManager extends React.Component {
         }
         <h2>Project language menu</h2>
         <p>
-          Tick languages here to publish those translations, and make them available to your volunteers. If you've submitted translations for a language missing in the checkboxes, email contact@zooniverse.org.
+          Tick languages here to publish those translations, and make them available to your volunteers. If you've submitted translations for a language and it's missing a checkbox, email contact@zooniverse.org.
         </p>
         <table>
           <tr>

--- a/app/pages/lab/translations/index.jsx
+++ b/app/pages/lab/translations/index.jsx
@@ -58,7 +58,7 @@ class TranslationsManager extends React.Component {
         }
         <h2>Project language menu</h2>
         <p>
-          Tick languages here to publish those translations, and make them available to your volunteers.
+          Tick languages here to publish those translations, and make them available to your volunteers. If you've submitted translations for a language missing in the checkboxes, email contact@zooniverse.org.
         </p>
         <table>
           <tr>

--- a/app/pages/lab/translations/index.jsx
+++ b/app/pages/lab/translations/index.jsx
@@ -58,12 +58,12 @@ class TranslationsManager extends React.Component {
         }
         <h2>Project language menu</h2>
         <p>
-          Tick languages here to publish those translations, and make them available to your volunteers. If you've submitted translations for a language and it's missing a checkbox, email contact@zooniverse.org.
+          Check which languages you’d like to make available to your volunteers. If you don’t see a published language as a selection below please email <a href="mailto:contact@zooniverse.org">contact@zooniverse.org</a> with your project ID.
         </p>
         <table>
           <tr>
             <th>Language</th>
-            <th>Published?</th>
+            <th>Publish</th>
           </tr>
           {languageMenuCodes.map((language) => {
             const disabled = language === project.primary_language;


### PR DESCRIPTION
Staging branch URL: https://pr-6755.pfe-preview.zooniverse.org

I added an additional sentence to the Translations tab in the lab instructing project owners to email Zooniverse if they've submitted translations for a language, but that language doesn't show up as a checkbox. That scenario means they're the first project to translate that language and it needs to be added to the menus on frontend apps.
<img width="1034" alt="Screenshot 2023-08-04 at 10 42 51 AM" src="https://github.com/zooniverse/Panoptes-Front-End/assets/23665803/2b75ce0b-551c-446d-8269-4d88d7612334">

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
