### PR TITLE
Emphasise that JSON subject viewers are deprecated

### DIFF
--- a/app/pages/admin/project-status.jsx
+++ b/app/pages/admin/project-status.jsx
@@ -412,7 +412,7 @@ class ProjectStatus extends Component {
               <div>
                 <h4>Classifier 2.0 (rewrite) settings</h4>
                 <div id="subject-viewer-help-text">
-                  <p>Note that 'JSON data charts' is preferred over TESS Light Curve for JSON subject data. The TESS light curve viewer is built specifically for their requirements. The code in the viewer assumes the project is using a task like them. Individual JSON data viewers are deprecated and should not be used on new projects.</p>
+                  <p>Note that 'JSON data charts' is preferred over TESS Light Curve for JSON subject data. The TESS light curve viewer is built specifically for their requirements. The code in the viewer assumes the project is using a task like them. <strong>Individual JSON data viewers are deprecated and should not be used on new projects.</strong></p>
                   <p>Subjects with a <abbr title="Multipurpose Internet Mail Extensions">MIME</abbr> type of <code>application/json</code> will use the JSON data setting by default.</p>
                 </div>
 


### PR DESCRIPTION
On a project's workflow admin settings, emphasise that individual data subject viewers have been deprecated by displaying that text in bold.

Staging branch URL: https://pr-6792.pfe-preview.zooniverse.org/admin/project_status/nora-dot-eisner/planet-hunters-tess

<img width="500" alt="Screenshot of PH-TESS workflow settings, showing that the warning about deprecated subject viewers is now bold." src="https://github.com/zooniverse/Panoptes-Front-End/assets/59547/8fa22056-92f6-48be-9548-c139132e6eb3">

