### PR TITLE
Pages Editor: Save/Update Workflow

### DIFF
--- a/app/pages/lab-pages-editor/DataManager.jsx
+++ b/app/pages/lab-pages-editor/DataManager.jsx
@@ -57,19 +57,36 @@ function DataManager({
     fetchWorkflow();
   }, [workflowId]);
 
-  /*
-  Updates the workflow with new data.
-   */
-  function update(data) {
-    console.log('+++ TODO');
-  }
-
   // Wrap contextData in a memo so it doesn't re-create a new object on every render.
   // See https://react.dev/reference/react/useContext#optimizing-re-renders-when-passing-objects-and-functions
-  const contextData = useMemo(() => ({
-    workflow: apiData.workflow,
-    update
-  }), [apiData.workflow]);
+  const contextData = useMemo(() => {
+    console.log('+++ DataManager.useMemo');
+
+    /*
+    Updates the workflow with new data.
+    */
+    async function update(data) {
+      console.log('+++ DataManager.update()');
+
+      setApiData({
+        workflow: apiData.workflow,
+        status: 'updating'
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+
+      // Note to self: hang on, will setting setApiData() cause the useMemo to update perpetually?
+      setApiData({
+        workflow: apiData.workflow,
+        status: 'ready'
+      });
+    }
+
+    return {
+      workflow: apiData.workflow,
+      update
+    };
+  }, [apiData.workflow]); // Note to self: change this to workflowId?
 
   if (!workflowId) return (<div>ERROR: no Workflow ID specified</div>);
   // if (!workflow) return null

--- a/app/pages/lab-pages-editor/DataManager.jsx
+++ b/app/pages/lab-pages-editor/DataManager.jsx
@@ -67,13 +67,15 @@ function DataManager({
     */
     async function update(data) {
       console.log('+++ DataManager.update()');
+      const wf = apiData.workflow;
+      if (!wf) return;
 
       setApiData({
-        workflow: apiData.workflow,
+        workflow: wf,
         status: 'updating'
       });
 
-      await new Promise((resolve) => setTimeout(resolve, 1000));
+      await wf.update(data).save();
 
       // Note to self: hang on, will setting setApiData() cause the useMemo to update perpetually?
       setApiData({

--- a/app/pages/lab-pages-editor/DataManager.jsx
+++ b/app/pages/lab-pages-editor/DataManager.jsx
@@ -24,6 +24,8 @@ function DataManager({
     status: 'ready'
   });
 
+  const [randomFlagToPromptMemoUpdate, setRandomFlagToPromptMemoUpdate] = useState(0);
+
   // Fetch workflow when the component loads for the first time.
   // See notes about 'key' prop, to ensure states are reset:
   // https://react.dev/learn/you-might-not-need-an-effect#resetting-all-state-when-a-prop-changes
@@ -82,13 +84,23 @@ function DataManager({
         workflow: apiData.workflow,
         status: 'ready'
       });
+
+      // Hmmm... this seems to be the only thing that's updating the context properly.
+      // Without it, it seems that setApiData() isn't changing the value
+      // (object reference) of`apiData.workflow`, which means the useMemo
+      // doesn't realise that oohhh wait I think I get it now.
+      // TODO: how to indicate that the value of the apiData.workflow object
+      // has changed when the change is local to the resource itself?
+      // Does the workflow object have an internal version tracker?
+      // @shaunanoordin 20230902
+      setRandomFlagToPromptMemoUpdate(Math.floor(Math.random() * 10000));
     }
 
     return {
       workflow: apiData.workflow,
       update
     };
-  }, [apiData.workflow]); // Note to self: change this to workflowId?
+  }, [apiData.workflow, randomFlagToPromptMemoUpdate]);
 
   if (!workflowId) return (<div>ERROR: no Workflow ID specified</div>);
   // if (!workflow) return null

--- a/app/pages/lab-pages-editor/DataManager.jsx
+++ b/app/pages/lab-pages-editor/DataManager.jsx
@@ -32,7 +32,6 @@ function DataManager({
   // https://react.dev/reference/react/useEffect#fetching-data-with-effects
   useEffect(() => {
     async function fetchWorkflow() {
-      console.log('+++ fetchWorkflow');
       try {
         setApiData({
           workflow: null,
@@ -58,37 +57,23 @@ function DataManager({
     fetchWorkflow();
   }, [workflowId]);
 
-  // Option B
+  // Listen for workflow changes, and update a counter to prompt useMemo to update the context.
   useEffect(() => {
     const wf = apiData.workflow;
-    // When workflow changes, update the counter so useMemo knows to update the context.
     function onWorkflowChange() {
-      console.log('+++ 🟡 onWorkflowChange');
       setUpdateCounter((uc) => uc + 1);
     }
-
-    function onWorkflowSave() {
-      console.log('+++ 🔵 onWorkflowSave');
-    }
-
     wf?.listen('change', onWorkflowChange);
-    wf?.listen('save', onWorkflowSave);
     return () => {
       wf?.stopListening('change', onWorkflowChange);
-      wf?.stopListening('save', onWorkflowSave);
     };
   }, [apiData.workflow]);
 
   // Wrap contextData in a memo so it doesn't re-create a new object on every render.
   // See https://react.dev/reference/react/useContext#optimizing-re-renders-when-passing-objects-and-functions
   const contextData = useMemo(() => {
-    console.log('+++ 🌀 DataManager.useMemo');
-
-    /*
-    Updates the workflow with new data.
-    */
+    // Updates the workflow with new data.
     async function update(data) {
-      console.log('+++ DataManager.update()');
       const wf = apiData.workflow;
       if (!wf) return;
 
@@ -97,9 +82,7 @@ function DataManager({
         status: 'updating'
       }));
 
-      console.log('+++ 🔴 DataManager.update() updating...');
       const newWorkflow = await wf.update(data).save();
-      console.log('+++ 🟢 DataManager.update() complete');
 
       setApiData({
         workflow: newWorkflow, // Note: newWorkflow is actually the same as the old wf, so useMemo will have to listen to status changing instead.
@@ -111,8 +94,7 @@ function DataManager({
       workflow: apiData.workflow,
       update
     };
-  // }, [apiData.workflow, apiData.status]); // Option A
-  }, [apiData.workflow, updateCounter]); // Option B
+  }, [apiData.workflow, updateCounter]);
 
   if (!workflowId) return (<div>ERROR: no Workflow ID specified</div>);
   // if (!workflow) return null

--- a/app/pages/lab-pages-editor/DataManager.jsx
+++ b/app/pages/lab-pages-editor/DataManager.jsx
@@ -24,8 +24,6 @@ function DataManager({
     status: 'ready'
   });
 
-  const [randomFlagToPromptMemoUpdate, setRandomFlagToPromptMemoUpdate] = useState(0);
-
   // Fetch workflow when the component loads for the first time.
   // See notes about 'key' prop, to ensure states are reset:
   // https://react.dev/learn/you-might-not-need-an-effect#resetting-all-state-when-a-prop-changes
@@ -79,30 +77,17 @@ function DataManager({
 
       const newWorkflow = await wf.update(data).save();
 
-      console.log('+++ are they the same? ', newWorkflow === wf);
-
-      // Note to self: hang on, will setting setApiData() cause the useMemo to update perpetually?
       setApiData({
-        workflow: newWorkflow,
+        workflow: newWorkflow, // Note: newWorkflow is actually the same as the old wf, so useMemo will have to listen to status changing instead.
         status: 'ready'
       });
-
-      // Hmmm... this seems to be the only thing that's updating the context properly.
-      // Without it, it seems that setApiData() isn't changing the value
-      // (object reference) of`apiData.workflow`, which means the useMemo
-      // doesn't realise that oohhh wait I think I get it now.
-      // TODO: how to indicate that the value of the apiData.workflow object
-      // has changed when the change is local to the resource itself?
-      // Does the workflow object have an internal version tracker?
-      // @shaunanoordin 20230902
-      // setRandomFlagToPromptMemoUpdate(Math.floor(Math.random() * 10000));
     }
 
     return {
       workflow: apiData.workflow,
       update
     };
-  }, [apiData.workflow, randomFlagToPromptMemoUpdate]);
+  }, [apiData.workflow, apiData.status]);
 
   if (!workflowId) return (<div>ERROR: no Workflow ID specified</div>);
   // if (!workflow) return null

--- a/app/pages/lab-pages-editor/DataManager.jsx
+++ b/app/pages/lab-pages-editor/DataManager.jsx
@@ -72,16 +72,18 @@ function DataManager({
       const wf = apiData.workflow;
       if (!wf) return;
 
-      setApiData({
-        workflow: wf,
+      setApiData((prevState) => ({
+        ...prevState,
         status: 'updating'
-      });
+      }));
 
-      await wf.update(data).save();
+      const newWorkflow = await wf.update(data).save();
+
+      console.log('+++ are they the same? ', newWorkflow === wf);
 
       // Note to self: hang on, will setting setApiData() cause the useMemo to update perpetually?
       setApiData({
-        workflow: apiData.workflow,
+        workflow: newWorkflow,
         status: 'ready'
       });
 
@@ -93,7 +95,7 @@ function DataManager({
       // has changed when the change is local to the resource itself?
       // Does the workflow object have an internal version tracker?
       // @shaunanoordin 20230902
-      setRandomFlagToPromptMemoUpdate(Math.floor(Math.random() * 10000));
+      // setRandomFlagToPromptMemoUpdate(Math.floor(Math.random() * 10000));
     }
 
     return {

--- a/app/pages/lab-pages-editor/DataManager.jsx
+++ b/app/pages/lab-pages-editor/DataManager.jsx
@@ -60,6 +60,7 @@ function DataManager({
 
   // Option B
   useEffect(() => {
+    const wf = apiData.workflow;
     // When workflow changes, update the counter so useMemo knows to update the context.
     function onWorkflowChange() {
       console.log('+++ 🟡 onWorkflowChange');
@@ -70,13 +71,13 @@ function DataManager({
       console.log('+++ 🔵 onWorkflowSave');
     }
 
-    apiClient.listen('change', onWorkflowChange);
-    apiClient.listen('save', onWorkflowSave);
+    wf?.listen('change', onWorkflowChange);
+    wf?.listen('save', onWorkflowSave);
     return () => {
-      apiClient.stopListening('change', onWorkflowChange);
-      apiClient.stopListening('save', onWorkflowSave);
+      wf?.stopListening('change', onWorkflowChange);
+      wf?.stopListening('save', onWorkflowSave);
     };
-  }, [apiClient]);
+  }, [apiData.workflow]);
 
   // Wrap contextData in a memo so it doesn't re-create a new object on every render.
   // See https://react.dev/reference/react/useContext#optimizing-re-renders-when-passing-objects-and-functions

--- a/app/pages/lab-pages-editor/Tester.jsx
+++ b/app/pages/lab-pages-editor/Tester.jsx
@@ -7,9 +7,7 @@ import { useWorkflowContext } from './context.js';
 
 export default function Tester() {
   const { workflow, update } = useWorkflowContext();
-
-  console.log('+++ workflow: ', workflow);
-  console.log('+++ HELLO WORLD!');
+  console.log('+++ <Tester> render');
 
   function doUpdate(e) {
     console.log('+++ doUpdate: ', e);

--- a/app/pages/lab-pages-editor/Tester.jsx
+++ b/app/pages/lab-pages-editor/Tester.jsx
@@ -13,7 +13,9 @@ export default function Tester() {
 
   function doUpdate(e) {
     console.log('+++ doUpdate: ', e);
-    update();
+    update({
+      display_name: e.target.value || ''
+    });
   }
 
   if (!workflow) return null;

--- a/app/pages/lab-pages-editor/Tester.jsx
+++ b/app/pages/lab-pages-editor/Tester.jsx
@@ -7,10 +7,8 @@ import { useWorkflowContext } from './context.js';
 
 export default function Tester() {
   const { workflow, update } = useWorkflowContext();
-  console.log('+++ <Tester> render');
 
   function doUpdate(e) {
-    console.log('+++ doUpdate: ', e);
     update({
       display_name: e.target.value || ''
     });


### PR DESCRIPTION
## PR Overview

Part of: **Pages Editor MVP** project and **FEM Lab** super-project
Follows #6787 
Staging branch URL: https://pr-{NUMBER}.pfe-preview.zooniverse.org

The aim of this PR is to allow the Pages Editor to update Workflow resources and save those changes to Panoptes.

The plan:
- The `DataManager` component should have an `update()` function 
  - [ ] The update() function must be passed to child components via context
  - [ ] Calling the update() function should update the values in the Workflow resource and save changes to Panoptes.
  - [ ] Child components should be notified of changes to the Workflow resource. (⚠️ the Panoptes Workflow object has its own 'memory', so keep that in mind.)
  - [ ] The DataManager should try to keep track of the update progress, to prevent multiple updates from overwriting each other. (see [PFE AutoSave's timed delay to saving data](https://github.com/zooniverse/Panoptes-Front-End/blob/1366d5c4900a7e69188687bc77bb0ea386075d57/app/components/auto-save.coffee#L65-L67))
  - ⚠️ OR better yet, updates should be queued _(Shaun's note: Not sure if this needs to be a stretch goal, or if this is already handled by [PJC's "save()"](https://github.com/zooniverse/panoptes-javascript-client/blob/master/lib/json-api-client/resource.js#L40-L75) functionality)_
- For this PR the `Tester` UI component serves as a rudimentary read/write interface.

### Status

WIP