### PR TITLE
FEM redirect for astopy/black-hole-hunters

### DIFF
--- a/app/monorepoUtils.js
+++ b/app/monorepoUtils.js
@@ -35,7 +35,8 @@ export const SLUGS = [
   'zooniverse/gravity-spy',
   'communitiesandcrowds/how-did-we-get-here',
   'zooniverse/snapshot-serengeti',
-  'aeuk/elephant-id'
+  'aeuk/elephant-id',
+  'astopy/black-hole-hunters'
 ];
 
 export function usesMonorepo(slug) {


### PR DESCRIPTION
Route `astopy/black-hole-hunters` to the Next.js project app.

Staging branch URL: https://pr-6804.pfe-preview.zooniverse.org

See https://github.com/zooniverse/static/pull/327.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
