### PR TITLE
Add the data selection task to the project builder

### DIFF
--- a/app/classifier/tasks/dataVisAnnotation/index.jsx
+++ b/app/classifier/tasks/dataVisAnnotation/index.jsx
@@ -1,0 +1,66 @@
+import PropTypes from 'prop-types';
+import GenericTaskEditor from '../generic-editor';
+import GenericTask from '../generic';
+
+
+export default function DataVisAnnotation() {
+  return <p>This is a stub for the data annotation task.</p>
+}
+
+DataVisAnnotation.Editor = GenericTaskEditor;
+
+DataVisAnnotation.getDefaultTask = () => ({
+  help: '',
+  tools: [],
+  instruction: 'Select data from the chart.',
+  type: 'dataVisAnnotation'
+});
+
+DataVisAnnotation.getTaskText = task => task.instruction;
+
+DataVisAnnotation.getDefaultAnnotation = () => ({ _toolIndex: 0, value: [] });
+
+DataVisAnnotation.defaultProps = {
+  onChange: () => null,
+  showRequiredNotice: false,
+  task: {
+    help: '',
+    tools: [],
+    type: 'dataVisAnnotation',
+    instruction: 'Select data from the chart.'
+  },
+  workflow: {
+    tasks: []
+  }
+};
+
+DataVisAnnotation.propTypes = {
+  annotation: PropTypes.shape({
+    _toolIndex: PropTypes.number,
+    task: PropTypes.string
+  }),
+  onChange: PropTypes.func,
+  showRequiredNotice: PropTypes.bool,
+  task: PropTypes.shape({
+    help: PropTypes.string,
+    instruction: PropTypes.string,
+    required: PropTypes.bool,
+    tools: PropTypes.array,
+    type: PropTypes.string
+  }),
+  workflow: PropTypes.shape({
+    tasks: PropTypes.object
+  })
+};
+
+DataVisAnnotation.defaultProps = {
+  annotation: {
+    value: []
+  },
+  task: {
+    help: '',
+    tools: [],
+    instruction: 'Select data from the chart.',
+    type: 'dataVisAnnotation'
+  }
+}

--- a/app/classifier/tasks/generic-editor.cjsx
+++ b/app/classifier/tasks/generic-editor.cjsx
@@ -46,6 +46,7 @@ module.exports = createReactClass
       when 'text' then ['instruction']
       when 'slider' then ['instruction']
       when 'highlighter' then ['instruction', 'highlighterLabels']
+      when 'dataVisAnnotation' then ['instruction', 'tools']
 
     isAQuestion = @props.task.type in ['single', 'multiple']
     canBeRequired = @props.task.type in ['single', 'multiple', 'text']
@@ -134,6 +135,23 @@ module.exports = createReactClass
                       </div>
 
                   when 'highlighter'
+                    <div className="workflow-choice-setting" >
+                      <AutoSave resource={@props.workflow} >
+                        Color{' '}
+                        <select style={{background: choice.color}} name="#{@props.taskPrefix}.#{choicesKey}.#{index}.color" value={choice.color} onChange={handleChange}>
+                          {for labelOption in highlighterLabelColorOptions
+                            <option
+                              key={labelOption.value}
+                              style={{ background: labelOption.value }}
+                              value={labelOption.value}
+                            >
+                              {labelOption.label}
+                            </option>}
+                        </select>
+                      </AutoSave>
+                    </div>
+
+                  when 'dataVisAnnotation'
                     <div className="workflow-choice-setting" >
                       <AutoSave resource={@props.workflow} >
                         Color{' '}
@@ -259,22 +277,27 @@ module.exports = createReactClass
                 <small className="form-help"> Add labels for the highlighter tool.</small>
               </div>
             when 'tools'
-              <div>
-                <small className="form-help">Select which marks you want for this task, and what to call each of them. The tool name will be displayed on the classification page next to each marking option. Use the simplest tool that will give you the results you need for your research.</small><br />
-                <small className="form-help"><b>bezier:</b> an arbitrary shape made of point-to-point curves. The midpoint of each segment drawn can be dragged to adjust the curvature. </small><br />
-                <small className="form-help"><b>circle:</b> a point and a radius.</small><br />
-                <small className="form-help"><b>column:</b> a box with full height but variable width; this tool <i>cannot</i> be rotated.</small><br />
-                <small className="form-help"><b>ellipse:</b> an oval of any size and axis ratio; this tool <i>can</i> be rotated.</small><br />
-                <small className="form-help"><b>line:</b> a straight line at any angle.</small><br />
-                <small className="form-help"><b>point:</b> X marks the spot.</small><br />
-                <small className="form-help"><b>polygon:</b> an arbitrary shape made of point-to-point lines.</small><br />
-                <small className="form-help"><b>rectangle:</b> a box of any size and length-width ratio; this tool <i>cannot</i> be rotated.</small><br />
-                <small className="form-help"><b>triangle:</b> an equilateral triangle of any size and vertex distance from the center; this tool <i>can</i> be rotated.</small><br />
-                {if @canUse("grid")
-                  <small className="form-help"><b>grid table</b>: cells which can be made into a table for consecutive annotations.</small>}
-                {if @canUse("anchoredEllipse")
-                  <small className="form-help"><b>anchored ellipse</b>: creates an ellipes in the center of the subject during the first click, and does not allow it to be dragged.</small>}}
-              </div>}
+              if @props.task.type is 'dataVisAnnotation'
+                <div>
+                  <small className="form-help"> Add labels for the data selection tool.</small>
+                </div>
+              if @props.task.type is 'drawing'
+                <div>
+                  <small className="form-help">Select which marks you want for this task, and what to call each of them. The tool name will be displayed on the classification page next to each marking option. Use the simplest tool that will give you the results you need for your research.</small><br />
+                  <small className="form-help"><b>bezier:</b> an arbitrary shape made of point-to-point curves. The midpoint of each segment drawn can be dragged to adjust the curvature. </small><br />
+                  <small className="form-help"><b>circle:</b> a point and a radius.</small><br />
+                  <small className="form-help"><b>column:</b> a box with full height but variable width; this tool <i>cannot</i> be rotated.</small><br />
+                  <small className="form-help"><b>ellipse:</b> an oval of any size and axis ratio; this tool <i>can</i> be rotated.</small><br />
+                  <small className="form-help"><b>line:</b> a straight line at any angle.</small><br />
+                  <small className="form-help"><b>point:</b> X marks the spot.</small><br />
+                  <small className="form-help"><b>polygon:</b> an arbitrary shape made of point-to-point lines.</small><br />
+                  <small className="form-help"><b>rectangle:</b> a box of any size and length-width ratio; this tool <i>cannot</i> be rotated.</small><br />
+                  <small className="form-help"><b>triangle:</b> an equilateral triangle of any size and vertex distance from the center; this tool <i>can</i> be rotated.</small><br />
+                  {if @canUse("grid")
+                    <small className="form-help"><b>grid table</b>: cells which can be made into a table for consecutive annotations.</small>}
+                  {if @canUse("anchoredEllipse")
+                    <small className="form-help"><b>anchored ellipse</b>: creates an ellipes in the center of the subject during the first click, and does not allow it to be dragged.</small>}}
+                </div>}
         </div>}
 
       {unless @props.task.type is 'single' or @props.isSubtask
@@ -324,11 +347,21 @@ module.exports = createReactClass
     @props.onChange @props.task
 
   addTool: ->
-    @props.task.tools.push
-      type: 'point'
-      label: 'Tool name'
-      color: '#00ff00'
-      details: []
+    if @props.task.type is 'drawing'
+      @props.task.tools.push
+        type: 'point'
+        label: 'Tool name'
+        color: '#00ff00'
+        details: []
+    if @props.task.type is 'dataVisAnnotation'
+      # data selection uses the same colours as the text selection tool.
+      highlighterLabelColors = highlighterLabelColorOptions.map((option) => option.value)
+      taskColors = @props.task.tools.map((tool) => tool.color)
+      newColor = highlighterLabelColors.find((color) => taskColors.indexOf(color) == -1) || highlighterLabelColors[0]
+      @props.task.tools.push
+        type: 'graph2dRangeX'
+        label: 'Tool name'
+        color: newColor
     @props.onChange @props.task
 
   editToolDetails: (task, toolIndex) ->

--- a/app/classifier/tasks/index.js
+++ b/app/classifier/tasks/index.js
@@ -12,6 +12,7 @@ import ShortcutTask from './shortcut';
 import Highlighter from './highlighter';
 import TranscriptionTask from './transcription';
 import SubjectGroupComparisonTask from './subjectGroupComparison';
+import DataVisAnnotationTask from './dataVisAnnotation'
 
 const tasks = {
   combo: ComboTask,
@@ -27,7 +28,8 @@ const tasks = {
   shortcut: ShortcutTask,
   highlighter: Highlighter,
   transcription: TranscriptionTask,
-  subjectGroupComparison: SubjectGroupComparisonTask
+  subjectGroupComparison: SubjectGroupComparisonTask,
+  dataVisAnnotation: DataVisAnnotationTask
 };
 
 export default tasks;

--- a/app/pages/lab-fem/fem-lab-utilities.js
+++ b/app/pages/lab-fem/fem-lab-utilities.js
@@ -1,3 +1,4 @@
+import apiClient from 'panoptes-client/lib/api-client';
 /*
 These utilities are used to determine if a Zooniverse project should be using
 the FEM-compatible (Front-End-Monorepo) version of the Project Builder (Lab).
@@ -27,3 +28,16 @@ export function isThisProjectUsingFEMLab (project, location) {
 }
 
 export const FEM_LAB_PREVIEW_HOST = 'https://frontend.preview.zooniverse.org'
+
+export async function isWorkflowUsingJSONSubjects(workflow) {
+  if (workflow?.configuration.subject_viewer === 'jsonData') {
+    return true;
+  }
+  const subjects = await apiClient.type('subjects').get({ workflow_id: workflow.id });
+  return subjects.some(subject => {
+    return subject.locations.some(l => {
+      const [ key ] = Object.keys(l);
+      return key === 'application/json';
+    });
+  });
+}

--- a/app/pages/lab-fem/workflow.jsx
+++ b/app/pages/lab-fem/workflow.jsx
@@ -19,7 +19,7 @@ import Tutorials from '../lab/workflow-components/tutorials.jsx';
 import TaskOptions from '../lab/workflow-components/task-options.jsx';
 import TaskEditor from '../lab/workflow-components/task-editor.jsx';
 import TaskPicker from '../lab/workflow-components/task-picker.jsx';
-import { isThisProjectUsingFEMLab, FEM_LAB_PREVIEW_HOST } from './fem-lab-utilities.js';
+import { isThisProjectUsingFEMLab, isWorkflowUsingJSONSubjects, FEM_LAB_PREVIEW_HOST } from './fem-lab-utilities.js';
 
 const DEMO_SUBJECT_SET_ID = process.env.NODE_ENV === 'production'
 ? '6' // Cats
@@ -56,8 +56,11 @@ class EditWorkflowPage extends Component {
       deletionInProgress: false,
       deletionError: null,
       workflowCreationInProgress: false,
-      showTaskAddButtons: false
+      showTaskAddButtons: false,
+      workflowUsesJSONSubjects: false
     };
+    isWorkflowUsingJSONSubjects(props.workflow)
+      .then(workflowUsesJSONSubjects => this.setState({ workflowUsesJSONSubjects }))
   }
 
   workflowLink() {
@@ -280,6 +283,14 @@ class EditWorkflowPage extends Component {
                             <i className="fa fa-th fa-2x"></i>
                             <br />
                             <small><strong>Subject Group Comparison (aka "Grid")</strong></small>
+                          </button>
+                        </AutoSave> : undefined}{' '}
+                        { this.state.workflowUsesJSONSubjects ?
+                        <AutoSave resource={this.props.workflow}>
+                          <button type="button" className="minor-button" onClick={this.addNewTask.bind(this, 'dataVisAnnotation')} title="Data annotation: the volunteer can select chart data.">
+                            <i className="fa fa-i-cursor fa-2x"></i>
+                            <br />
+                            <small><strong>Data annotation</strong></small>
                           </button>
                         </AutoSave> : undefined}{' '}
                       </div> : undefined}


### PR DESCRIPTION
Add the data selection task (`dataVisAnnotation`) to the list of new tasks in the workflow editor. Only one tool is available at the moment, `graph2dRangeX`, so that's hardcoded into the editor (similar to the point tool for drawing tasks.)

Data selection is available as an option if either:
- the workflow has `application/json` subjects.
- the workflow is configured to use the JSON data viewer.

Staging branch URL: https://pr-6808.pfe-preview.zooniverse.org/lab/908/workflows/3762?femLab=true&env=staging


# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
