### PR TITLE
Sort recent blog posts by created_at

### DIFF
--- a/app/lib/get-social-data.js
+++ b/app/lib/get-social-data.js
@@ -61,7 +61,7 @@ async function getBlogPosts() {
     });
     return posts
       .map(parseFeedPost)
-      .sort((a,b) => a.created_at < b.created_at);
+      .sort((a,b) => b.created_at - a.created_at);
   } catch (error) {
     console.error(error);
   }

--- a/app/lib/get-social-data.js
+++ b/app/lib/get-social-data.js
@@ -20,7 +20,7 @@ function parseFeedPost(post) {
     id: post.ID,
     title: removeEntities(post.title),
     excerpt: removeEntities(post.excerpt),
-    created_at: post.date,
+    created_at: new Date(post.date),
     link: post.URL,
     image: post.featured_image
   };

--- a/app/lib/get-social-data.js
+++ b/app/lib/get-social-data.js
@@ -59,7 +59,9 @@ async function getBlogPosts() {
     feeds.forEach(feed => {
       posts = posts.concat(feed.slice(0,3))
     });
-    return posts.map(parseFeedPost);
+    return posts
+      .map(parseFeedPost)
+      .sort((a,b) => a.created_at < b.created_at);
   } catch (error) {
     console.error(error);
   }

--- a/app/pages/home-common/social.jsx
+++ b/app/pages/home-common/social.jsx
@@ -65,7 +65,7 @@ export default class HomePageSocial extends React.Component {
       'home-social__blog-section--white': i === 0,
       'home-social__blog-section--gray': i !== 0
     });
-    const timestamp = moment(new Date(post.created_at)).fromNow();
+    const timestamp = moment(post.created_at).fromNow();
     return (
       <div key={i} className={classes}>
         {i !== 0 && (<hr />)}


### PR DESCRIPTION
Sort recent blog posts by `created_at`, so that the most recent blog post is always first on the home page.

<img width="600" alt="The recent blog posts section, from the home page, showing yesterday's announcement at the top of the list." src="https://github.com/zooniverse/Panoptes-Front-End/assets/59547/a8b9ab44-7334-4b25-9ba6-4bd5645d52a4">


Staging branch URL: https://pr-6814.pfe-preview.zooniverse.org

Fixes #6813.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
