### PR TITLE
Pages Editor: improve Workflow Header with Tabs pattern

### DIFF
--- a/app/pages/lab-pages-editor/PagesEditor.jsx
+++ b/app/pages/lab-pages-editor/PagesEditor.jsx
@@ -8,7 +8,7 @@ Main component of the Pages Editor feature.
 /* eslint-disable react/react-in-jsx-scope */
 /* eslint-disable react/require-default-props */
 
-import { StrictMode } from 'react';
+import { StrictMode, useState } from 'react';
 import PropTypes from 'prop-types';
 
 import DataManager from './DataManager.jsx';
@@ -18,6 +18,7 @@ import WorkflowSettingsPage from './components/WorkflowSettingsPage.jsx';
 
 function PagesEditor({ params }) {
   const { workflowID: workflowId, projectID: projectId } = params;
+  const [currentTab, setCurrentTab] = useState(0);
 
   return (
     <StrictMode>
@@ -26,8 +27,13 @@ function PagesEditor({ params }) {
           key={workflowId || '-'} //
           workflowId={workflowId}
         >
-          <WorkflowHeader projectId={projectId} />
-          <WorkflowSettingsPage />
+          <WorkflowHeader
+            currentTab={currentTab}
+            projectId={projectId}
+            setCurrentTab={setCurrentTab}
+          />
+          {(currentTab === 0) && <p>tasks</p>}
+          {(currentTab === 1) && <WorkflowSettingsPage />}
         </DataManager>
       </div>
     </StrictMode>

--- a/app/pages/lab-pages-editor/PagesEditor.jsx
+++ b/app/pages/lab-pages-editor/PagesEditor.jsx
@@ -22,10 +22,12 @@ function PagesEditor({ params }) {
   const tabs = [
     {
       id: 'pages-editor_workflow-header-tab-button_task',
-      label: strings.PagesEditor.components.WorkflowHeader.tasks
+      label: strings.PagesEditor.components.WorkflowHeader.tasks,
+      targetPanel: 'pages-editor_tab-panel_task'
     }, {
       id: 'pages-editor_workflow-header-tab-button_settings',
-      label: strings.PagesEditor.components.WorkflowHeader.workflow_settings
+      label: strings.PagesEditor.components.WorkflowHeader.workflow_settings,
+      targetPanel: 'pages-editor_tab-panel_settings'
     }
   ];
 
@@ -45,6 +47,7 @@ function PagesEditor({ params }) {
           {(currentTab === 0) && (
             <div
               aria-labelledby={tabs[0].id}
+              id={tabs[0].targetPanel}
               role="tabpanel"
             >
               <p>Tasks will appear on this panel.</p>
@@ -56,6 +59,7 @@ function PagesEditor({ params }) {
           {(currentTab === 1) && (
             <div
               aria-labelledby={tabs[1].id}
+              id={tabs[1].targetPanel}
               role="tabpanel"
             >
               <WorkflowSettingsPage />

--- a/app/pages/lab-pages-editor/PagesEditor.jsx
+++ b/app/pages/lab-pages-editor/PagesEditor.jsx
@@ -32,7 +32,14 @@ function PagesEditor({ params }) {
             projectId={projectId}
             setCurrentTab={setCurrentTab}
           />
-          {(currentTab === 0) && <p>tasks</p>}
+          {(currentTab === 0) && (
+            <div role="tabpanel" aria-labelledby="pages-editor_workflow-header-tab-button_task">
+              <p>Tasks will appear on this panel.</p>
+              <button type="button" onClick={() => console.log('This is a placeholder')}>
+                And this is a button for you to focus on with keyboard navigation.
+              </button>
+            </div>
+          )}
           {(currentTab === 1) && <WorkflowSettingsPage />}
         </DataManager>
       </div>

--- a/app/pages/lab-pages-editor/PagesEditor.jsx
+++ b/app/pages/lab-pages-editor/PagesEditor.jsx
@@ -12,13 +12,22 @@ import { StrictMode, useState } from 'react';
 import PropTypes from 'prop-types';
 
 import DataManager from './DataManager.jsx';
-import Tester from './Tester.jsx';
 import WorkflowHeader from './components/WorkflowHeader.jsx';
 import WorkflowSettingsPage from './components/WorkflowSettingsPage.jsx';
+import strings from './strings.json';
 
 function PagesEditor({ params }) {
   const { workflowID: workflowId, projectID: projectId } = params;
   const [currentTab, setCurrentTab] = useState(0);
+  const tabs = [
+    {
+      id: 'pages-editor_workflow-header-tab-button_task',
+      label: strings.PagesEditor.components.WorkflowHeader.tasks
+    }, {
+      id: 'pages-editor_workflow-header-tab-button_settings',
+      label: strings.PagesEditor.components.WorkflowHeader.workflow_settings
+    }
+  ];
 
   return (
     <StrictMode>
@@ -31,16 +40,27 @@ function PagesEditor({ params }) {
             currentTab={currentTab}
             projectId={projectId}
             setCurrentTab={setCurrentTab}
+            tabs={tabs}
           />
           {(currentTab === 0) && (
-            <div role="tabpanel" aria-labelledby="pages-editor_workflow-header-tab-button_task">
+            <div
+              aria-labelledby={tabs[0].id}
+              role="tabpanel"
+            >
               <p>Tasks will appear on this panel.</p>
               <button type="button" onClick={() => console.log('This is a placeholder')}>
                 And this is a button for you to focus on with keyboard navigation.
               </button>
             </div>
           )}
-          {(currentTab === 1) && <WorkflowSettingsPage />}
+          {(currentTab === 1) && (
+            <div
+              aria-labelledby={tabs[1].id}
+              role="tabpanel"
+            >
+              <WorkflowSettingsPage />
+            </div>
+          )}
         </DataManager>
       </div>
     </StrictMode>

--- a/app/pages/lab-pages-editor/components/WorkflowHeader.jsx
+++ b/app/pages/lab-pages-editor/components/WorkflowHeader.jsx
@@ -11,7 +11,7 @@ import { useWorkflowContext } from '../context.js';
 import strings from '../strings.json';
 
 export default function WorkflowHeader({
-  currentTab = 1000,
+  currentTab = 0,
   projectId = '',
   setCurrentTab = () => {}
 }) {
@@ -27,9 +27,27 @@ export default function WorkflowHeader({
     }
   ];
 
+  // When clicking a tab button, make that tab active. This is pretty straightforward.
   function onClick(e) {
     const { tab } = e.target.dataset;
     setCurrentTab(parseInt(tab));
+  }
+
+  // When a tab button has focus, the left/right keys will switch to the prev/next tab.
+  function onKeyUp(e) {
+    let changeTab = 0;
+    if (e.key === 'ArrowLeft') changeTab = -1;
+    if (e.key === 'ArrowRight') changeTab = +1;
+
+    if (changeTab !== 0) {
+      const newTab = (currentTab + changeTab + tabs.length) % tabs.length;
+      setCurrentTab(newTab);
+      e.preventDefault?.();
+      e.stopPropagation?.();
+      return false;
+    }
+
+    return true;
   }
 
   if (!workflow) return null;
@@ -51,6 +69,7 @@ export default function WorkflowHeader({
             key={`${tab.id}`}
             label={tab.label}
             onClick={onClick}
+            onKeyUp={onKeyUp}
             selected={(currentTab === index)}
           />
         ))}
@@ -70,6 +89,7 @@ function TabButton({
   index,
   label = '',
   onClick = () => {},
+  onKeyUp = () => {},
   selected = false
 }) {
   return (
@@ -79,6 +99,7 @@ function TabButton({
       data-tab={index}
       id={id}
       onClick={onClick}
+      onKeyUp={onKeyUp}
       role="tab"
       type="button"
     >
@@ -92,5 +113,6 @@ TabButton.propTypes = {
   index: PropTypes.number,
   label: PropTypes.string,
   onClick: PropTypes.func,
+  onKeyUp: PropTypes.func,
   selected: PropTypes.bool
 };

--- a/app/pages/lab-pages-editor/components/WorkflowHeader.jsx
+++ b/app/pages/lab-pages-editor/components/WorkflowHeader.jsx
@@ -13,19 +13,11 @@ import strings from '../strings.json';
 export default function WorkflowHeader({
   currentTab = 0,
   projectId = '',
-  setCurrentTab = () => {}
+  setCurrentTab = () => {},
+  tabs = []
 }) {
   const { workflow } = useWorkflowContext();
   const returnUrl = `/lab/${projectId}/workflows`;
-  const tabs = [
-    {
-      id: 'pages-editor_workflow-header-tab-button_task',
-      label: strings.PagesEditor.components.WorkflowHeader.tasks
-    }, {
-      id: 'pages-editor_workflow-header-tab-button_settings',
-      label: strings.PagesEditor.components.WorkflowHeader.workflow_settings
-    }
-  ];
 
   // When clicking a tab button, make that tab active. This is pretty straightforward.
   function onClick(e) {
@@ -83,7 +75,13 @@ export default function WorkflowHeader({
 WorkflowHeader.propTypes = {
   currentTab: PropTypes.number,
   projectId: PropTypes.string,
-  setCurrentTab: PropTypes.func
+  setCurrentTab: PropTypes.func,
+  tabs: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string,
+      label: PropTypes.string
+    })
+  )
 };
 
 function TabButton({

--- a/app/pages/lab-pages-editor/components/WorkflowHeader.jsx
+++ b/app/pages/lab-pages-editor/components/WorkflowHeader.jsx
@@ -95,7 +95,6 @@ function TabButton({
   return (
     <button
       aria-selected={selected}
-      className={selected ? 'selected' : 'unselected'}
       data-tab={index}
       id={id}
       onClick={onClick}

--- a/app/pages/lab-pages-editor/components/WorkflowHeader.jsx
+++ b/app/pages/lab-pages-editor/components/WorkflowHeader.jsx
@@ -42,6 +42,8 @@ export default function WorkflowHeader({
     if (changeTab !== 0) {
       const newTab = (currentTab + changeTab + tabs.length) % tabs.length;
       setCurrentTab(newTab);
+      document?.querySelector(`#${tabs[newTab]?.id}`)?.focus();
+
       e.preventDefault?.();
       e.stopPropagation?.();
       return false;
@@ -101,6 +103,7 @@ function TabButton({
       onClick={onClick}
       onKeyUp={onKeyUp}
       role="tab"
+      tabIndex={selected ? undefined : -1}
       type="button"
     >
       {label}

--- a/app/pages/lab-pages-editor/components/WorkflowHeader.jsx
+++ b/app/pages/lab-pages-editor/components/WorkflowHeader.jsx
@@ -65,6 +65,7 @@ export default function WorkflowHeader({
             onClick={onClick}
             onKeyUp={onKeyUp}
             selected={(currentTab === index)}
+            targetPanel={tab.targetPanel}
           />
         ))}
       </div>
@@ -79,7 +80,8 @@ WorkflowHeader.propTypes = {
   tabs: PropTypes.arrayOf(
     PropTypes.shape({
       id: PropTypes.string,
-      label: PropTypes.string
+      label: PropTypes.string,
+      targetPanel: PropTypes.string
     })
   )
 };
@@ -90,10 +92,12 @@ function TabButton({
   label = '',
   onClick = () => {},
   onKeyUp = () => {},
-  selected = false
+  selected = false,
+  targetPanel = ''
 }) {
   return (
     <button
+      aria-controls={targetPanel}
       aria-selected={selected}
       data-tab={index}
       id={id}
@@ -114,5 +118,6 @@ TabButton.propTypes = {
   label: PropTypes.string,
   onClick: PropTypes.func,
   onKeyUp: PropTypes.func,
-  selected: PropTypes.bool
+  selected: PropTypes.bool,
+  targetPanel: PropTypes.string
 };

--- a/app/pages/lab-pages-editor/components/WorkflowHeader.jsx
+++ b/app/pages/lab-pages-editor/components/WorkflowHeader.jsx
@@ -17,6 +17,15 @@ export default function WorkflowHeader({
 }) {
   const { workflow } = useWorkflowContext();
   const returnUrl = `/lab/${projectId}/workflows`;
+  const tabs = [
+    {
+      id: 'pages-editor_workflow-header-tab-button_task',
+      label: strings.PagesEditor.components.WorkflowHeader.tasks
+    }, {
+      id: 'pages-editor_workflow-header-tab-button_settings',
+      label: strings.PagesEditor.components.WorkflowHeader.workflow_settings
+    }
+  ];
 
   function onClick(e) {
     const { tab } = e.target.dataset;
@@ -31,23 +40,20 @@ export default function WorkflowHeader({
         <ReturnIcon />
         {strings.PagesEditor.components.WorkflowHeader.return}
       </Link>
-      <div className="flex-row flex-item justify-around">
-        <button
-          className={(currentTab === 0) ? 'selected' : 'unselected'}
-          data-tab="0"
-          onClick={onClick}
-          type="button"
-        >
-          {strings.PagesEditor.components.WorkflowHeader.tasks}
-        </button>
-        <button
-          className={(currentTab === 1) ? 'selected' : 'unselected'}
-          data-tab="1"
-          onClick={onClick}
-          type="button"
-        >
-          {strings.PagesEditor.components.WorkflowHeader.workflow_settings}
-        </button>
+      <div
+        role="tablist"
+        className="flex-row flex-item justify-around"
+      >
+        {tabs.map((tab, index) => (
+          <TabButton
+            id={tab.id}
+            index={index}
+            key={`${tab.id}`}
+            label={tab.label}
+            onClick={onClick}
+            selected={(currentTab === index)}
+          />
+        ))}
       </div>
     </div>
   );
@@ -57,4 +63,34 @@ WorkflowHeader.propTypes = {
   currentTab: PropTypes.number,
   projectId: PropTypes.string,
   setCurrentTab: PropTypes.func
+};
+
+function TabButton({
+  id,
+  index,
+  label = '',
+  onClick = () => {},
+  selected = false
+}) {
+  return (
+    <button
+      aria-selected={selected}
+      className={selected ? 'selected' : 'unselected'}
+      data-tab={index}
+      id={id}
+      onClick={onClick}
+      role="tab"
+      type="button"
+    >
+      {label}
+    </button>
+  );
+}
+
+TabButton.propTypes = {
+  id: PropTypes.string,
+  index: PropTypes.number,
+  label: PropTypes.string,
+  onClick: PropTypes.func,
+  selected: PropTypes.bool
 };

--- a/app/pages/lab-pages-editor/components/WorkflowHeader.jsx
+++ b/app/pages/lab-pages-editor/components/WorkflowHeader.jsx
@@ -1,6 +1,7 @@
 /* eslint-disable no-console */
 /* eslint-disable react/react-in-jsx-scope */
 /* eslint-disable react/require-default-props */
+/* eslint-disable radix */
 
 import PropTypes from 'prop-types';
 import { Link } from 'react-router';
@@ -10,13 +11,16 @@ import { useWorkflowContext } from '../context.js';
 import strings from '../strings.json';
 
 export default function WorkflowHeader({
-  projectId = ''
+  currentTab = 1000,
+  projectId = '',
+  setCurrentTab = () => {}
 }) {
   const { workflow } = useWorkflowContext();
   const returnUrl = `/lab/${projectId}/workflows`;
 
-  function onClick() {
-    console.log('TODO');
+  function onClick(e) {
+    const { tab } = e.target.dataset;
+    setCurrentTab(parseInt(tab));
   }
 
   if (!workflow) return null;
@@ -28,10 +32,20 @@ export default function WorkflowHeader({
         {strings.PagesEditor.components.WorkflowHeader.return}
       </Link>
       <div className="flex-row flex-item justify-around">
-        <button className="unselected" type="button" onClick={onClick}>
+        <button
+          className={(currentTab === 0) ? 'selected' : 'unselected'}
+          data-tab="0"
+          onClick={onClick}
+          type="button"
+        >
           {strings.PagesEditor.components.WorkflowHeader.tasks}
         </button>
-        <button className="selected" type="button" onClick={onClick}>
+        <button
+          className={(currentTab === 1) ? 'selected' : 'unselected'}
+          data-tab="1"
+          onClick={onClick}
+          type="button"
+        >
           {strings.PagesEditor.components.WorkflowHeader.workflow_settings}
         </button>
       </div>
@@ -40,5 +54,7 @@ export default function WorkflowHeader({
 }
 
 WorkflowHeader.propTypes = {
-  projectId: PropTypes.string
+  currentTab: PropTypes.number,
+  projectId: PropTypes.string,
+  setCurrentTab: PropTypes.func
 };

--- a/app/pages/lab-pages-editor/components/WorkflowHeader.jsx
+++ b/app/pages/lab-pages-editor/components/WorkflowHeader.jsx
@@ -98,7 +98,7 @@ function TabButton({
   return (
     <button
       aria-controls={targetPanel}
-      aria-selected={selected}
+      aria-selected={selected ? 'true' : 'false'}
       data-tab={index}
       id={id}
       onClick={onClick}

--- a/app/pages/lab-pages-editor/components/WorkflowHeader.jsx
+++ b/app/pages/lab-pages-editor/components/WorkflowHeader.jsx
@@ -104,7 +104,7 @@ function TabButton({
       onClick={onClick}
       onKeyUp={onKeyUp}
       role="tab"
-      tabIndex={selected ? undefined : -1}
+      tabIndex={selected ? 0 : -1}
       type="button"
     >
       {label}

--- a/app/pages/lab-pages-editor/components/WorkflowSettingsPage.jsx
+++ b/app/pages/lab-pages-editor/components/WorkflowSettingsPage.jsx
@@ -47,7 +47,12 @@ export default function WorkflowSettingsPage() {
   if (!workflow) return null;
 
   return (
-    <form className="workflow-settings-page" onSubmit={onSubmit}>
+    <form
+      aria-labelledby="pages-editor_workflow-header-tab-button_settings"
+      className="workflow-settings-page"
+      onSubmit={onSubmit}
+      role="tabpanel"
+    >
       <label htmlFor="display_name">
         Workflow Name
         <input

--- a/app/pages/lab-pages-editor/components/WorkflowSettingsPage.jsx
+++ b/app/pages/lab-pages-editor/components/WorkflowSettingsPage.jsx
@@ -48,10 +48,8 @@ export default function WorkflowSettingsPage() {
 
   return (
     <form
-      aria-labelledby="pages-editor_workflow-header-tab-button_settings"
       className="workflow-settings-page"
       onSubmit={onSubmit}
-      role="tabpanel"
     >
       <label htmlFor="display_name">
         Workflow Name

--- a/css/lab-pages-editor.styl
+++ b/css/lab-pages-editor.styl
@@ -118,10 +118,10 @@ $fontWeightBoldPlus = 700
       font-weight: $fontWeightBoldPlus
       text-transform: uppercase
 
-      &.selected
+      &[aria-selected=true]
         border-bottom: 4px solid $teal
       
-      &.unselected
+      &[aria-selected=false]
         color: $grey1
         border-bottom: 4px solid transparent
 


### PR DESCRIPTION
## PR Overview

Part of: **Pages Editor MVP** project and **FEM Lab** super-project
Follows #6822
Staging Example: https://pr-6836.pfe-preview.zooniverse.org/lab/1982/workflows/editor/3711?env=staging
Tabs Pattern: https://www.w3.org/WAI/ARIA/apg/patterns/tabs/

This PR adjusts the Workflow Header so that the navigation/paging tabs actually behaves like the ARIA-specified Tabs patten. This follows [feedback](https://github.com/zooniverse/Panoptes-Front-End/pull/6822#pullrequestreview-1630968196) from the previous PR.

- Elements should now have `tablist`, `tab`, and `tabpanel` roles
- Mouse: clicking on Task or Workflow Settings should switch to the appropriate panel (or placeholder panel)
- Keyboard:
  - tab-navigation (pressing the Tab key on a keyboard) should only allow users to focus on the active/selected tab button on the tabs list (e.g. so if the Task tab button is active, pressing the Tab key _shouldn't_ take you to the Workflow Settings tab button, but instead to the next focusable element on the page.)
  - _when_ the user is focused on the active/selected tab, then the left/right keys should switch between the tabs (similar to clicking on 'em). Note that you don't need to press Enter or Space to confirm that you want to switch tabs.

### Testing

Go to the staging example URL, and confirm that the "Tasks" and "Workflow Settings" tabs work as described by the ARIA Tabs pattern.

### Status

Ready for review!