### PR TITLE
Add labels to text tasks

### DIFF
--- a/app/classifier/task.jsx
+++ b/app/classifier/task.jsx
@@ -73,6 +73,7 @@ class Task extends React.Component {
                 taskTypes={tasks}
                 workflow={workflow}
                 task={task}
+                taskKey={annotation.task}
                 preferences={this.props.preferences}
                 annotation={annotation}
                 onChange={this.handleAnnotationChange}

--- a/app/classifier/tasks/combo/index.cjsx
+++ b/app/classifier/tasks/combo/index.cjsx
@@ -116,7 +116,7 @@ ComboTask = createReactClass
             task={taskDescription}
             workflowID={@props.workflow.id}
           >
-            <TaskComponent {...@props} autoFocus={i is 0} task={taskDescription} annotation={annotation} onChange={@handleChange.bind this, i} />
+            <TaskComponent {...@props} autoFocus={i is 0} task={taskDescription} taskKey={task} annotation={annotation} onChange={@handleChange.bind this, i} />
           </TaskTranslations>
         </div>}
     </div>

--- a/app/classifier/tasks/text/index.jsx
+++ b/app/classifier/tasks/text/index.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import _ from 'lodash';
+import { Markdown } from 'markdownz';
 
 import GenericTask from '../generic';
 import TextTaskEditor from './editor';
@@ -100,23 +101,30 @@ export default class TextTask extends React.PureComponent {
   }
 
   render() {
+    const inputID = `text-${this.props.taskKey}`
     return (
       <GenericTask
-        question={this.props.translation.instruction}
         help={this.props.translation.help}
         required={this.props.task.required}
       >
-        <label className="answer" htmlFor="textInput">
-          <textarea
-            className="standard-input full"
-            onBlur={this.debouncedUpdateAnnotation.flush}
-            onChange={this.handleChange}
-            ref={this.textInput}
-            rows={this.state.rows}
-            style={{ lineHeight: `${LINEHEIGHT}px`, overflow: 'hidden' }}
-            value={this.state.value}
-          />
+        <label className="question" htmlFor={inputID}>
+          <Markdown
+            inline
+            tag='span'
+          >
+            {this.props.translation.instruction}
+          </Markdown>
         </label>
+        <textarea
+          id={inputID}
+          className="standard-input full"
+          onBlur={this.debouncedUpdateAnnotation.flush}
+          onChange={this.handleChange}
+          ref={this.textInput}
+          rows={this.state.rows}
+          style={{ lineHeight: `${LINEHEIGHT}px`, overflow: 'hidden' }}
+          value={this.state.value}
+        />
         {this.props.task.text_tags && this.props.task.text_tags.length > 0 &&
           <div className="transcription-metadata-tags">
             {this.props.task.text_tags.map(tag => (
@@ -166,7 +174,8 @@ TextTask.propTypes = {
     text_tags: PropTypes.arrayOf(
       PropTypes.string
     )
-  })
+  }),
+  taskKey: PropTypes.string.isRequired
 };
 
 TextTask.defaultProps = {

--- a/app/classifier/tasks/text/index.spec.js
+++ b/app/classifier/tasks/text/index.spec.js
@@ -27,7 +27,7 @@ describe('TextTask', function () {
     });
 
     it('should have an instruction', function () {
-      const instruction = wrapper.find('.question');
+      const instruction = wrapper.find('label.question');
       expect(instruction.hostNodes()).to.have.lengthOf(1);
     });
 

--- a/css/text-task.styl
+++ b/css/text-task.styl
@@ -1,3 +1,7 @@
+label.question
+  display: inline-block
+  margin: 1em 0
+
 .transcription-metadata-tags
   align-content: space-around
   align-items: center


### PR DESCRIPTION
Replace the current paragraph with a `<label>` for the text task instruction. Pass `taskKey` down to all tasks, so that we can use the task key to generate a unique ID for each text input.

Staging branch URL: https://pr-{NUMBER}.pfe-preview.zooniverse.org

- Fixes #6870.
- Fixes level A accessibility failures for projects using the text task.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
