### PR TITLE
Limit FEMLab Dropdown to only allow between 4-200 options.

### DIFF
--- a/app/classifier/tasks/dropdown/dropdown-dialog.cjsx
+++ b/app/classifier/tasks/dropdown/dropdown-dialog.cjsx
@@ -10,6 +10,9 @@ provincesCanada = require './presets/provinces-Canada' # value = two-letter post
 statesMexico = require './presets/states-Mexico' # value = three-letter ISO 3166-2 abbreviation
 # IMPORTANT: before adding preset options, confirm values are not duplicated in existing presets
 
+OPTIONS_MIN = 4
+OPTIONS_MAX = 250
+
 DropdownDialog = createReactClass
 
   getDefaultProps: ->
@@ -150,6 +153,13 @@ DropdownDialog = createReactClass
     if not @state.editSelect.title
       return window.alert('Dropdowns must have a Title.')
 
+    # for FEMLab we want to enforce a min and max number of options
+    numOptions = @state.editSelect.options['*'].length
+    if @props.pfeLab is false and numOptions < OPTIONS_MIN
+      return window.alert('Dropdowns must have at least 4 options.')
+    else if @props.pfeLab is false and numOptions > OPTIONS_MAX
+      return window.alert('Dropdowns must have fewer than 200 options.')
+
     selectTitles = @props.selects
       .filter (select) => select isnt @props.initialSelect
       .map (select) -> select.title
@@ -196,6 +206,9 @@ DropdownDialog = createReactClass
         {if select.condition?
           <span>Dependent on {@state.conditionalSelects[@state.conditionalSelects.length - 1]?.title}</span>}
       </p>
+      {if @props.pfeLab is false # for FEMLab we want to indicate a minimum number of options
+        <p><i>Enter a minimum of 4 choices</i></p>
+      }
 
       <label className="pill-button" title={dropdownEditorHelp.required}>
         Required <input type="checkbox" ref="required" checked={select.required} onChange={@editSelect}></input>


### PR DESCRIPTION

Staging branch URL: https://pr-6872.pfe-preview.zooniverse.org

# Overview
Limit the SimpleDropdown within FEMLab to between 4-200 options. 

Toward https://github.com/zooniverse/Panoptes-Front-End/issues/6765

[PFE without FEMLab enabled for a Dropdown](https://pr-6872.pfe-preview.zooniverse.org/lab/1996/workflows/3771?env=staging):
- [ ] Should not limit options to greater than 4
- [ ] Should not limit options to less than 200

[PFE with FEMLab enabled for a Dropdown should](https://pr-6872.pfe-preview.zooniverse.org/lab/1995/workflows/3770?env=staging):
- [ ] Should limit options to greater than 4
- [ ] Should limit options to less than 200

# Review Checklist
- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?