### PR TITLE
Pages Editor: add "Add New Task" Dialog

### DIFF
--- a/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
@@ -18,11 +18,10 @@ export default function TasksPage() {
   const { workflow, update } = useWorkflowContext();
   const isActive = true; // TODO
 
-  // Automatically adds one pre-built Text Task
-  function experimentalAddNewTaskWithStep() {
+  function experimentalAddNewTaskWithStep(taskType) {
     const newTaskKey = getNewTaskKey(workflow?.tasks);
     const newStepKey = getNewStepKey(workflow?.steps);
-    const newTask = createTask('text');
+    const newTask = createTask(taskType);
     const newStep = createStep(newStepKey, [newTaskKey]);
 
     if (!newTaskKey || !newStepKey || !newTask || !newStep) {
@@ -58,7 +57,9 @@ export default function TasksPage() {
       <section aria-labelledby="workflow-tasks-heading">
         <h3 id="workflow-tasks-heading">Tasks</h3>
         <div className="flex-row">
-          <NewTaskButtonAndDialog />
+          <NewTaskButtonAndDialog
+            addTaskWithStep={experimentalAddNewTaskWithStep}
+          />
           {/* Dev observation: the <select> should have some label to indicate it's for choosing the starting task. */}
           <select
             aria-label="Choose starting page"

--- a/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
@@ -11,6 +11,7 @@ import createTask from '../../helpers/createTask.js';
 import createStep from '../../helpers/createStep.js';
 // import strings from '../../strings.json'; // TODO: move all text into strings
 
+import NewTaskButtonAndDialog from './components/NewTaskButtonAndDialog.jsx';
 import StepItem from './components/StepItem.jsx';
 
 export default function TasksPage() {
@@ -57,13 +58,7 @@ export default function TasksPage() {
       <section aria-labelledby="workflow-tasks-heading">
         <h3 id="workflow-tasks-heading">Tasks</h3>
         <div className="flex-row">
-          <button
-            className="flex-item big primary"
-            onClick={experimentalAddNewTaskWithStep}
-            type="button"
-          >
-            Add a new Task +
-          </button>
+          <NewTaskButtonAndDialog />
           {/* Dev observation: the <select> should have some label to indicate it's for choosing the starting task. */}
           <select
             aria-label="Choose starting page"

--- a/app/pages/lab-pages-editor/components/TasksPage/components/NewTaskButtonAndDialog.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/NewTaskButtonAndDialog.jsx
@@ -53,6 +53,7 @@ function NewTaskButtonAndDialog({
             Choose a Task type
           </h4>
           <button
+            aria-label="Close dialog"
             className="plain"
             onClick={closeNewTaskDialog}
             type="button"

--- a/app/pages/lab-pages-editor/components/TasksPage/components/NewTaskButtonAndDialog.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/NewTaskButtonAndDialog.jsx
@@ -1,0 +1,58 @@
+/* eslint-disable no-console */
+/* eslint-disable react/react-in-jsx-scope */
+/* eslint-disable react/require-default-props */
+/* eslint-disable radix */
+/* eslint-disable react/jsx-boolean-value */
+/* eslint-disable react/forbid-prop-types */
+
+import { useRef } from 'react';
+
+// import strings from '../../../strings.json'; // TODO: move all text into strings
+
+function NewTaskButtonAndDialog() {
+  const newTaskDialog = useRef(null);
+
+  function openNewTaskDialog() {
+    newTaskDialog.current?.showModal();
+  }
+
+  function closeNewTaskDialog() {
+    newTaskDialog.current?.close();
+  }
+
+  /*
+  WARNING: the <dialog> element should automatically close with the Esc key,
+  but this seems disabled. This doesn't seem to be a problem with React, but
+  with PFE.
+   */
+  // function dialogOnKeyUp(e) {
+  //  if (e.key === 'Escape') newTaskDialog.current?.close();
+  // }
+
+  return (
+    <>
+      <button
+        className="flex-item big primary"
+        onClick={openNewTaskDialog}
+        type="button"
+      >
+        Add a new Task +
+      </button>
+      <dialog
+        autofocus="true"
+        className="new-task-dialog"
+        ref={newTaskDialog}
+        /* open="true"  // MDN recommends not using this attribute. But if we have to, use "true", not {true} */
+      >
+        <div>Add New Task</div>
+        <button type="button" onClick={closeNewTaskDialog}>Close</button>
+        <form>
+        </form>
+      </dialog>
+    </>
+  );
+}
+
+NewTaskButtonAndDialog.propTypes = {};
+
+export default NewTaskButtonAndDialog;

--- a/app/pages/lab-pages-editor/components/TasksPage/components/NewTaskButtonAndDialog.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/NewTaskButtonAndDialog.jsx
@@ -37,11 +37,11 @@ function NewTaskButtonAndDialog({
   return (
     <>
       <button
-        className="flex-item big primary"
+        className="flex-item big primary decoration-plus"
         onClick={openNewTaskDialog}
         type="button"
       >
-        Add a new Task +
+        Add a new Task
       </button>
       <dialog
         aria-labelledby="dialog-title"

--- a/app/pages/lab-pages-editor/components/TasksPage/components/NewTaskButtonAndDialog.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/NewTaskButtonAndDialog.jsx
@@ -14,7 +14,7 @@ import TaskIcon from '../../../icons/TaskIcon.jsx';
 // import strings from '../../../strings.json'; // TODO: move all text into strings
 
 function NewTaskButtonAndDialog({
-  addTask = () => {}
+  addTaskWithStep = () => {}
 }) {
   const newTaskDialog = useRef(null);
 
@@ -30,7 +30,8 @@ function NewTaskButtonAndDialog({
     const tasktype = e?.currentTarget?.dataset?.tasktype;
     // Protip: don't use event.target, since it might return the child of the button, instead of the button itself
 
-    addTask(tasktype);
+    closeNewTaskDialog();
+    addTaskWithStep(tasktype);
   }
 
   return (
@@ -100,7 +101,7 @@ function NewTaskButtonAndDialog({
 }
 
 NewTaskButtonAndDialog.propTypes = {
-  addTask: PropTypes.func
+  addTaskWithStep: PropTypes.func
 };
 
 export default NewTaskButtonAndDialog;

--- a/app/pages/lab-pages-editor/components/TasksPage/components/NewTaskButtonAndDialog.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/NewTaskButtonAndDialog.jsx
@@ -4,6 +4,7 @@
 /* eslint-disable radix */
 /* eslint-disable react/jsx-boolean-value */
 /* eslint-disable react/forbid-prop-types */
+/* eslint-disable react/no-unknown-property */
 
 import { useRef } from 'react';
 

--- a/app/pages/lab-pages-editor/components/TasksPage/components/NewTaskButtonAndDialog.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/NewTaskButtonAndDialog.jsx
@@ -58,8 +58,21 @@ function NewTaskButtonAndDialog() {
             <CloseIcon />
           </button>
         </div>
-        <form className="dialog-body">
-          ...
+        <form className="dialog-body new-task">
+          <p>
+            A task is a unit of work you are asking volunteers to do.
+            You can ask them to answer a question or mark an image.
+          </p>
+          <div>
+            <button type="button" className="new-task-button">
+              <span
+                aria-label="Task type: text"
+                className="fa fa fa-file-text-o fa-fw"
+                role="img"
+              />
+              <span>Text</span>
+            </button>
+          </div>
         </form>
       </dialog>
     </>

--- a/app/pages/lab-pages-editor/components/TasksPage/components/NewTaskButtonAndDialog.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/NewTaskButtonAndDialog.jsx
@@ -9,6 +9,7 @@
 import { useRef } from 'react';
 
 import CloseIcon from '../../../icons/CloseIcon.jsx';
+import TaskIcon from '../../../icons/TaskIcon.jsx';
 // import strings from '../../../strings.json'; // TODO: move all text into strings
 
 function NewTaskButtonAndDialog() {
@@ -65,28 +66,16 @@ function NewTaskButtonAndDialog() {
           </p>
           <div className="flex-row flex-wrap">
             <button type="button" className="new-task-button">
-              <span
-                aria-label="Task type: text"
-                className="fa fa fa-file-text-o fa-fw"
-                role="img"
-              />
+              <TaskIcon type='text' />
               <span>Text</span>
             </button>
             <button type="button" className="new-task-button">
-              <span
-                aria-label="Task type: text"
-                className="fa fa fa-file-text-o fa-fw"
-                role="img"
-              />
-              <span>Text</span>
+              <TaskIcon type='single' />
+              <span>Question</span>
             </button>
             <button type="button" className="new-task-button">
-              <span
-                aria-label="Task type: text"
-                className="fa fa fa-file-text-o fa-fw"
-                role="img"
-              />
-              <span>Text</span>
+              <TaskIcon type='drawing' />
+              <span>Drawing</span>
             </button>
           </div>
         </form>

--- a/app/pages/lab-pages-editor/components/TasksPage/components/NewTaskButtonAndDialog.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/NewTaskButtonAndDialog.jsx
@@ -68,6 +68,7 @@ function NewTaskButtonAndDialog({
           </p>
           <div className="flex-row flex-wrap">
             <button
+              aria-label="Add new Text Task"
               className="new-task-button"
               data-tasktype="text"
               onClick={addNewTask}
@@ -77,6 +78,7 @@ function NewTaskButtonAndDialog({
               <span>Text</span>
             </button>
             <button
+              aria-label="Add new Question Task"
               className="new-task-button"
               data-tasktype="single"
               onClick={addNewTask}
@@ -86,6 +88,7 @@ function NewTaskButtonAndDialog({
               <span>Question</span>
             </button>
             <button
+              aria-label="Add new Drawing Task"
               className="new-task-button"
               data-tasktype="drawing"
               onClick={addNewTask}

--- a/app/pages/lab-pages-editor/components/TasksPage/components/NewTaskButtonAndDialog.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/NewTaskButtonAndDialog.jsx
@@ -33,15 +33,6 @@ function NewTaskButtonAndDialog({
     addTask(tasktype);
   }
 
-  /*
-  WARNING: the <dialog> element should automatically close with the Esc key,
-  but this seems disabled. This doesn't seem to be a problem with React, but
-  with PFE.
-   */
-  // function dialogOnKeyUp(e) {
-  //  if (e.key === 'Escape') newTaskDialog.current?.close();
-  // }
-
   return (
     <>
       <button

--- a/app/pages/lab-pages-editor/components/TasksPage/components/NewTaskButtonAndDialog.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/NewTaskButtonAndDialog.jsx
@@ -63,7 +63,23 @@ function NewTaskButtonAndDialog() {
             A task is a unit of work you are asking volunteers to do.
             You can ask them to answer a question or mark an image.
           </p>
-          <div>
+          <div className="flex-row flex-wrap">
+            <button type="button" className="new-task-button">
+              <span
+                aria-label="Task type: text"
+                className="fa fa fa-file-text-o fa-fw"
+                role="img"
+              />
+              <span>Text</span>
+            </button>
+            <button type="button" className="new-task-button">
+              <span
+                aria-label="Task type: text"
+                className="fa fa fa-file-text-o fa-fw"
+                role="img"
+              />
+              <span>Text</span>
+            </button>
             <button type="button" className="new-task-button">
               <span
                 aria-label="Task type: text"

--- a/app/pages/lab-pages-editor/components/TasksPage/components/NewTaskButtonAndDialog.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/NewTaskButtonAndDialog.jsx
@@ -7,12 +7,15 @@
 /* eslint-disable react/no-unknown-property */
 
 import { useRef } from 'react';
+import PropTypes from 'prop-types';
 
 import CloseIcon from '../../../icons/CloseIcon.jsx';
 import TaskIcon from '../../../icons/TaskIcon.jsx';
 // import strings from '../../../strings.json'; // TODO: move all text into strings
 
-function NewTaskButtonAndDialog() {
+function NewTaskButtonAndDialog({
+  addTask = () => {}
+}) {
   const newTaskDialog = useRef(null);
 
   function openNewTaskDialog() {
@@ -21,6 +24,13 @@ function NewTaskButtonAndDialog() {
 
   function closeNewTaskDialog() {
     newTaskDialog.current?.close();
+  }
+
+  function addNewTask(e) {
+    const tasktype = e?.currentTarget?.dataset?.tasktype;
+    // Protip: don't use event.target, since it might return the child of the button, instead of the button itself
+
+    addTask(tasktype);
   }
 
   /*
@@ -64,15 +74,30 @@ function NewTaskButtonAndDialog() {
             You can ask them to answer a question or mark an image.
           </p>
           <div className="flex-row flex-wrap">
-            <button type="button" className="new-task-button">
+            <button
+              className="new-task-button"
+              data-tasktype="text"
+              onClick={addNewTask}
+              type="button"
+            >
               <TaskIcon type='text' />
               <span>Text</span>
             </button>
-            <button type="button" className="new-task-button">
+            <button
+              className="new-task-button"
+              data-tasktype="single"
+              onClick={addNewTask}
+              type="button"
+            >
               <TaskIcon type='single' />
               <span>Question</span>
             </button>
-            <button type="button" className="new-task-button">
+            <button
+              className="new-task-button"
+              data-tasktype="drawing"
+              onClick={addNewTask}
+              type="button"
+            >
               <TaskIcon type='drawing' />
               <span>Drawing</span>
             </button>
@@ -83,6 +108,8 @@ function NewTaskButtonAndDialog() {
   );
 }
 
-NewTaskButtonAndDialog.propTypes = {};
+NewTaskButtonAndDialog.propTypes = {
+  addTask: PropTypes.func
+};
 
 export default NewTaskButtonAndDialog;

--- a/app/pages/lab-pages-editor/components/TasksPage/components/NewTaskButtonAndDialog.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/NewTaskButtonAndDialog.jsx
@@ -42,7 +42,6 @@ function NewTaskButtonAndDialog() {
         Add a new Task +
       </button>
       <dialog
-        autofocus="true"
         aria-labelledby="dialog-title"
         ref={newTaskDialog}
         /* open="true"  // MDN recommends not using this attribute. But if we have to, use "true", not {true} */

--- a/app/pages/lab-pages-editor/components/TasksPage/components/NewTaskButtonAndDialog.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/NewTaskButtonAndDialog.jsx
@@ -7,6 +7,7 @@
 
 import { useRef } from 'react';
 
+import CloseIcon from '../../../icons/CloseIcon.jsx';
 // import strings from '../../../strings.json'; // TODO: move all text into strings
 
 function NewTaskButtonAndDialog() {
@@ -40,13 +41,24 @@ function NewTaskButtonAndDialog() {
       </button>
       <dialog
         autofocus="true"
-        className="new-task-dialog"
+        aria-labelledby="dialog-title"
         ref={newTaskDialog}
         /* open="true"  // MDN recommends not using this attribute. But if we have to, use "true", not {true} */
       >
-        <div>Add New Task</div>
-        <button type="button" onClick={closeNewTaskDialog}>Close</button>
-        <form>
+        <div className="dialog-header flex-row">
+          <h4 id="dialog-title" className="flex-item">
+            Choose a Task type
+          </h4>
+          <button
+            className="plain"
+            onClick={closeNewTaskDialog}
+            type="button"
+          >
+            <CloseIcon />
+          </button>
+        </div>
+        <form className="dialog-body">
+          ...
         </form>
       </dialog>
     </>

--- a/app/pages/lab-pages-editor/components/TasksPage/components/StepItem.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/StepItem.jsx
@@ -9,7 +9,12 @@ import PropTypes from 'prop-types';
 
 // import strings from '../../../strings.json'; // TODO: move all text into strings
 import TaskItem from './TaskItem.jsx';
+import CopyIcon from '../../../icons/CopyIcon.jsx';
+import DeleteIcon from '../../../icons/DeleteIcon.jsx';
+import EditIcon from '../../../icons/EditIcon.jsx';
 import GripIcon from '../../../icons/GripIcon.jsx';
+import MoveDownIcon from '../../../icons/MoveDownIcon.jsx';
+import MoveUpIcon from '../../../icons/MoveUpIcon.jsx';
 
 function StepItem({
   allTasks,
@@ -26,23 +31,23 @@ function StepItem({
         <span className="step-controls-left" />
         <div className="step-controls-center">
           <button aria-label={`Rearrange Page ${stepKey} upwards`} className="plain" type="button">
-            <span className="fa fa-caret-up" />
+            <MoveUpIcon />
           </button>
           {/* TODO: add drag/drop functionality. Perhaps this needs to be wider, too. */}
           <GripIcon className="grab-handle" />
           <button aria-label={`Rearrange Page/Step ${stepKey} downwards`} className="plain" type="button">
-            <span className="fa fa-caret-down" />
+            <MoveDownIcon />
           </button>
         </div>
         <div className="step-controls-right">
           <button aria-label={`Delete Page/Step ${stepKey}`} className="plain" type="button">
-            <span className="fa fa-trash" />
+            <DeleteIcon />
           </button>
           <button aria-label={`Copy Page/Step ${stepKey}`} className="plain" type="button">
-            <span className="fa fa-copy" />
+            <CopyIcon />
           </button>
           <button aria-label={`Edit Page/Step ${stepKey}`} className="plain" type="button">
-            <span className="fa fa-pencil" />
+            <EditIcon />
           </button>
         </div>
       </div>

--- a/app/pages/lab-pages-editor/components/TasksPage/components/StepItem.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/StepItem.jsx
@@ -29,7 +29,7 @@ function StepItem({
             <span className="fa fa-caret-up" />
           </button>
           {/* TODO: add drag/drop functionality. Perhaps this needs to be wider, too. */}
-          <GripIcon className="grab-handle" color="#A6A7A9" />
+          <GripIcon className="grab-handle" />
           <button aria-label={`Rearrange Page/Step ${stepKey} downwards`} className="plain" type="button">
             <span className="fa fa-caret-down" />
           </button>

--- a/app/pages/lab-pages-editor/components/TasksPage/components/TaskItem.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/TaskItem.jsx
@@ -8,6 +8,7 @@
 import PropTypes from 'prop-types';
 
 // import strings from '../../../strings.json'; // TODO: move all text into strings
+import TaskIcon from '../../../icons/TaskIcon.jsx';
 
 function TaskItem({
   task,
@@ -18,7 +19,7 @@ function TaskItem({
   // TODO: use Panoptes Translations API.
   // e.g. pull from workflow.strings['tasks.T0.instruction']
   // Task.instruction/question isn't particularly standardised across different task types.
-  const text = task.instruction || task.question || '';
+  const taskText = task.instruction || task.question || '';
 
   return (
     <li className="task-item">
@@ -26,13 +27,9 @@ function TaskItem({
         <span className="task-key">{taskKey}</span>
         <span className="task-icon">
           {/* TODO: change icon and aria label depending on task type */}
-          <span
-            aria-label="Task type: text"
-            className="fa fa fa-file-text-o fa-fw"
-            role="img"
-          />
+          <TaskIcon type={task.type} />
         </span>
-        <span className="task-text flex-item">{text}</span>
+        <span className="task-text flex-item">{taskText}</span>
       </div>
     </li>
   );

--- a/app/pages/lab-pages-editor/components/TasksPage/components/TaskItem.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/TaskItem.jsx
@@ -10,6 +10,12 @@ import PropTypes from 'prop-types';
 // import strings from '../../../strings.json'; // TODO: move all text into strings
 import TaskIcon from '../../../icons/TaskIcon.jsx';
 
+const TaskLabels = {
+  'drawing': 'Drawing Task',
+  'single': 'Question Task',  // Single question
+  'text': 'Text Task'
+};
+
 function TaskItem({
   task,
   taskKey
@@ -26,8 +32,10 @@ function TaskItem({
       <div className="flex-row spacing-bottom-M">
         <span className="task-key">{taskKey}</span>
         <span className="task-icon">
-          {/* TODO: change icon and aria label depending on task type */}
-          <TaskIcon type={task.type} />
+          <TaskIcon
+            alt={TaskLabels[task.type]}
+            type={task.type}
+          />
         </span>
         <span className="task-text flex-item">{taskText}</span>
       </div>

--- a/app/pages/lab-pages-editor/icons/CloseIcon.jsx
+++ b/app/pages/lab-pages-editor/icons/CloseIcon.jsx
@@ -2,6 +2,6 @@
 
 export default function CloseIcon({ alt }) {
   return (
-    <span className="icon fa fa-close" alt={alt} role={!!alt ? 'img' : undefined} />
+    <span className="icon fa fa-close" aria-label={alt} role={!!alt ? 'img' : undefined} />
   );
 }

--- a/app/pages/lab-pages-editor/icons/CloseIcon.jsx
+++ b/app/pages/lab-pages-editor/icons/CloseIcon.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/react-in-jsx-scope */
 
-export default function CloseIcon() {
+export default function CloseIcon({ alt }) {
   return (
-    <span className="icon fa fa-close" role="img" />
+    <span className="icon fa fa-close" alt={alt} role={!!alt ? 'img' : undefined} />
   );
 }

--- a/app/pages/lab-pages-editor/icons/CloseIcon.jsx
+++ b/app/pages/lab-pages-editor/icons/CloseIcon.jsx
@@ -1,0 +1,7 @@
+/* eslint-disable react/react-in-jsx-scope */
+
+export default function CloseIcon() {
+  return (
+    <span className="icon fa fa-close" role="img" />
+  );
+}

--- a/app/pages/lab-pages-editor/icons/CopyIcon.jsx
+++ b/app/pages/lab-pages-editor/icons/CopyIcon.jsx
@@ -1,0 +1,7 @@
+/* eslint-disable react/react-in-jsx-scope */
+
+export default function CopyIcon() {
+  return (
+    <span className="icon fa fa-copy" role="img" />
+  );
+}

--- a/app/pages/lab-pages-editor/icons/CopyIcon.jsx
+++ b/app/pages/lab-pages-editor/icons/CopyIcon.jsx
@@ -2,6 +2,6 @@
 
 export default function CopyIcon({ alt }) {
   return (
-    <span className="icon fa fa-copy" alt={alt} role={!!alt ? 'img' : undefined} />
+    <span className="icon fa fa-copy" aria-label={alt} role={!!alt ? 'img' : undefined} />
   );
 }

--- a/app/pages/lab-pages-editor/icons/CopyIcon.jsx
+++ b/app/pages/lab-pages-editor/icons/CopyIcon.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/react-in-jsx-scope */
 
-export default function CopyIcon() {
+export default function CopyIcon({ alt }) {
   return (
-    <span className="icon fa fa-copy" role="img" />
+    <span className="icon fa fa-copy" alt={alt} role={!!alt ? 'img' : undefined} />
   );
 }

--- a/app/pages/lab-pages-editor/icons/DeleteIcon.jsx
+++ b/app/pages/lab-pages-editor/icons/DeleteIcon.jsx
@@ -1,0 +1,7 @@
+/* eslint-disable react/react-in-jsx-scope */
+
+export default function DeleteIcon() {
+  return (
+    <span className="icon fa fa-trash" role="img" />
+  );
+}

--- a/app/pages/lab-pages-editor/icons/DeleteIcon.jsx
+++ b/app/pages/lab-pages-editor/icons/DeleteIcon.jsx
@@ -2,6 +2,6 @@
 
 export default function DeleteIcon({ alt }) {
   return (
-    <span className="icon fa fa-trash" alt={alt} role={!!alt ? 'img' : undefined} />
+    <span className="icon fa fa-trash" aria-label={alt} role={!!alt ? 'img' : undefined} />
   );
 }

--- a/app/pages/lab-pages-editor/icons/DeleteIcon.jsx
+++ b/app/pages/lab-pages-editor/icons/DeleteIcon.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/react-in-jsx-scope */
 
-export default function DeleteIcon() {
+export default function DeleteIcon({ alt }) {
   return (
-    <span className="icon fa fa-trash" role="img" />
+    <span className="icon fa fa-trash" alt={alt} role={!!alt ? 'img' : undefined} />
   );
 }

--- a/app/pages/lab-pages-editor/icons/EditIcon.jsx
+++ b/app/pages/lab-pages-editor/icons/EditIcon.jsx
@@ -2,6 +2,6 @@
 
 export default function EditIcon({ alt }) {
   return (
-    <span className="icon fa fa-pencil" alt={alt} role={!!alt ? 'img' : undefined} />
+    <span className="icon fa fa-pencil" aria-label={alt} role={!!alt ? 'img' : undefined} />
   );
 }

--- a/app/pages/lab-pages-editor/icons/EditIcon.jsx
+++ b/app/pages/lab-pages-editor/icons/EditIcon.jsx
@@ -1,0 +1,7 @@
+/* eslint-disable react/react-in-jsx-scope */
+
+export default function EditIcon() {
+  return (
+    <span className="icon fa fa-pencil" role="img" />
+  );
+}

--- a/app/pages/lab-pages-editor/icons/EditIcon.jsx
+++ b/app/pages/lab-pages-editor/icons/EditIcon.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/react-in-jsx-scope */
 
-export default function EditIcon() {
+export default function EditIcon({ alt }) {
   return (
-    <span className="icon fa fa-pencil" role="img" />
+    <span className="icon fa fa-pencil" alt={alt} role={!!alt ? 'img' : undefined} />
   );
 }

--- a/app/pages/lab-pages-editor/icons/GripIcon.jsx
+++ b/app/pages/lab-pages-editor/icons/GripIcon.jsx
@@ -4,6 +4,7 @@
 import PropTypes from 'prop-types';
 
 export default function GripIcon({
+  alt,
   className = 'icon',
   color = 'currentColor',
   size = 16
@@ -16,7 +17,7 @@ export default function GripIcon({
   const r = (1.5 / 16) * size;
 
   return (
-    <svg width={size} height={size} className={className}>
+    <svg aria-label={alt} width={size} height={size} className={className}>
       <g fill={color}>
         <circle r={r} cx={x1} cy={y1} />
         <circle r={r} cx={x2} cy={y1} />

--- a/app/pages/lab-pages-editor/icons/GripIcon.jsx
+++ b/app/pages/lab-pages-editor/icons/GripIcon.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 
 export default function GripIcon({
   className = '',
-  color = '#000000',
+  color = 'currentColor',
   size = 16
 }) {
   const x1 = (4 / 16) * size;

--- a/app/pages/lab-pages-editor/icons/GripIcon.jsx
+++ b/app/pages/lab-pages-editor/icons/GripIcon.jsx
@@ -4,7 +4,7 @@
 import PropTypes from 'prop-types';
 
 export default function GripIcon({
-  className = '',
+  className = 'icon',
   color = 'currentColor',
   size = 16
 }) {

--- a/app/pages/lab-pages-editor/icons/MoveDownIcon.jsx
+++ b/app/pages/lab-pages-editor/icons/MoveDownIcon.jsx
@@ -1,0 +1,7 @@
+/* eslint-disable react/react-in-jsx-scope */
+
+export default function MoveDownIcon() {
+  return (
+    <span className="icon fa fa-caret-down" role="img" />
+  );
+}

--- a/app/pages/lab-pages-editor/icons/MoveDownIcon.jsx
+++ b/app/pages/lab-pages-editor/icons/MoveDownIcon.jsx
@@ -2,6 +2,6 @@
 
 export default function MoveDownIcon({ alt }) {
   return (
-    <span className="icon fa fa-caret-down" alt={alt} role={!!alt ? 'img' : undefined} />
+    <span className="icon fa fa-caret-down" aria-label={alt} role={!!alt ? 'img' : undefined} />
   );
 }

--- a/app/pages/lab-pages-editor/icons/MoveDownIcon.jsx
+++ b/app/pages/lab-pages-editor/icons/MoveDownIcon.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/react-in-jsx-scope */
 
-export default function MoveDownIcon() {
+export default function MoveDownIcon({ alt }) {
   return (
-    <span className="icon fa fa-caret-down" role="img" />
+    <span className="icon fa fa-caret-down" alt={alt} role={!!alt ? 'img' : undefined} />
   );
 }

--- a/app/pages/lab-pages-editor/icons/MoveUpIcon.jsx
+++ b/app/pages/lab-pages-editor/icons/MoveUpIcon.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/react-in-jsx-scope */
 
-export default function MoveUpIcon() {
+export default function MoveUpIcon({ alt }) {
   return (
-    <span className="icon fa fa-caret-up" role="img" />
+    <span className="icon fa fa-caret-up" alt={alt} role={!!alt ? 'img' : undefined} />
   );
 }

--- a/app/pages/lab-pages-editor/icons/MoveUpIcon.jsx
+++ b/app/pages/lab-pages-editor/icons/MoveUpIcon.jsx
@@ -2,6 +2,6 @@
 
 export default function MoveUpIcon({ alt }) {
   return (
-    <span className="icon fa fa-caret-up" alt={alt} role={!!alt ? 'img' : undefined} />
+    <span className="icon fa fa-caret-up" aria-label={alt} role={!!alt ? 'img' : undefined} />
   );
 }

--- a/app/pages/lab-pages-editor/icons/MoveUpIcon.jsx
+++ b/app/pages/lab-pages-editor/icons/MoveUpIcon.jsx
@@ -1,0 +1,7 @@
+/* eslint-disable react/react-in-jsx-scope */
+
+export default function MoveUpIcon() {
+  return (
+    <span className="icon fa fa-caret-up" role="img" />
+  );
+}

--- a/app/pages/lab-pages-editor/icons/ReturnIcon.jsx
+++ b/app/pages/lab-pages-editor/icons/ReturnIcon.jsx
@@ -2,6 +2,6 @@
 
 export default function ReturnIcon({ alt }) {
   return (
-    <span className="icon fa fa-chevron-left" alt={alt} role={!!alt ? 'img' : undefined} />
+    <span className="icon fa fa-chevron-left" aria-label={alt} role={!!alt ? 'img' : undefined} />
   );
 }

--- a/app/pages/lab-pages-editor/icons/ReturnIcon.jsx
+++ b/app/pages/lab-pages-editor/icons/ReturnIcon.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/react-in-jsx-scope */
 
-export default function ReturnIcon() {
+export default function ReturnIcon({ alt }) {
   return (
-    <span className="icon fa fa-chevron-left" role="img" />
+    <span className="icon fa fa-chevron-left" alt={alt} role={!!alt ? 'img' : undefined} />
   );
 }

--- a/app/pages/lab-pages-editor/icons/TaskIcon.jsx
+++ b/app/pages/lab-pages-editor/icons/TaskIcon.jsx
@@ -9,6 +9,7 @@ const faTaskIcons = {
 };
 
 function TaskIcon({
+  alt,
   type
 }) {
   const faTaskIcon = faTaskIcons[type] || 'fa-times-circle';

--- a/app/pages/lab-pages-editor/icons/TaskIcon.jsx
+++ b/app/pages/lab-pages-editor/icons/TaskIcon.jsx
@@ -16,9 +16,9 @@ function TaskIcon({
 
   return (
     <span
-      aria-label="Task type: text"
       className={`fa fa-fw ${faTaskIcon}`}
-      role="img"
+      aria-label={alt}
+      role={!!alt ? 'img' : undefined}
     />
   );
 }

--- a/app/pages/lab-pages-editor/icons/TaskIcon.jsx
+++ b/app/pages/lab-pages-editor/icons/TaskIcon.jsx
@@ -1,0 +1,29 @@
+/* eslint-disable react/react-in-jsx-scope */
+
+import PropTypes from 'prop-types';
+
+const faTaskIcons = {
+  'drawing': 'fa-pencil',
+  'single': 'fa-question-circle',  // Single question
+  'text': 'fa-file-text-o'
+};
+
+function TaskIcon({
+  type
+}) {
+  const faTaskIcon = faTaskIcons[type] || 'fa-times-circle';
+
+  return (
+    <span
+      aria-label="Task type: text"
+      className={`fa fa-fw ${faTaskIcon}`}
+      role="img"
+    />
+  );
+}
+
+TaskIcon.propTypes = {
+  type: PropTypes.string
+};
+
+export default TaskIcon;

--- a/css/lab-pages-editor.styl
+++ b/css/lab-pages-editor.styl
@@ -9,7 +9,7 @@ $greenBright = #1ED359
 $redBright = #E45950
 $yellow = #F0B200
 $white = #FFFFFF
-$backdropColour = #80800080
+$backdropColour = #80808080
 $shadowColour = #00000080
 
 

--- a/css/lab-pages-editor.styl
+++ b/css/lab-pages-editor.styl
@@ -9,6 +9,9 @@ $greenBright = #1ED359
 $redBright = #E45950
 $yellow = #F0B200
 $white = #FFFFFF
+$backdropColour = #80800080
+$shadowColour = #00000080
+
 
 $sizeXS = 0.25em
 $sizeS = 0.5em
@@ -235,6 +238,23 @@ $fontWeightBoldPlus = 700
 
       .status-inactive
         color: $redBright
+    
+    dialog
+      border: 1px solid $grey1
+      border-radius: $sizeM
+      box-shadow: 1px 1px 6px 0px $shadowColour
+      padding: 0
+
+      &::backdrop
+        background: $backdropColour
+      
+      .dialog-header
+        background: $teal
+        color: $white
+        padding: $sizeXS $sizeM
+
+        button
+          color: $white
     
     section
       h3

--- a/css/lab-pages-editor.styl
+++ b/css/lab-pages-editor.styl
@@ -17,6 +17,7 @@ $sizeS = 8px
 $sizeM = 16px
 $sizeL = 24px
 $sizeXL = 32px
+$sizeXXL = 64px
 
 $fontFamilies = Karla, Arial, sans-serif
 
@@ -108,6 +109,9 @@ $fontWeightBoldPlus = 700
     display: flex
     flex-direction: row
     gap: $sizeS
+  
+  .flex-wrap
+    flex-wrap: wrap
   
   .small-width
     width: 60px
@@ -253,6 +257,7 @@ $fontWeightBoldPlus = 700
         background: $teal
         color: $white
         padding: $sizeXS $sizeM
+        text-transform: uppercase
 
         button
           color: $white
@@ -267,10 +272,20 @@ $fontWeightBoldPlus = 700
           background: $white
         
         button.new-task-button
+          align-items: center
           display: flex
-          flex-direction: vertical
-          width: $sizeXL
-          height: $sizeXL
+          flex-direction: column
+          justify-content: center
+          margin-bottom: $sizeM
+          margin-right: $sizeM
+          height: $sizeXXL
+          width: $sizeXXL
+
+          &:last-child
+            margin-right: 0
+
+          .fa
+            font-size: $fontSizeXL
     
     section
       h3

--- a/css/lab-pages-editor.styl
+++ b/css/lab-pages-editor.styl
@@ -285,8 +285,6 @@ $fontWeightBoldPlus = 700
 
           > *
             vertical-align: middle
-          
-          .fa
             color: $grey1
         
         .step-controls-right

--- a/css/lab-pages-editor.styl
+++ b/css/lab-pages-editor.styl
@@ -100,6 +100,10 @@ $fontWeightBoldPlus = 700
   
   .disabled, .disabled *
     color: $grey1
+  
+  .decoration-plus
+    &::after
+      content: ' +'
 
   // General Layout
   // ---------------------------------------------------------------------------

--- a/css/lab-pages-editor.styl
+++ b/css/lab-pages-editor.styl
@@ -14,7 +14,9 @@ $shadowColour = #00000080
 
 $sizeXS = 4px
 $sizeS = 8px
-$sizeM = 20px
+$sizeM = 16px
+$sizeL = 24px
+$sizeXL = 32px
 
 $fontFamilies = Karla, Arial, sans-serif
 
@@ -123,7 +125,7 @@ $fontWeightBoldPlus = 700
     margin-bottom: $sizeXS
   
   .spacing-bottom-M
-      margin-bottom: $sizeM
+    margin-bottom: $sizeM
 
   // Component: Workflow Header
   // ---------------------------------------------------------------------------
@@ -254,6 +256,21 @@ $fontWeightBoldPlus = 700
 
         button
           color: $white
+      
+      .dialog-body
+        padding: $sizeS $sizeL
+
+        &.new-task
+          background: $grey5
+        
+        &.edit-step
+          background: $white
+        
+        button.new-task-button
+          display: flex
+          flex-direction: vertical
+          width: $sizeXL
+          height: $sizeXL
     
     section
       h3

--- a/css/lab-pages-editor.styl
+++ b/css/lab-pages-editor.styl
@@ -12,9 +12,8 @@ $white = #FFFFFF
 $backdropColour = #80808080
 $shadowColour = #00000080
 
-
-$sizeXS = 0.25em
-$sizeS = 0.5em
+$sizeXS = 4px
+$sizeS = 8px
 $sizeM = 20px
 
 $fontFamilies = Karla, Arial, sans-serif
@@ -241,7 +240,7 @@ $fontWeightBoldPlus = 700
     
     dialog
       border: 1px solid $grey1
-      border-radius: $sizeM
+      border-radius: $sizeS
       box-shadow: 1px 1px 6px 0px $shadowColour
       padding: 0
 


### PR DESCRIPTION
## PR Overview

Part of: **Pages Editor MVP** project and **FEM Lab** super-project
Follow #6898
Staging branch URL: https://pr-6915.pfe-preview.zooniverse.org/lab/1982/workflows/editor/3711?env=staging

This PR adds the "Add New Task" Dialog.

Expected behaviour:
- On the Tasks Page:
  - clicking "Add a new Task" button should open the Add New Task dialog
- On the Add New Task Dialog:
  - clicking on a Task type should...
    - create a new Step, e.g. `P0`
    - create a new Task, corresponding to the Task type, e.g. `T0`.
    - add the new Task to the new Step.
    - update the workflow resource with the task and steps (NOTE: most of the above has a POC with experimentalAddNewTaskWithStep())
    - close the Add New Task dialog, ~~then open the Edit Step dialog with the new Step selected.~~
  - pressing Esc or clicking the 'x' close button should close the dialog
- ~~On the Edit Step dialog:~~
  - ~~pressing Esc or clicking the 'x' close button should close the dialog~~
  - _No other actions for now, to be resolved in a follow up PR._

Design: Tasks Page, with 0 Tasks

<img width="462" alt="image" src="https://github.com/zooniverse/Panoptes-Front-End/assets/13952701/b3e5f3da-0ed7-405e-ad32-d86d38f42f57">

Design: "Add a new Task" dialog

<img width="408" alt="image" src="https://github.com/zooniverse/Panoptes-Front-End/assets/13952701/80956530-d9fe-456b-b680-3ccf0f878979">

Design: "Create Task" dialog (actually, it's the **"Edit Step"** dialog)

<img width="403" alt="image" src="https://github.com/zooniverse/Panoptes-Front-End/assets/13952701/e5482f4a-9526-4f06-9a54-6157c12d7704">

Code notes:
- We're using the standard HTML `<dialog>` for modals; see #6914 for additional details on some shenanigans that needed to be solved.

### Status

WIP