### PR TITLE
update non logged in home page to call out to ERAS stats service

### DIFF
--- a/app/pages/home-not-logged-in.jsx
+++ b/app/pages/home-not-logged-in.jsx
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Link } from 'react-router';
-import statsClient from 'panoptes-client/lib/stats-client';
 import Translate from 'react-translate-component';
 import counterpart from 'counterpart';
 import apiClient from 'panoptes-client/lib/api-client';

--- a/app/pages/home-not-logged-in.jsx
+++ b/app/pages/home-not-logged-in.jsx
@@ -12,6 +12,10 @@ import HomePageSocial from './home-common/social';
 import HomePageDiscover from './home-not-logged-in/discover';
 import HomePageResearch from './home-not-logged-in/research';
 
+const ERAS_STATS_URL = (process.env.NODE_ENV === 'staging' || process.env.NODE_ENV === 'development')
+  ? 'https://eras-staging.zooniverse.org'
+  : 'https://eras.zooniverse.org';
+
 counterpart.registerTranslations('en', {
   notLoggedInHomePage: {
     projects: 'See All Projects',
@@ -64,17 +68,18 @@ export default class HomePage extends React.Component {
   }
 
   getClassificationCounts() {
-    let count = 0;
-    statsClient.query({
-      period: 'year',
-      type: 'classification'
+    fetch(ERAS_STATS_URL + '/classifications').then((response) => {
+      if (!response.ok) {
+        console.error('ERAS STATS CLASSIFICATIONS COUNT NONLOGGED IN HOMEPAGE: ERROR')
+        throw Error(response.statusText);
+      }
+      return response.json()
+    }).then(data => {
+      let count = data.total_count
+      this.setState({ count });
+    }).catch((err) => {
+      console.error('ERAS TOTAL CLASSIFICATION COUNT: from ' + ERAS_STATS_URL + '/classifications', err)
     })
-    .then((data) => {
-      data.map((statObject) => {
-        count += statObject.doc_count;
-      });
-      this.setState({ count }); // number will only appear on production
-    });
   }
 
   showDialog(event) {


### PR DESCRIPTION
Staging branch URL: https://pr-6925.pfe-preview.zooniverse.org

Updating Non-Logged In Home Page to Callout to new Stats Service for Stress Testing new stats service. (Stress testing CPU usage on managed timescale + current app resources, to see if we need to scale up) 

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [ ] Can you submit a classification?
- [x] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [x] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
