### PR TITLE
Pages Editor: link Steps together

### DIFF
--- a/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
@@ -48,7 +48,6 @@ export default function TasksPage() {
 
   function experimentalLinkSteps() {
     const newSteps = linkStepsInWorkflow(workflow?.steps, workflow?.tasks);
-    console.log('+++ linkStepsInWorkflow()\n', workflow?.steps, '\n==>\n', newSteps);
     update({ steps: newSteps });
   }
 

--- a/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
@@ -34,7 +34,7 @@ export default function TasksPage() {
       ...workflow.tasks,
       [newTaskKey]: newTask
     };
-    const steps = [...workflow.steps, newStep];
+    const steps = linkStepsInWorkflow([...workflow.steps, newStep]);
 
     update({ tasks, steps });
   }

--- a/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
@@ -93,16 +93,18 @@ export default function TasksPage() {
           }}
         >
           <button
-            className="big primary"
+            className="big"
             onClick={experimentalReset}
             type="button"
+            style={{ margin: '0 4px' }}
           >
             RESET
           </button>
           <button
-            className="big primary"
+            className="big"
             onClick={experimentalLinkSteps}
             type="button"
+            style={{ margin: '0 4px' }}
           >
             LINK
           </button>

--- a/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
@@ -49,6 +49,7 @@ export default function TasksPage() {
   function experimentalLinkSteps() {
     const newSteps = linkStepsInWorkflow(workflow?.steps, workflow?.tasks);
     console.log('+++ linkStepsInWorkflow()\n', workflow?.steps, '\n==>\n', newSteps);
+    update({ steps: newSteps });
   }
 
   if (!workflow) return null;

--- a/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
@@ -9,6 +9,7 @@ import getNewTaskKey from '../../helpers/getNewTaskKey.js';
 import getNewStepKey from '../../helpers/getNewStepKey.js';
 import createTask from '../../helpers/createTask.js';
 import createStep from '../../helpers/createStep.js';
+import linkStepsInWorkflow from '../../helpers/linkStepsInWorkflow.js';
 // import strings from '../../strings.json'; // TODO: move all text into strings
 
 import NewTaskButtonAndDialog from './components/NewTaskButtonAndDialog.jsx';
@@ -45,6 +46,11 @@ export default function TasksPage() {
     });
   }
 
+  function experimentalLinkSteps() {
+    const newSteps = linkStepsInWorkflow(workflow?.steps);
+    console.log('+++ linkStepsInWorkflow()\n', workflow?.steps, '\n==>\n', newSteps);
+  }
+
   if (!workflow) return null;
 
   return (
@@ -77,13 +83,30 @@ export default function TasksPage() {
             />
           ))}
         </ul>
-        <button
-          className="big primary"
-          onClick={experimentalReset}
-          type="button"
+
+        {/* EXPERIMENTAL */}
+        <div
+          style={{
+            padding: '16px',
+            margin: '8px 0',
+            border: '2px dashed #c04040'
+          }}
         >
-          RESET
-        </button>
+          <button
+            className="big primary"
+            onClick={experimentalReset}
+            type="button"
+          >
+            RESET
+          </button>
+          <button
+            className="big primary"
+            onClick={experimentalLinkSteps}
+            type="button"
+          >
+            LINK
+          </button>
+        </div>
       </section>
     </div>
   );

--- a/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
@@ -47,7 +47,7 @@ export default function TasksPage() {
   }
 
   function experimentalLinkSteps() {
-    const newSteps = linkStepsInWorkflow(workflow?.steps);
+    const newSteps = linkStepsInWorkflow(workflow?.steps, workflow?.tasks);
     console.log('+++ linkStepsInWorkflow()\n', workflow?.steps, '\n==>\n', newSteps);
   }
 

--- a/app/pages/lab-pages-editor/helpers/linkStepsInWorkflow.js
+++ b/app/pages/lab-pages-editor/helpers/linkStepsInWorkflow.js
@@ -1,0 +1,30 @@
+/*
+Links Steps in a Workflow together.
+
+- Input: array of Steps
+- Output: copy of array of Steps, with their `step.next`s updated.
+
+Rules for linking steps:
+- If a Step is branching, then step.next = undefined.
+- If a Step is the final step in the array, then step.next = undefined. 
+- Otherwise, each Step's step.next will be the ID of the next Step in the array.
+ */
+
+export default function linkStepsInWorkflow(steps = []) {
+  const newSteps = [];
+
+  return newSteps;
+}
+
+/*
+Checks if a step is branching.
+- If yes, returns Task ID of the Task that's causing the branch.
+- If no, returns false.
+ */
+function isStepBranching(step) {
+  // TODO: actually implement the darn check
+  // FEM's convertWorkflowToUseSteps has a method for checking if a Task is branching (isThereBranching())
+  // https://github.com/zooniverse/front-end-monorepo/blob/master/packages/lib-classifier/src/store/helpers/convertWorkflowToUseSteps/convertWorkflowToUseSteps.js
+  // QUESTION: what happens when a Step has multiple branching Questions?
+  return false;
+}

--- a/app/pages/lab-pages-editor/helpers/linkStepsInWorkflow.js
+++ b/app/pages/lab-pages-editor/helpers/linkStepsInWorkflow.js
@@ -14,9 +14,9 @@ export default function linkStepsInWorkflow(steps = [], tasks = {}) {
   const newSteps = steps.map((step, index) => {
     const [stepId, stepBody] = step;
 
-    const isFinalStep = index >= (steps.length - 1);
+    const isFinalStepInArray = index >= (steps.length - 1);
     const canBranch = canStepBranch(step, tasks);
-    const nextStep = (isFinalStep || canBranch) ? undefined : steps[index+1]?.[0];
+    const nextStep = (isFinalStepInArray || canBranch) ? undefined : steps[index+1]?.[0];
 
     const newStepBody = {
       ...stepBody,

--- a/app/pages/lab-pages-editor/helpers/linkStepsInWorkflow.js
+++ b/app/pages/lab-pages-editor/helpers/linkStepsInWorkflow.js
@@ -14,7 +14,7 @@ export default function linkStepsInWorkflow(steps = [], tasks = {}) {
   const newSteps = steps.map((step, index) => {
     const [stepId, stepBody] = step;
 
-    const isFinalStepInArray = index >= (steps.length - 1);
+    const isFinalStepInArray = index === (steps.length - 1);
     const canBranch = canStepBranch(step, tasks);
     const nextStep = (isFinalStepInArray || canBranch) ? undefined : steps[index+1]?.[0];
 

--- a/app/pages/lab-pages-editor/helpers/linkStepsInWorkflow.js
+++ b/app/pages/lab-pages-editor/helpers/linkStepsInWorkflow.js
@@ -5,7 +5,7 @@ Links Steps in a Workflow together.
 - Output: COPY of array of Steps, with their `step.next`s updated.
 
 Rules for linking steps:
-- If a Step is branching, then step.next = undefined.
+- If a Step *can* branch, then step.next = undefined.
 - If a Step is the final step in the array, then step.next = undefined. 
 - Otherwise, each Step's step.next will be the ID of the next Step in the array.
  */
@@ -15,8 +15,8 @@ export default function linkStepsInWorkflow(steps = [], tasks = {}) {
     const [stepId, stepBody] = step;
 
     const isFinalStep = index >= (steps.length - 1);
-    const isBranching = isStepBranching(step, tasks);
-    const nextStep = (isFinalStep || isBranching) ? undefined : steps[index+1]?.[0];
+    const canBranch = canStepBranch(step, tasks);
+    const nextStep = (isFinalStep || canBranch) ? undefined : steps[index+1]?.[0];
 
     const newStepBody = {
       ...stepBody,
@@ -30,14 +30,25 @@ export default function linkStepsInWorkflow(steps = [], tasks = {}) {
 }
 
 /*
-Checks if a step is branching.
+Checks if a step can branch. We're not asking if the step IS branching, but if it *can.*
 - If yes, returns Task ID of the Task that's causing the branch.
+  - If multiple Tasks qualify, only return the FIRST.
 - If no, returns false.
  */
-function isStepBranching(step, tasks) {
-  // TODO: actually implement the darn check
-  // FEM's convertWorkflowToUseSteps has a method for checking if a Task is branching (isThereBranching())
-  // https://github.com/zooniverse/front-end-monorepo/blob/master/packages/lib-classifier/src/store/helpers/convertWorkflowToUseSteps/convertWorkflowToUseSteps.js
-  // QUESTION: what happens when a Step has multiple branching Questions?
-  return false;
+function canStepBranch(step = [], tasks = {}) {
+  // TODO/QUESTION: what happens when a Step has multiple branching Questions?
+  // TODO/CHECK: if a Question Task has 0 answers, is it still considered 'branching'? Check what happens with FEM Classifier
+  const [stepId, stepBody] = step;
+  const tasksInStep = stepBody?.taskKeys?.map(taskKey => tasks[taskKey] ? [taskKey, tasks[taskKey]]: undefined).filter(task => !!task) || []
+  return tasksInStep.find(canTaskBranch)?.[0] || false;
+}
+
+/*
+Checks if a task can branch.
+- Returns true or false.
+- At the moment, only "Single Question" tasks can branch. 
+- Compare with "isTaskBranching" in https://github.com/zooniverse/front-end-monorepo/blob/master/packages/lib-classifier/src/store/helpers/convertWorkflowToUseSteps/convertWorkflowToUseSteps.js
+ */
+function canTaskBranch([taskKey, task]) {
+  return task?.type === 'single';
 }

--- a/app/pages/lab-pages-editor/helpers/linkStepsInWorkflow.js
+++ b/app/pages/lab-pages-editor/helpers/linkStepsInWorkflow.js
@@ -1,8 +1,8 @@
 /*
 Links Steps in a Workflow together.
 
-- Input: array of Steps
-- Output: copy of array of Steps, with their `step.next`s updated.
+- Input: array of Steps, and Tasks object.
+- Output: COPY of array of Steps, with their `step.next`s updated.
 
 Rules for linking steps:
 - If a Step is branching, then step.next = undefined.
@@ -10,8 +10,21 @@ Rules for linking steps:
 - Otherwise, each Step's step.next will be the ID of the next Step in the array.
  */
 
-export default function linkStepsInWorkflow(steps = []) {
-  const newSteps = [];
+export default function linkStepsInWorkflow(steps = [], tasks = {}) {
+  const newSteps = steps.map((step, index) => {
+    const [stepId, stepBody] = step;
+
+    const isFinalStep = index >= (steps.length - 1);
+    const isBranching = isStepBranching(step, tasks);
+    const nextStep = (isFinalStep || isBranching) ? undefined : steps[index+1]?.[0];
+
+    const newStepBody = {
+      ...stepBody,
+      next: nextStep
+    };
+
+    return [stepId, newStepBody];
+  })
 
   return newSteps;
 }
@@ -21,7 +34,7 @@ Checks if a step is branching.
 - If yes, returns Task ID of the Task that's causing the branch.
 - If no, returns false.
  */
-function isStepBranching(step) {
+function isStepBranching(step, tasks) {
   // TODO: actually implement the darn check
   // FEM's convertWorkflowToUseSteps has a method for checking if a Task is branching (isThereBranching())
   // https://github.com/zooniverse/front-end-monorepo/blob/master/packages/lib-classifier/src/store/helpers/convertWorkflowToUseSteps/convertWorkflowToUseSteps.js


### PR DESCRIPTION
## PR Overview

Part of: **Pages Editor MVP** project and **FEM Lab** super-project
Follows #6915
Staging branch URL: https://pr-6939.pfe-preview.zooniverse.org/lab/1982/workflows/editor/3711?env=staging

This PR ensures that Steps are automatically linked to each other (i.e. Page 1 goes to Page 2, etc) 

- `linkStepsInWorkflow()` added.
  - This function is currently called every time a new Step is added...
  - ...and _will_ also be called when a Step is rearranged or deleted. 
- The rules:
  - If a Step ~~is branching~~ **can** branch OR is the last Step in the workflow, step.next = undefined
  - Otherwise, that Step's step.next = next step's ID. 

Additional thoughts:
- In the future, linkStepsInWorkflow() could be part of a cleanUp() workflow function, which is called every time the WF is updated, and does the following: 1. delete all Tasks that don't belong to a Step, 2. delete anything in Steps.tasks without a corresponding Task, 3. delete all empty Steps (i.e. no associated Tasks), and 4. automatically link all Steps together (linkStepsInWorkflow()).
- See [FEM's convertWorkflowToUseSteps.spec.js](https://github.com/zooniverse/front-end-monorepo/blob/master/packages/lib-classifier/src/store/helpers/convertWorkflowToUseSteps/convertWorkflowToUseSteps.spec.js) for an idea of how Workflows with Steps should look like.

### Status

~~WIP, I'm still running tests to ensure this is working as expected. Actually rearranging Steps will be done in a separate PR.~~ Ready for review.

Do not merge until 6915 is merged. Currently targets pages-editor-pt8 for reviewing purposes; this will be re-targeted to master when ready.