### PR TITLE
Pages Editor: allow Steps to be rearranged

### DIFF
--- a/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
@@ -54,6 +54,11 @@ export default function TasksPage() {
 
   function moveStep(from, to) {
     console.log('+++ moveStep: ', from, to);
+    const oldSteps = workflow?.steps || [];
+    if (from < 0 || to < 0 || from >= oldSteps.length || to >= oldSteps.length) return;
+
+    const steps = linkStepsInWorkflow(moveItemInArray(oldSteps, from, to));
+    update({ steps });
   }
 
   if (!workflow) return null;

--- a/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
@@ -53,7 +53,6 @@ export default function TasksPage() {
   }
 
   function moveStep(from, to) {
-    console.log('+++ moveStep: ', from, to);
     const oldSteps = workflow?.steps || [];
     if (from < 0 || to < 0 || from >= oldSteps.length || to >= oldSteps.length) return;
 

--- a/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
@@ -86,6 +86,7 @@ export default function TasksPage() {
         <ul className="steps-list" aria-label="Pages/Steps">
           {workflow.steps.map(([stepKey, step], index) => (
             <StepItem
+              key={`stepItem-${stepKey}`}
               allTasks={workflow.tasks}
               moveStep={moveStep}
               step={step}

--- a/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
@@ -4,6 +4,7 @@
 /* eslint-disable radix */
 /* eslint-disable react/jsx-boolean-value */
 
+import { useState } from 'react'
 import { useWorkflowContext } from '../../context.js';
 import createStep from '../../helpers/createStep.js';
 import createTask from '../../helpers/createTask.js';
@@ -18,6 +19,7 @@ import StepItem from './components/StepItem.jsx';
 
 export default function TasksPage() {
   const { workflow, update } = useWorkflowContext();
+  const [ activeDragItem, setActiveDragItem ] = useState(-1);  // Keeps track of active item being dragged (StepItem). This is because "dragOver" CAN'T read the data from dragEnter.dataTransfer.getData().
   const isActive = true; // TODO
 
   function experimentalAddNewTaskWithStep(taskType) {
@@ -87,8 +89,10 @@ export default function TasksPage() {
           {workflow.steps.map(([stepKey, step], index) => (
             <StepItem
               key={`stepItem-${stepKey}`}
+              activeDragItem={activeDragItem}
               allTasks={workflow.tasks}
               moveStep={moveStep}
+              setActiveDragItem={setActiveDragItem}
               step={step}
               stepKey={stepKey}
               stepIndex={index}

--- a/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
@@ -5,11 +5,12 @@
 /* eslint-disable react/jsx-boolean-value */
 
 import { useWorkflowContext } from '../../context.js';
-import getNewTaskKey from '../../helpers/getNewTaskKey.js';
-import getNewStepKey from '../../helpers/getNewStepKey.js';
-import createTask from '../../helpers/createTask.js';
 import createStep from '../../helpers/createStep.js';
+import createTask from '../../helpers/createTask.js';
+import getNewStepKey from '../../helpers/getNewStepKey.js';
+import getNewTaskKey from '../../helpers/getNewTaskKey.js';
 import linkStepsInWorkflow from '../../helpers/linkStepsInWorkflow.js';
+import moveItemInArray from '../../helpers/moveItemInArray.js';
 // import strings from '../../strings.json'; // TODO: move all text into strings
 
 import NewTaskButtonAndDialog from './components/NewTaskButtonAndDialog.jsx';
@@ -51,6 +52,10 @@ export default function TasksPage() {
     update({ steps: newSteps });
   }
 
+  function moveStep(from, to) {
+    console.log('+++ moveStep: ', from, to);
+  }
+
   if (!workflow) return null;
 
   return (
@@ -75,11 +80,13 @@ export default function TasksPage() {
           </select>
         </div>
         <ul className="steps-list" aria-label="Pages/Steps">
-          {workflow.steps.map(([stepKey, step]) => (
+          {workflow.steps.map(([stepKey, step], index) => (
             <StepItem
               allTasks={workflow.tasks}
+              moveStep={moveStep}
               step={step}
               stepKey={stepKey}
+              stepIndex={index}
             />
           ))}
         </ul>

--- a/app/pages/lab-pages-editor/components/TasksPage/components/StepItem.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/StepItem.jsx
@@ -57,7 +57,7 @@ function StepItem({
           <div className="step-controls-center">
             <button
               aria-label={`Rearrange Page ${stepKey} upwards`}
-              className="plain"
+              className="move-button plain"
               onClick={moveStepUp}
               type="button"
             >
@@ -69,7 +69,7 @@ function StepItem({
             />
             <button
               aria-label={`Rearrange Page/Step ${stepKey} downwards`}
-              className="plain"
+              className="move-button plain"
               onClick={moveStepDown}
               type="button"
             >

--- a/app/pages/lab-pages-editor/components/TasksPage/components/StepItem.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/StepItem.jsx
@@ -35,9 +35,45 @@ function StepItem({
     moveStep(stepIndex, stepIndex + 1);
   }
 
+  function onDragStart(e) {
+    // TODO: drag item is step-body, but only the drag handle should initiate drag start
+    console.log('+++ dragStart:', e);
+    e.dataTransfer.setData('text/plain', stepIndex + '');
+  }
+
+  function onDragEnter(e) {
+    e.preventDefault(); // Prevent default, to ensure onDrop works.
+  }
+
+  function onDragLeave(e) {
+    e.preventDefault();
+  }
+
+  function onDrop(e) {
+    const from = parseInt(e.dataTransfer.getData('text/plain')) || 0;
+    const to = stepIndex;
+    console.log('+++ onDrop: ', from, to);
+    moveStep(from, to);
+    e.preventDefault();
+  }
+
+  function onDragOver(e) {
+    e.preventDefault(); // Prevent default, to ensure onDrop works.
+  }
+
   return (
     <li className="step-item">
-      <div className="step-body">
+      <div
+        className="step-drop-target"
+        onDragEnter={onDragEnter}
+        onDragOver={onDragOver}
+        onDrop={onDrop}
+      ></div>
+      <div
+        className="step-body"
+        draggable="true" /* This is enumerated, and has to be a string. */
+        onDragStart={onDragStart}
+      >
         <div className="step-controls flex-row spacing-bottom-XS">
           <span className="step-controls-left" />
           <div className="step-controls-center">
@@ -52,7 +88,6 @@ function StepItem({
             {/* TODO: add drag/drop functionality. Perhaps this needs to be wider, too. */}
             <GripIcon
               className="grab-handle"
-              draggable="true" /* This is enumerated, and has to be a string. */
             />
             <button
               aria-label={`Rearrange Page/Step ${stepKey} downwards`}
@@ -88,6 +123,7 @@ function StepItem({
           })}
         </ul>
       </div>
+      <div className="step-drop-target"></div>
     </li>
   );
 }

--- a/app/pages/lab-pages-editor/components/TasksPage/components/StepItem.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/StepItem.jsx
@@ -38,7 +38,6 @@ function StepItem({
 
   function onDragStart(e) {
     // TODO: drag item is step-body, but only the drag handle should initiate drag start
-    console.log('+++ dragStart:', e);
     e.dataTransfer.setData('text/plain', stepIndex + '');
   }
 

--- a/app/pages/lab-pages-editor/components/TasksPage/components/StepItem.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/StepItem.jsx
@@ -37,52 +37,57 @@ function StepItem({
 
   return (
     <li className="step-item">
-      <div className="step-controls flex-row spacing-bottom-XS">
-        <span className="step-controls-left" />
-        <div className="step-controls-center">
-          <button
-            aria-label={`Rearrange Page ${stepKey} upwards`}
-            className="plain"
-            onClick={moveStepUp}
-            type="button"
-          >
-            <MoveUpIcon />
-          </button>
-          {/* TODO: add drag/drop functionality. Perhaps this needs to be wider, too. */}
-          <GripIcon className="grab-handle" />
-          <button
-            aria-label={`Rearrange Page/Step ${stepKey} downwards`}
-            className="plain"
-            onClick={moveStepDown}
-            type="button"
-          >
-            <MoveDownIcon />
-          </button>
-        </div>
-        <div className="step-controls-right">
-          <button aria-label={`Delete Page/Step ${stepKey}`} className="plain" type="button">
-            <DeleteIcon />
-          </button>
-          <button aria-label={`Copy Page/Step ${stepKey}`} className="plain" type="button">
-            <CopyIcon />
-          </button>
-          <button aria-label={`Edit Page/Step ${stepKey}`} className="plain" type="button">
-            <EditIcon />
-          </button>
-        </div>
-      </div>
-      <ul className="tasks-list" aria-label={`Tasks for Page/Step ${stepKey}`}>
-        {taskKeys.map((taskKey) => {
-          const task = allTasks[taskKey];
-          return (
-            <TaskItem
-              key={`taskItem-${taskKey}`}
-              task={task}
-              taskKey={taskKey}
+      <div className="step-body">
+        <div className="step-controls flex-row spacing-bottom-XS">
+          <span className="step-controls-left" />
+          <div className="step-controls-center">
+            <button
+              aria-label={`Rearrange Page ${stepKey} upwards`}
+              className="plain"
+              onClick={moveStepUp}
+              type="button"
+            >
+              <MoveUpIcon />
+            </button>
+            {/* TODO: add drag/drop functionality. Perhaps this needs to be wider, too. */}
+            <GripIcon
+              className="grab-handle"
+              draggable="true" /* This is enumerated, and has to be a string. */
             />
-          );
-        })}
-      </ul>
+            <button
+              aria-label={`Rearrange Page/Step ${stepKey} downwards`}
+              className="plain"
+              onClick={moveStepDown}
+              type="button"
+            >
+              <MoveDownIcon />
+            </button>
+          </div>
+          <div className="step-controls-right">
+            <button aria-label={`Delete Page/Step ${stepKey}`} className="plain" type="button">
+              <DeleteIcon />
+            </button>
+            <button aria-label={`Copy Page/Step ${stepKey}`} className="plain" type="button">
+              <CopyIcon />
+            </button>
+            <button aria-label={`Edit Page/Step ${stepKey}`} className="plain" type="button">
+              <EditIcon />
+            </button>
+          </div>
+        </div>
+        <ul className="tasks-list" aria-label={`Tasks for Page/Step ${stepKey}`}>
+          {taskKeys.map((taskKey) => {
+            const task = allTasks[taskKey];
+            return (
+              <TaskItem
+                key={`taskItem-${taskKey}`}
+                task={task}
+                taskKey={taskKey}
+              />
+            );
+          })}
+        </ul>
+      </div>
     </li>
   );
 }

--- a/app/pages/lab-pages-editor/components/TasksPage/components/StepItem.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/StepItem.jsx
@@ -136,9 +136,8 @@ function DropTarget({
 
   function onDrop(e) {
     const from = parseInt(e.dataTransfer.getData('text/plain')) || 0;
-    const to = targetIndex;
-    console.log('+++ onDrop: ', from, to);
-    // moveStep(from, to);
+    const to = (from < targetIndex) ? targetIndex - 1 : targetIndex;
+    moveStep(from, to);
     setActive(false);
     e.preventDefault();
   }

--- a/app/pages/lab-pages-editor/components/TasksPage/components/StepItem.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/StepItem.jsx
@@ -5,6 +5,7 @@
 /* eslint-disable react/jsx-boolean-value */
 /* eslint-disable react/forbid-prop-types */
 
+import { useState } from 'react';
 import PropTypes from 'prop-types';
 
 // import strings from '../../../strings.json'; // TODO: move all text into strings
@@ -41,34 +42,11 @@ function StepItem({
     e.dataTransfer.setData('text/plain', stepIndex + '');
   }
 
-  function onDragEnter(e) {
-    e.preventDefault(); // Prevent default, to ensure onDrop works.
-  }
-
-  function onDragLeave(e) {
-    e.preventDefault();
-  }
-
-  function onDrop(e) {
-    const from = parseInt(e.dataTransfer.getData('text/plain')) || 0;
-    const to = stepIndex;
-    console.log('+++ onDrop: ', from, to);
-    moveStep(from, to);
-    e.preventDefault();
-  }
-
-  function onDragOver(e) {
-    e.preventDefault(); // Prevent default, to ensure onDrop works.
-  }
-
   return (
     <li className="step-item">
-      <div
-        className="step-drop-target"
-        onDragEnter={onDragEnter}
-        onDragOver={onDragOver}
-        onDrop={onDrop}
-      ></div>
+      {(stepIndex === 0)
+      ? <DropTarget targetIndex={stepIndex} moveStep={moveStep} />
+      : null}
       <div
         className="step-body"
         draggable="true" /* This is enumerated, and has to be a string. */
@@ -123,7 +101,7 @@ function StepItem({
           })}
         </ul>
       </div>
-      <div className="step-drop-target"></div>
+      <DropTarget targetIndex={stepIndex + 1} moveStep={moveStep} />
     </li>
   );
 }
@@ -135,5 +113,45 @@ StepItem.propTypes = {
   stepKey: PropTypes.string,
   stepIndex: PropTypes.number
 };
+
+function DropTarget({
+  targetIndex = 0,
+  moveStep = () => {}
+}) {
+  const [active, setActive] = useState(false);
+
+  function onDragEnter(e) {
+    setActive(true);
+    e.preventDefault(); // Prevent default, to ensure onDrop works.
+  }
+
+  function onDragLeave(e) {
+    setActive(false);
+    e.preventDefault();  // Probably unnecessary for onDrop, but oh well
+  }
+
+  function onDragOver(e) {
+    e.preventDefault(); // Prevent default, to ensure onDrop works.
+  }
+
+  function onDrop(e) {
+    const from = parseInt(e.dataTransfer.getData('text/plain')) || 0;
+    const to = targetIndex;
+    console.log('+++ onDrop: ', from, to);
+    // moveStep(from, to);
+    setActive(false);
+    e.preventDefault();
+  }
+
+  return (
+    <div
+      className={`step-drop-target ${active ? 'active' : ''}`}
+      onDragEnter={onDragEnter}
+      onDragLeave={onDragLeave}
+      onDragOver={onDragOver}
+      onDrop={onDrop}
+    ></div>
+  );
+}
 
 export default StepItem;

--- a/app/pages/lab-pages-editor/components/TasksPage/components/StepItem.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/StepItem.jsx
@@ -75,7 +75,11 @@ function StepItem({
         {taskKeys.map((taskKey) => {
           const task = allTasks[taskKey];
           return (
-            <TaskItem task={task} taskKey={taskKey} />
+            <TaskItem
+              key={`taskItem-${taskKey}`}
+              task={task}
+              taskKey={taskKey}
+            />
           );
         })}
       </ul>

--- a/app/pages/lab-pages-editor/components/TasksPage/components/StepItem.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/StepItem.jsx
@@ -18,24 +18,44 @@ import MoveUpIcon from '../../../icons/MoveUpIcon.jsx';
 
 function StepItem({
   allTasks,
+  moveStep = () => {},
   step,
-  stepKey
+  stepKey,
+  stepIndex
 }) {
   if (!step || !stepKey || !allTasks) return <li className="step-item">ERROR: could not render Step</li>;
 
   const taskKeys = step.taskKeys || [];
+
+  function moveStepUp() {
+    moveStep(stepIndex, stepIndex - 1);
+  }
+
+  function moveStepDown() {
+    moveStep(stepIndex, stepIndex + 1);
+  }
 
   return (
     <li className="step-item">
       <div className="step-controls flex-row spacing-bottom-XS">
         <span className="step-controls-left" />
         <div className="step-controls-center">
-          <button aria-label={`Rearrange Page ${stepKey} upwards`} className="plain" type="button">
+          <button
+            aria-label={`Rearrange Page ${stepKey} upwards`}
+            className="plain"
+            onClick={moveStepUp}
+            type="button"
+          >
             <MoveUpIcon />
           </button>
           {/* TODO: add drag/drop functionality. Perhaps this needs to be wider, too. */}
           <GripIcon className="grab-handle" />
-          <button aria-label={`Rearrange Page/Step ${stepKey} downwards`} className="plain" type="button">
+          <button
+            aria-label={`Rearrange Page/Step ${stepKey} downwards`}
+            className="plain"
+            onClick={moveStepDown}
+            type="button"
+          >
             <MoveDownIcon />
           </button>
         </div>
@@ -65,8 +85,10 @@ function StepItem({
 
 StepItem.propTypes = {
   allTasks: PropTypes.object,
+  moveStep: PropTypes.func,
   step: PropTypes.object,
-  stepKey: PropTypes.string
+  stepKey: PropTypes.string,
+  stepIndex: PropTypes.number
 };
 
 export default StepItem;

--- a/app/pages/lab-pages-editor/components/WorkflowHeader.jsx
+++ b/app/pages/lab-pages-editor/components/WorkflowHeader.jsx
@@ -4,7 +4,6 @@
 /* eslint-disable radix */
 
 import PropTypes from 'prop-types';
-import { Link } from 'react-router';
 
 import ReturnIcon from '../icons/ReturnIcon.jsx';
 import { useWorkflowContext } from '../context.js';
@@ -48,10 +47,10 @@ export default function WorkflowHeader({
 
   return (
     <div className="workflow-header flex-row">
-      <Link to={returnUrl}>
+      <a href={returnUrl}> {/* Formerly <Link> from 'react-router', but React was throwing Legacy Context errors. */}
         <ReturnIcon />
         {strings.PagesEditor.components.WorkflowHeader.return}
-      </Link>
+      </a>
       <div
         role="tablist"
         className="flex-row flex-item justify-around"

--- a/app/pages/lab-pages-editor/components/WorkflowSettingsPage.jsx
+++ b/app/pages/lab-pages-editor/components/WorkflowSettingsPage.jsx
@@ -12,7 +12,6 @@ export default function WorkflowSettingsPage() {
   function onSubmit(e) {
     e.preventDefault();
     try {
-      console.log('+++ onSubmit: ', e);
       // TODO: on Submit, run update() on every available field.
       // also, make sure the 'data-updaterule' rules are implemented.
     } catch (err) {

--- a/app/pages/lab-pages-editor/helpers/moveItemInArray.js
+++ b/app/pages/lab-pages-editor/helpers/moveItemInArray.js
@@ -1,0 +1,22 @@
+/*
+Moves an item in an array.
+
+- Input: array of whatever, index of item to be moved from, index to move item to.
+- Output: returns a COPY of the array, with the items moved.
+ */
+
+export default function moveItemInArray(
+  array = [],
+  from = -1,
+  to = -1
+) {
+  if (from < 0 || to < -1 || from >= array.length || to >= array.length) {
+    throw new Error('moveItemInArray: invalid "to" or "from" index values.');
+  }
+  
+  const newArray = array.slice();  // Create a copy of the original array that we can modify
+  newArray.splice((from < to) ? to + 1 : to, 0, array[from]);  // Add item to destination position
+  newArray.splice((from < to) ? from : from + 1, 1);  // Remove item from old position
+
+  return newArray;
+}

--- a/app/pages/lab-pages-editor/helpers/moveItemInArray.js
+++ b/app/pages/lab-pages-editor/helpers/moveItemInArray.js
@@ -3,6 +3,10 @@ Moves an item in an array.
 
 - Input: array of whatever, index of item to be moved from, index to move item to.
 - Output: returns a COPY of the array, with the items moved.
+
+Examples:
+- moveItemInArray(['a','b','c','d','e'], 2, 3) => ['a', 'b', 'd', 'c', 'e']
+- moveItemInArray(['a','b','c','d','e'], 2, 1) => ['a', 'c', 'b', 'd', 'e']
  */
 
 export default function moveItemInArray(

--- a/css/lab-pages-editor.styl
+++ b/css/lab-pages-editor.styl
@@ -305,11 +305,12 @@ $fontWeightBoldPlus = 700
       padding: 0
 
     .step-item
-      background: $grey5
-      border: 1px solid $grey1
-      border-radius: $sizeXS
-      margin-top: $sizeM
-      padding: $sizeS $sizeM
+      .step-body
+        background: $grey5
+        border: 1px solid $grey1
+        border-radius: $sizeXS
+        margin-top: $sizeM
+        padding: $sizeS $sizeM
 
       .step-controls
         .step-controls-left

--- a/css/lab-pages-editor.styl
+++ b/css/lab-pages-editor.styl
@@ -312,11 +312,17 @@ $fontWeightBoldPlus = 700
         border-radius: $sizeXS
         padding: $sizeS $sizeM
 
+        &:has(.move-button:focus)  // Note: :has() is experimental as of Nov 2023, and not supported on Firefox
+          outline: 2px solid $yellow
+
       .step-controls
         cursor: grab
 
         &:active
           cursor: grabbing
+        
+        .move-button:focus
+          outline: 1px solid $yellow
         
         .step-controls-left
           min-width: 5rem

--- a/css/lab-pages-editor.styl
+++ b/css/lab-pages-editor.styl
@@ -301,15 +301,15 @@ $fontWeightBoldPlus = 700
     
     .steps-list
       list-style: none
-      margin: $sizeM 0 0 0
+      margin: $sizeS 0 0 0
       padding: 0
 
     .step-item
+
       .step-body
         background: $grey5
         border: 1px solid $grey1
         border-radius: $sizeXS
-        margin-top: $sizeM
         padding: $sizeS $sizeM
 
       .step-controls
@@ -335,6 +335,9 @@ $fontWeightBoldPlus = 700
 
             .fa
               color: $grey3
+
+      .step-drop-target
+        padding: $sizeXS
 
     .tasks-list
       list-style: none

--- a/css/lab-pages-editor.styl
+++ b/css/lab-pages-editor.styl
@@ -313,6 +313,11 @@ $fontWeightBoldPlus = 700
         padding: $sizeS $sizeM
 
       .step-controls
+        cursor: grab
+
+        &:active
+          cursor: grabbing
+        
         .step-controls-left
           min-width: 5rem
         

--- a/css/lab-pages-editor.styl
+++ b/css/lab-pages-editor.styl
@@ -337,7 +337,11 @@ $fontWeightBoldPlus = 700
               color: $grey3
 
       .step-drop-target
-        padding: $sizeXS
+        padding: $sizeS
+
+        &.active
+          background: $greenBright
+          padding: $sizeL $sizeS
 
     .tasks-list
       list-style: none


### PR DESCRIPTION
## PR Overview

Part of: **Pages Editor MVP** project and **FEM Lab** super-project
Follows #6939
Staging branch URL: https://pr-6947.pfe-preview.zooniverse.org/lab/1982/workflows/editor/3711?env=staging

This PR allows Pages/Steps in the workflow.steps array to be rearranged.

- New helper: `moveItemInArray()`. This is a pretty useful general-purpose utility function, as it turns out.
- TasksPage: new `moveStep()` function can be called to rearrange Pages/Steps, _run a cleanup process that re-links the newly arranged Pages/Steps,_ and saves the changes to Panoptes.
- StepsItem:
  - New action: pressing the up/down buttons will rearrange the Page/Step.
  - **[TODO]** New action: Page/Step can be rearranged via dragging & dropping

### Status

WIP, I still need to do that drag & drop.

Do not merge until 6915 + 6939 are merged. Currently targets pages-editor-pt9 for reviewing purposes; this will be re-targeted to master when ready.