### PR TITLE
[DRAFT] Add admin pages for user_groups

### DIFF
--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -237,7 +237,8 @@ export default {
       createAdmin: 'Manage Users',
       projectStatus: 'Set Project Status',
       grantbot: 'Grantbot',
-      organizationStatus: 'Set Organization Status'
+      organizationStatus: 'Set Organization Status',
+      userGroupStatus: 'Set User Group Status',
     },
     notAdminMessage: 'You are not an administrator',
     notSignedInMessage: 'You are not signed in'

--- a/app/pages/admin.jsx
+++ b/app/pages/admin.jsx
@@ -55,6 +55,14 @@ const AdminPage = ({ user, children }) => {
                 >
                   <Translate content="userAdminPage.nav.organizationStatus" />
                 </Link>
+                <Link
+                  to="/admin/user-group-status"
+                  type="button"
+                  className="secret-button admin-button"
+                  activeClassName="active"
+                >
+                  <Translate content="userAdminPage.nav.userGroupStatus" />
+                </Link>
               </nav>
             </aside>
             <section className="admin-tab-content">

--- a/app/pages/admin/user-group-search-selector.jsx
+++ b/app/pages/admin/user-group-search-selector.jsx
@@ -1,3 +1,4 @@
+import { debounce } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { browserHistory } from 'react-router';
@@ -16,11 +17,11 @@ class SearchSelector extends Component {
     browserHistory.push(['/admin/user-group-status', userGroupID].join('/'));
   }
 
-  searchByName(value) {
+  searchByName = debounce((value) => {
     const query = {
       search: `%${value}%`
     };
-    if ((value != null ? value.trim().length : undefined) > 5) {
+    if ((value != null ? value.trim().length : undefined) > 3) {
       return apiClient.type('user_groups').get(query, {
         page_size: 10
       }).then((userGroups) => {
@@ -33,7 +34,7 @@ class SearchSelector extends Component {
     } else {
       return Promise.resolve({ options: [] });
     }
-  }
+  }, 500); // 500ms delay
 
   render() {
     const { className } = this.props;

--- a/app/pages/admin/user-group-search-selector.jsx
+++ b/app/pages/admin/user-group-search-selector.jsx
@@ -1,0 +1,64 @@
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { browserHistory } from 'react-router';
+import apiClient from 'panoptes-client/lib/api-client';
+import Select from 'react-select';
+
+class SearchSelector extends Component {
+  constructor(props) {
+    super(props);
+    this.navigateToUserGroup = this.navigateToUserGroup.bind(this);
+    this.searchByName = this.searchByName.bind(this);
+  }
+
+  navigateToUserGroup(userGroupOption) {
+    const userGroupID = userGroupOption.value;
+    browserHistory.push(['/admin/user-group-status', userGroupID].join('/'));
+  }
+
+  searchByName(value) {
+    const query = {
+      search: `%${value}%`
+    };
+    if ((value != null ? value.trim().length : undefined) > 5) {
+      return apiClient.type('user_groups').get(query, {
+        page_size: 10
+      }).then((userGroups) => {
+        const opts = userGroups.map(userGroup => ({
+          value: userGroup.id,
+          label: userGroup.display_name
+        }));
+        return { options: opts };
+      });
+    } else {
+      return Promise.resolve({ options: [] });
+    }
+  }
+
+  render() {
+    const { className } = this.props;
+
+    return (
+      <Select.Async
+        multi={false}
+        name="resourcesid"
+        placeholder="Display Name:"
+        value=""
+        searchPromptText="Search by display name..."
+        loadOptions={this.searchByName}
+        onChange={this.navigateToUserGroup}
+        className={`search card-search standard-input ${className}`}
+      />
+    );
+  }
+}
+
+SearchSelector.propTypes = {
+  className: PropTypes.string
+};
+
+SearchSelector.defaultProps = {
+  className: ''
+};
+
+export default SearchSelector;

--- a/app/pages/admin/user-group-status-list.jsx
+++ b/app/pages/admin/user-group-status-list.jsx
@@ -1,0 +1,80 @@
+import React, { Component } from 'react';
+import { Link } from 'react-router';
+import apiClient from 'panoptes-client/lib/api-client';
+
+import SearchSelector from './user-group-search-selector';
+import LoadingIndicator from '../../components/loading-indicator';
+import Paginator from '../../talk/lib/paginator';
+
+class UserGroupStatusList extends Component {
+  constructor(props) {
+    super(props);
+    this.getUserGroups = this.getUserGroups.bind(this);
+    this.renderUserGroupList = this.renderUserGroupList.bind(this);
+    this.renderUserGroupListItem = this.renderUserGroupListItem.bind(this);
+    this.state = {
+      loading: false,
+      userGroups: [],
+      error: null
+    };
+  }
+
+  componentDidMount() {
+    this.getUserGroups();
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.location.query !== this.props.location.query) {
+      this.getUserGroups();
+    }
+  }
+
+  getUserGroups() {
+    const { query } = this.props.location;
+
+    this.setState({ loading: true, error: null });
+    return apiClient.type('user_groups').get(query)
+      .then((userGroups) => { this.setState({ userGroups, loading: false }); })
+      .catch((error) => { this.setState({ error: `Error requesting userGroups:, ${error}`, loading: false }); });
+  }
+
+  renderUserGroupList() {
+    const { userGroups } = this.state;
+    let meta = {};
+    if (userGroups.length > 0) {
+      meta = userGroups[0].getMeta();
+    }
+
+    return (userGroups.length === 0) ?
+      <div className="project-status-list">No user groups found for this filter</div> :
+      <div>
+        <h4 style={{ marginLeft: '20px' }}>Display Name - ID</h4>
+        <menu>
+          {userGroups.map(userGroup => this.renderUserGroupListItem(userGroup))}
+        </menu>
+        <Paginator page={meta.page} pageCount={meta.page_count} />
+      </div>;
+  }
+
+  renderUserGroupListItem(userGroup) {
+    return (
+      <li key={userGroup.id}>
+        <Link to={`/admin/user-group-status/${userGroup.id}`}>
+          <span>{userGroup.display_name} - {userGroup.id}</span>
+        </Link>
+      </li>
+    )
+  }
+
+  render() {
+    return (
+      <div className="project-status-page">
+        <SearchSelector className="project-status-search" />
+        {(this.state.error) ? <p>{this.state.error}</p> : null}
+        {(this.state.loading) ? <LoadingIndicator /> : this.renderUserGroupList()}
+      </div>
+    );
+  }
+}
+
+export default UserGroupStatusList;

--- a/app/pages/admin/user-group-status.jsx
+++ b/app/pages/admin/user-group-status.jsx
@@ -1,0 +1,97 @@
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { Link } from 'react-router';
+import apiClient from 'panoptes-client/lib/api-client';
+import moment from 'moment';
+
+import LoadingIndicator from '../../components/loading-indicator';
+
+class UserGroupStatus extends Component {
+  constructor(props) {
+    super(props);
+    this.handleInputChange = this.handleInputChange.bind(this);
+
+    this.state = {
+      userGroup: null,
+      error: null,
+      loading: false
+    };
+  }
+
+  componentDidMount() {
+    this.getUserGroup();
+  }
+
+  getUserGroup() {
+    const { id } = this.props.params;
+
+    this.setState({ loading: true, error: null });
+    return apiClient.type('user_groups').get(id)
+      .then((userGroup) => {
+        this.setState({ userGroup, loading: false });
+      })
+      .catch((error) => { this.setState({ error: `Error requesting userGroup:, ${error}`, loading: false }); });
+  }
+
+  handleInputChange(event) {
+    this.setState({ error: null, loading: true });
+
+    const change = {};
+    change[event.target.name] = event.target.checked;
+
+    this.state.userGroup.update(change).save()
+      .catch(error => this.setState({ error, loading: false }))
+      .then(() => {
+        this.getUserGroup()
+        this.setState({ error: null, loading: false });
+      });
+  }
+
+  renderError() {
+    if (this.state.error) {
+      return <div>{this.state.error}</div>;
+    }
+  }
+
+  render() {
+    if (this.state.loading) {
+      return <LoadingIndicator />;
+    }
+
+    const { userGroup } = this.state;
+
+    if (!userGroup) {
+      return <div>User Group not found</div>;
+    }
+
+    return (
+      <div className="project-status">
+        <Link to={`/groups/${userGroup.id}`}>{`${userGroup.display_name} - ${userGroup.id}`}</Link>
+        <div className="project-status__section">
+          <h4>Information</h4>
+          <ul>
+            <li>ID: {userGroup.id}</li>
+            <li>Display Name: {userGroup.display_name}</li>
+            <li>Name: {userGroup.name}</li>
+            <li>Created: {moment(userGroup.created_at).format('MMMM Do YYYY, h:mm:ss a')}</li>
+            <li>Updated: {moment(userGroup.updated_at).format('MMMM Do YYYY, h:mm:ss a')}</li>
+            <li>Join Token: {userGroup.join_token}</li>
+          </ul>
+          <h4>Visibility Settings</h4>
+          <ul>
+            <li>Stats Visibility: {userGroup.stats_visibility}</li>
+            <li>🚧 input to change stats visibility coming soon... 🚧</li>
+          </ul>
+        </div>
+      </div>
+    );
+  }
+}
+
+UserGroupStatus.propTypes = {
+  params: PropTypes.shape({
+    id: PropTypes.string
+  })
+};
+
+export default UserGroupStatus;

--- a/app/router.jsx
+++ b/app/router.jsx
@@ -18,6 +18,8 @@ import ProjectStatus from './pages/admin/project-status';
 import Grantbot from './pages/admin/grantbot';
 import OrganizationStatusList from './pages/admin/organization-status-list';
 import OrganizationStatus from './pages/admin/organization-status';
+import UserGroupStatusList from './pages/admin/user-group-status-list';
+import UserGroupStatus from './pages/admin/user-group-status';
 import EditProjectTalk from './pages/lab/talk';
 import EditMediaPage from './pages/lab/media';
 import UserProfilePage from './pages/profile/index';
@@ -372,6 +374,8 @@ export const routes = (
       <Route path="grantbot" component={Grantbot} />
       <Route path="organization-status" component={OrganizationStatusList} />
       <Route path="organization-status/:owner/:name" component={OrganizationStatus} />
+      <Route path="user-group-status" component={UserGroupStatusList} />
+      <Route path="user-group-status/:id" component={UserGroupStatus} />
     </Route>
 
     <Route path="todo" component={() => <div className="content-container"><i className="fa fa-cogs"></i> TODO</div>} />


### PR DESCRIPTION
Staging branch URL: https://pr-6968.pfe-preview.zooniverse.org/admin/user-group-status?env=staging

Describe your changes.
- adds admin user_group list (paginated)
- adds admin user_group view
- [ ] adds input to change `stats_visibility`
- [ ] adds other input(s) to change other properties?

Questions
- a user_group is created for every user? if that's correct, I'm not sure the paginated list of user_groups is helpful, maybe there's just a search (similar to admin for users)

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
