### PR TITLE
Fix notification-section tests

### DIFF
--- a/app/pages/notifications/notification-section.jsx
+++ b/app/pages/notifications/notification-section.jsx
@@ -19,6 +19,7 @@ export default class NotificationSection extends Component {
       lastMeta: { },
       loading: false,
       notificationData: [],
+      notifications: [],
       notificationsMap: { },
       page: 1,
       project: null
@@ -318,5 +319,6 @@ NotificationSection.contextTypes = {
 
 NotificationSection.defaultProps = {
   expanded: false,
-  toggleSection: () => {}
+  toggleSection: () => {},
+  user: null
 };

--- a/app/pages/notifications/notification-section.spec.js
+++ b/app/pages/notifications/notification-section.spec.js
@@ -138,12 +138,26 @@ describe('Notification Section', function() {
     const notificationsCounter = {
       update: sinon.stub()
     };
-    wrapper = shallow(
-      <NotificationSection expanded={true} />,
-      { context: { notificationsCounter }, disableLifeCycleMethods: true }
-    );
-    wrapper.setState({ notifications: newNotifications });
-    wrapper.instance().markAsRead(newNotifications[0]);
+
+    before(function () {
+      wrapper = shallow(
+        <NotificationSection
+          expanded={true}
+          section="zooniverse"
+          user={{ id: '1' }}
+        />,
+        {
+          context: { notificationsCounter }, 
+          disableLifeCycleMethods: true
+        }
+      );
+      wrapper.setState({
+        loading: false,
+        notificationData: [],
+        notifications: newNotifications
+      });
+      wrapper.instance().markAsRead(newNotifications[0]);
+    });
 
     it('should update read notification as read (delivered)', function () {
       assert.equal(newNotifications[0].update.calledWith({ delivered: true }), true);


### PR DESCRIPTION
Staging branch URL: https://pr-6972.pfe-preview.zooniverse.org

Fixes issue noted with recent PRs CI testing on node v20.10.0. The NotificationSection tests were providing a non-iterable value for an item that the component needs to be iterable.

This issue reminded me notifications would benefit from a refactor like #6815 or similar.

Describe your changes.
- refactor tests with props and state values such that component doesn't error when shallow rendered for tests

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
