### PR TITLE
Pages Editor: implement Edit Task Form

### DIFF
--- a/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
@@ -62,6 +62,7 @@ export default function TasksPage() {
     update({ steps });
   }
 
+  // aka openEditStepDialog
   function editStep(stepIndex) {
     setActiveStepIndex(stepIndex);
     editStepDialog.current?.openDialog();
@@ -69,6 +70,17 @@ export default function TasksPage() {
 
   function openNewTaskDialog() {
     newTaskDialog.current?.openDialog();
+  }
+
+  function deleteTask(taskKey) {
+    // TODO
+  }
+
+  function updateTask(taskKey, task) {
+    if (!taskKey) return;
+    const tasks = JSON.parse(JSON.stringify(workflow?.tasks || {}));
+    tasks[taskKey] = task
+    update({tasks});
   }
 
   if (!workflow) return null;
@@ -123,6 +135,8 @@ export default function TasksPage() {
           allTasks={workflow.tasks}
           step={workflow.steps[activeStepIndex]}
           stepIndex={activeStepIndex}
+          deleteTask={deleteTask}
+          updateTask={updateTask}
         />
 
         {/* EXPERIMENTAL */}

--- a/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/EditStepDialog.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/EditStepDialog.jsx
@@ -67,9 +67,6 @@ function EditStepDialog({
             />
           );
         })}
-        <div className="edit-task-form-controls">
-          <button>Save</button>
-        </div>
       </form>
     </dialog>
   );

--- a/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/EditStepDialog.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/EditStepDialog.jsx
@@ -4,6 +4,12 @@ import PropTypes from 'prop-types';
 import EditTaskForm from './EditTaskForm.jsx';
 import CloseIcon from '../../../../icons/CloseIcon.jsx';
 
+const taskNames = {
+  'drawing': 'Drawing',
+  'single': 'Single Question',
+  'text': 'Text',
+}
+
 function EditStepDialog({
   allTasks = {},
   step = [],
@@ -29,7 +35,9 @@ function EditStepDialog({
     };
   });
 
-  const title = 'Create a (???) Task'
+  const firstTask = allTasks?.[taskKeys?.[0]]
+  const taskName = taskNames[firstTask?.type] || '???';
+  const title = `Edit ${taskName} Task`;
 
   return (
     <dialog

--- a/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/EditStepDialog.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/EditStepDialog.jsx
@@ -7,7 +7,8 @@ import CloseIcon from '../../../../icons/CloseIcon.jsx';
 function EditStepDialog({
   allTasks = {},
   step = [],
-  stepIndex = -1
+  stepIndex = -1,
+  updateTask
 }, forwardedRef) {
   const [ stepKey, stepBody ] = step ;
   const taskKeys = stepBody?.taskKeys || [];
@@ -62,6 +63,7 @@ function EditStepDialog({
               key={`editTaskForm-${taskKey}`}
               task={task}
               taskKey={taskKey}
+              updateTask={updateTask}
             />
           );
         })}

--- a/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/EditStepDialog.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/EditStepDialog.jsx
@@ -76,6 +76,14 @@ function EditStepDialog({
           );
         })}
       </form>
+      <div className="dialog-footer">
+        <button
+          onClick={closeDialog}
+          type="button"
+        >
+          Done
+        </button>
+      </div>
     </dialog>
   );
 }

--- a/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/EditStepDialog.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/EditStepDialog.jsx
@@ -76,8 +76,10 @@ function EditStepDialog({
           );
         })}
       </form>
-      <div className="dialog-footer">
+      <div className="dialog-footer flex-row">
+        <div className="flex-item" />
         <button
+          className="big"
           onClick={closeDialog}
           type="button"
         >

--- a/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/EditTaskForm.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/EditTaskForm.jsx
@@ -1,6 +1,8 @@
+import SingleQuestionTask from './types/SingleQuestionTask.jsx';
 import TextTask from './types/TextTask.jsx';
 
 const taskTypes = {
+  'single': SingleQuestionTask,
   'text': TextTask
 };
 

--- a/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/EditTaskForm.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/EditTaskForm.jsx
@@ -6,19 +6,24 @@ const taskTypes = {
 
 export default function EditTaskForm({  // It's not actually a form, but a fieldset that's part of a form.
   task,
-  taskKey
+  taskKey,
+  updateTask
 }) {
   if (!task || !taskKey) return <li>ERROR: could not render Task</li>;
 
   const TaskForm = taskTypes[task.type];
-
+  
   return (
     <fieldset
       className="edit-task-form"
     >
       <legend>{taskKey}</legend>
       {(TaskForm)
-        ? <TaskForm />
+        ? <TaskForm
+            task={task}
+            taskKey={taskKey}
+            updateTask={updateTask}
+          />
         : null
       }
     </fieldset>

--- a/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/EditTaskForm.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/EditTaskForm.jsx
@@ -17,7 +17,7 @@ export default function EditTaskForm({  // It's not actually a form, but a field
     <fieldset
       className="edit-task-form"
     >
-      <legend>{taskKey}</legend>
+      <legend className="task-key">{taskKey}</legend>
       {(TaskForm)
         ? <TaskForm
             task={task}

--- a/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/types/SingleQuestionTask.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/types/SingleQuestionTask.jsx
@@ -22,6 +22,11 @@ export default function SingleQuestionTask({
     updateTask(taskKey, newTask);
   }
 
+  function addChoice(e) {
+    e.preventDefault();
+    return false;
+  }
+
   // For inputs that don't have onBlur, update triggers automagically.
   // (You can't call update() in the onChange() right after setStateValue().)
   useEffect(update, [required]);
@@ -49,18 +54,42 @@ export default function SingleQuestionTask({
         {/* <button>Delete</button> */}
       </div>
       <div className="input-row">
-        <label className="narrow">
-          <input
-            type="checkbox"
-            checked={required}
-            onChange={(e) => {
-              setRequired(!!e?.target?.checked);
-            }}
-          />
-          <span>
-            Required
-          </span>
-        </label>
+        <label className="big">Choices</label>
+        <div className="flex-row">
+          <button
+            aria-label="Add choice"
+            class="big"
+            onClick={addChoice}
+            type="button"
+          >
+            +
+          </button>
+          <label className="narrow">
+            <input
+              type="checkbox"
+              checked={required}
+              onChange={(e) => {
+                setRequired(!!e?.target?.checked);
+              }}
+            />
+            <span>
+              Required
+            </span>
+          </label>
+        </div>
+      </div>
+      <div className="input-row">
+        <ul>
+          {answers.map(({ label, next }, index) => (
+            <li>
+              <input
+                key={`single-question-task-answer-${index}`}
+                type="text"
+                value={label}
+              />
+            </li>
+          ))}
+        </ul>
       </div>
       <div className="input-row">
         <label

--- a/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/types/SingleQuestionTask.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/types/SingleQuestionTask.jsx
@@ -14,8 +14,9 @@ export default function SingleQuestionTask({
   const [ required, setRequired ] = useState(!!task?.required);
 
   // Update is usually called manually onBlur, after user input is complete.
-  function update() {
-    const nonEmptyAnswers = answers.filter(({ label }) => label.trim().length > 0);
+  function update(optionalStateOverrides) { 
+    const _answers = optionalStateOverrides?.answers || answers
+    const nonEmptyAnswers = _answers.filter(({ label }) => label.trim().length > 0);
 
     const newTask = {
       ...task,
@@ -46,17 +47,13 @@ export default function SingleQuestionTask({
   }
 
   function deleteAnswer(e) {
-    console.log('+++ deleteAnswer: ', e?.target, e?.target?.dataset?.index)
-
     const index = e?.target?.dataset?.index;
     if (index === undefined || index < 0 || index >= answers.length) return;
 
     const newAnswers = answers.slice()
     newAnswers.splice(index, 1);
     setAnswers(newAnswers);
-
-    // TODO: UPDATE!
-    // update(newAnswers)
+    update({ answer: newAnswers });  // Use optional state override, since setAnswers() won't reflect new values in this step of the lifecycle.
 
     e.preventDefault();
     return false;

--- a/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/types/SingleQuestionTask.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/types/SingleQuestionTask.jsx
@@ -12,9 +12,11 @@ export default function SingleQuestionTask({
 
   // Update is usually called manually onBlur, after user input is complete.
   function update() {
+    const nonEmptyAnswers = answers.filter(({ label }) => label.trim().length > 0);
+
     const newTask = {
       ...task,
-      answers,
+      answers: nonEmptyAnswers,
       help,
       question,
       required
@@ -22,7 +24,30 @@ export default function SingleQuestionTask({
     updateTask(taskKey, newTask);
   }
 
-  function addChoice(e) {
+  function addAnswer(e) {
+    const newAnswers = [ ...answers, { label: '', next: undefined }];
+    setAnswers(newAnswers);
+
+    e.preventDefault();
+    return false;
+  }
+
+  function editAnswer(e) {
+    const index = e?.target?.dataset?.index;
+    if (index === undefined || index < 0 || index >= answers.length) return;
+
+    const answer = answers[index];
+    const newLabel = e?.target?.value || '';
+
+    setAnswers(answers.with(index, { ...answer, label: newLabel }));
+  }
+
+  function deleteAnswer(e) {
+    // const newAnswers = [ ...answers, { label: '', next: undefined }];
+    // setAnswers(newAnswers);
+    
+    // update()
+
     e.preventDefault();
     return false;
   }
@@ -58,8 +83,8 @@ export default function SingleQuestionTask({
         <div className="flex-row">
           <button
             aria-label="Add choice"
-            class="big"
-            onClick={addChoice}
+            className="big"
+            onClick={addAnswer}
             type="button"
           >
             +
@@ -81,12 +106,26 @@ export default function SingleQuestionTask({
       <div className="input-row">
         <ul>
           {answers.map(({ label, next }, index) => (
-            <li>
+            <li
+              aria-label={`Choice ${index}`}
+              className="flex-row"
+              key={`single-question-task-answer-${index}`}
+            >
               <input
-                key={`single-question-task-answer-${index}`}
+                className="flex-item"
+                onChange={editAnswer}
+                onBlur={update}
                 type="text"
                 value={label}
+                data-index={index}
               />
+              <button
+                aria-label={`Delete choice ${index}`}
+                onClick={deleteAnswer}
+                data-index={index}
+              >
+                x
+              </button>
             </li>
           ))}
         </ul>

--- a/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/types/SingleQuestionTask.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/types/SingleQuestionTask.jsx
@@ -1,0 +1,81 @@
+import { useEffect, useState } from 'react';
+
+export default function SingleQuestionTask({
+  task,
+  taskKey,
+  updateTask = () => {}
+}) {
+  const [ answers, setAnswers ] = useState(task?.answers || []);
+  const [ help, setHelp ] = useState(task?.help || '');
+  const [ question, setQuestion ] = useState(task?.question || '');  // TODO: figure out if FEM is standardising Question vs Instructions
+  const [ required, setRequired ] = useState(!!task?.required);
+
+  // Update is usually called manually onBlur, after user input is complete.
+  function update() {
+    const newTask = {
+      ...task,
+      answers,
+      help,
+      question,
+      required
+    };
+    updateTask(taskKey, newTask);
+  }
+
+  // For inputs that don't have onBlur, update triggers automagically.
+  // (You can't call update() in the onChange() right after setStateValue().)
+  useEffect(update, [required]);
+
+  return (
+    <div className="single-question-task">
+      <div className="input-row">
+        <label
+          className="big"
+          htmlFor={`task-${taskKey}-instruction`}
+        >
+          Main Text
+        </label>
+        <div className="flex-row">
+          <span className="task-key">{taskKey}</span>
+          <input
+            className="flex-item"
+            id={`task-${taskKey}-question`}
+            type="text"
+            value={question}
+            onBlur={update}
+            onChange={(e) => { setQuestion(e?.target?.value) }}
+          />
+        </div>
+        {/* <button>Delete</button> */}
+      </div>
+      <div className="input-row">
+        <label className="narrow">
+          <input
+            type="checkbox"
+            checked={required}
+            onChange={(e) => {
+              setRequired(!!e?.target?.checked);
+            }}
+          />
+          <span>
+            Required
+          </span>
+        </label>
+      </div>
+      <div className="input-row">
+        <label
+          className="big"
+          htmlFor={`task-${taskKey}-help`}
+        >
+          Help Text
+        </label>
+        <textarea
+          id={`task-${taskKey}-help`}
+          value={help}
+          onBlur={update}
+          onChange={(e) => { setHelp(e?.target?.value) }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/types/SingleQuestionTask.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/types/SingleQuestionTask.jsx
@@ -43,10 +43,15 @@ export default function SingleQuestionTask({
   }
 
   function deleteAnswer(e) {
-    // const newAnswers = [ ...answers, { label: '', next: undefined }];
-    // setAnswers(newAnswers);
-    
-    // update()
+    const index = e?.target?.dataset?.index;
+    if (index === undefined || index < 0 || index >= answers.length) return;
+
+    const newAnswers = answers.slice()
+    newAnswers.splice(index, 1);
+    setAnswers(newAnswers);
+
+    // TODO: UPDATE!
+    // update(newAnswers)
 
     e.preventDefault();
     return false;

--- a/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/types/SingleQuestionTask.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/types/SingleQuestionTask.jsx
@@ -1,5 +1,8 @@
 import { useEffect, useState } from 'react';
 
+import MinusIcon from '../../../../../icons/MinusIcon.jsx';
+import PlusIcon from '../../../../../icons/PlusIcon.jsx';
+
 export default function SingleQuestionTask({
   task,
   taskKey,
@@ -43,6 +46,8 @@ export default function SingleQuestionTask({
   }
 
   function deleteAnswer(e) {
+    console.log('+++ deleteAnswer: ', e?.target, e?.target?.dataset?.index)
+
     const index = e?.target?.dataset?.index;
     if (index === undefined || index < 0 || index >= answers.length) return;
 
@@ -92,7 +97,7 @@ export default function SingleQuestionTask({
             onClick={addAnswer}
             type="button"
           >
-            +
+            <PlusIcon />
           </button>
           <label className="narrow">
             <input
@@ -127,9 +132,10 @@ export default function SingleQuestionTask({
               <button
                 aria-label={`Delete choice ${index}`}
                 onClick={deleteAnswer}
+                className="big"
                 data-index={index}
               >
-                x
+                <MinusIcon data-index={index} />
               </button>
             </li>
           ))}

--- a/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/types/TextTask.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/types/TextTask.jsx
@@ -25,20 +25,23 @@ export default function TextTask({
   useEffect(update, [required]);
 
   return (
-    <div>
-      <div>
-        <label>Main Text</label>
-        <div className="flex-row">
-          <input
-            className="flex-item"
-            value={instruction}
-            onBlur={update}
-            onChange={(e) => { setInstruction(e?.target?.value) }}
-          />
-          <button>Delete</button>
-        </div>
+    <div className="text-task">
+      <div className="input-row">
+        <label
+          htmlFor={`task-${taskKey}-instruction`}
+        >
+          Main Text
+        </label>
+        <input
+          id={`task-${taskKey}-instruction`}
+          type="text"
+          value={instruction}
+          onBlur={update}
+          onChange={(e) => { setInstruction(e?.target?.value) }}
+        />
+        {/* <button>Delete</button> */}
       </div>
-      <div>
+      <div className="input-row">
         <label>
           <input
             type="checkbox"
@@ -50,9 +53,14 @@ export default function TextTask({
           Required
         </label>
       </div>
-      <div>
-        <label>Help Text</label>
+      <div className="input-row">
+        <label
+          htmlFor={`task-${taskKey}-help`}
+        >
+          Help Text
+        </label>
         <textarea
+          id={`task-${taskKey}-help`}
           value={help}
           onBlur={update}
           onChange={(e) => { setHelp(e?.target?.value) }}

--- a/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/types/TextTask.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/types/TextTask.jsx
@@ -1,7 +1,24 @@
+import { useState } from 'react';
+
 export default function TextTask({
   task,
-  taskKey
+  taskKey,
+  updateTask = () => {}
 }) {
+  const [ help, setHelp ] = useState(task?.help || '');
+  const [ instruction, setInstruction ] = useState(task?.instruction || '');
+  const [ required, setRequired ] = useState(!!task?.required);
+
+  function update() {
+    const newTask = {
+      ...task,
+      help,
+      instruction,
+      required
+    };
+    updateTask(taskKey, newTask);
+  }
+
   return (
     <div>
       <div>
@@ -9,19 +26,33 @@ export default function TextTask({
         <div className="flex-row">
           <input
             className="flex-item"
+            value={instruction}
+            onBlur={update}
+            onChange={(e) => { setInstruction(e?.target?.value) }}
           />
           <button>Delete</button>
         </div>
       </div>
       <div>
         <label>
-          <input type="checkbox" />
+          <input
+            type="checkbox"
+            checked={required}
+            onChange={(e) => {
+              setRequired(!!e?.target?.checked);
+              update();
+            }}
+          />
           Required
         </label>
       </div>
       <div>
         <label>Help Text</label>
-        <textarea />
+        <textarea
+          value={help}
+          onBlur={update}
+          onChange={(e) => { setHelp(e?.target?.value) }}
+        />
       </div>
     </div>
   );

--- a/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/types/TextTask.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/types/TextTask.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 export default function TextTask({
   task,
@@ -9,6 +9,7 @@ export default function TextTask({
   const [ instruction, setInstruction ] = useState(task?.instruction || '');
   const [ required, setRequired ] = useState(!!task?.required);
 
+  // Update is usually called manually onBlur, after user input is complete.
   function update() {
     const newTask = {
       ...task,
@@ -18,6 +19,10 @@ export default function TextTask({
     };
     updateTask(taskKey, newTask);
   }
+
+  // For inputs that don't have onBlur, update triggers automagically.
+  // (You can't call update() in the onChange() right after setStateValue().)
+  useEffect(update, [required]);
 
   return (
     <div>
@@ -40,7 +45,6 @@ export default function TextTask({
             checked={required}
             onChange={(e) => {
               setRequired(!!e?.target?.checked);
-              update();
             }}
           />
           Required

--- a/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/types/TextTask.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/types/TextTask.jsx
@@ -43,7 +43,7 @@ export default function TextTask({
         {/* <button>Delete</button> */}
       </div>
       <div className="input-row">
-        <label>
+        <label className="narrow">
           <input
             type="checkbox"
             checked={required}
@@ -51,7 +51,9 @@ export default function TextTask({
               setRequired(!!e?.target?.checked);
             }}
           />
-          Required
+          <span>
+            Required
+          </span>
         </label>
       </div>
       <div className="input-row">

--- a/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/types/TextTask.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/types/TextTask.jsx
@@ -28,6 +28,7 @@ export default function TextTask({
     <div className="text-task">
       <div className="input-row">
         <label
+          className="big"
           htmlFor={`task-${taskKey}-instruction`}
         >
           Main Text
@@ -55,6 +56,7 @@ export default function TextTask({
       </div>
       <div className="input-row">
         <label
+          className="big"
           htmlFor={`task-${taskKey}-help`}
         >
           Help Text

--- a/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/types/TextTask.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/types/TextTask.jsx
@@ -33,13 +33,17 @@ export default function TextTask({
         >
           Main Text
         </label>
-        <input
-          id={`task-${taskKey}-instruction`}
-          type="text"
-          value={instruction}
-          onBlur={update}
-          onChange={(e) => { setInstruction(e?.target?.value) }}
-        />
+        <div className="flex-row">
+          <span className="task-key">{taskKey}</span>
+          <input
+            className="flex-item"
+            id={`task-${taskKey}-instruction`}
+            type="text"
+            value={instruction}
+            onBlur={update}
+            onChange={(e) => { setInstruction(e?.target?.value) }}
+          />
+        </div>
         {/* <button>Delete</button> */}
       </div>
       <div className="input-row">

--- a/app/pages/lab-pages-editor/icons/CloseIcon.jsx
+++ b/app/pages/lab-pages-editor/icons/CloseIcon.jsx
@@ -1,5 +1,3 @@
-/* eslint-disable react/react-in-jsx-scope */
-
 export default function CloseIcon({ alt }) {
   return (
     <span className="icon fa fa-close" aria-label={alt} role={!!alt ? 'img' : undefined} />

--- a/app/pages/lab-pages-editor/icons/CopyIcon.jsx
+++ b/app/pages/lab-pages-editor/icons/CopyIcon.jsx
@@ -1,5 +1,3 @@
-/* eslint-disable react/react-in-jsx-scope */
-
 export default function CopyIcon({ alt }) {
   return (
     <span className="icon fa fa-copy" aria-label={alt} role={!!alt ? 'img' : undefined} />

--- a/app/pages/lab-pages-editor/icons/DeleteIcon.jsx
+++ b/app/pages/lab-pages-editor/icons/DeleteIcon.jsx
@@ -1,5 +1,3 @@
-/* eslint-disable react/react-in-jsx-scope */
-
 export default function DeleteIcon({ alt }) {
   return (
     <span className="icon fa fa-trash" aria-label={alt} role={!!alt ? 'img' : undefined} />

--- a/app/pages/lab-pages-editor/icons/EditIcon.jsx
+++ b/app/pages/lab-pages-editor/icons/EditIcon.jsx
@@ -1,5 +1,3 @@
-/* eslint-disable react/react-in-jsx-scope */
-
 export default function EditIcon({ alt }) {
   return (
     <span className="icon fa fa-pencil" aria-label={alt} role={!!alt ? 'img' : undefined} />

--- a/app/pages/lab-pages-editor/icons/GripIcon.jsx
+++ b/app/pages/lab-pages-editor/icons/GripIcon.jsx
@@ -1,6 +1,3 @@
-/* eslint-disable react/react-in-jsx-scope */
-/* eslint-disable react/require-default-props */
-
 import PropTypes from 'prop-types';
 
 export default function GripIcon({

--- a/app/pages/lab-pages-editor/icons/MinusIcon.jsx
+++ b/app/pages/lab-pages-editor/icons/MinusIcon.jsx
@@ -1,0 +1,5 @@
+export default function MinusIcon({ alt, ...rest }) {
+  return (
+    <span className="icon fa fa-minus" aria-label={alt} role={!!alt ? 'img' : undefined} {...rest} />
+  );
+}

--- a/app/pages/lab-pages-editor/icons/MoveDownIcon.jsx
+++ b/app/pages/lab-pages-editor/icons/MoveDownIcon.jsx
@@ -1,5 +1,3 @@
-/* eslint-disable react/react-in-jsx-scope */
-
 export default function MoveDownIcon({ alt }) {
   return (
     <span className="icon fa fa-caret-down" aria-label={alt} role={!!alt ? 'img' : undefined} />

--- a/app/pages/lab-pages-editor/icons/MoveUpIcon.jsx
+++ b/app/pages/lab-pages-editor/icons/MoveUpIcon.jsx
@@ -1,5 +1,3 @@
-/* eslint-disable react/react-in-jsx-scope */
-
 export default function MoveUpIcon({ alt }) {
   return (
     <span className="icon fa fa-caret-up" aria-label={alt} role={!!alt ? 'img' : undefined} />

--- a/app/pages/lab-pages-editor/icons/PlusIcon.jsx
+++ b/app/pages/lab-pages-editor/icons/PlusIcon.jsx
@@ -1,0 +1,5 @@
+export default function PlusIcon({ alt, ...rest }) {
+  return (
+    <span className="icon fa fa-plus" aria-label={alt} role={!!alt ? 'img' : undefined} {...rest} />
+  );
+}

--- a/app/pages/lab-pages-editor/icons/ReturnIcon.jsx
+++ b/app/pages/lab-pages-editor/icons/ReturnIcon.jsx
@@ -1,5 +1,3 @@
-/* eslint-disable react/react-in-jsx-scope */
-
 export default function ReturnIcon({ alt }) {
   return (
     <span className="icon fa fa-chevron-left" aria-label={alt} role={!!alt ? 'img' : undefined} />

--- a/app/pages/lab-pages-editor/icons/TaskIcon.jsx
+++ b/app/pages/lab-pages-editor/icons/TaskIcon.jsx
@@ -1,5 +1,3 @@
-/* eslint-disable react/react-in-jsx-scope */
-
 import PropTypes from 'prop-types';
 
 const faTaskIcons = {

--- a/css/lab-pages-editor.styl
+++ b/css/lab-pages-editor.styl
@@ -337,7 +337,10 @@ $fontWeightBoldPlus = 700
           
           textarea
             min-height: 8em
-    
+        
+      .dialog-footer
+        padding: $sizeXS $sizeM
+
     section
       h3
         color: $black

--- a/css/lab-pages-editor.styl
+++ b/css/lab-pages-editor.styl
@@ -15,6 +15,7 @@ $shadowColour = #00000080
 
 $sizeXS = 4px
 $sizeS = 8px
+$sizeSM = 12px
 $sizeM = 16px
 $sizeL = 24px
 $sizeXL = 32px
@@ -91,8 +92,8 @@ $fontWeightBoldPlus = 700
     &.big
       border: none
       box-shadow: 1px 1px 4px 0px #00000040
-      font-size: 14px
-      padding: 12px
+      font-size: $fontSizeS
+      padding: $sizeSM
     
     &.primary
       background: $yellow
@@ -339,7 +340,14 @@ $fontWeightBoldPlus = 700
             min-height: 8em
         
       .dialog-footer
-        padding: $sizeXS $sizeM
+        padding: $sizeXS $sizeL $sizeL $sizeL
+
+        button.big
+          border: 3px solid $grey1
+          border-radius: $sizeXS
+          font-size: $fontSizeM
+          padding: $sizeS $sizeXL
+          text-transform: uppercase
 
     section
       h3

--- a/css/lab-pages-editor.styl
+++ b/css/lab-pages-editor.styl
@@ -312,12 +312,13 @@ $fontWeightBoldPlus = 700
             display: none  // TODO: reconsider design
 
           .input-row
-            margin-bottom: $sizeS
+            margin-bottom: $sizeSM
           
           label.big
             display: block
             font-weight: $fontWeightBold
             font-size: $fontSizeL
+            margin-bottom: $sizeS
             text-transform: uppercase
           
           label.narrow

--- a/css/lab-pages-editor.styl
+++ b/css/lab-pages-editor.styl
@@ -324,6 +324,7 @@ $fontWeightBoldPlus = 700
           input[type=text]
           textarea
             background: $grey6
+            border-radius: $sizeXS
             color: $black
             width: 100%
           

--- a/css/lab-pages-editor.styl
+++ b/css/lab-pages-editor.styl
@@ -294,6 +294,33 @@ $fontWeightBoldPlus = 700
       
         .dialog-body
           padding: $sizeS $sizeL
+      
+        .edit-task-form
+
+          .input-row
+            margin-bottom: $sizeS
+          
+          label.big
+            display: block
+            font-weight: $fontWeightBold
+            font-size: $fontSizeL
+            text-transform: uppercase
+
+          input[type=text]
+          input[type=checkbox]
+          textarea
+            border: 1.5px solid $grey1
+            box-shadow: 1px 1px 4px 0px #00000040 inset
+          
+          input[type=text]
+          textarea
+            background: $grey5
+            color: $black
+            font-family: $fontFamilies
+            width: 100%
+          
+          textarea
+            min-height: 8em
     
     section
       h3

--- a/css/lab-pages-editor.styl
+++ b/css/lab-pages-editor.styl
@@ -3,6 +3,7 @@ $grey2 = #808080
 $grey3 = #5C5C5C
 $grey4 = #979797
 $grey5 = #E2E5E9
+$grey6 = #EFF2F5
 $black = #000000
 $teal = #00979D
 $greenBright = #1ED359
@@ -58,6 +59,7 @@ $fontWeightBoldPlus = 700
     text-decoration: none
 
   input
+  textarea
     font-family: $fontFamilies
     font-size: $fontSizeM
   
@@ -70,6 +72,10 @@ $fontWeightBoldPlus = 700
     flex: 0 0 auto
     width: $fontSizeM
     height: $fontSizeM
+  
+  textarea
+    border: 1.5px solid $grey1
+    padding: $sizeS
   
   select
     border: 1.5px solid $grey1
@@ -305,18 +311,20 @@ $fontWeightBoldPlus = 700
             font-weight: $fontWeightBold
             font-size: $fontSizeL
             text-transform: uppercase
+          
+          label.narrow
+            > *
+              vertical-align: middle
 
           input[type=text]
           input[type=checkbox]
           textarea
-            border: 1.5px solid $grey1
             box-shadow: 1px 1px 4px 0px #00000040 inset
           
           input[type=text]
           textarea
-            background: $grey5
+            background: $grey6
             color: $black
-            font-family: $fontFamilies
             width: 100%
           
           textarea

--- a/css/lab-pages-editor.styl
+++ b/css/lab-pages-editor.styl
@@ -266,6 +266,13 @@ $fontWeightBoldPlus = 700
       &::backdrop
         background: $backdropColour
       
+      button.big
+        border: 3px solid $grey1
+        border-radius: $sizeXS
+        font-size: $fontSizeM
+        padding: $sizeS $sizeXL
+        text-transform: uppercase
+      
       .dialog-header
         background: $teal
         color: $white
@@ -335,20 +342,24 @@ $fontWeightBoldPlus = 700
             background: $grey6
             border-radius: $sizeXS
             color: $black
+            padding: $sizeS $sizeM
             width: 100%
           
           textarea
             min-height: 8em
+          
+          .single-question-task
+            ul
+              list-style: none
+              margin: 0
+              padding: 0
+            
+            li
+              margin: $sizeSM 0
+              padding: 0
         
       .dialog-footer
         padding: $sizeXS $sizeL $sizeL $sizeL
-
-        button.big
-          border: 3px solid $grey1
-          border-radius: $sizeXS
-          font-size: $fontSizeM
-          padding: $sizeS $sizeXL
-          text-transform: uppercase
 
     section
       h3

--- a/css/lab-pages-editor.styl
+++ b/css/lab-pages-editor.styl
@@ -302,6 +302,13 @@ $fontWeightBoldPlus = 700
           padding: $sizeS $sizeL
       
         .edit-task-form
+          // Yup, the form is actually a fieldset, so maybe strip out the default values
+          padding: 0
+          margin: 0
+          border: none
+
+          legend
+            display: none  // TODO: reconsider design
 
           .input-row
             margin-bottom: $sizeS


### PR DESCRIPTION
## PR Overview

Part of: **Pages Editor MVP** project and **FEM Lab** super-project
Follows #6973
Staging branch URL: https://pr-6981.pfe-preview.zooniverse.org/lab/1982/workflows/editor/3711?env=staging

This PR implements the Edit Task Form (the actual interesting bits inside the Edit Step/Page dialog).

- Currently supports editing: **Text Task** and **Single Question Task**
  - Deferred for another PR: Drawing Task
- Text Task: project owners can edit main text, help text, and is required y/n.
- Single Question Task: project owners can...
  - edit main text, help text and is required y/n
  - add, edit, and delete choices (Answers)
  - NOT choose the next Step/Page yet. That's for the next PR.

_Screenshot: user editing Page P0, Text Task T0_

<img width="400" alt="image" src="https://github.com/zooniverse/Panoptes-Front-End/assets/13952701/3947af24-a845-44e1-ac59-945d0988b816">

_Screenshot: user editing Page P0, Single Question Task T0 with 3 choices_

<img width="400" alt="image" src="https://github.com/zooniverse/Panoptes-Front-End/assets/13952701/83df9ee7-4e19-48ee-b2a8-9ade56073530">

### Status

~~WIP~~ Ready for review!

Do not merge until 6973 is merged. Currently targets pages-editor-pt11 for reviewing purposes; this will be re-targeted to master when ready.