### PR TITLE
Pages Editor: implement Branching Controls

### DIFF
--- a/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
@@ -11,6 +11,7 @@ import moveItemInArray from '../../helpers/moveItemInArray.js';
 import EditStepDialog from './components/EditStepDialog';
 import NewTaskDialog from './components/NewTaskDialog.jsx';
 import StepItem from './components/StepItem';
+import ExternalLinkIcon from '../../icons/ExternalLinkIcon.jsx';
 
 export default function TasksPage() {
   const { workflow, update } = useWorkflowContext();
@@ -100,6 +101,7 @@ export default function TasksPage() {
     update({ tasks: newTasks });
   }
 
+  const previewUrl = 'https://frontend.preview.zooniverse.org/projects/darkeshard/example-1982/classify/workflow/3711?env=staging';
   if (!workflow) return null;
 
   return (
@@ -119,13 +121,13 @@ export default function TasksPage() {
           >
             Add a new Task
           </button>
-          {/* Dev observation: the <select> should have some label to indicate it's for choosing the starting task. */}
-          <select
-            aria-label="Choose starting page"
-            className="flex-item"
+          <a
+            className="flex-item button-link"
+            href={previewUrl}
+            target='_blank'
           >
-            <option disabled>Choose starting Page</option>
-          </select>
+            Preview Workflow <ExternalLinkIcon />
+          </a>
         </div>
         <ul className="steps-list" aria-label="Pages/Steps">
           {workflow.steps.map((step, index) => (

--- a/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
@@ -115,6 +115,7 @@ export default function TasksPage() {
             <StepItem
               key={`stepItem-${step[0]}`}
               activeDragItem={activeDragItem}
+              allSteps={workflow.steps}
               allTasks={workflow.tasks}
               editStep={editStep}
               moveStep={moveStep}

--- a/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
@@ -83,6 +83,23 @@ export default function TasksPage() {
     update({tasks});
   }
 
+  // Changes the optional "next page" of a branching answer/choice
+  function updateAnswerNext(taskKey, answerIndex, next = undefined) {
+    // Check if input is valid
+    const task = workflow?.tasks?.[taskKey];
+    const answer = task?.answers[answerIndex];
+    if (!task || !answer) return;
+    
+    const newTasks = workflow.tasks ? { ...workflow.tasks } : {};  // Copy tasks
+    const newAnswers = task.answers.with(answerIndex, { ...answer, next })  // Copy, then modify, answers
+    newTasks[taskKey] = {  // Insert modified answers into the task inside the copied tasks. Phew!
+      ...task,
+      answers: newAnswers
+    }
+
+    update({ tasks: newTasks });
+  }
+
   if (!workflow) return null;
 
   return (
@@ -123,6 +140,7 @@ export default function TasksPage() {
               step={step}
               stepKey={step[0]}
               stepIndex={index}
+              updateAnswerNext={updateAnswerNext}
             />
           ))}
         </ul>

--- a/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
@@ -124,6 +124,7 @@ export default function TasksPage() {
           <a
             className="flex-item button-link"
             href={previewUrl}
+            rel="noopener noreferrer"
             target='_blank'
           >
             Preview Workflow <ExternalLinkIcon />

--- a/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
@@ -111,16 +111,16 @@ export default function TasksPage() {
           </select>
         </div>
         <ul className="steps-list" aria-label="Pages/Steps">
-          {workflow.steps.map(([stepKey, step], index) => (
+          {workflow.steps.map((step, index) => (
             <StepItem
-              key={`stepItem-${stepKey}`}
+              key={`stepItem-${step[0]}`}
               activeDragItem={activeDragItem}
               allTasks={workflow.tasks}
               editStep={editStep}
               moveStep={moveStep}
               setActiveDragItem={setActiveDragItem}
               step={step}
-              stepKey={stepKey}
+              stepKey={step[0]}
               stepIndex={index}
             />
           ))}

--- a/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/types/SingleQuestionTask.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/types/SingleQuestionTask.jsx
@@ -49,6 +49,7 @@ export default function SingleQuestionTask({
   }
 
   function deleteAnswer(e) {
+    console.log('+++ deleteAnswer', e?.target)
     const index = e?.target?.dataset?.index;
     if (index === undefined || index < 0 || index >= answers.length) return;
 
@@ -78,7 +79,7 @@ export default function SingleQuestionTask({
           <span className="task-key">{taskKey}</span>
           <input
             className="flex-item"
-            id={`task-${taskKey}-question`}
+            id={`task-${taskKey}-instruction`}
             type="text"
             value={question}
             onBlur={update}
@@ -88,7 +89,7 @@ export default function SingleQuestionTask({
         {/* <button>Delete</button> */}
       </div>
       <div className="input-row">
-        <label className="big">Choices</label>
+        <span className="big">Choices</span>
         <div className="flex-row">
           <button
             aria-label="Add choice"
@@ -98,29 +99,30 @@ export default function SingleQuestionTask({
           >
             <PlusIcon />
           </button>
-          <label className="narrow">
+          <span className="narrow">
             <input
+              id={`task-${taskKey}-required`}
               type="checkbox"
               checked={required}
               onChange={(e) => {
                 setRequired(!!e?.target?.checked);
               }}
             />
-            <span>
+            <label htmlFor={`task-${taskKey}-required`}>
               Required
-            </span>
-          </label>
+            </label>
+          </span>
         </div>
       </div>
       <div className="input-row">
         <ul>
           {answers.map(({ label, next }, index) => (
             <li
-              aria-label={`Choice ${index}`}
               className="flex-row"
               key={`single-question-task-answer-${index}`}
             >
               <input
+                aria-label={`Choice ${index}`}
                 className="flex-item"
                 onChange={editAnswer}
                 onBlur={update}
@@ -133,6 +135,7 @@ export default function SingleQuestionTask({
                 onClick={deleteAnswer}
                 className="big"
                 data-index={index}
+                type="button"
               >
                 <MinusIcon data-index={index} />
               </button>

--- a/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/types/SingleQuestionTask.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/types/SingleQuestionTask.jsx
@@ -3,10 +3,12 @@ import { useEffect, useState } from 'react';
 import MinusIcon from '../../../../../icons/MinusIcon.jsx';
 import PlusIcon from '../../../../../icons/PlusIcon.jsx';
 
+const DEFAULT_HANDLER = () => {};
+
 export default function SingleQuestionTask({
   task,
   taskKey,
-  updateTask = () => {}
+  updateTask = DEFAULT_HANDLER
 }) {
   const [ answers, setAnswers ] = useState(task?.answers || []);
   const [ help, setHelp ] = useState(task?.help || '');

--- a/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/types/TextTask.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/types/TextTask.jsx
@@ -49,18 +49,19 @@ export default function TextTask({
         {/* <button>Delete</button> */}
       </div>
       <div className="input-row">
-        <label className="narrow">
+        <span className="narrow">
           <input
+            id={`task-${taskKey}-required`}
             type="checkbox"
             checked={required}
             onChange={(e) => {
               setRequired(!!e?.target?.checked);
             }}
           />
-          <span>
+          <label htmlFor={`task-${taskKey}-required`}>
             Required
-          </span>
-        </label>
+          </label>
+        </span>
       </div>
       <div className="input-row">
         <label

--- a/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/types/TextTask.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/types/TextTask.jsx
@@ -1,9 +1,11 @@
 import { useEffect, useState } from 'react';
 
+const DEFAULT_HANDLER = () => {};
+
 export default function TextTask({
   task,
   taskKey,
-  updateTask = () => {}
+  updateTask = DEFAULT_HANDLER
 }) {
   const [ help, setHelp ] = useState(task?.help || '');
   const [ instruction, setInstruction ] = useState(task?.instruction || '');

--- a/app/pages/lab-pages-editor/components/TasksPage/components/NewTaskDialog.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/NewTaskDialog.jsx
@@ -5,9 +5,11 @@ import CloseIcon from '../../../icons/CloseIcon.jsx';
 import TaskIcon from '../../../icons/TaskIcon.jsx';
 // import strings from '../../../strings.json'; // TODO: move all text into strings
 
+const DEFAULT_HANDLER = () => {};
+
 function NewTaskDialog({
-  addTaskWithStep = () => {},
-  editStep = () => {}
+  addTaskWithStep = DEFAULT_HANDLER,
+  editStep = DEFAULT_HANDLER
 }, forwardedRef) {
   const newTaskDialog = useRef(null);
 

--- a/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/BranchingControls.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/BranchingControls.jsx
@@ -1,22 +1,46 @@
-export default function BranchingControls({ task, allSteps }) {
-  if (!task) return null;
+export default function BranchingControls({
+  allSteps = [],
+  task,
+  taskKey
+}) {
+  if (!task || !taskKey) return null;
 
   const answers = task.answers || []
   console.log('+++ task ', task)
+
+  function onChange(e) {
+    console.log('+++ onChange: ', e?.target?.value, e?.target?.dataset.index);
+  }
 
   return (
     <ul className="branching-controls">
       {answers.map((answer, index) => (
         <li key={`branching-controls-answer-${index}`}>
-          <div>{answer.label}</div>
-          <select>
-            <option>P0</option>
-            <option>P1</option>
-            <option>P2</option>
+          <div className="not-button">{answer.label}</div>
+          <select
+            data-index={index}
+            onChange={onChange}
+            value={answer?.next || ''}
+          >
+            <option
+              value={''}
+            >
+              SUBMIT
+            </option>
+            {allSteps.map(([stepKey, stepBody]) => {
+              const taskKeys = stepBody?.taskKeys?.toString() || '(none)';
+              return (
+                <option
+                  key={`branching-controls-answer-${index}-option-${stepKey}`}
+                  value={stepKey}
+                >
+                  {taskKeys}
+                </option>
+              );
+            })}
           </select>
         </li>
       ))}
-
     </ul>
   );
 }

--- a/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/BranchingControls.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/BranchingControls.jsx
@@ -16,8 +16,9 @@ export default function BranchingControls({
     <ul className="branching-controls">
       {answers.map((answer, index) => (
         <li key={`branching-controls-answer-${index}`}>
-          <div className="not-button">{answer.label}</div>
+          <div className="fake-button">{answer.label}</div>
           <select
+            className={(!answer?.next) ? 'next-is-submit' : ''}
             data-index={index}
             onChange={onChange}
             value={answer?.next || ''}
@@ -25,7 +26,7 @@ export default function BranchingControls({
             <option
               value={''}
             >
-              SUBMIT
+              Submit
             </option>
             {allSteps.map(([stepKey, stepBody]) => {
               const taskKeys = stepBody?.taskKeys?.toString() || '(none)';

--- a/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/BranchingControls.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/BranchingControls.jsx
@@ -1,0 +1,22 @@
+export default function BranchingControls({ task, allSteps }) {
+  if (!task) return null;
+
+  const answers = task.answers || []
+  console.log('+++ task ', task)
+
+  return (
+    <ul className="branching-controls">
+      {answers.map((answer, index) => (
+        <li key={`branching-controls-answer-${index}`}>
+          <div>{answer.label}</div>
+          <select>
+            <option>P0</option>
+            <option>P1</option>
+            <option>P2</option>
+          </select>
+        </li>
+      ))}
+
+    </ul>
+  );
+}

--- a/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/BranchingControls.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/BranchingControls.jsx
@@ -17,6 +17,7 @@ export default function BranchingControls({
       {answers.map((answer, index) => (
         <li key={`branching-controls-answer-${index}`}>
           <div className="fake-button">{answer.label}</div>
+          <NextStepArrow className="next-arrow" />
           <select
             className={(!answer?.next) ? 'next-is-submit' : ''}
             data-index={index}
@@ -43,5 +44,32 @@ export default function BranchingControls({
         </li>
       ))}
     </ul>
+  );
+}
+
+function NextStepArrow({
+  alt,
+  className = 'icon',
+  color = 'currentColor',
+  height = 48,
+  pad = 4,
+  strokeWidth = 2,
+  width = 16
+}) {
+  const xA = 0 + pad;
+  const xB = width * 0.5;
+  const xC = width - pad;
+  const yA = 0 + pad;
+  const yB = height - (width / 2);
+  const yC = height - pad;
+
+  return (
+    <svg aria-label={alt} width={width} height={height} className={className}>
+      <g stroke={color} strokeWidth={strokeWidth}>
+        <line x1={xB} y1={yA} x2={xB} y2={yC} />
+        <line x1={xA} y1={yB} x2={xB} y2={yC} />
+        <line x1={xC} y1={yB} x2={xB} y2={yC} />
+      </g>
+    </svg>
   );
 }

--- a/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/BranchingControls.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/BranchingControls.jsx
@@ -1,8 +1,10 @@
+const DEFAULT_HANDLER = () => {};
+
 export default function BranchingControls({
   allSteps = [],
   task,
   taskKey,
-  updateAnswerNext = () => {}
+  updateAnswerNext = DEFAULT_HANDLER
 }) {
   if (!task || !taskKey) return null;
 

--- a/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/BranchingControls.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/BranchingControls.jsx
@@ -1,15 +1,17 @@
 export default function BranchingControls({
   allSteps = [],
   task,
-  taskKey
+  taskKey,
+  updateAnswerNext = () => {}
 }) {
   if (!task || !taskKey) return null;
 
   const answers = task.answers || []
-  console.log('+++ task ', task)
 
   function onChange(e) {
-    console.log('+++ onChange: ', e?.target?.value, e?.target?.dataset.index);
+    const next = e.target?.value;
+    const index = e?.target?.dataset.index;
+    updateAnswerNext(taskKey, index, next);
   }
 
   return (

--- a/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/DropTarget.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/DropTarget.jsx
@@ -1,10 +1,12 @@
 import { useState } from 'react';
 import PropTypes from 'prop-types';
 
+const DEFAULT_HANDLER = () => {};
+
 function DropTarget({
   activeDragItem = -1,
-  moveStep = () => {},
-  setActiveDragItem = () => {},
+  moveStep = DEFAULT_HANDLER,
+  setActiveDragItem = DEFAULT_HANDLER,
   targetIndex = 0
 }) {
   const [active, setActive] = useState(false);

--- a/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/StepItem.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/StepItem.jsx
@@ -22,7 +22,8 @@ function StepItem({
   moveStep = () => {},
   setActiveDragItem = () => {},
   step,
-  stepIndex
+  stepIndex,
+  updateAnswerNext = () => {}
 }) {
   const [stepKey, stepBody] = step || [];
   if (!stepKey || !stepBody || !allSteps || !allTasks) return <li className="step-item">ERROR: could not render Step</li>;
@@ -126,6 +127,7 @@ function StepItem({
             allSteps={allSteps}
             task={branchingTask}
             taskKey={branchingTaskKey}
+            updateAnswerNext={updateAnswerNext}
           />
         )}
       </div>
@@ -147,7 +149,8 @@ StepItem.propTypes = {
   moveStep: PropTypes.func,
   setActiveDragItem: PropTypes.func,
   step: PropTypes.array,
-  stepIndex: PropTypes.number
+  stepIndex: PropTypes.number,
+  updateAnswerNext: PropTypes.func
 };
 
 export default StepItem;

--- a/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/StepItem.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/StepItem.jsx
@@ -16,6 +16,7 @@ import MoveUpIcon from '../../../../icons/MoveUpIcon.jsx';
 
 function StepItem({
   activeDragItem = -1,
+  allSteps,
   allTasks,
   editStep = () => {},
   moveStep = () => {},
@@ -24,7 +25,7 @@ function StepItem({
   stepIndex
 }) {
   const [stepKey, stepBody] = step || [];
-  if (!stepKey || !stepBody || !allTasks) return <li className="step-item">ERROR: could not render Step</li>;
+  if (!stepKey || !stepBody || !allSteps || !allTasks) return <li className="step-item">ERROR: could not render Step</li>;
 
   const taskKeys = stepBody.taskKeys || [];
 
@@ -122,7 +123,9 @@ function StepItem({
         </ul>
         {branchingTask && (
           <BranchingControls
+            allSteps={allSteps}
             task={branchingTask}
+            taskKey={branchingTaskKey}
           />
         )}
       </div>
@@ -138,6 +141,7 @@ function StepItem({
 
 StepItem.propTypes = {
   activeDragItem: PropTypes.number,
+  allSteps: PropTypes.array,
   allTasks: PropTypes.object,
   editStep: PropTypes.func,
   moveStep: PropTypes.func,

--- a/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/StepItem.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/StepItem.jsx
@@ -14,16 +14,18 @@ import GripIcon from '../../../../icons/GripIcon.jsx';
 import MoveDownIcon from '../../../../icons/MoveDownIcon.jsx';
 import MoveUpIcon from '../../../../icons/MoveUpIcon.jsx';
 
+const DEFAULT_HANDLER = () => {};
+
 function StepItem({
   activeDragItem = -1,
   allSteps,
   allTasks,
-  editStep = () => {},
-  moveStep = () => {},
-  setActiveDragItem = () => {},
+  editStep = DEFAULT_HANDLER,
+  moveStep = DEFAULT_HANDLER,
+  setActiveDragItem = DEFAULT_HANDLER,
   step,
   stepIndex,
-  updateAnswerNext = () => {}
+  updateAnswerNext = DEFAULT_HANDLER
 }) {
   const [stepKey, stepBody] = step || [];
   if (!stepKey || !stepBody || !allSteps || !allTasks) return <li className="step-item">ERROR: could not render Step</li>;

--- a/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/StepItem.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/StepItem.jsx
@@ -114,6 +114,7 @@ function StepItem({
             );
           })}
         </ul>
+        ...
       </div>
       <DropTarget
         activeDragItem={activeDragItem}

--- a/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/StepItem.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/StepItem.jsx
@@ -4,6 +4,9 @@ import PropTypes from 'prop-types';
 import DropTarget from './DropTarget.jsx';
 import TaskItem from './TaskItem.jsx';
 
+import canStepBranch from '../../../../helpers/canStepBranch.js';
+
+import BranchingControls from './BranchingControls.jsx';
 import CopyIcon from '../../../../icons/CopyIcon.jsx';
 import DeleteIcon from '../../../../icons/DeleteIcon.jsx';
 import EditIcon from '../../../../icons/EditIcon.jsx';
@@ -18,12 +21,12 @@ function StepItem({
   moveStep = () => {},
   setActiveDragItem = () => {},
   step,
-  stepKey,
   stepIndex
 }) {
-  if (!step || !stepKey || !allTasks) return <li className="step-item">ERROR: could not render Step</li>;
+  const [stepKey, stepBody] = step || [];
+  if (!stepKey || !stepBody || !allTasks) return <li className="step-item">ERROR: could not render Step</li>;
 
-  const taskKeys = step.taskKeys || [];
+  const taskKeys = stepBody.taskKeys || [];
 
   function edit() {
     editStep(stepIndex);
@@ -42,6 +45,9 @@ function StepItem({
     e.dataTransfer.setData('text/plain', stepIndex + '');
     setActiveDragItem(stepIndex);  // Use state because DropTarget's onDragEnter CAN'T read dragEvent.dataTransfer.getData()
   }
+
+  const branchingTaskKey = canStepBranch(step, allTasks);
+  const branchingTask = allTasks?.[branchingTaskKey];
 
   return (
     <li className="step-item">
@@ -114,7 +120,11 @@ function StepItem({
             );
           })}
         </ul>
-        ...
+        {branchingTask && (
+          <BranchingControls
+            task={branchingTask}
+          />
+        )}
       </div>
       <DropTarget
         activeDragItem={activeDragItem}
@@ -132,8 +142,7 @@ StepItem.propTypes = {
   editStep: PropTypes.func,
   moveStep: PropTypes.func,
   setActiveDragItem: PropTypes.func,
-  step: PropTypes.object,
-  stepKey: PropTypes.string,
+  step: PropTypes.array,
   stepIndex: PropTypes.number
 };
 

--- a/app/pages/lab-pages-editor/components/WorkflowHeader.jsx
+++ b/app/pages/lab-pages-editor/components/WorkflowHeader.jsx
@@ -4,10 +4,12 @@ import ReturnIcon from '../icons/ReturnIcon.jsx';
 import { useWorkflowContext } from '../context.js';
 import strings from '../strings.json';
 
+const DEFAULT_HANDLER = () => {};
+
 export default function WorkflowHeader({
   currentTab = 0,
   projectId = '',
-  setCurrentTab = () => {},
+  setCurrentTab = DEFAULT_HANDLER,
   tabs = []
 }) {
   const { workflow } = useWorkflowContext();
@@ -84,8 +86,8 @@ function TabButton({
   id,
   index,
   label = '',
-  onClick = () => {},
-  onKeyUp = () => {},
+  onClick = DEFAULT_HANDLER,
+  onKeyUp = DEFAULT_HANDLER,
   selected = false,
   targetPanel = ''
 }) {

--- a/app/pages/lab-pages-editor/helpers/canStepBranch.js
+++ b/app/pages/lab-pages-editor/helpers/canStepBranch.js
@@ -1,0 +1,23 @@
+/*
+Checks if a step can branch. We're not asking if the step IS branching, but if it *can.*
+- If yes, returns Task ID of the Task that's causing the branch.
+  - If multiple Tasks qualify, only return the FIRST.
+- If no, returns false.
+ */
+export default function canStepBranch(step = [], tasks = {}) {
+  // TODO/QUESTION: what happens when a Step has multiple branching Questions?
+  // TODO/CHECK: if a Question Task has 0 answers, is it still considered 'branching'? Check what happens with FEM Classifier
+  const [stepId, stepBody] = step;
+  const tasksInStep = stepBody?.taskKeys?.map(taskKey => tasks[taskKey] ? [taskKey, tasks[taskKey]]: undefined).filter(task => !!task) || []
+  return tasksInStep.find(canTaskBranch)?.[0] || false;
+}
+
+/*
+Checks if a task can branch.
+- Returns true or false.
+- At the moment, only "Single Question" tasks can branch. 
+- Compare with "isTaskBranching" in https://github.com/zooniverse/front-end-monorepo/blob/master/packages/lib-classifier/src/store/helpers/convertWorkflowToUseSteps/convertWorkflowToUseSteps.js
+ */
+function canTaskBranch([taskKey, task]) {
+  return task?.type === 'single';
+}

--- a/app/pages/lab-pages-editor/helpers/linkStepsInWorkflow.js
+++ b/app/pages/lab-pages-editor/helpers/linkStepsInWorkflow.js
@@ -10,6 +10,8 @@ Rules for linking steps:
 - Otherwise, each Step's step.next will be the ID of the next Step in the array.
  */
 
+import canStepBranch from './canStepBranch.js';
+
 export default function linkStepsInWorkflow(steps = [], tasks = {}) {
   const newSteps = steps.map((step, index) => {
     const [stepId, stepBody] = step;
@@ -27,28 +29,4 @@ export default function linkStepsInWorkflow(steps = [], tasks = {}) {
   })
 
   return newSteps;
-}
-
-/*
-Checks if a step can branch. We're not asking if the step IS branching, but if it *can.*
-- If yes, returns Task ID of the Task that's causing the branch.
-  - If multiple Tasks qualify, only return the FIRST.
-- If no, returns false.
- */
-function canStepBranch(step = [], tasks = {}) {
-  // TODO/QUESTION: what happens when a Step has multiple branching Questions?
-  // TODO/CHECK: if a Question Task has 0 answers, is it still considered 'branching'? Check what happens with FEM Classifier
-  const [stepId, stepBody] = step;
-  const tasksInStep = stepBody?.taskKeys?.map(taskKey => tasks[taskKey] ? [taskKey, tasks[taskKey]]: undefined).filter(task => !!task) || []
-  return tasksInStep.find(canTaskBranch)?.[0] || false;
-}
-
-/*
-Checks if a task can branch.
-- Returns true or false.
-- At the moment, only "Single Question" tasks can branch. 
-- Compare with "isTaskBranching" in https://github.com/zooniverse/front-end-monorepo/blob/master/packages/lib-classifier/src/store/helpers/convertWorkflowToUseSteps/convertWorkflowToUseSteps.js
- */
-function canTaskBranch([taskKey, task]) {
-  return task?.type === 'single';
 }

--- a/app/pages/lab-pages-editor/icons/ExternalLinkIcon.jsx
+++ b/app/pages/lab-pages-editor/icons/ExternalLinkIcon.jsx
@@ -1,0 +1,5 @@
+export default function ExternalLinkIcon({ alt }) {
+  return (
+    <span className="icon fa fa-external-link" aria-label={alt} role={!!alt ? 'img' : undefined} />
+  );
+}

--- a/css/lab-pages-editor.styl
+++ b/css/lab-pages-editor.styl
@@ -85,6 +85,7 @@ $fontWeightBoldPlus = 700
     padding: $sizeS
   
   button
+    border-radius: $sizeXS
     color: $black
     cursor: pointer
     font-family: $fontFamilies
@@ -102,6 +103,18 @@ $fontWeightBoldPlus = 700
       background: none
       border: none
   
+  a.button-link
+    border: 1px solid $yellow
+    border-radius: $sizeXS
+    color: $black
+    cursor: pointer
+    display: inline-block
+    font-family: $fontFamilies
+    font-size: $fontSizeS
+    line-height: 1em
+    padding: $sizeSM
+    text-align: center
+
   hr
     border-top: 1px solid $grey2
   
@@ -268,7 +281,6 @@ $fontWeightBoldPlus = 700
       
       button.big
         border: 3px solid $grey1
-        border-radius: $sizeXS
         font-size: $fontSizeM
         padding: $sizeS $sizeXL
         text-transform: uppercase

--- a/css/lab-pages-editor.styl
+++ b/css/lab-pages-editor.styl
@@ -393,6 +393,7 @@ $fontWeightBoldPlus = 700
         border-radius: $sizeXS
         padding: $sizeS $sizeM
 
+        &:active
         &:has(.move-button:focus)  // Note: :has() is experimental as of Nov 2023, and not supported on Firefox
           outline: 2px solid $yellow
 

--- a/css/lab-pages-editor.styl
+++ b/css/lab-pages-editor.styl
@@ -448,6 +448,8 @@ $fontWeightBoldPlus = 700
       padding: 0
       
       li
+        display: flex
+        flex-direction: column
         margin: 0 $sizeM $sizeL $sizeM
         padding: 0
       
@@ -460,6 +462,11 @@ $fontWeightBoldPlus = 700
         font-size: $fontSizeXS
         padding: $sizeS $sizeM
         text-align: center
+      
+      .next-arrow
+        color: $yellow
+        display: block
+        margin: 0 auto
       
       select
         background: $yellow

--- a/css/lab-pages-editor.styl
+++ b/css/lab-pages-editor.styl
@@ -333,14 +333,14 @@ $fontWeightBoldPlus = 700
           .input-row
             margin-bottom: $sizeSM
           
-          label.big
+          label.big, span.big
             display: block
             font-weight: $fontWeightBold
             font-size: $fontSizeL
             margin-bottom: $sizeS
             text-transform: uppercase
           
-          label.narrow
+          label.narrow, span.narrow
             > *
               vertical-align: middle
 

--- a/css/lab-pages-editor.styl
+++ b/css/lab-pages-editor.styl
@@ -437,6 +437,39 @@ $fontWeightBoldPlus = 700
 
       &:active
         cursor: grabbing
+    
+    ul.branching-controls
+      display: flex
+      flex-direction: row
+      flex-wrap: wrap
+      justify-content: center
+      list-style: none
+      margin: 0
+      padding: 0
+      
+      li
+        margin: 0 $sizeM $sizeL $sizeM
+        padding: 0
+      
+      .fake-button
+        background: $white
+        border: 1px solid $grey1
+        border-radius: 2px
+        color: $black
+        font-family: $fontFamilies
+        font-size: $fontSizeXS
+        padding: $sizeS $sizeM
+        text-align: center
+      
+      select
+        background: $yellow
+        border-radius: $sizeM
+        border: 2px solid $grey1
+        font-size: $fontSizeXS
+
+        &.next-is-submit
+          background: $white
+          border: 2px solid $yellow
   
   .task-key
   .step-key


### PR DESCRIPTION
## PR Overview

Part of: **Pages Editor MVP** project and **FEM Lab** super-project
Follows #6981
Staging branch URL: https://pr-6991.pfe-preview.zooniverse.org/lab/1982/workflows/editor/3711?env=staging

This PR adds the ability to **choose the next Page**, for Steps with branching Tasks.

- i.e. any Step with a Single Question Task will enable branching controls.
  - When branching controls are enabled, a choice of Next Step/Page is given for every answer/choice in the task
  - The Next Step/Page is identified by the Tasks keys within that Step/Page. 
- The visual UI doesn't fully match Sean's design (notably, the yellow arrows aren't going beyond the Step body's container) but that's
  - _(2024.02.13 EDIT: I forgot to finish this sentence earlier. It should have said "The visual UI doesn't fully match Sean's design, but that's something I'll take care of in a future PR.")_

<img width="400" alt="image" src="https://github.com/zooniverse/Panoptes-Front-End/assets/13952701/3b5dd628-d279-48be-8fcf-bad314b3c83e">

Other changes:
- Add "Preview Workflow" button (⚠️ hardcoded to WF 3711! I need to update DataManager to pull project data to get this fully working)
- When dragging Steps to rearrange, the Steps now have a yellow outline

### Status

Ready for review!

Do not merge until 6981 is merged. Currently targets pages-editor-pt12 for reviewing purposes; this will be re-targeted to master when ready.