### PR TITLE
Fix dropdown task editor dropdown dialog

### DIFF
--- a/app/classifier/tasks/dropdown/dropdown-dialog.cjsx
+++ b/app/classifier/tasks/dropdown/dropdown-dialog.cjsx
@@ -154,7 +154,7 @@ DropdownDialog = createReactClass
       return window.alert('Dropdowns must have a Title.')
 
     # for FEMLab we want to enforce a min and max number of options
-    numOptions = @state.editSelect.options['*'].length
+    numOptions = @state.editSelect.options['*']?.length
     if @props.pfeLab is false and numOptions < OPTIONS_MIN
       return window.alert('Dropdowns must have at least 4 options.')
     else if @props.pfeLab is false and numOptions > OPTIONS_MAX


### PR DESCRIPTION
Staging branch URL: https://pr-{NUMBER}.pfe-preview.zooniverse.org

Fixes dropdown editor issue - related [contact ticket](https://zooniverse.freshdesk.com/helpdesk/tickets/18612).

Describe your changes.
- add optional chaining operator to check if `options['*']` defined
- this is happening because the `editSelect` of a dependent dropdown has options keyed based on the main dropdown, so if the main dropdown is Months with option values of 1-12, then the options for the dependent Days dropdown will be keyed on 1-12, so attempting to get `options['*']` causes an `Uncaught TypeError: Cannot read properties of undefined (reading 'length')`.

To test:
- create a dropdown task with months as main select
- create dropdown dependent on month, with related number of days in month

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
