### PR TITLE
Add thumbnails for application/json subjects

### DIFF
--- a/app/components/file-viewer/canvas-viewer.jsx
+++ b/app/components/file-viewer/canvas-viewer.jsx
@@ -195,8 +195,10 @@ CanvasViewer.propTypes = {
   }),
   onLoad: PropTypes.func
 };
+const DEFAULT_HANDLER = () => true;
 /* eslint-enable react/forbid-prop-types */
 CanvasViewer.defaultProps = {
+  onLoad: DEFAULT_HANDLER,
   viewBoxDimensions: { height: 512, width: 512, x: 0, y: 0 }
 };
 

--- a/app/components/thumbnail.jsx
+++ b/app/components/thumbnail.jsx
@@ -1,6 +1,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
+import FileViewer from './file-viewer'
+
 export default class Thumbnail extends React.Component {
   constructor(props) {
     super(props);
@@ -61,11 +63,19 @@ export default class Thumbnail extends React.Component {
     }
 
     if (this.props.type === 'application') {
-      return null;
+      const fakeSubject = {
+        locations: [{ 'application/json': this.props.src }],
+        metadata: {}
+      };
+      return (
+        <div style={style}>
+          <FileViewer type='application' format='json' src={this.props.src} subject={fakeSubject} />
+        </div>
+      );
     }
 
     return (
-      <div  style={style}>
+      <div style={style}>
         <img alt="" {...this.props} src={src} {...dimensions} onError={this.handleError} />
       </div>
     );


### PR DESCRIPTION
Show a small `FileViewer` as the thumbnail for data subjects, with the MIME type `application/json`.

<img width="600" alt="Subject thumbnails for the #lensing hash tag on Black Hole Hunters." src="https://github.com/zooniverse/Panoptes-Front-End/assets/59547/e8792d84-fcd0-4f0f-bafe-6c63e940b574">


Staging branch URL: https://pr-7019.pfe-preview.zooniverse.org

You can test this out on the relaunched Black Hole Hunters, where the `Thumbnail` component is used to show subject previews for hashtags:
https://www.zooniverse.org/projects/cobalt-lensing/black-hole-hunters/talk/tags/lensing

- Closes #7020.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
