### PR TITLE
edit extension list for lab uploader

### DIFF
--- a/app/pages/lab/subject-set.cjsx
+++ b/app/pages/lab/subject-set.cjsx
@@ -17,7 +17,7 @@ isAdmin = require '../../lib/is-admin'
 
 NOOP = Function.prototype
 
-VALID_SUBJECT_EXTENSIONS = ['.jpg', '.jpeg', '.png', '.gif', '.svg', '.mp3', '.m4a', '.mpeg', '.txt', '.json']
+VALID_SUBJECT_EXTENSIONS = ['.jpg', '.jpeg', '.png', '.gif', '.svg', '.mp3', '.mp4', '.m4a', '.mpeg', '.txt', '.json']
 VALID_FILE_TYPES = [
   'text/csv',
   'text/plain',


### PR DESCRIPTION
Adds `mp4` as a supported file type to list in the Lab's drag-and-drop subject uploader (on subject set page).  File type is already supported but not included in the list displayed in the Lab.

Staging branch URL: https://pr-7025.pfe-preview.zooniverse.org
