### PR TITLE
Pages Editor: implement Delete Page action

### DIFF
--- a/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
@@ -74,7 +74,9 @@ export default function TasksPage() {
   }
 
   function deleteTask(taskKey) {
-    // TODO
+    if (!taskKey) return;
+
+    console.log('+++ deleteTask: ', taskKey);
   }
 
   function updateTask(taskKey, task) {

--- a/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
@@ -81,6 +81,36 @@ export default function TasksPage() {
 
     console.log('+++ newSteps: ', steps, '\n ===> \n', newSteps);
     console.log('+++ newTasks: ', tasks, '\n ===> \n', newTasks);
+
+    cleanupTasksAndSteps(newTasks, newSteps);
+  }
+
+  /*
+  Clean up tasks and steps.
+  - Remove orphaned references in branching tasks.
+  - Remove steps without tasks.
+  - Remove tasks not associated with any step.
+   */
+  function cleanupTasksAndSteps(tasks = {}, steps = []) {
+    const newTasks = { ...tasks };  // Copy tasks
+    const newSteps = steps.slice();  // Copy steps
+
+    const taskKeys = Object.keys(newTasks);
+    const stepKeys = newSteps.map(step => step[0]);
+
+    console.log('+++ cleanupTasksAndSteps: ', taskKeys, stepKeys);
+
+    // WARNING: modifying task object.
+    // TODO: create a deep copy before modifying?
+    Object.values(tasks).forEach(taskBody => {
+      taskBody?.answers?.forEach(answer => {
+        if (answer.next && !taskKeys.includes(answer.next) && !stepKeys.includes(answer.next)) {
+          console.log('+++ answer: ', answer);
+        }
+      })
+    });
+
+    return { tasks: newTasks, steps: newSteps };
   }
 
   // aka openEditStepDialog

--- a/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
@@ -69,43 +69,35 @@ export default function TasksPage() {
     const [ stepKey, stepBody ] = steps[stepIndex] || [];
     const tasksToBeDeleted = stepBody?.taskKeys || [];
 
-    // const confirmed = confirm(`Delete Page ${stepKey}?`);
-    // if (!confirmed) return;
-
-    // TODO
-    console.log('+++ deleteStep: ', stepKey, stepBody, tasksToBeDeleted);
+    const confirmed = confirm(`Delete Page ${stepKey}?`);
+    if (!confirmed) return;
 
     const newSteps = steps.toSpliced(stepIndex, 1);  // Copy then delete Step at stepIndex
     const newTasks = tasks ? { ...tasks } : {};  // Copy tasks
     tasksToBeDeleted.forEach(taskKey => delete newTasks[taskKey]);
 
-    console.log('+++ newSteps: ', steps, '\n ===> \n', newSteps);
-    console.log('+++ newTasks: ', tasks, '\n ===> \n', newTasks);
-
-    cleanupTasksAndSteps(newTasks, newSteps);
+    const cleanedTasksAndSteps = cleanupTasksAndSteps(newTasks, newSteps); 
+    update(cleanedTasksAndSteps);
   }
 
   /*
   Clean up tasks and steps.
   - Remove orphaned references in branching tasks.
-  - Remove steps without tasks.
-  - Remove tasks not associated with any step.
+  - TODO: Remove steps without tasks.
+  - TODO: Remove tasks not associated with any step.
    */
   function cleanupTasksAndSteps(tasks = {}, steps = []) {
-    const newTasks = { ...tasks };  // Copy tasks
+    const newTasks = structuredClone(tasks);  // Copy tasks
     const newSteps = steps.slice();  // Copy steps
 
     const taskKeys = Object.keys(newTasks);
     const stepKeys = newSteps.map(step => step[0]);
 
-    console.log('+++ cleanupTasksAndSteps: ', taskKeys, stepKeys);
-
-    // WARNING: modifying task object.
-    // TODO: create a deep copy before modifying?
     Object.values(tasks).forEach(taskBody => {
       taskBody?.answers?.forEach(answer => {
+        // If the branching answer points to a non-existent Task Key or Step Key, remove the 'next'.
         if (answer.next && !taskKeys.includes(answer.next) && !stepKeys.includes(answer.next)) {
-          console.log('+++ answer: ', answer);
+          delete answer.next;
         }
       })
     });
@@ -125,9 +117,7 @@ export default function TasksPage() {
 
   function deleteTask(taskKey) {
     if (!taskKey) return;
-
     // TODO
-    console.log('+++ deleteTask: ', taskKey);
   }
 
   function updateTask(taskKey, task) {

--- a/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
@@ -82,9 +82,9 @@ export default function TasksPage() {
 
   /*
   Clean up tasks and steps.
-  - Remove orphaned references in branching tasks.
   - TODO: Remove steps without tasks.
   - TODO: Remove tasks not associated with any step.
+  - Remove orphaned references in branching tasks.
    */
   function cleanupTasksAndSteps(tasks = {}, steps = []) {
     const newTasks = structuredClone(tasks);  // Copy tasks
@@ -93,7 +93,7 @@ export default function TasksPage() {
     const taskKeys = Object.keys(newTasks);
     const stepKeys = newSteps.map(step => step[0]);
 
-    Object.values(tasks).forEach(taskBody => {
+    Object.values(newTasks).forEach(taskBody => {
       taskBody?.answers?.forEach(answer => {
         // If the branching answer points to a non-existent Task Key or Step Key, remove the 'next'.
         if (answer.next && !taskKeys.includes(answer.next) && !stepKeys.includes(answer.next)) {

--- a/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
@@ -63,6 +63,11 @@ export default function TasksPage() {
     update({ steps });
   }
 
+  function deleteStep(stepKey) {
+    // TODO
+    console.log('+++ deleteStep: ', stepKey);
+  }
+
   // aka openEditStepDialog
   function editStep(stepIndex) {
     setActiveStepIndex(stepIndex);
@@ -76,6 +81,7 @@ export default function TasksPage() {
   function deleteTask(taskKey) {
     if (!taskKey) return;
 
+    // TODO
     console.log('+++ deleteTask: ', taskKey);
   }
 
@@ -139,6 +145,7 @@ export default function TasksPage() {
               activeDragItem={activeDragItem}
               allSteps={workflow.steps}
               allTasks={workflow.tasks}
+              deleteStep={deleteStep}
               editStep={editStep}
               moveStep={moveStep}
               setActiveDragItem={setActiveDragItem}

--- a/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
@@ -50,9 +50,29 @@ export default function TasksPage() {
     });
   }
 
-  function experimentalLinkSteps() {
-    const newSteps = linkStepsInWorkflow(workflow?.steps, workflow?.tasks);
-    update({ steps: newSteps });
+  function experimentalQuickSetup() {
+    update({
+      tasks: {
+        'T0': {
+          answers: [
+            {next: "P1", label: "Animals"},
+            {next: "P2", label: "Fruits"},
+            {label: "Neither"}
+          ],
+          help: '',
+          question: 'Do you like Animals or Fruits?',
+          required: false,
+          type: 'single'
+        },
+        'T1': { help: '', type: 'text', required: false, instruction: 'Which animal?' },
+        'T2': { help: '', type: 'text', required: false, instruction: 'Which fruit?' }
+      },
+      steps: [
+        ['P0', { next: 'P1', stepKey: 'P0', taskKeys: ["T0"] }],
+        ['P1', { next: 'P2', stepKey: 'P1', taskKeys: ["T1"] }],
+        ['P2', { stepKey: 'P2', taskKeys: ["T2"] }]
+      ]
+    });
   }
 
   function moveStep(from, to) {
@@ -223,19 +243,11 @@ export default function TasksPage() {
           </button>
           <button
             className="big"
-            onClick={experimentalLinkSteps}
+            onClick={experimentalQuickSetup}
             type="button"
             style={{ margin: '0 4px' }}
           >
-            LINK
-          </button>
-          <button
-            className="big"
-            onClick={editStep}
-            type="button"
-            style={{ margin: '0 4px' }}
-          >
-            EDIT STEP
+            QUICK SETUP
           </button>
         </div>
       </section>

--- a/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
@@ -6,6 +6,7 @@ import getNewStepKey from '../../helpers/getNewStepKey.js';
 import getNewTaskKey from '../../helpers/getNewTaskKey.js';
 import linkStepsInWorkflow from '../../helpers/linkStepsInWorkflow.js';
 import moveItemInArray from '../../helpers/moveItemInArray.js';
+import cleanupTasksAndSteps from '../../helpers/cleanupTasksAndSteps.js';
 // import strings from '../../strings.json'; // TODO: move all text into strings
 
 import EditStepDialog from './components/EditStepDialog';
@@ -98,31 +99,6 @@ export default function TasksPage() {
 
     const cleanedTasksAndSteps = cleanupTasksAndSteps(newTasks, newSteps); 
     update(cleanedTasksAndSteps);
-  }
-
-  /*
-  Clean up tasks and steps.
-  - TODO: Remove steps without tasks.
-  - TODO: Remove tasks not associated with any step.
-  - Remove orphaned references in branching tasks.
-   */
-  function cleanupTasksAndSteps(tasks = {}, steps = []) {
-    const newTasks = structuredClone(tasks);  // Copy tasks
-    const newSteps = steps.slice();  // Copy steps
-
-    const taskKeys = Object.keys(newTasks);
-    const stepKeys = newSteps.map(step => step[0]);
-
-    Object.values(newTasks).forEach(taskBody => {
-      taskBody?.answers?.forEach(answer => {
-        // If the branching answer points to a non-existent Task Key or Step Key, remove the 'next'.
-        if (answer.next && !taskKeys.includes(answer.next) && !stepKeys.includes(answer.next)) {
-          delete answer.next;
-        }
-      })
-    });
-
-    return { tasks: newTasks, steps: newSteps };
   }
 
   // aka openEditStepDialog

--- a/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
@@ -66,6 +66,9 @@ export default function TasksPage() {
   function deleteStep(stepKey) {
     // TODO
     console.log('+++ deleteStep: ', stepKey);
+    const confirmed = confirm(`Delete Page ${stepKey}?`);
+    if (!confirmed) return;
+    alert('Deleted!');
   }
 
   // aka openEditStepDialog

--- a/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
@@ -63,12 +63,24 @@ export default function TasksPage() {
     update({ steps });
   }
 
-  function deleteStep(stepKey) {
+  function deleteStep(stepIndex) {
+    if (!workflow) return;
+    const { steps, tasks } = workflow;
+    const [ stepKey, stepBody ] = steps[stepIndex] || [];
+    const tasksToBeDeleted = stepBody?.taskKeys || [];
+
+    // const confirmed = confirm(`Delete Page ${stepKey}?`);
+    // if (!confirmed) return;
+
     // TODO
-    console.log('+++ deleteStep: ', stepKey);
-    const confirmed = confirm(`Delete Page ${stepKey}?`);
-    if (!confirmed) return;
-    alert('Deleted!');
+    console.log('+++ deleteStep: ', stepKey, stepBody, tasksToBeDeleted);
+
+    const newSteps = steps.toSpliced(stepIndex, 1);  // Copy then delete Step at stepIndex
+    const newTasks = tasks ? { ...tasks } : {};  // Copy tasks
+    tasksToBeDeleted.forEach(taskKey => delete newTasks[taskKey]);
+
+    console.log('+++ newSteps: ', steps, '\n ===> \n', newSteps);
+    console.log('+++ newTasks: ', tasks, '\n ===> \n', newTasks);
   }
 
   // aka openEditStepDialog

--- a/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/types/SingleQuestionTask.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/types/SingleQuestionTask.jsx
@@ -16,7 +16,7 @@ export default function SingleQuestionTask({
   const [ required, setRequired ] = useState(!!task?.required);
 
   // Update is usually called manually onBlur, after user input is complete.
-  function update(optionalStateOverrides) { 
+  function update(optionalStateOverrides) {
     const _answers = optionalStateOverrides?.answers || answers
     const nonEmptyAnswers = _answers.filter(({ label }) => label.trim().length > 0);
 
@@ -49,15 +49,14 @@ export default function SingleQuestionTask({
   }
 
   function deleteAnswer(e) {
-    console.log('+++ deleteAnswer', e?.target)
     const index = e?.target?.dataset?.index;
     if (index === undefined || index < 0 || index >= answers.length) return;
 
     const newAnswers = answers.slice()
     newAnswers.splice(index, 1);
     setAnswers(newAnswers);
-    update({ answer: newAnswers });  // Use optional state override, since setAnswers() won't reflect new values in this step of the lifecycle.
-
+    update({ answers: newAnswers });  // Use optional state override, since setAnswers() won't reflect new values in this step of the lifecycle.
+    
     e.preventDefault();
     return false;
   }

--- a/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/StepItem.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/StepItem.jsx
@@ -34,7 +34,7 @@ function StepItem({
   const taskKeys = stepBody.taskKeys || [];
 
   function doDelete() {
-    deleteStep(stepKey);
+    deleteStep(stepIndex);
   }
 
   function doEdit() {

--- a/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/StepItem.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/StepItem.jsx
@@ -20,6 +20,7 @@ function StepItem({
   activeDragItem = -1,
   allSteps,
   allTasks,
+  deleteStep = DEFAULT_HANDLER,
   editStep = DEFAULT_HANDLER,
   moveStep = DEFAULT_HANDLER,
   setActiveDragItem = DEFAULT_HANDLER,
@@ -32,7 +33,11 @@ function StepItem({
 
   const taskKeys = stepBody.taskKeys || [];
 
-  function edit() {
+  function doDelete() {
+    deleteStep(stepKey);
+  }
+
+  function doEdit() {
     editStep(stepIndex);
   }
 
@@ -93,16 +98,21 @@ function StepItem({
             </button>
           </div>
           <div className="step-controls-right">
-            <button aria-label={`Delete Page/Step ${stepKey}`} className="plain" type="button">
+            <button
+              aria-label={`Delete Page/Step ${stepKey}`}
+              className="plain"
+              onClick={doDelete}
+              type="button"
+            >
               <DeleteIcon />
             </button>
-            <button aria-label={`Copy Page/Step ${stepKey}`} className="plain" type="button">
+            <button aria-label={`Copy Page/Step ${stepKey}`} className="disabled plain" type="button">
               <CopyIcon />
             </button>
             <button
               aria-label={`Edit Page/Step ${stepKey}`}
               className="plain"
-              onClick={edit}
+              onClick={doEdit}
               type="button"
             >
               <EditIcon />
@@ -147,6 +157,7 @@ StepItem.propTypes = {
   activeDragItem: PropTypes.number,
   allSteps: PropTypes.array,
   allTasks: PropTypes.object,
+  deleteStep: PropTypes.func,
   editStep: PropTypes.func,
   moveStep: PropTypes.func,
   setActiveDragItem: PropTypes.func,

--- a/app/pages/lab-pages-editor/helpers/cleanupTasksAndSteps.js
+++ b/app/pages/lab-pages-editor/helpers/cleanupTasksAndSteps.js
@@ -1,0 +1,26 @@
+/*
+Clean up tasks and steps.
+- TODO: Remove steps without tasks.
+- TODO: Remove tasks not associated with any step.
+- Remove orphaned references in branching tasks.
+
+- Returns { tasks, steps }
+  */
+export default function cleanupTasksAndSteps(tasks = {}, steps = []) {
+  const newTasks = structuredClone(tasks);  // Copy tasks
+  const newSteps = steps.slice();  // Copy steps
+
+  const taskKeys = Object.keys(newTasks);
+  const stepKeys = newSteps.map(step => step[0]);
+
+  Object.values(newTasks).forEach(taskBody => {
+    taskBody?.answers?.forEach(answer => {
+      // If the branching answer points to a non-existent Task Key or Step Key, remove the 'next'.
+      if (answer.next && !taskKeys.includes(answer.next) && !stepKeys.includes(answer.next)) {
+        delete answer.next;
+      }
+    })
+  });
+
+  return { tasks: newTasks, steps: newSteps };
+}

--- a/app/pages/lab-pages-editor/helpers/cleanupTasksAndSteps.js
+++ b/app/pages/lab-pages-editor/helpers/cleanupTasksAndSteps.js
@@ -5,7 +5,10 @@ Clean up tasks and steps.
 - Remove orphaned references in branching tasks.
 
 - Returns { tasks, steps }
-  */
+ */
+
+import linkStepsInWorkflow from './linkStepsInWorkflow.js';
+
 export default function cleanupTasksAndSteps(tasks = {}, steps = []) {
   const newTasks = structuredClone(tasks);  // Copy tasks
   const newSteps = steps.slice();  // Copy steps
@@ -13,6 +16,7 @@ export default function cleanupTasksAndSteps(tasks = {}, steps = []) {
   const taskKeys = Object.keys(newTasks);
   const stepKeys = newSteps.map(step => step[0]);
 
+  // Remove orphaned references in branching tasks.
   Object.values(newTasks).forEach(taskBody => {
     taskBody?.answers?.forEach(answer => {
       // If the branching answer points to a non-existent Task Key or Step Key, remove the 'next'.
@@ -22,5 +26,8 @@ export default function cleanupTasksAndSteps(tasks = {}, steps = []) {
     })
   });
 
-  return { tasks: newTasks, steps: newSteps };
+  // Remember to re-link steps to close gaps created by missing Steps.
+  const newStepsLinked = linkStepsInWorkflow(newSteps, newTasks);
+
+  return { tasks: newTasks, steps: newStepsLinked };
 }

--- a/css/lab-pages-editor.styl
+++ b/css/lab-pages-editor.styl
@@ -428,6 +428,9 @@ $fontWeightBoldPlus = 700
 
             .fa
               color: $grey3
+            
+            &.disabled
+              background: $grey2
 
       .step-drop-target
         padding: $sizeS


### PR DESCRIPTION
## PR Overview

Part of: **Pages Editor MVP** project and **FEM Lab** super-project
Follows #6991
Staging branch URL: https://pr-7046.pfe-preview.zooniverse.org/lab/1982/workflows/editor/3711?env=staging

This PR adds the ability to **delete a Step/Page**.

- Clicking on the "trash can" icon on a Page will prompt a confirmation dialog, before deleting a Step/Page.
- Any _Branching Task_ with answers that pointed to the now-deleted Page will be updated, so the answers now point to nothing (i.e. "Submit").
  - A new `cleanupTasksAndSteps()` helper function has been added to remove orphaned references in branching tasks, (this has been implemented). This maaay be updated in the future to also remove Tasks that aren't associated with any Steps, and remove Steps that have 0 Tasks. We'll see.

Other changes:
- Fixed an issue where deleting Answers in a Single Question Task (by clicking on the "minus" button) didn't actually register changes.

Notes:
- ⚠️ The "Preview Workflow" button is _still_ hardcoded to WF 3711. Shaun: please remember to fix this by loading the Project resource in DataManager in the next PR.

### Status

Ready for review!