### PR TITLE
Pages Editor: implement Associated Subject Sets & fetch more data

### DIFF
--- a/app/pages/lab-pages-editor/DataManager.jsx
+++ b/app/pages/lab-pages-editor/DataManager.jsx
@@ -2,6 +2,10 @@
 Data Manager
 Responsible for fetching, updating, and saving Workflow resources from/to
 the Panoptes service.
+
+Also fetches the project resource for secondary purposes. (e.g. figuring out
+which Subject Sets are available for the workflow, available experimental tools,
+and the workflow's preview URL.)
  */
 
 // ESLint: don't import global React, and don't use .defaultProps.
@@ -68,6 +72,7 @@ function DataManager({
   }, [workflowId]);
 
   // Listen for workflow changes, and update a counter to prompt useMemo to update the context.
+  // NOTE: we're not listening for *project* changes, as the DataManager isn't meant to update that resource.
   useEffect(() => {
     const wf = apiData.workflow;
     function onWorkflowChange() {
@@ -94,19 +99,21 @@ function DataManager({
 
       const newWorkflow = await wf.update(data).save();
 
-      setApiData({
+      setApiData((prevState) => ({
+        ...prevState,
         workflow: newWorkflow, // Note: newWorkflow is actually the same as the old wf, so useMemo will have to listen to status changing instead.
         status: 'ready'
-      });
+      }));
 
       return newWorkflow;
     }
 
     return {
+      project: apiData.project,
       workflow: apiData.workflow,
       update
     };
-  }, [apiData.workflow, updateCounter]);
+  }, [apiData.project, apiData.workflow, updateCounter]);
 
   if (!workflowId) return (<div>ERROR: no Workflow ID specified</div>);
   // if (!workflow) return null

--- a/app/pages/lab-pages-editor/DataManager.jsx
+++ b/app/pages/lab-pages-editor/DataManager.jsx
@@ -122,7 +122,12 @@ function DataManager({
     <WorkflowContext.Provider
       value={contextData}
     >
-      <div>{apiData.status}</div>
+      {apiData.status === 'fetching' && (
+        <div className="status-banner fetching">Fetching data...</div>
+      )}
+      {apiData.status === 'error' && (
+        <div className="status-banner error">ERROR: could not fetch data</div>
+      )}
       {children}
     </WorkflowContext.Provider>
   );

--- a/app/pages/lab-pages-editor/PagesEditor.jsx
+++ b/app/pages/lab-pages-editor/PagesEditor.jsx
@@ -19,8 +19,7 @@ import strings from './strings.json';
 
 function PagesEditor({ params }) {
   const { workflowID: workflowId, projectID: projectId } = params;
-  // const [currentTab, setCurrentTab] = useState(0);
-  const [currentTab, setCurrentTab] = useState(1);  // TEMP: set default tab to WorkflowSettingsPage while in development.
+  const [currentTab, setCurrentTab] = useState(0);
   const tabs = [
     {
       id: 'pages-editor_workflow-header-tab-button_task',

--- a/app/pages/lab-pages-editor/PagesEditor.jsx
+++ b/app/pages/lab-pages-editor/PagesEditor.jsx
@@ -14,12 +14,13 @@ import PropTypes from 'prop-types';
 import DataManager from './DataManager.jsx';
 import WorkflowHeader from './components/WorkflowHeader.jsx';
 import TasksPage from './components/TasksPage';
-import WorkflowSettingsPage from './components/WorkflowSettingsPage.jsx';
+import WorkflowSettingsPage from './components/WorkflowSettingsPage';
 import strings from './strings.json';
 
 function PagesEditor({ params }) {
   const { workflowID: workflowId, projectID: projectId } = params;
-  const [currentTab, setCurrentTab] = useState(0);
+  // const [currentTab, setCurrentTab] = useState(0);
+  const [currentTab, setCurrentTab] = useState(1);  // TEMP: set default tab to WorkflowSettingsPage while in development.
   const tabs = [
     {
       id: 'pages-editor_workflow-header-tab-button_task',

--- a/app/pages/lab-pages-editor/PagesEditor.jsx
+++ b/app/pages/lab-pages-editor/PagesEditor.jsx
@@ -38,6 +38,7 @@ function PagesEditor({ params }) {
       <div className="lab-pages-editor">
         <DataManager
           key={workflowId || '-'} //
+          projectId={projectId}
           workflowId={workflowId}
         >
           <WorkflowHeader

--- a/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
@@ -15,7 +15,7 @@ import StepItem from './components/StepItem';
 import ExternalLinkIcon from '../../icons/ExternalLinkIcon.jsx';
 
 export default function TasksPage() {
-  const { workflow, update } = useWorkflowContext();
+  const { project, workflow, update } = useWorkflowContext();
   const editStepDialog = useRef(null);
   const newTaskDialog = useRef(null);
   const [ activeStepIndex, setActiveStepIndex ] = useState(-1);  // Tracks which Step is being edited.
@@ -140,6 +140,7 @@ export default function TasksPage() {
     update({ tasks: newTasks });
   }
 
+  console.log('+++ project: ', project);
   const previewUrl = 'https://frontend.preview.zooniverse.org/projects/darkeshard/example-1982/classify/workflow/3711?env=staging';
   if (!workflow) return null;
 

--- a/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
@@ -7,6 +7,7 @@ import getNewTaskKey from '../../helpers/getNewTaskKey.js';
 import linkStepsInWorkflow from '../../helpers/linkStepsInWorkflow.js';
 import moveItemInArray from '../../helpers/moveItemInArray.js';
 import cleanupTasksAndSteps from '../../helpers/cleanupTasksAndSteps.js';
+import getPreviewEnv from '../../helpers/getPreviewEnv.js';
 // import strings from '../../strings.json'; // TODO: move all text into strings
 
 import EditStepDialog from './components/EditStepDialog';
@@ -230,22 +231,4 @@ export default function TasksPage() {
       </section>
     </div>
   );
-}
-
-function getPreviewEnv() {
-  const hostname = window?.location?.hostname || '';
-  const params = new URLSearchParams(window?.location?.search);
-  const explicitEnv = params.get('env');
-
-  // If an explicit ?env=... is specified, use that.
-  if (explicitEnv) return `?env=${explicitEnv}`;
-
-  // The following URLs default to using staging:
-  // https://local.zooniverse.org:3735/lab/1982/workflows/editor/3711
-  // https://pr-7046.pfe-preview.zooniverse.org/lab/1982/workflows/editor/3711?env=staging
-  if (hostname.match(/^(local|.*\.pfe-preview)\.zooniverse\.org$/ig)) {
-    return '?env=staging'
-  }
-
-  return '';
 }

--- a/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
@@ -140,8 +140,8 @@ export default function TasksPage() {
     update({ tasks: newTasks });
   }
 
-  console.log('+++ project: ', project);
-  const previewUrl = 'https://frontend.preview.zooniverse.org/projects/darkeshard/example-1982/classify/workflow/3711?env=staging';
+  const previewEnv = getPreviewEnv();
+  const previewUrl = `https://frontend.preview.zooniverse.org/projects/${project?.slug}/classify/workflow/${workflow?.id}${previewEnv}`;
   if (!workflow) return null;
 
   return (
@@ -230,4 +230,22 @@ export default function TasksPage() {
       </section>
     </div>
   );
+}
+
+function getPreviewEnv() {
+  const hostname = window?.location?.hostname || '';
+  const params = new URLSearchParams(window?.location?.search);
+  const explicitEnv = params.get('env');
+
+  // If an explicit ?env=... is specified, use that.
+  if (explicitEnv) return `?env=${explicitEnv}`;
+
+  // The following URLs default to using staging:
+  // https://local.zooniverse.org:3735/lab/1982/workflows/editor/3711
+  // https://pr-7046.pfe-preview.zooniverse.org/lab/1982/workflows/editor/3711?env=staging
+  if (hostname.match(/^(local|.*\.pfe-preview)\.zooniverse\.org$/ig)) {
+    return '?env=staging'
+  }
+
+  return '';
 }

--- a/app/pages/lab-pages-editor/components/WorkflowSettingsPage/WorkflowSettingsPage.jsx
+++ b/app/pages/lab-pages-editor/components/WorkflowSettingsPage/WorkflowSettingsPage.jsx
@@ -1,4 +1,5 @@
 import { useWorkflowContext } from '../../context.js';
+import AssociatedSubjectSets from './components/AssociatedSubjectSets.jsx';
 
 export default function WorkflowSettingsPage() {
   const { workflow, update } = useWorkflowContext();
@@ -55,6 +56,7 @@ export default function WorkflowSettingsPage() {
           <legend>Associated Subject Sets</legend>
           <p>Choose the set of subjects you want to use for this workflow. Add subject sets in the Subject Sets tab.</p>
           <p>TODO</p>
+          <AssociatedSubjectSets workflow={workflow} />
         </fieldset>
 
         <fieldset>

--- a/app/pages/lab-pages-editor/components/WorkflowSettingsPage/WorkflowSettingsPage.jsx
+++ b/app/pages/lab-pages-editor/components/WorkflowSettingsPage/WorkflowSettingsPage.jsx
@@ -2,7 +2,7 @@ import { useWorkflowContext } from '../../context.js';
 import AssociatedSubjectSets from './components/AssociatedSubjectSets.jsx';
 
 export default function WorkflowSettingsPage() {
-  const { workflow, update } = useWorkflowContext();
+  const { workflow, update, project } = useWorkflowContext();
 
   function onSubmit(e) {
     e.preventDefault();
@@ -55,8 +55,7 @@ export default function WorkflowSettingsPage() {
         <fieldset>
           <legend>Associated Subject Sets</legend>
           <p>Choose the set of subjects you want to use for this workflow. Add subject sets in the Subject Sets tab.</p>
-          <p>TODO</p>
-          <AssociatedSubjectSets workflow={workflow} />
+          <AssociatedSubjectSets project={project} workflow={workflow} />
         </fieldset>
 
         <fieldset>

--- a/app/pages/lab-pages-editor/components/WorkflowSettingsPage/WorkflowSettingsPage.jsx
+++ b/app/pages/lab-pages-editor/components/WorkflowSettingsPage/WorkflowSettingsPage.jsx
@@ -147,99 +147,14 @@ export default function WorkflowSettingsPage() {
 
         <hr />
 
-        <fieldset>
+        <fieldset className="disabled">
           <legend>Classification Tools</legend>
-          <p>TEST: HTML and styling for checkbox input</p>
-          <label
-            htmlFor="placeholder-1"
-            className="flex-row align-start spacing-bottom-XS"
-          >
-            <input
-              type="checkbox"
-              id="placeholder-1"
-              name="placeholder-1"
-              onChange={testUpdate}
-            />
-            <span>Placeholder 1</span>
-          </label>
-          <label
-            htmlFor="placeholder-2"
-            className="flex-row align-start spacing-bottom-XS"
-          >
-            <input
-              defaultChecked={true}
-              type="checkbox"
-              id="placeholder-2"
-              name="placeholder-2"
-              onChange={testUpdate}
-            />
-            <span>
-              Placeholder 2 -
-              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam vel tellus quam.
-            </span>
-          </label>
-          <label
-            htmlFor="placeholder-3"
-            className="flex-row align-start spacing-bottom-XS"
-          >
-            <input
-              type="checkbox"
-              id="placeholder-3"
-              name="placeholder-3"
-              onChange={testUpdate}
-            />
-            <span>
-              Placeholder 3 -
-              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam vel tellus quam.
-              Praesent lobortis dapibus nisi, ultricies blandit quam mattis vel.
-              Nunc consequat sem finibus, facilisis augue quis, euismod velit.
-            </span>
-          </label>
+          <p>TODO</p>
         </fieldset>
 
-        <fieldset>
+        <fieldset className="disabled">
           <legend>Quicktalk</legend>
-          <p>TEST: HTML and styling for radio options</p>
-          <label
-            className="flex-row align-start spacing-bottom-XS"
-            htmlFor="placeholder-4-a"
-          >
-            <input
-              type="radio"
-              id="placeholder-4-a"
-              name="placeholder-4"
-              onChange={testUpdate}
-              value="Option A"
-            />
-            <span>Placeholder 4, Option A</span>
-          </label>
-          <label
-            className="flex-row align-start spacing-bottom-XS"
-            htmlFor="placeholder-4-b"
-          >
-            <input
-              defaultChecked={true}
-              type="radio"
-              id="placeholder-4-b"
-              name="placeholder-4"
-              onChange={testUpdate}
-              value="Option B"
-            />
-            <span>Placeholder 4, Option B</span>
-          </label>
-          <label
-            className="flex-row align-start spacing-bottom-XS"
-            htmlFor="placeholder-4-c"
-          >
-            <input
-              type="radio"
-              id="placeholder-4-c"
-              name="placeholder-4"
-              onChange={testUpdate}
-              value="Option C"
-            />
-            <span>Placeholder 4, Option C</span>
-          </label>
+          <p>TODO</p>
         </fieldset>
 
       </div>

--- a/app/pages/lab-pages-editor/components/WorkflowSettingsPage/WorkflowSettingsPage.jsx
+++ b/app/pages/lab-pages-editor/components/WorkflowSettingsPage/WorkflowSettingsPage.jsx
@@ -1,5 +1,4 @@
-import { useWorkflowContext } from '../context.js';
-import strings from '../strings.json'; // TODO: move all text into strings
+import { useWorkflowContext } from '../../context.js';
 
 export default function WorkflowSettingsPage() {
   const { workflow, update } = useWorkflowContext();

--- a/app/pages/lab-pages-editor/components/WorkflowSettingsPage/components/AssociatedSubjectSets.jsx
+++ b/app/pages/lab-pages-editor/components/WorkflowSettingsPage/components/AssociatedSubjectSets.jsx
@@ -1,15 +1,55 @@
-export default function AssociatedSubjectSets({ workflow }) {
-  if (!workflow) return null;
+import { useState, useEffect } from 'react';
 
-  const subjectSets = [
-    { id: '1234', display_name: 'Test 1' },
-    { id: '1235', display_name: 'Test 2' }
-  ];
+const ARBITRARY_PAGE_SIZE = 250;  // If a project has more than this number of subject sets, then we need a better solution.
+
+export default function AssociatedSubjectSets({ project, workflow }) {
+  const [apiData, setApiData] = useState({
+    subjectSets: null,
+    status: 'ready'
+  });
+
+  useEffect(() => {
+    async function fetchSubjectSets() {
+      try {
+        setApiData({
+          subjectSets: null,
+          status: 'fetching'
+        });
+
+        const ssets = await project.get('subject_sets', { sort: '-id', page_size: ARBITRARY_PAGE_SIZE });
+        if (!ssets) throw new Error('No subject sets');
+
+        setApiData({
+          subjectSets: ssets,
+          status: 'ready'
+        });
+
+      } catch (err) {
+        console.error('AssosicatedSubjectSets: ', err);
+        setApiData({
+          subjectSets: null,
+          status: 'error'
+        });
+      }
+    }
+
+    fetchSubjectSets();
+  }, [project, workflow]);
+
+  if (!project || !workflow) return null;
+
+  if (apiData.status === 'fetching') {
+    return (<div className="status-banner fetching">Fetching Subject Sets...</div>)
+  }
+
+  if (apiData.status === 'error') {
+    return (<div className="status-banner error">ERROR: couldn't fetch Subject Sets</div>)
+  }
 
   return (
     <ul className="checkbox-group">
-      {subjectSets.map((subjectSet, index) => (
-        <li>
+      {apiData?.subjectSets?.map((subjectSet, index) => (
+        <li key={`associated-subject-set-${subjectSet.id}`}>
           <input id={`associated-subject-set-${subjectSet.id}`} type="checkbox" />
           <label htmlFor={`associated-subject-set-${subjectSet.id}`}>{subjectSet.display_name || '???'}</label>
         </li>

--- a/app/pages/lab-pages-editor/components/WorkflowSettingsPage/components/AssociatedSubjectSets.jsx
+++ b/app/pages/lab-pages-editor/components/WorkflowSettingsPage/components/AssociatedSubjectSets.jsx
@@ -17,7 +17,7 @@ export default function AssociatedSubjectSets({ project, workflow }) {
           status: 'fetching'
         });
 
-        const ssets = await project.get('subject_sets', { sort: '-id', page_size: ARBITRARY_PAGE_SIZE });
+        const ssets = await project.get('subject_sets', { sort: '+id', page_size: ARBITRARY_PAGE_SIZE });
         if (!ssets) throw new Error('No subject sets');
 
         setApiData({
@@ -42,10 +42,12 @@ export default function AssociatedSubjectSets({ project, workflow }) {
     if (!subjectSetId) return;
     const alreadyLinked = linkedSubjectSets.includes(subjectSetId);
 
-    if (alreadyLinked) {
+    if (alreadyLinked) {  // If already linked, remove it.
       setLinkedSubjectSets(linkedSubjectSets.filter(sset => sset !== subjectSetId));
-    } else {
-      setLinkedSubjectSets([ ...linkedSubjectSets, subjectSetId]);  // Copy, then push
+      workflow.removeLink('subject_sets', [subjectSetId]);
+    } else {  // If not yet linked, add it.
+      setLinkedSubjectSets([ ...linkedSubjectSets, subjectSetId]);
+      workflow.addLink('subject_sets', [subjectSetId]);
     }
   }
 
@@ -61,8 +63,6 @@ export default function AssociatedSubjectSets({ project, workflow }) {
 
   return (
     <ul className="checkbox-group">
-      <li>DEBUG (state): {(linkedSubjectSets).join(' , ')}</li>
-      <li>DEBUG (workflow): {(workflow?.links?.subject_sets || []).join(' , ')}</li>
       {apiData?.subjectSets?.map((subjectSet, index) => (
         <li key={`associated-subject-set-${subjectSet.id}`}>
           <input

--- a/app/pages/lab-pages-editor/components/WorkflowSettingsPage/components/AssociatedSubjectSets.jsx
+++ b/app/pages/lab-pages-editor/components/WorkflowSettingsPage/components/AssociatedSubjectSets.jsx
@@ -1,0 +1,19 @@
+export default function AssociatedSubjectSets({ workflow }) {
+  if (!workflow) return null;
+
+  const subjectSets = [
+    { id: '1234', display_name: 'Test 1' },
+    { id: '1235', display_name: 'Test 2' }
+  ];
+
+  return (
+    <ul className="checkbox-group">
+      {subjectSets.map((subjectSet, index) => (
+        <li>
+          <input id={`associated-subject-set-${subjectSet.id}`} type="checkbox" />
+          <label htmlFor={`associated-subject-set-${subjectSet.id}`}>{subjectSet.display_name || '???'}</label>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/app/pages/lab-pages-editor/components/WorkflowSettingsPage/components/AssociatedSubjectSets.jsx
+++ b/app/pages/lab-pages-editor/components/WorkflowSettingsPage/components/AssociatedSubjectSets.jsx
@@ -62,7 +62,7 @@ export default function AssociatedSubjectSets({ project, workflow }) {
   }
 
   return (
-    <ul className="checkbox-group">
+    <ul className="input-group">
       {apiData?.subjectSets?.map((subjectSet, index) => (
         <li key={`associated-subject-set-${subjectSet.id}`}>
           <input

--- a/app/pages/lab-pages-editor/components/WorkflowSettingsPage/components/AssociatedSubjectSets.jsx
+++ b/app/pages/lab-pages-editor/components/WorkflowSettingsPage/components/AssociatedSubjectSets.jsx
@@ -26,7 +26,7 @@ export default function AssociatedSubjectSets({ project, workflow }) {
         });
 
       } catch (err) {
-        console.error('AssosicatedSubjectSets: ', err);
+        console.error('AssociatedSubjectSets: ', err);
         setApiData({
           subjectSets: null,
           status: 'error'

--- a/app/pages/lab-pages-editor/components/WorkflowSettingsPage/components/AssociatedSubjectSets.jsx
+++ b/app/pages/lab-pages-editor/components/WorkflowSettingsPage/components/AssociatedSubjectSets.jsx
@@ -7,6 +7,7 @@ export default function AssociatedSubjectSets({ project, workflow }) {
     subjectSets: null,
     status: 'ready'
   });
+  const [linkedSubjectSets, setLinkedSubjectSets] = useState(workflow?.links?.subject_sets || []);
 
   useEffect(() => {
     async function fetchSubjectSets() {
@@ -36,6 +37,18 @@ export default function AssociatedSubjectSets({ project, workflow }) {
     fetchSubjectSets();
   }, [project, workflow]);
 
+  function toggleSubjectSet(e) {
+    const subjectSetId = e?.currentTarget?.dataset?.subjectset;
+    if (!subjectSetId) return;
+    const alreadyLinked = linkedSubjectSets.includes(subjectSetId);
+
+    if (alreadyLinked) {
+      setLinkedSubjectSets(linkedSubjectSets.filter(sset => sset !== subjectSetId));
+    } else {
+      setLinkedSubjectSets([ ...linkedSubjectSets, subjectSetId]);  // Copy, then push
+    }
+  }
+
   if (!project || !workflow) return null;
 
   if (apiData.status === 'fetching') {
@@ -48,10 +61,20 @@ export default function AssociatedSubjectSets({ project, workflow }) {
 
   return (
     <ul className="checkbox-group">
+      <li>DEBUG (state): {(linkedSubjectSets).join(' , ')}</li>
+      <li>DEBUG (workflow): {(workflow?.links?.subject_sets || []).join(' , ')}</li>
       {apiData?.subjectSets?.map((subjectSet, index) => (
         <li key={`associated-subject-set-${subjectSet.id}`}>
-          <input id={`associated-subject-set-${subjectSet.id}`} type="checkbox" />
-          <label htmlFor={`associated-subject-set-${subjectSet.id}`}>{subjectSet.display_name || '???'}</label>
+          <input
+            checked={!!linkedSubjectSets.includes(subjectSet.id)}
+            data-subjectset={subjectSet.id}
+            id={`associated-subject-set-${subjectSet.id}`}
+            onChange={toggleSubjectSet}
+            type="checkbox"
+          />
+          <label htmlFor={`associated-subject-set-${subjectSet.id}`}>
+            {subjectSet.display_name || '???'} (#{subjectSet.id})
+          </label>
         </li>
       ))}
     </ul>

--- a/app/pages/lab-pages-editor/components/WorkflowSettingsPage/index.jsx
+++ b/app/pages/lab-pages-editor/components/WorkflowSettingsPage/index.jsx
@@ -1,0 +1,3 @@
+import WorkflowSettingsPage from './WorkflowSettingsPage.jsx';
+
+export default WorkflowSettingsPage;

--- a/app/pages/lab-pages-editor/helpers/getPreviewEnv.js
+++ b/app/pages/lab-pages-editor/helpers/getPreviewEnv.js
@@ -1,0 +1,21 @@
+/*
+Figures out of the "Preview Workflow" link requires "?env=staging" or
+"?env=production"
+ */
+export default function getPreviewEnv() {
+  const hostname = window?.location?.hostname || '';
+  const params = new URLSearchParams(window?.location?.search);
+  const explicitEnv = params.get('env');
+
+  // If an explicit ?env=... is specified, use that.
+  if (explicitEnv) return `?env=${explicitEnv}`;
+
+  // The following URLs default to using staging:
+  // https://local.zooniverse.org:3735/lab/1982/workflows/editor/3711
+  // https://pr-7046.pfe-preview.zooniverse.org/lab/1982/workflows/editor/3711?env=staging
+  if (hostname.match(/^(local|.*\.pfe-preview)\.zooniverse\.org$/ig)) {
+    return '?env=staging'
+  }
+
+  return '';
+}

--- a/css/lab-pages-editor.styl
+++ b/css/lab-pages-editor.styl
@@ -48,7 +48,7 @@ $fontWeightBoldPlus = 700
   font-size: $fontSizeM
   max-width: 840px
   margin: 0 auto
-  padding: 0 $sizeM
+  padding: $sizeM $sizeM
 
   // General UI
   // ---------------------------------------------------------------------------

--- a/css/lab-pages-editor.styl
+++ b/css/lab-pages-editor.styl
@@ -124,6 +124,17 @@ $fontWeightBoldPlus = 700
   .decoration-plus
     &::after
       content: ' +'
+  
+  .status-banner
+    display: flex
+    flex-direction: column
+    justify-content: center
+    align-items: center
+    padding: 0.5em
+
+    &.error
+      background: $redBright
+      color: $white
 
   // General Layout
   // ---------------------------------------------------------------------------

--- a/css/lab-pages-editor.styl
+++ b/css/lab-pages-editor.styl
@@ -247,6 +247,21 @@ $fontWeightBoldPlus = 700
     .col-2
       grid-column: 2
       grid-row: 2
+    
+    ul.input-group
+      list-style: none
+      padding: 0
+      margin: 0
+
+      li
+        display: flex
+        flex-direction: row
+        gap: $sizeXS
+        margin: $sizeXS 0
+        padding: 0
+
+        input[type=checkbox]
+          margin: $sizeXS
 
   // Component: Tasks Page
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## PR Overview

Part of: **Pages Editor MVP** project and **FEM Lab** super-project
Follows #7046
Staging branch URL: https://pr-7048.pfe-preview.zooniverse.org/lab/1982/workflows/editor/3711?env=staging

This PR implements the "Associated Subject Sets" feature on the Workflow Settings sub-page.

- New component: AssociatedSubjectSets.
- New behaviour/feature: on Pages Editor (for any Workflow) -> Workflow Settings...
  - The _Associated Subject Sets_ feature should list all Subject Sets available to the Project _(caveat: up to a max of 250. Paging may be a future problem to solve.)_
  - The Associated Subject Sets feature _(and no, I will not shorten it to an acronym)_ should show which Subject Sets are linked to the Workflow via ticked checkboxes.
  - Clicking on the checkboxes should link/unlink Subject Sets to/from the Workflow.

Also, some background work was required to fetch the Subject Sets, so the DataManager was updated as well.
- Updated behaviour: DataManager now fetches the **project** resource.
- Misc update: the Preview Workflow link now works as intended. 

_Screenshot: example workflow with 3 available subject sets, 2 of which are linked._

<img width="618" alt="image" src="https://github.com/zooniverse/Panoptes-Front-End/assets/13952701/8b8d11e5-9619-4b50-a18f-194800dafac0">

### Testing

- Open the staging URL. You should be looking at a test workflow (e.g. staging wf 3711)
- Click on the Workflow Settings tab/button to view the sub-page.
- Look for the Associated Subject Sets feature.
  - It should list all available subject sets, and show which ones are already linked.
  - Click on a subject set to link/unlink them
  - Reload the page to confirm
  - Expectation: you should be able to link or unlink as many sets as you want. Changes should be committed to Panoptes.

### Status

Ready for review!

This PR is currently targeting pages-editor-pt14 for review purposes. Do not merge until 6974 is ready and this branch's merge is re-targeted to `master`.