### PR TITLE
Add confirmed at to admin page

### DIFF
--- a/app/pages/admin/user-settings/details.jsx
+++ b/app/pages/admin/user-settings/details.jsx
@@ -7,6 +7,7 @@ import handleInputChange from '../../../lib/handle-input-change';
 const UserDetails = (props) => {
   const handleUserChange = handleInputChange.bind(props.user);
   const created = new Date(props.user.created_at)
+  const confirmed = props.user.confirmed_at ? new Date(props.user.confirmed_at) : 'Not Confirmed'
 
   function onChange(e) {
     handleUserChange(e);
@@ -21,7 +22,7 @@ const UserDetails = (props) => {
         <li>Display name: {props.user.display_name}</li>
         <li>Email address: {props.user.email}</li>
         <li>Signed up: {created.toString()}</li>
-        <li>Email confirmed at: {props.user.confirmed_at ?? "Not Confirmed"}</li>
+        <li>Email confirmed at: {confirmed.toString()}</li>
         <li>
           <label>
             Valid email:{' '}

--- a/app/pages/admin/user-settings/details.jsx
+++ b/app/pages/admin/user-settings/details.jsx
@@ -21,7 +21,7 @@ const UserDetails = (props) => {
         <li>Display name: {props.user.display_name}</li>
         <li>Email address: {props.user.email}</li>
         <li>Signed up: {created.toString()}</li>
-        <li>Email confirmed at: {props.user.confirmed_at}</li>
+        <li>Email confirmed at: {props.user.confirmed_at ?? "Not Confirmed"}</li>
         <li>
           <label>
             Valid email:{' '}

--- a/app/pages/admin/user-settings/details.jsx
+++ b/app/pages/admin/user-settings/details.jsx
@@ -21,6 +21,7 @@ const UserDetails = (props) => {
         <li>Display name: {props.user.display_name}</li>
         <li>Email address: {props.user.email}</li>
         <li>Signed up: {created.toString()}</li>
+        <li>Email confirmed at: {props.user.confirmed_at}</li>
         <li>
           <label>
             Valid email:{' '}


### PR DESCRIPTION
Adds `confirmed_at` User property to admin page, helping verify email confirmation status (especially useful for troubleshooting Talk posting problems).

Staging branch URL: https://pr-7050.pfe-preview.zooniverse.org

For testing (assuming tester can enter admin mode):
- Unconfirmed user: https://pr-7050.pfe-preview.zooniverse.org/admin/users/2698362
- Confirmed User: https://pr-7050.pfe-preview.zooniverse.org/admin/users/1901126