### PR TITLE
Pages Editor: rebuild "Next Page" logic. Add placeholder answers.

### DIFF
--- a/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
@@ -4,7 +4,6 @@ import createStep from '../../helpers/createStep.js';
 import createTask from '../../helpers/createTask.js';
 import getNewStepKey from '../../helpers/getNewStepKey.js';
 import getNewTaskKey from '../../helpers/getNewTaskKey.js';
-import linkStepsInWorkflow from '../../helpers/linkStepsInWorkflow.js';
 import moveItemInArray from '../../helpers/moveItemInArray.js';
 import cleanupTasksAndSteps from '../../helpers/cleanupTasksAndSteps.js';
 import getPreviewEnv from '../../helpers/getPreviewEnv.js';
@@ -39,7 +38,7 @@ export default function TasksPage() {
       ...workflow.tasks,
       [newTaskKey]: newTask
     };
-    const steps = linkStepsInWorkflow([...workflow.steps, newStep]);
+    const steps = [...workflow.steps, newStep];
 
     await update({ tasks, steps });
     return steps.length - 1;
@@ -119,7 +118,7 @@ export default function TasksPage() {
     const oldSteps = workflow?.steps || [];
     if (from < 0 || to < 0 || from >= oldSteps.length || to >= oldSteps.length) return;
 
-    const steps = linkStepsInWorkflow(moveItemInArray(oldSteps, from, to));
+    const steps = moveItemInArray(oldSteps, from, to);
     update({ steps });
   }
 

--- a/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
@@ -163,7 +163,7 @@ export default function TasksPage() {
   }
 
   // Changes the optional "next page" of a branching answer/choice
-  function updateAnswerNext(taskKey, answerIndex, next = undefined) {
+  function updateNextStepForTaskAnswer(taskKey, answerIndex, next = undefined) {
     // Check if input is valid
     const task = workflow?.tasks?.[taskKey];
     const answer = task?.answers[answerIndex];
@@ -223,7 +223,7 @@ export default function TasksPage() {
               step={step}
               stepKey={step[0]}
               stepIndex={index}
-              updateAnswerNext={updateAnswerNext}
+              updateNextStepForTaskAnswer={updateNextStepForTaskAnswer}
             />
           ))}
         </ul>

--- a/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
@@ -162,6 +162,19 @@ export default function TasksPage() {
     update({tasks});
   }
 
+  // Changes the optional "next page" of a step/page
+  function updateNextStepForStep(stepKey, next = undefined) {
+    // Check if input is valid
+    const stepIndex = workflow?.steps?.findIndex(step => step[0] === stepKey);
+    const stepBody = workflow?.steps?.[stepIndex]?.[1];
+    if (!stepBody) return;
+
+    const newSteps = workflow.steps.slice();
+    newSteps[stepIndex] = [stepKey, { ...stepBody, next }];
+
+    update({ steps: newSteps });
+  }
+
   // Changes the optional "next page" of a branching answer/choice
   function updateNextStepForTaskAnswer(taskKey, answerIndex, next = undefined) {
     // Check if input is valid
@@ -223,6 +236,7 @@ export default function TasksPage() {
               step={step}
               stepKey={step[0]}
               stepIndex={index}
+              updateNextStepForStep={updateNextStepForStep}
               updateNextStepForTaskAnswer={updateNextStepForTaskAnswer}
             />
           ))}

--- a/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
@@ -57,9 +57,9 @@ export default function TasksPage() {
       tasks: {
         'T0': {
           answers: [
-            {next: "P1", label: "Animals"},
-            {next: "P2", label: "Fruits"},
-            {label: "Neither"}
+            {next: 'P1', label: 'Animals'},
+            {next: 'P2', label: 'Fruits'},
+            {label: 'Neither'}
           ],
           help: '',
           question: 'Do you like Animals or Fruits?',
@@ -70,9 +70,47 @@ export default function TasksPage() {
         'T2': { help: '', type: 'text', required: false, instruction: 'Which fruit?' }
       },
       steps: [
-        ['P0', { next: 'P1', stepKey: 'P0', taskKeys: ["T0"] }],
+        ['P0', { stepKey: 'P0', taskKeys: ["T0"] }],
         ['P1', { next: 'P2', stepKey: 'P1', taskKeys: ["T1"] }],
         ['P2', { stepKey: 'P2', taskKeys: ["T2"] }]
+      ]
+    });
+  }
+
+  function experimentalQuickSetupBranching() {
+    update({
+      tasks: {
+        'T1.1': {
+          answers: [
+            {next: 'P2', label: 'Go to the 🔴 RED page'},
+            {next: 'P3', label: 'Go to the 🔵 BLUE page'},
+          ],
+          help: '',
+          question: 'Oh dear, this page has multiple branching tasks. Let\'s see what happens',
+          required: false,
+          type: 'single'
+        },
+        'T1.2': {
+          answers: [
+            {next: 'P4', label: 'Go to the 🟡 YELLOW page'},
+            {next: 'P5', label: 'Go to the 🟢 GREEN page'},
+          ],
+          help: '',
+          question: 'This is the second branching task. If you answer both on the page, where do you branch to?',
+          required: false,
+          type: 'single'
+        },
+        'T2': { help: '', type: 'text', required: false, instruction: 'Welcome to the 🔴 RED page! How do you feel?' },
+        'T3': { help: '', type: 'text', required: false, instruction: 'Welcome to the 🔵 BLUE page! How do you feel?' },
+        'T4': { help: '', type: 'text', required: false, instruction: 'Welcome to the 🟡 YELLOW page! How do you feel?' },
+        'T5': { help: '', type: 'text', required: false, instruction: 'Welcome to the 🟢 GREEN page! How do you feel?' },
+      },
+      steps: [
+        ['P1', { stepKey: 'P1', taskKeys: ['T1.1', 'T1.2'] }],
+        ['P2', { stepKey: 'P2', taskKeys: ['T2'] }],
+        ['P3', { stepKey: 'P3', taskKeys: ['T3'] }],
+        ['P4', { stepKey: 'P4', taskKeys: ['T4'] }],
+        ['P5', { stepKey: 'P5', taskKeys: ['T5'] }],
       ]
     });
   }
@@ -225,7 +263,15 @@ export default function TasksPage() {
             type="button"
             style={{ margin: '0 4px' }}
           >
-            QUICK SETUP
+            QUICK SETUP (simple)
+          </button>
+          <button
+            className="big"
+            onClick={experimentalQuickSetupBranching}
+            type="button"
+            style={{ margin: '0 4px' }}
+          >
+            QUICK SETUP (advanced, branching)
           </button>
         </div>
       </section>

--- a/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/BranchingNextControls.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/BranchingNextControls.jsx
@@ -1,6 +1,6 @@
 const DEFAULT_HANDLER = () => {};
 
-export default function BranchingControls({
+export default function BranchingNextControls({
   allSteps = [],
   task,
   taskKey,

--- a/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/BranchingNextControls.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/BranchingNextControls.jsx
@@ -21,7 +21,7 @@ export default function BranchingNextControls({
   return (
     <ul className="next-step-controls branching-next-controls">
       {answers.map((answer, index) => (
-        <li key={`branching-controls-answer-${index}`}>
+        <li key={`branching-next-controls-answer-${index}`}>
           <div className="fake-button">{answer.label}</div>
           <NextStepArrow className="next-arrow" />
           <select
@@ -39,7 +39,7 @@ export default function BranchingNextControls({
               const taskKeys = stepBody?.taskKeys?.toString() || '(none)';
               return (
                 <option
-                  key={`branching-controls-answer-${index}-option-${stepKey}`}
+                  key={`branching-next-controls-answer-${index}-option-${stepKey}`}
                   value={stepKey}
                 >
                   {taskKeys}

--- a/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/BranchingNextControls.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/BranchingNextControls.jsx
@@ -6,7 +6,7 @@ export default function BranchingNextControls({
   allSteps = [],
   task,
   taskKey,
-  updateAnswerNext = DEFAULT_HANDLER
+  updateNextStepForTaskAnswer = DEFAULT_HANDLER
 }) {
   if (!task || !taskKey) return null;
 
@@ -15,7 +15,7 @@ export default function BranchingNextControls({
   function onChange(e) {
     const next = e.target?.value;
     const index = e?.target?.dataset.index;
-    updateAnswerNext(taskKey, index, next);
+    updateNextStepForTaskAnswer(taskKey, index, next);
   }
 
   return (

--- a/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/BranchingNextControls.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/BranchingNextControls.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import NextStepArrow from './NextStepArrow.jsx';
 
 const DEFAULT_HANDLER = () => {};
@@ -52,3 +53,10 @@ export default function BranchingNextControls({
     </ul>
   );
 }
+
+BranchingNextControls.propTypes = {
+  allSteps: PropTypes.arrayOf(PropTypes.array),
+  task: PropTypes.object,
+  taskKey: PropTypes.string,
+  updateNextStepForTaskAnswer: PropTypes.func
+};

--- a/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/BranchingNextControls.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/BranchingNextControls.jsx
@@ -19,7 +19,7 @@ export default function BranchingNextControls({
   }
 
   return (
-    <ul className="next-step-controls branching-next-controls">
+    <ul className="next-controls horizontal-list">
       {answers.map((answer, index) => (
         <li key={`branching-next-controls-answer-${index}`}>
           <div className="fake-button">{answer.label}</div>

--- a/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/BranchingNextControls.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/BranchingNextControls.jsx
@@ -1,3 +1,5 @@
+import NextStepArrow from './NextStepArrow.jsx';
+
 const DEFAULT_HANDLER = () => {};
 
 export default function BranchingNextControls({
@@ -17,7 +19,7 @@ export default function BranchingNextControls({
   }
 
   return (
-    <ul className="branching-controls">
+    <ul className="next-step-controls branching-next-controls">
       {answers.map((answer, index) => (
         <li key={`branching-controls-answer-${index}`}>
           <div className="fake-button">{answer.label}</div>
@@ -48,32 +50,5 @@ export default function BranchingNextControls({
         </li>
       ))}
     </ul>
-  );
-}
-
-function NextStepArrow({
-  alt,
-  className = 'icon',
-  color = 'currentColor',
-  height = 48,
-  pad = 4,
-  strokeWidth = 2,
-  width = 16
-}) {
-  const xA = 0 + pad;
-  const xB = width * 0.5;
-  const xC = width - pad;
-  const yA = 0 + pad;
-  const yB = height - (width / 2);
-  const yC = height - pad;
-
-  return (
-    <svg aria-label={alt} width={width} height={height} className={className}>
-      <g stroke={color} strokeWidth={strokeWidth}>
-        <line x1={xB} y1={yA} x2={xB} y2={yC} />
-        <line x1={xA} y1={yB} x2={xB} y2={yC} />
-        <line x1={xC} y1={yB} x2={xB} y2={yC} />
-      </g>
-    </svg>
   );
 }

--- a/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/NextStepArrow.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/NextStepArrow.jsx
@@ -1,0 +1,26 @@
+export default function NextStepArrow({
+  alt,
+  className = 'icon',
+  color = 'currentColor',
+  height = 48,
+  pad = 4,
+  strokeWidth = 2,
+  width = 16
+}) {
+  const xA = 0 + pad;
+  const xB = width * 0.5;
+  const xC = width - pad;
+  const yA = 0 + pad;
+  const yB = height - (width / 2);
+  const yC = height - pad;
+
+  return (
+    <svg aria-label={alt} width={width} height={height} className={className}>
+      <g stroke={color} strokeWidth={strokeWidth}>
+        <line x1={xB} y1={yA} x2={xB} y2={yC} />
+        <line x1={xA} y1={yB} x2={xB} y2={yC} />
+        <line x1={xC} y1={yB} x2={xB} y2={yC} />
+      </g>
+    </svg>
+  );
+}

--- a/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/SimpleNextControls.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/SimpleNextControls.jsx
@@ -1,0 +1,12 @@
+export default function SimpleNextControls({
+  step
+}) {
+  if (!step) return null;
+  const [ stepId, stepBody ] = step;
+
+  return (
+    <div>
+      NEXT: {stepBody?.next}
+    </div>
+  );
+}

--- a/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/SimpleNextControls.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/SimpleNextControls.jsx
@@ -41,7 +41,6 @@ export default function SimpleNextControls({
           );
         })}
       </select>
-      <div>[[{stepBody?.next}]]</div>
     </div>
   );
 }

--- a/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/SimpleNextControls.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/SimpleNextControls.jsx
@@ -1,13 +1,20 @@
+import PropTypes from 'prop-types';
 import NextStepArrow from './NextStepArrow.jsx';
+
+const DEFAULT_HANDLER = () => {};
 
 export default function SimpleNextControls({
   allSteps = [],
-  step
+  step,
+  updateNextStepForStep = DEFAULT_HANDLER
 }) {
   if (!step) return null;
   const [ stepKey, stepBody ] = step;
 
-  function onChange() {}
+  function onChange(e) {
+    const next = e.target?.value;
+    updateNextStepForStep(stepKey, next);
+  }
 
   return (
     <div className="next-controls vertical-layout">
@@ -37,3 +44,9 @@ export default function SimpleNextControls({
     </div>
   );
 }
+
+SimpleNextControls.propTypes = {
+  allSteps: PropTypes.arrayOf(PropTypes.array),
+  step: PropTypes.array,
+  updateNextStepForStep: PropTypes.func
+};

--- a/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/SimpleNextControls.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/SimpleNextControls.jsx
@@ -1,15 +1,39 @@
 import NextStepArrow from './NextStepArrow.jsx';
 
 export default function SimpleNextControls({
+  allSteps = [],
   step
 }) {
   if (!step) return null;
-  const [ stepId, stepBody ] = step;
+  const [ stepKey, stepBody ] = step;
+
+  function onChange() {}
 
   return (
     <div className="next-step-controls simple-next-controls">
       <NextStepArrow className="next-arrow" />
-      <div>NEXT: {stepBody?.next}</div>
+      <select
+        className={(!stepBody?.next) ? 'next-is-submit' : ''}
+        onChange={onChange}
+        value={stepBody?.next || ''}
+      >
+        <option
+          value={''}
+        >
+          Submit
+        </option>
+        {allSteps.map(([otherStepKey, otherStepBody]) => {
+          const taskKeys = otherStepBody?.taskKeys?.toString() || '(none)';
+          return (
+            <option
+              key={`simple-next-controls-option-${otherStepKey}`}
+              value={otherStepKey}
+            >
+              {taskKeys}
+            </option>
+          );
+        })}
+      </select>
     </div>
   );
 }

--- a/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/SimpleNextControls.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/SimpleNextControls.jsx
@@ -41,6 +41,7 @@ export default function SimpleNextControls({
           );
         })}
       </select>
+      <div>[[{stepBody?.next}]]</div>
     </div>
   );
 }

--- a/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/SimpleNextControls.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/SimpleNextControls.jsx
@@ -10,7 +10,7 @@ export default function SimpleNextControls({
   function onChange() {}
 
   return (
-    <div className="next-step-controls simple-next-controls">
+    <div className="next-controls vertical-layout">
       <NextStepArrow className="next-arrow" />
       <select
         className={(!stepBody?.next) ? 'next-is-submit' : ''}

--- a/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/SimpleNextControls.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/SimpleNextControls.jsx
@@ -1,3 +1,5 @@
+import NextStepArrow from './NextStepArrow.jsx';
+
 export default function SimpleNextControls({
   step
 }) {
@@ -5,8 +7,9 @@ export default function SimpleNextControls({
   const [ stepId, stepBody ] = step;
 
   return (
-    <div>
-      NEXT: {stepBody?.next}
+    <div className="next-step-controls simple-next-controls">
+      <NextStepArrow className="next-arrow" />
+      <div>NEXT: {stepBody?.next}</div>
     </div>
   );
 }

--- a/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/StepItem.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/StepItem.jsx
@@ -6,7 +6,9 @@ import TaskItem from './TaskItem.jsx';
 
 import canStepBranch from '../../../../helpers/canStepBranch.js';
 
-import BranchingControls from './BranchingControls.jsx';
+import BranchingNextControls from './BranchingNextControls.jsx';
+import SimpleNextControls from './SimpleNextControls.jsx';
+
 import CopyIcon from '../../../../icons/CopyIcon.jsx';
 import DeleteIcon from '../../../../icons/DeleteIcon.jsx';
 import EditIcon from '../../../../icons/EditIcon.jsx';
@@ -135,7 +137,7 @@ function StepItem({
           })}
         </ul>
         {branchingTask && (
-          <BranchingControls
+          <BranchingNextControls
             allSteps={allSteps}
             task={branchingTask}
             taskKey={branchingTaskKey}
@@ -143,9 +145,9 @@ function StepItem({
           />
         )}
         {!branchingTask && (
-          <div>
-            DEBUG: Next is {stepBody?.next || '(undefined)'}
-          </div>
+          <SimpleNextControls
+            step={step}
+          />
         )}
       </div>
       <DropTarget

--- a/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/StepItem.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/StepItem.jsx
@@ -146,6 +146,7 @@ function StepItem({
         )}
         {!branchingTask && (
           <SimpleNextControls
+            allSteps={allSteps}
             step={step}
           />
         )}

--- a/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/StepItem.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/StepItem.jsx
@@ -27,7 +27,7 @@ function StepItem({
   setActiveDragItem = DEFAULT_HANDLER,
   step,
   stepIndex,
-  updateAnswerNext = DEFAULT_HANDLER
+  updateNextStepForTaskAnswer = DEFAULT_HANDLER
 }) {
   const [stepKey, stepBody] = step || [];
   if (!stepKey || !stepBody || !allSteps || !allTasks) return <li className="step-item">ERROR: could not render Step</li>;
@@ -132,7 +132,7 @@ function StepItem({
                 key={`taskItem-${taskKey}`}
                 task={task}
                 taskKey={taskKey}
-                updateAnswerNext={updateAnswerNext}
+                updateNextStepForTaskAnswer={updateNextStepForTaskAnswer}
               />
             );
           })}
@@ -164,7 +164,7 @@ StepItem.propTypes = {
   setActiveDragItem: PropTypes.func,
   step: PropTypes.array,
   stepIndex: PropTypes.number,
-  updateAnswerNext: PropTypes.func
+  updateNextStepForTaskAnswer: PropTypes.func
 };
 
 export default StepItem;

--- a/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/StepItem.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/StepItem.jsx
@@ -6,7 +6,6 @@ import TaskItem from './TaskItem.jsx';
 
 import canStepBranch from '../../../../helpers/canStepBranch.js';
 
-import BranchingNextControls from './BranchingNextControls.jsx';
 import SimpleNextControls from './SimpleNextControls.jsx';
 
 import CopyIcon from '../../../../icons/CopyIcon.jsx';
@@ -58,8 +57,7 @@ function StepItem({
   }
 
   const branchingTaskKey = canStepBranch(step, allTasks);
-  const branchingTask = allTasks?.[branchingTaskKey];
-
+  
   return (
     <li className="step-item">
       {(stepIndex === 0)
@@ -129,22 +127,17 @@ function StepItem({
             const task = allTasks[taskKey];
             return (
               <TaskItem
+                allSteps={allSteps}
+                isBranchingTask={branchingTaskKey === taskKey}
                 key={`taskItem-${taskKey}`}
                 task={task}
                 taskKey={taskKey}
+                updateAnswerNext={updateAnswerNext}
               />
             );
           })}
         </ul>
-        {branchingTask && (
-          <BranchingNextControls
-            allSteps={allSteps}
-            task={branchingTask}
-            taskKey={branchingTaskKey}
-            updateAnswerNext={updateAnswerNext}
-          />
-        )}
-        {!branchingTask && (
+        {!branchingTaskKey && (
           <SimpleNextControls
             allSteps={allSteps}
             step={step}

--- a/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/StepItem.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/StepItem.jsx
@@ -142,6 +142,11 @@ function StepItem({
             updateAnswerNext={updateAnswerNext}
           />
         )}
+        {!branchingTask && (
+          <div>
+            DEBUG: Next is {stepBody?.next || '(undefined)'}
+          </div>
+        )}
       </div>
       <DropTarget
         activeDragItem={activeDragItem}

--- a/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/StepItem.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/StepItem.jsx
@@ -27,6 +27,7 @@ function StepItem({
   setActiveDragItem = DEFAULT_HANDLER,
   step,
   stepIndex,
+  updateNextStepForStep = DEFAULT_HANDLER,
   updateNextStepForTaskAnswer = DEFAULT_HANDLER
 }) {
   const [stepKey, stepBody] = step || [];
@@ -141,6 +142,7 @@ function StepItem({
           <SimpleNextControls
             allSteps={allSteps}
             step={step}
+            updateNextStepForStep={updateNextStepForStep}
           />
         )}
       </div>
@@ -164,6 +166,7 @@ StepItem.propTypes = {
   setActiveDragItem: PropTypes.func,
   step: PropTypes.array,
   stepIndex: PropTypes.number,
+  updateNextStepForStep: PropTypes.func,
   updateNextStepForTaskAnswer: PropTypes.func
 };
 

--- a/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/TaskItem.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/TaskItem.jsx
@@ -54,7 +54,7 @@ function TaskItem({
 }
 
 TaskItem.propTypes = {
-  allSteps: PropTypes.arrayOf(PropTypes.object),
+  allSteps: PropTypes.arrayOf(PropTypes.array),
   isBranchingTask: PropTypes.bool,
   task: PropTypes.object,
   taskKey: PropTypes.string,

--- a/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/TaskItem.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/TaskItem.jsx
@@ -14,7 +14,7 @@ const DEFAULT_HANDLER = () => {};
 
 function TaskItem({
   allSteps = [],
-  isBranchingTask = true,
+  isBranchingTask = false,
   task,
   taskKey,
   updateAnswerNext = DEFAULT_HANDLER
@@ -46,13 +46,50 @@ function TaskItem({
           updateAnswerNext={updateAnswerNext}
         />
       )}
+      {!isBranchingTask && (
+        <PlaceholderAnswers task={task} taskKey={taskKey} />
+      )}
     </li>
   );
 }
 
 TaskItem.propTypes = {
+  allSteps: PropTypes.arrayOf(PropTypes.object),
+  isBranchingTask: PropTypes.bool,
   task: PropTypes.object,
-  taskKey: PropTypes.string
+  taskKey: PropTypes.string,
+  updateAnswerNext: PropTypes.func
 };
 
 export default TaskItem;
+
+function PlaceholderAnswers({
+  task,
+  taskKey
+}) {
+  if (!task || !taskKey) return null;
+
+  if (task.type === 'single') {
+    const answers = task.answers || [];
+
+    return (
+      <ul className="horizontal-list">
+        {answers.map((answer, index) => (
+          <li key={`placeholder-answer-${taskKey}-${index}`}>
+            <div className="fake-button">{answer.label}</div>
+          </li>
+        ))}
+      </ul>
+    );
+  }
+
+  if (task.type === 'text') {
+    return (
+      <div>
+        <div className="fake-text-input">Participant text here</div>
+      </div>
+    );
+  }
+
+  return null;
+}

--- a/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/TaskItem.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/TaskItem.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 
 // import strings from '../../../strings.json'; // TODO: move all text into strings
 import TaskIcon from '../../../../icons/TaskIcon.jsx';
+import BranchingNextControls from './BranchingNextControls.jsx';
 
 const TaskLabels = {
   'drawing': 'Drawing Task',
@@ -9,9 +10,14 @@ const TaskLabels = {
   'text': 'Text Task'
 };
 
+const DEFAULT_HANDLER = () => {};
+
 function TaskItem({
+  allSteps = [],
+  isBranchingTask = true,
   task,
-  taskKey
+  taskKey,
+  updateAnswerNext = DEFAULT_HANDLER
 }) {
   if (!task || !taskKey) return <li className="task-item">ERROR: could not render Task</li>;
 
@@ -32,6 +38,14 @@ function TaskItem({
         </span>
         <span className="task-text flex-item">{taskText}</span>
       </div>
+      {isBranchingTask && (
+        <BranchingNextControls
+          allSteps={allSteps}
+          task={task}
+          taskKey={taskKey}
+          updateAnswerNext={updateAnswerNext}
+        />
+      )}
     </li>
   );
 }

--- a/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/TaskItem.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/TaskItem.jsx
@@ -17,7 +17,7 @@ function TaskItem({
   isBranchingTask = false,
   task,
   taskKey,
-  updateAnswerNext = DEFAULT_HANDLER
+  updateNextStepForTaskAnswer = DEFAULT_HANDLER
 }) {
   if (!task || !taskKey) return <li className="task-item">ERROR: could not render Task</li>;
 
@@ -43,7 +43,7 @@ function TaskItem({
           allSteps={allSteps}
           task={task}
           taskKey={taskKey}
-          updateAnswerNext={updateAnswerNext}
+          updateNextStepForTaskAnswer={updateNextStepForTaskAnswer}
         />
       )}
       {!isBranchingTask && (
@@ -58,7 +58,7 @@ TaskItem.propTypes = {
   isBranchingTask: PropTypes.bool,
   task: PropTypes.object,
   taskKey: PropTypes.string,
-  updateAnswerNext: PropTypes.func
+  updateNextStepForTaskAnswer: PropTypes.func
 };
 
 export default TaskItem;

--- a/app/pages/lab-pages-editor/helpers/cleanupTasksAndSteps.js
+++ b/app/pages/lab-pages-editor/helpers/cleanupTasksAndSteps.js
@@ -7,8 +7,6 @@ Clean up tasks and steps.
 - Returns { tasks, steps }
  */
 
-import linkStepsInWorkflow from './linkStepsInWorkflow.js';
-
 export default function cleanupTasksAndSteps(tasks = {}, steps = []) {
   const newTasks = structuredClone(tasks);  // Copy tasks
   const newSteps = steps.slice();  // Copy steps
@@ -26,8 +24,5 @@ export default function cleanupTasksAndSteps(tasks = {}, steps = []) {
     })
   });
 
-  // Remember to re-link steps to close gaps created by missing Steps.
-  const newStepsLinked = linkStepsInWorkflow(newSteps, newTasks);
-
-  return { tasks: newTasks, steps: newStepsLinked };
+  return { tasks: newTasks, steps: newSteps };
 }

--- a/app/pages/lab-pages-editor/helpers/cleanupTasksAndSteps.js
+++ b/app/pages/lab-pages-editor/helpers/cleanupTasksAndSteps.js
@@ -3,13 +3,14 @@ Clean up tasks and steps.
 - TODO: Remove steps without tasks.
 - TODO: Remove tasks not associated with any step.
 - Remove orphaned references in branching tasks.
+- Remove orphaned references in steps.
 
 - Returns { tasks, steps }
  */
 
 export default function cleanupTasksAndSteps(tasks = {}, steps = []) {
   const newTasks = structuredClone(tasks);  // Copy tasks
-  const newSteps = steps.slice();  // Copy steps
+  let newSteps = steps.slice();  // Copy steps
 
   const taskKeys = Object.keys(newTasks);
   const stepKeys = newSteps.map(step => step[0]);
@@ -23,6 +24,19 @@ export default function cleanupTasksAndSteps(tasks = {}, steps = []) {
       }
     })
   });
+  
+  // Remove orphaned references in steps.
+  newSteps = newSteps.map(step => {
+    const [stepKey, stepBody] = step;
+    const newStepBody = { ...stepBody };
+    
+    // If the stepBody points to a non-existent Task Key or Step Key, remove the 'next'.
+    if (newStepBody.next && !taskKeys.includes(newStepBody.next) && !stepKeys.includes(newStepBody.next)) {
+      delete newStepBody.next;
+    }
+    
+    return [ stepKey, newStepBody ]
+  })
 
   return { tasks: newTasks, steps: newSteps };
 }

--- a/css/lab-pages-editor.styl
+++ b/css/lab-pages-editor.styl
@@ -479,22 +479,9 @@ $fontWeightBoldPlus = 700
 
       &:active
         cursor: grabbing
-    
-    ul.branching-controls
-      display: flex
-      flex-direction: row
-      flex-wrap: wrap
-      justify-content: center
-      list-style: none
-      margin: 0
-      padding: 0
-      
-      li
-        display: flex
-        flex-direction: column
-        margin: 0 $sizeM $sizeL $sizeM
-        padding: 0
-      
+
+    .next-step-controls
+
       .fake-button
         background: $white
         border: 1px solid $grey1
@@ -519,6 +506,25 @@ $fontWeightBoldPlus = 700
         &.next-is-submit
           background: $white
           border: 2px solid $yellow
+
+      &.simple-next-controls
+        display: flex
+        flex-direction: column
+      
+      &.branching-next-controls
+        display: flex
+        flex-direction: row
+        flex-wrap: wrap
+        justify-content: center
+        list-style: none
+        margin: 0
+        padding: 0
+        
+        li
+          display: flex
+          flex-direction: column
+          margin: 0 $sizeM $sizeL $sizeM
+          padding: 0
   
   .task-key
   .step-key

--- a/css/lab-pages-editor.styl
+++ b/css/lab-pages-editor.styl
@@ -480,18 +480,8 @@ $fontWeightBoldPlus = 700
       &:active
         cursor: grabbing
 
-    .next-step-controls
+    .next-controls
 
-      .fake-button
-        background: $white
-        border: 1px solid $grey1
-        border-radius: 2px
-        color: $black
-        font-family: $fontFamilies
-        font-size: $fontSizeXS
-        padding: $sizeS $sizeM
-        text-align: center
-      
       .next-arrow
         color: $yellow
         display: block
@@ -510,21 +500,26 @@ $fontWeightBoldPlus = 700
       &.simple-next-controls
         display: flex
         flex-direction: column
+    
+    ul.horizontal-list
+      display: flex
+      flex-direction: row
+      flex-wrap: wrap
+      justify-content: center
+      list-style: none
+      margin: 0
+      padding: 0
       
-      &.branching-next-controls
+      li
         display: flex
-        flex-direction: row
-        flex-wrap: wrap
-        justify-content: center
-        list-style: none
-        margin: 0
+        flex-direction: column
+        margin: 0 $sizeM $sizeL $sizeM
         padding: 0
-        
-        li
-          display: flex
-          flex-direction: column
-          margin: 0 $sizeM $sizeL $sizeM
-          padding: 0
+    
+    div.vertical-layout
+      display: flex
+      flex-direction: column
+      align-items: center
   
   .task-key
   .step-key
@@ -533,6 +528,26 @@ $fontWeightBoldPlus = 700
     color: $white
     font-size: $fontSizeXS
     padding: 0 $sizeS
+  
+  .fake-button
+    background: $white
+    border: 1px solid $grey1
+    border-radius: 2px
+    color: $black
+    font-family: $fontFamilies
+    font-size: $fontSizeXS
+    padding: $sizeS $sizeM
+    text-align: center
+  
+  .fake-text-input
+    background: $white
+    border: 1px solid $grey1
+    border-radius: 2px
+    color: $grey4
+    font-family: $fontFamilies
+    font-size: $fontSizeS
+    padding: $sizeS $sizeM
+    box-shadow: 1px 1px 4px 0px $shadowColour inset
 
 .debug-0
   width: 6em


### PR DESCRIPTION
## PR Overview

Part of: **Pages Editor MVP** project and **FEM Lab** super-project
Follows #7052
Staging branch URL: https://pr-7055.pfe-preview.zooniverse.org/lab/1982/workflows/editor/3711?env=staging

This PR rebuilds the "Next Page" logic. Plus, it adds placeholder answers (fake text input & fake buttons for tasks). All this has been done mostly for UI examining purposes.

Next Page Logic:
- Previously, the Branching Controls (the component that lets were the property of the Page/Step.
  - However, this was a problem - the branching controls weren't setting `step.next`, but instead `step.task[x].answer[y].next`! This meant that if we have more than 1 Single Question Task on the Page/Step, and _especially_ if that SQT _wasn't the final Task_ on the Page/Step, the visual design would be broken.
- Now, we're moving "Branching Next Controls" from the Page/Step level to the Task level.
  - The branching next page controls will only appear on the FIRST Single Question Task of the Page/Step, if it has any.
  - ❗ The FEM classifier has this rule: if there are multiple Single Question Tasks on a Page/Step, then the FIRST SQTask dictates the branching logic.
- We're also adding a "Simple Next Controls" at the Page/Step level.
  - If a Page/Step doesn't have a branching Task, then it'll have a "simple next page controls" at the end of it.

Placeholder Answers:
- Text Tasks and Single Question Tasks (if they're not the branching task) now have placeholder answers (fake text input/buttons), as per Sean's designs.
- This UI feature has been packaged with this PR, as it's required to visualise various wonky workflow combinations, for a design review.

Misc:
- A new Quick Setup button has been added to demonstrate wonky workflow configurations. And by "wonky" I mean it may bork the intended UI design, but is otherwise _technically_ functional to the FEM classifier.

_Screenshot: an example workflow created by the new Quick Setup. Has 2 pages with 3 tasks. The first page has two SQTasks, but only the first has branching controls. The 2nd and 3rd tasks have fake text input/buttons to visually demonstrate how the task would looks like in the classifier. The 2nd page has simple "next page" control, currently pointing to "Submit"_

<img width="814" alt="image" src="https://github.com/zooniverse/Panoptes-Front-End/assets/13952701/dee03720-7af6-44da-93b5-501c5446783f">

### Testing

- Open the staging URL. You should be looking at a test workflow (e.g. staging wf 3711)
- Click on the Quick Setup (Advanced, Branching) button in the debug menu below
- Observe the visual layout of the workflow on the Pages Editor. _Confirm that it looks readable to you._
- Attempt to change the "Next Page" of any branching page. Confirm that the change works.
- Attempt to change the "Next Page" of any non-branching page. Confirm that the change works. 
  - ⚠️ NOTE: when re-arranging pages, pages are automatically re-linked to the next page. This is a behaviour that's still under discussion, please ignore it until further confirmation.

### Status

~~Mon 11 Mar: WIP~~

Mon 18 Mar: Ready for Review

This PR is currently targeting pages-editor-pt16 for review purposes. Do not merge until 7052 is ready and this branch's merge is re-targeted to `master`.