### PR TITLE
Remove polyfill.io

### DIFF
--- a/views/index.ejs
+++ b/views/index.ejs
@@ -69,7 +69,6 @@
 
     <div id="panoptes-main-container"></div>
 
-    <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=default,es6,Promise,fetch,Array.prototype.includes,Array.prototype.find,Object.entries,Object.values&amp;flags=gated"></script>
     <script>('assign' in Object) || document.write('<script src="/fallback-polyfills.js"></'+'script>');</script>
   </body>
 </html>


### PR DESCRIPTION
## PR Overview

Staging branch URL: https://pr-7057.pfe-preview.zooniverse.org
Closes #7051 . Fixes #7056 

This PR removes `polyfill.io` from our base HTML file. At the moment, Polyfill.io breaks our Markdown components for _Safari browsers._ For example, posts on Talk pages viewed on Safari  are no longer formatted.

Example of what we expect to see:
<img width="200" alt="image" src="https://github.com/zooniverse/Panoptes-Front-End/assets/13952701/b0f3f0d1-e524-4fe5-864b-85221457fae9">

Example of what we actually see, prior to the fix in this PR:
<img width="200" alt="image" src="https://github.com/zooniverse/Panoptes-Front-End/assets/13952701/3bfb62b4-f87b-44eb-9d01-bf5547d57772">

Issue was confirmed on local with macOS + Safari 15.6.1 (yes, that old) and on Browserstack with macOS + Safari 17.3

### Testing

**For the tester:** since this is a small change that may have a large effect, a second set of eyes running some very thorough checks would be very appreciated. I've listed my suggested testing method, and I've also retained the default testing checklist that comes with PFE PRs since they may be pertinent in this case.

Suggested testing:
- Choose a desktop browser: Chrome, Safari, Edge, Safari
  - (Optional) choose a mobile browser: Chrome, Safari
- Open https://pr-7057.pfe-preview.zooniverse.org/talk/17/3290666?comment=5400019&env=production&page=1 . **Specifically,** confirm that text is being formatted correctly. (See screenshot above)
- Perform sanity checks. Open Zooniverse home page.
  - Confirm non-logged-in home page is rendering correctly.
  - Log in. Confirm logged-in page is rendering correctly.
- Open Projects page. Confirm that projects are being listed and that browsing is possible.
- Select a Project. Confirm that project page is displaying properly. **Specifically,** check that Markdown-formatted content such as the About page [(e.g.)](https://pr-7057.pfe-preview.zooniverse.org/projects/orionnau/active-asteroids/about/research?env=production) is being formatted correctly.
- Make and submit a Classification.
- Repeat from start with other browsers.

So far I've confirmed all the tests above with:
- local machine
  - macOS + Chrome 122
  - macOS + Safari 15.6.1
- Browserstack
  - macOS (Sonoma) + Safari 17.3
  - iOS + Safari 17
  - Win 11 + Firefox 123
  - Win 11 + Edge 122 
  - Win 10 + IE11 ⚠️ nothing renders, white page! ...but then again, `www.zooniverse.org` (without the polyfill.io removal) also doesn't work, so IE11 has bigger problems than Polyfill. 🤷 

**Default Checklist 1**
- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

**Default Checklist 2**
- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- ~~Can you `npm ci` and app works as expected?~~ Yes.
- ~~If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?~~
- [ ] Are the tests passing locally and on GitHub Actions?

### Status

Ready for review.
