### PR TITLE
Pages Editor: add "Add Task to existing Page" functionality

### DIFF
--- a/app/pages/lab-pages-editor/components/TasksPage/ExperimentalPanel.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/ExperimentalPanel.jsx
@@ -1,0 +1,110 @@
+const DEFAULT_HANDLER = () => {};
+
+export default function ExperimentalPanel({
+  update = DEFAULT_HANDLER
+}) {
+  function experimentalReset() {
+    update({
+      tasks: {},
+      steps: []
+    });
+  }
+
+  function experimentalQuickSetup() {
+    update({
+      tasks: {
+        'T0': {
+          answers: [
+            {next: 'P1', label: 'Animals'},
+            {next: 'P2', label: 'Fruits'},
+            {label: 'Neither'}
+          ],
+          help: '',
+          question: 'Do you like Animals or Fruits?',
+          required: false,
+          type: 'single'
+        },
+        'T1': { help: '', type: 'text', required: false, instruction: 'Which animal?' },
+        'T2': { help: '', type: 'text', required: false, instruction: 'Which fruit?' }
+      },
+      steps: [
+        ['P0', { stepKey: 'P0', taskKeys: ["T0"] }],
+        ['P1', { next: 'P2', stepKey: 'P1', taskKeys: ["T1"] }],
+        ['P2', { stepKey: 'P2', taskKeys: ["T2"] }]
+      ]
+    });
+  }
+
+  function experimentalQuickSetupBranching() {
+    update({
+      tasks: {
+        'T1.1': {
+          answers: [
+            {next: 'P2', label: 'Go to the 🔴 RED page'},
+            {next: 'P3', label: 'Go to the 🔵 BLUE page'},
+          ],
+          help: '',
+          question: 'Oh dear, this page has multiple branching tasks. Let\'s see what happens',
+          required: false,
+          type: 'single'
+        },
+        'T1.2': {
+          answers: [
+            {next: 'P4', label: 'Go to the 🟡 YELLOW page'},
+            {next: 'P5', label: 'Go to the 🟢 GREEN page'},
+          ],
+          help: '',
+          question: 'This is the second branching task. If you answer both on the page, where do you branch to?',
+          required: false,
+          type: 'single'
+        },
+        'T2': { help: '', type: 'text', required: false, instruction: 'Welcome to the 🔴 RED page! How do you feel?' },
+        'T3': { help: '', type: 'text', required: false, instruction: 'Welcome to the 🔵 BLUE page! How do you feel?' },
+        'T4': { help: '', type: 'text', required: false, instruction: 'Welcome to the 🟡 YELLOW page! How do you feel?' },
+        'T5': { help: '', type: 'text', required: false, instruction: 'Welcome to the 🟢 GREEN page! How do you feel?' },
+      },
+      steps: [
+        ['P1', { stepKey: 'P1', taskKeys: ['T1.1', 'T1.2'] }],
+        ['P2', { stepKey: 'P2', taskKeys: ['T2'] }],
+        ['P3', { stepKey: 'P3', taskKeys: ['T3'] }],
+        ['P4', { stepKey: 'P4', taskKeys: ['T4'] }],
+        ['P5', { stepKey: 'P5', taskKeys: ['T5'] }],
+      ]
+    });
+  }
+
+  return (
+    <div
+      style={{
+        padding: '16px',
+        margin: '8px 0',
+        border: '2px dashed #c04040'
+      }}
+    >
+      <button
+        className="big"
+        onClick={experimentalReset}
+        type="button"
+        style={{ margin: '0 4px' }}
+      >
+        RESET
+      </button>
+      <button
+        className="big"
+        onClick={experimentalQuickSetup}
+        type="button"
+        style={{ margin: '0 4px' }}
+      >
+        QUICK SETUP (simple)
+      </button>
+      <button
+        className="big"
+        onClick={experimentalQuickSetupBranching}
+        type="button"
+        style={{ margin: '0 4px' }}
+      >
+        QUICK SETUP (advanced, branching)
+      </button>
+    </div>
+  );
+}

--- a/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
@@ -9,6 +9,7 @@ import cleanupTasksAndSteps from '../../helpers/cleanupTasksAndSteps.js';
 import getPreviewEnv from '../../helpers/getPreviewEnv.js';
 // import strings from '../../strings.json'; // TODO: move all text into strings
 
+import ExperimentalPanel from './ExperimentalPanel.jsx';
 import EditStepDialog from './components/EditStepDialog';
 import NewTaskDialog from './components/NewTaskDialog.jsx';
 import StepItem from './components/StepItem';
@@ -139,76 +140,6 @@ export default function TasksPage() {
     update({ tasks: newTasks });
   }
 
-  function experimentalReset() {
-    update({
-      tasks: {},
-      steps: []
-    });
-  }
-
-  function experimentalQuickSetup() {
-    update({
-      tasks: {
-        'T0': {
-          answers: [
-            {next: 'P1', label: 'Animals'},
-            {next: 'P2', label: 'Fruits'},
-            {label: 'Neither'}
-          ],
-          help: '',
-          question: 'Do you like Animals or Fruits?',
-          required: false,
-          type: 'single'
-        },
-        'T1': { help: '', type: 'text', required: false, instruction: 'Which animal?' },
-        'T2': { help: '', type: 'text', required: false, instruction: 'Which fruit?' }
-      },
-      steps: [
-        ['P0', { stepKey: 'P0', taskKeys: ["T0"] }],
-        ['P1', { next: 'P2', stepKey: 'P1', taskKeys: ["T1"] }],
-        ['P2', { stepKey: 'P2', taskKeys: ["T2"] }]
-      ]
-    });
-  }
-
-  function experimentalQuickSetupBranching() {
-    update({
-      tasks: {
-        'T1.1': {
-          answers: [
-            {next: 'P2', label: 'Go to the 🔴 RED page'},
-            {next: 'P3', label: 'Go to the 🔵 BLUE page'},
-          ],
-          help: '',
-          question: 'Oh dear, this page has multiple branching tasks. Let\'s see what happens',
-          required: false,
-          type: 'single'
-        },
-        'T1.2': {
-          answers: [
-            {next: 'P4', label: 'Go to the 🟡 YELLOW page'},
-            {next: 'P5', label: 'Go to the 🟢 GREEN page'},
-          ],
-          help: '',
-          question: 'This is the second branching task. If you answer both on the page, where do you branch to?',
-          required: false,
-          type: 'single'
-        },
-        'T2': { help: '', type: 'text', required: false, instruction: 'Welcome to the 🔴 RED page! How do you feel?' },
-        'T3': { help: '', type: 'text', required: false, instruction: 'Welcome to the 🔵 BLUE page! How do you feel?' },
-        'T4': { help: '', type: 'text', required: false, instruction: 'Welcome to the 🟡 YELLOW page! How do you feel?' },
-        'T5': { help: '', type: 'text', required: false, instruction: 'Welcome to the 🟢 GREEN page! How do you feel?' },
-      },
-      steps: [
-        ['P1', { stepKey: 'P1', taskKeys: ['T1.1', 'T1.2'] }],
-        ['P2', { stepKey: 'P2', taskKeys: ['T2'] }],
-        ['P3', { stepKey: 'P3', taskKeys: ['T3'] }],
-        ['P4', { stepKey: 'P4', taskKeys: ['T4'] }],
-        ['P5', { stepKey: 'P5', taskKeys: ['T5'] }],
-      ]
-    });
-  }
-
   const previewEnv = getPreviewEnv();
   const previewUrl = `https://frontend.preview.zooniverse.org/projects/${project?.slug}/classify/workflow/${workflow?.id}${previewEnv}`;
   if (!workflow) return null;
@@ -273,38 +204,9 @@ export default function TasksPage() {
         />
 
         {/* EXPERIMENTAL */}
-        <div
-          style={{
-            padding: '16px',
-            margin: '8px 0',
-            border: '2px dashed #c04040'
-          }}
-        >
-          <button
-            className="big"
-            onClick={experimentalReset}
-            type="button"
-            style={{ margin: '0 4px' }}
-          >
-            RESET
-          </button>
-          <button
-            className="big"
-            onClick={experimentalQuickSetup}
-            type="button"
-            style={{ margin: '0 4px' }}
-          >
-            QUICK SETUP (simple)
-          </button>
-          <button
-            className="big"
-            onClick={experimentalQuickSetupBranching}
-            type="button"
-            style={{ margin: '0 4px' }}
-          >
-            QUICK SETUP (advanced, branching)
-          </button>
-        </div>
+        <ExperimentalPanel
+          update={update}
+        />
       </section>
     </div>
   );

--- a/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
@@ -75,12 +75,6 @@ export default function TasksPage() {
     // TODO
   }
 
-  // aka openEditStepDialog
-  function editStep(stepIndex) {
-    setActiveStepIndex(stepIndex);
-    editStepDialog.current?.openDialog();
-  }
-
   function moveStep(from, to) {
     const oldSteps = workflow?.steps || [];
     if (from < 0 || to < 0 || from >= oldSteps.length || to >= oldSteps.length) return;
@@ -108,6 +102,11 @@ export default function TasksPage() {
 
   function openNewTaskDialog() {
     newTaskDialog.current?.openDialog();
+  }
+
+  function openEditStepDialog(stepIndex) {
+    setActiveStepIndex(stepIndex);
+    editStepDialog.current?.openDialog();
   }
 
   // Changes the optional "next page" of a step/page
@@ -248,8 +247,8 @@ export default function TasksPage() {
               allSteps={workflow.steps}
               allTasks={workflow.tasks}
               deleteStep={deleteStep}
-              editStep={editStep}
               moveStep={moveStep}
+              openEditStepDialog={openEditStepDialog}
               setActiveDragItem={setActiveDragItem}
               step={step}
               stepKey={step[0]}
@@ -262,7 +261,7 @@ export default function TasksPage() {
         <NewTaskDialog
           ref={newTaskDialog}
           addTask={addTask}
-          editStep={editStep}
+          openEditStepDialog={openEditStepDialog}
         />
         <EditStepDialog
           ref={editStepDialog}

--- a/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/EditStepDialog.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/EditStepDialog.jsx
@@ -77,9 +77,15 @@ function EditStepDialog({
         })}
       </form>
       <div className="dialog-footer flex-row">
-        <div className="flex-item" />
         <button
-          className="big"
+          className="big flex-item"
+          onClick={closeDialog}
+          type="button"
+        >
+          Add New Task
+        </button>
+        <button
+          className="big teal-border"
           onClick={closeDialog}
           type="button"
         >

--- a/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/EditStepDialog.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/EditStepDialog.jsx
@@ -13,10 +13,9 @@ const taskNames = {
 function EditStepDialog({
   allTasks = {},
   step = [],
-  stepIndex = -1,
   updateTask
 }, forwardedRef) {
-  const [ stepKey, stepBody ] = step ;
+  const [ stepKey, stepBody ] = step;
   const taskKeys = stepBody?.taskKeys || [];
   const editStepDialog = useRef(null);
 
@@ -99,7 +98,7 @@ function EditStepDialog({
 EditStepDialog.propTypes = {
   allTasks: PropTypes.object,
   step: PropTypes.object,
-  stepIndex: PropTypes.number
+  updateTask: PropTypes.func
 };
 
 function onSubmit(e) {

--- a/app/pages/lab-pages-editor/components/TasksPage/components/NewTaskDialog.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/NewTaskDialog.jsx
@@ -9,7 +9,7 @@ const DEFAULT_HANDLER = () => {};
 
 function NewTaskDialog({
   addTask = DEFAULT_HANDLER,
-  editStep = DEFAULT_HANDLER
+  openEditStepDialog = DEFAULT_HANDLER
 }, forwardedRef) {
   const newTaskDialog = useRef(null);
 
@@ -34,7 +34,7 @@ function NewTaskDialog({
 
     closeDialog();
     const newStepIndex = await addTask(tasktype);
-    editStep(newStepIndex);
+    openEditStepDialog(newStepIndex);
   }
 
   return (
@@ -104,7 +104,7 @@ function NewTaskDialog({
 
 NewTaskDialog.propTypes = {
   addTask: PropTypes.func,
-  editStep: PropTypes.func
+  openEditStepDialog: PropTypes.func
 };
 
 function onSubmit(e) {

--- a/app/pages/lab-pages-editor/components/TasksPage/components/NewTaskDialog.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/NewTaskDialog.jsx
@@ -8,7 +8,7 @@ import TaskIcon from '../../../icons/TaskIcon.jsx';
 const DEFAULT_HANDLER = () => {};
 
 function NewTaskDialog({
-  addTaskWithStep = DEFAULT_HANDLER,
+  addTask = DEFAULT_HANDLER,
   editStep = DEFAULT_HANDLER
 }, forwardedRef) {
   const newTaskDialog = useRef(null);
@@ -33,7 +33,7 @@ function NewTaskDialog({
     // Protip: don't use event.target, since it might return the child of the button, instead of the button itself
 
     closeDialog();
-    const newStepIndex = await addTaskWithStep(tasktype);
+    const newStepIndex = await addTask(tasktype);
     editStep(newStepIndex);
   }
 
@@ -103,7 +103,7 @@ function NewTaskDialog({
 }
 
 NewTaskDialog.propTypes = {
-  addTaskWithStep: PropTypes.func,
+  addTask: PropTypes.func,
   editStep: PropTypes.func
 };
 

--- a/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/StepItem.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/StepItem.jsx
@@ -22,8 +22,8 @@ function StepItem({
   allSteps,
   allTasks,
   deleteStep = DEFAULT_HANDLER,
-  editStep = DEFAULT_HANDLER,
   moveStep = DEFAULT_HANDLER,
+  openEditStepDialog = DEFAULT_HANDLER,
   setActiveDragItem = DEFAULT_HANDLER,
   step,
   stepIndex,
@@ -40,7 +40,7 @@ function StepItem({
   }
 
   function doEdit() {
-    editStep(stepIndex);
+    openEditStepDialog(stepIndex);
   }
 
   function moveStepUp() {
@@ -161,8 +161,8 @@ StepItem.propTypes = {
   allSteps: PropTypes.array,
   allTasks: PropTypes.object,
   deleteStep: PropTypes.func,
-  editStep: PropTypes.func,
   moveStep: PropTypes.func,
+  openEditStepDialog: PropTypes.func,
   setActiveDragItem: PropTypes.func,
   step: PropTypes.array,
   stepIndex: PropTypes.number,

--- a/css/lab-pages-editor.styl
+++ b/css/lab-pages-editor.styl
@@ -309,7 +309,11 @@ $fontWeightBoldPlus = 700
         border: 3px solid $grey1
         font-size: $fontSizeM
         padding: $sizeS $sizeXL
+        box-shadow: none
         text-transform: uppercase
+
+        &.teal-border
+          border: 3px solid $teal
       
       .dialog-header
         background: $teal
@@ -398,6 +402,7 @@ $fontWeightBoldPlus = 700
         
       .dialog-footer
         padding: $sizeXS $sizeL $sizeL $sizeL
+        margin-bottom: $sizeL
 
     section
       h3


### PR DESCRIPTION
## PR Overview

Part of: **Pages Editor MVP** project and **FEM Lab** super-project
Follows #7055
Staging branch URL: https://pr-???.pfe-preview.zooniverse.org/lab/1982/workflows/editor/3711?env=staging

This PR implements the "Add Task" functionality, but to an _existing_ Page. Prior to this PR, the "Add Task" functionality can only be triggered at the Tasks Page's top level, creating a new Step alongside the new Task.

Code changes:
- code of interest:
  - `addTask()` (previously addTaskWithStep()) now asks for the Step to which the task needs to be added. If no Step is specified, it creates a new Step.
  - NewStepDialog needs to be rewired so that it functions similarly; a "target Step" should be specified when it opens.
- ⚠️ A large amount of code has been refactored, so that may make the code a bit harder to review in this PR, but should make the overall Pages Editor code easier to read.

Considerations: (separate PR? I don't know)
- Tasks need to be delete-able
  - If a Step/Page has no Task, it should be deleted.
- Rule: a Step should not be able to have more than 1 branching Task (aka Single Answer Question Task)

### Status

WIP