### PR TITLE
fix: undefined project.slug in Talk search results

### DIFF
--- a/app/talk/search-result.jsx
+++ b/app/talk/search-result.jsx
@@ -50,6 +50,9 @@ export default class TalkSearchResult extends React.Component {
     const comment = this.props.data;
     const discussion = this.discussionFromComment(comment);
     const [owner, name] = comment.project_slug ? comment.project_slug.split('/') : [];
+    const commentProject = {
+      slug: comment?.project_slug || ''
+    }
 
     return (
       <div className="talk-search-result talk-module">
@@ -67,7 +70,7 @@ export default class TalkSearchResult extends React.Component {
         )}
         <CommentContextIcon comment={comment} />
         <CommentLink comment={comment} project={this.props.project}>{comment.discussion_title}</CommentLink>
-        <Markdown content={comment.body} project={this.props.project} />
+        <Markdown content={comment.body} project={commentProject}/>
         <DiscussionPreview {...this.props} discussion={discussion} owner={owner} name={name} comment={comment} />
       </div>
     );


### PR DESCRIPTION
Fix an error where `project.slug` is undefined in Talk search results,
leading to raw markdown strings being passed to the HTML parser in
the `Markdown` component.

Staging branch URL: https://pr-7068.pfe-preview.zooniverse.org/talk/search?page=11&query=add&env=production

- Fixes #7067.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
