### PR TITLE
Lab: edit the External Links section copy

### DIFF
--- a/app/pages/lab/project-details.cjsx
+++ b/app/pages/lab/project-details.cjsx
@@ -210,8 +210,7 @@ module.exports = createReactClass
             External links<br />
             <small className="form-help">
               Adding an external link will populate an entry in a list of links
-              in the bottom right section of the project landing page.  These
-              links open in a new tab when clicked. You can rearrange the
+              in the bottom right section of the project landing page. You can rearrange the
               displayed order by clicking and dragging on the left gray tab next
               to each link.
             </small>


### PR DESCRIPTION
Staging branch URL: https://pr-7070.pfe-preview.zooniverse.org

Closes https://github.com/zooniverse/front-end-monorepo/issues/3633

Removed the phrase "These links open in a new tab when clicked." External links behave differently in PFE and FEM, so I just removed the related help text in the lab for now. FEM-hosted projects still use parts the PFE lab for the foreseeable future, so lab instructions must make sense to both.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
