### PR TITLE
deps: preview API client fixes for Talk searches

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "markdownz": "~9.1.6",
         "modal-form": "~2.9",
         "moment": "~2.29.0",
-        "panoptes-client": "~5.6.0",
+        "panoptes-client": "eatyourgreens/panoptes-javascript-client#ignore-null-comments",
         "papaparse": "^5.4.1",
         "polished": "~4.3.1",
         "prop-types": "~15.8.1",
@@ -12786,9 +12786,9 @@
       }
     },
     "node_modules/panoptes-client": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-5.6.0.tgz",
-      "integrity": "sha512-XML9SeuYxhS9qtwSRPbMfsOD8VjiLpcctAaHMOJSDEp+BpOrxXfEqnP5J6Bjl7q7WiATWc116mVHt27JBOE3QQ==",
+      "version": "5.6.1",
+      "resolved": "git+ssh://git@github.com/eatyourgreens/panoptes-javascript-client.git#43bcf0e582e3de933cbe0397e6b6d490df586917",
+      "license": "Apache-2.0",
       "dependencies": {
         "local-storage": "^2.0.0",
         "normalizeurl": "~1.0.0",
@@ -27227,9 +27227,8 @@
       }
     },
     "panoptes-client": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-5.6.0.tgz",
-      "integrity": "sha512-XML9SeuYxhS9qtwSRPbMfsOD8VjiLpcctAaHMOJSDEp+BpOrxXfEqnP5J6Bjl7q7WiATWc116mVHt27JBOE3QQ==",
+      "version": "git+ssh://git@github.com/eatyourgreens/panoptes-javascript-client.git#43bcf0e582e3de933cbe0397e6b6d490df586917",
+      "from": "panoptes-client@eatyourgreens/panoptes-javascript-client#ignore-null-comments",
       "requires": {
         "local-storage": "^2.0.0",
         "normalizeurl": "~1.0.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "markdownz": "~9.1.6",
     "modal-form": "~2.9",
     "moment": "~2.29.0",
-    "panoptes-client": "~5.6.0",
+    "panoptes-client": "eatyourgreens/panoptes-javascript-client#ignore-null-comments",
     "papaparse": "^5.4.1",
     "polished": "~4.3.1",
     "prop-types": "~15.8.1",


### PR DESCRIPTION
Installs a version of the API client that shouldn't crash when a
response contains `null` items.

Staging branch URL: https://pr-7071.pfe-preview.zooniverse.org/talk/search?query=depression&env=production


# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
