### PR TITLE
Pages Editor: add "Delete Task from Page" functionality

### DIFF
--- a/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
@@ -77,10 +77,25 @@ export default function TasksPage() {
   }
 
   function deleteTask(taskKey) {
+    // First check: does it exist?
     if (!taskKey) return;
+    if (!workflow?.tasks?.[taskKey]) return;
 
-    console.log('+++ Delete Task: ', taskKey);
-    // TODO
+    // Delete the task
+    const newTasks = structuredClone(workflow?.tasks || {});
+    delete newTasks[taskKey];
+
+    // Delete task 
+    const newSteps = structuredClone(workflow?.steps || {});
+    newSteps.forEach(step => {
+      const stepBody = step[1] || {};
+      stepBody.taskKeys = (stepBody?.taskKeys || []).filter(key => key !== taskKey);
+    }); 
+
+    // Cleanup, then commit
+    const cleanedTasksAndSteps = cleanupTasksAndSteps(newTasks, newSteps);    
+    // console.log('+++ Delete Task: ', taskKey, ' ==> \n', cleanedTasksAndSteps);
+    update(cleanedTasksAndSteps);
   }
 
   function moveStep(from, to) {

--- a/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
@@ -21,7 +21,6 @@ export default function TasksPage() {
   const newTaskDialog = useRef(null);
   const [ activeStepIndex, setActiveStepIndex ] = useState(-1);  // Tracks which Step is being edited.
   const [ activeDragItem, setActiveDragItem ] = useState(-1);  // Keeps track of active item being dragged (StepItem). This is because "dragOver" CAN'T read the data from dragEnter.dataTransfer.getData().
-  const activeStepKey = workflow?.steps?.[activeStepIndex]?.[0];
   const isActive = true; // TODO
 
   /*
@@ -85,7 +84,7 @@ export default function TasksPage() {
     const newTasks = structuredClone(workflow?.tasks || {});
     delete newTasks[taskKey];
 
-    // Delete task 
+    // Delete the task reference in steps
     const newSteps = structuredClone(workflow?.steps || {});
     newSteps.forEach(step => {
       const stepBody = step[1] || {};
@@ -94,7 +93,6 @@ export default function TasksPage() {
 
     // Cleanup, then commit
     const cleanedTasksAndSteps = cleanupTasksAndSteps(newTasks, newSteps);    
-    // console.log('+++ Delete Task: ', taskKey, ' ==> \n', cleanedTasksAndSteps);
     update(cleanedTasksAndSteps);
   }
 
@@ -109,16 +107,15 @@ export default function TasksPage() {
   function deleteStep(stepIndex) {
     if (!workflow) return;
     const { steps, tasks } = workflow;
-    const [ stepKey, stepBody ] = steps[stepIndex] || [];
-    const tasksToBeDeleted = stepBody?.taskKeys || [];
+    const [ stepKey ] = steps[stepIndex] || [];
 
     const confirmed = confirm(`Delete Page ${stepKey}?`);
     if (!confirmed) return;
 
     const newSteps = steps.toSpliced(stepIndex, 1);  // Copy then delete Step at stepIndex
     const newTasks = tasks ? { ...tasks } : {};  // Copy tasks
-    tasksToBeDeleted.forEach(taskKey => delete newTasks[taskKey]);
 
+    // cleanedupTasksAndSteps() will also remove tasks not associated with any step.
     const cleanedTasksAndSteps = cleanupTasksAndSteps(newTasks, newSteps); 
     update(cleanedTasksAndSteps);
   }

--- a/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
@@ -78,6 +78,8 @@ export default function TasksPage() {
 
   function deleteTask(taskKey) {
     if (!taskKey) return;
+
+    console.log('+++ Delete Task: ', taskKey);
     // TODO
   }
 

--- a/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/EditStepDialog.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/EditStepDialog.jsx
@@ -27,6 +27,7 @@ function EditStepDialog({
 
   useImperativeHandle(forwardedRef, () => {
     return {
+      closeDialog,
       openDialog
     };
   });

--- a/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/EditStepDialog.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/EditStepDialog.jsx
@@ -14,6 +14,7 @@ const DEFAULT_HANDLER = () => {};
 
 function EditStepDialog({
   allTasks = {},
+  deleteTask,
   onClose = DEFAULT_HANDLER,
   openNewTaskDialog = DEFAULT_HANDLER,
   step = [],
@@ -78,6 +79,7 @@ function EditStepDialog({
           return (
             <EditTaskForm
               key={`editTaskForm-${taskKey}`}
+              deleteTask={deleteTask}
               task={task}
               taskKey={taskKey}
               updateTask={updateTask}
@@ -94,7 +96,7 @@ function EditStepDialog({
           Add New Task
         </button>
         <button
-          className="big teal-border"
+          className="big done"
           onClick={closeDialog}
           type="button"
         >
@@ -107,6 +109,7 @@ function EditStepDialog({
 
 EditStepDialog.propTypes = {
   allTasks: PropTypes.object,
+  deleteTask: PropTypes.func,
   onClose: PropTypes.func,
   step: PropTypes.object,
   stepIndex: PropTypes.number,

--- a/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/EditTaskForm.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/EditTaskForm.jsx
@@ -7,6 +7,7 @@ const taskTypes = {
 };
 
 export default function EditTaskForm({  // It's not actually a form, but a fieldset that's part of a form.
+  deleteTask,
   task,
   taskKey,
   updateTask
@@ -22,6 +23,7 @@ export default function EditTaskForm({  // It's not actually a form, but a field
       <legend className="task-key">{taskKey}</legend>
       {(TaskForm)
         ? <TaskForm
+            deleteTask={deleteTask}
             task={task}
             taskKey={taskKey}
             updateTask={updateTask}

--- a/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/types/SingleQuestionTask.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/types/SingleQuestionTask.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 
+import DeleteIcon from '../../../../../icons/DeleteIcon.jsx';
 import MinusIcon from '../../../../../icons/MinusIcon.jsx';
 import PlusIcon from '../../../../../icons/PlusIcon.jsx';
 
@@ -8,6 +9,7 @@ const DEFAULT_HANDLER = () => {};
 export default function SingleQuestionTask({
   task,
   taskKey,
+  deleteTask = DEFAULT_HANDLER,
   updateTask = DEFAULT_HANDLER
 }) {
   const [ answers, setAnswers ] = useState(task?.answers || []);
@@ -28,6 +30,10 @@ export default function SingleQuestionTask({
       required
     };
     updateTask(taskKey, newTask);
+  }
+
+  function doDelete() {
+    deleteTask(taskKey);
   }
 
   function addAnswer(e) {
@@ -84,8 +90,15 @@ export default function SingleQuestionTask({
             onBlur={update}
             onChange={(e) => { setQuestion(e?.target?.value) }}
           />
+          <button
+            aria-label={`Delete Task ${taskKey}`}
+            className="big"
+            onClick={doDelete}
+            type="button"
+          >
+            <DeleteIcon />
+          </button>
         </div>
-        {/* <button>Delete</button> */}
       </div>
       <div className="input-row">
         <span className="big">Choices</span>

--- a/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/types/TextTask.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/types/TextTask.jsx
@@ -1,10 +1,12 @@
 import { useEffect, useState } from 'react';
+import DeleteIcon from '../../../../../icons/DeleteIcon.jsx';
 
 const DEFAULT_HANDLER = () => {};
 
 export default function TextTask({
   task,
   taskKey,
+  deleteTask = DEFAULT_HANDLER,
   updateTask = DEFAULT_HANDLER
 }) {
   const [ help, setHelp ] = useState(task?.help || '');
@@ -20,6 +22,10 @@ export default function TextTask({
       required
     };
     updateTask(taskKey, newTask);
+  }
+
+  function doDelete() {
+    deleteTask(taskKey);
   }
 
   // For inputs that don't have onBlur, update triggers automagically.
@@ -45,8 +51,15 @@ export default function TextTask({
             onBlur={update}
             onChange={(e) => { setInstruction(e?.target?.value) }}
           />
+          <button
+            aria-label={`Delete Task ${taskKey}`}
+            className="big"
+            onClick={doDelete}
+            type="button"
+          >
+            <DeleteIcon />
+          </button>
         </div>
-        {/* <button>Delete</button> */}
       </div>
       <div className="input-row">
         <span className="narrow">

--- a/app/pages/lab-pages-editor/helpers/cleanupTasksAndSteps.js
+++ b/app/pages/lab-pages-editor/helpers/cleanupTasksAndSteps.js
@@ -10,7 +10,7 @@ Clean up tasks and steps.
 
 export default function cleanupTasksAndSteps(tasks = {}, steps = []) {
   const newTasks = structuredClone(tasks);  // Copy tasks
-  let newSteps = steps.slice();  // Copy steps
+  let newSteps = structuredClone(steps);  // Copy steps. This is a deep copy, compared to steps.slice()
 
   const taskKeys = Object.keys(newTasks);
   const stepKeys = newSteps.map(step => step[0]);
@@ -28,14 +28,13 @@ export default function cleanupTasksAndSteps(tasks = {}, steps = []) {
   // Remove orphaned references in steps.
   newSteps = newSteps.map(step => {
     const [stepKey, stepBody] = step;
-    const newStepBody = { ...stepBody };
     
     // If the stepBody points to a non-existent Task Key or Step Key, remove the 'next'.
-    if (newStepBody.next && !taskKeys.includes(newStepBody.next) && !stepKeys.includes(newStepBody.next)) {
-      delete newStepBody.next;
+    if (stepBody.next && !taskKeys.includes(stepBody.next) && !stepKeys.includes(stepBody.next)) {
+      delete stepBody.next;
     }
     
-    return [ stepKey, newStepBody ]
+    return [ stepKey, stepBody ]
   })
 
   return { tasks: newTasks, steps: newSteps };

--- a/app/pages/lab-pages-editor/helpers/cleanupTasksAndSteps.js
+++ b/app/pages/lab-pages-editor/helpers/cleanupTasksAndSteps.js
@@ -16,6 +16,7 @@ export default function cleanupTasksAndSteps(tasks = {}, steps = []) {
   const stepKeys = newSteps.map(step => step[0]);
 
   // Remove steps without tasks
+  newSteps = newSteps.filter(step => step?.[1]?.taskKeys?.length > 0);
 
   // Remove orphaned references in branching tasks.
   Object.values(newTasks).forEach(task => {

--- a/app/pages/lab-pages-editor/helpers/cleanupTasksAndSteps.js
+++ b/app/pages/lab-pages-editor/helpers/cleanupTasksAndSteps.js
@@ -1,7 +1,7 @@
 /*
 Clean up tasks and steps.
-- TODO: Remove steps without tasks.
-- TODO: Remove tasks not associated with any step.
+- Remove steps without tasks.
+- Remove tasks not associated with any step.
 - Remove orphaned references in branching tasks.
 - Remove orphaned references in steps.
 
@@ -15,8 +15,17 @@ export default function cleanupTasksAndSteps(tasks = {}, steps = []) {
   const taskKeys = Object.keys(newTasks);
   const stepKeys = newSteps.map(step => step[0]);
 
-  // Remove steps without tasks
+  // Remove steps without tasks.
   newSteps = newSteps.filter(step => step?.[1]?.taskKeys?.length > 0);
+
+  // Remove tasks not associated with any step.
+  Object.keys(newTasks).forEach(taskKey => {
+    let existsInAnyStep = false;
+    newSteps.forEach(step => {
+      existsInAnyStep = existsInAnyStep || !!step?.[1]?.taskKeys?.includes(taskKey);
+    });
+    if (!existsInAnyStep) delete newTasks[taskKey];
+  });
 
   // Remove orphaned references in branching tasks.
   Object.values(newTasks).forEach(task => {
@@ -30,13 +39,11 @@ export default function cleanupTasksAndSteps(tasks = {}, steps = []) {
   
   // Remove orphaned references in steps.
   newSteps = newSteps.map(step => {
-    const [stepKey, stepBody] = step;
-    
     // If the stepBody points to a non-existent Task Key or Step Key, remove the 'next'.
+    const [stepKey, stepBody] = step;
     if (stepBody.next && !taskKeys.includes(stepBody.next) && !stepKeys.includes(stepBody.next)) {
       delete stepBody.next;
     }
-    
     return [ stepKey, stepBody ]
   })
 

--- a/app/pages/lab-pages-editor/helpers/cleanupTasksAndSteps.js
+++ b/app/pages/lab-pages-editor/helpers/cleanupTasksAndSteps.js
@@ -12,9 +12,6 @@ export default function cleanupTasksAndSteps(tasks = {}, steps = []) {
   const newTasks = structuredClone(tasks);  // Copy tasks
   let newSteps = structuredClone(steps);  // Copy steps. This is a deep copy, compared to steps.slice()
 
-  const taskKeys = Object.keys(newTasks);
-  const stepKeys = newSteps.map(step => step[0]);
-
   // Remove steps without tasks.
   newSteps = newSteps.filter(step => step?.[1]?.taskKeys?.length > 0);
 
@@ -26,6 +23,9 @@ export default function cleanupTasksAndSteps(tasks = {}, steps = []) {
     });
     if (!existsInAnyStep) delete newTasks[taskKey];
   });
+
+  const taskKeys = Object.keys(newTasks);
+  const stepKeys = newSteps.map(step => step[0]);
 
   // Remove orphaned references in branching tasks.
   Object.values(newTasks).forEach(task => {

--- a/app/pages/lab-pages-editor/helpers/cleanupTasksAndSteps.js
+++ b/app/pages/lab-pages-editor/helpers/cleanupTasksAndSteps.js
@@ -15,14 +15,16 @@ export default function cleanupTasksAndSteps(tasks = {}, steps = []) {
   const taskKeys = Object.keys(newTasks);
   const stepKeys = newSteps.map(step => step[0]);
 
+  // Remove steps without tasks
+
   // Remove orphaned references in branching tasks.
-  Object.values(newTasks).forEach(taskBody => {
-    taskBody?.answers?.forEach(answer => {
+  Object.values(newTasks).forEach(task => {
+    task?.answers?.forEach(answer => {
       // If the branching answer points to a non-existent Task Key or Step Key, remove the 'next'.
       if (answer.next && !taskKeys.includes(answer.next) && !stepKeys.includes(answer.next)) {
         delete answer.next;
       }
-    })
+    });
   });
   
   // Remove orphaned references in steps.

--- a/css/lab-pages-editor.styl
+++ b/css/lab-pages-editor.styl
@@ -308,12 +308,13 @@ $fontWeightBoldPlus = 700
       button.big
         border: 3px solid $grey1
         font-size: $fontSizeM
-        padding: $sizeS $sizeXL
+        padding: $sizeS $sizeM
         box-shadow: none
         text-transform: uppercase
 
-        &.teal-border
+        &.done
           border: 3px solid $teal
+          padding: $sizeS $sizeXL
       
       .dialog-header
         background: $teal


### PR DESCRIPTION
## PR Overview

Part of: **Pages Editor MVP** project and **FEM Lab** super-project
Follows #7065
Staging branch URL: https://pr-7075.pfe-preview.zooniverse.org/lab/1982/workflows/editor/3711?env=staging

This PR implements the "Delete Task" functionality, which deletes Tasks from an _existing_ Page. Prior to this PR, you only had the "Delete Page/Step" functionality.

New Behaviour:
- Tasks in the "Edit Page/Step" modal should now have a "Delete Task" button (trashcan icon).
- Clicking on the button will prompt users to confirm if they want to delete the task.
  - If this is the only task in a page/step, additional information will be given.
- Confirming the action will result in the Task being deleted.
  - Cancelling will result in no action.
  - If the only task in a page/step is deleted, the page/step will also be deleted. The Edit Page/Step modal will then close.

⚠️ Important Behind-The-Scenes Bit:
- `cleanupTasksAndSteps()` now properly removes Steps/Pages that have 0 Tasks, and removes Tasks that aren't associated with any Page/Step.

### Testing Steps

- Go to the testing URL: https://pr-7065.pfe-preview.zooniverse.org/lab/1982/workflows/editor/3711?env=staging
- Click on "Quick Setup" in the debug panel to quickly setup a pre-fabricated workflow.
- Click on the "Edit Page/Step" button (pencil icon) to edit any Page/Step
  - Optional: add new Tasks to this Page/Step.
- In the "Edit Page/Step" modal, click on the "Delete Task" button (trash can icon) to delete any Task.
  - Observe that Task is correctly removed from the Page.
  - If the Task removed is the last one in the Page, the Page should also be deleted and the Edit Page/Step modal should close.
- Confirm that changes to the Workflow resource is correct (i.e. check what's submitted to the Panoptes API).
  - Be sure that there are no orphaned references.

### Status

Ready for review!