### PR TITLE
Pages Editor: add rules to "Add Task to Page" functionality

### DIFF
--- a/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
@@ -193,7 +193,7 @@ export default function TasksPage() {
   // Limited Branching Rule:
   // - a Step can only have 1 branching task.
   // - If a Step has a branching task, it can't have any other tasks.
-  const enforceLimitedBranchingRule = !!canStepBranch(workflow?.steps?.[activeStepIndex], workflow?.tasks)
+  const enforceLimitedBranchingRule = workflow?.steps?.[activeStepIndex]?.[1]?.taskKeys?.length > 0
 
   const previewEnv = getPreviewEnv();
   const previewUrl = `https://frontend.preview.zooniverse.org/projects/${project?.slug}/classify/workflow/${workflow?.id}${previewEnv}`;

--- a/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
@@ -30,20 +30,21 @@ export default function TasksPage() {
   Returns the newly created step index.
    */
   async function addTask(taskType, stepIndex = -1) {
-    const newTaskKey = getNewTaskKey(workflow?.tasks);
+    if (!workflow) return;
+    const newTaskKey = getNewTaskKey(workflow.tasks);
     const newTask = createTask(taskType);
-    const steps = workflow?.steps?.slice() || [];
+    const steps = workflow.steps?.slice() || [];
     
     let step
     if (stepIndex < 0) {
       // If no step is specified, we create a new one.
-      const newStepKey = getNewStepKey(workflow?.steps);
+      const newStepKey = getNewStepKey(workflow.steps);
       step = createStep(newStepKey, [newTaskKey]);
       steps.push(step);
 
     } else {
       // If a step is specified, we'll add the Task to that one.
-      step = workflow?.steps?.[stepIndex];
+      step = workflow.steps?.[stepIndex];
       if (step) {
         const [stepKey, stepBody] = step;
         const stepBodyTaskKeys = stepBody?.taskKeys?.slice() || [];
@@ -70,8 +71,8 @@ export default function TasksPage() {
   Updates (or adds) a Task
    */
   function updateTask(taskKey, task) {
-    if (!taskKey) return;
-    const newTasks = structuredClone(workflow?.tasks || {});  // Copy tasks
+    if (!workflow || !taskKey) return;
+    const newTasks = structuredClone(workflow.tasks);  // Copy tasks
     newTasks[taskKey] = task;
     update({ tasks: newTasks });
   }
@@ -91,11 +92,11 @@ export default function TasksPage() {
     if (!confirmed) return;
 
     // Delete the task.
-    const newTasks = structuredClone(workflow.tasks || {});
+    const newTasks = structuredClone(workflow.tasks) || {};
     delete newTasks[taskKey];
 
     // Delete the task reference in steps.
-    const newSteps = structuredClone(workflow.steps || {});
+    const newSteps = structuredClone(workflow.steps) || [];
     newSteps.forEach(step => {
       const stepBody = step[1] || {};
       stepBody.taskKeys = (stepBody?.taskKeys || []).filter(key => key !== taskKey);
@@ -113,7 +114,8 @@ export default function TasksPage() {
   }
 
   function moveStep(from, to) {
-    const oldSteps = workflow?.steps || [];
+    if (!workflow) return;
+    const oldSteps = workflow.steps || [];
     if (from < 0 || to < 0 || from >= oldSteps.length || to >= oldSteps.length) return;
 
     const steps = moveItemInArray(oldSteps, from, to);
@@ -156,9 +158,11 @@ export default function TasksPage() {
 
   // Changes the optional "next page" of a step/page
   function updateNextStepForStep(stepKey, next = undefined) {
+    if (!workflow || !workflow.steps) return;
+
     // Check if input is valid
-    const stepIndex = workflow?.steps?.findIndex(step => step[0] === stepKey);
-    const stepBody = workflow?.steps?.[stepIndex]?.[1];
+    const stepIndex = workflow.steps.findIndex(step => step[0] === stepKey);
+    const stepBody = workflow.steps[stepIndex]?.[1];
     if (!stepBody) return;
 
     const newSteps = workflow.steps.slice();
@@ -169,12 +173,14 @@ export default function TasksPage() {
 
   // Changes the optional "next page" of a branching answer/choice
   function updateNextStepForTaskAnswer(taskKey, answerIndex, next = undefined) {
+    if (!workflow || !workflow?.tasks) return;
+
     // Check if input is valid
-    const task = workflow?.tasks?.[taskKey];
+    const task = workflow.tasks[taskKey];
     const answer = task?.answers[answerIndex];
     if (!task || !answer) return;
     
-    const newTasks = workflow.tasks ? { ...workflow.tasks } : {};  // Copy tasks
+    const newTasks = structuredClone(workflow.tasks);  // Copy tasks
     const newAnswers = task.answers.with(answerIndex, { ...answer, next })  // Copy, then modify, answers
     newTasks[taskKey] = {  // Insert modified answers into the task inside the copied tasks. Phew!
       ...task,

--- a/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
@@ -193,11 +193,14 @@ export default function TasksPage() {
   // Limited Branching Rule:
   // 0. a Step can only have 1 branching task (single answer question task)
   // 1. if a Step has a branching task, it can't have any other tasks.
-  // 2. if a Step already has tasks, any added question task must be a multiple answer question task.
+  // 2. if a Step already has at least one task, any added question task must be a multiple answer question task.
+  // 3. if a Step already has many tasks, any multiple answer question task can't be transformed into a single answer question task. 
   const activeStep = workflow?.steps?.[activeStepIndex]
-  const enforceLimitedBranchingRule1 = !!canStepBranch(activeStep, workflow?.tasks)
-  const enforceLimitedBranchingRule2 = activeStep?.[1]?.taskKeys?.length > 0
-
+  const enforceLimitedBranchingRule = {
+    stepHasBranch: !!canStepBranch(activeStep, workflow?.tasks),
+    stepHasOneTask: activeStep?.[1]?.taskKeys?.length > 0,
+    stepHasManyTasks: activeStep?.[1]?.taskKeys?.length > 1
+  }
   const previewEnv = getPreviewEnv();
   const previewUrl = `https://frontend.preview.zooniverse.org/projects/${project?.slug}/classify/workflow/${workflow?.id}${previewEnv}`;
   if (!workflow) return null;
@@ -250,14 +253,14 @@ export default function TasksPage() {
         <NewTaskDialog
           ref={newTaskDialog}
           addTask={addTask}
-          enforceLimitedBranchingRule={enforceLimitedBranchingRule2}
+          enforceLimitedBranchingRule={enforceLimitedBranchingRule}
           openEditStepDialog={openEditStepDialog}
           stepIndex={activeStepIndex}
         />
         <EditStepDialog
           ref={editStepDialog}
           allTasks={workflow.tasks}
-          enforceLimitedBranchingRule={enforceLimitedBranchingRule1}
+          enforceLimitedBranchingRule={enforceLimitedBranchingRule}
           onClose={handleCloseEditStepDialog}
           openNewTaskDialog={openNewTaskDialog}
           step={workflow.steps[activeStepIndex]}

--- a/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
@@ -191,9 +191,12 @@ export default function TasksPage() {
   }
   
   // Limited Branching Rule:
-  // - a Step can only have 1 branching task.
-  // - If a Step has a branching task, it can't have any other tasks.
-  const enforceLimitedBranchingRule = workflow?.steps?.[activeStepIndex]?.[1]?.taskKeys?.length > 0
+  // 0. a Step can only have 1 branching task (single answer question task)
+  // 1. if a Step has a branching task, it can't have any other tasks.
+  // 2. if a Step already has tasks, any added question task must be a multiple answer question task.
+  const activeStep = workflow?.steps?.[activeStepIndex]
+  const enforceLimitedBranchingRule1 = !!canStepBranch(activeStep, workflow?.tasks)
+  const enforceLimitedBranchingRule2 = activeStep?.[1]?.taskKeys?.length > 0
 
   const previewEnv = getPreviewEnv();
   const previewUrl = `https://frontend.preview.zooniverse.org/projects/${project?.slug}/classify/workflow/${workflow?.id}${previewEnv}`;
@@ -247,14 +250,14 @@ export default function TasksPage() {
         <NewTaskDialog
           ref={newTaskDialog}
           addTask={addTask}
-          enforceLimitedBranchingRule={enforceLimitedBranchingRule}
+          enforceLimitedBranchingRule={enforceLimitedBranchingRule2}
           openEditStepDialog={openEditStepDialog}
           stepIndex={activeStepIndex}
         />
         <EditStepDialog
           ref={editStepDialog}
           allTasks={workflow.tasks}
-          enforceLimitedBranchingRule={enforceLimitedBranchingRule}
+          enforceLimitedBranchingRule={enforceLimitedBranchingRule1}
           onClose={handleCloseEditStepDialog}
           openNewTaskDialog={openNewTaskDialog}
           step={workflow.steps[activeStepIndex]}

--- a/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
@@ -1,5 +1,6 @@
 import { useRef, useState } from 'react'
 import { useWorkflowContext } from '../../context.js';
+import canStepBranch from '../../helpers/canStepBranch.js';
 import createStep from '../../helpers/createStep.js';
 import createTask from '../../helpers/createTask.js';
 import getNewStepKey from '../../helpers/getNewStepKey.js';
@@ -182,6 +183,11 @@ export default function TasksPage() {
 
     update({ tasks: newTasks });
   }
+  
+  // Limited Branching Rule:
+  // - a Step can only have 1 branching task.
+  // - If a Step has a branching task, it can't have any other tasks.
+  const shouldEnforceLimitedBranchingRule = !!canStepBranch(workflow?.steps?.[activeStepIndex], workflow?.tasks)
 
   const previewEnv = getPreviewEnv();
   const previewUrl = `https://frontend.preview.zooniverse.org/projects/${project?.slug}/classify/workflow/${workflow?.id}${previewEnv}`;

--- a/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
@@ -193,7 +193,7 @@ export default function TasksPage() {
   // Limited Branching Rule:
   // - a Step can only have 1 branching task.
   // - If a Step has a branching task, it can't have any other tasks.
-  const shouldEnforceLimitedBranchingRule = !!canStepBranch(workflow?.steps?.[activeStepIndex], workflow?.tasks)
+  const enforceLimitedBranchingRule = !!canStepBranch(workflow?.steps?.[activeStepIndex], workflow?.tasks)
 
   const previewEnv = getPreviewEnv();
   const previewUrl = `https://frontend.preview.zooniverse.org/projects/${project?.slug}/classify/workflow/${workflow?.id}${previewEnv}`;
@@ -247,12 +247,14 @@ export default function TasksPage() {
         <NewTaskDialog
           ref={newTaskDialog}
           addTask={addTask}
+          enforceLimitedBranchingRule={enforceLimitedBranchingRule}
           openEditStepDialog={openEditStepDialog}
           stepIndex={activeStepIndex}
         />
         <EditStepDialog
           ref={editStepDialog}
           allTasks={workflow.tasks}
+          enforceLimitedBranchingRule={enforceLimitedBranchingRule}
           onClose={handleCloseEditStepDialog}
           openNewTaskDialog={openNewTaskDialog}
           step={workflow.steps[activeStepIndex]}

--- a/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/EditStepDialog.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/EditStepDialog.jsx
@@ -6,7 +6,8 @@ import CloseIcon from '../../../../icons/CloseIcon.jsx';
 
 const taskNames = {
   'drawing': 'Drawing',
-  'single': 'Single Question',
+  'multiple': 'Multiple Answer Question',
+  'single': 'Single Answer Question',
   'text': 'Text',
 }
 

--- a/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/EditStepDialog.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/EditStepDialog.jsx
@@ -16,7 +16,7 @@ const DEFAULT_HANDLER = () => {};
 function EditStepDialog({
   allTasks = {},
   deleteTask,
-  enforceLimitedBranchingRule = false,
+  enforceLimitedBranchingRule,
   onClose = DEFAULT_HANDLER,
   openNewTaskDialog = DEFAULT_HANDLER,
   step = [],
@@ -85,6 +85,7 @@ function EditStepDialog({
             <EditTaskForm
               key={`editTaskForm-${taskKey}`}
               deleteTask={deleteTask}
+              enforceLimitedBranchingRule={enforceLimitedBranchingRule}
               task={task}
               taskKey={taskKey}
               updateTask={updateTask}
@@ -95,7 +96,7 @@ function EditStepDialog({
       <div className="dialog-footer flex-row">
         <button
           className="big flex-item"
-          disabled={!!enforceLimitedBranchingRule}
+          disabled={!!enforceLimitedBranchingRule?.stepHasBranch}
           onClick={handleClickAddTaskButton}
           type="button"
         >
@@ -116,7 +117,11 @@ function EditStepDialog({
 EditStepDialog.propTypes = {
   allTasks: PropTypes.object,
   deleteTask: PropTypes.func,
-  enforceLimitedBranchingRule: PropTypes.bool,
+  enforceLimitedBranchingRule: PropTypes.shape({
+    stepHasBranch: PropTypes.bool,
+    stepHasOneTask: PropTypes.bool,
+    stepHasManyTasks: PropTypes.bool
+  }),
   onClose: PropTypes.func,
   step: PropTypes.object,
   stepIndex: PropTypes.number,

--- a/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/EditStepDialog.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/EditStepDialog.jsx
@@ -93,6 +93,7 @@ function EditStepDialog({
       <div className="dialog-footer flex-row">
         <button
           className="big flex-item"
+          disabled={!!enforceLimitedBranchingRule}
           onClick={handleClickAddTaskButton}
           type="button"
         >

--- a/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/EditStepDialog.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/EditStepDialog.jsx
@@ -16,6 +16,7 @@ const DEFAULT_HANDLER = () => {};
 function EditStepDialog({
   allTasks = {},
   deleteTask,
+  enforceLimitedBranchingRule = false,
   onClose = DEFAULT_HANDLER,
   openNewTaskDialog = DEFAULT_HANDLER,
   step = [],
@@ -112,6 +113,7 @@ function EditStepDialog({
 EditStepDialog.propTypes = {
   allTasks: PropTypes.object,
   deleteTask: PropTypes.func,
+  enforceLimitedBranchingRule: PropTypes.bool,
   onClose: PropTypes.func,
   step: PropTypes.object,
   stepIndex: PropTypes.number,

--- a/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/EditStepDialog.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/EditStepDialog.jsx
@@ -50,7 +50,9 @@ function EditStepDialog({
 
   const firstTask = allTasks?.[taskKeys?.[0]]
   const taskName = taskNames[firstTask?.type] || '???';
-  const title = `Edit ${taskName} Task`;
+  const title = taskKeys?.length > 1
+    ? 'Edit A Multi-Task Page'
+    : `Edit ${taskName} Task`;
 
   return (
     <dialog

--- a/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/EditTaskForm.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/EditTaskForm.jsx
@@ -1,3 +1,5 @@
+import PropTypes from 'prop-types';
+
 import SingleQuestionTask from './types/SingleQuestionTask.jsx';
 import TextTask from './types/TextTask.jsx';
 
@@ -7,8 +9,9 @@ const taskTypes = {
   'text': TextTask
 };
 
-export default function EditTaskForm({  // It's not actually a form, but a fieldset that's part of a form.
+function EditTaskForm({  // It's not actually a form, but a fieldset that's part of a form.
   deleteTask,
+  enforceLimitedBranchingRule,
   task,
   taskKey,
   updateTask
@@ -25,6 +28,7 @@ export default function EditTaskForm({  // It's not actually a form, but a field
       {(TaskForm)
         ? <TaskForm
             deleteTask={deleteTask}
+            enforceLimitedBranchingRule={enforceLimitedBranchingRule}
             task={task}
             taskKey={taskKey}
             updateTask={updateTask}
@@ -35,4 +39,16 @@ export default function EditTaskForm({  // It's not actually a form, but a field
   );
 }
 
+EditTaskForm.propTypes = {
+  deleteTask: PropTypes.func,
+  enforceLimitedBranchingRule: PropTypes.shape({
+    stepHasBranch: PropTypes.bool,
+    stepHasOneTask: PropTypes.bool,
+    stepHasManyTasks: PropTypes.bool
+  }),
+  task: PropTypes.object,
+  taskKey: PropTypes.string,
+  updateTask: PropTypes.func
+}
 
+export default EditTaskForm;

--- a/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/EditTaskForm.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/EditTaskForm.jsx
@@ -2,6 +2,7 @@ import SingleQuestionTask from './types/SingleQuestionTask.jsx';
 import TextTask from './types/TextTask.jsx';
 
 const taskTypes = {
+  'multiple': SingleQuestionTask,  // Shared with single answer question task
   'single': SingleQuestionTask,
   'text': TextTask
 };

--- a/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/types/SingleQuestionTask.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/types/SingleQuestionTask.jsx
@@ -16,6 +16,7 @@ export default function SingleQuestionTask({
   const [ help, setHelp ] = useState(task?.help || '');
   const [ question, setQuestion ] = useState(task?.question || '');  // TODO: figure out if FEM is standardising Question vs Instructions
   const [ required, setRequired ] = useState(!!task?.required);
+  const [ isMultiple, setIsMultiple ] = useState(task?.type === 'multiple');
 
   // Update is usually called manually onBlur, after user input is complete.
   function update(optionalStateOverrides) {
@@ -24,6 +25,7 @@ export default function SingleQuestionTask({
 
     const newTask = {
       ...task,
+      type: (!isMultiple) ? 'single' : 'multiple',
       answers: nonEmptyAnswers,
       help,
       question,
@@ -69,7 +71,8 @@ export default function SingleQuestionTask({
 
   // For inputs that don't have onBlur, update triggers automagically.
   // (You can't call update() in the onChange() right after setStateValue().)
-  useEffect(update, [required]);
+  // TODO: useEffect() means update() is called on the first render, which is unnecessary. Clean this up.
+  useEffect(update, [required, isMultiple]);
 
   return (
     <div className="single-question-task">
@@ -122,6 +125,19 @@ export default function SingleQuestionTask({
             />
             <label htmlFor={`task-${taskKey}-required`}>
               Required
+            </label>
+          </span>
+          <span className="narrow">
+            <input
+              id={`task-${taskKey}-multiple`}
+              type="checkbox"
+              checked={isMultiple}
+              onChange={(e) => {
+                setIsMultiple(!!e?.target?.checked);
+              }}
+            />
+            <label htmlFor={`task-${taskKey}-multiple`}>
+              Allow multiple
             </label>
           </span>
         </div>

--- a/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/types/SingleQuestionTask.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/types/SingleQuestionTask.jsx
@@ -7,10 +7,11 @@ import PlusIcon from '../../../../../icons/PlusIcon.jsx';
 const DEFAULT_HANDLER = () => {};
 
 export default function SingleQuestionTask({
+  enforceLimitedBranchingRule,
+  deleteTask = DEFAULT_HANDLER,
   task,
   taskKey,
-  deleteTask = DEFAULT_HANDLER,
-  updateTask = DEFAULT_HANDLER
+  updateTask = DEFAULT_HANDLER  
 }) {
   const [ answers, setAnswers ] = useState(task?.answers || []);
   const [ help, setHelp ] = useState(task?.help || '');
@@ -132,6 +133,7 @@ export default function SingleQuestionTask({
               id={`task-${taskKey}-multiple`}
               type="checkbox"
               checked={isMultiple}
+              disabled={enforceLimitedBranchingRule?.stepHasManyTasks && isMultiple /* If rule is enforced, you can't switch a Multi Question Task to a Single Question Task. */}
               onChange={(e) => {
                 setIsMultiple(!!e?.target?.checked);
               }}

--- a/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/types/TextTask.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/types/TextTask.jsx
@@ -30,6 +30,7 @@ export default function TextTask({
 
   // For inputs that don't have onBlur, update triggers automagically.
   // (You can't call update() in the onChange() right after setStateValue().)
+  // TODO: useEffect() means update() is called on the first render, which is unnecessary. Clean this up.
   useEffect(update, [required]);
 
   return (

--- a/app/pages/lab-pages-editor/components/TasksPage/components/NewTaskDialog.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/NewTaskDialog.jsx
@@ -9,7 +9,7 @@ const DEFAULT_HANDLER = () => {};
 
 function NewTaskDialog({
   addTask = DEFAULT_HANDLER,
-  enforceLimitedBranchingRule = false,
+  enforceLimitedBranchingRule,
   openEditStepDialog = DEFAULT_HANDLER,
   stepIndex = -1
 }, forwardedRef) {
@@ -55,7 +55,7 @@ function NewTaskDialog({
 
   // The Question Task is either a Single Answer Question Task, or a Multiple Answer Question Task.
   // By default, this is 'single', but under certain conditions, a new Question Task will be created as a Multiple Answer Question Task.
-  const questionTaskType = (!enforceLimitedBranchingRule) ? 'single' : 'multiple'
+  const questionTaskType = (!enforceLimitedBranchingRule?.stepHasOneTask) ? 'single' : 'multiple'
 
   return (
     <dialog
@@ -124,7 +124,11 @@ function NewTaskDialog({
 
 NewTaskDialog.propTypes = {
   addTask: PropTypes.func,
-  enforceLimitedBranchingRule: PropTypes.bool,
+  enforceLimitedBranchingRule: PropTypes.shape({
+    stepHasBranch: PropTypes.bool,
+    stepHasOneTask: PropTypes.bool,
+    stepHasManyTasks: PropTypes.bool
+  }),
   openEditStepDialog: PropTypes.func,
   stepIndex: PropTypes.number
 };

--- a/app/pages/lab-pages-editor/components/TasksPage/components/NewTaskDialog.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/NewTaskDialog.jsx
@@ -117,7 +117,7 @@ function NewTaskDialog({
             <span>Drawing</span>
           </button>
         </div>
-        <div>DEBUG: enforceLimitedBranchingRule = {!!enforceLimitedBranchingRule}</div>
+        <div>DEBUG: enforceLimitedBranchingRule = {enforceLimitedBranchingRule ? 'YES' : 'NO'}</div>
       </form>
     </dialog>
   );

--- a/app/pages/lab-pages-editor/components/TasksPage/components/NewTaskDialog.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/NewTaskDialog.jsx
@@ -41,10 +41,12 @@ function NewTaskDialog({
 
     closeDialog();
 
-    if (stepIndex < 0) {
+    const addingTaskToNewStep = stepIndex < 0
+    if (addingTaskToNewStep) {
       const newStepIndex = await addTask(tasktype);
       openEditStepDialog(newStepIndex);
-    } else {
+
+    } else {  // Adding task to existing Step
       await addTask(tasktype, stepIndex);
       openEditStepDialog(stepIndex);
     }

--- a/app/pages/lab-pages-editor/components/TasksPage/components/NewTaskDialog.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/NewTaskDialog.jsx
@@ -9,6 +9,7 @@ const DEFAULT_HANDLER = () => {};
 
 function NewTaskDialog({
   addTask = DEFAULT_HANDLER,
+  enforceLimitedBranchingRule = false,
   openEditStepDialog = DEFAULT_HANDLER,
   stepIndex = -1
 }, forwardedRef) {
@@ -52,6 +53,10 @@ function NewTaskDialog({
     }
   }
 
+  // The Question Task is either a Single Answer Question Task, or a Multiple Answer Question Task.
+  // By default, this is 'single', but under certain conditions, a new Question Task will be created as a Multiple Answer Question Task.
+  const questionTaskType = (!enforceLimitedBranchingRule) ? 'single' : 'multiple'
+
   return (
     <dialog
       aria-labelledby="dialog-title"
@@ -94,11 +99,11 @@ function NewTaskDialog({
           <button
             aria-label="Add new Question Task"
             className="new-task-button"
-            data-tasktype="single"
+            data-tasktype={questionTaskType}
             onClick={handleClickAddTask}
             type="button"
           >
-            <TaskIcon type='single' />
+            <TaskIcon type={questionTaskType} />
             <span>Question</span>
           </button>
           <button
@@ -112,6 +117,7 @@ function NewTaskDialog({
             <span>Drawing</span>
           </button>
         </div>
+        <div>DEBUG: enforceLimitedBranchingRule = {!!enforceLimitedBranchingRule}</div>
       </form>
     </dialog>
   );
@@ -119,6 +125,7 @@ function NewTaskDialog({
 
 NewTaskDialog.propTypes = {
   addTask: PropTypes.func,
+  enforceLimitedBranchingRule: PropTypes.bool,
   openEditStepDialog: PropTypes.func,
   stepIndex: PropTypes.number
 };

--- a/app/pages/lab-pages-editor/components/TasksPage/components/NewTaskDialog.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/NewTaskDialog.jsx
@@ -117,7 +117,6 @@ function NewTaskDialog({
             <span>Drawing</span>
           </button>
         </div>
-        <div>DEBUG: enforceLimitedBranchingRule = {enforceLimitedBranchingRule ? 'YES' : 'NO'}</div>
       </form>
     </dialog>
   );

--- a/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/SimpleNextControls.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/SimpleNextControls.jsx
@@ -18,7 +18,7 @@ export default function SimpleNextControls({
 
   return (
     <div className="next-controls vertical-layout">
-      <NextStepArrow className="next-arrow" />
+      <NextStepArrow className="next-arrow" height="8" />
       <select
         className={(!stepBody?.next) ? 'next-is-submit' : ''}
         onChange={onChange}

--- a/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/SimpleNextControls.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/SimpleNextControls.jsx
@@ -18,7 +18,7 @@ export default function SimpleNextControls({
 
   return (
     <div className="next-controls vertical-layout">
-      <NextStepArrow className="next-arrow" height="8" />
+      <NextStepArrow className="next-arrow" height="10" />
       <select
         className={(!stepBody?.next) ? 'next-is-submit' : ''}
         onChange={onChange}

--- a/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/StepItem.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/StepItem.jsx
@@ -138,14 +138,14 @@ function StepItem({
             );
           })}
         </ul>
-        {!branchingTaskKey && (
-          <SimpleNextControls
-            allSteps={allSteps}
-            step={step}
-            updateNextStepForStep={updateNextStepForStep}
-          />
-        )}
       </div>
+      {!branchingTaskKey && (
+        <SimpleNextControls
+          allSteps={allSteps}
+          step={step}
+          updateNextStepForStep={updateNextStepForStep}
+        />
+      )}
       <DropTarget
         activeDragItem={activeDragItem}
         moveStep={moveStep}

--- a/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/TaskItem.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/TaskItem.jsx
@@ -69,7 +69,7 @@ function PlaceholderAnswers({
 }) {
   if (!task || !taskKey) return null;
 
-  if (task.type === 'single') {
+  if (task.type === 'single' || task.type === 'multiple') {
     const answers = task.answers || [];
 
     return (

--- a/app/pages/lab-pages-editor/icons/TaskIcon.jsx
+++ b/app/pages/lab-pages-editor/icons/TaskIcon.jsx
@@ -2,7 +2,8 @@ import PropTypes from 'prop-types';
 
 const faTaskIcons = {
   'drawing': 'fa-pencil',
-  'single': 'fa-question-circle',  // Single question
+  'multiple': 'fa-question-circle',  // Multiple answer question
+  'single': 'fa-question-circle',  // Single answer question
   'text': 'fa-file-text-o'
 };
 

--- a/css/lab-pages-editor.styl
+++ b/css/lab-pages-editor.styl
@@ -315,6 +315,9 @@ $fontWeightBoldPlus = 700
         &.done
           border: 3px solid $teal
           padding: $sizeS $sizeXL
+        
+        &[disabled]
+          color: $grey1
       
       .dialog-header
         background: $teal


### PR DESCRIPTION
## PR Overview

Part of: **Pages Editor MVP** project and **FEM Lab** super-project
Follows #7075
Staging branch URL: https://pr-7079.pfe-preview.zooniverse.org/lab/1982/workflows/editor/3711?env=staging

This PR adds special rules for the "Add Task to Page" functionality. (See #7065)

The overall rule is this: _a Step can only have 1 branching task (single answer question task)_

(New behaviour) The specific sub-rules are:
1. if a Step has a branching task, it can't have any other tasks.
    _Screenshot: The "Add New Task to Page" button is disabled when (and only when) there's a branching ('Single'-type) Task._
    <img width="200" alt="image" src="https://github.com/zooniverse/Panoptes-Front-End/assets/13952701/0488525f-6ad5-42f9-a544-9f991079179a">

2. if a Step already has at least one task, any added Question task must be a Multiple Answer Question Task.
    _Screenshot: no visible changes, but clicking 'Question' will add a 'Multiple'-type Task, instead of a 'Single'-type Task_
    <img width="401" alt="image" src="https://github.com/zooniverse/Panoptes-Front-End/assets/13952701/b91a3080-960b-446a-862c-0946ef6c31bd">

3. if a Step already has many tasks, any Multiple Answer Question Task can't be transformed into a Single Answer Question Task.
    _Screenshot: 'Allow multiple' checkboxes are disabled for all Question tasks on pages with > 1 tasks._
    <img width="401" alt="image" src="https://github.com/zooniverse/Panoptes-Front-End/assets/13952701/019a45db-98b0-426d-b076-0108cc84b69e">

Other changes in this PR:
- Multiple Answer Question Task (aka "Multiple" Task) has been added.
  - It shares many same code as the Single Answer Question Task (aka "Single"-type Task)
- [design] For non-branching Steps/Pages, the "Next Step/Page now appears OUTSIDE the grey box.
    Old vs New:
    <img width="200" alt="image" src="https://github.com/zooniverse/Panoptes-Front-End/assets/13952701/7527d3d2-8cfc-4301-be3e-6f763204fd20"> <img width="200" alt="image" src="https://github.com/zooniverse/Panoptes-Front-End/assets/13952701/d7cfad68-a2f9-40d2-aa0f-6026f6cc0611">
- [minor] functions in TasksPage have been refactored with better safety checks (e.g. if workflow doesn't exist, don't bother running "delete Task from workflow")

**FAQ**

Q: how do I visually tell the difference between a Single Answer Question Task (aka "Single"-type Task) and a Multiple Answer Question Task (aka "Multiple"-type Task) on the Pages Editor?
A: check whether the "Allow Multiple" checkbox is ticked. Also, "Single"-type Tasks allows you to choose the next page for _each_ answer, not for the whole page.

"Single"-type Task:
<img width="200" alt="image" src="https://github.com/zooniverse/Panoptes-Front-End/assets/13952701/f51b48af-d64a-4a76-bfca-4ecd45a2869d"> <img width="200" alt="image" src="https://github.com/zooniverse/Panoptes-Front-End/assets/13952701/771fa051-2df6-4ed6-ac89-93171ce57696">

"Multiple"-type Task:
<img width="200" alt="image" src="https://github.com/zooniverse/Panoptes-Front-End/assets/13952701/151902cf-cb24-455d-98d3-e67a5d18c786"> <img width="200" alt="image" src="https://github.com/zooniverse/Panoptes-Front-End/assets/13952701/4044129f-cba0-48d8-b5ab-c716aeb1849b">

### Testing Steps

- Go to the testing URL: https://pr-7065.pfe-preview.zooniverse.org/lab/1982/workflows/editor/3711?env=staging
- Click on "Reset" in the debug panel to start a workflow from scratch.
- Add a new Page with 1 Question Task ("Single"-type).
  - You should not be able to add any further Tasks to this Page.
- Click on the "Allow Multiple" button to change the Single Answer Question Task into a Multiple Answer Question Task.
  - You should now be able to add additional Tasks to this Page
- Add a new Text Task to the page.
  - The "allow multiple" checkbox of the Question Task should now be disabled/locked
- Add a new Question Task to the page.
  - The newly added Question Task should have its "allow multiple" checkbox ticked and disabled/locked. (i.e. you can't change it to a "Single"-type.)
- Delete the Text Task and one Question Task.
  - The "allow multiple" button of the remaining Question Task should now be enabled again.

It's also worth running some quick basic tests to make sure the refactor works as expected:
- Start with an empty workflow.
- Add Tasks with new Pages.
  - Add Text Tasks,
  - Add Single Answer Question Tasks, and make sure the answers branch to different Tasks.
- Add Tasks into existing Pages.
- Edit Tasks in Pages.
- Delete Tasks from Pages. 
  - Delete all Tasks from a Page. This should delete the Page.
- Delete Pages.
  - Any "next page => deleted Page" linkages should revert to the default "next page => submit".

### Status

Ready for review. 👌

EDIT: ready to review _from a functional standpoint_ Improvements I could/should add to this PR:
- UI icons/tooltips to tell users why certain buttons are disabled. 🤔 