### PR TITLE
Home Page: minor text update to volunteer numbers

### DIFF
--- a/app/pages/home-not-logged-in/research.jsx
+++ b/app/pages/home-not-logged-in/research.jsx
@@ -13,7 +13,7 @@ counterpart.registerTranslations('en', {
     about: `
       Zooniverse gives people of all ages and backgrounds the chance to participate
       in real research with over 50 active online citizen science projects. Work with
-      2.7 million registered users around the world to contribute to research
+      millions of registered users around the world to contribute to research
       projects led by hundreds of researchers.
     `,
     classifications: 'Classifications so far by',

--- a/app/pages/home-not-logged-in/research.jsx
+++ b/app/pages/home-not-logged-in/research.jsx
@@ -13,7 +13,7 @@ counterpart.registerTranslations('en', {
     about: `
       Zooniverse gives people of all ages and backgrounds the chance to participate
       in real research with over 50 active online citizen science projects. Work with
-      1.6 million registered users around the world to contribute to research
+      2.7 million registered users around the world to contribute to research
       projects led by hundreds of researchers.
     `,
     classifications: 'Classifications so far by',


### PR DESCRIPTION
## PR Overview

Staging branch URL: https://pr-7081.pfe-preview.zooniverse.org

This PR is a very small text update to the (hardcoded) number of volunteers on the non-signed-in home page. Requested by @apreleva , since the static number of volunteers (1.6m) clashes with the dynamic number of volunteers (2,729,414 as of 23 Apr 14:40 BST).

<img width="662" alt="image" src="https://github.com/zooniverse/Panoptes-Front-End/assets/13952701/2c35cec9-e9ec-47f6-b814-e4aad03ab6cd">

Ready for review.

Long term, we may want to rewrite this `researchHomePage.about` text block to be _numerically agnostic,_ since the number of volunteers is already dynamically fetched and displayed.