### PR TITLE
Email Settings: add "valid email" and "verified email" status

### DIFF
--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -287,7 +287,13 @@ export default {
       manual: 'Manage projects individually',
       beta: 'Get beta project email updates and become a beta tester',
       partnerPreferences: 'Zooniverse partner email preferences',
-      nasa: 'Get periodic email updates from NASA regarding broader NASA citizen science projects and efforts'
+      nasa: 'Get periodic email updates from NASA regarding broader NASA citizen science projects and efforts',
+      emailValid: 'Valid email',
+      emailInvalid: 'Verified email',
+      emailInvalidPrompt: 'Please re-enter your email above',
+      emailVerified: 'Verified email',
+      emailUnverified: 'Unverified email',
+      emailUnverifiedPrompt: 'Resend confirmation email'
     },
     talk: {
       section: 'Talk email preferences',

--- a/app/pages/settings/email.jsx
+++ b/app/pages/settings/email.jsx
@@ -256,12 +256,12 @@ class EmailSettingsPage extends React.Component {
           </AutoSave>
           <div>
             {(isEmailValid)
-              ? <div><i className='fa fa-check-circle' style={{ color: '#51db72' }} /> Yeah looking good</div>
-              : <div><i className='fa fa-times-circle' style={{ color: '#e35950' }} /> Oh no</div>
+              ? <div><i className='fa fa-check-circle' style={{ color: '#51db72' }} /> <Translate content="emailSettings.general.emailValid" /></div>
+              : <div><i className='fa fa-times-circle' style={{ color: '#e35950' }} /> <Translate content="emailSettings.general.emailInvalid" /> | <Translate content="emailSettings.general.emailInvalidPrompt" /></div>
             }
             {(isEmailVerfied)
-              ? <div><i className='fa fa-check-circle' style={{ color: '#51db72' }} /> Yeah looking good</div>
-              : <div><i className='fa fa-times-circle' style={{ color: '#e35950' }} /> Oh no</div>
+              ? <div><i className='fa fa-check-circle' style={{ color: '#51db72' }} /> <Translate content="emailSettings.general.emailVerified" /></div>
+              : <div><i className='fa fa-times-circle' style={{ color: '#e35950' }} /> <Translate content="emailSettings.general.emailUnverified" /> | <Translate content="emailSettings.general.emailUnverifiedPrompt" /></div>
             }
           </div>
         </p>

--- a/app/pages/settings/email.jsx
+++ b/app/pages/settings/email.jsx
@@ -284,10 +284,12 @@ class EmailSettingsPage extends React.Component {
                   <i className='fa fa-times-circle' style={{ color: '#e35950' }} />
                   {' '}
                   <Translate content="emailSettings.general.emailUnverified" />
+                  {/*
                   {' | '}
                   <a href="#" onClick={this.requestConfirmationEmail}>
                     <Translate content="emailSettings.general.emailUnverifiedPrompt" />
                   </a>
+                  */}
                 </div>
             }
           </div>

--- a/app/pages/settings/email.jsx
+++ b/app/pages/settings/email.jsx
@@ -235,6 +235,9 @@ class EmailSettingsPage extends React.Component {
   }
 
   render() {
+    const isEmailValid = !!this.props.user?.valid_email;
+    const isEmailVerfied = !!this.props.user?.confirmed_at;
+  
     return (
       <div className="content-container">
         <p>
@@ -251,6 +254,16 @@ class EmailSettingsPage extends React.Component {
               onChange={handleInputChange.bind(this.props.user)}
             />
           </AutoSave>
+          <div>
+            {(isEmailValid)
+              ? <div><i className='fa fa-check-circle' style={{ color: '#51db72' }} /> Yeah looking good</div>
+              : <div><i className='fa fa-times-circle' style={{ color: '#e35950' }} /> Oh no</div>
+            }
+            {(isEmailVerfied)
+              ? <div><i className='fa fa-check-circle' style={{ color: '#51db72' }} /> Yeah looking good</div>
+              : <div><i className='fa fa-times-circle' style={{ color: '#e35950' }} /> Oh no</div>
+            }
+          </div>
         </p>
         <p>
           <strong>

--- a/app/pages/settings/email.jsx
+++ b/app/pages/settings/email.jsx
@@ -151,6 +151,7 @@ class EmailSettingsPage extends React.Component {
     };
     this.handleProjectPreferenceChange = this.handleProjectPreferenceChange.bind(this);
     this.handleTalkPreferenceChange = this.handleTalkPreferenceChange.bind(this);
+    this.requestConfirmationEmail = this.requestConfirmationEmail.bind(this);
     this.getProjectForPreferences(props.user);
     this.getTalkPreferences();
   }
@@ -197,6 +198,10 @@ class EmailSettingsPage extends React.Component {
     });
   }
 
+  requestConfirmationEmail() {
+    console.log('+++ Send confirmation email!')
+  }
+
   handleProjectPreferenceChange(index, event) {
     const { projectPreferences } = this.state;
     projectPreferences[index].update({
@@ -235,8 +240,8 @@ class EmailSettingsPage extends React.Component {
   }
 
   render() {
-    const isEmailValid = !!this.props.user?.valid_email;
-    const isEmailVerfied = !!this.props.user?.confirmed_at;
+    const isEmailValid = false && !!this.props.user?.valid_email;
+    const isEmailVerfied = true || !!this.props.user?.confirmed_at;
   
     return (
       <div className="content-container">
@@ -256,12 +261,33 @@ class EmailSettingsPage extends React.Component {
           </AutoSave>
           <div>
             {(isEmailValid)
-              ? <div><i className='fa fa-check-circle' style={{ color: '#51db72' }} /> <Translate content="emailSettings.general.emailValid" /></div>
-              : <div><i className='fa fa-times-circle' style={{ color: '#e35950' }} /> <Translate content="emailSettings.general.emailInvalid" /> | <Translate content="emailSettings.general.emailInvalidPrompt" /></div>
+              ? <div>
+                  <i className='fa fa-check-circle' style={{ color: '#51db72' }} />
+                  {' '}
+                  <Translate content="emailSettings.general.emailValid" />
+                </div>
+              : <div>
+                  <i className='fa fa-times-circle' style={{ color: '#e35950' }} />
+                  {' '}
+                  <Translate content="emailSettings.general.emailInvalid" />
+                  {' | '}
+                  <Translate content="emailSettings.general.emailInvalidPrompt" />
+                </div>
             }
             {(isEmailVerfied)
-              ? <div><i className='fa fa-check-circle' style={{ color: '#51db72' }} /> <Translate content="emailSettings.general.emailVerified" /></div>
-              : <div><i className='fa fa-times-circle' style={{ color: '#e35950' }} /> <Translate content="emailSettings.general.emailUnverified" /> | <Translate content="emailSettings.general.emailUnverifiedPrompt" /></div>
+              ? <div>
+                  <i className='fa fa-check-circle' style={{ color: '#51db72' }} />
+                  {' '}
+                  <Translate content="emailSettings.general.emailVerified" /></div>
+              : <div>
+                  <i className='fa fa-times-circle' style={{ color: '#e35950' }} />
+                  {' '}
+                  <Translate content="emailSettings.general.emailUnverified" />
+                  {' | '}
+                  <a href="#" onClick={requestConfirmationEmail}>
+                    <Translate content="emailSettings.general.emailUnverifiedPrompt" />
+                  </a>
+                </div>
             }
           </div>
         </p>

--- a/app/pages/settings/email.jsx
+++ b/app/pages/settings/email.jsx
@@ -140,6 +140,8 @@ Pagination.defaultProps = {
   page: 1
 };
 
+const FAUX_PARAGRAPH_STYLE = { margin: '1em 0' };
+
 class EmailSettingsPage extends React.Component {
   constructor(props) {
     super(props);
@@ -245,15 +247,21 @@ class EmailSettingsPage extends React.Component {
   
     return (
       <div className="content-container">
-        <p>
+        <div style={FAUX_PARAGRAPH_STYLE}>
           <AutoSave resource={this.props.user}>
-            <span className="form-label">
+            <label
+              className="form-label"
+              htmlFor="user-email"
+            >
               <Translate content="emailSettings.email" />
-            </span>
+            </label>
             <br />
             <input
               type="text"
+              aria-describedby="user-email-valid,user-email-verified"
+              autoComplete="email"
               className="standard-input full"
+              id="user-email"
               name="email"
               value={this.props.user.email}
               onChange={handleInputChange.bind(this.props.user)}
@@ -261,12 +269,12 @@ class EmailSettingsPage extends React.Component {
           </AutoSave>
           <div>
             {(isEmailValid)
-              ? <div>
+              ? <div id="user-email-valid">
                   <i className='fa fa-check-circle' style={{ color: '#51db72' }} />
                   {' '}
                   <Translate content="emailSettings.general.emailValid" />
                 </div>
-              : <div>
+              : <div id="user-email-valid">
                   <i className='fa fa-times-circle' style={{ color: '#e35950' }} />
                   {' '}
                   <Translate content="emailSettings.general.emailInvalid" />
@@ -275,12 +283,12 @@ class EmailSettingsPage extends React.Component {
                 </div>
             }
             {(isEmailVerfied)
-              ? <div>
+              ? <div id="user-email-verified">
                   <i className='fa fa-check-circle' style={{ color: '#51db72' }} />
                   {' '}
                   <Translate content="emailSettings.general.emailVerified" />
                 </div>
-              : <div>
+              : <div id="user-email-verified">
                   <i className='fa fa-times-circle' style={{ color: '#e35950' }} />
                   {' '}
                   <Translate content="emailSettings.general.emailUnverified" />
@@ -293,7 +301,7 @@ class EmailSettingsPage extends React.Component {
                 </div>
             }
           </div>
-        </p>
+        </div>
         <p>
           <strong>
             <Translate content="emailSettings.general.section" />

--- a/app/pages/settings/email.jsx
+++ b/app/pages/settings/email.jsx
@@ -240,8 +240,8 @@ class EmailSettingsPage extends React.Component {
   }
 
   render() {
-    const isEmailValid = false && !!this.props.user?.valid_email;
-    const isEmailVerfied = true || !!this.props.user?.confirmed_at;
+    const isEmailValid = !!this.props.user?.valid_email;
+    const isEmailVerfied = !!this.props.user?.confirmed_at;
   
     return (
       <div className="content-container">
@@ -278,13 +278,14 @@ class EmailSettingsPage extends React.Component {
               ? <div>
                   <i className='fa fa-check-circle' style={{ color: '#51db72' }} />
                   {' '}
-                  <Translate content="emailSettings.general.emailVerified" /></div>
+                  <Translate content="emailSettings.general.emailVerified" />
+                </div>
               : <div>
                   <i className='fa fa-times-circle' style={{ color: '#e35950' }} />
                   {' '}
                   <Translate content="emailSettings.general.emailUnverified" />
                   {' | '}
-                  <a href="#" onClick={requestConfirmationEmail}>
+                  <a href="#" onClick={this.requestConfirmationEmail}>
                     <Translate content="emailSettings.general.emailUnverifiedPrompt" />
                   </a>
                 </div>

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -14,7 +14,7 @@ var config = {
     ],
     historyApiFallback: true,
     client: {
-      overlay: true,
+      overlay: false,
       progress: true
     },
     server: 'https',

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -14,7 +14,7 @@ var config = {
     ],
     historyApiFallback: true,
     client: {
-      overlay: false,
+      overlay: true,
       progress: true
     },
     server: 'https',


### PR DESCRIPTION
## PR Overview

Staging branch URL: https://pr-7083.pfe-preview.zooniverse.org
Towards #7032

This PR adds "🟢 valid / 🔴 invalid email" and "🟢 verified / 🔴 unverified email" indicators to the [Email Settings page](https://www.zooniverse.org/settings/email) (under User -> Settings -> Email)

- These indicators are based on the `user.valid_email` and `user.confirmed_at` values of the User resource.

<img width="600" alt="Screenshot 2024-04-24 at 02 55 55" src="https://github.com/zooniverse/Panoptes-Front-End/assets/13952701/bc07a817-f3d6-4014-a709-2c10daf9e13c">

### Status

Ready for review.

Next steps: the "request confirmation email" functionality requires either
1. a fairly custom (and complex) fetch() function inside email.jsx to POST to panoptes.zooniverse.org/api/users/confirmation with the auth token inside the code, or
2. an update to PJC to do the same, or
3. _as a placeholder,_ a simple link to https://panoptes.zooniverse.org/users/confirmation/new

For this PR, the "request confirmation email" has been disabled. (I got halfway through option 1 but ran into some bugs due to a malformed request, and option 3 hit a small snag when I realised I need to check the env to get the correct URL.)

