### PR TITLE
Revert FEM migration for Walleye project

### DIFF
--- a/app/monorepoUtils.js
+++ b/app/monorepoUtils.js
@@ -53,7 +53,6 @@ export const SLUGS = [
   'elwest/woodpecker-cavity-cam',
   'victorav/the-koster-seafloor-observatory',
   'victorav/spyfish-aotearoa',
-  'dangogh/wheres-walleye',
   'bcosentino/squirrelmapper',
   'embeller/offal-wildlife-watching'
 ];


### PR DESCRIPTION
Newly migrated project [Where's Walleye](https://www.zooniverse.org/projects/dangogh/wheres-walleye) is having issues with FEM. This migrates the project back but will require a Friday deploy to get out quickly.

static PR: https://github.com/zooniverse/static/pull/350


# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
