### PR TITLE
Pages Editor: add "Choose Starting Page" dropdown

### DIFF
--- a/app/pages/lab-pages-editor/components/TasksPage/ExperimentalPanel.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/ExperimentalPanel.jsx
@@ -13,7 +13,7 @@ export default function ExperimentalPanel({
 
   function experimentalQuickSetup() {
     update({
-      first_task: 'P0',
+      first_task: '',
       tasks: {
         'T0': {
           answers: [

--- a/app/pages/lab-pages-editor/components/TasksPage/ExperimentalPanel.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/ExperimentalPanel.jsx
@@ -5,6 +5,7 @@ export default function ExperimentalPanel({
 }) {
   function experimentalReset() {
     update({
+      first_task: '',
       tasks: {},
       steps: []
     });
@@ -12,6 +13,7 @@ export default function ExperimentalPanel({
 
   function experimentalQuickSetup() {
     update({
+      first_task: 'P0',
       tasks: {
         'T0': {
           answers: [

--- a/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
@@ -231,6 +231,7 @@ export default function TasksPage() {
             aria-label="Choose starting Page"
             className="flex-item workflow-starting-page"
             onChange={handleChangeStartingPage}
+            style={(workflow?.steps?.length < 1) ? { display: 'none' } : undefined}
             value={firstStepKey}
           >
             <option value="">Choose starting page</option>

--- a/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
@@ -229,7 +229,7 @@ export default function TasksPage() {
           </button>
           <select
             aria-label="Choose starting Page"
-            className="flex-item"
+            className="flex-item workflow-starting-page"
             onChange={handleChangeStartingPage}
             value={firstStepKey}
           >

--- a/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
@@ -7,14 +7,12 @@ import getNewStepKey from '../../helpers/getNewStepKey.js';
 import getNewTaskKey from '../../helpers/getNewTaskKey.js';
 import moveItemInArray from '../../helpers/moveItemInArray.js';
 import cleanupTasksAndSteps from '../../helpers/cleanupTasksAndSteps.js';
-import getPreviewEnv from '../../helpers/getPreviewEnv.js';
 // import strings from '../../strings.json'; // TODO: move all text into strings
 
 import ExperimentalPanel from './ExperimentalPanel.jsx';
 import EditStepDialog from './components/EditStepDialog';
 import NewTaskDialog from './components/NewTaskDialog.jsx';
 import StepItem from './components/StepItem';
-import ExternalLinkIcon from '../../icons/ExternalLinkIcon.jsx';
 
 export default function TasksPage() {
   const { project, workflow, update } = useWorkflowContext();
@@ -156,6 +154,10 @@ export default function TasksPage() {
     setActiveStepIndex(-1);
   }
 
+  function handleChangeStartingPage(e) {
+    console.log('+++ handleChangeStartingPage: ', e);
+  }
+
   // Changes the optional "next page" of a step/page
   function updateNextStepForStep(stepKey, next = undefined) {
     if (!workflow || !workflow.steps) return;
@@ -201,8 +203,6 @@ export default function TasksPage() {
     stepHasOneTask: activeStep?.[1]?.taskKeys?.length > 0,
     stepHasManyTasks: activeStep?.[1]?.taskKeys?.length > 1
   }
-  const previewEnv = getPreviewEnv();
-  const previewUrl = `https://frontend.preview.zooniverse.org/projects/${project?.slug}/classify/workflow/${workflow?.id}${previewEnv}`;
   if (!workflow) return null;
 
   return (
@@ -222,14 +222,21 @@ export default function TasksPage() {
           >
             Add a new Task
           </button>
-          <a
-            className="flex-item button-link"
-            href={previewUrl}
-            rel="noopener noreferrer"
-            target='_blank'
+          <select
+            aria-label="Choose starting Page"
+            className="flex-item"
+            onChange={handleChangeStartingPage}
           >
-            Preview Workflow <ExternalLinkIcon />
-          </a>
+            <option value="">Choose starting page</option>
+            {workflow?.steps?.map(([stepKey, stepBody]) => (
+              <option
+                key={`choose-starting-page-${stepKey}`}
+                value={stepKey}
+              >
+                {stepBody?.taskKeys?.join(', ') || `Page ${stepKey}`}
+              </option>
+            ))}
+          </select>
         </div>
         <ul className="steps-list" aria-label="Pages/Steps">
           {workflow.steps.map((step, index) => (

--- a/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
@@ -20,6 +20,7 @@ export default function TasksPage() {
   const newTaskDialog = useRef(null);
   const [ activeStepIndex, setActiveStepIndex ] = useState(-1);  // Tracks which Step is being edited.
   const [ activeDragItem, setActiveDragItem ] = useState(-1);  // Keeps track of active item being dragged (StepItem). This is because "dragOver" CAN'T read the data from dragEnter.dataTransfer.getData().
+  const firstStepKey = workflow?.steps?.[0]?.[0] || '';
   const isActive = true; // TODO
 
   /*
@@ -155,8 +156,10 @@ export default function TasksPage() {
   }
 
   function handleChangeStartingPage(e) {
-    const first_task = e?.target?.value || '';
-    update({ first_task });
+    const targetStepKey = e?.target?.value || '';
+    const targetStepIndex = workflow?.steps?.findIndex(([stepKey]) => stepKey === targetStepKey) || -1;
+    if (targetStepIndex < 0) return;
+    moveStep(targetStepIndex, 0);
   }
 
   // Changes the optional "next page" of a step/page
@@ -228,7 +231,7 @@ export default function TasksPage() {
             aria-label="Choose starting Page"
             className="flex-item"
             onChange={handleChangeStartingPage}
-            defaultValue={workflow?.first_task || ''}
+            value={firstStepKey}
           >
             <option value="">Choose starting page</option>
             {workflow.steps?.map(([stepKey, stepBody]) => (
@@ -236,7 +239,7 @@ export default function TasksPage() {
                 key={`choose-starting-page-${stepKey}`}
                 value={stepKey}
               >
-                {workflow.first_task === stepKey && 'Starting page: '}
+                {firstStepKey === stepKey && 'Starting page: '}
                 {stepBody?.taskKeys?.join(', ') || `(${stepKey})` /* Note: if you see the stepKey instead of the taskKeys, something's wrong. */}
               </option>
             ))}

--- a/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
@@ -155,7 +155,7 @@ export default function TasksPage() {
   }
 
   function handleChangeStartingPage(e) {
-    console.log('+++ handleChangeStartingPage: ', e);
+    console.log('+++ handleChangeStartingPage: ', e?.target?.value);
   }
 
   // Changes the optional "next page" of a step/page

--- a/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
@@ -15,7 +15,7 @@ import NewTaskDialog from './components/NewTaskDialog.jsx';
 import StepItem from './components/StepItem';
 
 export default function TasksPage() {
-  const { project, workflow, update } = useWorkflowContext();
+  const { workflow, update } = useWorkflowContext();
   const editStepDialog = useRef(null);
   const newTaskDialog = useRef(null);
   const [ activeStepIndex, setActiveStepIndex ] = useState(-1);  // Tracks which Step is being edited.
@@ -155,7 +155,8 @@ export default function TasksPage() {
   }
 
   function handleChangeStartingPage(e) {
-    console.log('+++ handleChangeStartingPage: ', e?.target?.value);
+    const first_task = e?.target?.value || '';
+    update({ first_task });
   }
 
   // Changes the optional "next page" of a step/page
@@ -203,13 +204,14 @@ export default function TasksPage() {
     stepHasOneTask: activeStep?.[1]?.taskKeys?.length > 0,
     stepHasManyTasks: activeStep?.[1]?.taskKeys?.length > 1
   }
+
   if (!workflow) return null;
 
   return (
     <div className="tasks-page">
       <div className="workflow-title flex-row">
-        <h2 className="flex-item">{workflow?.display_name}</h2>
-        <span className="workflow-id">{`#${workflow?.id}`}</span>
+        <h2 className="flex-item">{workflow.display_name}</h2>
+        <span className="workflow-id">{`#${workflow.id}`}</span>
         {(isActive) ? <span className="status-active">Active</span> : <span className="status-inactive">Inactive</span>}
       </div>
       <section aria-labelledby="workflow-tasks-heading">
@@ -226,20 +228,22 @@ export default function TasksPage() {
             aria-label="Choose starting Page"
             className="flex-item"
             onChange={handleChangeStartingPage}
+            defaultValue={workflow?.first_task || ''}
           >
             <option value="">Choose starting page</option>
-            {workflow?.steps?.map(([stepKey, stepBody]) => (
+            {workflow.steps?.map(([stepKey, stepBody]) => (
               <option
                 key={`choose-starting-page-${stepKey}`}
                 value={stepKey}
               >
-                {stepBody?.taskKeys?.join(', ') || `Page ${stepKey}`}
+                {workflow.first_task === stepKey && 'Starting page: '}
+                {stepBody?.taskKeys?.join(', ') || `(${stepKey})` /* Note: if you see the stepKey instead of the taskKeys, something's wrong. */}
               </option>
             ))}
           </select>
         </div>
         <ul className="steps-list" aria-label="Pages/Steps">
-          {workflow.steps.map((step, index) => (
+          {workflow.steps?.map((step, index) => (
             <StepItem
               key={`stepItem-${step[0]}`}
               activeDragItem={activeDragItem}

--- a/app/pages/lab-pages-editor/components/WorkflowHeader.jsx
+++ b/app/pages/lab-pages-editor/components/WorkflowHeader.jsx
@@ -1,5 +1,7 @@
 import PropTypes from 'prop-types';
 
+import getPreviewEnv from '../helpers/getPreviewEnv.js';
+import ExternalLinkIcon from '../icons/ExternalLinkIcon.jsx';
 import ReturnIcon from '../icons/ReturnIcon.jsx';
 import { useWorkflowContext } from '../context.js';
 import strings from '../strings.json';
@@ -12,8 +14,10 @@ export default function WorkflowHeader({
   setCurrentTab = DEFAULT_HANDLER,
   tabs = []
 }) {
-  const { workflow } = useWorkflowContext();
+  const { project, workflow } = useWorkflowContext();
   const returnUrl = `/lab/${projectId}/workflows`;
+  const previewEnv = getPreviewEnv();
+  const previewUrl = `https://frontend.preview.zooniverse.org/projects/${project?.slug}/classify/workflow/${workflow?.id}${previewEnv}`;
 
   // When clicking a tab button, make that tab active. This is pretty straightforward.
   function onClick(e) {
@@ -43,14 +47,25 @@ export default function WorkflowHeader({
   if (!workflow) return null;
 
   return (
-    <div className="workflow-header flex-row">
-      <a href={returnUrl}> {/* Formerly <Link> from 'react-router', but React was throwing Legacy Context errors. */}
-        <ReturnIcon />
-        {strings.PagesEditor.components.WorkflowHeader.return}
-      </a>
+    <div className="workflow-header">
+      <div className="workflow-header-links flex-row">
+        <a href={returnUrl}> {/* Formerly <Link> from 'react-router', but React was throwing Legacy Context errors. */}
+          <ReturnIcon />
+          {strings.PagesEditor.components.WorkflowHeader.return}
+        </a>
+        <span className="flex-item" />
+        <a
+          className="button-link"
+          href={previewUrl}
+          rel="noopener noreferrer"
+          target='_blank'
+        >
+          Preview Workflow <ExternalLinkIcon />
+        </a>
+      </div>
       <div
         role="tablist"
-        className="flex-row flex-item justify-around"
+        className="workflow-header-tabs flex-row flex-item justify-around"
       >
         {tabs.map((tab, index) => (
           <TabButton

--- a/app/pages/lab-pages-editor/components/WorkflowHeader.jsx
+++ b/app/pages/lab-pages-editor/components/WorkflowHeader.jsx
@@ -21,7 +21,7 @@ export default function WorkflowHeader({
 
   // When clicking a tab button, make that tab active. This is pretty straightforward.
   function onClick(e) {
-    const { tab } = e.target.dataset;
+    const { tab } = e?.target?.dataset || {};
     setCurrentTab(parseInt(tab));
   }
 

--- a/app/pages/lab-pages-editor/components/WorkflowSettingsPage/WorkflowSettingsPage.jsx
+++ b/app/pages/lab-pages-editor/components/WorkflowSettingsPage/WorkflowSettingsPage.jsx
@@ -13,9 +13,10 @@ export default function WorkflowSettingsPage() {
   }
 
   function doUpdate(e) {
-    const key = e.target.name;
-    let value = e.target.value || '';
-    const { updaterule } = e.target.dataset;
+    const key = e?.target?.name;
+    let value = e?.target?.value || '';
+    const { updaterule } = e?.target?.dataset || {};
+    if (!key) return;
 
     if (updaterule === 'convert_to_number') value = parseInt(value);
     if (updaterule === 'undefined_if_empty') value = value || undefined;

--- a/css/lab-pages-editor.styl
+++ b/css/lab-pages-editor.styl
@@ -170,7 +170,10 @@ $fontWeightBoldPlus = 700
   // ---------------------------------------------------------------------------
 
   .workflow-header
-    margin-bottom: $sizeXL
+    margin-bottom: $sizeXXL
+
+    a
+      min-width: 40%
 
     .workflow-header-links
       margin-bottom: $sizeM
@@ -184,6 +187,8 @@ $fontWeightBoldPlus = 700
           margin-right: $sizeS
 
     .workflow-header-tabs
+      gap: $sizeXL
+      justify-content: center
       border-bottom: 0.5px solid $grey1
 
       button

--- a/css/lab-pages-editor.styl
+++ b/css/lab-pages-editor.styl
@@ -170,7 +170,7 @@ $fontWeightBoldPlus = 700
   // ---------------------------------------------------------------------------
 
   .workflow-header
-    margin-bottom: $sizeXXL
+    margin-bottom: $sizeXL
 
     a
       min-width: 40%

--- a/css/lab-pages-editor.styl
+++ b/css/lab-pages-editor.styl
@@ -170,30 +170,36 @@ $fontWeightBoldPlus = 700
   // ---------------------------------------------------------------------------
 
   .workflow-header
-    border-bottom: 0.5px solid $grey1
+    margin-bottom: $sizeXL
 
-    a
-      display: inline-block
-      font-size: $fontSizeS
-      text-decoration: none
+    .workflow-header-links
+      margin-bottom: $sizeM
 
-      .icon
-        margin-right: $sizeS
+      a
+        display: inline-block
+        font-size: $fontSizeS
+        text-decoration: none
 
-    button
-      background: none
-      border: none
-      cursor: pointer
-      font-size: $fontSizeL
-      font-weight: $fontWeightBoldPlus
-      text-transform: uppercase
+        .icon
+          margin-right: $sizeS
 
-      &[aria-selected=true]
-        border-bottom: 4px solid $teal
-      
-      &[aria-selected=false]
-        color: $grey1
-        border-bottom: 4px solid transparent
+    .workflow-header-tabs
+      border-bottom: 0.5px solid $grey1
+
+      button
+        background: none
+        border: none
+        cursor: pointer
+        font-size: $fontSizeL
+        font-weight: $fontWeightBoldPlus
+        text-transform: uppercase
+
+        &[aria-selected=true]
+          border-bottom: 4px solid $teal
+        
+        &[aria-selected=false]
+          color: $grey1
+          border-bottom: 4px solid transparent
 
   // Component: Workflow Settings Page
   // ---------------------------------------------------------------------------

--- a/css/lab-pages-editor.styl
+++ b/css/lab-pages-editor.styl
@@ -305,6 +305,11 @@ $fontWeightBoldPlus = 700
       .status-inactive
         color: $redBright
     
+    .workflow-starting-page
+      border: 1.5px solid $grey1
+      border-radius: $sizeXS
+      color: $grey2
+    
     dialog
       border: 1px solid $grey1
       border-radius: $sizeS


### PR DESCRIPTION
## PR Overview

Part of: **Pages Editor MVP** project and **FEM Lab** super-project
Follows #7079
Staging branch URL: https://pr-7088.pfe-preview.zooniverse.org/lab/1982/workflows/editor/3711?env=staging

This PR adds the ability for project owners to set the _starting_ page/step of a workflow, by selecting the appropriate page/step in a dropdown.

NOTE: in this PR, the term **"first page/step"** means the "first item in the workflow.steps data array". The term **"starting page/step"** means the initial page/step a volunteer sees on the FEM Classifier for this workflow. _Functionally, these are the same._

New changes in this PR:
- ⭐ Added "choose starting page" dropdown
  - Selecting a page/task in the "choose starting page" dropdown will now **rearrange** the target page/step so it's the _first step._ 
  - Dropdown will clearly spell out which page/step is the "starting page".
  - [(update)](https://github.com/zooniverse/Panoptes-Front-End/pull/7088#issuecomment-2079896064) Dropdown is hidden when there are 0 steps.
- Workflow header rearrange and restyled.
  - "Preview Workflow" link now moved to the top of the page.
- Minor/misc:
  - several bit of code have existential safeties (e.g. `e.target.name` -> `e?.target?.name`) added.
  - ExperimentalPanel's functions now blanks out the first_task, to be safe.

Screenshot: "preview link" moved to the top of the page. The "choose starting page" dropdown (seen as "Starting Page: T0") is visible next to the "Add New Task" button.

<img width="400" alt="image" src="https://github.com/zooniverse/Panoptes-Front-End/assets/13952701/2b21ca84-4254-4999-9854-5187b6a888e0">

### Dev Notes

❗⚠️ Due to how the FEM Classifier defines the "starting page/step/**task**", "choosing the starting page" may not work the way you expect, _if you came from PFE._
- History: in PFE, `workflow.first_task` is used to define the first Task a volunteer works on, on the PFE Classifier. (This older classifier organises by _tasks,_ not by _steps._)
- Observation: On FEM's Classifier, `workflow.first_task` is ignored if a workflow has (a non-empty) `workflow.steps`. This means explicitly setting `workflow.first_task = 'P3'` (step key) or `workflow.first_task = 'T3'` (task key, assuming the task is in the target page) does nothing.
- Observation: On FEM's Classifier, the first item in a (non-empty) `workflow.steps` array defines the starting page/step presented to the volunteer.
- Solution: when "choosing the starting page", the chosen page/step will become the _first page/step_ in the workflow.steps array.

### Testing

- Go to the testing URL.
- Click on "Quick Setup" in the debug panel, or create a multi-page workflow.
- The "choose starting page" dropdown should indicate which is the starting page (i.e. the first step/page in the array)
- Clicking on a Page option dropdown should 1. rearrange the workflow's steps so the target Page is now the first step, and 2. update the result in the dropdown accordingly.
- Clicking on "Preview Workflow" should take you to the FEM Classifier, where the first step/page is the starting step/page.

Other conditions:
- If a workflow has 0 Pages, the dropdown ~~should just show the "Choose starting page" option.~~ is hidden.
  - ~~(🤔 thought: maybe I should make this invisible then.)~~
- If the "Choose starting page" (default) option is chosen for whatever reason... nothing happens.
- If a Page is manually rearranged (e.g. dragged-and-dropped) to be the first step/page in the array, the dropdown should also update its details accordingly.

### Status

Ready for review. 👌 

Requires 7079 to be merged first before this can be merged.