### PR TITLE
Remove feedback check for mobile compatibility

### DIFF
--- a/app/pages/lab/mobile/mobile-section-container.fixtures.js
+++ b/app/pages/lab/mobile/mobile-section-container.fixtures.js
@@ -97,6 +97,13 @@ const validationFixtures = {
   },
   taskFeedbackEnabled: {
     task: {
+      type: 'drawing',
+      tools: [
+        {
+          type: 'rectangle',
+          details: []
+        }
+      ],
       feedback: {
         enabled: true
       }

--- a/app/pages/lab/mobile/mobile-section-container.jsx
+++ b/app/pages/lab/mobile/mobile-section-container.jsx
@@ -101,7 +101,6 @@ function drawingTaskHasNoSubtasks({ task }) {
 const validatorFns = {
   single: {
     taskQuestionNotTooLong,
-    taskFeedbackDisabled,
     workflowHasSingleTask,
     workflowNotTooManyShortcuts: workflowHasNoMoreThanXShortcuts(2),
     workflowDoesNotUseGroupedSubjectSelection,
@@ -109,7 +108,6 @@ const validatorFns = {
   },
   multiple: {
     taskQuestionNotTooLong,
-    taskFeedbackDisabled,
     workflowHasSingleTask,
     workflowNotTooManyShortcuts: workflowHasNoMoreThanXShortcuts(2),
     workflowDoesNotUseGroupedSubjectSelection,

--- a/app/pages/lab/mobile/mobile-section-container.spec.js
+++ b/app/pages/lab/mobile/mobile-section-container.spec.js
@@ -118,8 +118,8 @@ describe('<MobileSectionContainer />', function () {
       testValidationProp('taskInstructionNotTooLong', validationFixtures.taskInstructionTooLong, false);
     });
 
-    it('should check whether the task uses feedback', function () {
-      testValidationProp('taskFeedbackDisabled');
+    it('should check whether the task uses feedback if the task type is drawing', function () {
+      testValidationProp('taskFeedbackDisabled', validationFixtures.workflowHasValidDrawingTask, true);
       testValidationProp('taskFeedbackDisabled', validationFixtures.taskFeedbackEnabled, false);
     });
 
@@ -187,7 +187,6 @@ describe('<MobileSectionContainer />', function () {
     it('should equal false if any of the validations aren\'t met', function () {
       [
         fixtures.validationFixtures.taskQuestionTooLong,
-        fixtures.validationFixtures.taskFeedbackEnabled,
         fixtures.validationFixtures.workflowHasMultipleTasks,
         fixtures.validationFixtures.workflowTooManyShortcuts,
         fixtures.validationFixtures.workflowUsesGroupedSubjectSelection


### PR DESCRIPTION
Staging branch URL: https://pr-7092.pfe-preview.zooniverse.org

Based on addition of feedback on mobile for single or multiple answer question tasks (see https://github.com/zooniverse/mobile/pull/572), I've removed the feedback-related check for mobile compatible for workflows with that task type.  Code and tests were rewritten to only apply this check for drawing tasks.

For testing, consider this production project: https://www.zooniverse.org/lab/15140
- [Workflow 26145](https://www.zooniverse.org/lab/15140/workflows/26145): feedback check should not be applied, all checks should pass, and the workflow should be able to be enabled for mobile.
- [Workflow 18155](https://www.zooniverse.org/lab/15140/workflows/18155): feedback check should applied and the workflow should be able to be enabled for mobile when no feedback is enabled.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
