### PR TITLE
Pages Editor: UI tweaks, improved Workflow Settings

### DIFF
--- a/app/pages/lab-pages-editor/DataManager.jsx
+++ b/app/pages/lab-pages-editor/DataManager.jsx
@@ -110,10 +110,11 @@ function DataManager({
 
     return {
       project: apiData.project,
+      status: apiData.status,
       workflow: apiData.workflow,
       update
     };
-  }, [apiData.project, apiData.workflow, updateCounter]);
+  }, [apiData.project, apiData.workflow, apiData.status, updateCounter]);
 
   if (!workflowId) return (<div>ERROR: no Workflow ID specified</div>);
   // if (!workflow) return null

--- a/app/pages/lab-pages-editor/PagesEditor.jsx
+++ b/app/pages/lab-pages-editor/PagesEditor.jsx
@@ -17,9 +17,17 @@ import TasksPage from './components/TasksPage';
 import WorkflowSettingsPage from './components/WorkflowSettingsPage';
 import strings from './strings.json';
 
+function getDefaultTab() {  // Use ?tab=1 or tab='settings' to link directly to Workflow Settings
+  const params = new URLSearchParams(window?.location?.search);
+  const tab = params.get('tab');
+
+  if ([1, '1', 'settings', 'workflowsettings'].includes(tab)) return 1;
+  return 0;
+}
+
 function PagesEditor({ params }) {
   const { workflowID: workflowId, projectID: projectId } = params;
-  const [currentTab, setCurrentTab] = useState(0);
+  const [currentTab, setCurrentTab] = useState(getDefaultTab());  // Default tab is 0
   const tabs = [
     {
       id: 'pages-editor_workflow-header-tab-button_task',

--- a/app/pages/lab-pages-editor/components/TasksPage/ExperimentalPanel.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/ExperimentalPanel.jsx
@@ -5,6 +5,7 @@ export default function ExperimentalPanel({
 }) {
   function experimentalReset() {
     update({
+      configuration: {},
       first_task: '',
       tasks: {},
       steps: []

--- a/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
@@ -17,6 +17,15 @@ import StepItem from './components/StepItem';
 import WorkflowVersion from '../WorkflowVersion.jsx';
 import WrenchIcon from '../../icons/WrenchIcon.jsx';
 
+// Use ?advanced=true to enable advanced mode.
+// - switches from simpler "linear workflow" to "manual workflow".
+// - enables Experimental Panel.
+// - shows hidden options in workflow settings.
+function getAdvancedMode() {
+  const params = new URLSearchParams(window?.location?.search);
+  return !!params.get('advanced');
+}
+
 export default function TasksPage() {
   const { workflow, update } = useWorkflowContext();
   const editStepDialog = useRef(null);
@@ -25,12 +34,13 @@ export default function TasksPage() {
   const [ activeDragItem, setActiveDragItem ] = useState(-1);  // Keeps track of active item being dragged (StepItem). This is because "dragOver" CAN'T read the data from dragEnter.dataTransfer.getData().
   const firstStepKey = workflow?.steps?.[0]?.[0] || '';
   const isActive = true; // TODO
+  const advancedMode = getAdvancedMode();
 
   // A linear workflow means every step (except branching steps) will move into
   // the next step in the workflow.steps array. e.g. step0.next = step1 
   // A manual (i.e. non-linear) workflow asks the user to explicity spell out
   // the next step of each step. 
-  const isLinearWorkflow = true;
+  const isLinearWorkflow = !advancedMode;
 
   /*
   Adds a new Task of a specified type (with default settings) to a Step.
@@ -313,9 +323,11 @@ export default function TasksPage() {
         />
 
         {/* EXPERIMENTAL */}
-        <ExperimentalPanel
-          update={update}
-        />
+        {advancedMode && (
+          <ExperimentalPanel
+            update={update}
+          />
+        )}
       </section>
     </div>
   );

--- a/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
@@ -25,6 +25,12 @@ export default function TasksPage() {
   const firstStepKey = workflow?.steps?.[0]?.[0] || '';
   const isActive = true; // TODO
 
+  // A linear workflow means every step (except branching steps) will move into
+  // the next step in the workflow.steps array. e.g. step0.next = step1 
+  // A manual (i.e. non-linear) workflow asks the user to explicity spell out
+  // the next step of each step. 
+  const isLinearWorkflow = true;
+
   /*
   Adds a new Task of a specified type (with default settings) to a Step.
   If no Step is specified, a new Step is created.
@@ -265,6 +271,7 @@ export default function TasksPage() {
               allTasks={workflow.tasks}
               deleteStep={deleteStep}
               moveStep={moveStep}
+              isLinearWorkflow={isLinearWorkflow}
               openEditStepDialog={openEditStepDialog}
               setActiveDragItem={setActiveDragItem}
               step={step}

--- a/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
@@ -13,6 +13,7 @@ import ExperimentalPanel from './ExperimentalPanel.jsx';
 import EditStepDialog from './components/EditStepDialog';
 import NewTaskDialog from './components/NewTaskDialog.jsx';
 import StepItem from './components/StepItem';
+import WorkflowVersion from '../WorkflowVersion.jsx';
 
 export default function TasksPage() {
   const { workflow, update } = useWorkflowContext();
@@ -217,7 +218,10 @@ export default function TasksPage() {
         {(isActive) ? <span className="status-active">Active</span> : <span className="status-inactive">Inactive</span>}
       </div>
       <section aria-labelledby="workflow-tasks-heading">
-        <h3 id="workflow-tasks-heading">Tasks</h3>
+        <div className="flex-row">
+          <h3 id="workflow-tasks-heading" className="flex-item">Tasks</h3>
+          <WorkflowVersion />
+        </div>
         <div className="flex-row">
           <button
             className="flex-item big primary decoration-plus"

--- a/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
@@ -214,7 +214,6 @@ export default function TasksPage() {
     <div className="tasks-page">
       <div className="workflow-title flex-row">
         <h2 className="flex-item">{workflow.display_name}</h2>
-        <span className="workflow-id">{`#${workflow.id}`}</span>
         {(isActive) ? <span className="status-active">Active</span> : <span className="status-inactive">Inactive</span>}
       </div>
       <section aria-labelledby="workflow-tasks-heading">

--- a/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
@@ -14,6 +14,7 @@ import EditStepDialog from './components/EditStepDialog';
 import NewTaskDialog from './components/NewTaskDialog.jsx';
 import StepItem from './components/StepItem';
 import WorkflowVersion from '../WorkflowVersion.jsx';
+import WrenchIcon from '../../icons/WrenchIcon.jsx';
 
 export default function TasksPage() {
   const { workflow, update } = useWorkflowContext();
@@ -249,6 +250,12 @@ export default function TasksPage() {
             ))}
           </select>
         </div>
+        {!(workflow.steps?.length > 0) && (
+          <div className="no-tasks-notice">
+            <WrenchIcon />
+            <p>Start by adding tasks to build your Task Funnel here.</p>
+          </div>
+        )}
         <ul className="steps-list" aria-label="Pages/Steps">
           {workflow.steps?.map((step, index) => (
             <StepItem

--- a/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
@@ -5,6 +5,7 @@ import createStep from '../../helpers/createStep.js';
 import createTask from '../../helpers/createTask.js';
 import getNewStepKey from '../../helpers/getNewStepKey.js';
 import getNewTaskKey from '../../helpers/getNewTaskKey.js';
+import linkStepsInWorkflow from '../../helpers/linkStepsInWorkflow.js';
 import moveItemInArray from '../../helpers/moveItemInArray.js';
 import cleanupTasksAndSteps from '../../helpers/cleanupTasksAndSteps.js';
 // import strings from '../../strings.json'; // TODO: move all text into strings
@@ -40,7 +41,7 @@ export default function TasksPage() {
     if (!workflow) return;
     const newTaskKey = getNewTaskKey(workflow.tasks);
     const newTask = createTask(taskType);
-    const steps = workflow.steps?.slice() || [];
+    let steps = workflow.steps?.slice() || [];
     
     let step
     if (stepIndex < 0) {
@@ -69,6 +70,10 @@ export default function TasksPage() {
       ...workflow.tasks,
       [newTaskKey]: newTask
     };
+
+    if (linkStepsInWorkflow) {
+      steps = linkStepsInWorkflow(steps, tasks);
+    }
 
     await update({ tasks, steps });
     return (stepIndex < 0) ? steps.length - 1 : stepIndex;
@@ -125,7 +130,10 @@ export default function TasksPage() {
     const oldSteps = workflow.steps || [];
     if (from < 0 || to < 0 || from >= oldSteps.length || to >= oldSteps.length) return;
 
-    const steps = moveItemInArray(oldSteps, from, to);
+    let steps = moveItemInArray(oldSteps, from, to);
+    if (linkStepsInWorkflow) {
+      steps = linkStepsInWorkflow(steps, workflow.tasks);
+    }
     update({ steps });
   }
 
@@ -142,6 +150,9 @@ export default function TasksPage() {
 
     // cleanedupTasksAndSteps() will also remove tasks not associated with any step.
     const cleanedTasksAndSteps = cleanupTasksAndSteps(newTasks, newSteps); 
+    if (linkStepsInWorkflow) {
+      cleanedTasksAndSteps.steps = linkStepsInWorkflow(cleanedTasksAndSteps.steps, cleanedTasksAndSteps.tasks);
+    }
     update(cleanedTasksAndSteps);
   }
 

--- a/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/SimpleNextControls.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/SimpleNextControls.jsx
@@ -5,12 +5,17 @@ const DEFAULT_HANDLER = () => {};
 
 export default function SimpleNextControls({
   allSteps = [],
+  isLastItem = false,
+  isLinearWorkflow = false,
   step,
   updateNextStepForStep = DEFAULT_HANDLER
 }) {
   if (!step) return null;
   const [ stepKey, stepBody ] = step;
-
+  const isLinearItem = isLinearWorkflow && !isLastItem;
+  const showFakeSubmit = isLinearWorkflow && isLastItem;
+  const showNextPageDropdown = !isLinearWorkflow && !showFakeSubmit;
+  
   function onChange(e) {
     const next = e.target?.value;
     updateNextStepForStep(stepKey, next);
@@ -18,35 +23,45 @@ export default function SimpleNextControls({
 
   return (
     <div className="next-controls vertical-layout">
-      <NextStepArrow className="next-arrow" height="10" />
-      <select
-        className={(!stepBody?.next) ? 'next-is-submit' : ''}
-        onChange={onChange}
-        value={stepBody?.next || ''}
-      >
-        <option
-          value={''}
+      <NextStepArrow
+        arrowhead={isLinearItem}
+        className="next-arrow"
+        height={isLinearItem ? 24 : 10}
+      />
+      {showNextPageDropdown && (<select
+          className={(!stepBody?.next) ? 'next-is-submit' : ''}
+          onChange={onChange}
+          value={stepBody?.next || ''}
         >
-          Submit
-        </option>
-        {allSteps.map(([otherStepKey, otherStepBody]) => {
-          const taskKeys = otherStepBody?.taskKeys?.toString() || '(none)';
-          return (
-            <option
-              key={`simple-next-controls-option-${otherStepKey}`}
-              value={otherStepKey}
-            >
-              {taskKeys}
-            </option>
-          );
-        })}
-      </select>
+          <option
+            value={''}
+          >
+            Submit
+          </option>
+          {allSteps.map(([otherStepKey, otherStepBody]) => {
+            const taskKeys = otherStepBody?.taskKeys?.toString() || '(none)';
+            return (
+              <option
+                key={`simple-next-controls-option-${otherStepKey}`}
+                value={otherStepKey}
+              >
+                {taskKeys}
+              </option>
+            );
+          })}
+        </select>
+      )}
+      {showFakeSubmit && (
+        <div className="fake-submit">Submit</div>
+      )}
     </div>
   );
 }
 
 SimpleNextControls.propTypes = {
   allSteps: PropTypes.arrayOf(PropTypes.array),
+  isLastItem: PropTypes.bool,
+  isLinearWorkflow: PropTypes.bool,
   step: PropTypes.array,
   updateNextStepForStep: PropTypes.func
 };

--- a/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/StepItem.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/StepItem.jsx
@@ -24,6 +24,7 @@ function StepItem({
   deleteStep = DEFAULT_HANDLER,
   moveStep = DEFAULT_HANDLER,
   openEditStepDialog = DEFAULT_HANDLER,
+  isLinearWorkflow = false,
   setActiveDragItem = DEFAULT_HANDLER,
   step,
   stepIndex,
@@ -33,6 +34,7 @@ function StepItem({
   const [stepKey, stepBody] = step || [];
   if (!stepKey || !stepBody || !allSteps || !allTasks) return <li className="step-item">ERROR: could not render Step</li>;
 
+  const isLastItem = stepIndex === allSteps.length - 1;
   const taskKeys = stepBody.taskKeys || [];
 
   function doDelete() {
@@ -142,6 +144,8 @@ function StepItem({
       {!branchingTaskKey && (
         <SimpleNextControls
           allSteps={allSteps}
+          isLastItem={isLastItem}
+          isLinearWorkflow={isLinearWorkflow}
           step={step}
           updateNextStepForStep={updateNextStepForStep}
         />
@@ -161,6 +165,7 @@ StepItem.propTypes = {
   allSteps: PropTypes.array,
   allTasks: PropTypes.object,
   deleteStep: PropTypes.func,
+  isLinearWorkflow: PropTypes.bool,
   moveStep: PropTypes.func,
   openEditStepDialog: PropTypes.func,
   setActiveDragItem: PropTypes.func,

--- a/app/pages/lab-pages-editor/components/WorkflowSettingsPage/WorkflowSettingsPage.jsx
+++ b/app/pages/lab-pages-editor/components/WorkflowSettingsPage/WorkflowSettingsPage.jsx
@@ -2,8 +2,16 @@ import { useWorkflowContext } from '../../context.js';
 import AssociatedSubjectSets from './components/AssociatedSubjectSets.jsx';
 import AssociatedTutorial from './components/AssociatedTutorial.jsx';
 
+// Use ?showRemovedOptions=true to show options that are technically valid in
+// the API, but removed from the editor.
+function getShowRemovedOptions() {
+  const params = new URLSearchParams(window?.location?.search);
+  return !!params.get('showRemovedOptions');
+}
+
 export default function WorkflowSettingsPage() {
   const { workflow, update, project } = useWorkflowContext();
+  const showRemovedOptions = getShowRemovedOptions();
   const showSeparateFramesOptions = !!workflow?.configuration?.enable_switching_flipbook_and_separate;
 
   function onSubmit(e) {
@@ -76,26 +84,31 @@ export default function WorkflowSettingsPage() {
               aria-label="Retirement criteria"
               className="flex-item"
               defaultValue={workflow?.retirement?.criteria}
+              disabled={!showRemovedOptions}
               aria-describedby="subject-retirement-info"
               name="retirement.criteria"
               onChange={doUpdate}
             >
               <option value="classification_count">Classification count</option>
-              {/* <option value="never_retire">Never retire</option> */}
-              {/* TODO: this is just a POC - never_retire should be removed, even though it's a valid option on the API. */}
+              {(showRemovedOptions || workflow?.retirement?.criteria === 'never_retire') &&
+                <option value="never_retire">Never retire</option>
+              }
             </select>
-            <input
-              aria-label="Retirement count"
-              className="small-width"
-              defaultValue={workflow?.retirement?.options?.count}
-              data-updaterule="convert_to_number"
-              max="100"
-              min="1"
-              name="retirement.options.count"
-              onBlur={doUpdate}
-              placeholder="∞"
-              type="number"
-            />
+            {/* Reason for removal (May 2024): standardisation. PFE/FEM Lab doesn't allow "never retire" option, nor setting the retirement count. */}
+            {showRemovedOptions && (workflow?.retirement?.criteria === 'classification_count') && (
+              <input
+                aria-label="Retirement count"
+                className="small-width"
+                defaultValue={workflow?.retirement?.options?.count}
+                data-updaterule="convert_to_number"
+                max="100"
+                min="1"
+                name="retirement.options.count"
+                onBlur={doUpdate}
+                placeholder="∞"
+                type="number"
+              />
+            )}
           </div>
           <p className="small-info">
             If you&apos;d like more complex retirement rules such as conditional
@@ -214,58 +227,36 @@ export default function WorkflowSettingsPage() {
           </div>
         </fieldset>
 
-        {/*
-        <hr />
+        {showRemovedOptions && (<>  {/* Reason for removal (Apr 2024): we want users to use automatic subject viewer selection, to reduce complexity and complications. */}
+          <hr />
 
-        <fieldset>
-          <legend>Subject Viewer</legend>
-          <p id="subject-viewer-info">
-            Choose how to display your subjects.
-            Refer to the Subject Viewer section of the Glossary for more info.
-          </p>
-          <div className="flex-row align-start spacing-bottom-XS">
-            <select
-              aria-label="Subject viewer"
-              className="flex-item"
-              data-updaterule="undefined_if_empty"
-              defaultValue={workflow?.configuration?.subject_viewer || ''}
-              aria-describedby="subject-viewer-info"
-              name="configuration.subject_viewer"
-              onChange={doUpdate}
-            >
-              <option value="">None selected (default)</option>
-              <option value="imageAndText">Image and Text</option>
-              <option value="jsonData">JSON data charts</option>
-              <option value="multiFrame">Multi-Frame</option>
-              <option value="singleImage">Single Image</option>
-              <option value="singleText">Single Text</option>
-              <option value="subjectGroup">Subject Group</option>
-            </select>
-          </div>
-        </fieldset>
-
-        <fieldset className="disabled">
-          <legend>Multi-Image Options</legend>
-          <p>
-            Choose how to display subjects with multiple images.
-            If your subjects are in a sequence, such as camera trap images,
-            volunteers can play them like a .gif using the Flipbook viewer.
-          </p>
-          <p>TODO</p>
-        </fieldset>
-
-        <hr />
-
-        <fieldset className="disabled">
-          <legend>Classification Tools</legend>
-          <p>TODO</p>
-        </fieldset>
-
-        <fieldset className="disabled">
-          <legend>Quicktalk</legend>
-          <p>TODO</p>
-        </fieldset>
-        */}
+          <fieldset>
+            <legend>Subject Viewer</legend>
+            <p id="subject-viewer-info">
+              Choose how to display your subjects.
+              Refer to the Subject Viewer section of the Glossary for more info.
+            </p>
+            <div className="flex-row align-start spacing-bottom-XS">
+              <select
+                aria-label="Subject viewer"
+                className="flex-item"
+                data-updaterule="undefined_if_empty"
+                defaultValue={workflow?.configuration?.subject_viewer || ''}
+                aria-describedby="subject-viewer-info"
+                name="configuration.subject_viewer"
+                onChange={doUpdate}
+              >
+                <option value="">None selected (default)</option>
+                <option value="imageAndText">Image and Text</option>
+                <option value="jsonData">JSON data charts</option>
+                <option value="multiFrame">Multi-Frame</option>
+                <option value="singleImage">Single Image</option>
+                <option value="singleText">Single Text</option>
+                <option value="subjectGroup">Subject Group</option>
+              </select>
+            </div>
+          </fieldset>
+        </>)}
 
       </div>
     </form>

--- a/app/pages/lab-pages-editor/components/WorkflowSettingsPage/WorkflowSettingsPage.jsx
+++ b/app/pages/lab-pages-editor/components/WorkflowSettingsPage/WorkflowSettingsPage.jsx
@@ -100,12 +100,12 @@ export default function WorkflowSettingsPage() {
               onChange={doUpdate}
             >
               <option value="classification_count">Classification count</option>
+              {/* Reason for removal (May 2024): standardisation. PFE/FEM Lab doesn't allow "never retire" option, nor setting the retirement count. */}
               {(showRemovedOptions || workflow?.retirement?.criteria === 'never_retire') &&
                 <option value="never_retire">Never retire</option>
               }
             </select>
-            {/* Reason for removal (May 2024): standardisation. PFE/FEM Lab doesn't allow "never retire" option, nor setting the retirement count. */}
-            {showRemovedOptions && (workflow?.retirement?.criteria === 'classification_count') && (
+            {(workflow?.retirement?.criteria === 'classification_count') && (
               <input
                 aria-label="Retirement count"
                 className="small-width"

--- a/app/pages/lab-pages-editor/components/WorkflowSettingsPage/WorkflowSettingsPage.jsx
+++ b/app/pages/lab-pages-editor/components/WorkflowSettingsPage/WorkflowSettingsPage.jsx
@@ -18,6 +18,7 @@ export default function WorkflowSettingsPage() {
     const { updaterule } = e?.target?.dataset || {};
     if (!key) return;
 
+    if (updaterule === 'checkbox') value = !!e?.target?.checked;
     if (updaterule === 'convert_to_number') value = parseInt(value);
     if (updaterule === 'undefined_if_empty') value = value || undefined;
 
@@ -104,6 +105,28 @@ export default function WorkflowSettingsPage() {
       </div>
 
       <div className="column-group col-2">
+
+        <fieldset>
+          <legend>Image Display Options</legend>
+          <p id="subject-viewer-info">
+            Check this option if you want to limit subject height to always fit in the browser window. The max height will be the image's original pixel height.
+          </p>
+          <div className="flex-row spacing-bottom-XS">
+            <input
+              checked={!!workflow?.configuration?.limit_subject_height}
+              data-updaterule="checkbox"
+              id="limit_subject_height"
+              name="configuration.limit_subject_height"
+              onChange={doUpdate}
+              type="checkbox"
+            />
+            <label htmlFor="limit_subject_height">
+              Limit subject image height
+            </label>
+          </div>
+        </fieldset>
+
+        {/*
         <fieldset>
           <legend>Subject Viewer</legend>
           <p id="subject-viewer-info">
@@ -152,6 +175,7 @@ export default function WorkflowSettingsPage() {
           <legend>Quicktalk</legend>
           <p>TODO</p>
         </fieldset>
+        */}
 
       </div>
     </form>

--- a/app/pages/lab-pages-editor/components/WorkflowSettingsPage/WorkflowSettingsPage.jsx
+++ b/app/pages/lab-pages-editor/components/WorkflowSettingsPage/WorkflowSettingsPage.jsx
@@ -4,6 +4,7 @@ import AssociatedTutorial from './components/AssociatedTutorial.jsx';
 
 export default function WorkflowSettingsPage() {
   const { workflow, update, project } = useWorkflowContext();
+  const showSeparateFramesOptions = !!workflow?.configuration?.enable_switching_flipbook_and_separate;
 
   function onSubmit(e) {
     e.preventDefault();
@@ -80,7 +81,7 @@ export default function WorkflowSettingsPage() {
               onChange={doUpdate}
             >
               <option value="classification_count">Classification count</option>
-              <option value="never_retire">Never retire</option>
+              {/* <option value="never_retire">Never retire</option> */}
               {/* TODO: this is just a POC - never_retire should be removed, even though it's a valid option on the API. */}
             </select>
             <input
@@ -107,8 +108,60 @@ export default function WorkflowSettingsPage() {
       <div className="column-group col-2">
 
         <fieldset>
+          <legend>Multi-Image Options</legend>
+          <p id="multi-image-info">
+            Choose how to display subjects with multiple images. If your subjects are in sequence, such as camera trap images, volunteers can play them like a .gif using the Flipbook viewer.
+          </p>
+
+          <div className="flex-row align-start spacing-bottom-XS">
+            <input
+              checked={!!workflow?.configuration?.flipbook_autoplay}
+              data-updaterule="checkbox"
+              id="flipbook_autoplay"
+              name="configuration.flipbook_autoplay"
+              onChange={doUpdate}
+              type="checkbox"
+            />
+            <label htmlFor="flipbook_autoplay">
+              Autoplay - automatically loop through a subject's images when the page loads
+            </label>
+          </div>
+
+          <div className="flex-row align-start spacing-bottom-XS">
+            <input
+              checked={!!workflow?.configuration?.enable_switching_flipbook_and_separate}
+              data-updaterule="checkbox"
+              id="enable_switching_flipbook_and_separate"
+              name="configuration.enable_switching_flipbook_and_separate"
+              onChange={doUpdate}
+              type="checkbox"
+            />
+            <label htmlFor="enable_switching_flipbook_and_separate">
+              Allow Separate Frames View - volunteers can choose flipbook or a separate frames view
+            </label>
+          </div>
+
+          <div className="flex-row align-start spacing-bottom-XS">
+            <input
+              checked={!!workflow?.configuration?.multi_image_clone_markers}
+              data-updaterule="checkbox"
+              id="multi_image_clone_markers"
+              name="configuration.multi_image_clone_markers"
+              onChange={doUpdate}
+              type="checkbox"
+            />
+            <label htmlFor="multi_image_clone_markers">
+              Clone marks in all frames - for drawing tasks
+            </label>
+          </div>
+
+        </fieldset>
+
+        <hr />
+
+        <fieldset>
           <legend>Image Display Options</legend>
-          <p id="subject-viewer-info">
+          <p id="limit-subject-height-info">
             Check "limit subject image height" if you want to limit subject height to always fit in the browser window. The max height will be the image's original pixel height.
           </p>
           <div className="flex-row align-start spacing-bottom-XS">
@@ -140,6 +193,8 @@ export default function WorkflowSettingsPage() {
         </fieldset>
 
         {/*
+        <hr />
+
         <fieldset>
           <legend>Subject Viewer</legend>
           <p id="subject-viewer-info">

--- a/app/pages/lab-pages-editor/components/WorkflowSettingsPage/WorkflowSettingsPage.jsx
+++ b/app/pages/lab-pages-editor/components/WorkflowSettingsPage/WorkflowSettingsPage.jsx
@@ -3,16 +3,18 @@ import AssociatedSubjectSets from './components/AssociatedSubjectSets.jsx';
 import AssociatedTutorial from './components/AssociatedTutorial.jsx';
 import WorkflowVersion from '../WorkflowVersion.jsx';
 
-// Use ?showRemovedOptions=true to show options that are technically valid in
-// the API, but removed from the editor.
-function getShowRemovedOptions() {
+// Use ?advanced=true to enable advanced mode.
+// - switches from simpler "linear workflow" to "manual workflow".
+// - enables Experimental Panel.
+// - shows hidden options in workflow settings.
+function getAdvancedMode() {
   const params = new URLSearchParams(window?.location?.search);
-  return !!params.get('showRemovedOptions');
+  return !!params.get('advanced');
 }
 
 export default function WorkflowSettingsPage() {
   const { workflow, update, project } = useWorkflowContext();
-  const showRemovedOptions = getShowRemovedOptions();
+  const advancedMode = getAdvancedMode();
   const showSeparateFramesOptions = !!workflow?.configuration?.enable_switching_flipbook_and_separate;
 
   function onSubmit(e) {
@@ -94,14 +96,14 @@ export default function WorkflowSettingsPage() {
               aria-label="Retirement criteria"
               className="flex-item"
               defaultValue={workflow?.retirement?.criteria}
-              disabled={!showRemovedOptions}
+              disabled={!advancedMode}
               aria-describedby="subject-retirement-info"
               name="retirement.criteria"
               onChange={doUpdate}
             >
               <option value="classification_count">Classification count</option>
               {/* Reason for removal (May 2024): standardisation. PFE/FEM Lab doesn't allow "never retire" option, nor setting the retirement count. */}
-              {(showRemovedOptions || workflow?.retirement?.criteria === 'never_retire') &&
+              {(advancedMode || workflow?.retirement?.criteria === 'never_retire') &&
                 <option value="never_retire">Never retire</option>
               }
             </select>
@@ -294,7 +296,7 @@ export default function WorkflowSettingsPage() {
           </div>
         </fieldset>
 
-        {showRemovedOptions && (<>  {/* Reason for removal (Apr 2024): we want users to use automatic subject viewer selection, to reduce complexity and complications. */}
+        {advancedMode && (<>  {/* Reason for removal (Apr 2024): we want users to use automatic subject viewer selection, to reduce complexity and complications. */}
           <hr />
 
           <fieldset>

--- a/app/pages/lab-pages-editor/components/WorkflowSettingsPage/WorkflowSettingsPage.jsx
+++ b/app/pages/lab-pages-editor/components/WorkflowSettingsPage/WorkflowSettingsPage.jsx
@@ -114,6 +114,28 @@ export default function WorkflowSettingsPage() {
           </p>
 
           <div className="flex-row align-start spacing-bottom-XS">
+            <select
+              aria-label="Play iterations"
+              className="flex-item"
+              defaultValue={ /* If undefined, default value is '3'. If empty string '', it's infinite. */
+                (workflow?.configuration?.playIterations === undefined)
+                ? '3'
+                : workflow?.configuration?.playIterations
+              }
+              id="playIterations"
+              name="configuration.playIterations"
+              onChange={doUpdate}
+            >
+              <option value="">Infinite</option>
+              <option value="3">3</option>
+              <option value="5">5</option>
+            </select>
+            <label htmlFor="playIterations">
+              Play Iterations - choose how many times the images loop
+            </label>
+          </div>
+
+          <div className="flex-row align-start spacing-bottom-XS">
             <input
               checked={!!workflow?.configuration?.flipbook_autoplay}
               data-updaterule="checkbox"

--- a/app/pages/lab-pages-editor/components/WorkflowSettingsPage/WorkflowSettingsPage.jsx
+++ b/app/pages/lab-pages-editor/components/WorkflowSettingsPage/WorkflowSettingsPage.jsx
@@ -109,9 +109,9 @@ export default function WorkflowSettingsPage() {
         <fieldset>
           <legend>Image Display Options</legend>
           <p id="subject-viewer-info">
-            Check this option if you want to limit subject height to always fit in the browser window. The max height will be the image's original pixel height.
+            Check "limit subject image height" if you want to limit subject height to always fit in the browser window. The max height will be the image's original pixel height.
           </p>
-          <div className="flex-row spacing-bottom-XS">
+          <div className="flex-row align-start spacing-bottom-XS">
             <input
               checked={!!workflow?.configuration?.limit_subject_height}
               data-updaterule="checkbox"
@@ -122,6 +122,19 @@ export default function WorkflowSettingsPage() {
             />
             <label htmlFor="limit_subject_height">
               Limit subject image height
+            </label>
+          </div>
+          <div className="flex-row align-start spacing-bottom-XS">
+            <input
+              checked={!!workflow?.configuration?.invert_subject}
+              data-updaterule="checkbox"
+              id="invert_subject"
+              name="configuration.invert_subject"
+              onChange={doUpdate}
+              type="checkbox"
+            />
+            <label htmlFor="invert_subject">
+              Allow users to flip image color
             </label>
           </div>
         </fieldset>

--- a/app/pages/lab-pages-editor/components/WorkflowSettingsPage/WorkflowSettingsPage.jsx
+++ b/app/pages/lab-pages-editor/components/WorkflowSettingsPage/WorkflowSettingsPage.jsx
@@ -190,6 +190,63 @@ export default function WorkflowSettingsPage() {
             </label>
           </div>
 
+          {showSeparateFramesOptions && (<>
+            <p>Show separate frames as:</p>
+            <ul className="input-group">
+              <li key="separate-frames-as-col">
+                <input
+                  checked={workflow?.configuration?.multi_image_layout === 'col'}
+                  id="separate-frames-as-col"
+                  onChange={doUpdate}
+                  name="configuration.multi_image_layout"
+                  value="col"
+                  type="radio"
+                />
+                <label htmlFor="separate-frames-as-col">
+                  Single column - all frames stacked vertically (recommended for landscape subjects; default for mobile devices)
+                </label>
+              </li>
+              <li key="separate-frames-as-row">
+                <input
+                  checked={workflow?.configuration?.multi_image_layout === 'row'}
+                  id="separate-frames-as-row"
+                  name="configuration.multi_image_layout"
+                  onChange={doUpdate}
+                  value="row"
+                  type="radio"
+                />
+                <label htmlFor="separate-frames-as-row">
+                  Single row - all frames side by side horizontally (recommended only for portrait subjects)
+                </label>
+              </li>
+              <li key="separate-frames-as-grid2">
+                <input
+                  checked={workflow?.configuration?.multi_image_layout === 'grid2'}
+                  id="separate-frames-as-grid2"
+                  name="configuration.multi_image_layout"
+                  onChange={doUpdate}
+                  value="grid2"
+                  type="radio"
+                />
+                <label htmlFor="separate-frames-as-grid2">
+                  Grid - frames distributed evenly over 2 columns
+                </label>
+              </li>
+              <li key="separate-frames-as-grid3">
+                <input
+                  checked={workflow?.configuration?.multi_image_layout === 'grid3'}
+                  id="separate-frames-as-grid3"
+                  name="configuration.multi_image_layout"
+                  onChange={doUpdate}
+                  value="grid3"
+                  type="radio"
+                />
+                <label htmlFor="separate-frames-as-grid3">
+                  Grid - frames distributed evenly over 3 columns
+                </label>
+              </li>
+            </ul>
+          </>)}
         </fieldset>
 
         <hr />

--- a/app/pages/lab-pages-editor/components/WorkflowSettingsPage/WorkflowSettingsPage.jsx
+++ b/app/pages/lab-pages-editor/components/WorkflowSettingsPage/WorkflowSettingsPage.jsx
@@ -47,15 +47,23 @@ export default function WorkflowSettingsPage() {
       className="workflow-settings-page"
       onSubmit={onSubmit}
     >
-      <label htmlFor="display_name">
-        Workflow Name
-        <input
-          type="text"
-          name="display_name"
-          defaultValue={workflow?.display_name || ''}
-          onBlur={doUpdate}
-        />
-      </label>
+      <div className="workflow-title">
+        <label htmlFor="display_name">
+          Workflow Name
+        </label>
+        <div className="flex-row">
+          <div className="flex-item flex-row">
+            <input
+              id="display_name"
+              type="text"
+              name="display_name"
+              defaultValue={workflow?.display_name || ''}
+              onBlur={doUpdate}
+            />
+            <span className="workflow-id">#{workflow.id}</span>
+          </div>
+        </div>
+      </div>
 
       <div className="column-group col-1">
         <fieldset>

--- a/app/pages/lab-pages-editor/components/WorkflowSettingsPage/WorkflowSettingsPage.jsx
+++ b/app/pages/lab-pages-editor/components/WorkflowSettingsPage/WorkflowSettingsPage.jsx
@@ -1,6 +1,7 @@
 import { useWorkflowContext } from '../../context.js';
 import AssociatedSubjectSets from './components/AssociatedSubjectSets.jsx';
 import AssociatedTutorial from './components/AssociatedTutorial.jsx';
+import WorkflowVersion from '../WorkflowVersion.jsx';
 
 // Use ?showRemovedOptions=true to show options that are technically valid in
 // the API, but removed from the editor.
@@ -52,7 +53,7 @@ export default function WorkflowSettingsPage() {
           Workflow Name
         </label>
         <div className="flex-row">
-          <div className="flex-item flex-row">
+          <div className="flex-item flex-row position-relative">
             <input
               id="display_name"
               type="text"
@@ -62,6 +63,7 @@ export default function WorkflowSettingsPage() {
             />
             <span className="workflow-id">#{workflow.id}</span>
           </div>
+          <WorkflowVersion />
         </div>
       </div>
 

--- a/app/pages/lab-pages-editor/components/WorkflowSettingsPage/WorkflowSettingsPage.jsx
+++ b/app/pages/lab-pages-editor/components/WorkflowSettingsPage/WorkflowSettingsPage.jsx
@@ -207,7 +207,7 @@ export default function WorkflowSettingsPage() {
             <ul className="input-group">
               <li key="separate-frames-as-col">
                 <input
-                  checked={workflow?.configuration?.multi_image_layout === 'col'}
+                  checked={workflow?.configuration?.multi_image_layout === 'col' || workflow?.configuration?.multi_image_layout === undefined /* Default option */}
                   id="separate-frames-as-col"
                   onChange={doUpdate}
                   name="configuration.multi_image_layout"

--- a/app/pages/lab-pages-editor/components/WorkflowSettingsPage/WorkflowSettingsPage.jsx
+++ b/app/pages/lab-pages-editor/components/WorkflowSettingsPage/WorkflowSettingsPage.jsx
@@ -144,7 +144,7 @@ export default function WorkflowSettingsPage() {
               <option value="5">5</option>
             </select>
             <label htmlFor="playIterations">
-              Play Iterations - choose how many times the images loop
+              Play Iterations <span className="small-info">- choose how many times the images loop</span>
             </label>
           </div>
 
@@ -158,7 +158,7 @@ export default function WorkflowSettingsPage() {
               type="checkbox"
             />
             <label htmlFor="flipbook_autoplay">
-              Autoplay - automatically loop through a subject's images when the page loads
+              Autoplay <span className="small-info">- automatically loop through a subject's images when the page loads</span>
             </label>
           </div>
 
@@ -172,7 +172,7 @@ export default function WorkflowSettingsPage() {
               type="checkbox"
             />
             <label htmlFor="enable_switching_flipbook_and_separate">
-              Allow Separate Frames View - volunteers can choose flipbook or a separate frames view
+              Allow Separate Frames View <span className="small-info">- volunteers can choose flipbook or a separate frames view</span>
             </label>
           </div>
 
@@ -186,7 +186,7 @@ export default function WorkflowSettingsPage() {
               type="checkbox"
             />
             <label htmlFor="multi_image_clone_markers">
-              Clone marks in all frames - for drawing tasks
+              Clone marks in all frames <span className="small-info">- for drawing tasks</span>
             </label>
           </div>
 
@@ -203,7 +203,7 @@ export default function WorkflowSettingsPage() {
                   type="radio"
                 />
                 <label htmlFor="separate-frames-as-col">
-                  Single column - all frames stacked vertically (recommended for landscape subjects; default for mobile devices)
+                  Single column <span className="small-info">- all frames stacked vertically (recommended for landscape subjects; default for mobile devices)</span>
                 </label>
               </li>
               <li key="separate-frames-as-row">
@@ -216,7 +216,7 @@ export default function WorkflowSettingsPage() {
                   type="radio"
                 />
                 <label htmlFor="separate-frames-as-row">
-                  Single row - all frames side by side horizontally (recommended only for portrait subjects)
+                  Single row <span className="small-info">- all frames side by side horizontally (recommended only for portrait subjects)</span>
                 </label>
               </li>
               <li key="separate-frames-as-grid2">
@@ -229,7 +229,7 @@ export default function WorkflowSettingsPage() {
                   type="radio"
                 />
                 <label htmlFor="separate-frames-as-grid2">
-                  Grid - frames distributed evenly over 2 columns
+                  Grid <span className="small-info">- frames distributed evenly over 2 columns</span>
                 </label>
               </li>
               <li key="separate-frames-as-grid3">
@@ -242,7 +242,7 @@ export default function WorkflowSettingsPage() {
                   type="radio"
                 />
                 <label htmlFor="separate-frames-as-grid3">
-                  Grid - frames distributed evenly over 3 columns
+                  Grid <span className="small-info">- frames distributed evenly over 3 columns</span>
                 </label>
               </li>
             </ul>

--- a/app/pages/lab-pages-editor/components/WorkflowVersion.jsx
+++ b/app/pages/lab-pages-editor/components/WorkflowVersion.jsx
@@ -1,0 +1,9 @@
+export default function WorkflowVersion({}) {
+  return (
+    <div className="workflow-version">
+      V. 123.456
+      loading...
+    </div>
+  );
+
+}

--- a/app/pages/lab-pages-editor/components/WorkflowVersion.jsx
+++ b/app/pages/lab-pages-editor/components/WorkflowVersion.jsx
@@ -1,5 +1,5 @@
 import { useWorkflowContext } from '../context.js';
-import PlusIcon from '../icons/PlusIcon.jsx'
+import LoadingIcon from '../icons/LoadingIcon.jsx'
 
 export default function WorkflowVersion({}) {
   const { workflow, status } = useWorkflowContext();
@@ -8,8 +8,8 @@ export default function WorkflowVersion({}) {
 
   return (
     <div className="workflow-version">
-      V. {workflow.version} {status}
-      {isBusy && <PlusIcon />}
+      V. {workflow.version}
+      {isBusy && <LoadingIcon alt="Loading" />}
     </div>
   );
 

--- a/app/pages/lab-pages-editor/components/WorkflowVersion.jsx
+++ b/app/pages/lab-pages-editor/components/WorkflowVersion.jsx
@@ -1,8 +1,15 @@
+import { useWorkflowContext } from '../context.js';
+import PlusIcon from '../icons/PlusIcon.jsx'
+
 export default function WorkflowVersion({}) {
+  const { workflow, status } = useWorkflowContext();
+  const isBusy = status === 'fetching' || status === 'updating';
+  if (!workflow) return;
+
   return (
     <div className="workflow-version">
-      V. 123.456
-      loading...
+      V. {workflow.version} {status}
+      {isBusy && <PlusIcon />}
     </div>
   );
 

--- a/app/pages/lab-pages-editor/icons/LoadingIcon.jsx
+++ b/app/pages/lab-pages-editor/icons/LoadingIcon.jsx
@@ -1,0 +1,5 @@
+export default function LoadingIcon({ alt, ...rest }) {
+  return (
+    <span className="icon fa fa-spinner fa-spin" aria-label={alt} role={!!alt ? 'img' : undefined} {...rest} />
+  );
+}

--- a/app/pages/lab-pages-editor/icons/WrenchIcon.jsx
+++ b/app/pages/lab-pages-editor/icons/WrenchIcon.jsx
@@ -1,0 +1,5 @@
+export default function WrenchIcon({ alt, ...rest }) {
+  return (
+    <span className="icon fa fa-wrench" aria-label={alt} role={!!alt ? 'img' : undefined} {...rest} />
+  );
+}

--- a/css/lab-pages-editor.styl
+++ b/css/lab-pages-editor.styl
@@ -171,7 +171,7 @@ $fontWeightBoldPlus = 700
     margin-bottom: $sizeM
   
   .workflow-version
-    background: red
+    border: 1px solid red
     color: $teal
 
   // Component: Workflow Header

--- a/css/lab-pages-editor.styl
+++ b/css/lab-pages-editor.styl
@@ -171,7 +171,6 @@ $fontWeightBoldPlus = 700
     margin-bottom: $sizeM
   
   .workflow-version
-    border: 1px solid red
     color: $teal
 
   // Component: Workflow Header

--- a/css/lab-pages-editor.styl
+++ b/css/lab-pages-editor.styl
@@ -267,7 +267,7 @@ $fontWeightBoldPlus = 700
         font-style: italic
       
       span.small-info
-        font-size: $fontSizeXS
+        font-size: $fontSizeS
 
     .col-1
       grid-column: 1

--- a/css/lab-pages-editor.styl
+++ b/css/lab-pages-editor.styl
@@ -324,6 +324,17 @@ $fontWeightBoldPlus = 700
       border-radius: $sizeXS
       color: $grey2
     
+    .no-tasks-notice
+      padding: $sizeL
+      text-align: center
+
+      .icon
+        color: $yellow
+        font-size: $sizeXXL
+      
+      p
+        color: $grey1
+
     dialog
       border: 1px solid $grey1
       border-radius: $sizeS

--- a/css/lab-pages-editor.styl
+++ b/css/lab-pages-editor.styl
@@ -212,7 +212,7 @@ $fontWeightBoldPlus = 700
   .workflow-settings-page
     display: grid
     gap: $sizeM
-    grid-template-columns: auto auto
+    grid-template-columns: 50% auto
     grid-template-rows: auto auto
     margin-top: $sizeS
 

--- a/css/lab-pages-editor.styl
+++ b/css/lab-pages-editor.styl
@@ -551,6 +551,7 @@ $fontWeightBoldPlus = 700
         &.next-is-submit
           background: $white
           border: 2px solid $yellow
+          color: $black
 
       &.simple-next-controls
         display: flex
@@ -593,6 +594,14 @@ $fontWeightBoldPlus = 700
     font-size: $fontSizeXS
     padding: $sizeS $sizeM
     text-align: center
+  
+  .fake-submit
+    background: $white
+    border-radius: $sizeM
+    border: 2px solid $yellow
+    color: $black
+    font-size: $fontSizeXS
+    padding: $sizeS $sizeM
   
   .fake-text-input
     background: $white

--- a/css/lab-pages-editor.styl
+++ b/css/lab-pages-editor.styl
@@ -161,11 +161,18 @@ $fontWeightBoldPlus = 700
   .justify-around
     justify-content: space-around
   
+  .position-relative
+    position: relative
+  
   .spacing-bottom-XS
     margin-bottom: $sizeXS
   
   .spacing-bottom-M
     margin-bottom: $sizeM
+  
+  .workflow-version
+    background: red
+    color: $teal
 
   // Component: Workflow Header
   // ---------------------------------------------------------------------------
@@ -221,9 +228,6 @@ $fontWeightBoldPlus = 700
     .workflow-title
       grid-column: 1 / span 2
       grid-row: 1
-
-      > div
-        position: relative
 
       label[for=display_name]
         display: block

--- a/css/lab-pages-editor.styl
+++ b/css/lab-pages-editor.styl
@@ -248,9 +248,12 @@ $fontWeightBoldPlus = 700
       p
         font-size: $fontSizeS
       
-      .small-info
+      p.small-info
         font-size: $fontSizeS
         font-style: italic
+      
+      span.small-info
+        font-size: $fontSizeXS
 
     .col-1
       grid-column: 1

--- a/css/lab-pages-editor.styl
+++ b/css/lab-pages-editor.styl
@@ -119,7 +119,7 @@ $fontWeightBoldPlus = 700
   hr
     border-top: 1px solid $grey2
   
-  .disabled, .disabled *
+  .disabled, .disabled *, [disabled]
     color: $grey1
   
   .decoration-plus

--- a/css/lab-pages-editor.styl
+++ b/css/lab-pages-editor.styl
@@ -218,20 +218,31 @@ $fontWeightBoldPlus = 700
     margin-top: $sizeS
 
     // Workflow Title
-    label[for=display_name]
-      display: block
-      font-size: $fontSizeL
-      font-weight: $fontWeightBoldPlus
+    .workflow-title
       grid-column: 1 / span 2
       grid-row: 1
-      text-transform: uppercase
 
-      input
+      > div
+        position: relative
+
+      label[for=display_name]
+        display: block
+        font-size: $fontSizeL
+        font-weight: $fontWeightBoldPlus
+        margin-bottom: $sizeXS
+        text-transform: uppercase
+
+      input[name=display_name]
         border-radius: $sizeXS
         display: block
         font-size: $fontSizeL
-        margin-top: $sizeXS
         width: 100%
+      
+      .workflow-id
+        color: $grey2
+        background: $white
+        position: absolute
+        right: $sizeS
     
     // Group of Config Options/Controls
     fieldset
@@ -294,10 +305,6 @@ $fontWeightBoldPlus = 700
         font-weight: $fontWeightBoldPlus
         text-transform: uppercase
       
-      .workflow-id
-        color: $grey4
-        font-size: $fontSizeS
-
       .status-active, .status-inactive
         font-size: $fontSizeS
         margin-left: $sizeS

--- a/css/lab-pages-editor.styl
+++ b/css/lab-pages-editor.styl
@@ -80,6 +80,7 @@ $fontWeightBoldPlus = 700
   
   select
     border: 1.5px solid $grey1
+    border-radius: $sizeXS
     color: $black
     font-size: $fontSizeM
     padding: $sizeS


### PR DESCRIPTION
## PR Overview

Part of: **Pages Editor MVP** project and **FEM Lab** super-project
Follows #7088
Staging branch URL: https://pr-7093.pfe-preview.zooniverse.org/lab/1982/workflows/editor/3711?env=staging

This PR combines a number of UI tweaks and updates to the Workflow Settings. The UI changes makes the visual presentation closer to [Sean's intended design](https://www.figma.com/file/gNOcFdlskfEXmVIFPvx7Yj/Pages-Editor?type=design&node-id=0-1&mode=design), while the Workflow Settings changes make that tab ⭐ _on par with the Project Builder FEM Lab's functionality._ [(comparative link)](https://master.pfe-preview.zooniverse.org/lab/1982/workflows/3711?femLab=true&env=staging)

**Part 1: UI changes**
- Workflow ID moved to Workflow Settings tab
- **Workflow Version** added, and also displays a spinner 🕐 to indicate loading/fetching activity
- TasksPage: now displays a "you have no tasks" notice if you have no tasks.

<img width="300" alt="image" src="https://github.com/zooniverse/Panoptes-Front-End/assets/13952701/bd29d2ca-6246-4998-b7a2-be45d328951a"> ➡️  <img width="300" alt="image" src="https://github.com/zooniverse/Panoptes-Front-End/assets/13952701/8c00f4e3-c907-43fe-a439-1956141aeaa1">

<img width="300" alt="image" src="https://github.com/zooniverse/Panoptes-Front-End/assets/13952701/0fe17209-fa22-4da4-999d-53d4aa49ea88"> ➡️ <img width="300" alt="image" src="https://github.com/zooniverse/Panoptes-Front-End/assets/13952701/dcca584c-001b-4bef-8cd8-0e7dfb8fbce6">

<img width="300" alt="image" src="https://github.com/zooniverse/Panoptes-Front-End/assets/13952701/8e60a66b-01ee-4d07-ac86-a0cd00821c3f">

**Part 2: Workflow Settings Tab**
- Subject Retirement rule now locked to Classification Count, with no ability to specify _how many_ to retirement.
- Multi Image Options rules added
  - Enable "Allow Separate Frames View" to show additional options.
- Image Display Options now includes "Allow users to flip color"
- Hidden features:
  - you can now access the Workflow Settings tab directly by adding `?tab=settings` to the URL
  - you can now access "removed options" (i.e. workflow options that are valid in the API but removed to keep things in line with Project Builder FEM Lab) by adding ~?tab=settings&showRemovedOptions=true~ `?tab=settings&advanced=true` to the URL

**Misc Changes**
- ❗ DataManager: the data memo is now updated when the ready/fetching/updating `status` value changes. This wasn't tracked previously!
  - Since I'm updating the data manager, I need to pay extra attention that that changes are being committed to the API properly, and updates from the API are being fetched properly. **Reviewer: I'd appreciate eyes on this as well.**
- The Experimental/Debug Panel's "Reset" button now also resets `workflow.configuration`
- Icons added: WrenchIcon, LoadingIcon (spinner)

**Update 1** [(link)](https://github.com/zooniverse/Panoptes-Front-End/pull/7093#issuecomment-2097156613)
- ⭐ Workflows are now **linear.**
- New advanced mode hidden behind `?advanced=true`. (Use this to enable manual/non-linear workflows, and the Experimental Panel)
- Fix: classifications count no longer hidden

### Testing

No specific tests recommended. Just check that general functionality is maintained, and the code makes sense.

- Open the Test URL
- Make general changes to the workflow on the Tasks tab:
  - If no tasks, "you have no tasks" notification should appear
  - You should be able to add tasks/pages, edit them, etc 
- Check the Workflow Settings Tab:
  - You should be able to change workflow-level settings, e.g. change the workflow's name.
  - The amount of workflow-level settings you can change should match the FEM Lab (?femLab=true) version of the Project Builder: https://master.pfe-preview.zooniverse.org/lab/1982/workflows/3711?femLab=true&env=staging
- Reload the page to confirm changes are made.

### Status

Ready for review. 👌 

Requires 7088 to be merged first before this can be merged.