### PR TITLE
Pages Editor: add Copy Page feature

### DIFF
--- a/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
@@ -147,6 +147,17 @@ export default function TasksPage() {
     update({ steps });
   }
 
+  function copyStep(stepIndex) {
+    if (!workflow) return;
+    const { steps, tasks } = workflow;
+    const [ stepKey ] = steps[stepIndex] || [];
+
+    const confirmed = confirm(`Copy Page ${stepKey}?`);
+    if (!confirmed) return;
+
+    console.log('+++ TODO');
+  }
+
   function deleteStep(stepIndex) {
     if (!workflow) return;
     const { steps, tasks } = workflow;
@@ -290,6 +301,7 @@ export default function TasksPage() {
               activeDragItem={activeDragItem}
               allSteps={workflow.steps}
               allTasks={workflow.tasks}
+              copyStep={copyStep}
               deleteStep={deleteStep}
               moveStep={moveStep}
               isLinearWorkflow={isLinearWorkflow}

--- a/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
@@ -150,12 +150,33 @@ export default function TasksPage() {
   function copyStep(stepIndex) {
     if (!workflow) return;
     const { steps, tasks } = workflow;
-    const [ stepKey ] = steps[stepIndex] || [];
+    const [ stepKey, stepBody ] = steps[stepIndex] || [];
 
     const confirmed = confirm(`Copy Page ${stepKey}?`);
     if (!confirmed) return;
 
-    console.log('+++ TODO');
+    const newSteps = steps.slice();  // Copy Steps.
+    const newTasks = tasks ? { ...tasks } : {};  // Copy Tasks.
+
+    const tasksToCopy = stepBody?.taskKeys || [];
+    const newTaskKeys = [];
+    tasksToCopy.forEach(originalKey => {
+      const newTaskKey = getNewTaskKey(newTasks);
+      newTaskKeys.push(newTaskKey);
+      const newTask = structuredClone(tasks[originalKey]);  // Copy.
+      newTasks[newTaskKey] = newTask;
+    })
+
+    console.log('+++ newTasks: ', newTasks);
+
+    // cleanedupTasksAndSteps() will also remove tasks not associated with any step.
+    const cleanedTasksAndSteps = cleanupTasksAndSteps(newTasks, newSteps); 
+    if (linkStepsInWorkflow) {
+      cleanedTasksAndSteps.steps = linkStepsInWorkflow(cleanedTasksAndSteps.steps, cleanedTasksAndSteps.tasks);
+    }
+    // update(cleanedTasksAndSteps);
+
+    console.log('+++ TEST: ', cleanedTasksAndSteps);
   }
 
   function deleteStep(stepIndex) {

--- a/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
@@ -158,6 +158,8 @@ export default function TasksPage() {
     const newSteps = steps.slice();  // Copy Steps.
     const newTasks = tasks ? { ...tasks } : {};  // Copy Tasks.
 
+    // Duplicate tasks of the Step we want to copy.
+    // Each task needs a new task key.
     const tasksToCopy = stepBody?.taskKeys || [];
     const newTaskKeys = [];
     tasksToCopy.forEach(originalKey => {
@@ -167,16 +169,17 @@ export default function TasksPage() {
       newTasks[newTaskKey] = newTask;
     })
 
-    console.log('+++ newTasks: ', newTasks);
+    // Duplicate the Step we want. It needs a new step key.
+    const newStepKey = getNewStepKey(newSteps);
+    const newStep = [ newStepKey, { ...stepBody, taskKeys: newTaskKeys } ];
+    newSteps.push(newStep);
 
     // cleanedupTasksAndSteps() will also remove tasks not associated with any step.
     const cleanedTasksAndSteps = cleanupTasksAndSteps(newTasks, newSteps); 
     if (linkStepsInWorkflow) {
       cleanedTasksAndSteps.steps = linkStepsInWorkflow(cleanedTasksAndSteps.steps, cleanedTasksAndSteps.tasks);
     }
-    // update(cleanedTasksAndSteps);
-
-    console.log('+++ TEST: ', cleanedTasksAndSteps);
+    update(cleanedTasksAndSteps);
   }
 
   function deleteStep(stepIndex) {

--- a/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/StepItem.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/StepItem.jsx
@@ -21,10 +21,11 @@ function StepItem({
   activeDragItem = -1,
   allSteps,
   allTasks,
+  copyStep = DEFAULT_HANDLER,
   deleteStep = DEFAULT_HANDLER,
+  isLinearWorkflow = false,
   moveStep = DEFAULT_HANDLER,
   openEditStepDialog = DEFAULT_HANDLER,
-  isLinearWorkflow = false,
   setActiveDragItem = DEFAULT_HANDLER,
   step,
   stepIndex,
@@ -36,6 +37,10 @@ function StepItem({
 
   const isLastItem = stepIndex === allSteps.length - 1;
   const taskKeys = stepBody.taskKeys || [];
+
+  function doCopy() {
+    copyStep(stepIndex);
+  }
 
   function doDelete() {
     deleteStep(stepIndex);
@@ -109,7 +114,12 @@ function StepItem({
             >
               <DeleteIcon />
             </button>
-            <button aria-label={`Copy Page/Step ${stepKey}`} className="disabled plain" type="button">
+            <button
+              aria-label={`Copy Page/Step ${stepKey}`}
+              className="plain"
+              onClick={doCopy}
+              type="button"
+            >
               <CopyIcon />
             </button>
             <button
@@ -164,6 +174,7 @@ StepItem.propTypes = {
   activeDragItem: PropTypes.number,
   allSteps: PropTypes.array,
   allTasks: PropTypes.object,
+  copyStep: PropTypes.func,
   deleteStep: PropTypes.func,
   isLinearWorkflow: PropTypes.bool,
   moveStep: PropTypes.func,


### PR DESCRIPTION
## PR Overview

Part of: **Pages Editor MVP** project and **FEM Lab** super-project
Follows #7100
Staging branch URL: https://pr-7102.pfe-preview.zooniverse.org/lab/1982/workflows/editor/3711?env=staging

This PR adds the ability to copy Pages/Steps - and their related Tasks - via the "copy" button. This PR adds the ability to copy Pages/Steps - and their related Tasks - via the "copy" button.

_Screenshot: the "copy" button is the "two pieces of paper" button at the top right._

<img width="400" alt="image" src="https://github.com/zooniverse/Panoptes-Front-End/assets/13952701/0067efca-08ef-4c07-ad35-88a2f3b175f5">

- New Feature: **Copy Page** (aka Copy Step)
  - duplicating Page also duplicates its Tasks.
  - each copied Page and copied Task is INDEPENDENT of the original Page/original Task. This means you can edit/delete a copied Step or Task without affecting the original.
  - A copied Page is appended at the END of the sequence of Pages.

### Testing

- Open the test workflow in the Pages Editor using the Staging Branch URL. (Or pick any workflow of your choice, really.)
- (If the workflow doesn't have any Tasks yet, create something, or use the "Quick Setup" option in the ?advanced=true panel)
- Click on the "copy button" for any page, say Page X (with Tasks X1 and X2).
- A copy of Page X should be created, let's call it Page Y (with Tasks Y1 and Y2).
- Try editing Page Y (e.g. adding or removing Tasks). The original Page X should remain unchanged.
  - try vice versa
- Try editing Task Y1. The original Task X1 should remain unchanged.
  - try vice versa
- Try deleting Page Y.

### Status

Ready for review. 👍 👍 

Requires 7100 to be merged first before this can be merged. Requires 7100 to be merged first before this can be merged.