### PR TITLE
Pages Editor: misc updates for internal review

### DIFF
--- a/app/pages/lab-pages-editor/DataManager.jsx
+++ b/app/pages/lab-pages-editor/DataManager.jsx
@@ -17,6 +17,7 @@ import { useEffect, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
 import apiClient from 'panoptes-client/lib/api-client';
 import { WorkflowContext } from './context.js';
+import checkIsPFEWorkflow from './helpers/checkIsPFEWorkflow.js';
 
 function DataManager({
   // key: to ensure DataManager renders FRESH (with states reset) whenever workflowId changes, use <DataManager key={workflowId} ... />
@@ -30,6 +31,7 @@ function DataManager({
     status: 'ready'
   });
   const [updateCounter, setUpdateCounter] = useState(0); // Number of updates so far, only used to trigger useMemo.
+  const isPFEWorkflow = checkIsPFEWorkflow(apiData.workflow);
 
   // Fetch workflow when the component loads for the first time.
   // See notes about 'key' prop, to ensure states are reset:
@@ -129,8 +131,24 @@ function DataManager({
       {apiData.status === 'error' && (
         <div className="status-banner error">ERROR: could not fetch data</div>
       )}
-      {children}
+      {isPFEWorkflow ? <PFEWorkflowWarning /> : children }
     </WorkflowContext.Provider>
+  );
+}
+
+/*
+At the moment, we don't fully support PFE workflows in the Pages Editor.
+Reason: the "autocleanup" functionality (see cleanupTasksAndSteps()) would
+annihilate all the tasks in a workflow with no steps (i.e. PFE workflows).
+We'd need to prompt users to convert from a PFE workflow to an FEM workflow
+first before allowing them 
+ */
+function PFEWorkflowWarning() {
+  return (
+    <div className="pfe-workflow-warning">
+      <p>Sorry, but the new workflow editor doesn't support traditional workflows.</p>
+      <p>Please check back with us later, as we improve the workflow editor.</p>
+    </div>
   );
 }
 

--- a/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
@@ -102,6 +102,8 @@ export default function TasksPage() {
   function deleteTask(taskKey) {
     // First check: does the task exist?
     // if (!workflow || !taskKey || !workflow?.tasks?.[taskKey]) return;
+    // UPDATE: DON'T actually check if the task exists.
+    // This is useful if a Step refers to a Task that doesn't exist.
 
     // Second check: is this the only task in the step?
     const activeStepTaskKeys = workflow.steps?.[activeStepIndex]?.[1]?.taskKeys || [];

--- a/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
@@ -267,9 +267,9 @@ export default function TasksPage() {
   // 3. if a Step already has many tasks, any multiple answer question task can't be transformed into a single answer question task. 
   const activeStep = workflow?.steps?.[activeStepIndex]
   const enforceLimitedBranchingRule = {
-    stepHasBranch: !!checkCanStepBranch(activeStep, workflow?.tasks),
-    stepHasOneTask: activeStep?.[1]?.taskKeys?.length > 0,
-    stepHasManyTasks: activeStep?.[1]?.taskKeys?.length > 1
+    stepHasBranch: false && !!checkCanStepBranch(activeStep, workflow?.tasks),
+    stepHasOneTask: false && activeStep?.[1]?.taskKeys?.length > 0,
+    stepHasManyTasks: false && activeStep?.[1]?.taskKeys?.length > 1
   }
 
   if (!workflow) return null;

--- a/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
@@ -262,9 +262,9 @@ export default function TasksPage() {
   
   // Limited Branching Rule:
   // 0. a Step can only have 1 branching task (single answer question task)
-  // 1. if a Step has a branching task, it can't have any other tasks.
-  // 2. if a Step already has at least one task, any added question task must be a multiple answer question task.
-  // 3. if a Step already has many tasks, any multiple answer question task can't be transformed into a single answer question task. 
+  // 1. if a Step has a branching task, it can't have ANOTHER BRANCHING TASK.
+  // 2. if a Step already has at least one BRANCHING task, any added question task must be a multiple answer question task.
+  // 3. if a Step already has many MULTIPLE ANSWER QUESTION tasks AND NO SINGLE ANSWER QUESTION TASK, ONLY ONE multiple answer question task CAN be transformed into a single answer question task.
   const activeStep = workflow?.steps?.[activeStepIndex]
   const enforceLimitedBranchingRule = {
     stepHasBranch: !!checkCanStepBranch(activeStep, workflow?.tasks),

--- a/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
@@ -267,9 +267,9 @@ export default function TasksPage() {
   // 3. if a Step already has many tasks, any multiple answer question task can't be transformed into a single answer question task. 
   const activeStep = workflow?.steps?.[activeStepIndex]
   const enforceLimitedBranchingRule = {
-    stepHasBranch: false && !!checkCanStepBranch(activeStep, workflow?.tasks),
-    stepHasOneTask: false && activeStep?.[1]?.taskKeys?.length > 0,
-    stepHasManyTasks: false && activeStep?.[1]?.taskKeys?.length > 1
+    stepHasBranch: !!checkCanStepBranch(activeStep, workflow?.tasks),
+    stepHasOneTask: activeStep?.[1]?.taskKeys?.length > 0,
+    stepHasManyTasks: activeStep?.[1]?.taskKeys?.length > 1
   }
 
   if (!workflow) return null;

--- a/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
@@ -100,10 +100,9 @@ export default function TasksPage() {
   }
 
   function deleteTask(taskKey) {
-    // First check: does the task exist?
-    // if (!workflow || !taskKey || !workflow?.tasks?.[taskKey]) return;
-    // UPDATE: DON'T actually check if the task exists.
-    // This is useful if a Step refers to a Task that doesn't exist.
+    if (!workflow) return;
+    // NOTE: don't check if task actually exists before deleting it.
+    // This is useful if a Step somehow refers to a Task that doesn't exist.
 
     // Second check: is this the only task in the step?
     const activeStepTaskKeys = workflow.steps?.[activeStepIndex]?.[1]?.taskKeys || [];

--- a/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
@@ -267,9 +267,7 @@ export default function TasksPage() {
   // 3. if a Step already has many MULTIPLE ANSWER QUESTION tasks AND NO SINGLE ANSWER QUESTION TASK, ONLY ONE multiple answer question task CAN be transformed into a single answer question task.
   const activeStep = workflow?.steps?.[activeStepIndex]
   const enforceLimitedBranchingRule = {
-    stepHasBranch: !!checkCanStepBranch(activeStep, workflow?.tasks),
-    stepHasOneTask: activeStep?.[1]?.taskKeys?.length > 0,
-    stepHasManyTasks: activeStep?.[1]?.taskKeys?.length > 1
+    stepHasBranch: !!checkCanStepBranch(activeStep, workflow?.tasks)
   }
 
   if (!workflow) return null;

--- a/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
@@ -1,6 +1,6 @@
 import { useRef, useState } from 'react'
 import { useWorkflowContext } from '../../context.js';
-import canStepBranch from '../../helpers/canStepBranch.js';
+import checkCanStepBranch from '../../helpers/checkCanStepBranch.js';
 import createStep from '../../helpers/createStep.js';
 import createTask from '../../helpers/createTask.js';
 import getNewStepKey from '../../helpers/getNewStepKey.js';
@@ -267,7 +267,7 @@ export default function TasksPage() {
   // 3. if a Step already has many tasks, any multiple answer question task can't be transformed into a single answer question task. 
   const activeStep = workflow?.steps?.[activeStepIndex]
   const enforceLimitedBranchingRule = {
-    stepHasBranch: !!canStepBranch(activeStep, workflow?.tasks),
+    stepHasBranch: !!checkCanStepBranch(activeStep, workflow?.tasks),
     stepHasOneTask: activeStep?.[1]?.taskKeys?.length > 0,
     stepHasManyTasks: activeStep?.[1]?.taskKeys?.length > 1
   }

--- a/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
@@ -101,7 +101,7 @@ export default function TasksPage() {
 
   function deleteTask(taskKey) {
     // First check: does the task exist?
-    if (!workflow || !taskKey || !workflow?.tasks?.[taskKey]) return;
+    // if (!workflow || !taskKey || !workflow?.tasks?.[taskKey]) return;
 
     // Second check: is this the only task in the step?
     const activeStepTaskKeys = workflow.steps?.[activeStepIndex]?.[1]?.taskKeys || [];

--- a/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/EditStepDialog.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/EditStepDialog.jsx
@@ -120,9 +120,7 @@ EditStepDialog.propTypes = {
   allTasks: PropTypes.object,
   deleteTask: PropTypes.func,
   enforceLimitedBranchingRule: PropTypes.shape({
-    stepHasBranch: PropTypes.bool,
-    stepHasOneTask: PropTypes.bool,
-    stepHasManyTasks: PropTypes.bool
+    stepHasBranch: PropTypes.bool
   }),
   onClose: PropTypes.func,
   step: PropTypes.object,

--- a/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/EditStepDialog.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/EditStepDialog.jsx
@@ -99,7 +99,6 @@ function EditStepDialog({
       <div className="dialog-footer flex-row">
         <button
           className="big flex-item"
-          disabled={!!enforceLimitedBranchingRule?.stepHasBranch}
           onClick={handleClickAddTaskButton}
           type="button"
         >

--- a/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/EditStepDialog.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/EditStepDialog.jsx
@@ -102,7 +102,7 @@ function EditStepDialog({
           onClick={handleClickAddTaskButton}
           type="button"
         >
-          Add New Task
+          Add another Task to this Page
         </button>
         <button
           className="big done"

--- a/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/EditTaskForm.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/EditTaskForm.jsx
@@ -48,9 +48,7 @@ function EditTaskForm({  // It's not actually a form, but a fieldset that's part
 EditTaskForm.propTypes = {
   deleteTask: PropTypes.func,
   enforceLimitedBranchingRule: PropTypes.shape({
-    stepHasBranch: PropTypes.bool,
-    stepHasOneTask: PropTypes.bool,
-    stepHasManyTasks: PropTypes.bool
+    stepHasBranch: PropTypes.bool
   }),
   stepHasManyTasks: PropTypes.bool,
   task: PropTypes.object,

--- a/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/EditTaskForm.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/EditTaskForm.jsx
@@ -4,6 +4,7 @@ import DrawingTask from './types/DrawingTask.jsx';
 import QuestionTask from './types/QuestionTask.jsx';
 import TextTask from './types/TextTask.jsx';
 import UnknownTask from './types/UnknownTask.jsx';
+import DeleteIcon from '../../../../icons/DeleteIcon.jsx';
 
 const taskTypes = {
   'drawing': DrawingTask,
@@ -21,7 +22,28 @@ function EditTaskForm({  // It's not actually a form, but a fieldset that's part
   taskIndexInStep,
   updateTask
 }) {
-  if (!task || !taskKey) return <li>ERROR: could not render Task</li>;
+  if (!task || !taskKey) return (
+    <fieldset
+      className="edit-task-form"
+    >
+      <div className="flex-row">
+        <span className="task-key">{taskKey || '???'}</span>
+        <p className="flex-item">
+          ERROR: could not render Task
+          {!task && ' (it doesn\'t exist in workflow.tasks)'}
+          {task?.type && ` of type: ${task.type}`}
+        </p>
+        <button
+          aria-label={`Delete Task ${taskKey || '???'}`}
+          className="big"
+          onClick={() => { deleteTask(taskKey) }}
+          type="button"
+        >
+          <DeleteIcon />
+        </button>
+      </div>
+    </fieldset>
+  );
 
   const TaskForm = taskTypes[task.type] || UnknownTask;
   

--- a/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/types/QuestionTask.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/types/QuestionTask.jsx
@@ -197,9 +197,7 @@ function QuestionTask({
 QuestionTask.propTypes = {
   deleteTask: PropTypes.func,
   enforceLimitedBranchingRule: PropTypes.shape({
-    stepHasBranch: PropTypes.bool,
-    stepHasOneTask: PropTypes.bool,
-    stepHasManyTasks: PropTypes.bool
+    stepHasBranch: PropTypes.bool
   }),
   stepHasManyTasks: PropTypes.bool,
   task: PropTypes.object,

--- a/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/types/QuestionTask.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/types/QuestionTask.jsx
@@ -136,7 +136,7 @@ function QuestionTask({
               id={`task-${taskKey}-multiple`}
               type="checkbox"
               checked={isMultiple}
-              disabled={enforceLimitedBranchingRule?.stepHasManyTasks && isMultiple /* If rule is enforced, you can't switch a Multi Question Task to a Single Question Task. */}
+              disabled={enforceLimitedBranchingRule?.stepHasBranch && isMultiple /* If rule is enforced, you can't switch a Multi Question Task to a Single Question Task. */}
               onChange={(e) => {
                 setIsMultiple(!!e?.target?.checked);
               }}

--- a/app/pages/lab-pages-editor/components/TasksPage/components/NewTaskDialog.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/NewTaskDialog.jsx
@@ -125,9 +125,7 @@ function NewTaskDialog({
 NewTaskDialog.propTypes = {
   addTask: PropTypes.func,
   enforceLimitedBranchingRule: PropTypes.shape({
-    stepHasBranch: PropTypes.bool,
-    stepHasOneTask: PropTypes.bool,
-    stepHasManyTasks: PropTypes.bool
+    stepHasBranch: PropTypes.bool
   }),
   openEditStepDialog: PropTypes.func,
   stepIndex: PropTypes.number

--- a/app/pages/lab-pages-editor/components/TasksPage/components/NewTaskDialog.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/NewTaskDialog.jsx
@@ -55,7 +55,7 @@ function NewTaskDialog({
 
   // The Question Task is either a Single Answer Question Task, or a Multiple Answer Question Task.
   // By default, this is 'single', but under certain conditions, a new Question Task will be created as a Multiple Answer Question Task.
-  const questionTaskType = (!enforceLimitedBranchingRule?.stepHasOneTask) ? 'single' : 'multiple'
+  const questionTaskType = (!enforceLimitedBranchingRule?.stepHasBranch) ? 'single' : 'multiple'
 
   return (
     <dialog

--- a/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/BranchingNextControls.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/BranchingNextControls.jsx
@@ -5,13 +5,15 @@ const DEFAULT_HANDLER = () => {};
 
 export default function BranchingNextControls({
   allSteps = [],
+  stepKey,
   task,
   taskKey,
   updateNextStepForTaskAnswer = DEFAULT_HANDLER
 }) {
   if (!task || !taskKey) return null;
 
-  const answers = task.answers || []
+  const answers = task.answers || [];
+  const selectableSteps = allSteps.filter(([otherStepKey]) => otherStepKey !== stepKey);
 
   function onChange(e) {
     const next = e.target?.value;
@@ -36,7 +38,7 @@ export default function BranchingNextControls({
             >
               Submit
             </option>
-            {allSteps.map(([stepKey, stepBody]) => {
+            {selectableSteps.map(([stepKey, stepBody]) => {
               const taskKeys = stepBody?.taskKeys?.toString() || '(none)';
               return (
                 <option
@@ -56,6 +58,7 @@ export default function BranchingNextControls({
 
 BranchingNextControls.propTypes = {
   allSteps: PropTypes.arrayOf(PropTypes.array),
+  stepKey: PropTypes.string,
   task: PropTypes.object,
   taskKey: PropTypes.string,
   updateNextStepForTaskAnswer: PropTypes.func

--- a/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/NextStepArrow.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/NextStepArrow.jsx
@@ -3,7 +3,7 @@ export default function NextStepArrow({
   arrowhead = false,
   className = 'icon',
   color = 'currentColor',
-  height = 48,
+  height = 32,
   pad = 0,
   strokeWidth = 2,
   width = 16

--- a/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/SimpleNextControls.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/SimpleNextControls.jsx
@@ -15,6 +15,7 @@ export default function SimpleNextControls({
   const isLinearItem = isLinearWorkflow && !isLastItem;
   const showFakeSubmit = isLinearWorkflow && isLastItem;
   const showNextPageDropdown = !isLinearWorkflow && !showFakeSubmit;
+  const selectableSteps = allSteps.filter(([otherStepKey]) => otherStepKey !== stepKey);
   
   function onChange(e) {
     const next = e.target?.value;
@@ -38,7 +39,7 @@ export default function SimpleNextControls({
           >
             Submit
           </option>
-          {allSteps.map(([otherStepKey, otherStepBody]) => {
+          {selectableSteps.map(([otherStepKey, otherStepBody]) => {
             const taskKeys = otherStepBody?.taskKeys?.toString() || '(none)';
             return (
               <option

--- a/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/StepItem.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/StepItem.jsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 
 // import strings from '../../../strings.json'; // TODO: move all text into strings
@@ -16,6 +17,8 @@ import MoveDownIcon from '../../../../icons/MoveDownIcon.jsx';
 import MoveUpIcon from '../../../../icons/MoveUpIcon.jsx';
 
 const DEFAULT_HANDLER = () => {};
+const ENABLE_EXPERIMENTAL_CONTAINER_STYLE = true;  // If enabled, and the last Task is a branching Task, then the .step-body container will be restyled so that the "next step" arrows APPEAR OUTSIDE the container.
+const CONTAINER_HEIGHT_OFFSET = 60;  // This value is eyeballed. Adjust as necessary.
 
 function StepItem({
   activeDragItem = -1,
@@ -32,11 +35,15 @@ function StepItem({
   updateNextStepForStep = DEFAULT_HANDLER,
   updateNextStepForTaskAnswer = DEFAULT_HANDLER
 }) {
+  const htmlContainer = useRef(null);
+  const htmlContent = useRef(null);
+  const [ containerStyle, setContainerStyle ] = useState({});
   const [stepKey, stepBody] = step || [];
   if (!stepKey || !stepBody || !allSteps || !allTasks) return <li className="step-item">ERROR: could not render Step</li>;
 
   const isLastItem = stepIndex === allSteps.length - 1;
   const taskKeys = stepBody.taskKeys || [];
+  const branchingTaskKey = checkCanStepBranch(step, allTasks);
 
   function doCopy() {
     copyStep(stepIndex);
@@ -64,7 +71,24 @@ function StepItem({
     setActiveDragItem(stepIndex);  // Use state because DropTarget's onDragEnter CAN'T read dragEvent.dataTransfer.getData()
   }
 
-  const branchingTaskKey = checkCanStepBranch(step, allTasks);
+  function experimentalRestyleContainer() {
+    const container = htmlContainer?.current;
+    const content = htmlContent?.current;
+    if (!content || !container || !ENABLE_EXPERIMENTAL_CONTAINER_STYLE) return;
+
+    const lastTaskInStep = taskKeys.at(-1);
+    const contentHeight = content.offsetHeight;
+    if (lastTaskInStep === branchingTaskKey && contentHeight) {
+      setContainerStyle({
+        height: `${content.offsetHeight - CONTAINER_HEIGHT_OFFSET}px`,
+        marginBottom: `${CONTAINER_HEIGHT_OFFSET}px`,
+      });
+    } else {
+      setContainerStyle({});
+    }
+  }
+
+  useEffect(experimentalRestyleContainer, [step])
   
   return (
     <li className="step-item">
@@ -80,77 +104,85 @@ function StepItem({
         className="step-body"
         draggable="true" /* This is enumerated, and has to be a string. */
         onDragStart={onDragStart}
+        ref={htmlContainer}
+        style={containerStyle}
       >
-        <div className="step-controls flex-row spacing-bottom-XS">
-          <span className="step-controls-left" />
-          <div className="step-controls-center">
-            <button
-              aria-label={`Rearrange Page ${stepKey} upwards`}
-              className="move-button plain"
-              onClick={moveStepUp}
-              type="button"
-            >
-              <MoveUpIcon />
-            </button>
-            {/* TODO: add drag/drop functionality. Perhaps this needs to be wider, too. */}
-            <GripIcon
-              className="grab-handle"
-            />
-            <button
-              aria-label={`Rearrange Page/Step ${stepKey} downwards`}
-              className="move-button plain"
-              onClick={moveStepDown}
-              type="button"
-            >
-              <MoveDownIcon />
-            </button>
-          </div>
-          <div className="step-controls-right">
-            <button
-              aria-label={`Delete Page/Step ${stepKey}`}
-              className="plain"
-              onClick={doDelete}
-              type="button"
-            >
-              <DeleteIcon />
-            </button>
-            <button
-              aria-label={`Copy Page/Step ${stepKey}`}
-              className="plain"
-              onClick={doCopy}
-              type="button"
-            >
-              <CopyIcon />
-            </button>
-            <button
-              aria-label={`Edit Page/Step ${stepKey}`}
-              className="plain"
-              onClick={doEdit}
-              type="button"
-            >
-              <EditIcon />
-            </button>
-          </div>
-        </div>
-        <ul
-          aria-label={`Tasks for Page/Step ${stepKey}`}
-          className="tasks-list"
+        <div
+          /* Redundant inner content is used for styling "branching next step extrudes from step-body" */
+          className="step-body-inner"
+          ref={htmlContent}
         >
-          {taskKeys.map((taskKey) => {
-            const task = allTasks[taskKey];
-            return (
-              <TaskItem
-                allSteps={allSteps}
-                isBranchingTask={branchingTaskKey === taskKey}
-                key={`taskItem-${taskKey}`}
-                stepKey={stepKey}
-                task={task}
-                taskKey={taskKey}
-                updateNextStepForTaskAnswer={updateNextStepForTaskAnswer}
+          <div className="step-controls flex-row spacing-bottom-XS">
+            <span className="step-controls-left" />
+            <div className="step-controls-center">
+              <button
+                aria-label={`Rearrange Page ${stepKey} upwards`}
+                className="move-button plain"
+                onClick={moveStepUp}
+                type="button"
+              >
+                <MoveUpIcon />
+              </button>
+              {/* TODO: add drag/drop functionality. Perhaps this needs to be wider, too. */}
+              <GripIcon
+                className="grab-handle"
               />
-            );
-          })}
-        </ul>
+              <button
+                aria-label={`Rearrange Page/Step ${stepKey} downwards`}
+                className="move-button plain"
+                onClick={moveStepDown}
+                type="button"
+              >
+                <MoveDownIcon />
+              </button>
+            </div>
+            <div className="step-controls-right">
+              <button
+                aria-label={`Delete Page/Step ${stepKey}`}
+                className="plain"
+                onClick={doDelete}
+                type="button"
+              >
+                <DeleteIcon />
+              </button>
+              <button
+                aria-label={`Copy Page/Step ${stepKey}`}
+                className="plain"
+                onClick={doCopy}
+                type="button"
+              >
+                <CopyIcon />
+              </button>
+              <button
+                aria-label={`Edit Page/Step ${stepKey}`}
+                className="plain"
+                onClick={doEdit}
+                type="button"
+              >
+                <EditIcon />
+              </button>
+            </div>
+          </div>
+          <ul
+            aria-label={`Tasks for Page/Step ${stepKey}`}
+            className="tasks-list"
+          >
+            {taskKeys.map((taskKey) => {
+              const task = allTasks[taskKey];
+              return (
+                <TaskItem
+                  allSteps={allSteps}
+                  isBranchingTask={branchingTaskKey === taskKey}
+                  key={`taskItem-${taskKey}`}
+                  stepKey={stepKey}
+                  task={task}
+                  taskKey={taskKey}
+                  updateNextStepForTaskAnswer={updateNextStepForTaskAnswer}
+                />
+              );
+            })}
+          </ul>
+        </div>
       </div>
       {!branchingTaskKey && (
         <SimpleNextControls

--- a/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/StepItem.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/StepItem.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import DropTarget from './DropTarget.jsx';
 import TaskItem from './TaskItem.jsx';
 
-import canStepBranch from '../../../../helpers/canStepBranch.js';
+import checkCanStepBranch from '../../../../helpers/checkCanStepBranch.js';
 
 import SimpleNextControls from './SimpleNextControls.jsx';
 
@@ -64,7 +64,7 @@ function StepItem({
     setActiveDragItem(stepIndex);  // Use state because DropTarget's onDragEnter CAN'T read dragEvent.dataTransfer.getData()
   }
 
-  const branchingTaskKey = canStepBranch(step, allTasks);
+  const branchingTaskKey = checkCanStepBranch(step, allTasks);
   
   return (
     <li className="step-item">

--- a/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/StepItem.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/StepItem.jsx
@@ -18,7 +18,7 @@ import MoveUpIcon from '../../../../icons/MoveUpIcon.jsx';
 
 const DEFAULT_HANDLER = () => {};
 const ENABLE_EXPERIMENTAL_CONTAINER_STYLE = true;  // If enabled, and the last Task is a branching Task, then the .step-body container will be restyled so that the "next step" arrows APPEAR OUTSIDE the container.
-const CONTAINER_HEIGHT_OFFSET = 60;  // This value is eyeballed. Adjust as necessary.
+const CONTAINER_HEIGHT_OFFSET = 64;  // This value is eyeballed. Adjust as necessary.
 
 function StepItem({
   activeDragItem = -1,
@@ -77,8 +77,9 @@ function StepItem({
     if (!content || !container || !ENABLE_EXPERIMENTAL_CONTAINER_STYLE) return;
 
     const lastTaskInStep = taskKeys.at(-1);
+    const lastTaskHasAnswers = allTasks?.[lastTaskInStep]?.answers?.length > 0
     const contentHeight = content.offsetHeight;
-    if (lastTaskInStep === branchingTaskKey && contentHeight) {
+    if (lastTaskInStep === branchingTaskKey && lastTaskHasAnswers && contentHeight) {
       setContainerStyle({
         height: `${content.offsetHeight - CONTAINER_HEIGHT_OFFSET}px`,
         marginBottom: `${CONTAINER_HEIGHT_OFFSET}px`,

--- a/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/StepItem.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/StepItem.jsx
@@ -143,6 +143,7 @@ function StepItem({
                 allSteps={allSteps}
                 isBranchingTask={branchingTaskKey === taskKey}
                 key={`taskItem-${taskKey}`}
+                stepKey={stepKey}
                 task={task}
                 taskKey={taskKey}
                 updateNextStepForTaskAnswer={updateNextStepForTaskAnswer}

--- a/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/StepItem.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/StepItem.jsx
@@ -83,12 +83,14 @@ function StepItem({
       setContainerStyle({
         height: `${content.offsetHeight - CONTAINER_HEIGHT_OFFSET}px`,
         marginBottom: `${CONTAINER_HEIGHT_OFFSET}px`,
+        // overflow: 'visible'  // Unnecessary here, as this is already specified in the .styl
       });
     } else {
       setContainerStyle({});
     }
   }
 
+  // TODO: experimentalRestyleContainer() should also trigger when the window resizes.
   useEffect(experimentalRestyleContainer, [step])
   
   return (

--- a/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/TaskItem.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/TaskItem.jsx
@@ -22,7 +22,18 @@ function TaskItem({
   taskKey,
   updateNextStepForTaskAnswer = DEFAULT_HANDLER
 }) {
-  if (!task || !taskKey) return <li className="task-item">ERROR: could not render Task</li>;
+  if (!task || !taskKey) return (
+    <li className="task-item">
+      <div className="flex-row">
+        <span className="task-key">{taskKey || '???'}</span>
+        <p>
+          ERROR: could not render Task
+          {!task && ' (it doesn\'t exist in workflow.tasks)'}
+          {task?.type && ` of type: ${task.type}`}
+        </p>
+      </div>
+    </li>
+  );
 
   // TODO: use Panoptes Translations API.
   // e.g. pull from workflow.strings['tasks.T0.instruction']

--- a/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/TaskItem.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/StepItem/TaskItem.jsx
@@ -17,6 +17,7 @@ const DEFAULT_HANDLER = () => {};
 function TaskItem({
   allSteps = [],
   isBranchingTask = false,
+  stepKey,
   task,
   taskKey,
   updateNextStepForTaskAnswer = DEFAULT_HANDLER
@@ -43,6 +44,7 @@ function TaskItem({
       {isBranchingTask && (
         <BranchingNextControls
           allSteps={allSteps}
+          stepKey={stepKey}
           task={task}
           taskKey={taskKey}
           updateNextStepForTaskAnswer={updateNextStepForTaskAnswer}
@@ -58,6 +60,7 @@ function TaskItem({
 TaskItem.propTypes = {
   allSteps: PropTypes.arrayOf(PropTypes.array),
   isBranchingTask: PropTypes.bool,
+  stepKey: PropTypes.string,
   task: PropTypes.object,
   taskKey: PropTypes.string,
   updateNextStepForTaskAnswer: PropTypes.func

--- a/app/pages/lab-pages-editor/components/WorkflowSettingsPage/WorkflowSettingsPage.jsx
+++ b/app/pages/lab-pages-editor/components/WorkflowSettingsPage/WorkflowSettingsPage.jsx
@@ -15,7 +15,7 @@ function getAdvancedMode() {
 export default function WorkflowSettingsPage() {
   const { workflow, update, project } = useWorkflowContext();
   const advancedMode = getAdvancedMode();
-  const showSeparateFramesOptions = !!workflow?.configuration?.enable_switching_flipbook_and_separate;
+  const showSeparateFramesOptions = workflow?.configuration?.multi_image_mode === 'separate';
 
   function onSubmit(e) {
     e.preventDefault();
@@ -137,6 +137,20 @@ export default function WorkflowSettingsPage() {
           <p id="multi-image-info">
             Choose how to display subjects with multiple images. If your subjects are in sequence, such as camera trap images, volunteers can play them like a .gif using the Flipbook viewer.
           </p>
+
+          <div className="flex-row align-start spacing-bottom-XS">
+            <select
+              aria-label="Viewer for multiple images"
+              className="flex-item"
+              defaultValue={workflow?.configuration?.multi_image_mode ?? 'flipbook'}
+              id="multi_image_mode"
+              name="configuration.multi_image_mode"
+              onChange={doUpdate}
+            >
+              <option value="flipbook">Flipbook Viewer (default)</option>
+              <option value="separate">Separate Frames Viewer</option>
+            </select>
+          </div>
 
           <div className="flex-row align-start spacing-bottom-XS">
             <select

--- a/app/pages/lab-pages-editor/helpers/checkCanStepBranch.js
+++ b/app/pages/lab-pages-editor/helpers/checkCanStepBranch.js
@@ -4,12 +4,12 @@ Checks if a step can branch. We're not asking if the step IS branching, but if i
   - If multiple Tasks qualify, only return the FIRST.
 - If no, returns false.
  */
-export default function canStepBranch(step = [], tasks = {}) {
+export default function checkCanStepBranch(step = [], tasks = {}) {
   // TODO/QUESTION: what happens when a Step has multiple branching Questions?
   // TODO/CHECK: if a Question Task has 0 answers, is it still considered 'branching'? Check what happens with FEM Classifier
   const [stepId, stepBody] = step;
   const tasksInStep = stepBody?.taskKeys?.map(taskKey => tasks[taskKey] ? [taskKey, tasks[taskKey]]: undefined).filter(task => !!task) || []
-  return tasksInStep.find(canTaskBranch)?.[0] || false;
+  return tasksInStep.find(checkCanTaskBranch)?.[0] || false;
 }
 
 /*
@@ -18,6 +18,6 @@ Checks if a task can branch.
 - At the moment, only "Single Question" tasks can branch. 
 - Compare with "isTaskBranching" in https://github.com/zooniverse/front-end-monorepo/blob/master/packages/lib-classifier/src/store/helpers/convertWorkflowToUseSteps/convertWorkflowToUseSteps.js
  */
-function canTaskBranch([taskKey, task]) {
+function checkCanTaskBranch([taskKey, task]) {
   return task?.type === 'single';
 }

--- a/app/pages/lab-pages-editor/helpers/checkCanStepBranch.js
+++ b/app/pages/lab-pages-editor/helpers/checkCanStepBranch.js
@@ -2,10 +2,10 @@
 Checks if a step can branch. We're not asking if the step IS branching, but if it *can.*
 - If yes, returns Task ID of the Task that's causing the branch.
   - If multiple Tasks qualify, only return the FIRST.
+  - NOTE: as of Jun 2024, if a step has multiple single-type tasks, only the first is "actually" a branching task that decides the branching logic of the FEM classifier.
 - If no, returns false.
  */
 export default function checkCanStepBranch(step = [], tasks = {}) {
-  // TODO/QUESTION: what happens when a Step has multiple branching Questions?
   // TODO/CHECK: if a Question Task has 0 answers, is it still considered 'branching'? Check what happens with FEM Classifier
   const [stepId, stepBody] = step;
   const tasksInStep = stepBody?.taskKeys?.map(taskKey => tasks[taskKey] ? [taskKey, tasks[taskKey]]: undefined).filter(task => !!task) || []

--- a/app/pages/lab-pages-editor/helpers/checkIsPFEWorkflow.js
+++ b/app/pages/lab-pages-editor/helpers/checkIsPFEWorkflow.js
@@ -1,0 +1,17 @@
+/*
+Checks if a workflow is a PFE workflow, as opposed to an FEM workflow.
+Quite simply, a workflow designed for the PFE classifier has tasks, but NO
+steps/pages. A workflow designed for the FEM classifier has tasks AND steps.
+
+- If a workflow has neither tasks nor steps, it's uninitialised.
+- If a workflow has no tasks, but has steps, then it's an anomaly.
+ */
+
+export default function checkIsPFEWorkflow(workflow) {
+  if (!workflow) return false;
+
+  const tasks = workflow?.tasks || {};
+  const steps = workflow?.steps || [];
+
+  return Object.keys(tasks).length > 0 && steps.length === 0;
+}

--- a/app/pages/lab-pages-editor/helpers/linkStepsInWorkflow.js
+++ b/app/pages/lab-pages-editor/helpers/linkStepsInWorkflow.js
@@ -10,14 +10,14 @@ Rules for linking steps:
 - Otherwise, each Step's step.next will be the ID of the next Step in the array.
  */
 
-import canStepBranch from './canStepBranch.js';
+import checkCanStepBranch from './checkCanStepBranch.js';
 
 export default function linkStepsInWorkflow(steps = [], tasks = {}) {
   const newSteps = steps.map((step, index) => {
     const [stepId, stepBody] = step;
 
     const isFinalStepInArray = index === (steps.length - 1);
-    const canBranch = canStepBranch(step, tasks);
+    const canBranch = checkCanStepBranch(step, tasks);
     const nextStep = (isFinalStepInArray || canBranch) ? undefined : steps[index+1]?.[0];
 
     const newStepBody = {

--- a/css/lab-pages-editor.styl
+++ b/css/lab-pages-editor.styl
@@ -594,7 +594,7 @@ $fontWeightBoldPlus = 700
         margin-top: 0
 
       .task-text
-        font-size: $fontSizeS
+        font-size: $fontSizeM
         font-weight: $fontWeightBold
       
     .grab-handle
@@ -614,7 +614,7 @@ $fontWeightBoldPlus = 700
         background: $yellow
         border-radius: $sizeM
         border: 2px solid $grey1
-        font-size: $fontSizeXS
+        font-size: $fontSizeS
 
         &.next-is-submit
           background: $white
@@ -659,7 +659,7 @@ $fontWeightBoldPlus = 700
     border-radius: 2px
     color: $black
     font-family: $fontFamilies
-    font-size: $fontSizeXS
+    font-size: $fontSizeS
     padding: $sizeS $sizeM
     text-align: center
   
@@ -668,7 +668,7 @@ $fontWeightBoldPlus = 700
     border-radius: $sizeM
     border: 2px solid $yellow
     color: $black
-    font-size: $fontSizeXS
+    font-size: $fontSizeS
     padding: $sizeS $sizeM
   
   .fake-text-input

--- a/css/lab-pages-editor.styl
+++ b/css/lab-pages-editor.styl
@@ -640,7 +640,7 @@ $fontWeightBoldPlus = 700
       li
         display: flex
         flex-direction: column
-        margin: 0 $sizeM
+        margin: 0 $sizeM $sizeS $sizeM
         padding: 0
     
     div.vertical-layout

--- a/css/lab-pages-editor.styl
+++ b/css/lab-pages-editor.styl
@@ -535,11 +535,14 @@ $fontWeightBoldPlus = 700
         background: $grey5
         border: 1px solid $grey1
         border-radius: $sizeXS
-        padding: $sizeS $sizeM
+        overflow: visible
 
         &:active
         &:has(.move-button:focus)  // Note: :has() is experimental as of Nov 2023, and not supported on Firefox
           outline: 2px solid $yellow
+        
+        .step-body-inner  // Redundant inner content is used for styling "branching next step extrudes from step-body"
+          padding: $sizeS $sizeM
 
       .step-controls
         cursor: grab

--- a/css/lab-pages-editor.styl
+++ b/css/lab-pages-editor.styl
@@ -85,6 +85,7 @@ $fontWeightBoldPlus = 700
     color: $black
     font-size: $fontSizeM
     padding: $sizeS
+    -webkit-appearance: none  // Remove gradient overlay in Safari
   
   button
     border-radius: $sizeXS

--- a/css/lab-pages-editor.styl
+++ b/css/lab-pages-editor.styl
@@ -703,6 +703,11 @@ $fontWeightBoldPlus = 700
       align-items: center
       padding: $sizeS
 
+  .pfe-workflow-warning
+    border: 1px solid $yellow
+    border-radius: $sizeS
+    padding: $sizeM
+
 .debug-0
   width: 6em
 


### PR DESCRIPTION
## PR Overview

Part of: **Pages Editor MVP** project and **FEM Lab** super-project
Follows #7102
Staging branch URL: https://pr-7105.pfe-preview.zooniverse.org/lab/1982/workflows/editor/3711?env=staging

This PR adds a number of misc updates in preparation for the internal team review, at the end of May. Here's the adapted ToDo List from [Slack, 13 May](https://zooniverse.slack.com/archives/C39AUB9UK/p1715631331033939):

Functional:

- [x] **Traditional PFE workflows** _shouldn't_ be openable in Pages Editor.
  - Current implementation: a warning screen appears to block users from viewing/editing traditional PFE workflows.
  - Future PR thoughts: the warning screen should have an option to perform a one-way conversion from classic PFE workflow to FEM workflow.
  - Note: a "traditional PFE workflow" is a WF with tasks, but no steps.
- [x] **Multi-Image Options** should be fixed.
  - Fixed: due to a misunderstanding on my part, I conflated the "Flipbook / Separate Frames Viewer" dropdown (which affects workflow.configuration.multi_image_mode) with the "Allow Separate Frames View" checkbox (which affects workflow.configuration.enable_switching_flipbook_and_separate).
- [x] The **Limited Branching Rule** needs to be updated. See below for more details.
- [x] A Page should _not_ be able to **set itself as its Next Page.**

Design:

- [x] branching task **"next page" arrows** should appear outside grey box.
  - NOTE: may clash with the new Limited Branching Rule update. 🤔 
- [x] **font sizes** should be standardised to 16px [(16pt?)](https://zooniverse.slack.com/archives/C39AUB9UK/p1715185131610989?thread_ts=1715122778.728279&cid=C39AUB9UK)
  - This is most important for the Simple & Branching Next Step controls

### Limited Branching Rule

The Pages Editor implements some **incredibly ad-hoc rules** on whether a Page can have more than one Question Task.

This is due to some unfortunate "logic overloading", i.e. a Single Answer Question Task (aka type=single) is ALWAYS a Branching Task. This can be a problem if e.g. you want to have 4x Single-Type Tasks on a page, but don't want the page to branch. 🤷 

(Also, a smaller reason is that having a Single Answer Question Task can make the design look wonky when it's not the _last item on the page,_ since the yellow "next page" indicators are supposed to sit _outside the grey box_ representing the page. But at least this is something we can figure out later.)

<img width="300" alt="image" src="https://github.com/zooniverse/Panoptes-Front-End/assets/13952701/f8e2e7ac-05fa-4a46-b2b1-f13e954067c2">

ANYWAY, here's the intended change to the Limited Branching Rule:

OLD:
```
// Limited Branching Rule:
// 0. a Step can only have 1 branching task (single answer question task)
// 1. if a Step has a branching task, it can't have any other tasks.
// 2. if a Step already has at least one task, any added question task must be a multiple answer question task.
// 3. if a Step already has many tasks, any multiple answer question task can't be transformed into a single answer question task. 
```

NEW:
```
// Limited Branching Rule:
// 0. a Step can only have 1 branching task (single answer question task)
// 1. if a Step has a branching task, it can't have ANOTHER BRANCHING TASK.
// 2. if a Step already has at least one BRANCHING task, any added question task must be a multiple answer question task.
// 3. if a Step already has many MULTIPLE ANSWER QUESTION tasks AND NO SINGLE ANSWER QUESTION TASK, ONLY ONE multiple answer question task CAN be transformed into a single answer question task. 
```

NOTE: it's easy to completely disable the Limited Branching Rule by setting this in the TasksPage:
```
const enforceLimitedBranchingRule = {
  stepHasBranch: false,
  stepHasOneTask: false,
  stepHasManyTasks: false
}

// Super useful if our tests users think the limited branching rule's too confusing.
```

### Status

~~WIP~~

[Update (2024.05.31 23:30 BST):](https://github.com/zooniverse/Panoptes-Front-End/pull/7105#issuecomment-2143057624) Ready for review!