### PR TITLE
Update panoptes-client (PJC) to 5.6.2 / fix 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "markdownz": "~9.1.6",
         "modal-form": "~2.9",
         "moment": "~2.29.0",
-        "panoptes-client": "~5.6.0",
+        "panoptes-client": "~5.6.2",
         "papaparse": "^5.4.1",
         "polished": "~4.3.1",
         "prop-types": "~15.8.1",
@@ -12788,9 +12788,9 @@
       }
     },
     "node_modules/panoptes-client": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-5.6.0.tgz",
-      "integrity": "sha512-XML9SeuYxhS9qtwSRPbMfsOD8VjiLpcctAaHMOJSDEp+BpOrxXfEqnP5J6Bjl7q7WiATWc116mVHt27JBOE3QQ==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-5.6.2.tgz",
+      "integrity": "sha512-IVJjM1Hqix/a/iac3RN9aOvfcsV3CO7pggFIFGOgd/7Bp0JFKyQhR+9MKtdpIqenS4nUKmRZZgNVAO8fXS4kfQ==",
       "dependencies": {
         "local-storage": "^2.0.0",
         "normalizeurl": "~1.0.0",
@@ -27234,9 +27234,9 @@
       }
     },
     "panoptes-client": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-5.6.0.tgz",
-      "integrity": "sha512-XML9SeuYxhS9qtwSRPbMfsOD8VjiLpcctAaHMOJSDEp+BpOrxXfEqnP5J6Bjl7q7WiATWc116mVHt27JBOE3QQ==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/panoptes-client/-/panoptes-client-5.6.2.tgz",
+      "integrity": "sha512-IVJjM1Hqix/a/iac3RN9aOvfcsV3CO7pggFIFGOgd/7Bp0JFKyQhR+9MKtdpIqenS4nUKmRZZgNVAO8fXS4kfQ==",
       "requires": {
         "local-storage": "^2.0.0",
         "normalizeurl": "~1.0.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "markdownz": "~9.1.6",
     "modal-form": "~2.9",
     "moment": "~2.29.0",
-    "panoptes-client": "~5.6.0",
+    "panoptes-client": "~5.6.2",
     "papaparse": "^5.4.1",
     "polished": "~4.3.1",
     "prop-types": "~15.8.1",


### PR DESCRIPTION
## PR Overview

Staging branch URL: https://pr-7111.pfe-preview.zooniverse.org
Related: #7066 

This PR bumps PJC to [5.6.2,](https://github.com/zooniverse/panoptes-javascript-client/pull/241) which includes a [fix](https://github.com/zooniverse/panoptes-javascript-client/pull/240) to responses on Talk posts going nuts on occasion.

Turns out that, while PJC was correctly updated with the fix, PFE wasn't updated with the latest version of PJC.

Note: this is more targeted than #7109, and only intends to fix the Talk issue.

### Testing

Compare: https://www.zooniverse.org/talk/search?page=3&query=depression

With: https://pr-7111.pfe-preview.zooniverse.org/talk/search?page=3&query=depression&env=production

The the second link should display all talk posts correctly.

Also, baseline tests: ensure you can login/logout, view the Projects page, view a random project, and submit a Classification.

### Status

Ready for review. Reviewer, please merge & deploy if everything looks good.