### PR TITLE
Add Instagram link to Zooniverse footer

### DIFF
--- a/app/layout/site-footer.jsx
+++ b/app/layout/site-footer.jsx
@@ -188,6 +188,16 @@ class AppFooter extends React.Component {
                   <i className="fa fa-twitter fa-fw"></i>
                 </a>{' '}
               </li>
+              <li>
+                <a
+                  aria-label="Zooniverse Instagram"
+                  href="https://www.instagram.com/the.zooniverse/"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  <i className="fa fa-instagram fa-fw"></i>
+                </a>{' '}
+              </li>
             </ul>
           </nav>
         </div>


### PR DESCRIPTION
## PR Overview

Preview: https://pr-7112.pfe-preview.zooniverse.org/
Closes #7110 

Adds an Instagram link to the Zooniverse footer.

<img width="839" alt="image" src="https://github.com/zooniverse/Panoptes-Front-End/assets/13952701/5b87b8c8-52e6-474b-afc4-50193e0db93d">

### Status

Ready for review