### PR TITLE
fix(accessibility): Fix user settings email description

### DIFF
--- a/app/pages/settings/email.jsx
+++ b/app/pages/settings/email.jsx
@@ -258,7 +258,7 @@ class EmailSettingsPage extends React.Component {
             <br />
             <input
               type="text"
-              aria-describedby="user-email-valid,user-email-verified"
+              aria-describedby="user-email-valid user-email-verified"
               autoComplete="email"
               className="standard-input full"
               id="user-email"


### PR DESCRIPTION
Fixes an empty description for the email address text input in the new verified email code.

- Fixes #7119.

<img width="352" alt="The Firefox accessibility inspector, showing the email address input's properties with the description filled out." src="https://github.com/zooniverse/Panoptes-Front-End/assets/59547/acf6432f-9deb-4dc9-aead-ab2a955fd7a6">



# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
