### PR TITLE
Add FEM redirect for SciScribbler Synapse Safari

### DIFF
--- a/app/monorepoUtils.js
+++ b/app/monorepoUtils.js
@@ -55,7 +55,8 @@ export const SLUGS = [
   'bcosentino/squirrelmapper',
   'embeller/offal-wildlife-watching',
   'safmcadmin/fishstory',
-  'bethzc/newark-digital-archive'
+  'bethzc/newark-digital-archive',
+  'chloezycheng/science-scribbler-synapse-safari'
 ];
 
 export function usesMonorepo(slug) {


### PR DESCRIPTION
Add FEM redirect for SciScribbler Synapse Safari (Project 21429)

Staging branch URL: https://pr-7127.pfe-preview.zooniverse.org/
Staging URL for Project: https://pr-7127.pfe-preview.zooniverse.org/projects/chloezycheng/science-scribbler-synapse-safari
Target Link: https://www.zooniverse.org/projects/chloezycheng/science-scribbler-synapse-safari
Project Lab Link: https://www.zooniverse.org/lab/21429

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?
