### PR TITLE
Enable Caesar fetching through a Workflow configuration key.

### DIFF
--- a/app/pages/admin/project-status/experimental-features.jsx
+++ b/app/pages/admin/project-status/experimental-features.jsx
@@ -5,6 +5,7 @@ import AutoSave from '../../../components/auto-save';
 const experimentalFeatures = [
   'allow workflow query',
   'anchoredEllipse',
+  'caesarDataFetching',  // Indicates that the Project should pull data from Caesar
   'combo',
   'crop',
   'dropdown',

--- a/app/pages/lab-fem/workflow.jsx
+++ b/app/pages/lab-fem/workflow.jsx
@@ -49,6 +49,7 @@ class EditWorkflowPage extends Component {
     this.showCreateWorkflow = this.showCreateWorkflow.bind(this);
     this.showTaskAddButtons = this.showTaskAddButtons.bind(this);
     this.handleTaskDelete = this.handleTaskDelete.bind(this);
+    this.toggleCaesarDataFetching = this.toggleCaesarDataFetching.bind(this);
 
     this.state = {
       selectedTaskKey: props.workflow.first_task,
@@ -118,6 +119,11 @@ class EditWorkflowPage extends Component {
     return this.setState(prevState => ({ showTaskAddButtons: !prevState.showTaskAddButtons }));
   }
 
+  toggleCaesarDataFetching(e) {
+    return this.props.workflow.update({
+      'configuration.enable_caesar_data_fetching': e.target.checked
+    }).save()
+  }
 
   render() {
     let definition;
@@ -145,6 +151,8 @@ class EditWorkflowPage extends Component {
     } = this.props.workflow.configuration;
     if (hide_classification_summaries === undefined) { hide_classification_summaries = true; }
 
+	  const isCaesarDataFetchingEnabled = this.props.workflow?.configuration?.enable_caesar_data_fetching ?? false;
+  
     return (
       <div className="edit-workflow-page">
         <h3>{this.props.workflow.display_name} #{this.props.workflow.id}{' '}
@@ -505,6 +513,26 @@ class EditWorkflowPage extends Component {
             </p>
 
             <hr />
+
+            {Array.from(this.props.project.experimental_tools).includes('caesarDataFetching') ?
+              <div>
+                <p>
+                  <label>
+                    <input
+                      type='checkbox'
+                      checked={isCaesarDataFetchingEnabled}
+                      onChange={this.toggleCaesarDataFetching}
+                    />
+                    Enable Caesar Data Fetching
+                  </label>
+                  <br />
+                  <small className="form-help">Enabling Caesar data fetching allows the website to pull in subject reductions when the subject loads in the classifier.</small>
+                </p>
+
+                <hr />
+
+              </div> : undefined}
+            
 
             {Array.from(this.props.project.experimental_tools).includes('worldwide telescope') ?
               <div>


### PR DESCRIPTION
Staging branch URL: https://pr-7148.pfe-preview.zooniverse.org

LInked Issue: https://github.com/zooniverse/front-end-monorepo/issues/6038
Linked FEM PR: https://github.com/zooniverse/front-end-monorepo/pull/6039

This PR does 2 things towards fetching Caesar reductions efficiently in FEM.
- First, it adds an Admin area toggle called "CaesarEnabled". This toggle, when enabled, shows part two.
- Second, it adds a small config section to the FEMLab workflow editing page - which is currently limited to a toggle - that enables this specific workflow to make requests from Caesar to fetch Reductions on Subject load in the Classifier
- The logic for using this workflow configuration in FEM is in a separate PR

# Required Manual Testing
- [ ] Does the Workflow Configuration area of FEMLab hide the Caesar Enabled section when the admin flag is false?
- [ ] Does the Workflow Configuration area of FEMLab show the Caesar Enabled section when the admin flag is true?

# Full Manual Testing
The full end-to-end connection between FEM & PFE for this PR can be reviewed as follows:

## Setup
- Open up the Admin section for the "[Annotate Or Not](https://local.zooniverse.org:3735/admin/project_status/kieftrav/annotate-or-not)" project
- Open up the Workflow Config for the "[Annotate Or Not](https://local.zooniverse.org:3735/lab/2002/workflows/3782)" project
- Open up the Classifier locally on the complementary branch for "[Annotate Or Not](https://localhost:8081/?project=kieftrav%2Fannotate-or-not&workflow=3782)"

## Testing
- With all 3 tabs open, you can toggle on and off the Caesar Enabled workflow setting in the Workflow Config page. If, for whatever reason it's not enabled (someone else testing), enable it in the Admin section of the first tab
- Go to the 3rd tab after enabling/disabling "Caesar Enabled" in the Workflow Config. Notice that when you refresh the Classifier page after each toggle that Caesar Reductions show up on the subject when enabled, and don't show up on the subject when disabled.