### PR TITLE
Revert minimum text length for collections search.

### DIFF
--- a/app/collections/searchCollections.js
+++ b/app/collections/searchCollections.js
@@ -1,7 +1,7 @@
 import apiClient from 'panoptes-client/lib/api-client';
 
 // Tune this value to determine when a search term is long enough to use Panoptes full-text search.
-const MIN_SEARCH_LENGTH = 3;
+const MIN_SEARCH_LENGTH = 1;
 
 /**
  * Query the Panoptes collections search API


### PR DESCRIPTION
Since #7124, collections search no longer finds short collection names for Gravity Spy.

Staging branch URL: https://pr-{NUMBER}.pfe-preview.zooniverse.org

- reopens #7121. 
- see https://www.zooniverse.org/talk/17/3411492?comment=5601913

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
