### PR TITLE
Pages Editor: check if workflow is part of project

### DIFF
--- a/app/pages/lab-pages-editor/DataManager.jsx
+++ b/app/pages/lab-pages-editor/DataManager.jsx
@@ -18,6 +18,7 @@ import PropTypes from 'prop-types';
 import apiClient from 'panoptes-client/lib/api-client';
 import { WorkflowContext } from './context.js';
 import checkIsPFEWorkflow from './helpers/checkIsPFEWorkflow.js';
+import checkIsWorkflowPartOfProject from './helpers/checkIsWorkflowPartOfProject.js';
 
 function DataManager({
   // key: to ensure DataManager renders FRESH (with states reset) whenever workflowId changes, use <DataManager key={workflowId} ... />
@@ -123,13 +124,13 @@ function DataManager({
 
   // Safety check: does this workflow belong to this project?
   if (apiData.workflow && apiData.project) {
-    const isWorkflowPartOfProject = false
-    if (isWorkflowPartOfProject) {
+    const isWorkflowPartOfProject = checkIsWorkflowPartOfProject(apiData.workflow, apiData.project);
+    if (!isWorkflowPartOfProject) {
       return (
         <div className="status-banner error">
           ERROR: workflow {apiData.workflow.id} doesn't belong to project {apiData.project.id}
         </div>
-      )
+      );
     }
   }
 

--- a/app/pages/lab-pages-editor/DataManager.jsx
+++ b/app/pages/lab-pages-editor/DataManager.jsx
@@ -118,8 +118,24 @@ function DataManager({
     };
   }, [apiData.project, apiData.workflow, apiData.status, updateCounter]);
 
+  // Safety check: did this component receive its minimum input?
   if (!workflowId) return (<div>ERROR: no Workflow ID specified</div>);
-  // if (!workflow) return null
+
+  // Safety check: does this workflow belong to this project?
+  if (apiData.workflow && apiData.project) {
+    const isWorkflowPartOfProject = false
+    if (isWorkflowPartOfProject) {
+      return (
+        <div className="status-banner error">
+          ERROR: workflow {apiData.workflow.id} doesn't belong to project {apiData.project.id}
+        </div>
+      )
+    }
+  }
+
+  // NOTE: no need to check for !workflow.
+  // This is automatically handled by "Error: could not fetch data"
+  // // if (!workflow) return null
 
   return (
     <WorkflowContext.Provider

--- a/app/pages/lab-pages-editor/helpers/checkIsWorkflowPartOfProject.js
+++ b/app/pages/lab-pages-editor/helpers/checkIsWorkflowPartOfProject.js
@@ -4,5 +4,5 @@ Checks if a workflow belongs to a project.
 
 export default function checkIsWorkflowPartOfProject(workflow, project) {
   if (!workflow || !project) return false;
-  return !!workflow.links?.subject_sets?.some(sset => project.links?.subject_sets?.includes(sset));
+  return !!project.links?.workflows?.includes(workflow.id);
 }

--- a/app/pages/lab-pages-editor/helpers/checkIsWorkflowPartOfProject.js
+++ b/app/pages/lab-pages-editor/helpers/checkIsWorkflowPartOfProject.js
@@ -1,0 +1,8 @@
+/*
+Checks if a workflow belongs to a project.
+ */
+
+export default function checkIsWorkflowPartOfProject(workflow, project) {
+  if (!workflow || !project) return false;
+  return !!workflow.links?.subject_sets?.some(sset => project.links?.subject_sets?.includes(sset));
+}


### PR DESCRIPTION
## PR Overview

Staging branch URL: https://pr-7156.pfe-preview.zooniverse.org/lab/1982/workflows/editor/3711?env=staging

This PR fixes an issue where it's possible to view/edit a Workflow in the incorrect Project.

The Issue:
- e.g. if you have a WF 1111 that's part of project 22, you can still access that WF at the URL for project 44: `/lab/44/workflows/editor/1111` This is clearly incorrect.
- Note that this issue exists even with the PFE workflow editor, i.e. `/lab/44/workflows/1111` still allows you to edit the WF on an incorrect project. This is a separate issue to be fixed.

The Fix:
- Add `checkIsWorkflowPartOfProject()` helper that returns true if, and only if, the Workflow is linked to the Project.
- Add error message if the Workflow isn't part of the higher-level Project.

### Testing

For the following tests, staging WF 3711 belongs to project 1982, not 1992.

- This URL should display the Pages Editor for the workflow: https://pr-7156.pfe-preview.zooniverse.org/lab/1982/workflows/editor/3711?env=staging
  - compare and contrast with master: https://master.pfe-preview.zooniverse.org/lab/1982/workflows/editor/3711?env=staging
- This URL should return an error, because the workflow doesn't belong to the project: https://pr-7156.pfe-preview.zooniverse.org/lab/1992/workflows/editor/3711?env=staging
  - compare and contrast with master: https://master.pfe-preview.zooniverse.org/lab/1992/workflows/editor/3711?env=staging

### Status

Ready to go