### PR TITLE
Freeze ERAS classification count

### DIFF
--- a/app/pages/home-not-logged-in/research.jsx
+++ b/app/pages/home-not-logged-in/research.jsx
@@ -43,11 +43,13 @@ const OUROBOROS_COUNT = 142800311
 const OTHERS_COUNT = 8680290
 const OUROBOROS_USER_COUNT = 124921
 
+/* TEMPORARY - Aug 2024: freezing classification count until FEM homepage launch */
+const PANOPTES_COUNT = 584492482
 
 const HomePageResearch = (({ count, screenWidth, showDialog, volunteerCount }) =>
   <section className="home-research">
     <Translate className="tertiary-kicker" component="h2" content="researchHomePage.works" />
-    <span className="class-counter">{(count + GZ123_COUNT + OUROBOROS_COUNT + OTHERS_COUNT).toLocaleString()}</span>
+    <span className="class-counter">{(PANOPTES_COUNT + GZ123_COUNT + OUROBOROS_COUNT + OTHERS_COUNT).toLocaleString()}</span>
     <Translate className="main-kicker" component="h3" content="researchHomePage.classifications" />
     <div className="home-research__classification-count">
       <h3 className="main-kicker">{(volunteerCount + OUROBOROS_USER_COUNT).toLocaleString()}</h3>{' '}

--- a/app/pages/home-not-logged-in/research.jsx
+++ b/app/pages/home-not-logged-in/research.jsx
@@ -44,7 +44,7 @@ const OTHERS_COUNT = 8680290
 const OUROBOROS_USER_COUNT = 124921
 
 /* TEMPORARY - Aug 2024: freezing classification count until FEM homepage launch */
-const PANOPTES_COUNT = 584492482
+const PANOPTES_COUNT = 580300364
 
 const HomePageResearch = (({ count, screenWidth, showDialog, volunteerCount }) =>
   <section className="home-research">


### PR DESCRIPTION
Freeze the Zoo-wide total classification count on the PFE not-logged-in homepage during ERAS backfill of Ouroboros classifications.  This change freezes the Panoptes classification count at a fixed value (as of 27 Aug 2024) and ignores the value returned by ERAS so that backfilled Ouroboros entries are not double counted (by ERAS and via pre-Panoptes fixed count totals). Keep this in place until the Ouroboros classifications are backfilled in ERAS and new offsets can be calculated and implemented here (as corrections to the ERAS total).

cc: @yuenmichelle1 

Staging branch URL: https://pr-7160.pfe-preview.zooniverse.org

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?
- [x] Can you load the classification page?
- [x] Can you submit a classification?
- [x] Does talk load correctly?
- [ ] Can you post a talk comment?