### PR TITLE
Unfreeze ERAS class count, update ouroboros count offsets

### DIFF
--- a/app/pages/home-not-logged-in/research.jsx
+++ b/app/pages/home-not-logged-in/research.jsx
@@ -38,18 +38,13 @@ counterpart.registerTranslations('en', {
   }
 });
 
-const GZ123_COUNT = 98989226
-const OUROBOROS_COUNT = 142800311
-const OTHERS_COUNT = 8680290
-const OUROBOROS_USER_COUNT = 124921
-
-/* TEMPORARY - Aug 2024: freezing classification count until FEM homepage launch */
-const PANOPTES_COUNT = 580300364
+const PREPANOPTES_COUNT = 25284786
+const OUROBOROS_USER_COUNT = 114576
 
 const HomePageResearch = (({ count, screenWidth, showDialog, volunteerCount }) =>
   <section className="home-research">
     <Translate className="tertiary-kicker" component="h2" content="researchHomePage.works" />
-    <span className="class-counter">{(PANOPTES_COUNT + GZ123_COUNT + OUROBOROS_COUNT + OTHERS_COUNT).toLocaleString()}</span>
+    <span className="class-counter">{(count + PREPANOPTES_COUNT).toLocaleString()}</span>
     <Translate className="main-kicker" component="h3" content="researchHomePage.classifications" />
     <div className="home-research__classification-count">
       <h3 className="main-kicker">{(volunteerCount + OUROBOROS_USER_COUNT).toLocaleString()}</h3>{' '}


### PR DESCRIPTION
Staging branch URL: https://pr-7167.pfe-preview.zooniverse.org

Actions Taken:
- Reverts freeze placed by #7160 so classification count is based on live total from ERAS.
- Revises classification count offset to account for ouroboros classifications that were successfully backfilled to ERAS. Details: Take the previous offsets (`GZ123_COUNT + OUROBOROS_COUNT + OTHERS_COUNT` = 250,469,827) and subtract the `NOW_IN_ERAS_COUNT` = 225,185,041 resulting in new offset -- `PREPANOPTES_COUNT` = 25,284,786
- Revises user count offset to up-to-date values. Details: Panoptes API returns a user count (via `/users` endpoint) that is less than the `users` table total. This is due to omissions of 1) deleted users (currently 2220); 2) `ouroboros_created` users (currently 114576).  In #5518 we added an offset to account for the `ouroboros_created` users, but over time if those users login via Panoptes, they will be converted to normal users and included in the main count.  Therefore, it is prudent to update this ouroboros offset from time to time.
    - Note: the `ouroboros_created` count includes ~42k automated accounts for CRUK Cell Slider project/game

Builds on previous work: #4511 and #5518

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?
