### PR TITLE
Add hungarian language option and dictionary

### DIFF
--- a/app/constants/languageMenu.js
+++ b/app/constants/languageMenu.js
@@ -11,6 +11,7 @@ export default {
   he: 'עברית',
   hi: 'हिन्दी',
   hr: 'Hrvatski',
+  hu: 'magyar nyelv',
   hy: 'հայերեն',
   xh: 'isiXhosa',
   zu: 'isiZulu',

--- a/app/constants/languageMenu.js
+++ b/app/constants/languageMenu.js
@@ -11,7 +11,7 @@ export default {
   he: 'עברית',
   hi: 'हिन्दी',
   hr: 'Hrvatski',
-  hu: 'magyar nyelv',
+  hu: 'Magyar',
   hy: 'հայերեն',
   xh: 'isiXhosa',
   zu: 'isiZulu',

--- a/app/locales/hu.js
+++ b/app/locales/hu.js
@@ -1,0 +1,159 @@
+export default {
+  loading: '(Betöltés alatt)',
+  aboutPages: {
+    missingContent: {
+      education: 'Ehhez a projekthez nem adtak meg oktatási anyagokat.',
+      faq: 'Ehhez a projekthez nem adtak meg gyakran ismételt kérdéseket.',
+      research: 'Ehhez a projekthez nem adtak meg tudományos hátteret.',
+      results: 'Ehhez a projekthez nem adtak meg tudományos eredményeket.',
+      team: 'Ehhez a projekthez nem adtak meg információt a csapattagokról.'
+    }
+  },
+  projectRoles: {
+    title: 'Csapattag',
+    owner: 'Projektgazda',
+    collaborator: 'Kollaborátor',
+    translator: 'Fordító',
+    scientist: 'Kutató',
+    moderator: 'Moderátor',
+    tester: 'Tesztelő',
+    expert: 'Szakértő',
+    museum: 'Múzeum'
+  },
+  classifier: {
+    back: 'Vissza',
+    backButtonWarning: 'Ha visszalépsz, törlődik a jelen feladathoz adott válaszod.',
+    close: 'Bezár',
+    continue: 'Folytatás',
+    detailsSubTaskFormSubmitButton: 'OK',
+    done: 'Kész',
+    doneAndTalk: 'Kész & komment',
+    dontShowMinicourse: 'Ne mutasd a mini kurzust a jövőben',
+    letsGo: 'Kezdjük!',
+    next: 'Következő',
+    optOut: 'Kihagy',
+    taskTabs: {
+      taskTab: 'Feladat',
+      tutorialTab: 'Útmutató'
+    },
+    recents: 'Legutóbbi osztályozásaid',
+    talk: 'Komment',
+    taskHelpButton: 'Segítségre van szükséged ehhez a feladathoz?',
+    miniCourseButton: 'Projekt bevezető kurzus újrakezdése',
+    workflowAssignmentDialog: {
+      promotionMessage: 'Gratulálunk!',
+      acceptButton: 'Vigyél a következő szintre!',
+      declineButton: 'Nem, köszönöm'
+    },
+    interventions: {
+      optOut: 'Ne mutasson további üzeneteket.',
+      studyInfo: 'Nem szeretnék részt venni ebbben a [kutatásban](+tab+https://docs.google.com/document/d/1gLyN6Dgff8dOCOC88f47OD6TtFrfSJltsLgJMKkYMso/preview).'
+    }
+  },
+  projects: {
+    welcome: {
+      heading: 'Üdvözlünk! Örülönk, hogy itt vagy',
+      thanks: 'Köszönjük érdeklődésedet a valódi kutatás segítése iránt. Összegyűjtöttünk néhány olyan projektet, amelyekhez most valóban szükségünk van a segítségedre. További lehetőségekért görgess le, és böngéssz az összes aktív projekt között.',
+      talk: 'Ne felejtsd el megnézni a [Talk fórum](/talk) oldalt is, ahol cseveghetsz más hasonló gondolkodású önkéntesekkel.',
+      scrollDown: 'Görgess lejjebb a további információért'
+    }
+  },
+  project: {
+    language: 'Nyelv',
+    loading: 'Projekt betöltése',
+    disclaimer: 'Ez a projekt a Zooniverse Project Builder segítségével készült, de még nem hivatalos Zooniverse projekt. Előfordulhat, hogy a Zooniverse csapatához intézett, a projekttel kapcsolatos kérdések és kérdések nem kapnak választ.',
+    fieldGuide: 'Útmutató',
+    about: {
+      header: 'Rólunk',
+      nav: {
+        research: 'Kutatás',
+        results: 'Eredmények',
+        faq: 'GyIK',
+        education: 'Oktatás',
+        team: 'Csapatunk'
+      }
+    },
+    nav: {
+      about: 'Rólunk',
+      adminPage: 'Admin oldal',
+      classify: 'Osztályozás',
+      collections: 'Gyűjtemény',
+      exploreProject: 'Projekt felfedezése',
+      lab: 'Labor',
+      recents: 'Legutóbbiak',
+      talk: 'Talk fórum',
+      underReview: 'Ellenőrzés alatt',
+      zooniverseApproved: 'Zooniverse jóváhagyta'
+    },
+    classifyPage: {
+      dark: 'Sötét',
+      light: 'Világos',
+      title: 'Osztályozás',
+      themeToggle: '%(theme)s témára váltás'
+    },
+    home: {
+      organization: 'Szervezet',
+      researcher: 'Üzenet a kutatóktól',
+      about: '%(title)s bemutatása',
+      metadata: {
+        statistics: '%(title)s statisztikája',
+        classifications: 'Osztályozások',
+        volunteers: 'Önkéntesek',
+        completedSubjects: 'Befejezett alanyok',
+        subjects: 'Alanyok'
+      },
+      talk: {
+        zero: 'Most éppen senki nem beszél a/az **%(title)s** projektről.',
+        one: 'Most éppen **1** ember beszél a/az **%(title)s** projektről.',
+        other: 'Most éppen **%(count)s** ember beszél a/az **%(title)s** projektről.'
+      },
+      joinIn: 'Csatlakozz',
+      learnMore: 'Tudj meg többet',
+      getStarted: 'Kezdj bele',
+      workflowAssignment: 'Mostmár beléphetsz a %(workflowDisplayName)s projektbe',
+      visitLink: 'Projekt meglátogatása',
+      links: 'Külső projekt linkek'
+    }
+  },
+  tasks: {
+    hidePreviousMarks: 'Előző %(count)s jelölés elrejtése',
+    less: 'Kevesebb',
+    more: 'Több',
+    shortcut: {
+      noAnswer: 'Nincs válasz'
+    },
+    survey: {
+      clear: 'Törlés',
+      clearFilters: 'Szűrők törlése',
+      makeSelection: 'Kiválasztás',
+      showing: '%(max)s -ból/ből %(count)s darab megjelenítése',
+      confused: 'Gyakran összetéveszthető ezzel:',
+      dismiss: 'Elutasít',
+      itsThis: 'Szerintem ez az',
+      cancel: 'Mégsem',
+      identify: 'Beazonosít',
+      surveyOf: '%(count)s darab felmérése',
+      identifications: {
+        zero: 'Nincs még beazonosítás',
+        one: '1 beazonosítás',
+        other: '%(count)s beazonosítás'
+      }
+    }
+  },
+  workflowToggle: {
+    label: 'Aktív'
+  },
+  collections: {
+    createForm: {
+      private: 'Privát',
+      submit: 'Gyűjteményhez ad'
+    }
+  },
+  feedback: {
+    categories: {
+      correct: 'Találatok',
+      incorrect: 'Tévesztések',
+      falsepos: 'Hamis pozitívok'
+    }
+  }
+}

--- a/app/locales/index.js
+++ b/app/locales/index.js
@@ -9,6 +9,7 @@ export default {
   he: require('./he').default,
   hi: require('./hi').default,
   hr: require('./hr').default,
+  hu: require('./hu').default,
   hy: require('./hy').default,
   it: require('./it').default,
   ja: require('./ja').default,


### PR DESCRIPTION
Staging branch URL: https://pr-7169.pfe-preview.zooniverse.org
Example project url: https://pr-7169.pfe-preview.zooniverse.org/projects/benjamin-dot-richards/oceaneyes?language=hu

Follows https://github.com/zooniverse/Panoptes-Front-End/pull/7140

Add hungarian language option and dictionary

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
