### PR TITLE
Remove react-router Link from /about and /get-involved

### DIFF
--- a/app/layout/site-nav.jsx
+++ b/app/layout/site-nav.jsx
@@ -105,22 +105,12 @@ const SiteNav = createReactClass({
         >
           <Translate content="siteNav.projects" />
         </Link>{' '}
-        <Link
-          to="https://www.zooniverse.org/about"
-          className="site-nav__link"
-          activeClassName="site-nav__link--active"
-          onClick={!!this.logClick ? this.logClick.bind(this, 'mainNav.about') : null}
-        >
+        <a href='https://www.zooniverse.org/about' className="site-nav__link">
           <Translate content="siteNav.about" />
-        </Link>{' '}
-        <Link
-          to="https://www.zooniverse.org/get-involved"
-          className="site-nav__link"
-          activeClassName="site-nav__link--active"
-          onClick={!!this.logClick ? this.logClick.bind(this, 'mainNav.getInvolved') : null}
-        >
+        </a>{' '}
+        <a href='https://www.zooniverse.org/get-involved' className="site-nav__link">
           <Translate content="siteNav.getInvolved" />
-        </Link>{' '}
+        </a>{' '}
         <Link
           to="/talk"
           className="site-nav__link"


### PR DESCRIPTION
Staging branch URL: https://pr-7172.pfe-preview.zooniverse.org

Removes react-router Link from /about and /get-involved in router.jsx.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
