### PR TITLE
Remove react-router Link from footer routes to FEM pages

### DIFF
--- a/app/layout/site-footer.jsx
+++ b/app/layout/site-footer.jsx
@@ -106,9 +106,9 @@ class AppFooter extends React.Component {
                 </a>, 'footer.discover.projectBuilderPolicies')}
               </li>
               <li>
-                {this.loggableLink(<Link to="https://www.zooniverse.org/about/faq">
+                <a href='https://www.zooniverse.org/about/faq'>
                   <Translate content="footer.discover.faq" />
-                </Link>, 'footer.discover.faq')}
+                </a>
               </li>
               {process.env.NODE_ENV !== 'production' &&
                 <li>
@@ -118,29 +118,29 @@ class AppFooter extends React.Component {
 
             <ul className="app-footer__nav-list">
               <li>
-                {this.loggableLink(<Link to="https://www.zooniverse.org/about">
+                <a href='https://www.zooniverse.org/about'>
                   <Translate content="footer.about.aboutUs" />
-                </Link>, 'footer.about.aboutUs')}
+                </a>
               </li>
               <li>
-                {this.loggableLink(<Link to="https://www.zooniverse.org/get-involved/educate">
+                <a href='https://www.zooniverse.org/get-involved/educate'>
                   <Translate content="footer.about.education" />
-                </Link>, 'footer.about.education')}
+                </a>
               </li>
               <li>
-                {this.loggableLink(<Link to="https://www.zooniverse.org/about/team">
+                <a href='https://www.zooniverse.org/about/team'>
                   <Translate content="footer.about.ourTeam" />
-                </Link>, 'footer.about.ourTeam')}
+                </a>
               </li>
               <li>
-                {this.loggableLink(<Link to="https://www.zooniverse.org/about/publications">
+                <a href='https://www.zooniverse.org/about/publications'>
                   <Translate content="footer.about.publications" />
-                </Link>, 'footer.about.publications')}
+                </a>
               </li>
               <li>
-                {this.loggableLink(<Link to="https://www.zooniverse.org/about#contact">
+                <a href='https://www.zooniverse.org/about#contact'>
                   <Translate content="footer.boilerplate.contact" />
-                </Link>, 'footer.boilerplate.contact')}
+                </a>
               </li>
             </ul>
 


### PR DESCRIPTION
Staging branch URL: https://pr-7173.pfe-preview.zooniverse.org

Remove sreact-router Link from footer routes to FEM pages such as /about and /get-involved.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
