### PR TITLE
Update image assets with absolute urls

### DIFF
--- a/app/pages/dev-classifier/mock-data.coffee
+++ b/app/pages/dev-classifier/mock-data.coffee
@@ -534,19 +534,19 @@ subject = apiClient.type('subjects').create
   locations: if navigator?.onLine
     if labs1715QueryPresent()
       [
-        {'image/jpeg': "#{window.location.origin}/assets/dev-classifier/1715_labs/london_street_view.jpeg"}
-        {'image/jpeg': "#{window.location.origin}/assets/dev-classifier/1715_labs/greenwich_satellite_image.jpeg"}
-        {'image/jpeg': "#{window.location.origin}/assets/dev-classifier/1715_labs/building_plans.jpeg"}
-        {'text/plain': "#{window.location.origin}/assets/dev-classifier/algernon.txt"}
+        {'image/jpeg': "https://static.zooniverse.org/pfe-assets/dev-classifier/1715_labs/london_street_view.jpeg"}
+        {'image/jpeg': "https://static.zooniverse.org/pfe-assets/dev-classifier/1715_labs/greenwich_satellite_image.jpeg"}
+        {'image/jpeg': "https://static.zooniverse.org/pfe-assets/dev-classifier/1715_labs/building_plans.jpeg"}
+        {'text/plain': "https://static.zooniverse.org/pfe-assets/dev-classifier/algernon.txt"}
       ]
     else
       [
-        {'image/jpeg': "#{window.location.origin}/assets/dev-classifier/landscape.jpeg"} # //lorempixel.com/900/600/animals/1
-        {'image/jpeg': "#{window.location.origin}/assets/dev-classifier/portrait.jpeg"} # //lorempixel.com/600/900/animals/2
-        {'image/jpeg': "#{window.location.origin}/assets/dev-classifier/very-wide.jpeg"} # //lorempixel.com/1900/1000/animals/3
-        {'image/jpeg': "#{window.location.origin}/assets/dev-classifier/very-tall.jpeg"} # //lorempixel.com/1000/1900/animals/4
-        {'image/jpeg': "#{window.location.origin}/assets/dev-classifier/small.jpeg"} # //lorempixel.com/400/300/animals/4
-        {'text/plain': "#{window.location.origin}/assets/dev-classifier/algernon.txt"}
+        {'image/jpeg': "https://static.zooniverse.org/pfe-assets/dev-classifier/landscape.jpeg"} # //lorempixel.com/900/600/animals/1
+        {'image/jpeg': "https://static.zooniverse.org/pfe-assets/dev-classifier/portrait.jpeg"} # //lorempixel.com/600/900/animals/2
+        {'image/jpeg': "https://static.zooniverse.org/pfe-assets/dev-classifier/very-wide.jpeg"} # //lorempixel.com/1900/1000/animals/3
+        {'image/jpeg': "https://static.zooniverse.org/pfe-assets/dev-classifier/very-tall.jpeg"} # //lorempixel.com/1000/1900/animals/4
+        {'image/jpeg': "https://static.zooniverse.org/pfe-assets/dev-classifier/small.jpeg"} # //lorempixel.com/400/300/animals/4
+        {'text/plain': "https://static.zooniverse.org/pfe-assets/dev-classifier/algernon.txt"}
       ]
   else
     [

--- a/app/pages/home-for-user/circle-ribbon.jsx
+++ b/app/pages/home-for-user/circle-ribbon.jsx
@@ -31,7 +31,7 @@ class CircleRibbon extends React.Component {
     data: [],
     hrefTemplate: defaultHREFTemplate,
     onClick: () => {},
-    user: { avatar_src: '/assets/simple-avatar.png' }
+    user: { avatar_src: 'https://static.zooniverse.org/pfe-assets/simple-avatar.png' }
   };
 
   state = {
@@ -175,7 +175,7 @@ class CircleRibbon extends React.Component {
       tooltipPosition = this.getTooltipPoint(hoveredArc, 50);
     }
 
-    const avatar = this.props.user.avatar_src ? this.props.user.avatar_src : '/assets/simple-avatar.png';
+    const avatar = this.props.user.avatar_src ? this.props.user.avatar_src : 'https://static.zooniverse.org/pfe-assets/simple-avatar.png';
 
     return (
       <div ref="container" className="circle-ribbon" style={{ position: 'relative' }}>

--- a/app/pages/home-for-user/recent-messages.jsx
+++ b/app/pages/home-for-user/recent-messages.jsx
@@ -163,7 +163,7 @@ class RecentCollectionsSection extends React.Component {
     const message = this.state.lastMessages[conversation.id];
     const sentLastMessage = !!message && (this.state.messageAuthors[message.id] === this.context.user);
 
-    let avatarSrc = '/assets/simple-avatar.png';
+    let avatarSrc = 'https://static.zooniverse.org/pfe-assets/simple-avatar.png';
     if (!!partner && !!this.state.avatars[partner.id]) {
       avatarSrc = this.state.avatars[partner.id].src;
     }

--- a/app/pages/home-not-logged-in.jsx
+++ b/app/pages/home-not-logged-in.jsx
@@ -99,11 +99,11 @@ export default class HomePage extends React.Component {
       <div className="on-home-page home-page-not-logged-in">
         <div className="flex-container">
           <section className="home-intro">
-            <img role="presentation" className="home-mobile-video-image" src="./assets/home-video.jpg" />
+            <img role="presentation" className="home-mobile-video-image" src="https://static.zooniverse.org/pfe-assets/home-video.jpg" />
             <video className="home-video" autoPlay={true} loop={true}>
-              <source type="video/ogg" src="./assets/home-video.ogv" />
-              <source type="video/webm" src="./assets/home-video.webm" />
-              <source type="video/mp4" src="./assets/home-video.mp4" />
+              <source type="video/ogg" src="https://static.zooniverse.org/pfe-assets/home-video.ogv" />
+              <source type="video/webm" src="https://static.zooniverse.org/pfe-assets/home-video.webm" />
+              <source type="video/mp4" src="https://static.zooniverse.org/pfe-assets/home-video.mp4" />
             </video>
 
             <Translate className="main-kicker" component="h1" content="notLoggedInHomePage.welcome" />

--- a/app/pages/lab/mobile/mobile-section.jsx
+++ b/app/pages/lab/mobile/mobile-section.jsx
@@ -158,7 +158,7 @@ class MobileSection extends Component {
           </div>
 
           <div className="workflow-mobile-form-right-panel">
-            <img alt="mobile-sample" src="/assets/mobile-sample.png" />
+            <img alt="mobile-sample" src="https://static.zooniverse.org/pfe-assets/mobile-sample.png" />
           </div>
 
         </div>

--- a/app/pages/notifications/notification-section.jsx
+++ b/app/pages/notifications/notification-section.jsx
@@ -166,7 +166,7 @@ export default class NotificationSection extends Component {
   }
 
   avatarFor() {
-    const src = this.state.avatar || '/assets/simple-avatar.jpg';
+    const src = this.state.avatar || 'https://static.zooniverse.org/pfe-assets/simple-avatar.png';
     let avatar;
 
     if (this.state.unread > 0) return this.unreadCircle();

--- a/app/pages/organization/organization-page.jsx
+++ b/app/pages/organization/organization-page.jsx
@@ -89,7 +89,7 @@ class OrganizationPage extends React.Component {
     const finishedProjects = projects.filter(project => project.state === 'finished');
     const pausedProjects = projects.filter(project => project.state === 'paused');
 
-    const researcherAvatarSrc = quoteObject.researcherAvatar || '/assets/simple-avatar.png';
+    const researcherAvatarSrc = quoteObject.researcherAvatar || 'https://static.zooniverse.org/pfe-assets/simple-avatar.png';
 
     const [aboutPage] = organizationPages.filter(page => page.url_key === 'about');
 

--- a/app/pages/project/components/ProjectNavbar/components/Background/Background.spec.js
+++ b/app/pages/project/components/ProjectNavbar/components/Background/Background.spec.js
@@ -11,7 +11,7 @@ import { expect } from 'chai';
 
 import Background, { BackgroundWrapper, ImgBackground } from './Background';
 
-const MOCK_SRC = '../../../../../assets/default-project-background.jpg';
+const MOCK_SRC = 'https://static.zooniverse.org/pfe-assets/default-project-background.jpg';
 
 describe('Background', function () {
   let wrapper;

--- a/app/pages/project/home/project-home.jsx
+++ b/app/pages/project/home/project-home.jsx
@@ -16,7 +16,7 @@ import ExternalLinksBlock from '../../../components/ExternalLinksBlock';
 const ProjectHomePage = (props) => {
   const projectIsNotRedirected = props.project && !props.project.redirect;
   const canClassify = props.project.links.active_workflows && props.project.links.active_workflows.length > 0;
-  const avatarSrc = props.researcherAvatar || '/assets/simple-avatar.png';
+  const avatarSrc = props.researcherAvatar || 'https://static.zooniverse.org/pfe-assets/simple-avatar.png';
 
   const descriptionClass = classnames(
     'project-home-page__description',

--- a/app/pages/project/home/project-home.spec.js
+++ b/app/pages/project/home/project-home.spec.js
@@ -239,7 +239,7 @@ describe('ProjectHome', function() {
     });
 
     it('should use the default avatar if props.researcherAvatar is not defined', function() {
-      expect(wrapper.find({ src: '/assets/simple-avatar.png' })).to.have.lengthOf(1);
+      expect(wrapper.find({ src: 'https://static.zooniverse.org/pfe-assets/simple-avatar.png' })).to.have.lengthOf(1);
     });
 
     it('should use props.researcherAvatar if it is defined', function() {

--- a/app/partials/avatar.cjsx
+++ b/app/partials/avatar.cjsx
@@ -2,7 +2,7 @@ React = require 'react'
 PropTypes = require 'prop-types'
 createReactClass = require 'create-react-class'
 
-DEFAULT_AVATAR = '/assets/simple-avatar.png'
+DEFAULT_AVATAR = 'https://static.zooniverse.org/pfe-assets/simple-avatar.png'
 
 module.exports = createReactClass
   displayName: 'Avatar'

--- a/app/partials/project-card.cjsx
+++ b/app/partials/project-card.cjsx
@@ -30,7 +30,7 @@ ProjectCard = createReactClass
     else if !!@props.project.avatar_src
       conditionalStyle.backgroundImage = "url('#{ @props.project.avatar_src }')"
     else
-      conditionalStyle.background = "url('/assets/simple-pattern.png') center center repeat"
+      conditionalStyle.background = "url('https://static.zooniverse.org/pfe-assets/simple-pattern.png') center center repeat"
 
     if conditionalStyle.backgroundImage?
       conditionalStyle.backgroundSize = "contain"

--- a/app/talk/comment.cjsx
+++ b/app/talk/comment.cjsx
@@ -19,7 +19,7 @@ SingleSubmitButton = require '../components/single-submit-button'
 DisplayRoles = require './lib/display-roles'
 CommentContextIcon = require './lib/comment-context-icon'
 `import WrappedMarkdown from '../components/wrapped-markdown';`
-DEFAULT_AVATAR = '/assets/simple-avatar.png'
+DEFAULT_AVATAR = 'https://static.zooniverse.org/pfe-assets/simple-avatar.png'
 
 module.exports = createReactClass
   displayName: 'TalkComment'

--- a/css/collection-card.styl
+++ b/css/collection-card.styl
@@ -3,7 +3,7 @@
 
 .collection-card
   @extends $owned-card
-  background: url('../public/assets/simple-pattern.png') center center repeat
+  background: url('https://static.zooniverse.org/pfe-assets/simple-pattern.png') center center repeat
 
   svg
     height: 150px

--- a/css/landing-page.styl
+++ b/css/landing-page.styl
@@ -1,6 +1,6 @@
 .landing-page
   align-items: center
-  background: #333 url('../public/assets/builder-landing.jpg') center center no-repeat
+  background: #333 url('https://static.zooniverse.org/pfe-assets/builder-landing.jpg') center center no-repeat
   background-size: cover
   color: #f9f9f9
   display: flex


### PR DESCRIPTION
Staging branch URL: https://pr-7175.pfe-preview.zooniverse.org

Fixes a bug where recent changes to the `static` repo to launch new pages caused some image assets in the PFE codebase to have faulty urls.

# Required Manual Testing

I tested this by running locally and visiting common urls where static image assets should load such as `/talk` and `/lab` while not signed-in.