### PR TITLE
Redirect the homepage to static proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,11 @@ Make sure you have Node 8 and `npm` 5 or greater. It's recommended you manage yo
 
 ### Viewing the Website
 
-Open your web browser of choice and go to `https://localhost:3735/`
+The root `/` is redirected to www.zooniverse.org because this frontend app is no longer used for the homepage. Point your browser to a subpath to view this app run locally.
 
-If you want to _login_ via the Panoptes API and _view authenticated pages,_ then you'll need to set up and use `https://local.zooniverse.org:3735` instead of using localhost:3735. Otherwise, you'll run into CORS errors. (You need to add the hostname to your hosts file, pointing to local. Instructions are on [our Stackoverflow](https://stackoverflow.com/c/zooniverse/questions/109).)
+Open your web browser of choice and go to `https://localhost:3735/lab`
+
+If you want to _login_ via the Panoptes API and _view authenticated pages,_ then you'll need to set up and use `https://local.zooniverse.org:3735/lab` instead of using localhost:3735. Otherwise, you'll run into CORS errors. (You need to add the hostname to your hosts file, pointing to local. Instructions are on [our Stackoverflow](https://stackoverflow.com/c/zooniverse/questions/109).)
 
 **Troubleshooting: web browser blocks local website**
 

--- a/app/layout/account-bar.jsx
+++ b/app/layout/account-bar.jsx
@@ -143,14 +143,13 @@ export default class AccountBar extends React.Component {
                 <Translate content="accountMenu.profile" />
               </Link>
               <br />
-              <Link
+              <a
                 role="menuitem"
-                to="/"
+                href="https://www.zooniverse.org"
                 className="site-nav__link"
-                onClick={this.logClick ? this.logClick.bind(this, 'accountMenu.home') : null}
               >
                 <Translate content="accountMenu.home" />
-              </Link>
+              </a>
               <br />
               <Link
                 role="menuitem"

--- a/app/layout/site-nav.jsx
+++ b/app/layout/site-nav.jsx
@@ -87,15 +87,12 @@ const SiteNav = createReactClass({
         })}
       >
         {!!this.state.isMobile &&
-          <Link
-            to="/"
+          <a
+            href="https://www.zooniverse.org"
             className="site-nav__link"
-            activeClassName="site-nav__link--active"
-            onlyActiveOnIndex={true}
-            onClick={!!this.logClick ? this.logClick.bind(this, 'mainNav.home') : null}
           >
             <Translate content="siteNav.home" />
-          </Link>
+          </a>
         }
         <Link
           to="/projects"
@@ -191,14 +188,12 @@ const SiteNav = createReactClass({
   render() {
     return (
       <nav className="site-nav">
-        <IndexLink
-          to="/"
+        <a
+          href="https://www.zooniverse.org"
           className="site-nav__link"
-          activeClassName="site-nav__link--active"
-          onClick={!!this.logClick ? this.logClick.bind(this, 'logo') : null}
         >
           {ZOO_LOGO}
-        </IndexLink>
+        </a>
 
         {!this.state.isMobile && this.renderLinks()}
 

--- a/app/pages/notifications/notification-section.jsx
+++ b/app/pages/notifications/notification-section.jsx
@@ -177,9 +177,9 @@ export default class NotificationSection extends Component {
       avatar = <img src={src} className="notification-section__img" alt="Project Avatar" />;
     }
     return (
-      <a href={this.props.slug ? `https://www.zooniverse.org/projects/${this.props.slug}` : 'https://www.zooniverse.org'}>
+      <Link to={this.props.slug ? `/projects/${this.props.slug}` : '/'}>
         {avatar}
-      </a>
+      </Link>
     );
   }
 

--- a/app/pages/notifications/notification-section.jsx
+++ b/app/pages/notifications/notification-section.jsx
@@ -177,9 +177,9 @@ export default class NotificationSection extends Component {
       avatar = <img src={src} className="notification-section__img" alt="Project Avatar" />;
     }
     return (
-      <Link to={this.props.slug ? `/projects/${this.props.slug}` : '/'}>
+      <a href={this.props.slug ? `https://www.zooniverse.org/projects/${this.props.slug}` : 'https://www.zooniverse.org'}>
         {avatar}
-      </Link>
+      </a>
     );
   }
 

--- a/app/pages/notifications/notification-section.spec.js
+++ b/app/pages/notifications/notification-section.spec.js
@@ -47,10 +47,6 @@ describe('Notification Section', function() {
       assert.equal(wrapper.find('.notification-section__title').text(), 'Zooniverse');
     });
 
-    it('should link to the home page', function () {
-      assert.equal(wrapper.find('Link').prop('to'), '/');
-    });
-
     it('shows the Zooniverse logo', function () {
       assert.equal(wrapper.find('ZooniverseLogo').length, 1);
     });
@@ -147,7 +143,7 @@ describe('Notification Section', function() {
           user={{ id: '1' }}
         />,
         {
-          context: { notificationsCounter }, 
+          context: { notificationsCounter },
           disableLifeCycleMethods: true
         }
       );

--- a/app/pages/profile/stats.cjsx
+++ b/app/pages/profile/stats.cjsx
@@ -3,5 +3,5 @@ React = require 'react'
 
 module.exports = (props) =>
   <div className="content-container">
-    <p>Your classification stats are now displayed on <Link to="/">your Zooniverse home page</Link>.</p>
+    <p>Your classification stats are now displayed on <Link to="https://www.zooniverse.org">your Zooniverse home page</Link>.</p>
   </div>

--- a/app/pages/profile/user.jsx
+++ b/app/pages/profile/user.jsx
@@ -82,9 +82,9 @@ class ProfileUser extends Component {
       );
     } else {
       return (
-        <Link to="/#projects" className={classes} onClick={this.logClick.bind(this, 'stats')}>
+        <a href={`https://www.zooniverse.org/users/${this.props.profileUser.login}/stats`} className={classes}>
           <Translate content="profile.nav.stats" />
-        </Link>
+        </a>
       );
     }
   }

--- a/app/router.jsx
+++ b/app/router.jsx
@@ -95,9 +95,8 @@ class ExternalRedirect extends React.Component {
 
 export const routes = (
   <Route path="/" component={require('./partials/app')}>
-    <IndexRoute component={HomePageRoot} />
+    <IndexRoute component={() => <ExternalRedirect newUrl='https://www.zooniverse.org' />} />
     <Route path="home" component={ONE_UP_REDIRECT} />
-    <Route path="home-for-user" component={require('./pages/home-for-user').default} />
 
     <Route path="about" onEnter={redirectAboutPage} ignoreScrollBehavior>
       <Route path="team" onEnter={redirectAboutPage} />


### PR DESCRIPTION
❌ Do not deploy until Sept 17

### Describe your changes.
- Removed react-router Link components from links we want to hit the static proxy (and passed on to FEM)
- Added a redirect to the router for `/`.
- Noted in PFE's readme this app is no longer used for the homepage so you must have a /subpath when run locally.

### How To Review

Visit https://pr-7176.pfe-preview.zooniverse.org and you'll be redirected to "www".
❓ The consequence of adding a redirect like this to the router is you can't use the browser back button 🤔 The only scenario where someone might hit this redirect though is if `'/'` is used in markdown beyond our control. All other links to the homepage are hardcoded to www.

Visit subpaths that are intended to still use PFE such as [/lab](https://pr-7176.pfe-preview.zooniverse.org/lab) and[ /talk](https://pr-7176.pfe-preview.zooniverse.org/talk) and [/projects](https://pr-7176.pfe-preview.zooniverse.org/projects) and see the app still works.