### PR TITLE
Project Builder: update thumbnails options for Survey Task

### DIFF
--- a/app/classifier/tasks/survey/editor.cjsx
+++ b/app/classifier/tasks/survey/editor.cjsx
@@ -311,12 +311,7 @@ module.exports = createReactClass
           </label>
           <p>
             <small>
-              <strong>Default</strong> - will show thumbnails as small, medium, large, or not at all (when choices > 30) based on the number of choices shown. Note that volunteer-selected filters change the number of choices shown.
-            </small>
-          </p>
-          <p>
-            <small>
-              <strong>Show Small</strong> - will always show thumbnails as small, regardless of the number of choices shown.
+              <strong>Default</strong> - thumbnails will show when there are 30 choices or less, otherwise no thumbnails will be shown.
             </small>
           </p>
           <p>
@@ -331,7 +326,6 @@ module.exports = createReactClass
           >
             <option value="default">Default</option>
             <option value="hide">Hide</option>
-            <option value="show">Show</option>
           </select>
         </AutoSave>
       </div>


### PR DESCRIPTION
## PR Overview

Fixes #7168 
Preview: https://pr-{NUMBER}.pfe-preview.zooniverse.org/lab/1966/workflows/3834?env=staging

This PR updates the Survey Task in the Project Builder, changing some text and options under the "thumbnails" section. Of note, we no longer list the "show small thumbnails" option.

<img width="499" alt="image" src="https://github.com/user-attachments/assets/e14eca97-97d9-4347-b3da-a31073d2f9e6">

### Testing

Testing methods:
- View any test project with a Survey Task.
- Confirm that the changes in the Thumbnails 

### Status

Ready for review.

Please observe the following warnings, as this may require input from the project management side of things, and possibly some retroactive database-updating follow ups:

- ⚠️ ❗ This change will affect both FEM and PFE labs. If we ONLY want to affect FEM-compatible projects (i.e. project.experimental_tools.femLab = true), then please let me know.
- ⚠️ Any existing project that has anySurveyTask.thumbnails = 'show' will continue to have that thumbnail setting in the database. If they view the page Survey Task editor, they will see it as "default".