### PR TITLE
Project Builder: add checks for Slider subtask for Drawing Tasks

### DIFF
--- a/app/classifier/tasks/drawing-task-details-editor.cjsx
+++ b/app/classifier/tasks/drawing-task-details-editor.cjsx
@@ -87,17 +87,22 @@ module.exports = createReactClass
                 <small><strong>Question</strong></small>
               </button>{' '}
 
-              <button type="submit" className="minor-button" onClick={@handleAddTask.bind this, 'slider'} title="Slider tasks: the volunteer uses a slider to select a numeric value.">
-                <i className="fa fa-sliders fa-2x"></i>
-                <br />
-                <small><strong>Slider</strong></small>
-              </button>{' '}
+              {
+                if 'slider' in @props.project.experimental_tools
+                  <button type="submit" className="minor-button" onClick={@handleAddTask.bind this, 'slider'} title="Slider tasks: the volunteer uses a slider to select a numeric value.">
+                    <i className="fa fa-sliders fa-2x"></i>
+                    <br />
+                    <small><strong>Slider</strong></small>
+                  </button>
+              }
+              {if 'slider' in @props.project.experimental_tools then ' '}
 
               <button type="submit" className="minor-button" onClick={@handleAddTask.bind this, 'text'} title="Text tasks: the volunteer writes free-form text into a dialog box.">
                 <i className="fa fa-file-text-o fa-2x"></i>
                 <br />
                 <small><strong>Text</strong></small>
               </button>{' '}
+
               {
                 if 'dropdown' in @props.project.experimental_tools
                   <button type="submit" className="minor-button" onClick={@handleAddTask.bind this, 'dropdown'} title="Dropdown tasks: the volunteer selects a text label from a list.">


### PR DESCRIPTION
## PR Overview

Towards #7185

This PR fixes an issue where the Slider subtask is always available for Drawing Tasks('s Drawing Tools).

- Old behaviour: when choosing to add a subtask to a Drawing Tool, the "Slider" option is always present, alongside the evergreen "Question" and "Text" options.
- New behaviour: the "Slider" option is ONLY present when project.experimental_tools includes "slider".

NOTE: this new behaviour reflects how the "dropdown" subtask already works.

### Testing

Testing steps:
- Select a test project with workflow with a Drawing Task, e.g. https://local.zooniverse.org:3735/lab/1966/workflows/3596?env=staging
- Go to the admin page and ensure the "slider" experimental tool is 🔴 disabled: https://local.zooniverse.org:3735/admin/project_status/darkeshard/test-project-2022?env=staging 
- View a workflow. Select a Drawing Task. Choose to add a Subtask.
- Confirm that there's 🔴 no option to add a Slider subtask.
- Go to the admin page and 🟢  enable the "slider" experimental tool.
- View the same workflow. Select a Drawing Task. Choose to add a Subtask.
- Confirm that there 🟢 IS an option to add a Slider subtask.

### Status

Ready for review.

❗ HOWEVER, do NOT merge until we have completed discussions [(see Slack)](https://zooniverse.slack.com/archives/C06LHUC6R/p1726677961864559) on how to proceed.

There are two parts to solving the "Drawing Tasks have Slider subtasks" problem:
- one, this PR, which prevents _new_ Slider subtasks from being created without the experimental flag enabled.
  - (Existing projects that already have Slider subtasks can continue to _edit_ the existing subtasks.)
- two, some data-cleaning for _existing_ projects that have Slider subtasks without the requisite Slider experimental tool enabled.