### PR TITLE
Update package.json to use node 20+

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,8 +102,8 @@
     "whatwg-url": "~14.0.0"
   },
   "engines": {
-    "node": ">=18",
-    "npm": ">=8"
+    "node": ">=20",
+    "npm": ">=10"
   },
   "license": "Apache-2.0",
   "nyc": {


### PR DESCRIPTION
## PR Overview

This PR modifies our package.json to specify that PFE's supposed to run with node 20+, and npm 10+.

- This brings our package.json to match our Dockerfile (node 20 alpine) and deploy files (lts/iron, aka Node.js 20)
- This is more of a preventative change for dev hygiene, instead of a fix for something that's actually broken.

This update was spurred by the [stylus dependabot bump](https://github.com/zooniverse/Panoptes-Front-End/pull/7183), as stylus 8.0.0 has a breaking change that requires node 18.12.0. In practice this isn't a problem as all our deploy & Docker files use Node.js 20, but in theory it could be a problem for local devs who think that PFE _should_ work with, say, Node 18.0.0.

### Status

Looking for comment, ready for review, but low priority, to be honest.