### PR TITLE
Revert "Bump @sentry/browser from 7.100.1 to 8.36.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "~7.23.9",
-        "@sentry/browser": "~8.36.0",
+        "@sentry/browser": "~7.100.1",
         "animated-scrollto": "~1.1.0",
         "chart.js": "~4.4.1",
         "chartist": "~0.11.0",
@@ -3131,106 +3131,106 @@
         "node": ">=14"
       }
     },
-    "node_modules/@sentry-internal/browser-utils": {
-      "version": "8.36.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-8.36.0.tgz",
-      "integrity": "sha512-AVJ9GmQW7jYxaal6hjQnnktsDNype01ajVC4q1RyOn1SfzSnXg6mXwj4xm4ovuJV+aBI7fAZJ55vEX5ASuP0ZA==",
-      "dependencies": {
-        "@sentry/core": "8.36.0",
-        "@sentry/types": "8.36.0",
-        "@sentry/utils": "8.36.0"
-      },
-      "engines": {
-        "node": ">=14.18"
-      }
-    },
     "node_modules/@sentry-internal/feedback": {
-      "version": "8.36.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-8.36.0.tgz",
-      "integrity": "sha512-aAMTm3uDBj8Ta7FwoohpLmJOpWzpWXvvtTbtmSgkeCtPJLUS8DZDCTZ9uCILUkpuYrv2savRUHsdPkxNjgL8FA==",
+      "version": "7.100.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-7.100.1.tgz",
+      "integrity": "sha512-yqcRVnjf+qS+tC4NxOKLJOaSJ+csHmh/dHUzvCTkf5rLsplwXYRnny2r0tqGTQ4tuXMxwgSMKPYwicg81P+xuw==",
       "dependencies": {
-        "@sentry/core": "8.36.0",
-        "@sentry/types": "8.36.0",
-        "@sentry/utils": "8.36.0"
+        "@sentry/core": "7.100.1",
+        "@sentry/types": "7.100.1",
+        "@sentry/utils": "7.100.1"
       },
       "engines": {
-        "node": ">=14.18"
-      }
-    },
-    "node_modules/@sentry-internal/replay": {
-      "version": "8.36.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-8.36.0.tgz",
-      "integrity": "sha512-lbic98GsSkDeinQDix54tBFEgHUlmBtO+HjXECk9jIE0vOzR4As20/s5ta46t1rKMLlnxOtJuT5jKXeUYogBUw==",
-      "dependencies": {
-        "@sentry-internal/browser-utils": "8.36.0",
-        "@sentry/core": "8.36.0",
-        "@sentry/types": "8.36.0",
-        "@sentry/utils": "8.36.0"
-      },
-      "engines": {
-        "node": ">=14.18"
+        "node": ">=12"
       }
     },
     "node_modules/@sentry-internal/replay-canvas": {
-      "version": "8.36.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-8.36.0.tgz",
-      "integrity": "sha512-KJPLf+qYdrQdmouoAqIPZ2KeapIBlHWbzNdQqNxJFWLHFFjpLUtt0b+87ruvbA/q3NYy2fDwD7EB0tGS1RHBaA==",
+      "version": "7.100.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-7.100.1.tgz",
+      "integrity": "sha512-TnqxqJGhbFhhYRhTG2WLFer+lVieV7mNGeIxFBiw1L4kuj8KGl+C0sknssKyZSRVJFSahhHIosHJGRMkkD//7g==",
       "dependencies": {
-        "@sentry-internal/replay": "8.36.0",
-        "@sentry/core": "8.36.0",
-        "@sentry/types": "8.36.0",
-        "@sentry/utils": "8.36.0"
+        "@sentry/core": "7.100.1",
+        "@sentry/replay": "7.100.1",
+        "@sentry/types": "7.100.1",
+        "@sentry/utils": "7.100.1"
       },
       "engines": {
-        "node": ">=14.18"
+        "node": ">=12"
+      }
+    },
+    "node_modules/@sentry-internal/tracing": {
+      "version": "7.100.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.100.1.tgz",
+      "integrity": "sha512-+u9RRf5eL3StiyiRyAHZmdkAR7GTSGx4Mt4Lmi5NEtCcWlTGZ1QgW2r8ZbhouVmTiJkjhQgYCyej3cojtazeJg==",
+      "dependencies": {
+        "@sentry/core": "7.100.1",
+        "@sentry/types": "7.100.1",
+        "@sentry/utils": "7.100.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@sentry/browser": {
-      "version": "8.36.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-8.36.0.tgz",
-      "integrity": "sha512-bLrQNe+wD4DkCfB8OD5TF3Rr8KA2+aTo5wF3t3Bf6KVn8//iX1ia1hhtptYiRnbRkG/0AEPxlqL6XfPZYVPQ5A==",
+      "version": "7.100.1",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.100.1.tgz",
+      "integrity": "sha512-IxHQ08ixf0bmaWpe4yt1J4UUsOpg02fxax9z3tOQYXw5MSzz5pDXn8M8DFUVJB3wWuyXhHXTub9yD3VIP9fnoA==",
       "dependencies": {
-        "@sentry-internal/browser-utils": "8.36.0",
-        "@sentry-internal/feedback": "8.36.0",
-        "@sentry-internal/replay": "8.36.0",
-        "@sentry-internal/replay-canvas": "8.36.0",
-        "@sentry/core": "8.36.0",
-        "@sentry/types": "8.36.0",
-        "@sentry/utils": "8.36.0"
+        "@sentry-internal/feedback": "7.100.1",
+        "@sentry-internal/replay-canvas": "7.100.1",
+        "@sentry-internal/tracing": "7.100.1",
+        "@sentry/core": "7.100.1",
+        "@sentry/replay": "7.100.1",
+        "@sentry/types": "7.100.1",
+        "@sentry/utils": "7.100.1"
       },
       "engines": {
-        "node": ">=14.18"
+        "node": ">=8"
       }
     },
     "node_modules/@sentry/core": {
-      "version": "8.36.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.36.0.tgz",
-      "integrity": "sha512-cbq1WQyRqc/+YpPhjwQxfniUM3ZxmO3Pm1oisTB8dw6mlbgQfGD6aznEIjXWWJY6k6acewJlMUx09N7DnprtBw==",
+      "version": "7.100.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.100.1.tgz",
+      "integrity": "sha512-f+ItUge/o9AjlveQq0ZUbQauKlPH1FIJbC1TRaYLJ4KNfOdrsh8yZ29RmWv0cFJ/e+FGTr603gWpRPObF5rM8Q==",
       "dependencies": {
-        "@sentry/types": "8.36.0",
-        "@sentry/utils": "8.36.0"
+        "@sentry/types": "7.100.1",
+        "@sentry/utils": "7.100.1"
       },
       "engines": {
-        "node": ">=14.18"
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/replay": {
+      "version": "7.100.1",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.100.1.tgz",
+      "integrity": "sha512-B1NFjzGEFaqejxBRdUyEzH8ChXc2kfiqlA/W/Lg0aoWIl2/7nuMk+l4ld9gW5F5bIAXDTVd5vYltb1lWEbpr7w==",
+      "dependencies": {
+        "@sentry-internal/tracing": "7.100.1",
+        "@sentry/core": "7.100.1",
+        "@sentry/types": "7.100.1",
+        "@sentry/utils": "7.100.1"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@sentry/types": {
-      "version": "8.36.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-8.36.0.tgz",
-      "integrity": "sha512-K1pVFfdGHw115RzGHpwSOqoEPeayn4N1F9IfM0kxrYpQSbFT1X29eak88GBfC8gPiLEF0iFGlSaQ4ERmF7oRcA==",
+      "version": "7.100.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.100.1.tgz",
+      "integrity": "sha512-fLM+LedHuKzOd8IhXBqaQuym+AA519MGjeczBa5kGakes/BbAsUMwsNfjsKQedp7Kh44RgYF99jwoRPK2oDrXw==",
       "engines": {
-        "node": ">=14.18"
+        "node": ">=8"
       }
     },
     "node_modules/@sentry/utils": {
-      "version": "8.36.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-8.36.0.tgz",
-      "integrity": "sha512-oJ3EDPj0I00z+AwC3EWBpSidXYUoKW0Id8MfMQP5Hflniz3gif7UEReblT+FJgPEVo6+6uNzAncY0MuNMxmDKQ==",
+      "version": "7.100.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.100.1.tgz",
+      "integrity": "sha512-Ve6dXr1o6xiBe3VCoJgiutmBKrugryI65EZAbYto5XI+t+PjiLLf9wXtEMF24ZrwImo4Lv3E9Uqza+fWkEbw6A==",
       "dependencies": {
-        "@sentry/types": "8.36.0"
+        "@sentry/types": "7.100.1"
       },
       "engines": {
-        "node": ">=14.18"
+        "node": ">=8"
       }
     },
     "node_modules/@sinonjs/commons": {
@@ -20096,82 +20096,82 @@
       "dev": true,
       "optional": true
     },
-    "@sentry-internal/browser-utils": {
-      "version": "8.36.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-8.36.0.tgz",
-      "integrity": "sha512-AVJ9GmQW7jYxaal6hjQnnktsDNype01ajVC4q1RyOn1SfzSnXg6mXwj4xm4ovuJV+aBI7fAZJ55vEX5ASuP0ZA==",
-      "requires": {
-        "@sentry/core": "8.36.0",
-        "@sentry/types": "8.36.0",
-        "@sentry/utils": "8.36.0"
-      }
-    },
     "@sentry-internal/feedback": {
-      "version": "8.36.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-8.36.0.tgz",
-      "integrity": "sha512-aAMTm3uDBj8Ta7FwoohpLmJOpWzpWXvvtTbtmSgkeCtPJLUS8DZDCTZ9uCILUkpuYrv2savRUHsdPkxNjgL8FA==",
+      "version": "7.100.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-7.100.1.tgz",
+      "integrity": "sha512-yqcRVnjf+qS+tC4NxOKLJOaSJ+csHmh/dHUzvCTkf5rLsplwXYRnny2r0tqGTQ4tuXMxwgSMKPYwicg81P+xuw==",
       "requires": {
-        "@sentry/core": "8.36.0",
-        "@sentry/types": "8.36.0",
-        "@sentry/utils": "8.36.0"
-      }
-    },
-    "@sentry-internal/replay": {
-      "version": "8.36.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-8.36.0.tgz",
-      "integrity": "sha512-lbic98GsSkDeinQDix54tBFEgHUlmBtO+HjXECk9jIE0vOzR4As20/s5ta46t1rKMLlnxOtJuT5jKXeUYogBUw==",
-      "requires": {
-        "@sentry-internal/browser-utils": "8.36.0",
-        "@sentry/core": "8.36.0",
-        "@sentry/types": "8.36.0",
-        "@sentry/utils": "8.36.0"
+        "@sentry/core": "7.100.1",
+        "@sentry/types": "7.100.1",
+        "@sentry/utils": "7.100.1"
       }
     },
     "@sentry-internal/replay-canvas": {
-      "version": "8.36.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-8.36.0.tgz",
-      "integrity": "sha512-KJPLf+qYdrQdmouoAqIPZ2KeapIBlHWbzNdQqNxJFWLHFFjpLUtt0b+87ruvbA/q3NYy2fDwD7EB0tGS1RHBaA==",
+      "version": "7.100.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-7.100.1.tgz",
+      "integrity": "sha512-TnqxqJGhbFhhYRhTG2WLFer+lVieV7mNGeIxFBiw1L4kuj8KGl+C0sknssKyZSRVJFSahhHIosHJGRMkkD//7g==",
       "requires": {
-        "@sentry-internal/replay": "8.36.0",
-        "@sentry/core": "8.36.0",
-        "@sentry/types": "8.36.0",
-        "@sentry/utils": "8.36.0"
+        "@sentry/core": "7.100.1",
+        "@sentry/replay": "7.100.1",
+        "@sentry/types": "7.100.1",
+        "@sentry/utils": "7.100.1"
+      }
+    },
+    "@sentry-internal/tracing": {
+      "version": "7.100.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.100.1.tgz",
+      "integrity": "sha512-+u9RRf5eL3StiyiRyAHZmdkAR7GTSGx4Mt4Lmi5NEtCcWlTGZ1QgW2r8ZbhouVmTiJkjhQgYCyej3cojtazeJg==",
+      "requires": {
+        "@sentry/core": "7.100.1",
+        "@sentry/types": "7.100.1",
+        "@sentry/utils": "7.100.1"
       }
     },
     "@sentry/browser": {
-      "version": "8.36.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-8.36.0.tgz",
-      "integrity": "sha512-bLrQNe+wD4DkCfB8OD5TF3Rr8KA2+aTo5wF3t3Bf6KVn8//iX1ia1hhtptYiRnbRkG/0AEPxlqL6XfPZYVPQ5A==",
+      "version": "7.100.1",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.100.1.tgz",
+      "integrity": "sha512-IxHQ08ixf0bmaWpe4yt1J4UUsOpg02fxax9z3tOQYXw5MSzz5pDXn8M8DFUVJB3wWuyXhHXTub9yD3VIP9fnoA==",
       "requires": {
-        "@sentry-internal/browser-utils": "8.36.0",
-        "@sentry-internal/feedback": "8.36.0",
-        "@sentry-internal/replay": "8.36.0",
-        "@sentry-internal/replay-canvas": "8.36.0",
-        "@sentry/core": "8.36.0",
-        "@sentry/types": "8.36.0",
-        "@sentry/utils": "8.36.0"
+        "@sentry-internal/feedback": "7.100.1",
+        "@sentry-internal/replay-canvas": "7.100.1",
+        "@sentry-internal/tracing": "7.100.1",
+        "@sentry/core": "7.100.1",
+        "@sentry/replay": "7.100.1",
+        "@sentry/types": "7.100.1",
+        "@sentry/utils": "7.100.1"
       }
     },
     "@sentry/core": {
-      "version": "8.36.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.36.0.tgz",
-      "integrity": "sha512-cbq1WQyRqc/+YpPhjwQxfniUM3ZxmO3Pm1oisTB8dw6mlbgQfGD6aznEIjXWWJY6k6acewJlMUx09N7DnprtBw==",
+      "version": "7.100.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.100.1.tgz",
+      "integrity": "sha512-f+ItUge/o9AjlveQq0ZUbQauKlPH1FIJbC1TRaYLJ4KNfOdrsh8yZ29RmWv0cFJ/e+FGTr603gWpRPObF5rM8Q==",
       "requires": {
-        "@sentry/types": "8.36.0",
-        "@sentry/utils": "8.36.0"
+        "@sentry/types": "7.100.1",
+        "@sentry/utils": "7.100.1"
+      }
+    },
+    "@sentry/replay": {
+      "version": "7.100.1",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.100.1.tgz",
+      "integrity": "sha512-B1NFjzGEFaqejxBRdUyEzH8ChXc2kfiqlA/W/Lg0aoWIl2/7nuMk+l4ld9gW5F5bIAXDTVd5vYltb1lWEbpr7w==",
+      "requires": {
+        "@sentry-internal/tracing": "7.100.1",
+        "@sentry/core": "7.100.1",
+        "@sentry/types": "7.100.1",
+        "@sentry/utils": "7.100.1"
       }
     },
     "@sentry/types": {
-      "version": "8.36.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-8.36.0.tgz",
-      "integrity": "sha512-K1pVFfdGHw115RzGHpwSOqoEPeayn4N1F9IfM0kxrYpQSbFT1X29eak88GBfC8gPiLEF0iFGlSaQ4ERmF7oRcA=="
+      "version": "7.100.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.100.1.tgz",
+      "integrity": "sha512-fLM+LedHuKzOd8IhXBqaQuym+AA519MGjeczBa5kGakes/BbAsUMwsNfjsKQedp7Kh44RgYF99jwoRPK2oDrXw=="
     },
     "@sentry/utils": {
-      "version": "8.36.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-8.36.0.tgz",
-      "integrity": "sha512-oJ3EDPj0I00z+AwC3EWBpSidXYUoKW0Id8MfMQP5Hflniz3gif7UEReblT+FJgPEVo6+6uNzAncY0MuNMxmDKQ==",
+      "version": "7.100.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.100.1.tgz",
+      "integrity": "sha512-Ve6dXr1o6xiBe3VCoJgiutmBKrugryI65EZAbYto5XI+t+PjiLLf9wXtEMF24ZrwImo4Lv3E9Uqza+fWkEbw6A==",
       "requires": {
-        "@sentry/types": "8.36.0"
+        "@sentry/types": "7.100.1"
       }
     },
     "@sinonjs/commons": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "panoptes-front-end",
   "dependencies": {
     "@babel/runtime": "~7.23.9",
-    "@sentry/browser": "~8.36.0",
+    "@sentry/browser": "~7.100.1",
     "animated-scrollto": "~1.1.0",
     "chart.js": "~4.4.1",
     "chartist": "~0.11.0",


### PR DESCRIPTION
Reverts zooniverse/Panoptes-Front-End#7206

This bump actually breaks PFE. The website renders a blank page, with the console error message:

```
Uncaught TypeError: _browser.BrowserTracing is not a constructor
    at initSentry (init-sentry.js:11:1)
    at ./app/main.cjsx (main.cjsx:48:1)
    at __webpack_require__ (bootstrap:22:1)
    at startup:6:1
    at startup:6:1
```

Follow up required:
- observe how FEM updated sentry: https://github.com/zooniverse/front-end-monorepo/pull/6387
- observe sentry 7->8 migration guide: https://docs.sentry.io/platforms/javascript/migration/v7-to-v8/
- approach all future sentry (major) bumps with a very wary eye.

(Thanks Delilah!)