### PR TITLE
fix(classifier): set started_at timestamp when annotation starts

### DIFF
--- a/app/classifier/classifier.jsx
+++ b/app/classifier/classifier.jsx
@@ -141,9 +141,15 @@ class Classifier extends React.Component {
       });
   }
 
-  updateAnnotations(annotations) {
+  updateAnnotations(annotations, fromUserAction = false) {
     this.setState({ annotations });
     this.props.actions.classify.saveAnnotations(annotations);
+    if (fromUserAction && !this.props.classification?.metadata._inProgress) {
+      this.props.actions.classify.updateMetadata({ 
+        _inProgress: true,
+        started_at: new Date().toISOString()
+       });
+    }
   }
 
   updateFeedback(taskId) {
@@ -203,12 +209,13 @@ class Classifier extends React.Component {
     actions.classify.updateMetadata({ subject_dimensions });
   }
 
+  // handle annotation changes from the subject viewer eg. drawing tasks
   handleAnnotationChange(classification, newAnnotation) {
     const { annotations } = this.state;
     const index = findLastIndex(annotations, annotation => annotation.task === newAnnotation.task);
     if (index > -1) {
       annotations[index] = newAnnotation;
-      this.updateAnnotations(annotations);
+      this.updateAnnotations(annotations, true);
     }
   }
 

--- a/app/classifier/task.jsx
+++ b/app/classifier/task.jsx
@@ -16,7 +16,7 @@ class Task extends React.Component {
     const index = findLastIndex(annotations, annotation => annotation.task === newAnnotation.task);
     if (index > -1) {
       annotations[index] = newAnnotation;
-      this.props.updateAnnotations(annotations);
+      this.props.updateAnnotations(annotations, true);
     }
   }
 

--- a/app/redux/ducks/classify.js
+++ b/app/redux/ducks/classify.js
@@ -51,6 +51,7 @@ function createNewClassification(project, workflow, subject, goldStandardMode, l
   // Delete the metadata key because we don't want volunteers to see it.
   subject.update({ 'metadata.intervention': undefined });
   const newMetadata = {
+    _inProgress: false,
     workflow_version: workflow.version,
     started_at: (new Date()).toISOString(),
     user_agent: navigator.userAgent,


### PR DESCRIPTION
- add `metadata._inProgress` to classifications, and set it to true when a volunteer first updates an annotation.
- set `classification.metadata.started_at` to the current time when `metadata._inProgress` changes from false to true.

Staging branch URL: https://pr-{NUMBER}.pfe-preview.zooniverse.org

Fixes #7215.

This is https://github.com/zooniverse/front-end-monorepo/pull/6449 adapted for PFE's redux store. It updates `classification.metadata.started_at` the first time that you interact with a subject, eg. by answering a question or drawing a mark from a drawing task.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
