### PR TITLE
Add a temporary notice banner to the layout

### DIFF
--- a/app/layout/index.jsx
+++ b/app/layout/index.jsx
@@ -10,6 +10,45 @@ export default function AppLayout(props) {
         <div className="app-layout__admin-indicator" title="Admin mode on!" />
       </AdminOnly>
 
+      <details
+          style={{
+            padding: '5px clamp(20px, 3vw, 30px)',
+            fontSize: '1rem',
+            lineHeight: 1.2,
+            color: '#000',
+            background: '#f0b200'
+          }}
+        >
+          <summary style={{ fontWeight: 'bold', cursor: 'pointer' }}>
+            Platform downtime scheduled on Wednesday November 20.
+          </summary>
+          <p style={{ paddingInline: '15px' }}>
+            The Zooniverse platform will be offline for scheduled maintenance on
+            Wednesday, November 20 from 4pm-10pm US Central Standard Time
+            (2024-11-20 22:00 UTC to 2024-11-21 4:00 UTC). During this period, all
+            projects and platform services will be inaccessible. We apologize for
+            the inconvenience; this maintenance is necessary to make updates to
+            platform infrastructure and improve long-term reliability and uptime.
+            Please visit{' '}
+            <a
+              href='https://status.zooniverse.org/incident/1019747'
+              target='_blank'
+              style={{ color: '#000' }}
+            >
+              status.zooniverse.org
+            </a>{' '}
+            for updates before and during the downtime period. For any additional
+            questions, please email{' '}
+            <a
+              style={{ color: '#000' }}
+              href='mailto:contact@zooniverse.org'
+            >
+              contact@zooniverse.org
+            </a>
+            .
+          </p>
+        </details>
+
       <header className='app-layout__header'>
         <SiteNav params={props.params} />
       </header>


### PR DESCRIPTION
Staging branch URL: https://pr-7217.pfe-preview.zooniverse.org/projects


## Linked Issues
Corresponds to: https://github.com/zooniverse/front-end-monorepo/pull/6456
Slack: https://zooniverse.slack.com/archives/C4RJRAGKA/p1731079514305719


## Changes
- Add html and css for a simple `<details>` and `<summary>` at the top of each layout.
- 🗒️ Noting that I am not using the existing AppStatus component in this repo because that banner is sticky and disruptive to users who have to close it each time they visit the site.

## Review Checklist

I will likely end up just self-reviewing and merging this due to its simplicity and non-permanence.

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?
