### PR TITLE
[Security] Update @sentry/browser to 7.120.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "~7.26.0",
-        "@sentry/browser": "~7.100.1",
+        "@sentry/browser": "~7.120.0",
         "animated-scrollto": "~1.1.0",
         "chart.js": "~4.4.6",
         "chartist": "~0.11.0",
@@ -3110,102 +3110,117 @@
       }
     },
     "node_modules/@sentry-internal/feedback": {
-      "version": "7.100.1",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-7.100.1.tgz",
-      "integrity": "sha512-yqcRVnjf+qS+tC4NxOKLJOaSJ+csHmh/dHUzvCTkf5rLsplwXYRnny2r0tqGTQ4tuXMxwgSMKPYwicg81P+xuw==",
+      "version": "7.120.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-7.120.0.tgz",
+      "integrity": "sha512-+nU2PXMAyrYyK64PlfxXyRZ+LIl6IWAcdnBeX916WqOJy2WWmtdOrAX8muVwLVIXHzp1EMG1nEZgtpL/Vr2XKQ==",
       "dependencies": {
-        "@sentry/core": "7.100.1",
-        "@sentry/types": "7.100.1",
-        "@sentry/utils": "7.100.1"
+        "@sentry/core": "7.120.0",
+        "@sentry/types": "7.120.0",
+        "@sentry/utils": "7.120.0"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/@sentry-internal/replay-canvas": {
-      "version": "7.100.1",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-7.100.1.tgz",
-      "integrity": "sha512-TnqxqJGhbFhhYRhTG2WLFer+lVieV7mNGeIxFBiw1L4kuj8KGl+C0sknssKyZSRVJFSahhHIosHJGRMkkD//7g==",
+      "version": "7.120.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-7.120.0.tgz",
+      "integrity": "sha512-ZEFZBP+Jxmy/8IY7IZDZVPqAJ6pPxAFo1lNTd8xfpbno3WAtHw0FLewLfjrFt0zfIgCk8EXj4PW355zRP3C2NQ==",
       "dependencies": {
-        "@sentry/core": "7.100.1",
-        "@sentry/replay": "7.100.1",
-        "@sentry/types": "7.100.1",
-        "@sentry/utils": "7.100.1"
+        "@sentry/core": "7.120.0",
+        "@sentry/replay": "7.120.0",
+        "@sentry/types": "7.120.0",
+        "@sentry/utils": "7.120.0"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/@sentry-internal/tracing": {
-      "version": "7.100.1",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.100.1.tgz",
-      "integrity": "sha512-+u9RRf5eL3StiyiRyAHZmdkAR7GTSGx4Mt4Lmi5NEtCcWlTGZ1QgW2r8ZbhouVmTiJkjhQgYCyej3cojtazeJg==",
+      "version": "7.120.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.120.0.tgz",
+      "integrity": "sha512-VymJoIGMV0PcTJyshka9uJ1sKpR7bHooqW5jTEr6g0dYAwB723fPXHjVW+7SETF7i5+yr2KMprYKreqRidKyKA==",
       "dependencies": {
-        "@sentry/core": "7.100.1",
-        "@sentry/types": "7.100.1",
-        "@sentry/utils": "7.100.1"
+        "@sentry/core": "7.120.0",
+        "@sentry/types": "7.120.0",
+        "@sentry/utils": "7.120.0"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/browser": {
-      "version": "7.100.1",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.100.1.tgz",
-      "integrity": "sha512-IxHQ08ixf0bmaWpe4yt1J4UUsOpg02fxax9z3tOQYXw5MSzz5pDXn8M8DFUVJB3wWuyXhHXTub9yD3VIP9fnoA==",
+      "version": "7.120.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.120.0.tgz",
+      "integrity": "sha512-2hRE3QPLBBX+qqZEHY2IbJv4YvfXY7m/bWmNjN15phyNK3oBcm2Pa8ZiKUYrk8u/4DCEGzNUlhOmFgaxwSfpNw==",
       "dependencies": {
-        "@sentry-internal/feedback": "7.100.1",
-        "@sentry-internal/replay-canvas": "7.100.1",
-        "@sentry-internal/tracing": "7.100.1",
-        "@sentry/core": "7.100.1",
-        "@sentry/replay": "7.100.1",
-        "@sentry/types": "7.100.1",
-        "@sentry/utils": "7.100.1"
+        "@sentry-internal/feedback": "7.120.0",
+        "@sentry-internal/replay-canvas": "7.120.0",
+        "@sentry-internal/tracing": "7.120.0",
+        "@sentry/core": "7.120.0",
+        "@sentry/integrations": "7.120.0",
+        "@sentry/replay": "7.120.0",
+        "@sentry/types": "7.120.0",
+        "@sentry/utils": "7.120.0"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/core": {
-      "version": "7.100.1",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.100.1.tgz",
-      "integrity": "sha512-f+ItUge/o9AjlveQq0ZUbQauKlPH1FIJbC1TRaYLJ4KNfOdrsh8yZ29RmWv0cFJ/e+FGTr603gWpRPObF5rM8Q==",
+      "version": "7.120.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.120.0.tgz",
+      "integrity": "sha512-uTc2sUQ0heZrMI31oFOHGxjKgw16MbV3C2mcT7qcrb6UmSGR9WqPOXZhnVVuzPWCnQ8B5IPPVdynK//J+9/m6g==",
       "dependencies": {
-        "@sentry/types": "7.100.1",
-        "@sentry/utils": "7.100.1"
+        "@sentry/types": "7.120.0",
+        "@sentry/utils": "7.120.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/integrations": {
+      "version": "7.120.0",
+      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.120.0.tgz",
+      "integrity": "sha512-/Hs9MgSmG4JFNyeQkJ+MWh/fxO/U38Pz0VSH3hDrfyCjI8vH9Vz9inGEQXgB9Ke4eH8XnhsQ7xPnM27lWJts6g==",
+      "dependencies": {
+        "@sentry/core": "7.120.0",
+        "@sentry/types": "7.120.0",
+        "@sentry/utils": "7.120.0",
+        "localforage": "^1.8.1"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/replay": {
-      "version": "7.100.1",
-      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.100.1.tgz",
-      "integrity": "sha512-B1NFjzGEFaqejxBRdUyEzH8ChXc2kfiqlA/W/Lg0aoWIl2/7nuMk+l4ld9gW5F5bIAXDTVd5vYltb1lWEbpr7w==",
+      "version": "7.120.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.120.0.tgz",
+      "integrity": "sha512-wV9fIYwNtMvFOHQB5eSm+kCorRXsX5+v1DxyTC8Lee1hfzcUQ2Wvqh75VktpXuM9TeZE8h7aQ4Wo4qCgTUdtvA==",
       "dependencies": {
-        "@sentry-internal/tracing": "7.100.1",
-        "@sentry/core": "7.100.1",
-        "@sentry/types": "7.100.1",
-        "@sentry/utils": "7.100.1"
+        "@sentry-internal/tracing": "7.120.0",
+        "@sentry/core": "7.120.0",
+        "@sentry/types": "7.120.0",
+        "@sentry/utils": "7.120.0"
       },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/@sentry/types": {
-      "version": "7.100.1",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.100.1.tgz",
-      "integrity": "sha512-fLM+LedHuKzOd8IhXBqaQuym+AA519MGjeczBa5kGakes/BbAsUMwsNfjsKQedp7Kh44RgYF99jwoRPK2oDrXw==",
+      "version": "7.120.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.120.0.tgz",
+      "integrity": "sha512-3mvELhBQBo6EljcRrJzfpGJYHKIZuBXmqh0y8prh03SWE62pwRL614GIYtd4YOC6OP1gfPn8S8h9w3dD5bF5HA==",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/utils": {
-      "version": "7.100.1",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.100.1.tgz",
-      "integrity": "sha512-Ve6dXr1o6xiBe3VCoJgiutmBKrugryI65EZAbYto5XI+t+PjiLLf9wXtEMF24ZrwImo4Lv3E9Uqza+fWkEbw6A==",
+      "version": "7.120.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.120.0.tgz",
+      "integrity": "sha512-XZsPcBHoYu4+HYn14IOnhabUZgCF99Xn4IdWn8Hjs/c+VPtuAVDhRTsfPyPrpY3OcN8DgO5fZX4qcv/6kNbX1A==",
       "dependencies": {
-        "@sentry/types": "7.100.1"
+        "@sentry/types": "7.120.0"
       },
       "engines": {
         "node": ">=8"
@@ -9274,6 +9289,11 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
+    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -10892,6 +10912,14 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lie": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+      "integrity": "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -10934,6 +10962,14 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/local-storage/-/local-storage-2.0.0.tgz",
       "integrity": "sha512-/0sRoeijw7yr/igbVVygDuq6dlYCmtsuTmmpnweVlVtl/s10pf5BCq8LWBxW/AMyFJ3MhMUuggMZiYlx6qr9tw=="
+    },
+    "node_modules/localforage": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
+      "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
+      "dependencies": {
+        "lie": "3.1.1"
+      }
     },
     "node_modules/locate-path": {
       "version": "3.0.0",
@@ -20069,81 +20105,93 @@
       "optional": true
     },
     "@sentry-internal/feedback": {
-      "version": "7.100.1",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-7.100.1.tgz",
-      "integrity": "sha512-yqcRVnjf+qS+tC4NxOKLJOaSJ+csHmh/dHUzvCTkf5rLsplwXYRnny2r0tqGTQ4tuXMxwgSMKPYwicg81P+xuw==",
+      "version": "7.120.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-7.120.0.tgz",
+      "integrity": "sha512-+nU2PXMAyrYyK64PlfxXyRZ+LIl6IWAcdnBeX916WqOJy2WWmtdOrAX8muVwLVIXHzp1EMG1nEZgtpL/Vr2XKQ==",
       "requires": {
-        "@sentry/core": "7.100.1",
-        "@sentry/types": "7.100.1",
-        "@sentry/utils": "7.100.1"
+        "@sentry/core": "7.120.0",
+        "@sentry/types": "7.120.0",
+        "@sentry/utils": "7.120.0"
       }
     },
     "@sentry-internal/replay-canvas": {
-      "version": "7.100.1",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-7.100.1.tgz",
-      "integrity": "sha512-TnqxqJGhbFhhYRhTG2WLFer+lVieV7mNGeIxFBiw1L4kuj8KGl+C0sknssKyZSRVJFSahhHIosHJGRMkkD//7g==",
+      "version": "7.120.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-7.120.0.tgz",
+      "integrity": "sha512-ZEFZBP+Jxmy/8IY7IZDZVPqAJ6pPxAFo1lNTd8xfpbno3WAtHw0FLewLfjrFt0zfIgCk8EXj4PW355zRP3C2NQ==",
       "requires": {
-        "@sentry/core": "7.100.1",
-        "@sentry/replay": "7.100.1",
-        "@sentry/types": "7.100.1",
-        "@sentry/utils": "7.100.1"
+        "@sentry/core": "7.120.0",
+        "@sentry/replay": "7.120.0",
+        "@sentry/types": "7.120.0",
+        "@sentry/utils": "7.120.0"
       }
     },
     "@sentry-internal/tracing": {
-      "version": "7.100.1",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.100.1.tgz",
-      "integrity": "sha512-+u9RRf5eL3StiyiRyAHZmdkAR7GTSGx4Mt4Lmi5NEtCcWlTGZ1QgW2r8ZbhouVmTiJkjhQgYCyej3cojtazeJg==",
+      "version": "7.120.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.120.0.tgz",
+      "integrity": "sha512-VymJoIGMV0PcTJyshka9uJ1sKpR7bHooqW5jTEr6g0dYAwB723fPXHjVW+7SETF7i5+yr2KMprYKreqRidKyKA==",
       "requires": {
-        "@sentry/core": "7.100.1",
-        "@sentry/types": "7.100.1",
-        "@sentry/utils": "7.100.1"
+        "@sentry/core": "7.120.0",
+        "@sentry/types": "7.120.0",
+        "@sentry/utils": "7.120.0"
       }
     },
     "@sentry/browser": {
-      "version": "7.100.1",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.100.1.tgz",
-      "integrity": "sha512-IxHQ08ixf0bmaWpe4yt1J4UUsOpg02fxax9z3tOQYXw5MSzz5pDXn8M8DFUVJB3wWuyXhHXTub9yD3VIP9fnoA==",
+      "version": "7.120.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.120.0.tgz",
+      "integrity": "sha512-2hRE3QPLBBX+qqZEHY2IbJv4YvfXY7m/bWmNjN15phyNK3oBcm2Pa8ZiKUYrk8u/4DCEGzNUlhOmFgaxwSfpNw==",
       "requires": {
-        "@sentry-internal/feedback": "7.100.1",
-        "@sentry-internal/replay-canvas": "7.100.1",
-        "@sentry-internal/tracing": "7.100.1",
-        "@sentry/core": "7.100.1",
-        "@sentry/replay": "7.100.1",
-        "@sentry/types": "7.100.1",
-        "@sentry/utils": "7.100.1"
+        "@sentry-internal/feedback": "7.120.0",
+        "@sentry-internal/replay-canvas": "7.120.0",
+        "@sentry-internal/tracing": "7.120.0",
+        "@sentry/core": "7.120.0",
+        "@sentry/integrations": "7.120.0",
+        "@sentry/replay": "7.120.0",
+        "@sentry/types": "7.120.0",
+        "@sentry/utils": "7.120.0"
       }
     },
     "@sentry/core": {
-      "version": "7.100.1",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.100.1.tgz",
-      "integrity": "sha512-f+ItUge/o9AjlveQq0ZUbQauKlPH1FIJbC1TRaYLJ4KNfOdrsh8yZ29RmWv0cFJ/e+FGTr603gWpRPObF5rM8Q==",
+      "version": "7.120.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.120.0.tgz",
+      "integrity": "sha512-uTc2sUQ0heZrMI31oFOHGxjKgw16MbV3C2mcT7qcrb6UmSGR9WqPOXZhnVVuzPWCnQ8B5IPPVdynK//J+9/m6g==",
       "requires": {
-        "@sentry/types": "7.100.1",
-        "@sentry/utils": "7.100.1"
+        "@sentry/types": "7.120.0",
+        "@sentry/utils": "7.120.0"
+      }
+    },
+    "@sentry/integrations": {
+      "version": "7.120.0",
+      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.120.0.tgz",
+      "integrity": "sha512-/Hs9MgSmG4JFNyeQkJ+MWh/fxO/U38Pz0VSH3hDrfyCjI8vH9Vz9inGEQXgB9Ke4eH8XnhsQ7xPnM27lWJts6g==",
+      "requires": {
+        "@sentry/core": "7.120.0",
+        "@sentry/types": "7.120.0",
+        "@sentry/utils": "7.120.0",
+        "localforage": "^1.8.1"
       }
     },
     "@sentry/replay": {
-      "version": "7.100.1",
-      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.100.1.tgz",
-      "integrity": "sha512-B1NFjzGEFaqejxBRdUyEzH8ChXc2kfiqlA/W/Lg0aoWIl2/7nuMk+l4ld9gW5F5bIAXDTVd5vYltb1lWEbpr7w==",
+      "version": "7.120.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.120.0.tgz",
+      "integrity": "sha512-wV9fIYwNtMvFOHQB5eSm+kCorRXsX5+v1DxyTC8Lee1hfzcUQ2Wvqh75VktpXuM9TeZE8h7aQ4Wo4qCgTUdtvA==",
       "requires": {
-        "@sentry-internal/tracing": "7.100.1",
-        "@sentry/core": "7.100.1",
-        "@sentry/types": "7.100.1",
-        "@sentry/utils": "7.100.1"
+        "@sentry-internal/tracing": "7.120.0",
+        "@sentry/core": "7.120.0",
+        "@sentry/types": "7.120.0",
+        "@sentry/utils": "7.120.0"
       }
     },
     "@sentry/types": {
-      "version": "7.100.1",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.100.1.tgz",
-      "integrity": "sha512-fLM+LedHuKzOd8IhXBqaQuym+AA519MGjeczBa5kGakes/BbAsUMwsNfjsKQedp7Kh44RgYF99jwoRPK2oDrXw=="
+      "version": "7.120.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.120.0.tgz",
+      "integrity": "sha512-3mvELhBQBo6EljcRrJzfpGJYHKIZuBXmqh0y8prh03SWE62pwRL614GIYtd4YOC6OP1gfPn8S8h9w3dD5bF5HA=="
     },
     "@sentry/utils": {
-      "version": "7.100.1",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.100.1.tgz",
-      "integrity": "sha512-Ve6dXr1o6xiBe3VCoJgiutmBKrugryI65EZAbYto5XI+t+PjiLLf9wXtEMF24ZrwImo4Lv3E9Uqza+fWkEbw6A==",
+      "version": "7.120.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.120.0.tgz",
+      "integrity": "sha512-XZsPcBHoYu4+HYn14IOnhabUZgCF99Xn4IdWn8Hjs/c+VPtuAVDhRTsfPyPrpY3OcN8DgO5fZX4qcv/6kNbX1A==",
       "requires": {
-        "@sentry/types": "7.100.1"
+        "@sentry/types": "7.120.0"
       }
     },
     "@sinonjs/commons": {
@@ -24644,6 +24692,11 @@
       "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
       "dev": true
     },
+    "immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
+    },
     "import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -25725,6 +25778,14 @@
         "type-check": "~0.4.0"
       }
     },
+    "lie": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+      "integrity": "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==",
+      "requires": {
+        "immediate": "~3.0.5"
+      }
+    },
     "lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -25761,6 +25822,14 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/local-storage/-/local-storage-2.0.0.tgz",
       "integrity": "sha512-/0sRoeijw7yr/igbVVygDuq6dlYCmtsuTmmpnweVlVtl/s10pf5BCq8LWBxW/AMyFJ3MhMUuggMZiYlx6qr9tw=="
+    },
+    "localforage": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
+      "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
+      "requires": {
+        "lie": "3.1.1"
+      }
     },
     "locate-path": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "panoptes-front-end",
   "dependencies": {
     "@babel/runtime": "~7.26.0",
-    "@sentry/browser": "~7.100.1",
+    "@sentry/browser": "~7.120.0",
     "animated-scrollto": "~1.1.0",
     "chart.js": "~4.4.6",
     "chartist": "~0.11.0",


### PR DESCRIPTION
## PR Overview

Staging branch URL: https://pr-7220.pfe-preview.zooniverse.org/projects

See [Dependabot notice](https://github.com/zooniverse/Panoptes-Front-End/security/dependabot/92)

This PR updates `@sentry/browser` to address some security advice provided by Dependabot.

- Dependabot previously tried to update sentry-browser to v8, but that broke PFE. #7206 
- We reverted that change. #7209 
- This PR updates `@sentry/browser` to the latest v7 iteration instead, which seems to work on local and I _think_ will address Dependabot's concerns.
- There's a longer [v7 to v8 migration guide,](https://docs.sentry.io/platforms/javascript/migration/v7-to-v8/) but we won't invest dev time into that until it's necessary.

### Testing

Open the Projects Page in the staging branch. If the page loads & renders properly, this branch should be fine.

### Status

Ready for review.