### PR TITLE
Create Volumetric Task

### DIFF
--- a/app/classifier/tasks/generic-editor.cjsx
+++ b/app/classifier/tasks/generic-editor.cjsx
@@ -47,6 +47,7 @@ module.exports = createReactClass
       when 'slider' then ['instruction']
       when 'highlighter' then ['instruction', 'highlighterLabels']
       when 'dataVisAnnotation' then ['instruction', 'tools']
+      when 'volumetric' then ['instruction']
 
     isAQuestion = @props.task.type in ['single', 'multiple']
     canBeRequired = @props.task.type in ['single', 'multiple', 'text']

--- a/app/classifier/tasks/index.js
+++ b/app/classifier/tasks/index.js
@@ -13,6 +13,7 @@ import Highlighter from './highlighter';
 import TranscriptionTask from './transcription';
 import SubjectGroupComparisonTask from './subjectGroupComparison';
 import DataVisAnnotationTask from './dataVisAnnotation'
+import VolumetricTask from './volumetric';
 
 const tasks = {
   combo: ComboTask,
@@ -29,7 +30,8 @@ const tasks = {
   highlighter: Highlighter,
   transcription: TranscriptionTask,
   subjectGroupComparison: SubjectGroupComparisonTask,
-  dataVisAnnotation: DataVisAnnotationTask
+  dataVisAnnotation: DataVisAnnotationTask,
+  volumetric: VolumetricTask
 };
 
 export default tasks;

--- a/app/classifier/tasks/volumetric/index.jsx
+++ b/app/classifier/tasks/volumetric/index.jsx
@@ -1,0 +1,50 @@
+import PropTypes from "prop-types";
+import React from "react";
+import GenericTaskEditor from "../generic-editor";
+
+export default class VolumetricTask extends React.Component {
+  constructor(props) {
+    super(props);
+  }
+  render() {
+    return <div>{"VolumetricTask Tool"}</div>;
+  }
+}
+
+VolumetricTask.Editor = GenericTaskEditor;
+
+VolumetricTask.getDefaultTask = () => ({
+  help: "",
+  instruction: "Describe how to use this tool",
+  type: "volumetric",
+});
+
+VolumetricTask.getTaskText = (task) => task.instruction;
+
+VolumetricTask.getDefaultAnnotation = () => ({ _toolIndex: 0, value: [] });
+
+VolumetricTask.defaultProps = {
+  showRequiredNotice: false,
+  task: {
+    help: "",
+    type: "volumetric",
+    instruction: "Describe how to use this tool",
+  },
+  workflow: {
+    tasks: [],
+  },
+};
+
+VolumetricTask.propTypes = {
+  showRequiredNotice: PropTypes.bool,
+  task: PropTypes.shape({
+    help: PropTypes.string,
+    instruction: PropTypes.string,
+    required: PropTypes.bool,
+    tools: PropTypes.array,
+    type: PropTypes.string,
+  }),
+  workflow: PropTypes.shape({
+    tasks: PropTypes.object,
+  }),
+};

--- a/app/classifier/tasks/volumetric/index.jsx
+++ b/app/classifier/tasks/volumetric/index.jsx
@@ -3,11 +3,8 @@ import React from "react";
 import GenericTaskEditor from "../generic-editor";
 
 export default class VolumetricTask extends React.Component {
-  constructor(props) {
-    super(props);
-  }
   render() {
-    return <div>{"VolumetricTask Tool"}</div>;
+    return <div>This is a placeholder for the Volumetric Task, which is only visible in the FEM Classifier</div>;
   }
 }
 
@@ -21,12 +18,13 @@ VolumetricTask.getDefaultTask = () => ({
 
 VolumetricTask.getTaskText = (task) => task.instruction;
 
-VolumetricTask.getDefaultAnnotation = () => ({ _toolIndex: 0, value: [] });
+VolumetricTask.getDefaultAnnotation = () => ({ value: [] });
 
 VolumetricTask.defaultProps = {
   showRequiredNotice: false,
   task: {
     help: "",
+    required: false,
     type: "volumetric",
     instruction: "Describe how to use this tool",
   },
@@ -41,10 +39,6 @@ VolumetricTask.propTypes = {
     help: PropTypes.string,
     instruction: PropTypes.string,
     required: PropTypes.bool,
-    tools: PropTypes.array,
     type: PropTypes.string,
-  }),
-  workflow: PropTypes.shape({
-    tasks: PropTypes.object,
-  }),
+  })
 };

--- a/app/pages/admin/project-status/experimental-features.jsx
+++ b/app/pages/admin/project-status/experimental-features.jsx
@@ -34,7 +34,7 @@ const experimentalFeatures = [
   'textFromSubject', // textFromSubject task only works in FEM!
   'transcription-task',
   'translator-role',
-  'volumetricViewer',
+  'volumetricProject', // Turns a project into a Volumetric-enabled Project
   'wildcam classroom', // Indicates a Project is linked to a "WildCam Lab"-type Zooniverse Classroom. Allows the classifier to select a workflow (i.e. "classroom assignment") directly via ID.
   'workflow assignment',
   'worldwide telescope'

--- a/app/pages/lab-fem/workflow.jsx
+++ b/app/pages/lab-fem/workflow.jsx
@@ -151,7 +151,7 @@ class EditWorkflowPage extends Component {
     } = this.props.workflow.configuration;
     if (hide_classification_summaries === undefined) { hide_classification_summaries = true; }
 
-	  const isCaesarDataFetchingEnabled = this.props.workflow?.configuration?.enable_caesar_data_fetching ?? false;
+    const isCaesarDataFetchingEnabled = this.props.workflow?.configuration?.enable_caesar_data_fetching ?? false;
 
     return (
       <div className="edit-workflow-page">
@@ -299,6 +299,14 @@ class EditWorkflowPage extends Component {
                             <i className="fa fa-i-cursor fa-2x"></i>
                             <br />
                             <small><strong>Data annotation</strong></small>
+                          </button>
+                        </AutoSave> : undefined}{' '}
+                      {this.canUseTask(this.props.project, "volumetricProject") ?
+                        <AutoSave resource={this.props.workflow}>
+                          <button type="button" className="minor-button" onClick={this.addNewTask.bind(this, 'volumetric')} title="Volumetric Task: the volunteer looks at a volumetric viewer, and selects the point of the volume to be annotated.">
+                            <i className="fa fa-th fa-2x"></i>
+                            <br />
+                            <small><strong>Volumetric Task</strong></small>
                           </button>
                         </AutoSave> : undefined}{' '}
                       </div> : undefined}


### PR DESCRIPTION
Staging branch URL: https://pr-7227.pfe-preview.zooniverse.org

Describe your changes.
- Rename experimental flag for the Volumetric Viewer to "volumetricProject" from "volumetricViewer"
- Create Volumetric task that it can be added to any project with the "volumetricProject" and "FemLab" flags enabled

# Required Manual Testing
- Open the [Admin Page](https://local.zooniverse.org:3735/admin/project_status/kieftrav/volumetric-viewer) and the [Workflow Editor](https://local.zooniverse.org:3735/lab/2015/workflows/3831) in separate tabs for my test/staging Volumetric Viewer project [Volumetric Viewer]() project for testing
- As of this writing, "FemLab" and "volumetricViewer" are enabled and you should see a Volumetric task existing on workflow 3831

### Things you should be able to do:
- [ ] Removing the Volumetric Task
- [ ] Adding a new Volumetric Task
- [ ] Saving / refreshing and the Volumetric Task still exists + works
- [ ] Disabling the "volumetricViewer" flag should prevent the use from adding a Volumetric task
- [ ] You should be able to add the Volumetric to any other project of your choosing as long as the two experimental flags are enabled

### Requests for PR Review
- The Volumetric task was _heavily_ inspired by the Highlighter task. I do not know if everything in that file is necessary/right/appropriate/correct. This is the file that might need the most review/iteration because I lack context on all its implications elsewhere in the codebase
- If there's something glaringly obvious/missing, please schedule a call/screenshare to walk through the details (I prefer that to a voluminous wall of text).
- If there is a place to write a test, I'm happy to do that. I'm not sure what/where would make sense though, if so.

### Standard Tests
- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist
- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional
- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?