### PR TITLE
Classifier: Remove the faulty session id code

### DIFF
--- a/app/lib/session.coffee
+++ b/app/lib/session.coffee
@@ -1,29 +1,17 @@
-storage = window.sessionStorage ? window.localStorage
+storage = window.sessionStorage
 stored = JSON.parse storage?.getItem('session_id')
 
 generateSessionID = () ->
   hash = require('hash.js')
   sha2 = hash.sha256()
   id = sha2.update("#{Math.random() * 10000 }#{Date.now()}#{Math.random() * 1000}").digest('hex')
-  ttl = fiveMinutesFromNow()
-  stored = {id, ttl}
+  stored = {id}
   try
     storage.setItem('session_id', JSON.stringify(stored))
   stored
 
 getSessionID = () ->
-  {id, ttl} = JSON.parse(storage.getItem('session_id')) ? generateSessionID()
-  if ttl < Date.now()
-    {id} = generateSessionID()
-  else
-    ttl = fiveMinutesFromNow()
-    try
-      storage.setItem('session_id', JSON.stringify({id, ttl}))
+  {id} = JSON.parse(storage.getItem('session_id')) ? generateSessionID()
   id
-
-fiveMinutesFromNow = () ->
-  d = new Date()
-  d.setMinutes(d.getMinutes() + 5)
-  d
 
 module.exports = {generateSessionID, getSessionID}


### PR DESCRIPTION
Staging branch URL: https://pr-7233.pfe-preview.zooniverse.org

Paired with https://github.com/zooniverse/front-end-monorepo/pull/6499

- While investigating https://github.com/zooniverse/front-end-monorepo/issues/6493, I found that the "generate a new session id after 5 minutes of inactivity" logic does not work in the classifier. As mentioned in that Issue, session id is attached to classification metadata and can be used for analysis of anonymous users contributing classifications.
- In this PR I removed the "5 minutes" logic because its original condition of comparing a Date() string to a Date.now() number was never met, and therefore the code never worked as intended.

# Required Manual Testing

- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?