### PR TITLE
[HOLD] Refactor survey task editor thumbnail input per FEM or PFE lab

### DIFF
--- a/app/classifier/tasks/survey/editor.cjsx
+++ b/app/classifier/tasks/survey/editor.cjsx
@@ -13,6 +13,7 @@ MediaArea = require('../../../pages/lab/media-area/').default
 {Markdown} = require 'markdownz'
 Papa = require 'papaparse'
 getAllLinked = require('../../../lib/get-all-linked').default
+{ isThisProjectUsingFEMLab } = require('../../../pages/lab-fem/fem-lab-utilities')
 
 module.exports = createReactClass
   displayName: 'SurveyTaskEditor'
@@ -309,30 +310,55 @@ module.exports = createReactClass
           <label htmlFor="#{@props.taskPrefix}.thumbnails">
               <span className="form-label">Thumbnails</span>
           </label>
-          <p>
-            <small>
-              <strong>Default</strong> - will show thumbnails as small, medium, large, or not at all (when choices > 30) based on the number of choices shown. Note that volunteer-selected filters change the number of choices shown.
-            </small>
-          </p>
-          <p>
-            <small>
-              <strong>Show Small</strong> - will always show thumbnails as small, regardless of the number of choices shown.
-            </small>
-          </p>
-          <p>
-            <small>
-              <strong>Hide All</strong> - will never show thumbnails.
-            </small>
-          </p>
-          <select
-            name="#{@props.taskPrefix}.thumbnails"
-            onChange={handleInputChange.bind @props.workflow}
-            value={if @props.task.thumbnails then @props.task.thumbnails else if @props.task.alwaysShowThumbnails then "show" else "default"}
-          >
-            <option value="default">Default</option>
-            <option value="hide">Hide</option>
-            <option value="show">Show</option>
-          </select>
+          {if (isThisProjectUsingFEMLab(@props.project, @props.location)) then (
+            <div>
+              <p>
+                <small>
+                  <strong>Show</strong> - will always show thumbnails.
+                </small>
+              </p>
+              <p>
+                <small>
+                  <strong>Hide</strong> - will never show thumbnails.
+                </small>
+              </p>
+              <select
+                name="#{@props.taskPrefix}.thumbnails"
+                onChange={handleInputChange.bind @props.workflow}
+                value={if @props.task.thumbnails then @props.task.thumbnails else "show"}
+              >
+                <option value="show">Show</option>
+                <option value="hide">Hide</option>
+              </select>
+            </div>
+          ) else (
+            <div>
+              <p>
+                <small>
+                  <strong>Default</strong> - will show thumbnails as small, medium, large, or not at all (when choices > 30) based on the number of choices shown. Note that volunteer-selected filters change the number of choices shown.
+                </small>
+              </p>
+              <p>
+                <small>
+                  <strong>Show Small</strong> - will always show thumbnails as small, regardless of the number of choices shown.
+                </small>
+              </p>
+              <p>
+                <small>
+                  <strong>Hide All</strong> - will never show thumbnails.
+                </small>
+              </p>
+              <select
+                name="#{@props.taskPrefix}.thumbnails"
+                onChange={handleInputChange.bind @props.workflow}
+                value={if @props.task.thumbnails then @props.task.thumbnails else if @props.task.alwaysShowThumbnails then "show" else "default"}
+              >
+                <option value="default">Default</option>
+                <option value="hide">Hide</option>
+                <option value="show">Show</option>
+              </select>
+            </div>
+          )}
         </AutoSave>
       </div>
     </div>


### PR DESCRIPTION
> [!CAUTION]
> related to and should be deployed to production with zooniverse/front-end-monorepo/pull/6574

Staging branch URL: https://pr-7246.pfe-preview.zooniverse.org

Technically different solution, but addresses and closes #7168 .
I think supersedes #7184 .

Describe your changes.
- use `isThisProjectUsingFEMLab` to conditionally display survey task thumbnail inputs
- if PFE lab / PFE project then render legacy/old thumbnail section
- if FEM lab / FEM project then render new thumbnail section with only `"show"` and `"hide"` 

Testing links
- PFE project, workflow editor with survey task: https://local.zooniverse.org:3735/lab/1775/workflows/3741
  - thumbnail input should include "default," "show," and "hide" (no changes from https://www.zooniverse.org:3735/lab/1775/workflows/3741?env=development)
- FEM project, workflow editor with survey task: https://local.zooniverse.org:3735/lab/1634/workflows/2434
  - thumbnail input should only have "show" and "hide" (changed from https://www.zooniverse.org:3735/lab/1634/workflows/2434?env=development)
  - view classify interface: https://fe-project-branch.preview.zooniverse.org/projects/markb-panoptes/survey-task-test-project/classify/workflow/2434?env=development

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
