### PR TITLE
Add FEM redirect for Axonal Pathfinders

### DIFF
--- a/app/monorepoUtils.js
+++ b/app/monorepoUtils.js
@@ -63,7 +63,8 @@ export const SLUGS = [
   'talkietoaster/void-orchestra',
   'hjsmith/the-material-culture-of-wills-england-1540-1790',
   'effeli/node-code-breakers-looking-for-patterns-in-lymph-nodes',
-  'md68135/notes-from-nature-ranges-mammal-traits-from-western-north-america'
+  'md68135/notes-from-nature-ranges-mammal-traits-from-western-north-america',
+  'cmcbrain/axonal-pathfinders'
 ];
 
 export function usesMonorepo(slug) {


### PR DESCRIPTION
FEM redirect for cmcbrain/axonal-pathfinders (Project 25108)

Staging branch URL: https://pr-7260.pfe-preview.zooniverse.org/
Staging URL for Project: https://pr-7260.pfe-preview.zooniverse.org/projects/cmcbrain/axonal-pathfinders
Target Link: https://www.zooniverse.org/projects/cmcbrain/axonal-pathfinders
Project Lab Link: https://www.zooniverse.org/lab/25108
Static PR: https://github.com/zooniverse/static/pull/387

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?
