### PR TITLE
Edit survey task thumbnail setting descriptions for FEM lab

### DIFF
--- a/app/classifier/tasks/survey/editor.cjsx
+++ b/app/classifier/tasks/survey/editor.cjsx
@@ -13,6 +13,7 @@ MediaArea = require('../../../pages/lab/media-area/').default
 {Markdown} = require 'markdownz'
 Papa = require 'papaparse'
 getAllLinked = require('../../../lib/get-all-linked').default
+{ isThisProjectUsingFEMLab } = require('../../../pages/lab-fem/fem-lab-utilities')
 
 module.exports = createReactClass
   displayName: 'SurveyTaskEditor'
@@ -309,21 +310,43 @@ module.exports = createReactClass
           <label htmlFor="#{@props.taskPrefix}.thumbnails">
               <span className="form-label">Thumbnails</span>
           </label>
-          <p>
-            <small>
-              <strong>Default</strong> - will show thumbnails as small, medium, large, or not at all (when choices > 30) based on the number of choices shown. Note that volunteer-selected filters change the number of choices shown.
-            </small>
-          </p>
-          <p>
-            <small>
-              <strong>Show Small</strong> - will always show thumbnails as small, regardless of the number of choices shown.
-            </small>
-          </p>
-          <p>
-            <small>
-              <strong>Hide All</strong> - will never show thumbnails.
-            </small>
-          </p>
+          {if (isThisProjectUsingFEMLab(@props.project, @props.location)) then (
+            <div>
+              <p>
+                <small>
+                  <strong>Default</strong> - will show thumbnails when choices are 30 or less, hide thumbnails when choices are greater than 30. Note that volunteer-selected filters change the number of choices shown.
+                </small>
+              </p>
+              <p>
+                <small>
+                  <strong>Show</strong> - will always show thumbnails.
+                </small>
+              </p>
+              <p>
+                <small>
+                  <strong>Hide</strong> - will never show thumbnails.
+                </small>
+              </p>
+            </div>
+          ) else (
+            <div>
+              <p>
+                <small>
+                  <strong>Default</strong> - will show thumbnails as small, medium, large, or not at all (when choices > 30) based on the number of choices shown. Note that volunteer-selected filters change the number of choices shown.
+                </small>
+              </p>
+              <p>
+                <small>
+                  <strong>Show Small</strong> - will always show thumbnails as small, regardless of the number of choices shown.
+                </small>
+              </p>
+              <p>
+                <small>
+                  <strong>Hide All</strong> - will never show thumbnails.
+                </small>
+              </p>
+            </div>
+          )}
           <select
             name="#{@props.taskPrefix}.thumbnails"
             onChange={handleInputChange.bind @props.workflow}


### PR DESCRIPTION
Staging branch URL: https://pr-7267.pfe-preview.zooniverse.org

Closes #7168 .
Supersedes #7184 . 

Describe your changes.
- for FEM project, edit survey task thumbnail setting descriptions

FEM project workflow with survey task:
- https://local.zooniverse.org:3735/lab/1634/workflows/2434
- https://pr-7267.pfe-preview.zooniverse.org/lab/1634/workflows/2434?env=staging

PFE project workflow with survey task: 
- https://local.zooniverse.org:3735/lab/1608/workflows/3319
- https://pr-7267.pfe-preview.zooniverse.org/lab/1608/workflows/3319?env=staging

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
