### PR TITLE
Remove checks for experimental translator-role flag

### DIFF
--- a/app/pages/admin/project-status/experimental-features.jsx
+++ b/app/pages/admin/project-status/experimental-features.jsx
@@ -33,7 +33,6 @@ const experimentalFeatures = [
   'temporalRotateRectangle', // temporal tools only works in FEM!
   'textFromSubject', // textFromSubject task only works in FEM!
   'transcription-task',
-  'translator-role',
   'volumetricProject', // Turns a project into a Volumetric-enabled Project
   'wildcam classroom', // Indicates a Project is linked to a "WildCam Lab"-type Zooniverse Classroom. Allows the classifier to select a workflow (i.e. "classroom assignment") directly via ID.
   'workflow assignment',

--- a/app/pages/lab/collaborators.jsx
+++ b/app/pages/lab/collaborators.jsx
@@ -32,12 +32,11 @@ export default function EditProjectCollaborators({
   const [projectOwner, setProjectOwner] = useState(null);
   const [projectRoleSets, setProjectRoleSets] = useState([]);
 
-  if (project?.experimental_tools.includes('translator-role') || isAdmin()) {
-    possibleRoles = {
-      ...possibleRoles,
-      translator: 'translator'
-    };
-  }
+  possibleRoles = {
+    ...possibleRoles,
+    translator: 'translator'
+  };
+
   if (project?.experimental_tools.includes('museum-role') || isAdmin()) {
     possibleRoles = {
       ...possibleRoles,

--- a/app/pages/lab/project.jsx
+++ b/app/pages/lab/project.jsx
@@ -222,18 +222,16 @@ function EditProjectPage({
                 Subject Sets
               </Link>
             </li>
-            {(project.experimental_tools?.includes('translator-role') || isAdmin()) ?
-              <li>
-                <Link
-                  aria-current={pathname === labPath('/translations') ? 'page' : undefined}
-                  to={labPath('/translations')}
-                  className="nav-list-item"
-                  title="Preview your project's translations"
-                >
-                  Translations
-                </Link>
-              </li>
-            : null}
+            <li>
+              <Link
+                aria-current={pathname === labPath('/translations') ? 'page' : undefined}
+                to={labPath('/translations')}
+                className="nav-list-item"
+                title="Preview your project's translations"
+              >
+                Translations
+              </Link>
+            </li>
             <li>
               <h2 className="nav-list-header">Need some help?</h2>
               <ul className="nav-list">


### PR DESCRIPTION
Draft while waiting for public-facing documentation needed for the lab's Translations tab.
_____

Staging branch URL: https://pr-{NUMBER}.pfe-preview.zooniverse.org

This PR removes the checks for the `translator-role` experimental flag. The translator features are not public-facing.

# Required Manual Testing

- [ ] Does the Translations tab appear for every Zooniverse project in the project builder?
- [ ] Is the translator role available in the Collaborators tab?
- [ ] Is the translator role checkbox deleted from the Admin page?