### PR TITLE
Turn off dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: daily
       time: "10:00"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 0
     ignore:
     - dependency-name: eslint-plugin-promise
       versions:


### PR DESCRIPTION
Editing the dependabot config to disable opening of PRs. The config [docs](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/customizing-dependabot-security-prs) say it’s possible to set open-pull-requests-limit to 0 in dependabot.yml

Security alerts are still available in the Security tab of this repo. Handling auto-generated dependabot PRs is not part of our frontend team maintenance.