### PR TITLE
Rearrange staging deploy action to fix branch deploy removal

### DIFF
--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -26,18 +26,23 @@ jobs:
     secrets:
       creds: ${{ secrets.AZURE_STATIC_SITES }}
 
-  remove_branch_deploy:
+  get_pr_number:
+    name: Get PR number
     runs-on: ubuntu-latest
     needs: deploy_staging
+    outputs:
+      pr_number: ${{ steps.pr.outputs.pr_number }}
     steps:
     - name: Checkout
       uses: actions/checkout@v4
 
     - name: Get Pull Request Number
       id: pr
-      run: echo "::set-output name=pr_number::$(gh pr view --json number -q .number || echo "")"
+      run: echo "pr_number=$(gh pr view --json number -q .number || echo "")" >> $GITHUB_OUTPUT
 
-    - name: Remove branch deploy
-      uses: zooniverse/ci-cd/.github/workflows/delete_blobs.yaml@main
-      with:
-        target: 'preview.zooniverse.org/panoptes-front-end/pr-${{ steps.pr.outputs.pr_number }}'
+  remove_branch_deploy:
+    name: Remove branch deploy
+    needs: [deploy_staging, get_pr_number]
+    uses: zooniverse/ci-cd/.github/workflows/delete_blobs.yaml@main
+    with:
+      target: 'preview.zooniverse.org/panoptes-front-end/pr-${{ needs.get_pr_number.outputs.pr_number }}'


### PR DESCRIPTION
Without an argument,`gh pr view` displays infor about the PR associated with the current branch. Since this is a master branch push event, this lets this action grab the PR number from outside any `github.event` actually associated with the PR.

This rearranged action allows the local runner to pull the PR number from a new job local to this event and pass it to the reusable workflow in a separate job.