### PR TITLE
Include creds in branch deploy remove shared workflow

### DIFF
--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -46,3 +46,5 @@ jobs:
     uses: zooniverse/ci-cd/.github/workflows/delete_blobs.yaml@main
     with:
       target: 'preview.zooniverse.org/panoptes-front-end/pr-${{ needs.get_pr_number.outputs.pr_number }}'
+    secrets:
+      creds: ${{ secrets.AZURE_STATIC_SITES }}


### PR DESCRIPTION
The branch deploy removal shared workflow requires credentials to be passed to it to ensure that the calling action has access to them. 