### PR TITLE
Parse git log for PR number

### DIFF
--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -38,7 +38,7 @@ jobs:
 
     - name: Get Pull Request Number
       id: pr
-      run: echo "pr_number=$(gh pr view --json number -q .number || echo "")" >> $GITHUB_OUTPUT
+      run: echo "pr_number=$(git log -1 --pretty=%B | grep -oP '(#\K\d+)' || echo "")" >> $GITHUB_OUTPUT
 
   remove_branch_deploy:
     name: Remove branch deploy


### PR DESCRIPTION
When a PR is merged, the branch is immediately deleted. This means that the previous way I was pulling the associated PR number wasn't working. Instead, just parse the git log: grab the most recent commit on the trunk and pluck the PR ID from the body.