### PR TITLE
fix: right clicking Done & Talk submits a classification

### DIFF
--- a/app/classifier/classifier.jsx
+++ b/app/classifier/classifier.jsx
@@ -238,7 +238,7 @@ class Classifier extends React.Component {
   completeClassification(e) {
     const { actions, classification, onComplete, intervention, project, subject, translations, user, workflow } = this.props;
     const originalElement = e.currentTarget;
-    const isCmdClick = e.metaKey;
+    const isCmdClick = e.metaKey || e.type === 'contextmenu';
     const annotations = this.state.annotations.slice();
     let workflowHistory = this.state.workflowHistory.slice();
     const taskKey = workflowHistory[workflowHistory.length - 1];

--- a/app/classifier/components/TaskNavButtons/components/TalkLink/TalkLink.jsx
+++ b/app/classifier/components/TaskNavButtons/components/TalkLink/TalkLink.jsx
@@ -87,10 +87,17 @@ export function TalkLink({ disabled, onClick, projectSlug, subjectId, theme, tra
     );
   }
 
+  function onRightClick(e) {
+    setTimeout(() => {
+      onClick(e);
+    }, 100);
+  }
+
   return (
     <ThemeProvider theme={{ mode: theme }}>
       <StyledTalkLink
         onClick={onClick}
+        onContextMenu={onRightClick}
         to={`/projects/${projectSlug}/talk/subjects/${subjectId}`}
       >
         <Translate content={translateContent} />


### PR DESCRIPTION
Fix a bug where you could look at Talk, without submitting your classification, by right-clicking Done & Talk to open Talk in a new tab. With the changes here, you can still open the current subject in a new tab (if desired) but right clicking will submit a classification and advance the subject queue.

Staging branch URL: https://pr-{NUMBER}.pfe-preview.zooniverse.org

Fixes # .

Describe your changes.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
