### PR TITLE
Webpack: serve bundled image files from /lab subpath

### DIFF
--- a/webpack.build.js
+++ b/webpack.build.js
@@ -32,6 +32,15 @@ module.exports = {
     path: path.join(__dirname, '/dist'),
     filename: '[name]-[chunkhash].js',
     chunkFilename: '[name]-[chunkhash].js',
+    // Image assets will be placed in the '/lab' subpath.
+    // This is due to how the www.zooniverse.org domain maps PFE and FEM to
+    // different subpaths; the root '/' path isn't set to serve PFE code, let
+    // alone PFE-related image assets.
+    // See https://github.com/zooniverse/static/blob/632be4f/nginx-pfe-redirects.conf
+    // The /lab subfolder was chosen since bundled image assets are primarily
+    // used ONLY by the Pages Editor system.
+    // See https://github.com/zooniverse/Panoptes-Front-End/issues/7295
+    assetModuleFilename: 'lab/[hash][ext][query]',
   },
   plugins: [
     new webpack.ProvidePlugin({

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -28,6 +28,15 @@ var config = {
     publicPath: '/',
     path: path.join(__dirname, '/dist'),
     filename: '[name].js',
+    // Image assets will be placed in the '/lab' subpath.
+    // This is due to how the www.zooniverse.org domain maps PFE and FEM to
+    // different subpaths; the root '/' path isn't set to serve PFE code, let
+    // alone PFE-related image assets.
+    // See https://github.com/zooniverse/static/blob/632be4f/nginx-pfe-redirects.conf
+    // The /lab subfolder was chosen since bundled image assets are primarily
+    // used ONLY by the Pages Editor system.
+    // See https://github.com/zooniverse/Panoptes-Front-End/issues/7295
+    assetModuleFilename: 'lab/[hash][ext][query]',
   },
   plugins: [
     new webpack.ProvidePlugin({


### PR DESCRIPTION
## PR Overview

Closes #7295

Staging branch URL: https://pr-7298.pfe-preview.zooniverse.org/lab/1982/workflows/editor/3711?env=staging

This PR updates the build process so that bundled image files are served from the `/lab` subpath, instead of the more sensible `/` root. Why change the path? Because we've configured the `www.zooniverse.org` domain to serve PFE code and FEM code on different paths, and the `/` root path is now the domain of FEM. Why the 'lab' subpath? Because in practice the only part of PFE that still uses bundled image files is the new Pages Editor.

- Changes are made to webpack.build.js (used for `www.zooniverse.org`) and webpack.dev.js (used on our local dev servers, i.e. on npm start)
- The changed subpath works properly on local, will work properly on the PFE staging link, but we won't know if the full production build will work properly until this PR is merged and deployed. ⚠️ 

### Testing

- Open the staging branch URL above ☝️ 
- On that Pages Editor page, you should see images (the Zooniverse word logo on the top right, and Task icons) served properly.
- You should not see broken images _anywhere_ on the Zooniverse.

### Status

Ready for review.