### PR TITLE
PFE Admin: add warnings to Manage Users -> (Semi-)Recent Classifications

### DIFF
--- a/app/pages/admin/user-settings.jsx
+++ b/app/pages/admin/user-settings.jsx
@@ -112,7 +112,8 @@ class UserSettings extends Component {
           </ul>
         </details>
         <details>
-          <summary>Recent classifications {this.state.classifications.length}</summary>
+          <summary>Semi-recent classifications {this.state.classifications.length}</summary>
+          <p>⚠️ WARNING: classifications are <b>not correctly sorted</b> by most recently created. Order of classifications is semi-random.</p>
           <form onSubmit={this.updateSubjectID}>
             <label for="subjectId">Filter by subject ID: </label>
             <input id="subjectId" name="subjectID" type="text" defaultValue='' pattern='\d+' />

--- a/app/pages/admin/user-settings.jsx
+++ b/app/pages/admin/user-settings.jsx
@@ -114,6 +114,8 @@ class UserSettings extends Component {
         <details>
           <summary>Semi-recent classifications {this.state.classifications.length}</summary>
           <p>⚠️ WARNING: classifications are <b>not correctly sorted</b> by most recently created. Order of classifications is semi-random.</p>
+          <p>⚠️ WARNING: filtering by Subject ID <b>may not work</b> and return no results, even if the classification actually exists.</p>
+          <p>⚠️ WARNING: actually, this feature may be pretty much broken.</p>
           <form onSubmit={this.updateSubjectID}>
             <label for="subjectId">Filter by subject ID: </label>
             <input id="subjectId" name="subjectID" type="text" defaultValue='' pattern='\d+' />

--- a/app/pages/admin/user-settings.jsx
+++ b/app/pages/admin/user-settings.jsx
@@ -111,7 +111,7 @@ class UserSettings extends Component {
           ))}
           </ul>
         </details>
-        <details>
+        <details style={{ background: '#c0c0c0' }}>
           <summary>Semi-recent classifications {this.state.classifications.length}</summary>
           <p>⚠️ WARNING: classifications are <b>not correctly sorted</b> by most recently created. Order of classifications is semi-random.</p>
           <p>⚠️ WARNING: filtering by Subject ID <b>may not work</b> and return no results, even if the classification actually exists.</p>

--- a/app/pages/admin/user-settings/stats.js
+++ b/app/pages/admin/user-settings/stats.js
@@ -84,7 +84,7 @@ export function getUserProjects(user, callback, _page = 1) {
 export function getUserClassifications(user, subject_id, _page = 1) {
   return user.get('classifications', {
     subject_id: subject_id ? subject_id : undefined,
-    sort: '-created_at',
+    // sort: '-created_at',  // WARNING: sorting doesn't work for Classifications
     page: _page
   })
 }


### PR DESCRIPTION
## PR Overview

Staging branch URL: https://pr-{NUMBER}.pfe-preview.zooniverse.org/admin/users/107?env=production

For whatever reason, our Admin page's Manage User section's "Recent Classifications" system is no longer working as intended. This PR adds a warning to our admin page, to remind us not to use it for debugging.

<img width="819" alt="image" src="https://github.com/user-attachments/assets/05d9f557-1fab-4631-b469-af76748254bd" />

- Here's what no longer works: 1. searching/filtering by classification ID, and 2. recent classifications being listed by the most recent. (Which basically means it's less "recent classifications" and more "random jumble of classifications")
- I'm tempted to delete the Recent Classifications code altogether, but I imagine this could be fixed at some point, maybe, possibly.

### Status

Ready for review. Low priority.

Credit to Michelle for figuring out what was wrong. See [Slack](https://zooniverse.slack.com/archives/C06DCM0V9/p1744900853598099?thread_ts=1744684185.651289&cid=C06DCM0V9) for more info on the API side of things.
