### PR TITLE
Workflow Editor phase 2, part 5: 

### DIFF
--- a/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/TasksPage.jsx
@@ -50,16 +50,34 @@ export default function TasksPage() {
   const isLinearWorkflow = !advancedMode
 
   /*
-  Adds a new Task of a specified type (with default settings) to a Step.
+  Add a new Task of a specified type (with default settings) to a Step.
   If no Step is specified, a new Step is created.
   Returns the newly created step index.
    */
   async function addTask(taskType, stepIndex = -1) {
+    // Add Special Task type
+    if (taskType === 'transcription') {
+      if (stepIndex !== -1) throw new Error('TasksPage: Transcription Tasks cannot be added to an existing Page; it must be a new Page.')
+      return await addFixedStepTranscriptionTask()
+    }
+
+    // Add standard Task type. This is the default behaviour.
+    return await addStandardTask(taskType, stepIndex)
+  }
+
+  /*
+  Add a standard Task type to a Step. See addTask() - this is actually the
+  default behaviour.
+   */
+  async function addStandardTask(taskType, stepIndex = -1) {
     if (!workflow) return
+
+    // Create Task (but don't stage or commit changes yet)
     const newTaskKey = getNewTaskKey(workflow.tasks)
     const newTask = createTask(taskType)
     let steps = workflow.steps?.slice() || []
     
+    // Create new Step, or select existing Step
     let step
     if (stepIndex < 0) {
       // If no step is specified, we create a new one.
@@ -78,11 +96,13 @@ export default function TasksPage() {
       }
     }
 
+    // Sanity check
     if (!newTaskKey || !newTask || !step) {
       console.error('TasksPage: could not create Task')
       return
     }
 
+    // Stage changes
     const tasks = {
       ...workflow.tasks,
       [newTaskKey]: newTask
@@ -92,6 +112,45 @@ export default function TasksPage() {
       steps = linkStepsInWorkflow(steps, tasks)
     }
 
+    // Commit changes
+    await update({ tasks, steps })
+    return (stepIndex < 0) ? steps.length - 1 : stepIndex
+  }
+
+  /*
+  Add a "Transcription Task" which is actually a Fixed Step (aka Fixed Page)
+  that contains exactly two Tasks:
+  1. a task.type=transcription and
+  2. a task.type=single
+  Both Tasks are added 
+   */
+  async function addFixedStepTranscriptionTask() {
+    if (!workflow) return
+
+    // Create Task (but don't stage or commit changes yet)
+    const newTaskKey1 = getNewTaskKey(workflow.tasks, 0)
+    const newTask1 = createTask('transcription-pt1')
+    const newTaskKey2 = getNewTaskKey(workflow.tasks, 1)
+    const newTask2 = createTask('transcription-pt2')
+    let steps = workflow.steps?.slice() || []
+
+    // Create new Step
+    const newStepKey = getNewStepKey(workflow.steps)
+    const step = createStep(newStepKey, [newTaskKey1, newTaskKey2])
+    steps.push(step)
+
+    // Stage changes
+    const tasks = {
+      ...workflow.tasks,
+      [newTaskKey1]: newTask1,
+      [newTaskKey2]: newTask2,
+    }
+
+    if (linkStepsInWorkflow) {
+      steps = linkStepsInWorkflow(steps, tasks)
+    }
+
+    // Commit changes
     await update({ tasks, steps })
     return (stepIndex < 0) ? steps.length - 1 : stepIndex
   }

--- a/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/EditStepDialog.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/EditStepDialog.jsx
@@ -126,13 +126,15 @@ function EditStepDialog({
         })}
       </form>
       <div className="dialog-footer">
-        <button
-          className="button add-task-button"
-          onClick={doAddTask}
-          type="button"
-        >
-          Add another task to this page
-        </button>
+        {(!isFixedStep) && ( 
+          <button
+            className="button add-task-button"
+            onClick={doAddTask}
+            type="button"
+          >
+            Add another task to this page
+          </button>
+        )}
         <button
           className="button done-button"
           onClick={closeDialog}

--- a/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/EditStepDialog.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/EditStepDialog.jsx
@@ -2,6 +2,7 @@ import { forwardRef, useEffect, useRef, useState, useImperativeHandle } from 're
 import PropTypes from 'prop-types'
 
 import EditTaskForm from './EditTaskForm.jsx'
+import checkIsFixedStep from '../../../../helpers/checkIsFixedStep.js'
 import CloseIcon from '../../../../icons/CloseIcon.jsx'
 import OptionsIcon from '../../../../icons/OptionsIcon.jsx'
 
@@ -62,8 +63,10 @@ function EditStepDialog({
     setShowOptions(!showOptions)
   }
 
+  const tasksInStep = taskKeys.map(taskKey => allTasks[taskKey] )
+  const isFixedStep = checkIsFixedStep(tasksInStep)
   const stepHasManyTasks = taskKeys?.length > 1
-  const showDeleteButtonOnEachTask = stepHasManyTasks
+  const showDeleteButtonOnEachTask = stepHasManyTasks && !isFixedStep
 
   return (
     <dialog
@@ -107,7 +110,7 @@ function EditStepDialog({
         className="dialog-body"
         onSubmit={onSubmit}
       >
-        {taskKeys.map((taskKey, index) => {
+        {taskKeys.map(taskKey => {
           const task = allTasks[taskKey]
           return (
             <EditTaskForm

--- a/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/EditStepDialog.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/EditStepDialog.jsx
@@ -63,6 +63,7 @@ function EditStepDialog({
   }
 
   const stepHasManyTasks = taskKeys?.length > 1
+  const showDeleteButtonOnEachTask = stepHasManyTasks
 
   return (
     <dialog
@@ -113,7 +114,7 @@ function EditStepDialog({
               key={`editTaskForm-${taskKey}`}
               deleteTask={deleteTask}
               enforceLimitedBranchingRule={enforceLimitedBranchingRule}
-              stepHasManyTasks={stepHasManyTasks}
+              showDeleteButton={showDeleteButtonOnEachTask}
               task={task}
               taskKey={taskKey}
               updateTask={updateTask}

--- a/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/EditTaskForm.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/EditTaskForm.jsx
@@ -15,7 +15,7 @@ const taskTypes = {
 function EditTaskForm({  // It's not actually a form, but a fieldset that's part of a form.
   deleteTask,
   enforceLimitedBranchingRule,
-  stepHasManyTasks,
+  showDeleteButton = false,
   task,
   taskKey,
   updateTask
@@ -30,7 +30,7 @@ function EditTaskForm({  // It's not actually a form, but a fieldset that's part
       <TaskForm
         deleteTask={deleteTask}
         enforceLimitedBranchingRule={enforceLimitedBranchingRule}
-        stepHasManyTasks={stepHasManyTasks}
+        showDeleteButton={showDeleteButton}
         task={task}
         taskKey={taskKey}
         updateTask={updateTask}
@@ -44,7 +44,7 @@ EditTaskForm.propTypes = {
   enforceLimitedBranchingRule: PropTypes.shape({
     stepHasBranch: PropTypes.bool
   }),
-  stepHasManyTasks: PropTypes.bool,
+  showDeleteButton: PropTypes.bool,
   task: PropTypes.object,
   taskKey: PropTypes.string,
   updateTask: PropTypes.func

--- a/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/task-types/DrawingTask/DrawingTask.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/task-types/DrawingTask/DrawingTask.jsx
@@ -11,7 +11,6 @@ import DrawingTool, { randomlySelectColor } from './DrawingTool.jsx'
 
 function DrawingTask({
   deleteTask = DEFAULT_HANDLER,
-  isFirstTaskInStep = true,
   stepHasManyTasks = false,
   task,
   taskKey,
@@ -113,11 +112,6 @@ function DrawingTask({
     update({ tools: newTools })
   }
 
-  const [ showHelpField, setShowHelpField ] = useState(isFirstTaskInStep || task?.help?.length > 0)
-  function toggleShowHelpField() {
-    setShowHelpField(!showHelpField)
-  }
-
   return (
     <div className="drawing-task">
       <TaskHeader
@@ -184,9 +178,7 @@ function DrawingTask({
       <TaskHelpField
         help={help}
         setHelp={setHelp}
-        showHelpField={showHelpField}
         taskKey={taskKey}
-        toggleShowHelpField={toggleShowHelpField}
         update={update}
       />
     </div>
@@ -195,7 +187,6 @@ function DrawingTask({
 
 DrawingTask.propTypes = {
   deleteTask: PropTypes.func,
-  isFirstTaskInStep: PropTypes.bool,
   stepHasManyTasks: PropTypes.bool,
   task: PropTypes.object,
   taskKey: PropTypes.string,

--- a/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/task-types/DrawingTask/DrawingTask.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/task-types/DrawingTask/DrawingTask.jsx
@@ -11,7 +11,7 @@ import DrawingTool, { randomlySelectColor } from './DrawingTool.jsx'
 
 function DrawingTask({
   deleteTask = DEFAULT_HANDLER,
-  stepHasManyTasks = false,
+  showDeleteButton = false,
   task,
   taskKey,
   updateTask = DEFAULT_HANDLER
@@ -125,7 +125,7 @@ function DrawingTask({
       <TaskInstructionField
         deleteTask={deleteTask}
         setValue={setInstruction}
-        showDeleteButton={stepHasManyTasks}
+        showDeleteButton={showDeleteButton}
         taskKey={taskKey}
         update={update}
         value={instruction}
@@ -187,7 +187,7 @@ function DrawingTask({
 
 DrawingTask.propTypes = {
   deleteTask: PropTypes.func,
-  stepHasManyTasks: PropTypes.bool,
+  showDeleteButton: PropTypes.bool,
   task: PropTypes.object,
   taskKey: PropTypes.string,
   updateTask: PropTypes.func

--- a/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/task-types/DrawingTask/SubTaskSubForm.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/task-types/DrawingTask/SubTaskSubForm.jsx
@@ -25,7 +25,7 @@ function SubTaskSubForm({
       <TaskForm
         deleteTask={deleteTask}
         isSubTask={true}
-        stepHasManyTasks={false}
+        showDeleteButton={false}
         task={task}
         taskKey={subTaskIndex}
         updateTask={updateTask}

--- a/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/task-types/QuestionTask.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/task-types/QuestionTask.jsx
@@ -14,7 +14,7 @@ function QuestionTask({
   deleteTask = DEFAULT_HANDLER,
   isSubTask = false,
   enforceLimitedBranchingRule,
-  stepHasManyTasks = false,
+  showDeleteButton = false,
   task,
   taskKey,
   updateTask = DEFAULT_HANDLER
@@ -116,7 +116,7 @@ function QuestionTask({
         isSubTask={isSubTask}
         label={isSubTask ? 'Question Sub-Task Instructions' : null}
         setValue={setQuestion}
-        showDeleteButton={stepHasManyTasks}
+        showDeleteButton={showDeleteButton}
         taskKey={taskKey}
         update={update}
         value={question}
@@ -209,7 +209,7 @@ QuestionTask.propTypes = {
   enforceLimitedBranchingRule: PropTypes.shape({
     stepHasBranch: PropTypes.bool
   }),
-  stepHasManyTasks: PropTypes.bool,
+  showDeleteButton: PropTypes.bool,
   task: PropTypes.object,
   taskKey: PropTypes.string,
   updateTask: PropTypes.func

--- a/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/task-types/TextTask.jsx
+++ b/app/pages/lab-pages-editor/components/TasksPage/components/EditStepDialog/task-types/TextTask.jsx
@@ -11,7 +11,7 @@ const TEXT_TAGS = ['deletion', 'insertion', 'unclear']
 function TextTask({
   deleteTask = DEFAULT_HANDLER,
   isSubTask = false,
-  stepHasManyTasks = false,
+  showDeleteButton = false,
   task,
   taskKey,
   updateTask = DEFAULT_HANDLER
@@ -83,7 +83,7 @@ function TextTask({
         isSubTask={isSubTask}
         label={isSubTask ? 'Text Sub-Task Instructions' : null}
         setValue={setInstruction}
-        showDeleteButton={stepHasManyTasks}
+        showDeleteButton={showDeleteButton}
         taskKey={taskKey}
         update={update}
         value={instruction}
@@ -147,7 +147,7 @@ function TextTask({
 TextTask.propTypes = {
   deleteTask: PropTypes.func,
   isSubTask: PropTypes.bool,
-  stepHasManyTasks: PropTypes.bool,
+  showDeleteButton: PropTypes.bool,
   task: PropTypes.object,
   taskKey: PropTypes.string,
   updateTask: PropTypes.func

--- a/app/pages/lab-pages-editor/helpers/checkIsFixedStep.js
+++ b/app/pages/lab-pages-editor/helpers/checkIsFixedStep.js
@@ -13,8 +13,5 @@ this is the "Transcription Task", which actually a Step/Page that contains
 
 export default function checkIsFixedStep(tasksInStep) {
   if (!Array.isArray(tasksInStep)) return false
-
-  console.log('+++ ', tasksInStep)
-
   return tasksInStep.some(task => task.type === 'transcription')
 }

--- a/app/pages/lab-pages-editor/helpers/checkIsFixedStep.js
+++ b/app/pages/lab-pages-editor/helpers/checkIsFixedStep.js
@@ -1,0 +1,20 @@
+/*
+Checks if a Step is considered a "Fixed Step".
+A "Fixed Step" is a "pre-packaged deal", i.e. it contains a specific set of
+Tasks that are added together, and must be deleted together. A good example of
+this is the "Transcription Task", which actually a Step/Page that contains
+1x Transcription-type Task and 1x Question-type Task.
+
+- Returns true if:
+  - Step contains a Transcription Task.
+  - (uh, and that's it as of May 2025)
+- Returns false otherwise.
+ */
+
+export default function checkIsFixedStep(tasksInStep) {
+  if (!Array.isArray(tasksInStep)) return false
+
+  console.log('+++ ', tasksInStep)
+
+  return tasksInStep.some(task => task.type === 'transcription')
+}

--- a/app/pages/lab-pages-editor/helpers/createTask.js
+++ b/app/pages/lab-pages-editor/helpers/createTask.js
@@ -5,8 +5,46 @@ function needs to assign the appropriate Task Key to this Task, and then add it
 to the Workflow.
  */
 
-import tasks from '../../../classifier/tasks';
+import tasks from '../../../classifier/tasks'
 
 export default function createTask(taskType) {
-  return tasks[taskType]?.getDefaultTask();
+
+  // Special type: transcription
+  if (taskType === 'transcription') {
+    throw new Error('createTask(): a "Transcription Task" is actually a Fixed Step that contains a two Tasks. createTask() only creates one Task at a time, so please specify either taskType=transcription-pt1 or taskType=transcription-pt2')
+
+  } else if (taskType === 'transcription-pt1') {
+    return {
+      help: '**To underline and transcribe**: Click a dot at the start and end of a row of text to create an underline mark. Adjust the mark by clicking and dragging the dots at the start and end of the line. Delete the mark by clicking on the X. Type into the pop-up box to transcribe the text you’ve underlined.      **To interact with previous annotations**: Click on a pink underline mark to see previous transcriptions. Select a transcription from the dropdown menu to populate the text box. Submit as is, or edit the text by clicking into the text box. If you don’t agree with any of the previous options, transcribe directly into the box.',
+      instruction: 'Welcome to the new Transcription Task! There are two ways to transcribe, depending on whether anyone else has seen this image previously.      1. If the document has no previous volunteer-made marks: underline a single row of text by clicking at the start and end of the line (please draw your marks in the order you’re reading the text), and follow the instructions on the pop-up for transcribing the text you’ve just underlined.      2. If the document has previous annotations: click on an underline mark to view, select, edit, and/or submit previous transcriptions.',
+      tools: [
+        {
+          color: '',
+          details: [
+            {
+              help: '',
+              instruction: 'Transcribe the line of text that you\'ve marked.',
+              required: 'true',
+              type: 'text'
+            }
+          ],
+          label: 'Single line of text',
+          type: 'transcriptionLine'
+        }
+      ],
+      type: 'transcription'
+    }
+
+  } else if (taskType === 'transcription-pt2') {
+    return {
+      answers: [{label: 'Yes'}, {label: 'No'}],
+      help: 'If all the volunteer-made underline marks are **grey**, that indicates that consensus (agreement) has been achieved for all lines on the page and it is now ready to be retired from the project: **click YES**. ↵↵If there are non-grey underline marks on the page, that means those lines have not yet reached consensus: **click NO**.',
+      question: 'Have all the volunteer-made underline marks turned grey?',
+      required: 'true',
+      type: 'single'
+    }
+  }
+
+  // Standard tasks: this covers 90% of Task types!
+  return tasks[taskType]?.getDefaultTask()
 }

--- a/app/pages/lab-pages-editor/helpers/getNewTaskKey.js
+++ b/app/pages/lab-pages-editor/helpers/getNewTaskKey.js
@@ -2,19 +2,25 @@
 Searches the Workflow's existing Tasks and finds the next available Task Key.
 - Goes through workflow.tasks and finds keys in the format of T0, T1, T2, etc
 - Finds the LARGEST/HIGHEST key and returns one higher.
-- e.g. if given [T0, T1, T5], this will return T6.
-- Return T0 by default.
+- e.g. if given [T0, T1, T5], this will return "T6".
+- Return "T0" by default.
+
+Also:
+- optionalOffset allow the returned Task Key to be adjusted by a value - this
+  is useful if you're creating multiple Tasks at the same time before updating
+  the 'tasks' object.
  */
 
-import { TASK_KEY_PREFIX } from './constants.js';
-import convertKeyToIndex from './convertKeyToIndex.js';
+import { TASK_KEY_PREFIX } from './constants.js'
+import convertKeyToIndex from './convertKeyToIndex.js'
 
-export default function getNewTaskKey(tasks = {}) {
-  let newIndex = 0;
-  const taskKeys = Object.keys(tasks);
+export default function getNewTaskKey(tasks = {}, optionalOffset = 0) {
+  let newIndex = 0
+  const taskKeys = Object.keys(tasks)
   taskKeys.forEach((taskKey) => {
-    const index = convertKeyToIndex(taskKey);
-    newIndex = (newIndex <= index) ? index + 1 : newIndex;
-  });
-  return `${TASK_KEY_PREFIX}${newIndex}`;
+    const index = convertKeyToIndex(taskKey)
+    newIndex = (newIndex <= index) ? index + 1 : newIndex
+  })
+  newIndex += optionalOffset
+  return `${TASK_KEY_PREFIX}${newIndex}`
 }


### PR DESCRIPTION
## PR Overview

Part of: **Workflow Editor** (aka **Pages Editor**) project phase 2
Related issue: TBD
Follows #7294
Staging branch URL: https://pr-???.pfe-preview.zooniverse.org/lab/1982/workflows/editor/3711?env=staging

This PR is the fifth update for the Workflow Editor project, phase 2. We're adding Transcription Tasks to the list of supported Tasks, which means we also need to introduce the concept of Fixed Pages.

Major new features and concepts:
- 🆕 Fixed Pages (aka Fixed Steps):
  - A Fixed Page is a "pre-packaged deal" where a Page comes with a preset configuration of Tasks.
  - Tasks on a Fixed Page are added together, and are deleted together. (i.e. you can't delete individual items in a "pre-packaged deal")
  - No new Tasks can be added to a Fixed page.
  - Each Task on a Fixed Page can be individually edited (i.e. change their instructions, tools) but not rearranged.
- 🆕 Transcription Task
  - A Fixed Page with two Tasks: 1. an actual Transcription Task (task.type=transcription) and 2. a single question Task.

### Testing

TBD

### Status

WIP