### PR TITLE
Update markdownz to v9.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "hash.js": "~1.1.7",
         "history": "~3.3.0",
         "lodash": "~4.17.11",
-        "markdownz": "~9.1.9",
+        "markdownz": "~9.2.0",
         "modal-form": "~2.9",
         "moment": "~2.29.0",
         "panoptes-client": "~5.6.2",
@@ -11260,10 +11260,9 @@
       "license": "Python-2.0"
     },
     "node_modules/markdownz": {
-      "version": "9.1.9",
-      "resolved": "https://registry.npmjs.org/markdownz/-/markdownz-9.1.9.tgz",
-      "integrity": "sha512-kiLgeb5bR3tPlPLtLq7hdtqZvDUKmTkk9SniFaEITS71WAil/bc3g0C07mpBsB8sK+Hi/quCn7/KTdvU4jpv+Q==",
-      "license": "Apache-2.0",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/markdownz/-/markdownz-9.2.0.tgz",
+      "integrity": "sha512-gvUmAX3LJapjrTErN03xvvgayCZRCQAmqT66G82VkTDDSq1RSoaSba2VahLfkcTtGJSjOetHuYXM523BS2gj/Q==",
       "dependencies": {
         "@twemoji/api": "~15.1.0",
         "isomorphic-dompurify": "~2.22.0",
@@ -11280,6 +11279,10 @@
         "mime": "~3.0.0",
         "rehype": "~11.0.0",
         "rehype-react": "~6.2.1"
+      },
+      "engines": {
+        "node": ">=20.5 <=20.18",
+        "npm": ">=10"
       },
       "peerDependencies": {
         "react": ">= 16.14",
@@ -25993,9 +25996,9 @@
       "version": "0.6.3"
     },
     "markdownz": {
-      "version": "9.1.9",
-      "resolved": "https://registry.npmjs.org/markdownz/-/markdownz-9.1.9.tgz",
-      "integrity": "sha512-kiLgeb5bR3tPlPLtLq7hdtqZvDUKmTkk9SniFaEITS71WAil/bc3g0C07mpBsB8sK+Hi/quCn7/KTdvU4jpv+Q==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/markdownz/-/markdownz-9.2.0.tgz",
+      "integrity": "sha512-gvUmAX3LJapjrTErN03xvvgayCZRCQAmqT66G82VkTDDSq1RSoaSba2VahLfkcTtGJSjOetHuYXM523BS2gj/Q==",
       "requires": {
         "@twemoji/api": "~15.1.0",
         "isomorphic-dompurify": "~2.22.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "hash.js": "~1.1.7",
     "history": "~3.3.0",
     "lodash": "~4.17.11",
-    "markdownz": "~9.1.9",
+    "markdownz": "~9.2.0",
     "modal-form": "~2.9",
     "moment": "~2.29.0",
     "panoptes-client": "~5.6.2",


### PR DESCRIPTION
## PR Overview

Staging branch URL: https://pr-{NUMBER}.pfe-preview.zooniverse.org/talk/38/423?env=staging

This PR updates Markdownz to v9.2.0. To understand why this is important, see zooniverse/markdownz#282 , zooniverse/markdownz#284 , and zooniverse/markdownz#285 - turns out our ol' Markdown help's been giving bad advice about image hosting (and had some broken example images to boot).

### Status

Ready for review. (This should be merged & deployed whenever it's convenient, except maybe _not on a Friday evening_ because I ain't that much of a gambler!)
