### PR TITLE
Refactor project error state messages

### DIFF
--- a/app/pages/project/index.jsx
+++ b/app/pages/project/index.jsx
@@ -1,8 +1,3 @@
-/*
- * decaffeinate suggestions:
- * DS205: Consider reworking code to avoid use of IIFEs
- * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
- */
 import { captureException, withScope } from '@sentry/browser';
 import React from 'react';
 import PropTypes from 'prop-types';

--- a/app/pages/project/index.jsx
+++ b/app/pages/project/index.jsx
@@ -339,13 +339,12 @@ class ProjectPageController extends React.Component {
         {!!this.state.error &&
           ((this.state.error.message === 'NOT_FOUND') ?
             <div className="content-container">
-              <p>Project <code>{slug}</code> not found.</p>
+              <p>Project not found.</p>
               <p>If you are sure the URL is correct, you might not have permission to view this project.</p>
             </div> :
             <div className="content-container">
               <p>
-                There was an error retrieving project{' '}
-                <strong>{slug}</strong>.
+                There was an error retrieving the project.
               </p>
               <p>
                 <code>{this.state.error.message}</code>


### PR DESCRIPTION
Staging branch URL: https://pr-7309.pfe-preview.zooniverse.org

Fixes:
- https://github.com/zooniverse/panoptes/security/advisories/GHSA-73mp-cxwx-hrgm
- https://zooniverse.freshdesk.com/a/tickets/19069

Describe your changes.
- remove slug from project error messages
- [opinion] preventing issue noted in links above outweighs any benefit to including slug in error messages

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
