### PR TITLE
Fix Bluesky External Links

### DIFF
--- a/app/components/ExternalLinksBlock/components/ExternalLink/ExternalLink.jsx
+++ b/app/components/ExternalLinksBlock/components/ExternalLink/ExternalLink.jsx
@@ -33,10 +33,11 @@ export default function ExternalLink({ className, isExternalLink, isSocialLink, 
     iconClasses = `fa ${icon} fa-fw`;
     linkLabel = path;
     linkProps['aria-label'] = socialIcons[site].ariaLabel;
+    const siteSubpath = socialIcons[site]?.siteSubpath || ''
     if (socialIcons[site]?.pathBeforeSite) {
       linkProps.href = `https://${path}.${site}`;
     } else {
-      linkProps.href = `https://${site}${path}`;
+      linkProps.href = `https://${site}${siteSubpath}${path}`;
     }
     const isValidLink = !!icon && linkProps.href.substring(0, 8) === 'https://';
     if (isValidLink) {

--- a/app/lib/nav-helpers/socialIcons.json
+++ b/app/lib/nav-helpers/socialIcons.json
@@ -75,7 +75,8 @@
     "icon": "fa-external-link",
     "ariaLabel": "Link to BlueSky page",
     "label": "BlueSky",
-    "pathBeforeSite": false
+    "pathBeforeSite": false,
+    "siteSubpath": "profile/"
   },
   "mastodon.social/": {
     "icon": "fa-external-link",

--- a/app/pages/lab/social-links-editor.jsx
+++ b/app/pages/lab/social-links-editor.jsx
@@ -37,8 +37,9 @@ export default class SocialLinksEditor extends React.Component {
 
   handleNewLink(site, e) {
     let index = this.indexFinder(this.props.project.urls, site);
+    const siteSubpath = socialIcons[site]?.siteSubpath || '';
     if (index < 0) { index = this.props.project.urls.length; }
-    let url = `https://${site}${e.target.value}`;
+    let url = `https://${site}${siteSubpath}${e.target.value}`;
     if (socialIcons[site]?.pathBeforeSite) {
       url = `https://${e.target.value}.${site}`;
     }

--- a/app/pages/lab/social-links-editor.jsx
+++ b/app/pages/lab/social-links-editor.jsx
@@ -92,11 +92,17 @@ export default class SocialLinksEditor extends React.Component {
     const index = this.indexFinder(this.props.project.urls, site);
     const value = index >= 0 ? this.props.project.urls[index].path : '';
     const precedeSiteName = socialIcons[site]?.pathBeforeSite;
+    const siteSubpath = socialIcons[site]?.siteSubpath || '';
 
     return (
       <tr key={i}>
         {!precedeSiteName && (
-          <td><label for={`socialLink${i}`}>{site}</label></td>
+          <td>
+            <label for={`socialLink${i}`}>{site}</label>
+            {siteSubpath && (
+              <span style={{ color: '#c0c0c0' }}>{siteSubpath}</span>
+            )} 
+          </td>
         )}
         <AutoSave tag="td" resource={this.props.project}>
           <input


### PR DESCRIPTION
## PR Overview

Fixes: #7312
Related: zooniverse/front-end-monorepo#6908
Staging branch URL: https://pr-7313.pfe-preview.zooniverse.org

This PR fixes an issue where Bluesky links were going to the wrong URLs, i.e. the Bluesky links should go to `bsky.app/PROFILE/accountname`, not `bsky.app/accountname`

Changes made:
- socialIcons.json: the idea of "siteSubpath" has been introduced to the our array of social media links.
  - siteSubpath is optional, and currently only used by bsky.app
- ExternalLink.jsx (seen on Projects home page): modified to apply siteSubpath, if any.
- SocialLinksEditor.jsx (see in Edit Project Details page):
  - modified to display siteSubpath, if any.
  - 🆕 siteSubpath is now saved to the `projectResource.urls[x]` object

### Testing

- Edit a test project, e.g. https://pr-7313.pfe-preview.zooniverse.org/lab/1982?env=staging
- Go to Project Details, Social Links section.
- Add/edit a Bluesky external link, e.g. add the `zooniverse.bsky.social` account
  - Also check that the SocialLinkEditor editor _visually makes sense_ by showing the subpath.
- Add/edit a non-Bluesky external link, e.g. add `therealzooniverse` account to the Facebook link.
- View the project home page on the **PFE**, e.g. https://pr-7313.pfe-preview.zooniverse.org/projects/darkeshard/example-1982?env=staging
  - Ensure that the Bluesky link opens to the correct webpage
  - Ensure that the non-Bluesky link opens to the correct webpage.

### Status

This PR is ready for review ~~but NOT ready to merge, since it needs a matching PR on FEM.~~

Update: matching FEM PR has been created. See zooniverse/front-end-monorepo#6908

Low priority.