### PR TITLE
Remove project slug from project loading message

### DIFF
--- a/app/pages/project/index.jsx
+++ b/app/pages/project/index.jsx
@@ -326,8 +326,7 @@ class ProjectPageController extends React.Component {
         {!!this.state.loading &&
           <div className="content-container">
             <p>
-              Loading{' '}
-              <strong>{slug}</strong>...
+              Loading...
             </p>
           </div>
         }


### PR DESCRIPTION
Staging branch URL: https://pr-7316.pfe-preview.zooniverse.org/projects

Iteration on #7309, see https://github.com/zooniverse/Panoptes-Front-End/pull/7309#issuecomment-2932544667

Describe your changes:
- removes slug from loading message when project is loading

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
