### PR TITLE
Rubin 2025 Landing Page pt3: style UI, add content, improve accessibility

### DIFF
--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -276,7 +276,7 @@ export default {
     required: 'Required',
     optional: 'Optional',
     looksGood: 'Looks good',
-    userName: 'User name',
+    userName: 'Username',
     whyUserName: 'You\'ll use this name to log in. It will be shown publicly. ',
     badChars: "Only letters, numbers, '.', '_', and '-'.",
     nameConflict: 'That username is taken',

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -263,6 +263,46 @@ export default {
       gotoProjects: 'Find a new project to explore'
     }
   },
+  signInForm: {
+    signIn: 'Sign in',
+    signOut: 'Sign out',
+    userName: 'User name or email address',
+    password: 'Password',
+    incorrectDetails: 'Username or password incorrect',
+    forgotPassword: 'Forgot my password',
+    alreadySignedIn: 'Signed in as %(name)s'
+  },
+  registerForm: {
+    required: 'Required',
+    optional: 'Optional',
+    looksGood: 'Looks good',
+    userName: 'User name',
+    whyUserName: 'You\'ll use this name to log in. It will be shown publicly. ',
+    badChars: "Only letters, numbers, '.', '_', and '-'.",
+    nameConflict: 'That username is taken',
+    forgotPassword: 'Forgot my password',
+    password: 'Password',
+    passwordTooShort: 'Must be at least 8 characters',
+    confirmPassword: 'Confirm password',
+    passwordsDontMatch: 'These don\'t match',
+    email: 'Email address',
+    emailConflict: 'An account with this address already exists',
+    realName: 'Real name',
+    realNamePatternHelp: "Enter a name, not an email address",
+    whyRealName: 'We\'ll use this to give you credit in scientific papers, posters, etc',
+    agreeToPrivacyPolicy: 'You agree to our %(link)s (required)',
+    privacyPolicy: 'privacy policy',
+    okayToEmail: 'It\'s okay to send me email every once in a while. (optional)',
+    betaTester: 'I\'d like to help test new projects, and be emailed when they\'re available. (optional)',
+    underAge: 'If you are under 16 years old, tick this box and complete the form with your parent/guardian.',
+    notRealName: 'Don\'t use your real name.',
+    guardianEmail: 'Parent/Guardian\'s email address',
+    underAgeConsent: 'I confirm I am the parent/guardian and give permission for my child to register by providing my email address as the main contact address. Both I and my child understand and agree to the %(link)s (required)',
+    underAgeEmail: 'If you agree, we will periodically send email promoting new research-related projects or other information relating to our research. We will not use your contact information for commercial purposes. (optional)',
+    register: 'Register',
+    alreadySignedIn: 'Signed in as %(name)s',
+    signOut: 'Sign out'
+  },
   notFoundPage: {
     message: 'Not found'
   },

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -266,7 +266,7 @@ export default {
   signInForm: {
     signIn: 'Sign in',
     signOut: 'Sign out',
-    userName: 'User name or email address',
+    userName: 'Username or email address',
     password: 'Password',
     incorrectDetails: 'Username or password incorrect',
     forgotPassword: 'Forgot my password',

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -287,6 +287,8 @@ export default {
     passwordsDontMatch: 'These don\'t match',
     email: 'Email address',
     emailConflict: 'An account with this address already exists',
+    emailInvalidChars: 'Email address contains invalid characters',
+    emailInvalidFormat: 'Email address doesn\'t look correct',
     realName: 'Real name',
     realNamePatternHelp: "Enter a name, not an email address",
     whyRealName: 'We\'ll use this to give you credit in scientific papers, posters, etc',

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -288,7 +288,7 @@ export default {
     email: 'Email address',
     emailConflict: 'An account with this address already exists',
     emailInvalidChars: 'Email address contains invalid characters',
-    emailInvalidFormat: 'Email address doesn\'t look correct',
+    emailInvalidFormat: 'Email address must contain @ and a valid domain',
     realName: 'Real name',
     realNamePatternHelp: "Enter a name, not an email address",
     whyRealName: 'We\'ll use this to give you credit in scientific papers, posters, etc',

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -248,10 +248,20 @@ export default {
     whyHaveAccount: 'Signed-in volunteers can keep track of their work and will be credited in any resulting publications.',
     signIn: 'Sign in',
     register: 'Register',
-    alreadySignedIn: 'Signed in as %(name)s',
     orThirdParty: 'Or sign in with another service',
     withFacebook: 'Sign in with Facebook',
     withGoogle: 'Sign in with Google'
+  },
+  newAccountsPage: {
+    signIn: 'Sign in',
+    register: 'Register',
+    successfullySignedIn: `You've successfully signed in!`,
+    successfullyRegistered: `You've successfully registered!`,
+    alreadySignedIn: 'Signed in as %(name)s',
+    alreadySignedInLinks: {
+      gotoHomepage: 'Go to the homepage',
+      gotoProjects: 'Find a new project to explore'
+    }
   },
   notFoundPage: {
     message: 'Not found'

--- a/app/rubin-2025/register-form.jsx
+++ b/app/rubin-2025/register-form.jsx
@@ -550,4 +550,4 @@ RegisterForm.propTypes = {
   user: PropTypes.object
 };
 
-export { RegisterForm }
+export { RegisterForm };

--- a/app/rubin-2025/register-form.jsx
+++ b/app/rubin-2025/register-form.jsx
@@ -307,10 +307,10 @@ class RegisterForm extends React.Component {
           }
         </p>
 
-        <div>
+        <div className="form-row submit-row">
           <button
             type="submit"
-            className="standard-button full"
+            className="standard-button"
             disabled={submitDisabled}
           >
             <Translate content="registerForm.register" />

--- a/app/rubin-2025/register-form.jsx
+++ b/app/rubin-2025/register-form.jsx
@@ -14,7 +14,7 @@ class RegisterForm extends React.Component {
     super(props);
     this.state = {
       badNameChars: null,
-      nameConflict: null,
+      nameConflict: null,  // This is null when uninitialised, false if there's no name conflict, and an array if there's a conflict.
       passwordTooShort: null,
       passwordsDontMatch: null,
       emailConflict: null,
@@ -92,22 +92,25 @@ class RegisterForm extends React.Component {
         <label>
           <span className="columns-container inline spread">
             <Translate content="registerForm.userName" />
-            {badNameChars?.length > 0
-              ? <Translate className="form-help error" content="registerForm.badChars" />
-              : "nameConflict" in this.state.pending
-              ? <LoadingIndicator />
-              : nameConflict != null
-              ? nameConflict
-              ? <span className="form-help error">
-                  <Translate content="registerForm.nameConflict" />{' '}
-                  <a href={`${window.location.origin}/reset-password`}>
-                    <Translate content="registerForm.forgotPassword" />
-                  </a>
-                </span> : <span className="form-help success">
-                  <Translate content="registerForm.looksGood" />
-                </span>
-              : null
-            }
+            {badNameChars?.length > 0 && (
+              <Translate className="form-help error" content="registerForm.badChars" />
+            )}
+            {"nameConflict" in this.state.pending && (
+              <LoadingIndicator />
+            )}
+            {nameConflict && (
+              <span className="form-help error">
+                <Translate content="registerForm.nameConflict" />{' '}
+                <a href={`${window.location.origin}/reset-password`}>
+                  <Translate content="registerForm.forgotPassword" />
+                </a>
+              </span>
+            )}
+            {(nameConflict === false) && (
+              <span className="form-help success">
+                <Translate content="registerForm.looksGood" />
+              </span>
+            )}
             <Translate className="form-help info right-align" content="registerForm.required" />
           </span>
           <input

--- a/app/rubin-2025/register-form.jsx
+++ b/app/rubin-2025/register-form.jsx
@@ -90,7 +90,7 @@ class RegisterForm extends React.Component {
             <Translate content="registerForm.userName" />
             {(badNameChars != null ? badNameChars.length : void 0) > 0 ? <Translate className="form-help error" content="registerForm.badChars" /> : "nameConflict" in this.state.pending ? <LoadingIndicator /> : nameConflict != null ? nameConflict ? <span className="form-help error">
                   <Translate content="registerForm.nameConflict" />{' '}
-                  <a href={`${window.location.origin}/reset-password`} onClick={this.props.onSuccess}>
+                  <a href={`${window.location.origin}/reset-password`}>
                     <Translate content="registerForm.forgotPassword" />
                   </a>
                 </span> : <span className="form-help success">
@@ -163,7 +163,7 @@ class RegisterForm extends React.Component {
             {this.state.underAge ? <Translate content="registerForm.guardianEmail" /> : <Translate content="registerForm.email" />}
             {'emailConflict' in this.state.pending ? <LoadingIndicator /> : emailConflict != null ? emailConflict ? <span className="form-help error">
                   <Translate content="registerForm.emailConflict" />{' '}
-                  <a href={`${window.location.origin}/reset-password`} onClick={this.props.onSuccess}>
+                  <a href={`${window.location.origin}/reset-password`}>
                     <Translate content="registerForm.forgotPassword" />
                   </a>
                 </span> : <Translate className="form-help success" content="registerForm.looksGood" /> : <Translate className="form-help info right-align" content="registerForm.required" />}

--- a/app/rubin-2025/register-form.jsx
+++ b/app/rubin-2025/register-form.jsx
@@ -15,8 +15,8 @@ class RegisterForm extends React.Component {
     this.state = {
       badNameChars: null,
       nameConflict: null,  // This is null when uninitialised, false if there's no name conflict, and an array if there's a conflict.
-      passwordTooShort: null,
-      passwordsDontMatch: null,
+      passwordTooShort: false,
+      passwordsDontMatch: false,
       emailConflict: null,
       emailInvalidChars: false,
       emailInvalidFormat: false,
@@ -156,7 +156,16 @@ class RegisterForm extends React.Component {
         <label>
           <span className="columns-container inline spread">
             <Translate content="registerForm.confirmPassword" /><br />
-            {passwordsDontMatch != null ? passwordsDontMatch ? <Translate className="form-help error" content="registerForm.passwordsDontMatch" /> : !passwordTooShort ? <Translate className="form-help success" content="registerForm.looksGood" /> : void 0 : void 0}
+            {passwordsDontMatch && (
+              <Translate className="form-help error" content="registerForm.passwordsDontMatch" />
+            )}
+            {(this.state.input_password?.length > 0
+              && this.state.input_confirmedPassword?.length > 0
+              && !passwordsDontMatch
+              && !passwordTooShort
+            ) && (
+              <Translate className="form-help success" content="registerForm.looksGood" />
+            )}
             <Translate className="form-help info right-align" content="registerForm.required" />
           </span>
           <input
@@ -374,14 +383,14 @@ class RegisterForm extends React.Component {
   }
 
   handlePasswordChange (password, confirmedPassword) {
-    var asLong, exists, longEnough, matches;
-    exists = password.length !== 0;
-    longEnough = password.length >= MIN_PASSWORD_LENGTH;
-    asLong = confirmedPassword.length >= password.length;
-    matches = password === confirmedPassword;
+    const passwordNotEmpty = password.length > 0;
+    const bothNotEmpty = password.length > 0 && confirmedPassword.length > 0;
+    const longEnough = password.length >= MIN_PASSWORD_LENGTH;
+    const matches = password === confirmedPassword;
+
     return this.setState({
-      passwordTooShort: exists ? !longEnough : void 0,
-      passwordsDontMatch: exists && asLong ? !matches : void 0
+      passwordTooShort: passwordNotEmpty && !longEnough,
+      passwordsDontMatch: bothNotEmpty && !matches
     });
   }
 

--- a/app/rubin-2025/register-form.jsx
+++ b/app/rubin-2025/register-form.jsx
@@ -13,11 +13,11 @@ class RegisterForm extends React.Component {
   constructor (props) {
     super(props);
     this.state = {
-      badNameChars: null,
+      badNameChars: [],
       nameConflict: null,  // This is null when uninitialised, false if there's no name conflict, and an array if there's a conflict.
       passwordTooShort: false,
       passwordsDontMatch: false,
-      emailConflict: null,
+      emailConflict: null,  // This is null when uninitialised, false if there's no name conflict, and an array if there's a conflict.
       emailInvalidChars: false,
       emailInvalidFormat: false,
       agreeToPrivacyPolicy: false,
@@ -106,7 +106,9 @@ class RegisterForm extends React.Component {
                 </a>
               </span>
             )}
-            {(nameConflict === false) && (
+            {(this.state.input_login?.length > 0
+              && nameConflict === false
+            ) && (
               <span className="form-help success">
                 <Translate content="registerForm.looksGood" />
               </span>
@@ -190,22 +192,28 @@ class RegisterForm extends React.Component {
             {emailInvalidChars && (
               <Translate className="form-help error" content="registerForm.emailInvalidChars" />
             )}
-            {emailInvalidFormat && (
+            {(!emailInvalidChars && emailInvalidFormat) && (
               <Translate className="form-help info" content="registerForm.emailInvalidFormat" />
             )}
-            {'emailConflict' in this.state.pending
-              ? <LoadingIndicator />
-              : emailConflict != null
-              ? emailConflict
-              ? <span className="form-help error">
-                  <Translate content="registerForm.emailConflict" />{' '}
-                  <a href={`${window.location.origin}/reset-password`}>
-                    <Translate content="registerForm.forgotPassword" />
-                  </a>
-                </span>
-              : <Translate className="form-help success" content="registerForm.looksGood" />
-              : <Translate className="form-help info right-align" content="registerForm.required" />
-            }
+            {'emailConflict' in this.state.pending && (
+              <LoadingIndicator />
+            )}
+            {emailConflict && (
+              <span className="form-help error">
+                <Translate content="registerForm.emailConflict" />{' '}
+                <a href={`${window.location.origin}/reset-password`}>
+                  <Translate content="registerForm.forgotPassword" />
+                </a>
+              </span>
+            )}
+            {(this.state.input_email?.length > 0
+              && !emailConflict
+              && !emailInvalidChars
+              && !emailInvalidFormat
+            ) && (
+              <Translate className="form-help success" content="registerForm.looksGood" />
+            )}
+            <Translate className="form-help info right-align" content="registerForm.required" />
           </span>
           <input
             type="text"
@@ -437,6 +445,8 @@ class RegisterForm extends React.Component {
       nameConflict,
       passwordsDontMatch,
       emailConflict,
+      emailInvalidChars,
+      emailInvalidFormat,
       agreeToPrivacyPolicy,
       nameExists
     } = this.state;
@@ -445,6 +455,8 @@ class RegisterForm extends React.Component {
       && !nameConflict
       && !passwordsDontMatch
       && !emailConflict
+      && !emailInvalidChars
+      && !emailInvalidFormat
       && nameExists
       && agreeToPrivacyPolicy
     );

--- a/app/rubin-2025/register-form.jsx
+++ b/app/rubin-2025/register-form.jsx
@@ -92,14 +92,21 @@ class RegisterForm extends React.Component {
         <label>
           <span className="columns-container inline spread">
             <Translate content="registerForm.userName" />
-            {(badNameChars != null ? badNameChars.length : void 0) > 0 ? <Translate className="form-help error" content="registerForm.badChars" /> : "nameConflict" in this.state.pending ? <LoadingIndicator /> : nameConflict != null ? nameConflict ? <span className="form-help error">
+            {badNameChars?.length > 0
+              ? <Translate className="form-help error" content="registerForm.badChars" />
+              : "nameConflict" in this.state.pending
+              ? <LoadingIndicator />
+              : nameConflict != null
+              ? nameConflict
+              ? <span className="form-help error">
                   <Translate content="registerForm.nameConflict" />{' '}
                   <a href={`${window.location.origin}/reset-password`}>
                     <Translate content="registerForm.forgotPassword" />
                   </a>
                 </span> : <span className="form-help success">
                   <Translate content="registerForm.looksGood" />
-                </span> : void 0
+                </span>
+              : null
             }
             <Translate className="form-help info right-align" content="registerForm.required" />
           </span>
@@ -169,10 +176,10 @@ class RegisterForm extends React.Component {
               : <Translate content="registerForm.email" />
             }
             {emailInvalidChars && (
-              <Translate content="registerForm.emailInvalidChars" />
+              <Translate className="form-help error" content="registerForm.emailInvalidChars" />
             )}
             {emailInvalidFormat && (
-              <Translate content="registerForm.emailInvalidFormat" />
+              <Translate className="form-help info" content="registerForm.emailInvalidFormat" />
             )}
             {'emailConflict' in this.state.pending
               ? <LoadingIndicator />
@@ -302,11 +309,7 @@ class RegisterForm extends React.Component {
   handleUserInput (e) {
     const input = e?.currentTarget;
     const inputName = input.name;
-    const inputValue = input.type === 'checkbox' ? !!input.checked : input.value;
-
-    this.setState({
-      [`input_${inputName}`]: inputValue
-    })
+    let inputValue = input.type === 'checkbox' ? !!input.checked : input.value;
 
     switch (inputName) {
       case "login":
@@ -319,10 +322,14 @@ class RegisterForm extends React.Component {
         this.handlePasswordChange(this.state.input_password, inputValue);
         break;
       case "email":
+        inputValue = (inputValue || '').replaceAll(' ', '');  // Trim out empty spaces
         this.handleEmailChange(inputValue);
         break;
     }
 
+    this.setState({
+      [`input_${inputName}`]: inputValue
+    });
   }
 
   handleLoginChange (login) {

--- a/app/rubin-2025/register-form.jsx
+++ b/app/rubin-2025/register-form.jsx
@@ -9,40 +9,6 @@ import debounce from 'debounce';
 const REMOTE_CHECK_DELAY = 1000;
 const MIN_PASSWORD_LENGTH = 8;
 
-counterpart.registerTranslations('en', {
-  registerForm: {
-    required: 'Required',
-    optional: 'Optional',
-    looksGood: 'Looks good',
-    userName: 'User name',
-    whyUserName: 'You’ll use this name to log in. It will be shown publicly. ',
-    badChars: "Only letters, numbers, '.', '_', and '-'.",
-    nameConflict: 'That username is taken',
-    forgotPassword: 'Forgot my password',
-    password: 'Password',
-    passwordTooShort: 'Must be at least 8 characters',
-    confirmPassword: 'Confirm password',
-    passwordsDontMatch: 'These don’t match',
-    email: 'Email address',
-    emailConflict: 'An account with this address already exists',
-    realName: 'Real name',
-    realNamePatternHelp: "Enter a name, not an email address",
-    whyRealName: 'We’ll use this to give you credit in scientific papers, posters, etc',
-    agreeToPrivacyPolicy: 'You agree to our %(link)s (required)',
-    privacyPolicy: 'privacy policy',
-    okayToEmail: 'It’s okay to send me email every once in a while. (optional)',
-    betaTester: 'I’d like to help test new projects, and be emailed when they’re available. (optional)',
-    underAge: 'If you are under 16 years old, tick this box and complete the form with your parent/guardian.',
-    notRealName: 'Don’t use your real name.',
-    guardianEmail: 'Parent/Guardian’s email address',
-    underAgeConsent: 'I confirm I am the parent/guardian and give permission for my child to register by providing my email address as the main contact address. Both I and my child understand and agree to the %(link)s (required)',
-    underAgeEmail: 'If you agree, we will periodically send email promoting new research-related projects or other information relating to our research. We will not use your contact information for commercial purposes. (optional)',
-    register: 'Register',
-    alreadySignedIn: 'Signed in as %(name)s',
-    signOut: 'Sign out'
-  }
-});
-
 class RegisterForm extends React.Component {
   constructor (props) {
     super(props);

--- a/app/rubin-2025/rubin-page.jsx
+++ b/app/rubin-2025/rubin-page.jsx
@@ -1,10 +1,20 @@
 import PropTypes from 'prop-types';
 import React, { useState } from 'react';
+import counterpart from 'counterpart';
 import Translate from 'react-translate-component';
 import Helmet from 'react-helmet';
 import { Link } from 'react-router';
 import { SignInForm } from './sign-in-form.jsx';
 import { RegisterForm } from './register-form.jsx';
+
+counterpart.registerTranslations('en', {
+  rubinPage: {
+    callToAction: {
+      toZooniverseProjects: 'Check out existing Zooniverse space projects',
+      toRubinAbout: 'Read more about Rubin'
+    }
+  }
+});
 
 function RubinPage ({
   user
@@ -71,8 +81,16 @@ function RubinPage ({
                 <Translate content="newAccountsPage.alreadySignedIn" name={user?.login} />
               </p>
               <ul className="call-to-action">
-                <li><Link to="/"><Translate content='newAccountsPage.alreadySignedInLinks.gotoHomepage' /></Link></li>
-                <li><Link to="/projects"><Translate content='newAccountsPage.alreadySignedInLinks.gotoProjects' /></Link></li>
+                <li>
+                  <Link to="/projects?discipline=astronomy&page=1&status=live">
+                    <Translate content='rubinPage.callToAction.toZooniverseProjects' />
+                  </Link>
+                </li>
+                <li>
+                  <a href="https://rubinobservatory.org/" rel="noopener nofollow noreferrer" target="_blank">
+                    <Translate content='rubinPage.callToAction.toRubinAbout' />
+                  </a>
+                </li>
               </ul>
             </div>
           ) : (

--- a/app/rubin-2025/rubin-page.jsx
+++ b/app/rubin-2025/rubin-page.jsx
@@ -7,17 +7,6 @@ import { Link } from 'react-router';
 import { SignInForm } from './sign-in-form.jsx';
 import { RegisterForm } from './register-form.jsx';
 
-counterpart.registerTranslations('en', {
-  newAccountsPage: {
-    successfullySignedIn: `You've successfully signed in!`,
-    successfullyRegistered: `You've successfully registered!`,
-    alreadySignedInLinks: {
-      gotoHomepage: 'Go to the homepage',
-      gotoProjects: 'Find a new project to explore'
-    }
-  }
-});
-
 function RubinPage ({
   user
 }) {
@@ -50,7 +39,7 @@ function RubinPage ({
 
       {user ? (
         <div className="already-signed-in">
-          <Translate content="signIn.alreadySignedIn" name={user?.login} />
+          <Translate content="newAccountsPage.alreadySignedIn" name={user?.login} />
           <ul>
             <li><Link to="/"><Translate content='newAccountsPage.alreadySignedInLinks.gotoHomepage' /></Link></li>
             <li><Link to="/projects"><Translate content='newAccountsPage.alreadySignedInLinks.gotoProjects' /></Link></li>
@@ -60,8 +49,8 @@ function RubinPage ({
         <div className="columns-container">
           <div className="tabbed-content column" data-side="top">
             <nav className="tabbed-content-tabs">
-              <button type="button" onClick={onTabClick} data-tab="sign-in" className="tabbed-content-tab"><Translate content="signIn.signIn" /></button>
-              <button type="button" onClick={onTabClick} data-tab="register" className="tabbed-content-tab"><Translate content="signIn.register" /></button>
+              <button type="button" onClick={onTabClick} data-tab="sign-in" className="tabbed-content-tab"><Translate content="newAccountsPage.signIn" /></button>
+              <button type="button" onClick={onTabClick} data-tab="register" className="tabbed-content-tab"><Translate content="newAccountsPage.register" /></button>
             </nav>
             {(tab !== 'register')
               ? <SignInForm user={user} onSuccess={onSignInSuccess} />

--- a/app/rubin-2025/rubin-page.jsx
+++ b/app/rubin-2025/rubin-page.jsx
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React, { useState } from 'react';
-import counterpart from 'counterpart';
 import Translate from 'react-translate-component';
 import Helmet from 'react-helmet';
 import { Link } from 'react-router';

--- a/app/rubin-2025/rubin-page.jsx
+++ b/app/rubin-2025/rubin-page.jsx
@@ -10,7 +10,7 @@ function RubinPage ({
   user
 }) {
   const [tab, setTab] = useState('register')
-  const [successMessage, setSuccessMessage] = useState('successfullyRegistered')
+  const [successMessage, setSuccessMessage] = useState('')
 
   function onTabClick (e) {
     setTab(e?.currentTarget?.dataset?.tab)
@@ -70,7 +70,7 @@ function RubinPage ({
                 <span className="fa fa-check-circle-o" />
                 <Translate content="newAccountsPage.alreadySignedIn" name={user?.login} />
               </p>
-              <ul>
+              <ul className="call-to-action">
                 <li><Link to="/"><Translate content='newAccountsPage.alreadySignedInLinks.gotoHomepage' /></Link></li>
                 <li><Link to="/projects"><Translate content='newAccountsPage.alreadySignedInLinks.gotoProjects' /></Link></li>
               </ul>

--- a/app/rubin-2025/rubin-page.jsx
+++ b/app/rubin-2025/rubin-page.jsx
@@ -68,7 +68,7 @@ function RubinPage ({
       </div>
       <section>
         <div className="inner">
-          <div className="info">
+          <div className="page-info">
             <Helmet title={'Zooniverse & Rubin 2025'} />
             <h1>Zooniverse &amp; Rubin 2025</h1>
             <p>Welcome to the Zooniverse, the home of Vera C. Rubin Observatory citizen science. We'll be launching the first projects with Rubin data in the next few weeks, so to be among the first to see data and help our scientists then sign up below, and we'll be in touch. In the meantime, to learn more and to enjoy the first images released by the Observatory go to <a href="https://rubinobservatory.org/" rel="noopener nofollow noreferrer" target="_blank">Rubinobservatory.org.</a></p>

--- a/app/rubin-2025/rubin-page.jsx
+++ b/app/rubin-2025/rubin-page.jsx
@@ -49,74 +49,78 @@ function RubinPage ({
 
   return (
     <div className="new-accounts-page content-container">
-      <Helmet title={'Zooniverse & Rubin 2025'} />
-      <h1>Zooniverse &amp; Rubin 2025</h1>
-      <p>Welcome to the Zooniverse, the home of Vera C. Rubin Observatory citizen science. We'll be launching the first projects with Rubin data in the next few weeks, so to be among the first to see data and help our scientists then sign up below, and we'll be in touch. In the meantime, to learn more and to enjoy the first images released by the Observatory go to <a href="https://rubinobservatory.org/" rel="noopener nofollow noreferrer" target="_blank">Rubinobservatory.org.</a></p>
+      <section>
+        <div className="inner">
+          <Helmet title={'Zooniverse & Rubin 2025'} />
+          <h1>Zooniverse &amp; Rubin 2025</h1>
+          <p>Welcome to the Zooniverse, the home of Vera C. Rubin Observatory citizen science. We'll be launching the first projects with Rubin data in the next few weeks, so to be among the first to see data and help our scientists then sign up below, and we'll be in touch. In the meantime, to learn more and to enjoy the first images released by the Observatory go to <a href="https://rubinobservatory.org/" rel="noopener nofollow noreferrer" target="_blank">Rubinobservatory.org.</a></p>
 
-      {user && successMessage && (
-        <div className="successMessage">
-          <Translate content={`newAccountsPage.${successMessage}`} />
-        </div>
-      )}
+          {user && successMessage && (
+            <div className="successMessage">
+              <Translate content={`newAccountsPage.${successMessage}`} />
+            </div>
+          )}
 
-      {user ? (
-        <div className="already-signed-in">
-          <Translate content="newAccountsPage.alreadySignedIn" name={user?.login} />
-          <ul>
-            <li><Link to="/"><Translate content='newAccountsPage.alreadySignedInLinks.gotoHomepage' /></Link></li>
-            <li><Link to="/projects"><Translate content='newAccountsPage.alreadySignedInLinks.gotoProjects' /></Link></li>
-          </ul>
-        </div>
-      ) : (
-        <div className="columns-container">
-          <div className="tabbed-content column" data-side="top">
-            <nav
-              className="tabbed-content-tabs"
-              role="tablist"
-            >
-              <button
-                role="tab"
-                id="new-accounts-page-tab-sign-in"
-                type="button"
-                onClick={onTabClick}
-                onKeyDown={onTabKeyPress}
-                data-tab="sign-in"
-                className={`tabbed-content-tab ${tab !== 'register' ? 'active' : ''}`}
-              >
-                <Translate content="newAccountsPage.signIn" />
-              </button>
-              <button
-                role="tab"
-                id="new-accounts-page-tab-register"
-                type="button"
-                onClick={onTabClick}
-                onKeyDown={onTabKeyPress}
-                data-tab="register"
-                className={`tabbed-content-tab ${tab === 'register' ? 'active' : ''}`}
-              >
-                <Translate content="newAccountsPage.register" />
-              </button>
-            </nav>
-            {(tab !== 'register')
-              ? (
-                <div
-                  role="tabpanel"
-                  aria-labelledby="new-accounts-page-tab-sign-in"
+          {user ? (
+            <div className="already-signed-in">
+              <Translate content="newAccountsPage.alreadySignedIn" name={user?.login} />
+              <ul>
+                <li><Link to="/"><Translate content='newAccountsPage.alreadySignedInLinks.gotoHomepage' /></Link></li>
+                <li><Link to="/projects"><Translate content='newAccountsPage.alreadySignedInLinks.gotoProjects' /></Link></li>
+              </ul>
+            </div>
+          ) : (
+            <div className="columns-container">
+              <div className="tabbed-content column" data-side="top">
+                <nav
+                  className="tabbed-content-tabs"
+                  role="tablist"
                 >
-                  <SignInForm user={user} onSuccess={onSignInSuccess} />
-                </div>
-              ) : (
-                <div
-                  role="tabpanel"
-                  aria-labelledby="new-accounts-page-tab-register"
-                >
-                  <RegisterForm user={user} onSuccess={onRegisterSuccess} />
-                </div>
-              )
-            }
-          </div>
+                  <button
+                    role="tab"
+                    id="new-accounts-page-tab-sign-in"
+                    type="button"
+                    onClick={onTabClick}
+                    onKeyDown={onTabKeyPress}
+                    data-tab="sign-in"
+                    className={`tabbed-content-tab ${tab !== 'register' ? 'active' : ''}`}
+                  >
+                    <Translate content="newAccountsPage.signIn" />
+                  </button>
+                  <button
+                    role="tab"
+                    id="new-accounts-page-tab-register"
+                    type="button"
+                    onClick={onTabClick}
+                    onKeyDown={onTabKeyPress}
+                    data-tab="register"
+                    className={`tabbed-content-tab ${tab === 'register' ? 'active' : ''}`}
+                  >
+                    <Translate content="newAccountsPage.register" />
+                  </button>
+                </nav>
+                {(tab !== 'register')
+                  ? (
+                    <div
+                      role="tabpanel"
+                      aria-labelledby="new-accounts-page-tab-sign-in"
+                    >
+                      <SignInForm user={user} onSuccess={onSignInSuccess} />
+                    </div>
+                  ) : (
+                    <div
+                      role="tabpanel"
+                      aria-labelledby="new-accounts-page-tab-register"
+                    >
+                      <RegisterForm user={user} onSuccess={onRegisterSuccess} />
+                    </div>
+                  )
+                }
+              </div>
+            </div>
+          )}
         </div>
-      )}
+      </section>
     </div>
   )
 };

--- a/app/rubin-2025/rubin-page.jsx
+++ b/app/rubin-2025/rubin-page.jsx
@@ -7,6 +7,9 @@ import { Link } from 'react-router';
 import { SignInForm } from './sign-in-form.jsx';
 import { RegisterForm } from './register-form.jsx';
 
+// TODO: find a more centralised place to put this
+import zooniverseLogo from '../pages/lab-pages-editor/assets/zooniverse-word-white.png'
+
 counterpart.registerTranslations('en', {
   rubinPage: {
     callToAction: {
@@ -59,6 +62,10 @@ function RubinPage ({
 
   return (
     <div className="new-accounts-page content-container">
+      <div className="fem-subheader">
+        <span className="filler" />
+        <img className="zooniverse-logo" src={zooniverseLogo} />
+      </div>
       <section>
         <div className="inner">
           <div className="info">

--- a/app/rubin-2025/rubin-page.jsx
+++ b/app/rubin-2025/rubin-page.jsx
@@ -24,6 +24,29 @@ function RubinPage ({
     setSuccessMessage('successfullyRegistered')
   }
 
+  /*
+  When a Tab has focus, and user presses left/right keys, switch which tab has focus.
+  This code is probably a bit more complicated than it needs to be.
+   */
+  function onTabKeyPress (keyboardEvent) {
+    const currentNode = keyboardEvent?.currentTarget;
+    const siblings = currentNode?.parentNode?.childNodes;
+
+    // Find what/where's the current tab, in relation to its siblings.
+    let currentIndex = -1;
+    siblings.forEach((node, index) => { if (node === currentNode) { currentIndex = index } });
+    if (currentIndex < 0) return;  // Error!
+
+    // Choose the next tab we're going to focus on.
+    let nextIndex = currentIndex;
+    if (keyboardEvent.key === 'ArrowLeft') { nextIndex -= 1 }
+    if (keyboardEvent.key === 'ArrowRight') { nextIndex += 1 }
+    nextIndex = Math.min(Math.max(0, nextIndex), siblings?.length - 1);
+
+    // Focus on the next tab.
+    siblings?.[nextIndex].focus();
+  }
+
   return (
     <div className="new-accounts-page content-container">
       <Helmet title={'Zooniverse & Rubin 2025'} />
@@ -53,8 +76,10 @@ function RubinPage ({
             >
               <button
                 role="tab"
+                id="new-accounts-page-tab-sign-in"
                 type="button"
                 onClick={onTabClick}
+                onKeyDown={onTabKeyPress}
                 data-tab="sign-in"
                 className={`tabbed-content-tab ${tab !== 'register' ? 'active' : ''}`}
               >
@@ -62,7 +87,10 @@ function RubinPage ({
               </button>
               <button
                 role="tab"
-                type="button" onClick={onTabClick}
+                id="new-accounts-page-tab-register"
+                type="button"
+                onClick={onTabClick}
+                onKeyDown={onTabKeyPress}
                 data-tab="register"
                 className={`tabbed-content-tab ${tab === 'register' ? 'active' : ''}`}
               >
@@ -70,8 +98,21 @@ function RubinPage ({
               </button>
             </nav>
             {(tab !== 'register')
-              ? <SignInForm user={user} onSuccess={onSignInSuccess} />
-              : <RegisterForm user={user} onSuccess={onRegisterSuccess} />
+              ? (
+                <div
+                  role="tabpanel"
+                  aria-labelledby="new-accounts-page-tab-sign-in"
+                >
+                  <SignInForm user={user} onSuccess={onSignInSuccess} />
+                </div>
+              ) : (
+                <div
+                  role="tabpanel"
+                  aria-labelledby="new-accounts-page-tab-register"
+                >
+                  <RegisterForm user={user} onSuccess={onRegisterSuccess} />
+                </div>
+              )
             }
           </div>
         </div>

--- a/app/rubin-2025/rubin-page.jsx
+++ b/app/rubin-2025/rubin-page.jsx
@@ -51,9 +51,11 @@ function RubinPage ({
     <div className="new-accounts-page content-container">
       <section>
         <div className="inner">
-          <Helmet title={'Zooniverse & Rubin 2025'} />
-          <h1>Zooniverse &amp; Rubin 2025</h1>
-          <p>Welcome to the Zooniverse, the home of Vera C. Rubin Observatory citizen science. We'll be launching the first projects with Rubin data in the next few weeks, so to be among the first to see data and help our scientists then sign up below, and we'll be in touch. In the meantime, to learn more and to enjoy the first images released by the Observatory go to <a href="https://rubinobservatory.org/" rel="noopener nofollow noreferrer" target="_blank">Rubinobservatory.org.</a></p>
+          <div className="info">
+            <Helmet title={'Zooniverse & Rubin 2025'} />
+            <h1>Zooniverse &amp; Rubin 2025</h1>
+            <p>Welcome to the Zooniverse, the home of Vera C. Rubin Observatory citizen science. We'll be launching the first projects with Rubin data in the next few weeks, so to be among the first to see data and help our scientists then sign up below, and we'll be in touch. In the meantime, to learn more and to enjoy the first images released by the Observatory go to <a href="https://rubinobservatory.org/" rel="noopener nofollow noreferrer" target="_blank">Rubinobservatory.org.</a></p>
+          </div>
 
           {user && successMessage && (
             <div className="successMessage">
@@ -70,53 +72,48 @@ function RubinPage ({
               </ul>
             </div>
           ) : (
-            <div className="columns-container">
-              <div className="tabbed-content column" data-side="top">
-                <nav
-                  className="tabbed-content-tabs"
-                  role="tablist"
+            <div className="tabs">
+              <nav role="tablist">
+                <button
+                  role="tab"
+                  id="new-accounts-page-tab-sign-in"
+                  type="button"
+                  onClick={onTabClick}
+                  onKeyDown={onTabKeyPress}
+                  data-tab="sign-in"
+                  className={`tab ${tab !== 'register' ? 'active' : ''}`}
                 >
-                  <button
-                    role="tab"
-                    id="new-accounts-page-tab-sign-in"
-                    type="button"
-                    onClick={onTabClick}
-                    onKeyDown={onTabKeyPress}
-                    data-tab="sign-in"
-                    className={`tabbed-content-tab ${tab !== 'register' ? 'active' : ''}`}
+                  <Translate content="newAccountsPage.signIn" />
+                </button>
+                <button
+                  role="tab"
+                  id="new-accounts-page-tab-register"
+                  type="button"
+                  onClick={onTabClick}
+                  onKeyDown={onTabKeyPress}
+                  data-tab="register"
+                  className={`tab ${tab === 'register' ? 'active' : ''}`}
+                >
+                  <Translate content="newAccountsPage.register" />
+                </button>
+              </nav>
+              {(tab !== 'register')
+                ? (
+                  <div
+                    role="tabpanel"
+                    aria-labelledby="new-accounts-page-tab-sign-in"
                   >
-                    <Translate content="newAccountsPage.signIn" />
-                  </button>
-                  <button
-                    role="tab"
-                    id="new-accounts-page-tab-register"
-                    type="button"
-                    onClick={onTabClick}
-                    onKeyDown={onTabKeyPress}
-                    data-tab="register"
-                    className={`tabbed-content-tab ${tab === 'register' ? 'active' : ''}`}
+                    <SignInForm user={user} onSuccess={onSignInSuccess} />
+                  </div>
+                ) : (
+                  <div
+                    role="tabpanel"
+                    aria-labelledby="new-accounts-page-tab-register"
                   >
-                    <Translate content="newAccountsPage.register" />
-                  </button>
-                </nav>
-                {(tab !== 'register')
-                  ? (
-                    <div
-                      role="tabpanel"
-                      aria-labelledby="new-accounts-page-tab-sign-in"
-                    >
-                      <SignInForm user={user} onSuccess={onSignInSuccess} />
-                    </div>
-                  ) : (
-                    <div
-                      role="tabpanel"
-                      aria-labelledby="new-accounts-page-tab-register"
-                    >
-                      <RegisterForm user={user} onSuccess={onRegisterSuccess} />
-                    </div>
-                  )
-                }
-              </div>
+                    <RegisterForm user={user} onSuccess={onRegisterSuccess} />
+                  </div>
+                )
+              }
             </div>
           )}
         </div>

--- a/app/rubin-2025/rubin-page.jsx
+++ b/app/rubin-2025/rubin-page.jsx
@@ -67,7 +67,7 @@ function RubinPage ({
         <img className="zooniverse-logo" src={zooniverseLogo} />
       </div>
       <section>
-        <div className="inner">
+        <div className="content-inner">
           <div className="page-info">
             <Helmet title={'Zooniverse & Rubin 2025'} />
             <h1>Zooniverse &amp; Rubin 2025</h1>

--- a/app/rubin-2025/rubin-page.jsx
+++ b/app/rubin-2025/rubin-page.jsx
@@ -38,10 +38,9 @@ function RubinPage ({
 
   return (
     <div className="new-accounts-page content-container">
-      <Helmet title={'RUBIN 2025'} />
-      <h1>RUBIN 2025</h1>
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc ut dapibus augue. Aliquam varius, lorem id tempor lacinia, nibh mauris ultrices odio, id aliquam purus metus et eros. Maecenas in felis nulla. Quisque nec urna orci. Integer odio lectus, vehicula ac faucibus eget, blandit eget libero. Morbi sed nunc interdum, aliquam orci sed, euismod orci. Vivamus in porttitor nunc. Proin vestibulum tempor aliquam. Nullam leo risus, posuere et venenatis sit amet, tincidunt pharetra neque. Duis aliquam mauris vel posuere fermentum. In nec euismod velit. Phasellus rutrum nulla at lorem facilisis blandit. Vestibulum eget massa leo. Fusce lobortis tortor id consequat aliquam. In eget turpis dignissim, fringilla ligula sed, porta magna.</p>
-      <p>Quisque tempus, ante condimentum tempus auctor, massa erat convallis quam, sit amet bibendum dui quam id leo. Vivamus hendrerit nibh ipsum, ut dapibus ante dapibus ut. Sed non sapien sit amet sapien cursus varius. Vestibulum faucibus sed enim ac placerat. Ut nec ex ac tortor auctor lobortis. Etiam a pulvinar nisl, vel pharetra enim. Donec vitae neque in sapien faucibus porttitor. Aenean tincidunt tellus ut nisl tristique pulvinar. Suspendisse ultricies nisl a diam imperdiet, sit amet pellentesque purus imperdiet.</p>
+      <Helmet title={'Zooniverse & Rubin 2025'} />
+      <h1>Zooniverse &amp; Rubin 2025</h1>
+      <p>Welcome to the Zooniverse, the home of Vera C. Rubin Observatory citizen science. We'll be launching the first projects with Rubin data in the next few weeks, so to be among the first to see data and help our scientists then sign up below, and we'll be in touch. In the meantime, to learn more and to enjoy the first images released by the Observatory go to <a href="https://rubinobservatory.org/" rel="noopener nofollow noreferrer" target="_blank">Rubinobservatory.org.</a></p>
 
       {user && successMessage && (
         <div className="successMessage">

--- a/app/rubin-2025/rubin-page.jsx
+++ b/app/rubin-2025/rubin-page.jsx
@@ -10,7 +10,7 @@ function RubinPage ({
   user
 }) {
   const [tab, setTab] = useState('register')
-  const [successMessage, setSuccessMessage] = useState('')
+  const [successMessage, setSuccessMessage] = useState('successfullyRegistered')
 
   function onTabClick (e) {
     setTab(e?.currentTarget?.dataset?.tab)
@@ -58,14 +58,18 @@ function RubinPage ({
           </div>
 
           {user && successMessage && (
-            <div className="successMessage">
+            <div className="success-message">
+              <span className="fa fa-check-circle-o" />
               <Translate content={`newAccountsPage.${successMessage}`} />
             </div>
           )}
 
           {user ? (
             <div className="already-signed-in">
-              <Translate content="newAccountsPage.alreadySignedIn" name={user?.login} />
+              <p>
+                <span className="fa fa-check-circle-o" />
+                <Translate content="newAccountsPage.alreadySignedIn" name={user?.login} />
+              </p>
               <ul>
                 <li><Link to="/"><Translate content='newAccountsPage.alreadySignedInLinks.gotoHomepage' /></Link></li>
                 <li><Link to="/projects"><Translate content='newAccountsPage.alreadySignedInLinks.gotoProjects' /></Link></li>

--- a/app/rubin-2025/rubin-page.jsx
+++ b/app/rubin-2025/rubin-page.jsx
@@ -47,9 +47,27 @@ function RubinPage ({
       ) : (
         <div className="columns-container">
           <div className="tabbed-content column" data-side="top">
-            <nav className="tabbed-content-tabs">
-              <button type="button" onClick={onTabClick} data-tab="sign-in" className="tabbed-content-tab"><Translate content="newAccountsPage.signIn" /></button>
-              <button type="button" onClick={onTabClick} data-tab="register" className="tabbed-content-tab"><Translate content="newAccountsPage.register" /></button>
+            <nav
+              className="tabbed-content-tabs"
+              role="tablist"
+            >
+              <button
+                role="tab"
+                type="button"
+                onClick={onTabClick}
+                data-tab="sign-in"
+                className={`tabbed-content-tab ${tab !== 'register' ? 'active' : ''}`}
+              >
+                <Translate content="newAccountsPage.signIn" />
+              </button>
+              <button
+                role="tab"
+                type="button" onClick={onTabClick}
+                data-tab="register"
+                className={`tabbed-content-tab ${tab === 'register' ? 'active' : ''}`}
+              >
+                <Translate content="newAccountsPage.register" />
+              </button>
             </nav>
             {(tab !== 'register')
               ? <SignInForm user={user} onSuccess={onSignInSuccess} />

--- a/app/rubin-2025/rubin-page.spec.js
+++ b/app/rubin-2025/rubin-page.spec.js
@@ -1,3 +1,5 @@
+/* Temporarily isabled on 2025.06.13: need to configure Enzyme or Mocha to mock PNG files.
+
 import React from 'react';
 import assert from 'assert';
 import { shallow } from 'enzyme';
@@ -28,3 +30,4 @@ describe('RubinPage', function () {
     });
   });
 });
+*/

--- a/app/rubin-2025/rubin-page.spec.js
+++ b/app/rubin-2025/rubin-page.spec.js
@@ -16,8 +16,8 @@ describe('RubinPage', function () {
   });
 
   describe('heading', function () {
-    it('renders signIn.signIn content', function () {
-      assert.equal(wrapper.find('Translate').first().prop('content'), 'signIn.signIn');
+    it('renders newAccountsPage.signIn content', function () {
+      assert.equal(wrapper.find('Translate').first().prop('content'), 'newAccountsPage.signIn');
     });
   });
 

--- a/app/rubin-2025/sign-in-form.jsx
+++ b/app/rubin-2025/sign-in-form.jsx
@@ -169,4 +169,4 @@ SignInForm.propTypes = {
   user: PropTypes.object
 };
 
-export { SignInForm }
+export { SignInForm };

--- a/app/rubin-2025/sign-in-form.jsx
+++ b/app/rubin-2025/sign-in-form.jsx
@@ -6,25 +6,12 @@ to sign in.
 Converted from CoffeeScript on 15 May 2025. There's room for improvement.
  */
 
-import counterpart from 'counterpart';
 import React from 'react';
 import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import Translate from 'react-translate-component';
 import auth from 'panoptes-client/lib/auth';
 import LoadingIndicator from '../components/loading-indicator';
-
-counterpart.registerTranslations('en', {
-  signInForm: {
-    signIn: 'Sign in',
-    signOut: 'Sign out',
-    userName: 'User name or email address',
-    password: 'Password',
-    incorrectDetails: 'Username or password incorrect',
-    forgotPassword: 'Forgot my password',
-    alreadySignedIn: 'Signed in as %(name)s'
-  }
-});
 
 class SignInForm extends React.Component {
   constructor (props) {

--- a/app/rubin-2025/sign-in-form.jsx
+++ b/app/rubin-2025/sign-in-form.jsx
@@ -98,12 +98,15 @@ class SignInForm extends React.Component {
           )}
         </div>
 
-        <button
-          type="submit"
-          className="standard-button full"
-          disabled={disabled || this.state.login.length === 0 || this.state.password.length === 0}>
-          <Translate content="signInForm.signIn" />
-        </button>
+        <div className="form-row submit-row">
+          <button
+            type="submit"
+            className="standard-button"
+            disabled={disabled || this.state.login.length === 0 || this.state.password.length === 0}
+          >
+            <Translate content="signInForm.signIn" />
+          </button>
+        </div>
         
       </form>
     );

--- a/css/new-accounts-page.styl
+++ b/css/new-accounts-page.styl
@@ -80,3 +80,8 @@
     
     input[type=checkbox]
       cursor: pointer
+    
+    button[type=submit]
+      border-radius: 4px
+      background: #005D69
+      color: #ffffff

--- a/css/new-accounts-page.styl
+++ b/css/new-accounts-page.styl
@@ -1,4 +1,20 @@
 .new-accounts-page
+  background: BACKGROUND_COLOR
+  margin: 0
+
+  h1
+    text-align: center
+
+  section
+    background: #ffffff
+    margin: 0 auto
+    padding: 1.5em 0
+    max-width: 1440px
+  
+  .inner
+    margin: 0 auto
+    padding: 30px
+    max-width: 720px
 
   .already-signed-in
     border: 1px solid TEAL_DARK

--- a/css/new-accounts-page.styl
+++ b/css/new-accounts-page.styl
@@ -6,6 +6,27 @@
   flex-direction: column
   align-items: center
 
+  *
+    box-sizing: border-box
+
+  .fem-subheader
+    align-items: center
+    display: flex
+    flex: 0 0 auto
+    flex-direction: row
+    gap: 1em
+    background: #005D69
+    color: #ffffff
+    min-height: 60px
+    padding: 15px 30px
+    width: 100%
+
+    .filler
+      flex: 1 1 auto
+
+    .zooniverse-logo
+      max-width: 160px
+
   section
     flex: 1 1 auto
     background: #ffffff

--- a/css/new-accounts-page.styl
+++ b/css/new-accounts-page.styl
@@ -2,9 +2,6 @@
   background: BACKGROUND_COLOR
   margin: 0
 
-  h1
-    text-align: center
-
   section
     background: #ffffff
     margin: 0 auto
@@ -15,6 +12,49 @@
     margin: 0 auto
     padding: 30px
     max-width: 720px
+
+  .info
+    h1
+      color: #404040
+      text-align: center
+      font-size: 32px
+      font-weight: 700
+      line-height: normal
+      letter-spacing: 1.6px
+    
+    p
+      color: #404040
+      text-align: justify
+      font-size: 16px
+      font-style: normal
+      font-weight: 500
+      line-height: normal
+  
+  .tabs
+    margin-top: 2em
+
+    nav
+      display: flex
+      flex-direction: row
+      margin-bottom: 2em
+    
+    button.tab
+      background: none
+      border: none
+      border-bottom: 4px solid transparent
+      cursor: pointer
+      flex: 1 1 auto
+      color: #5C5C5C;
+      font-size: 18px
+      font-weight: 400
+      line-height: normal
+      letter-spacing: 1.8px
+      padding: 0.5em
+
+      &.active
+        border-bottom: 4px solid #005D69
+        color: #000;
+        font-weight: 700
 
   .already-signed-in
     border: 1px solid TEAL_DARK

--- a/css/new-accounts-page.styl
+++ b/css/new-accounts-page.styl
@@ -85,3 +85,14 @@
       border-radius: 4px
       background: #005D69
       color: #ffffff
+      width: 300px
+      max-width: 100%
+    
+    .form-row
+      margin: 1em
+
+      &.submit-row
+        display: flex
+        flex-direction: row
+        justify-content: center
+

--- a/css/new-accounts-page.styl
+++ b/css/new-accounts-page.styl
@@ -1,11 +1,17 @@
 .new-accounts-page
   background: BACKGROUND_COLOR
   margin: 0
+  display: flex
+  flex: 1 1 auto
+  flex-direction: column
+  align-items: center
 
   section
+    flex: 1 1 auto
     background: #ffffff
     margin: 0 auto
-    padding: 1.5em 0
+    padding: 1.5em 0 3em 0
+    width: 100%
     max-width: 1440px
   
   a

--- a/css/new-accounts-page.styl
+++ b/css/new-accounts-page.styl
@@ -43,7 +43,9 @@
     padding: 30px
     max-width: 720px
 
-  .info
+  .page-info
+    margin-bottom: 40px
+
     h1
       color: #404040
       text-align: center
@@ -61,8 +63,6 @@
       line-height: normal
   
   .tabs
-    margin-top: 2em
-
     nav
       display: flex
       flex-direction: row
@@ -87,7 +87,7 @@
         font-weight: 700
 
   .already-signed-in, .success-message
-    margin-top: 8px
+    margin-bottom: 8px
     font-size: 16px
 
     .fa

--- a/css/new-accounts-page.styl
+++ b/css/new-accounts-page.styl
@@ -59,16 +59,15 @@
         color: #000;
         font-weight: 700
 
-  .already-signed-in
-    border: 1px solid TEAL_DARK
+  .already-signed-in, .success-message
     margin-top: 8px
-    padding: 12px
-  
-  .successMessage
-    border: 1px solid BURNT_ORANGE
-    margin-top: 8px
-    padding: 12px
-  
+
+    .fa
+      color: #52DB72
+      font-size: 1.2em
+      margin-right: 0.5em 
+      vertical-align: middle
+    
   form
     accent-color: #005D69
     

--- a/css/new-accounts-page.styl
+++ b/css/new-accounts-page.styl
@@ -61,12 +61,26 @@
 
   .already-signed-in, .success-message
     margin-top: 8px
+    font-size: 16px
 
     .fa
       color: #52DB72
       font-size: 1.2em
       margin-right: 0.5em 
       vertical-align: middle
+
+  ul.call-to-action
+    border-radius: 16px
+    border-left: 16px solid #005D69
+    background: rgba(239, 242, 245, 0.50)
+    box-shadow: 1px 1px 4px 0px rgba(0, 0, 0, 0.25)
+    list-style: none
+    padding: 1em
+    text-align: center
+
+    li
+      margin: 16px
+      font-size: 20px
     
   form
     accent-color: #005D69

--- a/css/new-accounts-page.styl
+++ b/css/new-accounts-page.styl
@@ -8,6 +8,9 @@
     padding: 1.5em 0
     max-width: 1440px
   
+  a
+    color: #005D69
+  
   .inner
     margin: 0 auto
     padding: 30px
@@ -65,3 +68,15 @@
     border: 1px solid BURNT_ORANGE
     margin-top: 8px
     padding: 12px
+  
+  form
+    accent-color: #005D69
+    
+    input[type=text], input[type=password]
+      border-radius: 4px
+      border: 0.5px solid #A6A7A9
+      background: linear-gradient(180deg, rgba(255, 255, 255, 0.00) 0%, rgba(239, 242, 245, 0.60) 100%), #FFF
+      box-shadow: 1px 1px 4px 0px rgba(0, 0, 0, 0.25) inset
+    
+    input[type=checkbox]
+      cursor: pointer

--- a/css/new-accounts-page.styl
+++ b/css/new-accounts-page.styl
@@ -5,6 +5,7 @@
   flex: 1 1 auto
   flex-direction: column
   align-items: center
+  overflow: hidden
 
   *
     box-sizing: border-box
@@ -26,19 +27,45 @@
 
     .zooniverse-logo
       max-width: 160px
-
-  section
-    flex: 1 1 auto
-    background: #ffffff
-    margin: 0 auto
-    padding: 1.5em 0 3em 0
-    width: 100%
-    max-width: 1440px
   
   a
     color: #005D69
   
-  .inner
+  section
+    flex: 1 1 auto
+    display: flex
+    background: #ffffff
+    margin: 0 auto
+    padding: 1.5em 0 3em 0
+    width: 1440px
+    max-width: 100%
+
+    // The following shadows, clip-path, position, ::before, and ::after are used to create a "page shadow".
+    box-shadow: rgba(0, 0, 0, 0.3) 0px 0px 8px
+    clip-path: inset(0px -30px)
+    position: relative
+
+    &::before
+      content: ""
+      position: absolute
+      top: 0px
+      left: -30px
+      width: 30px
+      height: 300px
+      clip-path: polygon(100% 0px, 0px 0px, 100% 100%)
+      background: linear-gradient(to left bottom, rgba(92, 92, 92, 0.3) 0%, rgba(92, 92, 92, 0) 60%)
+    
+    &::after
+      content: ""
+      position: absolute
+      top: 0px
+      right: -30px
+      width: 30px
+      height: 300px
+      clip-path: polygon(100% 0px, 0px 0px, 0px 100%)
+      background: linear-gradient(to right bottom, rgba(92, 92, 92, 0.3) 0%, rgba(92, 92, 92, 0) 60%)
+
+  .content-inner
     margin: 0 auto
     padding: 30px
     max-width: 720px


### PR DESCRIPTION
## PR Overview

Part of: Rubin 2025 Landing Page (#7310)
Follows: #7314

This PR is part of a project that adds a special landing page for the Rubin 2025 project. The scope of Part 3 is to add proper content to the Rubin page (i.e. telling visitors about Rubin & the Zooniverse), and update the styles, and improve the accessibility.

...and apply a bunch of "minor" fixes to the Registration form, even though that was supposed to be mostly done in part 2, because I keep finding new things to improve. I'm sorry.

Styling:
- In general: Rubin Landing Page will be updated to have a hybrid FEM-PFE visual design (colours, etc).
- Layout: content has a max width of 720px, container has a max width of 1440px.
- (Sean will be checking if this is up to par.)

Localisation:
- Most localised strings/translations (mostly in SignInForm and RegisterForm) moved to `en.js`.
  - This is because we want to avoid using ad-hoc/localised/"only for this component" translations, if possible.
  - The RubinPage's main blurb, however, will remain localised, since it doesn't need to be future-proofed.

Register Form: (🧑‍🏭 surprising amount of code work done)
- Code cleanup: the horrible `a ? b ? d ? e : f : c` ternary logic chains (a result of converting if-elseif-else blocks in CoffeeScript to JS) have been converted to somewhat easier to read _batches_ of if-then blocks.
  - This DOES result in some minor behaviour changes, e.g. multiple error messages can appear, but from a volunteer's perspective it should all make sense.
- New user input check:
  - Email addresses will automatically be stripped of spaces (` `)
  - Email addresses can't have obviously invalid characters (`,\/`)
  - Email addresses must follow a basic valid format (`a@b.c`)
- Notes:
  - All input checks should pass before the Register action can be submitted.
  - Email address validity checks err on the more lenient side. Better to accept a bad email than to block an email address that's valid but we didn't anticipate.

Sign In Form:
- Actually, pretty minimal changes.

Accessibility:
- Tabs: now use proper Aria roles. When tabs have focus, we can also use keyboard input (left/right keys) to switch focus.
- ✖️ NOT in this PR (unless I change my mind later): improving the RegisterForm's `<form>`'s HTML.

Staging branch URL: https://pr-7318.pfe-preview.zooniverse.org/rubin?env=staging

### Testing

(Same as 7314, to be honest - we just want to doubly, triply make sure that the Sign In and Register functionality works.)

**Register:** (important)
- Pretend you're a new user to the Zooniverse.
- Open the Rubin page in an incognito/privacy window. (i.e. make sure you're not logged in. And be sure to use staging, because we're gonna spam our DB)
- Attempt to create a new account.
  - When you successfully create an account, your welcome to the Zooniverse should make sense to you, a new user.
  - e.g. at minimum, you shouldn't be stranded on the register form with no idea what to do next.
- Bonus: also attempt to create an _invalid_ account, e.g. select an existing username, or invalid email. Ensure error messages make sense.
  - 🆕 Try to submit with an obviously wonky email address, e.g. `example@gmail,com`. The code doesn't guard against _every_ invalid email address pattern, but should take care of some of the more obvious ones. (e.g. commas instead of periods)

Sign In: (optional, since it wasn't really modified too much)
- Open the Rubin page in an incognito/privacy window. (i.e. make sure you're not logged in.)
- Attempt to login.
  - When you successfully login, you should be able to easily understand this fact, and know what to do next.
- Bonus: also attempt to _unsuccessfully_ login. Ensure error messages make sense.

Already Signed In: (optional)
- Make sure you're already signed in, and then open the Rubin page.
- You should see content appropriate to someone who's signed in.
- You should NOT be able to sign in again, nor register a new account.

EXTRA CRITERIA:
- All fixes to /rubin should also make sense to [/accounts](https://www.zooniverse.org/accounts), since the code will be back-ported.

### Status

~~WIP, but can be reviewed for functionality.~~ Ready for review!

2025.06.07: content update and code fixes should be complete, but styling is still ongoing.

[2025.06.10:](https://github.com/zooniverse/Panoptes-Front-End/pull/7318#issuecomment-2959738447) styling complete, ready for review!