### PR TITLE
fix: Rubin page logs out signed-in volunteers

### DIFF
--- a/app/partials/app.cjsx
+++ b/app/partials/app.cjsx
@@ -39,7 +39,7 @@ PanoptesApp = createReactClass
 
   getInitialState: ->
     initialLoadComplete: false
-    user: null
+    user: undefined
 
   getDefaultProps: ->
     notificationsCounter: new NotificationsCounter()

--- a/app/rubin-2025/rubin-page.jsx
+++ b/app/rubin-2025/rubin-page.jsx
@@ -60,6 +60,12 @@ function RubinPage ({
     siblings?.[nextIndex].focus();
   }
 
+  if (user === undefined) {
+    // If the user is undefined, we are still waiting for the user to be loaded.
+    // This is a common pattern in the app, so we return null here.
+    return null;
+  }
+
   return (
     <div className="new-accounts-page content-container">
       <div className="fem-subheader">


### PR DESCRIPTION
A quick fix for a bug where the register form logs you out if your browser autofills your details.

- change the `user` prop to have 3 states:
  - `undefined`: waiting to load.
  - `null`: not signed in.
  - `{ id, login, ...}`: signed in.

Delay rendering the Rubin page while `user` is undefined.

Staging branch URL: https://pr-{NUMBER}.pfe-preview.zooniverse.org

Fixes # .

Describe your changes.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
