### PR TITLE
Rubin 2025 Landing Page pt4: improve html+accessibility, various fixes 

### DIFF
--- a/app/rubin-2025/register-form.jsx
+++ b/app/rubin-2025/register-form.jsx
@@ -320,8 +320,6 @@ class RegisterForm extends React.Component {
             id="register-form-creditedName"
             name="creditedName"
             onChange={this.handleUserInput}
-            pattern='[^@]+'
-            title={counterpart('registerForm.realNamePatternHelp')}
             type="text"
             value={this.state.input_creditedName}
           />

--- a/app/rubin-2025/register-form.jsx
+++ b/app/rubin-2025/register-form.jsx
@@ -124,6 +124,7 @@ class RegisterForm extends React.Component {
 
             {(this.state.input_login?.length > 0
               && nameConflict === false
+              && !("nameConflict" in this.state.pending)
             ) && (
               <span className="form-help success">
                 <Translate content="registerForm.looksGood" />
@@ -253,6 +254,7 @@ class RegisterForm extends React.Component {
               && !emailConflict
               && !emailInvalidChars
               && !emailInvalidFormat
+              && !('emailConflict' in this.state.pending)
             ) && (
               <Translate className="form-help success" content="registerForm.looksGood" />
             )}

--- a/app/rubin-2025/register-form.jsx
+++ b/app/rubin-2025/register-form.jsx
@@ -79,25 +79,36 @@ class RegisterForm extends React.Component {
     return (
       <form className="register-form" method="POST" onSubmit={this.handleSubmit}>
         
-        <label className="form-separator">
-          <input
-            type="checkbox"
-            checked={this.state.underAge}
-            disabled={inputDisabled}
-            onChange={this.updateAge}
-          />
-          <Translate component="span" content="registerForm.underAge" />
-        </label>
+        <div className="form-row">
+          <span className="checkbox-pair">
+            <input
+              checked={this.state.underAge}
+              disabled={inputDisabled}
+              id="register-form-underAge"
+              name="underAge"
+              onChange={this.updateAge}
+              type="checkbox"
+            />
+            <label htmlFor="register-form-underAge">
+              <Translate component="span" content="registerForm.underAge" />
+            </label>
+          </span>
+        </div>
 
-        <label>
-          <span className="columns-container inline spread">
-            <Translate content="registerForm.userName" />
+        <div className="form-row">
+          <div className="label-block">
+            <label htmlFor="register-form-login">
+              <Translate content="registerForm.userName" />
+            </label>
+
             {badNameChars?.length > 0 && (
               <Translate className="form-help error" content="registerForm.badChars" />
             )}
+
             {"nameConflict" in this.state.pending && (
               <LoadingIndicator />
             )}
+
             {nameConflict && (
               <span className="form-help error">
                 <Translate content="registerForm.nameConflict" />{' '}
@@ -106,6 +117,7 @@ class RegisterForm extends React.Component {
                 </a>
               </span>
             )}
+
             {(this.state.input_login?.length > 0
               && nameConflict === false
             ) && (
@@ -113,8 +125,10 @@ class RegisterForm extends React.Component {
                 <Translate content="registerForm.looksGood" />
               </span>
             )}
+
             <Translate className="form-help info right-align" content="registerForm.required" />
-          </span>
+          </div>
+
           <input
             type="text"
             name="login"
@@ -125,11 +139,14 @@ class RegisterForm extends React.Component {
             onChange={this.handleUserInput}
             maxLength="255"
           />
-          <Translate component="span" className="form-help info" content="registerForm.whyUserName" />
-          {this.state.underAge && (
-            <Translate component="span" className="form-help info" content="registerForm.notRealName" />
-          )}
-        </label>
+
+          <div>
+            <Translate component="span" className="form-help info" content="registerForm.whyUserName" />
+            {this.state.underAge && (
+              <Translate component="span" className="form-help info" content="registerForm.notRealName" />
+            )}
+          </div>
+        </div>
 
         <br />
 

--- a/app/rubin-2025/register-form.jsx
+++ b/app/rubin-2025/register-form.jsx
@@ -363,11 +363,9 @@ class RegisterForm extends React.Component {
             </span>
           )}
 
-          <div>
+          <div id="register-form-error-message" className="form-help error">
             {this.state.error && (
-              <div id="register-form-error-message" className="form-help error">
-                <span>{this.state.error.toString()}</span>
-              </div>
+              <span>{this.state.error.toString()}</span>
             )}
           </div>
         </div>
@@ -376,7 +374,7 @@ class RegisterForm extends React.Component {
           <button
             type="submit"
             className="standard-button"
-            disabled={submitDisabled}
+            disabled={false && submitDisabled}
           >
             <Translate content="registerForm.register" />
           </button>

--- a/app/rubin-2025/register-form.jsx
+++ b/app/rubin-2025/register-form.jsx
@@ -130,14 +130,15 @@ class RegisterForm extends React.Component {
           </div>
 
           <input
-            type="text"
-            name="login"
-            id="register-form-login"
-            value={this.state.input_login}
+            aria-describedby="register-form-error-message"
             className="standard-input full"
             disabled={inputDisabled}
-            onChange={this.handleUserInput}
+            id="register-form-login"
             maxLength="255"
+            name="login"
+            onChange={this.handleUserInput}
+            type="text"
+            value={this.state.input_login}
           />
 
           <div>
@@ -159,6 +160,7 @@ class RegisterForm extends React.Component {
             <Translate className="form-help info right-align" content="registerForm.required" />
           </div>
           <input
+            aria-describedby="register-form-error-message"
             className="standard-input full"
             disabled={inputDisabled}
             id="register-form-password"
@@ -239,13 +241,14 @@ class RegisterForm extends React.Component {
           </div>
 
           <input
-            type="text"
-            name="email"
-            id="register-form-email"
-            value={this.state.input_email}
+            aria-describedby="register-form-error-message"
             className="standard-input full"
             disabled={inputDisabled}
+            id="register-form-email"
+            name="email"
             onChange={this.handleUserInput}
+            type="text"
+            value={this.state.input_email}
           />
         </div>
 
@@ -257,15 +260,15 @@ class RegisterForm extends React.Component {
             <Translate className="form-help info right-align" content="registerForm.optional" />
           </div>
           <input
-            type="text"
-            pattern='[^@]+'
-            name="creditedName"
-            id="register-form-creditedName"
-            value={this.state.input_creditedName}
             className="standard-input full"
             disabled={inputDisabled}
-            title={counterpart('registerForm.realNamePatternHelp')}
+            id="register-form-creditedName"
+            name="creditedName"
             onChange={this.handleUserInput}
+            pattern='[^@]+'
+            title={counterpart('registerForm.realNamePatternHelp')}
+            type="text"
+            value={this.state.input_creditedName}
           />
           <Translate component="span" className="form-help info" content="registerForm.whyRealName" />
         </div>
@@ -323,24 +326,31 @@ class RegisterForm extends React.Component {
         </div>
 
         <div className="center-align">
-          {'user' in this.state.pending
-            ? <LoadingIndicator />
-            : this.props.user != null
-            ? <span className="form-help warning">
-                <Translate content="registerForm.alreadySignedIn" name={this.props.user.login} />{' '}
-                <button type="button" className="minor-button" onClick={this.handleSignOut}><Translate content="registerForm.signOut" /></button>
-              </span>
-            : this.state.error != null
-            ? <span className="form-help error">{this.state.error.toString()}</span>
-            : <span>&nbsp;</span>
-          }
+          {'user' in this.state.pending && (
+            <LoadingIndicator />
+          )}
+
+          {this.props.user && (
+            <span className="form-help warning">
+              <Translate content="registerForm.alreadySignedIn" name={this.props.user.login} />{' '}
+              <button type="button" className="minor-button" onClick={this.handleSignOut}><Translate content="registerForm.signOut" /></button>
+            </span>
+          )}
+
+          <div aria-live="polite">
+            {this.state.error && (
+              <div id="register-form-error-message" className="form-help error">
+                <span>{this.state.error.toString()}</span>
+              </div>
+            )}
+          </div>
         </div>
 
         <div className="form-row submit-row">
           <button
             type="submit"
             className="standard-button"
-            disabled={submitDisabled}
+            disabled={false && submitDisabled}
           >
             <Translate content="registerForm.register" />
           </button>

--- a/app/rubin-2025/register-form.jsx
+++ b/app/rubin-2025/register-form.jsx
@@ -122,7 +122,6 @@ class RegisterForm extends React.Component {
             value={this.state.input_login}
             className="standard-input full"
             disabled={inputDisabled}
-            autoFocus
             onChange={this.handleUserInput}
             maxLength="255"
           />

--- a/app/rubin-2025/register-form.jsx
+++ b/app/rubin-2025/register-form.jsx
@@ -350,7 +350,7 @@ class RegisterForm extends React.Component {
           <button
             type="submit"
             className="standard-button"
-            disabled={false && submitDisabled}
+            disabled={submitDisabled}
           >
             <Translate content="registerForm.register" />
           </button>

--- a/app/rubin-2025/register-form.jsx
+++ b/app/rubin-2025/register-form.jsx
@@ -122,21 +122,29 @@ class RegisterForm extends React.Component {
               )}
             </div>
 
-            {(this.state.input_login?.length > 0
-              && nameConflict === false
-              && !("nameConflict" in this.state.pending)
-            ) && (
-              <span className="form-help success">
-                <Translate content="registerForm.looksGood" />
-              </span>
-            )}
+            <div id="register-form-login-help-message-looksGood">
+              {(this.state.input_login?.length > 0
+                && nameConflict === false
+                && !("nameConflict" in this.state.pending)
+              ) && (
+                <span className="form-help success">
+                  <Translate
+                    content="registerForm.looksGood"
+                  />
+                </span>
+              )}
+            </div>
 
-            <Translate className="form-help info right-align" content="registerForm.required" />
+            <Translate
+              className="form-help info right-align"
+              content="registerForm.required"
+              id="register-form-login-help-message-required"
+            />
           </div>
 
           <input
             autoComplete="username"
-            aria-describedby="register-form-error-message register-form-login-help-message-1 register-form-login-help-message-2"
+            aria-describedby="register-form-error-message register-form-login-help-message-1 register-form-login-help-message-2 register-form-login-help-message-looksGood register-form-login-help-message-required register-form-login-help-message-whyUserName"
             className="standard-input full"
             disabled={inputDisabled}
             id="register-form-login"
@@ -147,7 +155,7 @@ class RegisterForm extends React.Component {
             value={this.state.input_login}
           />
 
-          <div>
+          <div id="register-form-login-help-message-whyUserName">
             <Translate component="span" className="form-help info" content="registerForm.whyUserName" />
             {this.state.underAge && (
               <Translate component="span" className="form-help info" content="registerForm.notRealName" />
@@ -167,11 +175,15 @@ class RegisterForm extends React.Component {
               )}
             </div>
 
-            <Translate className="form-help info right-align" content="registerForm.required" />
+            <Translate
+              className="form-help info right-align"
+              content="registerForm.required"
+              id="register-form-password-help-required"
+            />
           </div>
           <input
             autoComplete="new-password"
-            aria-describedby="register-form-error-message register-form-password-help-message"
+            aria-describedby="register-form-error-message register-form-password-help-message register-form-password-help-required"
             className="standard-input full"
             disabled={inputDisabled}
             id="register-form-password"
@@ -194,18 +206,24 @@ class RegisterForm extends React.Component {
               )}
             </div>
 
-            {(this.state.input_password?.length > 0
-              && this.state.input_confirmedPassword?.length > 0
-              && !passwordsDontMatch
-              && !passwordTooShort
-            ) && (
-              <Translate className="form-help success" content="registerForm.looksGood" />
-            )}
+            <div id="register-form-confirmedPassword-help-looksGood">
+              {(this.state.input_password?.length > 0
+                && this.state.input_confirmedPassword?.length > 0
+                && !passwordsDontMatch
+                && !passwordTooShort
+              ) && (
+                <Translate className="form-help success" content="registerForm.looksGood" />
+              )}
+            </div>
 
-            <Translate className="form-help info right-align" content="registerForm.required" />
+            <Translate
+              className="form-help info right-align"
+              content="registerForm.required"
+              id="register-form-confirmedPassword-help-required"
+            />
           </div>
           <input
-            aria-describedby="register-form-confirmedPassword-help-message"
+            aria-describedby="register-form-confirmedPassword-help-message register-form-confirmedPassword-help-looksGood register-form-confirmedPassword-help-required"
             className="standard-input full"
             disabled={inputDisabled}
             id="register-form-confirmedPassword"
@@ -252,21 +270,27 @@ class RegisterForm extends React.Component {
               )}
             </div>
 
-            {(this.state.input_email?.length > 0
-              && !emailConflict
-              && !emailInvalidChars
-              && !emailInvalidFormat
-              && !('emailConflict' in this.state.pending)
-            ) && (
-              <Translate className="form-help success" content="registerForm.looksGood" />
-            )}
+            <div id="register-form-email-help-message-looksGood">
+              {(this.state.input_email?.length > 0
+                && !emailConflict
+                && !emailInvalidChars
+                && !emailInvalidFormat
+                && !('emailConflict' in this.state.pending)
+              ) && (
+                <Translate className="form-help success" content="registerForm.looksGood" />
+              )}
+            </div>
 
-            <Translate className="form-help info right-align" content="registerForm.required" />
+            <Translate
+              className="form-help info right-align"
+              content="registerForm.required"
+              id="register-form-email-help-message-required"
+            />
           </div>
 
           <input
             autoComplete="email"
-            aria-describedby="register-form-error-message register-form-email-help-message-1 register-form-email-help-message-2 register-form-email-help-message-3"
+            aria-describedby="register-form-error-message register-form-email-help-message-1 register-form-email-help-message-2 register-form-email-help-message-3 register-form-email-help-message-looksGood register-form-email-help-message-required"
             className="standard-input full"
             disabled={inputDisabled}
             id="register-form-email"
@@ -282,10 +306,15 @@ class RegisterForm extends React.Component {
             <label htmlFor="register-form-creditedName">
               <Translate content="registerForm.realName" />
             </label>
-            <Translate className="form-help info right-align" content="registerForm.optional" />
+            <Translate
+              className="form-help info right-align"
+              content="registerForm.optional"
+              id="register-form-creditedName-help-message-optional"
+            />
           </div>
           <input
             autoComplete="name"
+            aria-describedby="register-form-creditedName-help-message-optional register-form-creditedName-help-message-whyRealName"
             className="standard-input full"
             disabled={inputDisabled}
             id="register-form-creditedName"
@@ -296,7 +325,12 @@ class RegisterForm extends React.Component {
             type="text"
             value={this.state.input_creditedName}
           />
-          <Translate component="span" className="form-help info" content="registerForm.whyRealName" />
+          <Translate
+            component="span"
+            className="form-help info"
+            content="registerForm.whyRealName"
+            id="register-form-creditedName-help-message-whyRealName"
+          />
         </div>
 
         <div className="form-row">
@@ -374,7 +408,7 @@ class RegisterForm extends React.Component {
           <button
             type="submit"
             className="standard-button"
-            disabled={false && submitDisabled}
+            disabled={submitDisabled}
           >
             <Translate content="registerForm.register" />
           </button>

--- a/app/rubin-2025/register-form.jsx
+++ b/app/rubin-2025/register-form.jsx
@@ -101,7 +101,7 @@ class RegisterForm extends React.Component {
               <Translate content="registerForm.userName" />
             </label>
 
-            <div aria-live="polite" id="register-form-login-help-message-1">
+            <div id="register-form-login-help-message-1">
               {badNameChars?.length > 0 && (
                 <Translate className="form-help error" content="registerForm.badChars" />
               )}
@@ -111,7 +111,7 @@ class RegisterForm extends React.Component {
               <LoadingIndicator />
             )}
 
-            <div aria-live="polite" id="register-form-login-help-message-2">
+            <div id="register-form-login-help-message-2">
               {nameConflict && (
                 <span className="form-help error">
                   <Translate content="registerForm.nameConflict" />{' '}
@@ -160,7 +160,7 @@ class RegisterForm extends React.Component {
               <Translate content="registerForm.password" />
             </label>
             
-            <div aria-live="polite" id="register-form-password-help-message">
+            <div id="register-form-password-help-message">
               {passwordTooShort && (
                 <Translate className="form-help error" content="registerForm.passwordTooShort" />
               )}
@@ -186,7 +186,7 @@ class RegisterForm extends React.Component {
               <Translate content="registerForm.confirmPassword" />
             </label>
             
-            <div aria-live="polite" id="register-form-confirmedPassword-help-message">
+            <div id="register-form-confirmedPassword-help-message">
               {passwordsDontMatch && (
                 <Translate className="form-help error" content="registerForm.passwordsDontMatch" />
               )}
@@ -223,13 +223,13 @@ class RegisterForm extends React.Component {
               }
             </label>
 
-            <div aria-live="polite" id="register-form-email-help-message-1">
+            <div id="register-form-email-help-message-1">
               {emailInvalidChars && (
                 <Translate className="form-help error" content="registerForm.emailInvalidChars" />
               )}
             </div>
 
-            <div aria-live="polite" id="register-form-email-help-message-2">
+            <div id="register-form-email-help-message-2">
               {(!emailInvalidChars && emailInvalidFormat) && (
                 <Translate className="form-help info" content="registerForm.emailInvalidFormat" />
               )}
@@ -239,7 +239,7 @@ class RegisterForm extends React.Component {
               <LoadingIndicator />
             )}
 
-            <div aria-live="polite" id="register-form-email-help-message-3">
+            <div id="register-form-email-help-message-3">
               {emailConflict && (
                 <span className="form-help error">
                   <Translate content="registerForm.emailConflict" />{' '}
@@ -359,7 +359,7 @@ class RegisterForm extends React.Component {
             </span>
           )}
 
-          <div aria-live="polite">
+          <div>
             {this.state.error && (
               <div id="register-form-error-message" className="form-help error">
                 <span>{this.state.error.toString()}</span>

--- a/app/rubin-2025/register-form.jsx
+++ b/app/rubin-2025/register-form.jsx
@@ -296,7 +296,7 @@ class RegisterForm extends React.Component {
             id="register-form-email"
             name="email"
             onChange={this.handleUserInput}
-            type="text"
+            type="email"
             value={this.state.input_email}
           />
         </div>

--- a/app/rubin-2025/register-form.jsx
+++ b/app/rubin-2025/register-form.jsx
@@ -80,7 +80,7 @@ class RegisterForm extends React.Component {
       <form className="register-form" method="POST" onSubmit={this.handleSubmit}>
         
         <div className="form-row">
-          <span className="checkbox-pair">
+          <span className="checkbox-block">
             <input
               checked={this.state.underAge}
               disabled={inputDisabled}
@@ -148,32 +148,32 @@ class RegisterForm extends React.Component {
           </div>
         </div>
 
-        <br />
-
-        <label>
-          <span className="columns-container inline spread">
-            <Translate content="registerForm.password" />
+        <div className="form-row">
+          <div className="label-block">
+            <label htmlFor="register-form-password">
+              <Translate content="registerForm.password" />
+            </label>
             {passwordTooShort && (
               <Translate className="form-help error" content="registerForm.passwordTooShort" />
             )}
             <Translate className="form-help info right-align" content="registerForm.required" />
-          </span>
+          </div>
           <input
-            type="password"
-            name="password"
-            id="register-form-password"
-            value={this.state.input_password}
             className="standard-input full"
             disabled={inputDisabled}
+            id="register-form-password"
+            name="password"
             onChange={this.handleUserInput}
+            type="password"
+            value={this.state.input_password}
           />
-        </label>
+        </div>
 
-        <br />
-
-        <label>
-          <span className="columns-container inline spread">
-            <Translate content="registerForm.confirmPassword" /><br />
+        <div className="form-row">
+          <div className="label-block">
+            <label htmlFor="register-form-confirmedPassword">
+              <Translate content="registerForm.confirmPassword" />
+            </label>
             {passwordsDontMatch && (
               <Translate className="form-help error" content="registerForm.passwordsDontMatch" />
             )}
@@ -185,35 +185,39 @@ class RegisterForm extends React.Component {
               <Translate className="form-help success" content="registerForm.looksGood" />
             )}
             <Translate className="form-help info right-align" content="registerForm.required" />
-          </span>
+          </div>
           <input
-            type="password"
-            name="confirmedPassword"
-            id="register-form-confirmedPassword"
-            value={this.state.input_confirmedPassword}
             className="standard-input full"
             disabled={inputDisabled}
+            id="register-form-confirmedPassword"
+            name="confirmedPassword"
             onChange={this.handleUserInput}
+            type="password"
+            value={this.state.input_confirmedPassword}
           />
-        </label>
+        </div>
 
-        <br />
+        <div className="form-row">
+          <div className="label-block">
+            <label htmlFor="register-form-email">
+              {this.state.underAge
+                ? <Translate content="registerForm.guardianEmail" />
+                : <Translate content="registerForm.email" />
+              }
+            </label>
 
-        <label>
-          <span className="columns-container inline spread">
-            {this.state.underAge
-              ? <Translate content="registerForm.guardianEmail" />
-              : <Translate content="registerForm.email" />
-            }
             {emailInvalidChars && (
               <Translate className="form-help error" content="registerForm.emailInvalidChars" />
             )}
+
             {(!emailInvalidChars && emailInvalidFormat) && (
               <Translate className="form-help info" content="registerForm.emailInvalidFormat" />
             )}
+
             {'emailConflict' in this.state.pending && (
               <LoadingIndicator />
             )}
+
             {emailConflict && (
               <span className="form-help error">
                 <Translate content="registerForm.emailConflict" />{' '}
@@ -222,6 +226,7 @@ class RegisterForm extends React.Component {
                 </a>
               </span>
             )}
+
             {(this.state.input_email?.length > 0
               && !emailConflict
               && !emailInvalidChars
@@ -229,8 +234,10 @@ class RegisterForm extends React.Component {
             ) && (
               <Translate className="form-help success" content="registerForm.looksGood" />
             )}
+
             <Translate className="form-help info right-align" content="registerForm.required" />
-          </span>
+          </div>
+
           <input
             type="text"
             name="email"
@@ -240,15 +247,15 @@ class RegisterForm extends React.Component {
             disabled={inputDisabled}
             onChange={this.handleUserInput}
           />
-        </label>
+        </div>
 
-        <br />
-
-        <label>
-          <span className="columns-container inline spread">
-            <Translate content="registerForm.realName" />
+        <div className="form-row">
+          <div className="label-block">
+            <label htmlFor="register-form-creditedName">
+              <Translate content="registerForm.realName" />
+            </label>
             <Translate className="form-help info right-align" content="registerForm.optional" />
-          </span>
+          </div>
           <input
             type="text"
             pattern='[^@]+'
@@ -261,55 +268,61 @@ class RegisterForm extends React.Component {
             onChange={this.handleUserInput}
           />
           <Translate component="span" className="form-help info" content="registerForm.whyRealName" />
-        </label>
+        </div>
 
-        <br />
-        <br />
+        <div className="form-row">
+          <div className="checkbox-block">
+            <input
+              checked={!!this.state.agreeToPrivacyPolicy}
+              disabled={inputDisabled}
+              name="agreeToPrivacyPolicy"
+              id="register-form-agreeToPrivacyPolicy"
+              onChange={this.handlePrivacyPolicyChange}
+              type="checkbox"
+            />
+            <label htmlFor="register-form-agreeToPrivacyPolicy">
+              {this.state.underAge
+                ? <Translate component="span" content="registerForm.underAgeConsent" link={privacyPolicyLink} />
+                : <Translate component="span" content="registerForm.agreeToPrivacyPolicy" link={privacyPolicyLink} />
+              }
+            </label>
+          </div>
+        </div>
 
-        <label>
-          <input
-            type="checkbox"
-            disabled={inputDisabled}
-            checked={!!this.state.agreeToPrivacyPolicy}
-            onChange={this.handlePrivacyPolicyChange}
-          />
-          {this.state.underAge
-            ? <Translate component="span" content="registerForm.underAgeConsent" link={privacyPolicyLink} />
-            : <Translate component="span" content="registerForm.agreeToPrivacyPolicy" link={privacyPolicyLink} />
-          }
-        </label>
+        <div className="form-row">
+          <div className="checkbox-block">
+            <input
+              checked={this.state.input_okayToEmail}
+              disabled={inputDisabled}
+              name="okayToEmail"
+              id="register-form-okayToEmail"
+              onChange={this.handleUserInput}
+              type="checkbox"
+            />
+            <label htmlFor="register-form-okayToEmail">
+              {this.state.underAge
+                ? <Translate component="span" content="registerForm.underAgeEmail" />
+                : <Translate component="span" content="registerForm.okayToEmail" />
+              }
+            </label>
+          </div>
 
-        <br />
-        <br />
+          <div className="checkbox-block">
+            <input
+              checked={this.state.input_betaTester}
+              disabled={inputDisabled}
+              name="betaTester"
+              id="register-form-betaTester"
+              onChange={this.handleUserInput}
+              type="checkbox"
+            />
+            <label htmlFor="register-form-betaTester">
+              <Translate component="span" content="registerForm.betaTester" />
+            </label>
+          </div>
+        </div>
 
-        <label>
-          <input
-            type="checkbox"
-            name="okayToEmail"
-            id="register-form-okayToEmail"
-            checked={this.state.input_okayToEmail}
-            disabled={inputDisabled}
-            onChange={this.handleUserInput}
-          />
-          {this.state.underAge
-            ? <Translate component="span" content="registerForm.underAgeEmail" />
-            : <Translate component="span" content="registerForm.okayToEmail" />
-          }
-        </label><br />
-
-        <label>
-          <input
-            type="checkbox"
-            name="betaTester"
-            id="register-form-betaTester"
-            checked={this.state.input_betaTester}
-            disabled={inputDisabled}
-            onChange={this.handleUserInput}
-          />
-          <Translate component="span" content="registerForm.betaTester" />
-        </label><br />
-
-        <p style={{ textAlign: 'center' }}>
+        <div className="center-align">
           {'user' in this.state.pending
             ? <LoadingIndicator />
             : this.props.user != null
@@ -321,7 +334,7 @@ class RegisterForm extends React.Component {
             ? <span className="form-help error">{this.state.error.toString()}</span>
             : <span>&nbsp;</span>
           }
-        </p>
+        </div>
 
         <div className="form-row submit-row">
           <button

--- a/app/rubin-2025/register-form.jsx
+++ b/app/rubin-2025/register-form.jsx
@@ -101,22 +101,26 @@ class RegisterForm extends React.Component {
               <Translate content="registerForm.userName" />
             </label>
 
-            {badNameChars?.length > 0 && (
-              <Translate className="form-help error" content="registerForm.badChars" />
-            )}
+            <div aria-live="polite" id="register-form-login-help-message-1">
+              {badNameChars?.length > 0 && (
+                <Translate className="form-help error" content="registerForm.badChars" />
+              )}
+            </div>
 
             {"nameConflict" in this.state.pending && (
               <LoadingIndicator />
             )}
 
-            {nameConflict && (
-              <span className="form-help error">
-                <Translate content="registerForm.nameConflict" />{' '}
-                <a href={`${window.location.origin}/reset-password`}>
-                  <Translate content="registerForm.forgotPassword" />
-                </a>
-              </span>
-            )}
+            <div aria-live="polite" id="register-form-login-help-message-2">
+              {nameConflict && (
+                <span className="form-help error">
+                  <Translate content="registerForm.nameConflict" />{' '}
+                  <a href={`${window.location.origin}/reset-password`}>
+                    <Translate content="registerForm.forgotPassword" />
+                  </a>
+                </span>
+              )}
+            </div>
 
             {(this.state.input_login?.length > 0
               && nameConflict === false
@@ -130,7 +134,7 @@ class RegisterForm extends React.Component {
           </div>
 
           <input
-            aria-describedby="register-form-error-message"
+            aria-describedby="register-form-error-message register-form-login-help-message-1 register-form-login-help-message-2"
             className="standard-input full"
             disabled={inputDisabled}
             id="register-form-login"
@@ -154,13 +158,17 @@ class RegisterForm extends React.Component {
             <label htmlFor="register-form-password">
               <Translate content="registerForm.password" />
             </label>
-            {passwordTooShort && (
-              <Translate className="form-help error" content="registerForm.passwordTooShort" />
-            )}
+            
+            <div aria-live="polite" id="register-form-password-help-message">
+              {passwordTooShort && (
+                <Translate className="form-help error" content="registerForm.passwordTooShort" />
+              )}
+            </div>
+
             <Translate className="form-help info right-align" content="registerForm.required" />
           </div>
           <input
-            aria-describedby="register-form-error-message"
+            aria-describedby="register-form-error-message register-form-password-help-message"
             className="standard-input full"
             disabled={inputDisabled}
             id="register-form-password"
@@ -176,9 +184,13 @@ class RegisterForm extends React.Component {
             <label htmlFor="register-form-confirmedPassword">
               <Translate content="registerForm.confirmPassword" />
             </label>
-            {passwordsDontMatch && (
-              <Translate className="form-help error" content="registerForm.passwordsDontMatch" />
-            )}
+            
+            <div aria-live="polite" id="register-form-confirmedPassword-help-message">
+              {passwordsDontMatch && (
+                <Translate className="form-help error" content="registerForm.passwordsDontMatch" />
+              )}
+            </div>
+
             {(this.state.input_password?.length > 0
               && this.state.input_confirmedPassword?.length > 0
               && !passwordsDontMatch
@@ -186,9 +198,11 @@ class RegisterForm extends React.Component {
             ) && (
               <Translate className="form-help success" content="registerForm.looksGood" />
             )}
+
             <Translate className="form-help info right-align" content="registerForm.required" />
           </div>
           <input
+            aria-describedby="register-form-confirmedPassword-help-message"
             className="standard-input full"
             disabled={inputDisabled}
             id="register-form-confirmedPassword"
@@ -208,26 +222,32 @@ class RegisterForm extends React.Component {
               }
             </label>
 
-            {emailInvalidChars && (
-              <Translate className="form-help error" content="registerForm.emailInvalidChars" />
-            )}
+            <div aria-live="polite" id="register-form-email-help-message-1">
+              {emailInvalidChars && (
+                <Translate className="form-help error" content="registerForm.emailInvalidChars" />
+              )}
+            </div>
 
-            {(!emailInvalidChars && emailInvalidFormat) && (
-              <Translate className="form-help info" content="registerForm.emailInvalidFormat" />
-            )}
+            <div aria-live="polite" id="register-form-email-help-message-2">
+              {(!emailInvalidChars && emailInvalidFormat) && (
+                <Translate className="form-help info" content="registerForm.emailInvalidFormat" />
+              )}
+            </div>
 
             {'emailConflict' in this.state.pending && (
               <LoadingIndicator />
             )}
 
-            {emailConflict && (
-              <span className="form-help error">
-                <Translate content="registerForm.emailConflict" />{' '}
-                <a href={`${window.location.origin}/reset-password`}>
-                  <Translate content="registerForm.forgotPassword" />
-                </a>
-              </span>
-            )}
+            <div aria-live="polite" id="register-form-email-help-message-3">
+              {emailConflict && (
+                <span className="form-help error">
+                  <Translate content="registerForm.emailConflict" />{' '}
+                  <a href={`${window.location.origin}/reset-password`}>
+                    <Translate content="registerForm.forgotPassword" />
+                  </a>
+                </span>
+              )}
+            </div>
 
             {(this.state.input_email?.length > 0
               && !emailConflict
@@ -241,7 +261,7 @@ class RegisterForm extends React.Component {
           </div>
 
           <input
-            aria-describedby="register-form-error-message"
+            aria-describedby="register-form-error-message register-form-email-help-message-1 register-form-email-help-message-2 register-form-email-help-message-3"
             className="standard-input full"
             disabled={inputDisabled}
             id="register-form-email"

--- a/app/rubin-2025/register-form.jsx
+++ b/app/rubin-2025/register-form.jsx
@@ -135,6 +135,7 @@ class RegisterForm extends React.Component {
           </div>
 
           <input
+            autoComplete="username"
             aria-describedby="register-form-error-message register-form-login-help-message-1 register-form-login-help-message-2"
             className="standard-input full"
             disabled={inputDisabled}
@@ -169,6 +170,7 @@ class RegisterForm extends React.Component {
             <Translate className="form-help info right-align" content="registerForm.required" />
           </div>
           <input
+            autoComplete="new-password"
             aria-describedby="register-form-error-message register-form-password-help-message"
             className="standard-input full"
             disabled={inputDisabled}
@@ -263,6 +265,7 @@ class RegisterForm extends React.Component {
           </div>
 
           <input
+            autoComplete="email"
             aria-describedby="register-form-error-message register-form-email-help-message-1 register-form-email-help-message-2 register-form-email-help-message-3"
             className="standard-input full"
             disabled={inputDisabled}
@@ -282,6 +285,7 @@ class RegisterForm extends React.Component {
             <Translate className="form-help info right-align" content="registerForm.optional" />
           </div>
           <input
+            autoComplete="name"
             className="standard-input full"
             disabled={inputDisabled}
             id="register-form-creditedName"

--- a/app/rubin-2025/rubin-page.jsx
+++ b/app/rubin-2025/rubin-page.jsx
@@ -24,7 +24,6 @@ function RubinPage ({
   location,
   user
 }) {
-  console.log('+++ initialLoadComplete', initialLoadComplete)
   const startingTab = /\/sign\-in$/g.test(location?.pathname) ? 'sign-in' : 'register';
   const [tab, setTab] = useState(startingTab);
   const [successMessage, setSuccessMessage] = useState('');

--- a/app/rubin-2025/rubin-page.jsx
+++ b/app/rubin-2025/rubin-page.jsx
@@ -20,21 +20,25 @@ counterpart.registerTranslations('en', {
 });
 
 function RubinPage ({
+  location,
   user
 }) {
-  const [tab, setTab] = useState('register')
-  const [successMessage, setSuccessMessage] = useState('')
+  const startingTab = /\/sign\-in$/g.test(location?.pathname) ? 'sign-in' : 'register';
+  const [tab, setTab] = useState(startingTab);
+  const [successMessage, setSuccessMessage] = useState('');
+
+  console.log('+++ location', location?.pathname)
 
   function onTabClick (e) {
-    setTab(e?.currentTarget?.dataset?.tab)
+    setTab(e?.currentTarget?.dataset?.tab);
   }
 
   function onSignInSuccess () {
-    setSuccessMessage('successfullySignedIn')
+    setSuccessMessage('successfullySignedIn');
   }
 
   function onRegisterSuccess () {
-    setSuccessMessage('successfullyRegistered')
+    setSuccessMessage('successfullyRegistered');
   }
 
   /*
@@ -152,6 +156,9 @@ function RubinPage ({
 };
 
 RubinPage.propTypes = {
+  location: PropTypes.shape({  // .location is provided by react-router's Router in main.cjsx
+    pathname: PropTypes.string
+  }),
   user: PropTypes.shape({  // .user is provided by app.cjsx via React.cloneElement
     id: PropTypes.string
   })

--- a/app/rubin-2025/rubin-page.jsx
+++ b/app/rubin-2025/rubin-page.jsx
@@ -109,24 +109,26 @@ function RubinPage ({
             <div className="tabs">
               <nav role="tablist">
                 <button
-                  role="tab"
+                  aria-selected={tab !== 'register'}
+                  className={`tab ${tab !== 'register' ? 'active' : ''}`}
+                  data-tab="sign-in"
                   id="new-accounts-page-tab-sign-in"
-                  type="button"
                   onClick={onTabClick}
                   onKeyDown={onTabKeyPress}
-                  data-tab="sign-in"
-                  className={`tab ${tab !== 'register' ? 'active' : ''}`}
+                  role="tab"
+                  type="button"
                 >
                   <Translate content="newAccountsPage.signIn" />
                 </button>
                 <button
-                  role="tab"
+                  aria-selected={tab === 'register'}
+                  className={`tab ${tab === 'register' ? 'active' : ''}`}
+                  data-tab="register"
                   id="new-accounts-page-tab-register"
-                  type="button"
                   onClick={onTabClick}
                   onKeyDown={onTabKeyPress}
-                  data-tab="register"
-                  className={`tab ${tab === 'register' ? 'active' : ''}`}
+                  role="tab"
+                  type="button"
                 >
                   <Translate content="newAccountsPage.register" />
                 </button>

--- a/app/rubin-2025/rubin-page.jsx
+++ b/app/rubin-2025/rubin-page.jsx
@@ -20,14 +20,14 @@ counterpart.registerTranslations('en', {
 });
 
 function RubinPage ({
+  initialLoadComplete = false,
   location,
   user
 }) {
+  console.log('+++ initialLoadComplete', initialLoadComplete)
   const startingTab = /\/sign\-in$/g.test(location?.pathname) ? 'sign-in' : 'register';
   const [tab, setTab] = useState(startingTab);
   const [successMessage, setSuccessMessage] = useState('');
-
-  console.log('+++ location', location?.pathname)
 
   function onTabClick (e) {
     setTab(e?.currentTarget?.dataset?.tab);
@@ -63,6 +63,8 @@ function RubinPage ({
     // Focus on the next tab.
     siblings?.[nextIndex].focus();
   }
+
+  if (!initialLoadComplete) { return null; }
 
   return (
     <div className="new-accounts-page content-container">
@@ -156,6 +158,7 @@ function RubinPage ({
 };
 
 RubinPage.propTypes = {
+  initialLoadComplete: PropTypes.bool,  // .initialLoadComplete is provided by app.cjsx via React.cloneElement
   location: PropTypes.shape({  // .location is provided by react-router's Router in main.cjsx
     pathname: PropTypes.string
   }),

--- a/app/rubin-2025/rubin-page.spec.js
+++ b/app/rubin-2025/rubin-page.spec.js
@@ -9,7 +9,7 @@ describe('RubinPage', function () {
   let wrapper;
 
   before(function () {
-    wrapper = shallow(<RubinPage />);
+    wrapper = shallow(<RubinPage initialLoadComplete={true} />);
   });
 
   it('renders without crashing', function () {

--- a/app/rubin-2025/sign-in-form.jsx
+++ b/app/rubin-2025/sign-in-form.jsx
@@ -42,15 +42,16 @@ class SignInForm extends React.Component {
               <Translate content="signInForm.userName" />
             </label>
             <input
-              type="text"
-              className="standard-input full"
-              name="login"
-              id="sign-in-form-login"
-              value={this.state.login}
-              disabled={disabled}
+              aria-describedby="sign-in-form-error-message"
               autoFocus
-              onChange={this.handleInputChange}
+              className="standard-input full"
+              disabled={disabled}
+              id="sign-in-form-login"
               maxLength="255"
+              name="login"
+              onChange={this.handleInputChange}
+              type="text"
+              value={this.state.login}
             />
           </div>
 
@@ -62,13 +63,14 @@ class SignInForm extends React.Component {
               <Translate content="signInForm.password" />
             </label>
             <input
-              type="password"
+              aria-describedby="sign-in-form-error-message"
               className="standard-input full"
-              name="password"
-              id="sign-in-form-password"
-              value={this.state.password}
               disabled={disabled}
+              id="sign-in-form-password"
+              name="password"
               onChange={this.handleInputChange}
+              type="password"
+              value={this.state.password}
             />
           </div>
 
@@ -85,15 +87,17 @@ class SignInForm extends React.Component {
             </div>
           )}
 
-          {this.state.error && (
-            <div className="form-help error">
-              {this.state.error.message.match(/invalid(.+)password/i) ? (
-                <Translate content="signInForm.incorrectDetails" />
-              ) : (
-                <span>{this.state.error.toString()}</span>
-              )}{' '}
-            </div>
-          )}
+          <div aria-live="polite">
+            {this.state.error && (
+              <div id="sign-in-form-error-message" className="form-help error">
+                {this.state.error.message.match(/invalid(.+)password/i) ? (
+                  <Translate content="signInForm.incorrectDetails" />
+                ) : (
+                  <span>{this.state.error.toString()}</span>
+                )}{' '}
+              </div>
+            )}
+          </div>
 
           {this.state.busy ? (
             <LoadingIndicator />

--- a/app/rubin-2025/sign-in-form.jsx
+++ b/app/rubin-2025/sign-in-form.jsx
@@ -43,7 +43,6 @@ class SignInForm extends React.Component {
             </label>
             <input
               aria-describedby="sign-in-form-error-message"
-              autoFocus
               className="standard-input full"
               disabled={disabled}
               id="sign-in-form-login"
@@ -152,8 +151,6 @@ class SignInForm extends React.Component {
           error: error
         })
 
-        const ref = ReactDOM.findDOMNode(this).querySelector('[name="login"]');
-        ref?.focus();
         onFailure?.(error);
       });
 

--- a/app/rubin-2025/sign-in-form.jsx
+++ b/app/rubin-2025/sign-in-form.jsx
@@ -88,9 +88,9 @@ class SignInForm extends React.Component {
             </div>
           )}
 
-          <div aria-live="polite">
+          <div id="sign-in-form-error-message" className="form-help error">
             {this.state.error && (
-              <div id="sign-in-form-error-message" className="form-help error">
+              <div>
                 {this.state.error.message.match(/invalid(.+)password/i) ? (
                   <Translate content="signInForm.incorrectDetails" />
                 ) : (
@@ -135,12 +135,13 @@ class SignInForm extends React.Component {
 
     e.preventDefault();
     return this.setState({
-      working: true
+      busy: true,
+      error: null
     }, () => {
       const {login, password} = this.state;
       auth.signIn({login, password}).then((user) => {
         this.setState({
-          working: false,
+          busy: false,
           error: null
         })
 
@@ -149,7 +150,7 @@ class SignInForm extends React.Component {
 
       }).catch((error) => {
         this.setState({
-          working: false,
+          busy: false,
           error: error
         })
 

--- a/app/rubin-2025/sign-in-form.jsx
+++ b/app/rubin-2025/sign-in-form.jsx
@@ -32,10 +32,13 @@ class SignInForm extends React.Component {
     return (
       <form className="sign-in-form" method="POST" onSubmit={this.handleSubmit}>
 
-        <div style={{ margin: '1em 0' }}>
+        <div className="form-row">
 
-          <div style={{ margin: '1em 0' }}>
-            <label style={{ display: 'block' }} htmlFor="sign-in-form-login">
+          <div className="form-row">
+            <label
+              className="label-block"
+              htmlFor="sign-in-form-login"
+            >
               <Translate content="signInForm.userName" />
             </label>
             <input
@@ -51,8 +54,11 @@ class SignInForm extends React.Component {
             />
           </div>
 
-          <div style={{ margin: '1em 0' }}>
-            <label style={{ display: 'block' }} htmlFor="sign-in-form-password">
+          <div className="form-row">
+            <label
+              className="label-block"
+              htmlFor="sign-in-form-password"
+            >
               <Translate content="signInForm.password" />
             </label>
             <input
@@ -68,7 +74,7 @@ class SignInForm extends React.Component {
 
         </div>
 
-        <div style={{ textAlign: 'center', margin: '1em 0' }}>
+        <div className="form-row center-align">
           
           {this.props.user && ( 
             <div className="form-help">

--- a/app/rubin-2025/sign-in-form.jsx
+++ b/app/rubin-2025/sign-in-form.jsx
@@ -42,6 +42,7 @@ class SignInForm extends React.Component {
               <Translate content="signInForm.userName" />
             </label>
             <input
+              autoComplete="username email"
               aria-describedby="sign-in-form-error-message"
               className="standard-input full"
               disabled={disabled}
@@ -62,6 +63,7 @@ class SignInForm extends React.Component {
               <Translate content="signInForm.password" />
             </label>
             <input
+              autoComplete="current-password"
               aria-describedby="sign-in-form-error-message"
               className="standard-input full"
               disabled={disabled}

--- a/css/new-accounts-page.styl
+++ b/css/new-accounts-page.styl
@@ -156,9 +156,17 @@
       max-width: 100%
     
     .label-block
-      display: block
+      align-items: baseline
+      display: flex
+      flex-direction: row
+      flex-wrap: wrap
+      justify-content: space-between
       margin-bottom: 2px
     
+    .checkbox-pair
+      display: flex
+      gap: 0.1em
+
     .form-row
       margin: 1em 0
 

--- a/css/new-accounts-page.styl
+++ b/css/new-accounts-page.styl
@@ -163,7 +163,7 @@
       justify-content: space-between
       margin-bottom: 2px
     
-    .checkbox-pair
+    .checkbox-block
       display: flex
       gap: 0.1em
 
@@ -176,4 +176,3 @@
         flex-direction: row
         justify-content: center
         gap: 1em
-

--- a/css/new-accounts-page.styl
+++ b/css/new-accounts-page.styl
@@ -139,7 +139,7 @@
   form
     accent-color: #005D69
     
-    input[type=text], input[type=password]
+    input[type=text], input[type=password], input[type=email]
       border-radius: 4px
       border: 0.5px solid #A6A7A9
       background: linear-gradient(180deg, rgba(255, 255, 255, 0.00) 0%, rgba(239, 242, 245, 0.60) 100%), #FFF

--- a/css/new-accounts-page.styl
+++ b/css/new-accounts-page.styl
@@ -155,11 +155,17 @@
       width: 300px
       max-width: 100%
     
+    .label-block
+      display: block
+      margin-bottom: 2px
+    
     .form-row
-      margin: 1em
+      margin: 1em 0
 
       &.submit-row
+      &.center-align
         display: flex
         flex-direction: row
         justify-content: center
+        gap: 1em
 


### PR DESCRIPTION
## PR Overview

Part of: Rubin 2025 Landing Page (#7310)
Follows: #7318
Also: fixes #7319 

This PR is part of a project that adds a special landing page for the Rubin 2025 project. The scope of Part 4 is to improve accessibility even further (notably for the RegisterForm, taking notes from feedback in 7318), clean up the HTML of the register forms, (and probably clean up the CSS too,) and apply various fixes.

Now that the [Rubin page is live](https://www.zooniverse.org/rubin), a _meta-goal_ for Part 4 is the **prepare the code for back-porting the Sign In and Register functionality to the /accounts page**.

RegisterForm:
- Improve accessibility:
  - [x] error messages should appear next to the input element. Use aria-describedby/labelledby [(comment)](https://github.com/zooniverse/Panoptes-Front-End/pull/7318#discussion_r2133788429)
  - [x] prevent auto-focus [(comment)](https://github.com/zooniverse/Panoptes-Front-End/pull/7318#issuecomment-2961390749)
  - [x] add aria-live or aria-describedby for the general "on submit" error messages? [(comment)](https://github.com/zooniverse/Panoptes-Front-End/pull/7318#pullrequestreview-2921408534)
- [x] improve HTML + CSS? (i.e. pls use fewer arbitrary `<br/>`)

SignInForm:
- Improve accessibility:
  - [x] prevent auto-focus [(comment)](https://github.com/zooniverse/Panoptes-Front-End/pull/7318#issuecomment-2961390749)
  - [x] add aria-live or aria-describedby for the general "on submit" error messages? [(comment)](https://github.com/zooniverse/Panoptes-Front-End/pull/7318#pullrequestreview-2921408534)
- [x] improve HTML + CSS?

Rubin Page:
- Improve accessibility:
  - [x] consider aria-selected for tabs [(comment)](https://github.com/zooniverse/Panoptes-Front-End/pull/7318#pullrequestreview-2921408534)

Optional for this PR (can postpone for later part):
- ❌ ~~fix tests~~

Other changes:
- [x] Rubin Page will only render AFTER the app has completed initialisation, i.e. it knows whether a user has logged in or otherwise. (Fixes #7319, supersedes #7320)
- [x] New Rubin paths: `/rubin` (default, starts with Register form), `/rubin/sign-in` (starts with Sign In form), `/rubin/register` (starts with Register form)

Staging branch URL: https://pr-7324.pfe-preview.zooniverse.org/rubin?env=staging

### Testing

**Test case 1:** Core functions

(Same as 7314 just make sure the Sign In and Register functionality works.)

<details>
<summary>Test case 1a: Register function</summary>

- Pretend you're a new user to the Zooniverse.
- Open the Rubin page in an incognito/privacy window. (i.e. make sure you're not logged in. And be sure to use staging, because we're gonna spam our DB)
- Attempt to create a new account.
  - When you successfully create an account, your welcome to the Zooniverse should make sense to you, a new user.
  - e.g. at minimum, you shouldn't be stranded on the register form with no idea what to do next.
- Bonus: also attempt to create an _invalid_ account, e.g. select an existing username, or invalid email. Ensure error messages make sense.
  - 🆕 Try to submit with an obviously wonky email address, e.g. `example@gmail,com`. The code doesn't guard against _every_ invalid email address pattern, but should take care of some of the more obvious ones. (e.g. commas instead of periods)

</details>

<details>
<summary>Test case 1b: Sign In function</summary>

- Open the Rubin page in an incognito/privacy window. (i.e. make sure you're not logged in.)
- Attempt to login.
  - When you successfully login, you should be able to easily understand this fact, and know what to do next.
- Bonus: also attempt to _unsuccessfully_ login. Ensure error messages make sense.

</details>

<details>
<summary>Test case 1c: Already Signed In state</summary>

- Make sure you're already signed in, and then open the Rubin page.
- You should see content appropriate to someone who's signed in.
- You should NOT be able to sign in again, nor register a new account.

</details>

**Test case 2:** Fix for 7319

- Make sure you're already signed in, and then open the Rubin page.
- Ensure that you DON'T see a brief flash of the Register form _before the app finishes initialising_

**Test case 3:** New Rubin paths & starting forms

- While not signed in, open `/rubin`. Ensure the page starts with the Register form.
- Open `/rubin/sign-in`. Ensure the page starts with the Sign In form.
- Open `/rubin/register`. Ensure the page starts with the Register form.
- Note that the paths don't change when you click on the Sign In or Register tabs.

EXTRA CRITERIA:
- All fixes to /rubin should also make sense to [/accounts](https://www.zooniverse.org/accounts), since the code will be back-ported.

### Status

~~WIP~~

2025.06.17: ready for review!