### PR TITLE
(New) Accounts Page

### DIFF
--- a/app/pages/accounts/README.md
+++ b/app/pages/accounts/README.md
@@ -1,0 +1,10 @@
+# (New) Accounts Page
+
+This folder contains everything related to the Accounts Page, i.e. https://www.zooniverse.org/accounts
+
+Dev notes (Jul 2025):
+- Previously, the /accounts page was managed by [`/app/pages/sign-in.jsx`](https://github.com/zooniverse/Panoptes-Front-End/blob/a8412d3d43986f8d381d18a592150b22c6eefd0e/app/pages/sign-in.jsx) (the container), [`/app/partials/sign-in-form.cjsx`](https://github.com/zooniverse/Panoptes-Front-End/blob/a8412d3d43986f8d381d18a592150b22c6eefd0e/app/partials/sign-in-form.cjsx), and ['/app/partials/register-form.cjsx'](https://github.com/zooniverse/Panoptes-Front-End/blob/a8412d3d43986f8d381d18a592150b22c6eefd0e/app/partials/register-form.cjsx)
+- In Jun 2025, the Rubin Landing Page project (see [PFE issue 7310](https://github.com/zooniverse/Panoptes-Front-End/issues/7310)) rewrote _and fixed_ the code from the PFE accounts page _in a standalone module_ which _copied but didn't overwrite_ the original Sign In & Register code. (see [`/app/rubin-2025`](https://github.com/zooniverse/Panoptes-Front-End/tree/a8412d3d43986f8d381d18a592150b22c6eefd0e/app/rubin-2025)).
+  - Major fixes were necessary because the zooniverse.org/accounts page actually had a lot of problems, ranging from accessibility issues to outright broken functionality.
+  - While we fixed a _lot_ of issues, we didn't address _all_ potential improvements. Basically, we purposely avoided _a full rewrite of the Sign In & Register code_ because changes to PFE are meant to be lightweight, since PFE is meant to be phased out. Long-term improvements to sign-in and register functionality should be performed on the [FEM codebase](https://github.com/zooniverse/front-end-monorepo/).
+- Now that the Rubin Landing Page code has proven that it works, its fixes and improvements have finally been backported in to this (New) Accounts Page, which properly overwrites the original Sign In & Register code.

--- a/app/pages/accounts/accounts-page.jsx
+++ b/app/pages/accounts/accounts-page.jsx
@@ -1,0 +1,171 @@
+import PropTypes from 'prop-types';
+import React, { useState } from 'react';
+import counterpart from 'counterpart';
+import Translate from 'react-translate-component';
+import Helmet from 'react-helmet';
+import { Link } from 'react-router';
+import { SignInForm } from './sign-in-form.jsx';
+import { RegisterForm } from './register-form.jsx';
+
+// TODO: find a more centralised place to put this
+import zooniverseLogo from '../lab-pages-editor/assets/zooniverse-word-white.png'
+
+counterpart.registerTranslations('en', {
+  rubinPage: {
+    callToAction: {
+      toZooniverseProjects: 'Check out existing Zooniverse space projects',
+      toRubinAbout: 'Read more about Rubin'
+    }
+  }
+});
+
+function RubinPage ({
+  initialLoadComplete = false,
+  location,
+  user
+}) {
+  const startingTab = /\/sign\-in$/g.test(location?.pathname) ? 'sign-in' : 'register';
+  const [tab, setTab] = useState(startingTab);
+  const [successMessage, setSuccessMessage] = useState('');
+
+  function onTabClick (e) {
+    setTab(e?.currentTarget?.dataset?.tab);
+  }
+
+  function onSignInSuccess () {
+    setSuccessMessage('successfullySignedIn');
+  }
+
+  function onRegisterSuccess () {
+    setSuccessMessage('successfullyRegistered');
+  }
+
+  /*
+  When a Tab has focus, and user presses left/right keys, switch which tab has focus.
+  This code is probably a bit more complicated than it needs to be.
+   */
+  function onTabKeyPress (keyboardEvent) {
+    const currentNode = keyboardEvent?.currentTarget;
+    const siblings = currentNode?.parentNode?.childNodes;
+
+    // Find what/where's the current tab, in relation to its siblings.
+    let currentIndex = -1;
+    siblings.forEach((node, index) => { if (node === currentNode) { currentIndex = index } });
+    if (currentIndex < 0) return;  // Error!
+
+    // Choose the next tab we're going to focus on.
+    let nextIndex = currentIndex;
+    if (keyboardEvent.key === 'ArrowLeft') { nextIndex -= 1 }
+    if (keyboardEvent.key === 'ArrowRight') { nextIndex += 1 }
+    nextIndex = Math.min(Math.max(0, nextIndex), siblings?.length - 1);
+
+    // Focus on the next tab.
+    siblings?.[nextIndex].focus();
+  }
+
+  if (!initialLoadComplete) { return null; }
+
+  return (
+    <div className="new-accounts-page content-container">
+      <div className="fem-subheader">
+        <span className="filler" />
+        <img className="zooniverse-logo" src={zooniverseLogo} />
+      </div>
+      <section>
+        <div className="content-inner">
+          <div className="page-info">
+            <Helmet title={'Zooniverse & Rubin 2025'} />
+            <h1>Zooniverse &amp; Rubin 2025</h1>
+            <p>Welcome to the Zooniverse, the home of Vera C. Rubin Observatory citizen science. We'll be launching the first projects with Rubin data in the next few weeks, so to be among the first to see data and help our scientists then sign up below, and we'll be in touch. In the meantime, to learn more and to enjoy the first images released by the Observatory go to <a href="https://rubinobservatory.org/" rel="noopener nofollow noreferrer" target="_blank">Rubinobservatory.org.</a></p>
+          </div>
+
+          {user && successMessage && (
+            <div className="success-message">
+              <span className="fa fa-check-circle-o" />
+              <Translate content={`newAccountsPage.${successMessage}`} />
+            </div>
+          )}
+
+          {user ? (
+            <div className="already-signed-in">
+              <p>
+                <span className="fa fa-check-circle-o" />
+                <Translate content="newAccountsPage.alreadySignedIn" name={user?.login} />
+              </p>
+              <ul className="call-to-action">
+                <li>
+                  <Link to="/projects?discipline=astronomy&page=1&status=live">
+                    <Translate content='rubinPage.callToAction.toZooniverseProjects' />
+                  </Link>
+                </li>
+                <li>
+                  <a href="https://rubinobservatory.org/" rel="noopener nofollow noreferrer" target="_blank">
+                    <Translate content='rubinPage.callToAction.toRubinAbout' />
+                  </a>
+                </li>
+              </ul>
+            </div>
+          ) : (
+            <div className="tabs">
+              <nav role="tablist">
+                <button
+                  aria-selected={tab !== 'register'}
+                  className={`tab ${tab !== 'register' ? 'active' : ''}`}
+                  data-tab="sign-in"
+                  id="new-accounts-page-tab-sign-in"
+                  onClick={onTabClick}
+                  onKeyDown={onTabKeyPress}
+                  role="tab"
+                  type="button"
+                >
+                  <Translate content="newAccountsPage.signIn" />
+                </button>
+                <button
+                  aria-selected={tab === 'register'}
+                  className={`tab ${tab === 'register' ? 'active' : ''}`}
+                  data-tab="register"
+                  id="new-accounts-page-tab-register"
+                  onClick={onTabClick}
+                  onKeyDown={onTabKeyPress}
+                  role="tab"
+                  type="button"
+                >
+                  <Translate content="newAccountsPage.register" />
+                </button>
+              </nav>
+              {(tab !== 'register')
+                ? (
+                  <div
+                    role="tabpanel"
+                    aria-labelledby="new-accounts-page-tab-sign-in"
+                  >
+                    <SignInForm user={user} onSuccess={onSignInSuccess} />
+                  </div>
+                ) : (
+                  <div
+                    role="tabpanel"
+                    aria-labelledby="new-accounts-page-tab-register"
+                  >
+                    <RegisterForm user={user} onSuccess={onRegisterSuccess} />
+                  </div>
+                )
+              }
+            </div>
+          )}
+        </div>
+      </section>
+    </div>
+  )
+};
+
+RubinPage.propTypes = {
+  initialLoadComplete: PropTypes.bool,  // .initialLoadComplete is provided by app.cjsx via React.cloneElement
+  location: PropTypes.shape({  // .location is provided by react-router's Router in main.cjsx
+    pathname: PropTypes.string
+  }),
+  user: PropTypes.shape({  // .user is provided by app.cjsx via React.cloneElement
+    id: PropTypes.string
+  })
+};
+
+export default RubinPage;

--- a/app/pages/accounts/accounts-page.jsx
+++ b/app/pages/accounts/accounts-page.jsx
@@ -15,7 +15,7 @@ function AccountsPage ({
   location,
   user
 }) {
-  const startingTab = /\/sign\-in$/g.test(location?.pathname) ? 'sign-in' : 'register';
+  const startingTab = /\/register$/g.test(location?.pathname) ? 'register' : 'sign-in';
   const [tab, setTab] = useState(startingTab);
   const [successMessage, setSuccessMessage] = useState('');
 

--- a/app/pages/accounts/accounts-page.jsx
+++ b/app/pages/accounts/accounts-page.jsx
@@ -10,15 +10,6 @@ import { RegisterForm } from './register-form.jsx';
 // TODO: find a more centralised place to put this
 import zooniverseLogo from '../lab-pages-editor/assets/zooniverse-word-white.png'
 
-counterpart.registerTranslations('en', {
-  rubinPage: {
-    callToAction: {
-      toZooniverseProjects: 'Check out existing Zooniverse space projects',
-      toRubinAbout: 'Read more about Rubin'
-    }
-  }
-});
-
 function AccountsPage ({
   initialLoadComplete = false,
   location,
@@ -74,9 +65,9 @@ function AccountsPage ({
       <section>
         <div className="content-inner">
           <div className="page-info">
-            <Helmet title={'Zooniverse & Rubin 2025'} />
-            <h1>Zooniverse &amp; Rubin 2025</h1>
-            <p>Welcome to the Zooniverse, the home of Vera C. Rubin Observatory citizen science. We'll be launching the first projects with Rubin data in the next few weeks, so to be among the first to see data and help our scientists then sign up below, and we'll be in touch. In the meantime, to learn more and to enjoy the first images released by the Observatory go to <a href="https://rubinobservatory.org/" rel="noopener nofollow noreferrer" target="_blank">Rubinobservatory.org.</a></p>
+            <Helmet title={counterpart('signIn.register')} />
+            <Translate component="h1" content="signIn.withZooniverse" />
+            <Translate component="p" content="signIn.whyHaveAccount" />
           </div>
 
           {user && successMessage && (
@@ -94,14 +85,14 @@ function AccountsPage ({
               </p>
               <ul className="call-to-action">
                 <li>
-                  <Link to="/projects?discipline=astronomy&page=1&status=live">
-                    <Translate content='rubinPage.callToAction.toZooniverseProjects' />
+                  <Link to="/">
+                    <Translate content="newAccountsPage.alreadySignedInLinks.gotoHomepage" />
                   </Link>
                 </li>
                 <li>
-                  <a href="https://rubinobservatory.org/" rel="noopener nofollow noreferrer" target="_blank">
-                    <Translate content='rubinPage.callToAction.toRubinAbout' />
-                  </a>
+                  <Link to="/projects">
+                    <Translate content="newAccountsPage.alreadySignedInLinks.gotoProjects" />
+                  </Link>
                 </li>
               </ul>
             </div>

--- a/app/pages/accounts/accounts-page.jsx
+++ b/app/pages/accounts/accounts-page.jsx
@@ -1,4 +1,4 @@
-import PropTypes from 'prop-types';
+import { bool, shape, string } from 'prop-types';
 import React, { useState } from 'react';
 import counterpart from 'counterpart';
 import Translate from 'react-translate-component';
@@ -37,11 +37,10 @@ function AccountsPage ({
    */
   function onTabKeyPress (keyboardEvent) {
     const currentNode = keyboardEvent?.currentTarget;
-    const siblings = currentNode?.parentNode?.childNodes;
+    const siblings = Array.from(currentNode?.parentNode?.childNodes || []);
 
     // Find what/where's the current tab, in relation to its siblings.
-    let currentIndex = -1;
-    siblings.forEach((node, index) => { if (node === currentNode) { currentIndex = index } });
+    const currentIndex = siblings.indexOf(currentNode);
     if (currentIndex < 0) return;  // Error!
 
     // Choose the next tab we're going to focus on.
@@ -150,12 +149,12 @@ function AccountsPage ({
 };
 
 AccountsPage.propTypes = {
-  initialLoadComplete: PropTypes.bool,  // .initialLoadComplete is provided by app.cjsx via React.cloneElement
-  location: PropTypes.shape({  // .location is provided by react-router's Router in main.cjsx
-    pathname: PropTypes.string
+  initialLoadComplete: bool,  // .initialLoadComplete is provided by app.cjsx via React.cloneElement
+  location: shape({  // .location is provided by react-router's Router in main.cjsx
+    pathname: string
   }),
-  user: PropTypes.shape({  // .user is provided by app.cjsx via React.cloneElement
-    id: PropTypes.string
+  user: shape({  // .user is provided by app.cjsx via React.cloneElement
+    id: string
   })
 };
 

--- a/app/pages/accounts/accounts-page.jsx
+++ b/app/pages/accounts/accounts-page.jsx
@@ -19,7 +19,7 @@ counterpart.registerTranslations('en', {
   }
 });
 
-function RubinPage ({
+function AccountsPage ({
   initialLoadComplete = false,
   location,
   user
@@ -158,7 +158,7 @@ function RubinPage ({
   )
 };
 
-RubinPage.propTypes = {
+AccountsPage.propTypes = {
   initialLoadComplete: PropTypes.bool,  // .initialLoadComplete is provided by app.cjsx via React.cloneElement
   location: PropTypes.shape({  // .location is provided by react-router's Router in main.cjsx
     pathname: PropTypes.string
@@ -168,4 +168,4 @@ RubinPage.propTypes = {
   })
 };
 
-export default RubinPage;
+export default AccountsPage;

--- a/app/pages/accounts/index.jsx
+++ b/app/pages/accounts/index.jsx
@@ -1,0 +1,2 @@
+import AccountsPage from './accounts-page.jsx';
+export default AccountsPage;

--- a/app/pages/accounts/register-form.jsx
+++ b/app/pages/accounts/register-form.jsx
@@ -1,0 +1,648 @@
+import counterpart from 'counterpart';
+import React from 'react';
+import PropTypes from 'prop-types';
+import auth from 'panoptes-client/lib/auth';
+import Translate from 'react-translate-component';
+import LoadingIndicator from '../components/loading-indicator';
+import debounce from 'debounce';
+
+const REMOTE_CHECK_DELAY = 1000;
+const MIN_PASSWORD_LENGTH = 8;
+
+class RegisterForm extends React.Component {
+  constructor (props) {
+    super(props);
+    this.state = {
+      badNameChars: [],
+      nameConflict: null,  // This is null when uninitialised, false if there's no name conflict, and an array if there's a conflict.
+      passwordTooShort: false,
+      passwordsDontMatch: false,
+      emailConflict: null,  // This is null when uninitialised, false if there's no name conflict, and an array if there's a conflict.
+      emailInvalidChars: false,
+      emailInvalidFormat: false,
+      agreeToPrivacyPolicy: false,
+      error: null,
+      underAge: false,
+
+      input_login: '',
+      input_password: '',
+      input_confirmedPassword: '',
+      input_email: '',
+      input_creditedName: '',
+      input_okayToEmail: true,
+      input_betaTester: false,
+
+      // part of mixins from promiseToSetState
+      pending: {},
+      rejected: {}
+    };
+    
+    this.updateAge = this.updateAge.bind(this);
+    this.handleLoginChange = this.handleLoginChange.bind(this);
+    this.checkForLoginConflict = this.checkForLoginConflict.bind(this);
+    this.handlePasswordChange = this.handlePasswordChange.bind(this);
+    this.handleEmailChange = this.handleEmailChange.bind(this);
+    this.checkForEmailConflict = this.checkForEmailConflict.bind(this);
+    this.handlePrivacyPolicyChange = this.handlePrivacyPolicyChange.bind(this);
+    this.isFormValid = this.isFormValid.bind(this);
+    this.handleSubmit = this.handleSubmit.bind(this);
+    this.handleSignOut = this.handleSignOut.bind(this);
+    this.handleUserInput = this.handleUserInput.bind(this);
+    
+    this.debouncedCheckForLoginConflict = null;
+    this.debouncedCheckForEmailConflict = null;
+
+    // part of mixins from promiseToSetState
+    this._promiseStateKeys = {};
+  }
+
+  render () {
+    const {
+      badNameChars,
+      nameConflict,
+      passwordTooShort,
+      passwordsDontMatch,
+      emailConflict,
+      emailInvalidChars,
+      emailInvalidFormat,
+    } = this.state;
+
+    const privacyPolicyLink = (
+      <a target="_blank" href={`${window.location.origin}/privacy`}>
+        <Translate content="registerForm.privacyPolicy" />
+      </a>
+    );
+    
+    const inputDisabled = !!this.props.user;
+    const submitDisabled = !this.isFormValid() || Object.keys(this.state.pending).length !== 0 || (this.props.user != null)
+
+    return (
+      <form className="register-form" method="POST" onSubmit={this.handleSubmit}>
+        
+        <div className="form-row">
+          <span className="checkbox-block">
+            <input
+              checked={this.state.underAge}
+              disabled={inputDisabled}
+              id="register-form-underAge"
+              name="underAge"
+              onChange={this.updateAge}
+              type="checkbox"
+            />
+            <label htmlFor="register-form-underAge">
+              <Translate component="span" content="registerForm.underAge" />
+            </label>
+          </span>
+        </div>
+
+        <div className="form-row">
+          <div className="label-block">
+            <label htmlFor="register-form-login">
+              <Translate content="registerForm.userName" />
+            </label>
+
+            <div id="register-form-login-help-message-1">
+              {badNameChars?.length > 0 && (
+                <Translate className="form-help error" content="registerForm.badChars" />
+              )}
+            </div>
+
+            {"nameConflict" in this.state.pending && (
+              <LoadingIndicator />
+            )}
+
+            <div id="register-form-login-help-message-2">
+              {nameConflict && (
+                <span className="form-help error">
+                  <Translate content="registerForm.nameConflict" />{' '}
+                  <a href={`${window.location.origin}/reset-password`}>
+                    <Translate content="registerForm.forgotPassword" />
+                  </a>
+                </span>
+              )}
+            </div>
+
+            <div id="register-form-login-help-message-looksGood">
+              {(this.state.input_login?.length > 0
+                && nameConflict === false
+                && !("nameConflict" in this.state.pending)
+              ) && (
+                <span className="form-help success">
+                  <Translate
+                    content="registerForm.looksGood"
+                  />
+                </span>
+              )}
+            </div>
+
+            <Translate
+              className="form-help info right-align"
+              content="registerForm.required"
+              id="register-form-login-help-message-required"
+            />
+          </div>
+
+          <input
+            autoComplete="username"
+            aria-describedby="register-form-error-message register-form-login-help-message-1 register-form-login-help-message-2 register-form-login-help-message-looksGood register-form-login-help-message-required register-form-login-help-message-whyUserName"
+            className="standard-input full"
+            disabled={inputDisabled}
+            id="register-form-login"
+            maxLength="255"
+            name="login"
+            onChange={this.handleUserInput}
+            type="text"
+            value={this.state.input_login}
+          />
+
+          <div id="register-form-login-help-message-whyUserName">
+            <Translate component="span" className="form-help info" content="registerForm.whyUserName" />
+            {this.state.underAge && (
+              <Translate component="span" className="form-help info" content="registerForm.notRealName" />
+            )}
+          </div>
+        </div>
+
+        <div className="form-row">
+          <div className="label-block">
+            <label htmlFor="register-form-password">
+              <Translate content="registerForm.password" />
+            </label>
+            
+            <div id="register-form-password-help-message">
+              {passwordTooShort && (
+                <Translate className="form-help error" content="registerForm.passwordTooShort" />
+              )}
+            </div>
+
+            <Translate
+              className="form-help info right-align"
+              content="registerForm.required"
+              id="register-form-password-help-required"
+            />
+          </div>
+          <input
+            autoComplete="new-password"
+            aria-describedby="register-form-error-message register-form-password-help-message register-form-password-help-required"
+            className="standard-input full"
+            disabled={inputDisabled}
+            id="register-form-password"
+            name="password"
+            onChange={this.handleUserInput}
+            type="password"
+            value={this.state.input_password}
+          />
+        </div>
+
+        <div className="form-row">
+          <div className="label-block">
+            <label htmlFor="register-form-confirmedPassword">
+              <Translate content="registerForm.confirmPassword" />
+            </label>
+            
+            <div id="register-form-confirmedPassword-help-message">
+              {passwordsDontMatch && (
+                <Translate className="form-help error" content="registerForm.passwordsDontMatch" />
+              )}
+            </div>
+
+            <div id="register-form-confirmedPassword-help-looksGood">
+              {(this.state.input_password?.length > 0
+                && this.state.input_confirmedPassword?.length > 0
+                && !passwordsDontMatch
+                && !passwordTooShort
+              ) && (
+                <Translate className="form-help success" content="registerForm.looksGood" />
+              )}
+            </div>
+
+            <Translate
+              className="form-help info right-align"
+              content="registerForm.required"
+              id="register-form-confirmedPassword-help-required"
+            />
+          </div>
+          <input
+            aria-describedby="register-form-confirmedPassword-help-message register-form-confirmedPassword-help-looksGood register-form-confirmedPassword-help-required"
+            className="standard-input full"
+            disabled={inputDisabled}
+            id="register-form-confirmedPassword"
+            name="confirmedPassword"
+            onChange={this.handleUserInput}
+            type="password"
+            value={this.state.input_confirmedPassword}
+          />
+        </div>
+
+        <div className="form-row">
+          <div className="label-block">
+            <label htmlFor="register-form-email">
+              {this.state.underAge
+                ? <Translate content="registerForm.guardianEmail" />
+                : <Translate content="registerForm.email" />
+              }
+            </label>
+
+            <div id="register-form-email-help-message-1">
+              {emailInvalidChars && (
+                <Translate className="form-help error" content="registerForm.emailInvalidChars" />
+              )}
+            </div>
+
+            <div id="register-form-email-help-message-2">
+              {(!emailInvalidChars && emailInvalidFormat) && (
+                <Translate className="form-help info" content="registerForm.emailInvalidFormat" />
+              )}
+            </div>
+
+            {'emailConflict' in this.state.pending && (
+              <LoadingIndicator />
+            )}
+
+            <div id="register-form-email-help-message-3">
+              {emailConflict && (
+                <span className="form-help error">
+                  <Translate content="registerForm.emailConflict" />{' '}
+                  <a href={`${window.location.origin}/reset-password`}>
+                    <Translate content="registerForm.forgotPassword" />
+                  </a>
+                </span>
+              )}
+            </div>
+
+            <div id="register-form-email-help-message-looksGood">
+              {(this.state.input_email?.length > 0
+                && !emailConflict
+                && !emailInvalidChars
+                && !emailInvalidFormat
+                && !('emailConflict' in this.state.pending)
+              ) && (
+                <Translate className="form-help success" content="registerForm.looksGood" />
+              )}
+            </div>
+
+            <Translate
+              className="form-help info right-align"
+              content="registerForm.required"
+              id="register-form-email-help-message-required"
+            />
+          </div>
+
+          <input
+            autoComplete="email"
+            aria-describedby="register-form-error-message register-form-email-help-message-1 register-form-email-help-message-2 register-form-email-help-message-3 register-form-email-help-message-looksGood register-form-email-help-message-required"
+            className="standard-input full"
+            disabled={inputDisabled}
+            id="register-form-email"
+            name="email"
+            onChange={this.handleUserInput}
+            type="email"
+            value={this.state.input_email}
+          />
+        </div>
+
+        <div className="form-row">
+          <div className="label-block">
+            <label htmlFor="register-form-creditedName">
+              <Translate content="registerForm.realName" />
+            </label>
+            <Translate
+              className="form-help info right-align"
+              content="registerForm.optional"
+              id="register-form-creditedName-help-message-optional"
+            />
+          </div>
+          <input
+            autoComplete="name"
+            aria-describedby="register-form-creditedName-help-message-optional register-form-creditedName-help-message-whyRealName"
+            className="standard-input full"
+            disabled={inputDisabled}
+            id="register-form-creditedName"
+            name="creditedName"
+            onChange={this.handleUserInput}
+            type="text"
+            value={this.state.input_creditedName}
+          />
+          <Translate
+            component="span"
+            className="form-help info"
+            content="registerForm.whyRealName"
+            id="register-form-creditedName-help-message-whyRealName"
+          />
+        </div>
+
+        <div className="form-row">
+          <div className="checkbox-block">
+            <input
+              checked={!!this.state.agreeToPrivacyPolicy}
+              disabled={inputDisabled}
+              name="agreeToPrivacyPolicy"
+              id="register-form-agreeToPrivacyPolicy"
+              onChange={this.handlePrivacyPolicyChange}
+              type="checkbox"
+            />
+            <label htmlFor="register-form-agreeToPrivacyPolicy">
+              {this.state.underAge
+                ? <Translate component="span" content="registerForm.underAgeConsent" link={privacyPolicyLink} />
+                : <Translate component="span" content="registerForm.agreeToPrivacyPolicy" link={privacyPolicyLink} />
+              }
+            </label>
+          </div>
+        </div>
+
+        <div className="form-row">
+          <div className="checkbox-block">
+            <input
+              checked={this.state.input_okayToEmail}
+              disabled={inputDisabled}
+              name="okayToEmail"
+              id="register-form-okayToEmail"
+              onChange={this.handleUserInput}
+              type="checkbox"
+            />
+            <label htmlFor="register-form-okayToEmail">
+              {this.state.underAge
+                ? <Translate component="span" content="registerForm.underAgeEmail" />
+                : <Translate component="span" content="registerForm.okayToEmail" />
+              }
+            </label>
+          </div>
+
+          <div className="checkbox-block">
+            <input
+              checked={this.state.input_betaTester}
+              disabled={inputDisabled}
+              name="betaTester"
+              id="register-form-betaTester"
+              onChange={this.handleUserInput}
+              type="checkbox"
+            />
+            <label htmlFor="register-form-betaTester">
+              <Translate component="span" content="registerForm.betaTester" />
+            </label>
+          </div>
+        </div>
+
+        <div className="center-align">
+          {'user' in this.state.pending && (
+            <LoadingIndicator />
+          )}
+
+          {this.props.user && (
+            <span className="form-help warning">
+              <Translate content="registerForm.alreadySignedIn" name={this.props.user.login} />{' '}
+              <button type="button" className="minor-button" onClick={this.handleSignOut}><Translate content="registerForm.signOut" /></button>
+            </span>
+          )}
+
+          <div id="register-form-error-message" className="form-help error">
+            {this.state.error && (
+              <span>{this.state.error.toString()}</span>
+            )}
+          </div>
+        </div>
+
+        <div className="form-row submit-row">
+          <button
+            type="submit"
+            className="standard-button"
+            disabled={submitDisabled}
+          >
+            <Translate content="registerForm.register" />
+          </button>
+        </div>
+      </form>
+    );
+  }
+
+  updateAge (e) {
+    return this.setState({
+      underAge: !!e.currentTarget?.checked
+    });
+  }
+
+  handleUserInput (e) {
+    const input = e?.currentTarget;
+    const inputName = input.name;
+    let inputValue = input.type === 'checkbox' ? !!input.checked : input.value;
+
+    switch (inputName) {
+      case "login":
+        this.handleLoginChange(inputValue);
+        break;
+      case "password":
+        this.handlePasswordChange(inputValue, this.state.input_confirmedPassword);
+        break;
+      case "confirmedPassword":
+        this.handlePasswordChange(this.state.input_password, inputValue);
+        break;
+      case "email":
+        inputValue = (inputValue || '').replaceAll(' ', '');  // Trim out empty spaces
+        this.handleEmailChange(inputValue);
+        break;
+    }
+
+    this.setState({
+      [`input_${inputName}`]: inputValue
+    });
+  }
+
+  handleLoginChange (login) {
+    var badChars, char, exists;
+    exists = login.length !== 0;
+    badChars = (function() {
+      var i, len, ref, results;
+      ref = login.split('');
+      results = [];
+      for (i = 0, len = ref.length; i < len; i++) {
+        char = ref[i];
+        if (char.match(/[\w\-\'\.]/) === null) {
+          results.push(char);
+        }
+      }
+      return results;
+    })();
+    this.setState({
+      badNameChars: badChars,
+      nameConflict: null,
+      nameExists: exists
+    });
+    if (exists && badChars.length === 0) {
+      if (this.debouncedCheckForLoginConflict == null) {
+        this.debouncedCheckForLoginConflict = debounce(this.checkForLoginConflict, REMOTE_CHECK_DELAY);
+      }
+      return this.debouncedCheckForLoginConflict(login);
+    }
+  }
+
+  checkForLoginConflict (username) {
+    return this.promiseToSetState({
+      nameConflict: auth.register({
+        login: username
+      }).catch(function(error) {
+        return error.message.match(/login(.+)taken/mi) || false;
+      })
+    });
+  }
+
+  handlePasswordChange (password, confirmedPassword) {
+    const passwordNotEmpty = password.length > 0;
+    const bothNotEmpty = password.length > 0 && confirmedPassword.length > 0;
+    const longEnough = password.length >= MIN_PASSWORD_LENGTH;
+    const matches = password === confirmedPassword;
+
+    return this.setState({
+      passwordTooShort: passwordNotEmpty && !longEnough,
+      passwordsDontMatch: bothNotEmpty && !matches
+    });
+  }
+
+  handleEmailChange (email) {
+    this.promiseToSetState({
+      emailConflict: Promise.resolve(null) // Cancel any existing request.
+    });
+
+    // Sanity check for emails
+    // We're VERY LOOSE with our checks here, as it's better to admit an invalid email than to block a valid email we didn't correctly anticipate.
+    const emailInvalidChars = /[,\\\/]+/g.test(email);  // Does the email contain invalid characters? Mostly, this catches the common "comma instead of period" error.
+    const emailInvalidFormat = email?.length > 0 && !(/.+@.+\..+/).test(email);  // Does the email at least look SORTA like a proper email address?
+    this.setState({
+      emailInvalidChars,
+      emailInvalidFormat
+    });
+
+    if (email.match(/.+@.+\..+/)) {
+      if (this.debouncedCheckForEmailConflict == null) {
+        this.debouncedCheckForEmailConflict = debounce(this.checkForEmailConflict, REMOTE_CHECK_DELAY);
+      }
+      return this.debouncedCheckForEmailConflict(email);
+    }
+  }
+
+  checkForEmailConflict (email) {
+    return this.promiseToSetState({
+      emailConflict: auth.register({email}).catch(function(error) {
+        var ref;
+        return (ref = error.message.match(/email(.+)taken/mi)) != null ? ref : false;
+      })
+    });
+  }
+
+  handlePrivacyPolicyChange (e) {
+    return this.setState({
+      agreeToPrivacyPolicy: !!e.currentTarget?.checked
+    });
+  }
+
+  isFormValid () {
+    const {
+      badNameChars,
+      nameConflict,
+      passwordsDontMatch,
+      emailConflict,
+      emailInvalidChars,
+      emailInvalidFormat,
+      agreeToPrivacyPolicy,
+      nameExists
+    } = this.state;
+    return (
+      !(badNameChars?.length > 0)
+      && !nameConflict
+      && !passwordsDontMatch
+      && !emailConflict
+      && !emailInvalidChars
+      && !emailInvalidFormat
+      && nameExists
+      && agreeToPrivacyPolicy
+    );
+  }
+
+  handleSubmit (e) {
+    e.preventDefault();
+
+    const login = this.state.input_login;
+    const password = this.state.input_password;
+    const email = this.state.input_email;
+    const credited_name = this.state.input_creditedName;
+    const global_email_communication = this.state.input_okayToEmail;
+    const project_email_communication = global_email_communication;
+    const beta_email_communication = this.state.input_betaTester;
+    
+    const project_id = this.props.project?.id || undefined;
+
+    this.setState({
+      error: null
+    });
+
+    this.props.onSubmit?.();
+
+    return auth.register({
+      login,
+      password,
+      email,
+      credited_name,
+      project_email_communication,
+      global_email_communication,
+      project_id,
+      beta_email_communication
+    }).then((user) => {
+      return this.props.onSuccess?.(user);
+
+    }).catch((error) => {
+      this.setState({error});
+      return this.props.onFailure?.(error);
+    });
+  }
+
+  handleSignOut () {
+    return auth.signOut();
+  }
+
+  // part of mixins from promiseToSetState
+  promiseToSetState (keysAndPromises, callback) {
+    var handledPromise, key, pending, promise, promiseHandler, rejected;
+    ({pending, rejected} = this.state);
+    for (key in keysAndPromises) {
+      promise = keysAndPromises[key];
+      this._promiseStateKeys[key] = promise;
+      promiseHandler = this._handlePromisedState.bind(this, key, promise);
+      handledPromise = promise.then(promiseHandler.bind(this, false)).catch(promiseHandler.bind(this, true));
+      pending[key] = handledPromise;
+      delete rejected[key];
+    }
+    return this.setState({pending, rejected}, callback);
+  }
+
+  // part of mixins from promiseToSetState
+  _handlePromisedState (key, promise, caught, value) {
+    var isLatestPromise, newState, pending, rejected;
+    // Only change the state if its current value is the same promise that's resolving.
+    isLatestPromise = promise === this._promiseStateKeys[key];
+    if (this.isMounted() && isLatestPromise) {
+      ({pending, rejected} = this.state);
+      newState = {pending, rejected};
+      delete pending[key];
+      if (caught) {
+        newState[key] = null;
+        rejected[key] = value;
+      } else {
+        newState[key] = value;
+        delete rejected[key];
+      }
+      this.setState(newState);
+      return null;
+    }
+  }
+
+  // part of mixins from promiseToSetState
+  isMounted () { return true }
+}
+
+RegisterForm.propTypes = {
+  onFailure: PropTypes.func,
+  onSubmit: PropTypes.func,
+  onSuccess: PropTypes.func,
+  user: PropTypes.object
+};
+
+export { RegisterForm };

--- a/app/pages/accounts/register-form.jsx
+++ b/app/pages/accounts/register-form.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import PropTypes from 'prop-types';
+import { func, object } from 'prop-types';
 import auth from 'panoptes-client/lib/auth';
 import Translate from 'react-translate-component';
 import LoadingIndicator from '../../components/loading-indicator';
@@ -638,10 +638,10 @@ class RegisterForm extends React.Component {
 }
 
 RegisterForm.propTypes = {
-  onFailure: PropTypes.func,
-  onSubmit: PropTypes.func,
-  onSuccess: PropTypes.func,
-  user: PropTypes.object
+  onFailure: func,
+  onSubmit: func,
+  onSuccess: func,
+  user: object
 };
 
 export { RegisterForm };

--- a/app/pages/accounts/register-form.jsx
+++ b/app/pages/accounts/register-form.jsx
@@ -1,9 +1,8 @@
-import counterpart from 'counterpart';
 import React from 'react';
 import PropTypes from 'prop-types';
 import auth from 'panoptes-client/lib/auth';
 import Translate from 'react-translate-component';
-import LoadingIndicator from '../components/loading-indicator';
+import LoadingIndicator from '../../components/loading-indicator';
 import debounce from 'debounce';
 
 const REMOTE_CHECK_DELAY = 1000;

--- a/app/pages/accounts/rubin-page.spec.js
+++ b/app/pages/accounts/rubin-page.spec.js
@@ -1,0 +1,33 @@
+/* Temporarily isabled on 2025.06.13: need to configure Enzyme or Mocha to mock PNG files.
+
+import React from 'react';
+import assert from 'assert';
+import { shallow } from 'enzyme';
+import RubinPage from './rubin-page';
+
+describe('RubinPage', function () {
+  let wrapper;
+
+  before(function () {
+    wrapper = shallow(<RubinPage initialLoadComplete={true} />);
+  });
+
+  it('renders without crashing', function () {
+    const RubinPageContainer = wrapper.find('div.new-accounts-page');
+    assert.equal(RubinPageContainer.length, 1);
+  });
+
+  describe('heading', function () {
+    it('renders newAccountsPage.signIn content', function () {
+      assert.equal(wrapper.find('Translate').first().prop('content'), 'newAccountsPage.signIn');
+    });
+  });
+
+  describe('tabbed content tabs', function () {
+    it('renders two buttons', function () {
+      const tabElements = wrapper.find('button');
+      assert.equal(tabElements.length, 2);
+    });
+  });
+});
+*/

--- a/app/pages/accounts/sign-in-form.jsx
+++ b/app/pages/accounts/sign-in-form.jsx
@@ -7,7 +7,7 @@ Converted from CoffeeScript on 15 May 2025. There's room for improvement.
  */
 
 import React from 'react';
-import PropTypes from 'prop-types';
+import { func, object } from 'prop-types';
 import Translate from 'react-translate-component';
 import auth from 'panoptes-client/lib/auth';
 import LoadingIndicator from '../../components/loading-indicator';
@@ -175,10 +175,10 @@ class SignInForm extends React.Component {
 }
 
 SignInForm.propTypes = {
-  onFailure: PropTypes.func,
-  onSubmit: PropTypes.func,
-  onSuccess: PropTypes.func,
-  user: PropTypes.object
+  onFailure: func,
+  onSubmit: func,
+  onSuccess: func,
+  user: object
 };
 
 export { SignInForm };

--- a/app/pages/accounts/sign-in-form.jsx
+++ b/app/pages/accounts/sign-in-form.jsx
@@ -8,10 +8,9 @@ Converted from CoffeeScript on 15 May 2025. There's room for improvement.
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import ReactDOM from 'react-dom';
 import Translate from 'react-translate-component';
 import auth from 'panoptes-client/lib/auth';
-import LoadingIndicator from '../components/loading-indicator';
+import LoadingIndicator from '../../components/loading-indicator';
 
 class SignInForm extends React.Component {
   constructor (props) {

--- a/app/pages/accounts/sign-in-form.jsx
+++ b/app/pages/accounts/sign-in-form.jsx
@@ -1,0 +1,185 @@
+/*
+Basic Sign-In Form
+Renders a form that allows users to provide their sign-in details and attempt
+to sign in.
+
+Converted from CoffeeScript on 15 May 2025. There's room for improvement.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import ReactDOM from 'react-dom';
+import Translate from 'react-translate-component';
+import auth from 'panoptes-client/lib/auth';
+import LoadingIndicator from '../components/loading-indicator';
+
+class SignInForm extends React.Component {
+  constructor (props) {
+    super(props);
+    this.state = {
+      busy: false,
+      login: '',
+      password: '',
+      error: null
+    };
+    this.handleInputChange = this.handleInputChange.bind(this)
+    this.handleSignOut = this.handleSignOut.bind(this)
+    this.handleSubmit = this.handleSubmit.bind(this)
+  }
+
+  render () {
+    const disabled = !!this.props.user || this.state.busy;
+    return (
+      <form className="sign-in-form" method="POST" onSubmit={this.handleSubmit}>
+
+        <div className="form-row">
+
+          <div className="form-row">
+            <label
+              className="label-block"
+              htmlFor="sign-in-form-login"
+            >
+              <Translate content="signInForm.userName" />
+            </label>
+            <input
+              autoComplete="username email"
+              aria-describedby="sign-in-form-error-message"
+              className="standard-input full"
+              disabled={disabled}
+              id="sign-in-form-login"
+              maxLength="255"
+              name="login"
+              onChange={this.handleInputChange}
+              type="text"
+              value={this.state.login}
+            />
+          </div>
+
+          <div className="form-row">
+            <label
+              className="label-block"
+              htmlFor="sign-in-form-password"
+            >
+              <Translate content="signInForm.password" />
+            </label>
+            <input
+              autoComplete="current-password"
+              aria-describedby="sign-in-form-error-message"
+              className="standard-input full"
+              disabled={disabled}
+              id="sign-in-form-password"
+              name="password"
+              onChange={this.handleInputChange}
+              type="password"
+              value={this.state.password}
+            />
+          </div>
+
+        </div>
+
+        <div className="form-row center-align">
+          
+          {this.props.user && ( 
+            <div className="form-help">
+              <Translate content="signInForm.alreadySignedIn" name={this.props.user.login} />{' '}
+              <button type="button" className="minor-button" onClick={this.handleSignOut}>
+                <Translate content="signInForm.signOut" />
+              </button>
+            </div>
+          )}
+
+          <div id="sign-in-form-error-message" className="form-help error">
+            {this.state.error && (
+              <div>
+                {this.state.error.message.match(/invalid(.+)password/i) ? (
+                  <Translate content="signInForm.incorrectDetails" />
+                ) : (
+                  <span>{this.state.error.toString()}</span>
+                )}{' '}
+              </div>
+            )}
+          </div>
+
+          {this.state.busy ? (
+            <LoadingIndicator />
+          ) : (
+            <a href={`${window.location.origin}/reset-password`}>
+              <Translate content="signInForm.forgotPassword" />
+            </a>
+          )}
+        </div>
+
+        <div className="form-row submit-row">
+          <button
+            type="submit"
+            className="standard-button"
+            disabled={disabled || this.state.login.length === 0 || this.state.password.length === 0}
+          >
+            <Translate content="signInForm.signIn" />
+          </button>
+        </div>
+        
+      </form>
+    );
+  }
+
+  handleInputChange (e) {
+    var newState;
+    newState = {};
+    newState[e.target.name] = e.target.value;
+    return this.setState(newState);
+  }
+
+  handleSubmit (e) {
+    const { onSuccess, onSubmit, onFailure } = this.props;
+
+    e.preventDefault();
+    return this.setState({
+      busy: true,
+      error: null
+    }, () => {
+      const {login, password} = this.state;
+      auth.signIn({login, password}).then((user) => {
+        this.setState({
+          busy: false,
+          error: null
+        })
+
+        onSuccess?.(user);
+        // Historical note: onSuccess used to be in the callback for setState(), but for some reason, that callback doesn't trigger.
+
+      }).catch((error) => {
+        this.setState({
+          busy: false,
+          error: error
+        })
+
+        onFailure?.(error);
+      });
+
+      return onSubmit?.(e);
+    });
+  }
+
+  handleSignOut () {
+    return this.setState({
+      busy: true
+    }, () => {
+      return auth.signOut().then(() => {
+        return this.setState({
+          busy: false,
+          password: ''
+        });
+      });
+    });
+  }
+}
+
+SignInForm.propTypes = {
+  onFailure: PropTypes.func,
+  onSubmit: PropTypes.func,
+  onSuccess: PropTypes.func,
+  user: PropTypes.object
+};
+
+export { SignInForm };

--- a/app/router.jsx
+++ b/app/router.jsx
@@ -35,6 +35,7 @@ import YouthPrivacyPolicy from './pages/youth-privacy-policy';
 import SecurityPolicy from './pages/security-policy';
 import AdminPage from './pages/admin';
 import SignInPage from './pages/sign-in';
+import AccountsPage from './pages/accounts';
 import RubinPage from './rubin-2025/rubin-page.jsx';  // Part of Rubin 2025 project. See /app/rubin-2025 
 import NotFoundPage from './pages/not-found';
 import ResetPasswordPage from './pages/reset-password/reset-password';
@@ -121,10 +122,15 @@ export const routes = (
 
     <Route path="unsubscribe" component={UnsubscribeFromEmails} />
 
-    <Route path="accounts" component={SignInPage}>
+    <Route path="accounts-old" component={SignInPage}>
       <IndexRoute component={require('./partials/sign-in-form')} />
       <Route path="sign-in" component={require('./partials/sign-in-form')} />
       <Route path="register" component={require('./partials/register-form')} />
+    </Route>
+
+    <Route path="accounts" component={AccountsPage}>
+      <Route path="sign-in" />
+      <Route path="register" />
     </Route>
 
     {/* Part of Rubin 2025 project. See /app/rubin-2025 */}


### PR DESCRIPTION
## PR Overview

This PR updates & fixes the rather borked Sign In & Register page (i.e. https://www.zooniverse.org/accounts), using fixes & improvements from the recent Rubin Landing Page project. 

- We're backporting the fixes and improvements from the new `/rubin` page into the old `/accounts` page.
- Notes on code changes:
  - since the code in `/app/rubin-2025` is mostly self-contained, the code we see in `/app/pages/accounts` is mostly a copy-paste of that folder, with non-Rubin-specific content replaced.
  - The only other code change would be in the `router.jsx`, as the `/accounts` path now routes to the new AccountsPage.
- `/app/pages/sign-in.jsx`, `/app/partials/sign-in-form.cjsx`, and `/app/partials/register-form.cjsx` are now obsolete... _but I'm going to run a bunch of double checks to ensure this statement is accurate before I delete those files._

Related: #7310 
Staging branch URL: https://pr-7330.pfe-preview.zooniverse.org/accounts

### Testing

**Test case 1:** Core functions

(This uses the same tests as the Rubin Landing Page PRs, and should be pretty vanilla "common sense" checks. Just make sure Sign In and Register works.)

<details>
<summary>Test case 1a: Register function</summary>

- Pretend you're a new user to the Zooniverse.
- Open the Accounts page in an incognito/privacy window. (i.e. make sure you're not logged in. And be sure to use staging, because we're gonna spam our DB)
- Go to the Register form, and attempt to create a new account.
  - When you successfully create an account, your welcome to the Zooniverse should make sense to you, a new user.
  - e.g. at minimum, you shouldn't be stranded on the register form with no idea what to do next.
- Bonus: also attempt to create an _invalid_ account, e.g. select an existing username, or invalid email. Ensure error messages make sense.
  - Try to submit with an obviously wonky email address, e.g. `example@gmail,com`. The code doesn't guard against _every_ invalid email address pattern, but should take care of some of the more obvious ones. (e.g. commas instead of periods)

</details>

<details>
<summary>Test case 1b: Sign In function</summary>

- Open the Accounts page in an incognito/privacy window. (i.e. make sure you're not logged in.)
- Go to the Sign In form, and attempt to login.
  - When you successfully login, you should be able to easily understand this fact, and know what to do next.
- Bonus: also attempt to _unsuccessfully_ login. Ensure error messages make sense.

</details>

<details>
<summary>Test case 1c: Already Signed In state</summary>

- Make sure you're already signed in, and then open the Rubin page.
- You should see content appropriate to someone who's signed in.
- You should NOT be able to sign in again, nor register a new account.

</details>

**Additional tests:**
- Ensure that the /accounts/sign-in path takes you to the Sign In form.
- Ensure that the /accounts/register path takes you to the Register form.

### Status

~~WIP~~

[2025.07.05:](https://github.com/zooniverse/Panoptes-Front-End/pull/7330#issuecomment-3037408551) Ready for review.