### PR TITLE
Batch Aggregations pt3: improved UI (prettier visuals)

### DIFF
--- a/app/pages/lab/data-exports-batch-aggregations/batch-aggregations-dialog.jsx
+++ b/app/pages/lab/data-exports-batch-aggregations/batch-aggregations-dialog.jsx
@@ -58,7 +58,6 @@ function BatchAggregationsDialog ({
 
         <ExpandableContainer
           header={<span><b>1</b> Workflow Classifications</span>}
-          startExpanded={true}
         >
           <p>Choose which workflow to include in the export here. Only workflows with <b>Question</b> tasks or <b>Survey</b> tasks are compatible with our batch aggregation export at this time.</p>
           <WorkflowsList

--- a/app/pages/lab/data-exports-batch-aggregations/batch-aggregations-dialog.jsx
+++ b/app/pages/lab/data-exports-batch-aggregations/batch-aggregations-dialog.jsx
@@ -19,7 +19,6 @@ Component Props:
 
 import React, { useEffect, useState } from 'react';
 import WorkflowsList from './components/workflows-list.jsx';
-import AggregationsChecker from './components/aggregations-checker.jsx';
 import ExpandableContainer from './components/expandable-container.jsx';
 import WorkflowsExportChecker from './components/workflows-export-checker.jsx';
 import AggregationSummary from './components/aggregation-summary.jsx';

--- a/app/pages/lab/data-exports-batch-aggregations/batch-aggregations-dialog.jsx
+++ b/app/pages/lab/data-exports-batch-aggregations/batch-aggregations-dialog.jsx
@@ -85,15 +85,6 @@ function BatchAggregationsDialog ({
             workflowsExport={workflowsExportData}
           />
         </ExpandableContainer>
-        
-        <ExpandableContainer
-          header={<i>DEBUG</i>}
-        >
-          <AggregationsChecker
-            user={user}
-            workflow={workflow}
-          />
-        </ExpandableContainer>
       </div>
     </div>
   );

--- a/app/pages/lab/data-exports-batch-aggregations/batch-aggregations-dialog.jsx
+++ b/app/pages/lab/data-exports-batch-aggregations/batch-aggregations-dialog.jsx
@@ -51,13 +51,13 @@ function BatchAggregationsDialog ({
       </div>
       
       <div className="body">
-
-        <div className="info">
-          <p>Two exports are necessary to generate a batch aggregation.</p>
-        </div>
+        
+        <p className="info">
+          Two exports are necessary to generate a batch aggregation.
+        </p>
 
         <ExpandableContainer
-          header={<span><b>1</b> Classifications by Workflow</span>}
+          header={<span><b>1</b> Workflow Classifications</span>}
         >
           <p>Choose which workflow to include in the export here. Only workflows with Question tasks or Survey tasks are compatible with our batch aggregation export at this time.</p>
           <WorkflowsList

--- a/app/pages/lab/data-exports-batch-aggregations/batch-aggregations-dialog.jsx
+++ b/app/pages/lab/data-exports-batch-aggregations/batch-aggregations-dialog.jsx
@@ -51,15 +51,16 @@ function BatchAggregationsDialog ({
       </div>
       
       <div className="body">
-        
+
         <p className="info">
           Two exports are necessary to generate a batch aggregation.
         </p>
 
         <ExpandableContainer
           header={<span><b>1</b> Workflow Classifications</span>}
+          startExpanded={true}
         >
-          <p>Choose which workflow to include in the export here. Only workflows with Question tasks or Survey tasks are compatible with our batch aggregation export at this time.</p>
+          <p>Choose which workflow to include in the export here. Only workflows with <b>Question</b> tasks or <b>Survey</b> tasks are compatible with our batch aggregation export at this time.</p>
           <WorkflowsList
             project={project}
             setWorkflow={setWorkflow}

--- a/app/pages/lab/data-exports-batch-aggregations/batch-aggregations-dialog.jsx
+++ b/app/pages/lab/data-exports-batch-aggregations/batch-aggregations-dialog.jsx
@@ -39,7 +39,7 @@ function BatchAggregationsDialog ({
 
   return (
     <div className="batch-aggregations-dialog">
-      <div className="dialog-header">
+      <div className="header">
         <h2>Batch Aggregations</h2>
         <button
           aria-label="Close dialog"
@@ -50,7 +50,7 @@ function BatchAggregationsDialog ({
         </button>
       </div>
       
-      <div className="dialog-body">
+      <div className="body">
 
         <div className="info">
           <p>Two exports are necessary to generate a batch aggregation.</p>

--- a/app/pages/lab/data-exports-batch-aggregations/batch-aggregations-dialog.jsx
+++ b/app/pages/lab/data-exports-batch-aggregations/batch-aggregations-dialog.jsx
@@ -19,7 +19,7 @@ Component Props:
 
 import React, { useEffect, useState } from 'react';
 import WorkflowsList from './components/workflows-list.jsx';
-import ExpandableContainer from './components/expandable-container.jsx';
+import Accordion from './components/accordion.jsx';
 import WorkflowsExportChecker from './components/workflows-export-checker.jsx';
 import AggregationSummary from './components/aggregation-summary.jsx';
 import useWorkflowsExport from './helpers/useWorkflowsExport.js';
@@ -55,7 +55,7 @@ function BatchAggregationsDialog ({
           Two exports are necessary to generate a batch aggregation.
         </p>
 
-        <ExpandableContainer
+        <Accordion
           header={<span><b>1</b> Workflow Classifications</span>}
         >
           <p>Choose which workflow to include in the export here. Only workflows with <b>Question</b> tasks or <b>Survey</b> tasks are compatible with our batch aggregation export at this time.</p>
@@ -64,18 +64,18 @@ function BatchAggregationsDialog ({
             setWorkflow={setWorkflow}
             workflow={workflow}
           />
-        </ExpandableContainer>
+        </Accordion>
 
-        <ExpandableContainer
+        <Accordion
           header={<span><b>2</b> Workflow</span>}
         >
           <WorkflowsExportChecker
             status={workflowsExportStatus}
             workflowsExport={workflowsExportData}
           />
-        </ExpandableContainer>
+        </Accordion>
 
-        <ExpandableContainer
+        <Accordion
           header={<span><b>3</b> Summary</span>}
         >
           <AggregationSummary
@@ -83,7 +83,7 @@ function BatchAggregationsDialog ({
             workflow={workflow}
             workflowsExport={workflowsExportData}
           />
-        </ExpandableContainer>
+        </Accordion>
       </div>
     </div>
   );

--- a/app/pages/lab/data-exports-batch-aggregations/batch-aggregations-results.jsx
+++ b/app/pages/lab/data-exports-batch-aggregations/batch-aggregations-results.jsx
@@ -10,14 +10,14 @@ Component Props:
 
 import React from 'react';
 import AggregationsList from './components/aggregations-list.jsx';
-import ExpandableContainer from './components/expandable-container.jsx'
+import Accordion from './components/accordion.jsx'
 
 function BatchAggregationsResults ({
   project
 }) {
   return (
     <div className="batch-aggregations-results">
-      <ExpandableContainer
+      <Accordion
         header="View previous exports"
         headerAlign="right"
       >
@@ -27,7 +27,7 @@ function BatchAggregationsResults ({
         <AggregationsList
           project={project}
         />
-      </ExpandableContainer>
+      </Accordion>
     </div>
   );
 }

--- a/app/pages/lab/data-exports-batch-aggregations/batch-aggregations-results.jsx
+++ b/app/pages/lab/data-exports-batch-aggregations/batch-aggregations-results.jsx
@@ -20,6 +20,9 @@ function BatchAggregationsResults ({
       <ExpandableContainer
         header="View previous exports"
       >
+        <p>
+          <span className="fa fa-info-circle" /> If you'd like to request a new export for any of these workflows, delete the previous batch aggregation.
+        </p>
         <AggregationsList
           project={project}
         />

--- a/app/pages/lab/data-exports-batch-aggregations/batch-aggregations-results.jsx
+++ b/app/pages/lab/data-exports-batch-aggregations/batch-aggregations-results.jsx
@@ -15,10 +15,17 @@ import ExpandableContainer from './components/expandable-container.jsx'
 function BatchAggregationsResults ({
   project
 }) {
+  const header = (
+    <>
+      <span className="spacer" />
+      <span>View previous exports</span>
+    </>
+  );
+
   return (
     <div className="batch-aggregations-results">
       <ExpandableContainer
-        header="RESULTS"
+        header={header}
       >
         <AggregationsList
           project={project}

--- a/app/pages/lab/data-exports-batch-aggregations/batch-aggregations-results.jsx
+++ b/app/pages/lab/data-exports-batch-aggregations/batch-aggregations-results.jsx
@@ -19,6 +19,7 @@ function BatchAggregationsResults ({
     <div className="batch-aggregations-results">
       <ExpandableContainer
         header="View previous exports"
+        headerAlign="right"
       >
         <p>
           <span className="fa fa-info-circle" /> If you'd like to request a new export for any of these workflows, delete the previous batch aggregation.

--- a/app/pages/lab/data-exports-batch-aggregations/batch-aggregations-results.jsx
+++ b/app/pages/lab/data-exports-batch-aggregations/batch-aggregations-results.jsx
@@ -15,17 +15,10 @@ import ExpandableContainer from './components/expandable-container.jsx'
 function BatchAggregationsResults ({
   project
 }) {
-  const header = (
-    <>
-      <span className="spacer" />
-      <span>View previous exports</span>
-    </>
-  );
-
   return (
     <div className="batch-aggregations-results">
       <ExpandableContainer
-        header={header}
+        header="View previous exports"
       >
         <AggregationsList
           project={project}

--- a/app/pages/lab/data-exports-batch-aggregations/batch-aggregations.jsx
+++ b/app/pages/lab/data-exports-batch-aggregations/batch-aggregations.jsx
@@ -43,9 +43,10 @@ function BatchAggregations ({
 
   return (
     <section className="batch-aggregations">
-      <div className="flex-row">
+      <div className="header">
         <h3>Aggregate My Results</h3>
-        <span className="spacer" />
+        <p>Two exports are necessary to generate a batch aggregation. Before configuring, please ensure you have exported both a <b>Workflow Classification</b> export and a <b>Workflow</b> export.</p>
+        <span className="spacer">&nbsp;</span>
         <button onClick={toggleDialog}>
           Configure
         </button>

--- a/app/pages/lab/data-exports-batch-aggregations/batch-aggregations.jsx
+++ b/app/pages/lab/data-exports-batch-aggregations/batch-aggregations.jsx
@@ -39,7 +39,7 @@ function BatchAggregations ({
   }
 
   // DEBUG: open modal for development's sake
-  setTimeout(openModal, 100)
+  // setTimeout(openModal, 100)
 
   return (
     <section className="batch-aggregations">

--- a/app/pages/lab/data-exports-batch-aggregations/batch-aggregations.jsx
+++ b/app/pages/lab/data-exports-batch-aggregations/batch-aggregations.jsx
@@ -39,7 +39,7 @@ function BatchAggregations ({
   }
 
   // DEBUG: open modal for development's sake
-  // setTimeout(openModal, 100)
+  setTimeout(openModal, 100)
 
   return (
     <section className="batch-aggregations">

--- a/app/pages/lab/data-exports-batch-aggregations/batch-aggregations.jsx
+++ b/app/pages/lab/data-exports-batch-aggregations/batch-aggregations.jsx
@@ -47,7 +47,10 @@ function BatchAggregations ({
         <h3>Aggregate My Results</h3>
         <p>Two exports are necessary to generate a batch aggregation. Before configuring, please ensure you have exported both a <b>Workflow Classification</b> export and a <b>Workflow</b> export.</p>
         <span className="spacer">&nbsp;</span>
-        <button onClick={toggleDialog}>
+        <button
+          className="button"
+          onClick={toggleDialog}
+        >
           Configure
         </button>
       </div>

--- a/app/pages/lab/data-exports-batch-aggregations/components/accordion.jsx
+++ b/app/pages/lab/data-exports-batch-aggregations/components/accordion.jsx
@@ -13,7 +13,7 @@ TODO: accessibility pass
 
 import React, { useState } from 'react';
 
-export default function ExpandableContainer ({
+export default function Accordion ({
   children,
   header,
   headerAlign = "left",

--- a/app/pages/lab/data-exports-batch-aggregations/components/accordion.jsx
+++ b/app/pages/lab/data-exports-batch-aggregations/components/accordion.jsx
@@ -13,12 +13,25 @@ TODO: accessibility pass
 
 import React, { useState } from 'react';
 
+// React 17 doesn't have useId(), so we'll need to make up our own.
+function generateRandomId () {
+  const numberOfDigits = 8;
+  const randomNumberAsString = Math.floor(Math.random() * 10 ** numberOfDigits).toString().padStart(numberOfDigits, 0);
+  return `id-${randomNumberAsString}`;
+}
+function useId () {
+  const [id] = useState(generateRandomId);
+  return id;
+}
+
 export default function Accordion ({
   children,
   header,
   headerAlign = "left",
   startExpanded = false
 }) {
+  const headerId = useId();
+  const bodyId = useId();
   const [expanded, setExpanded] = useState(startExpanded);  
   
   function onClick () {
@@ -26,10 +39,14 @@ export default function Accordion ({
   }
     
   return (
-    <div className={`accordion ${expanded ? 'expanded' : 'collapsed'}`}>
+    <div
+      className={`accordion ${expanded ? 'expanded' : 'collapsed'}`}
+      aria-expanded={expanded ? 'true' : 'false'}
+    >
       <button className="header" onClick={onClick}>
         {headerAlign === 'right' && (<span className="spacer" />)}
         {header}
+        {headerId} {bodyId}
         {headerAlign === 'left' && (<span className="spacer" />)}
         <span className={`fa ${expanded ? 'fa-chevron-up' : 'fa-chevron-down'}`} />
       </button>

--- a/app/pages/lab/data-exports-batch-aggregations/components/accordion.jsx
+++ b/app/pages/lab/data-exports-batch-aggregations/components/accordion.jsx
@@ -43,18 +43,26 @@ export default function Accordion ({
       className={`accordion ${expanded ? 'expanded' : 'collapsed'}`}
       aria-expanded={expanded ? 'true' : 'false'}
     >
-      <button className="header" onClick={onClick}>
+      <button
+        aria-controls={bodyId}
+        id={headerId}
+        className="header"
+        onClick={onClick}
+      >
         {headerAlign === 'right' && (<span className="spacer" />)}
         {header}
-        {headerId} {bodyId}
         {headerAlign === 'left' && (<span className="spacer" />)}
         <span className={`fa ${expanded ? 'fa-chevron-up' : 'fa-chevron-down'}`} />
       </button>
-      {expanded && (
-        <div className="body">
-          {children}
-        </div>
-      )}
+      <div
+        aria-labelledby={headerId}
+        id={bodyId}
+        className="body"
+        hidden={!expanded}
+        role="region"
+      >
+        {children}
+      </div>
     </div>
   );
 }

--- a/app/pages/lab/data-exports-batch-aggregations/components/aggregation-item.jsx
+++ b/app/pages/lab/data-exports-batch-aggregations/components/aggregation-item.jsx
@@ -72,7 +72,11 @@ function AggregationItem ({
     return (
       <li className="aggregation-item">
         <div className={`message ${apiData.status === 'error' ? 'error' : ''}`}>
-          {apiData.status === 'deleting' && 'Deleting...'}
+          {apiData.status === 'deleting' && (
+            <>
+              <span className="fa fa-spinner fa-spin" /> &nbsp; Deleting...
+            </>
+          )}
           {apiData.status === 'deleted' && 'Deleted'}
           {apiData.status === 'error' && 'Error'}
         </div>

--- a/app/pages/lab/data-exports-batch-aggregations/components/aggregation-item.jsx
+++ b/app/pages/lab/data-exports-batch-aggregations/components/aggregation-item.jsx
@@ -22,14 +22,6 @@ import React, { useState } from 'react';
 import getAPIEnv from '../helpers/getAPIEnv.js';
 import generateAggregationDownloadUrl from '../helpers/generateAggregationDownloadUrl.js';
 
-function getAggStatusSymbol (aggStatus) {
-  switch (aggStatus) {
-    case 'pending': return '🟡';
-    case 'completed': return '🟢';
-    default: return '⚪️';
-  }
-}
-
 const DEFAULT_HANDLER = () => {};
 const DEFAULT_API_DATA = {
   status: 'ready'
@@ -95,14 +87,48 @@ function AggregationItem ({
 
   return (
     <li className="aggregation-item">
-      <div>Aggregation #{aggregation.id} for Workflow {aggregation.links?.workflow}</div>
-      <div>{getAggStatusSymbol(aggregation.status)} {aggregation.status}</div>
-      <div>Updated {updatedTime.toLocaleString()}</div>
-      <div className="flex-row">
-        <button onClick={deleteAggregation}>❌ Delete</button>
-        <span className="spacer" />
+      <div className="aggregation-id">
+        <h6>Aggregation #{aggregation.id}</h6>
+      </div>
+      <div className="aggregation-info">
+        <p className="workflow-id">
+          Workflow #{aggregation.links?.workflow}
+        </p>
+        <p className="aggregation-updated-at">
+          Last updated {updatedTime.toLocaleString()}
+        </p>
+      </div>
+      <div className="aggregation-status">
+        {aggregation.status === 'pending' && (
+          <>
+            <p className="aggregation-status-pending">An export is being generated.</p>
+            <p>This process may take a while.<br/>Check your email for updates.</p>
+          </>
+        )}
         {aggregation.status === 'completed' && (
-          <a className="plain button" href={linkForZip}>[⬇️ Download]</a>
+          <>
+            <p className="aggregation-status-completed"><span className="fa fa-check-circle-o" /> Successful Export.</p>
+            <p>Completed {updatedTime.toLocaleString()}</p>
+          </>
+        )}
+        {!['pending', 'completed'].includes(aggregation.status) && (
+          <p>Status: {aggregation.status}</p>
+        )}
+      </div>
+      <div className="aggregation-controls">
+        <button
+          className="button delete-button"
+          onClick={deleteAggregation}
+        >
+          Delete <span className="fa fa-trash" />
+        </button>
+        {aggregation.status === 'completed' && (
+          <a
+            className="button download-button"
+            href={linkForZip}
+          >
+            Download <span className="fa fa-download" />
+          </a>
         )}
       </div>
     </li>

--- a/app/pages/lab/data-exports-batch-aggregations/components/aggregation-summary.jsx
+++ b/app/pages/lab/data-exports-batch-aggregations/components/aggregation-summary.jsx
@@ -147,23 +147,36 @@ function AggregationSummary ({
 
   return (
     <div className="aggregation-summary">
-      <p>Aggregation Summary</p>
-
       {!workflow && (
-        <p>❌ No workflow selected</p>
+        <p className="bold warning">
+          <span className="fa fa-exclamation-triangle" />
+          <span>No workflow selected.</span>
+        </p>
       )}
       {workflow && !isWorkflowValid && (
-        <p>❌ Workflow {workflow.id} is invalid</p>
+        <p className="bold warning">
+          <span className="fa fa-exclamation-triangle" />
+          <span>Workflow {workflow.id} is invalid - check that the workflow only contains Question and Survey Tasks.</span>
+        </p>
       )}
       {workflow && isWorkflowValid && (
-        <p>✅ Workflow {workflow.id} is valid</p>
+        <p className="bold">
+          <span className="fa fa-check-circle-o" />
+          <span>Workflow {workflow.id} is valid.</span>
+        </p>
       )}
 
       {workflowsExport && (
-        <p>✅ Workflow export date: {workflowsExportUpdatedAt?.toLocaleString()}</p>
+        <p className="bold">
+          <span className="fa fa-check-circle-o" />
+          <span>Workflow export date: {workflowsExportUpdatedAt?.toLocaleString()}</span>
+        </p>
       )}
       {!workflowsExport && (
-        <p>❌ No workflow export has been generated.</p>
+        <p className="bold warning">
+          <span className="fa fa-exclamation-triangle" />
+          <span>No workflow export has been generated.</span>
+        </p>
       )}
 
       {!showExistingAggregation && (
@@ -178,10 +191,10 @@ function AggregationSummary ({
       {showExistingAggregation && (
         <>
           {apiData.status === 'fetched' && (
-            <p>Aggregation already exists</p>
+            <p>Aggregation already exists.</p>
           )}
           {apiData.status === 'requested' && (
-            <p>New aggregation requested</p>
+            <p>New aggregation requested.</p>
           )}
           <ul className="single-aggregation">
             <AggregationItem

--- a/app/pages/lab/data-exports-batch-aggregations/components/aggregation-summary.jsx
+++ b/app/pages/lab/data-exports-batch-aggregations/components/aggregation-summary.jsx
@@ -179,12 +179,31 @@ function AggregationSummary ({
         </p>
       )}
 
+      {apiData.status === 'error' && (
+        <div className="message error">
+          Unknown Error
+        </div>
+      )}
+
       {!showExistingAggregation && (
         <button
+          className="button generate-button"
           disabled={!requestEnabled}
           onClick={requestNewAggregation}
         >
-          Generate
+          {!['fetching', 'requesting'].includes(apiData.status) && (
+            'Generate'
+          )}
+          {apiData.status === 'fetching' && (
+            <>
+              <span className="fa fa-spinner fa-spin" /> &nbsp; 'Checking...'
+            </>
+          )}
+          {apiData.status === 'requesting' && (
+            <>
+              <span className="fa fa-spinner fa-spin" /> &nbsp; 'Generating...'
+            </>
+          )}
         </button>
       )}
 

--- a/app/pages/lab/data-exports-batch-aggregations/components/aggregation-summary.jsx
+++ b/app/pages/lab/data-exports-batch-aggregations/components/aggregation-summary.jsx
@@ -148,35 +148,52 @@ function AggregationSummary ({
   return (
     <div className="aggregation-summary">
       {!workflow && (
-        <p className="bold warning">
+        <div className="summary-item">
           <span className="fa fa-exclamation-triangle" />
-          <span>No workflow selected.</span>
-        </p>
+          <div>
+            <p className="mega-bold warning">No workflow selected.</p>
+            <p>Workflow Classifications</p>
+          </div>
+        </div>
       )}
       {workflow && !isWorkflowValid && (
-        <p className="bold warning">
+        <div className="summary-item">
           <span className="fa fa-exclamation-triangle" />
-          <span>Workflow {workflow.id} is invalid - check that the workflow only contains Question and Survey Tasks.</span>
-        </p>
+          <div>
+            <p className="mega-bold">Workflow #{workflow.id}</p>
+            <p>Workflow Classifications</p>
+            <p className="bold warning">Please select a valid workflow.</p>
+            <p className="warning">Only workflows with Question tasks or Survey tasks are compatible with our batch aggregation export at this time.</p>
+          </div>
+        </div>
       )}
       {workflow && isWorkflowValid && (
-        <p className="bold">
+        <div className="summary-item">
           <span className="fa fa-check-circle-o" />
-          <span>Workflow {workflow.id} is valid.</span>
-        </p>
+          <div>
+            <p className="mega-bold">Workflow #{workflow.id}</p>
+            <p>Workflow Classifications</p>
+          </div>
+        </div>
       )}
 
       {workflowsExport && (
-        <p className="bold">
+        <div className="summary-item">
           <span className="fa fa-check-circle-o" />
-          <span>Workflow export date: {workflowsExportUpdatedAt?.toLocaleString()}</span>
-        </p>
+          <div>
+            <p className="mega-bold">Export date: {workflowsExportUpdatedAt?.toLocaleString()}</p>
+            <p>Workflow</p>
+          </div>
+        </div>
       )}
       {!workflowsExport && (
-        <p className="bold warning">
+        <div className="summary-item">
           <span className="fa fa-exclamation-triangle" />
-          <span>No workflow export has been generated.</span>
-        </p>
+          <div>
+            <p className="mega-bold warning">No workflow export has been generated.</p>
+            <p>Workflow</p>
+          </div>
+        </div>
       )}
 
       {apiData.status === 'error' && (

--- a/app/pages/lab/data-exports-batch-aggregations/components/aggregations-list.jsx
+++ b/app/pages/lab/data-exports-batch-aggregations/components/aggregations-list.jsx
@@ -43,15 +43,6 @@ function AggregationsList ({
     setMaxPage(1);
   }
 
-  function onError (err) {
-    console.error(err);
-    setApiData({
-      aggregations: [],
-      status: 'error',
-      statusMessage: err
-    });
-  }
-
   async function fetchAggregations (page = currentPage) {
     // Sanity check: if there's no project, reset everything and then do nothing.
     if (!project) return reset();
@@ -86,7 +77,12 @@ function AggregationsList ({
       });
     
     } catch (err) {
-      onError(err);
+      // On failure... it's kinda expected. A project with no aggregations returns a 404.
+      setApiData({
+        aggregations: [],
+        status: 'no-data',
+        statusMessage: ''
+      });
     }
   }
 
@@ -106,36 +102,45 @@ function AggregationsList ({
 
   return (
     <div className="aggregations-list">
-      List of Aggregations: {apiData.status}
+      {apiData.status === 'fetching' && (
+        <span className="fa fa-spinner fa-spin" />
+      )}
 
-      <div>
-        Page
-        &nbsp;
-        <input
-          max={maxPage}
-          min="1"
-          onChange={pageInput_onChange}
-          type="number"
-          value={currentPage}
-        />
-        &nbsp;
-        of {maxPage}
-      </div>
+      {apiData.status === 'success' && ( 
+        <div className="paging">
+          Page
+          &nbsp;
+          <input
+            max={maxPage}
+            min="1"
+            onChange={pageInput_onChange}
+            type="number"
+            value={currentPage}
+          />
+          &nbsp;
+          of {maxPage}
+        </div>
+      )}
 
-      {apiData.status === 'success' && apiData.aggregations.length === 0 && (
+      {(
+        apiData.status === 'no-data'
+        || (apiData.status === 'success' && apiData.aggregations.length === 0)
+      ) && (
         <div className="message">
           There are no aggregations for this project.
         </div>
       )}
 
-      <ul>
-        {apiData.aggregations.map(agg => (
-          <AggregationItem
-            key={agg.id}
-            aggregation={agg}
-          />
-        ))}
-      </ul>
+      {apiData.status === 'success' && apiData.aggregations.length > 0 && (
+        <ul>
+          {apiData.aggregations.map(agg => (
+            <AggregationItem
+              key={agg.id}
+              aggregation={agg}
+            />
+          ))}
+        </ul>
+      )}
     </div>
   );
 }

--- a/app/pages/lab/data-exports-batch-aggregations/components/aggregations-list.jsx
+++ b/app/pages/lab/data-exports-batch-aggregations/components/aggregations-list.jsx
@@ -90,8 +90,6 @@ function AggregationsList ({
 
   if (!project) return null;
 
-  const env = getAPIEnv();
-
   return (
     <div className="aggregations-list">
       {apiData.status === 'fetching' && (

--- a/app/pages/lab/data-exports-batch-aggregations/components/aggregations-list.jsx
+++ b/app/pages/lab/data-exports-batch-aggregations/components/aggregations-list.jsx
@@ -13,7 +13,6 @@ Component Props:
 
 import React, { useEffect, useState } from 'react';
 import apiClient from 'panoptes-client/lib/api-client';
-import getAPIEnv from '../helpers/getAPIEnv.js';
 import AggregationItem from './aggregation-item.jsx'
 
 const DEFAULT_API_DATA = {

--- a/app/pages/lab/data-exports-batch-aggregations/components/aggregations-list.jsx
+++ b/app/pages/lab/data-exports-batch-aggregations/components/aggregations-list.jsx
@@ -95,7 +95,10 @@ function AggregationsList ({
   return (
     <div className="aggregations-list">
       {apiData.status === 'fetching' && (
-        <span className="fa fa-spinner fa-spin" />
+        <span
+          aria-label="Fetching..."
+          className="fa fa-spinner fa-spin"
+        />
       )}
 
       {(

--- a/app/pages/lab/data-exports-batch-aggregations/components/aggregations-list.jsx
+++ b/app/pages/lab/data-exports-batch-aggregations/components/aggregations-list.jsx
@@ -98,7 +98,16 @@ function AggregationsList ({
         <span className="fa fa-spinner fa-spin" />
       )}
 
-      {apiData.status === 'success' && ( 
+      {(
+        apiData.status === 'no-data'
+        || (apiData.status === 'success' && apiData.aggregations.length === 0)
+      ) && (
+        <div className="message">
+          There are no aggregations for this project.
+        </div>
+      )}
+
+      {(apiData.status === 'success' && apiData.aggregations.length > 0) && (
         <div className="paging">
           Page
           &nbsp;
@@ -114,16 +123,7 @@ function AggregationsList ({
         </div>
       )}
 
-      {(
-        apiData.status === 'no-data'
-        || (apiData.status === 'success' && apiData.aggregations.length === 0)
-      ) && (
-        <div className="message">
-          There are no aggregations for this project.
-        </div>
-      )}
-
-      {apiData.status === 'success' && apiData.aggregations.length > 0 && (
+      {(apiData.status === 'success' && apiData.aggregations.length > 0) && (
         <ul>
           {apiData.aggregations.map(agg => (
             <AggregationItem

--- a/app/pages/lab/data-exports-batch-aggregations/components/aggregations-list.jsx
+++ b/app/pages/lab/data-exports-batch-aggregations/components/aggregations-list.jsx
@@ -16,14 +16,6 @@ import apiClient from 'panoptes-client/lib/api-client';
 import getAPIEnv from '../helpers/getAPIEnv.js';
 import AggregationItem from './aggregation-item.jsx'
 
-function getAggStatusSymbol (aggStatus) {
-  switch (aggStatus) {
-    case 'pending': return '🟡';
-    case 'completed': return '🟢';
-    default: return '⚪️';
-  }
-}
-
 const DEFAULT_API_DATA = {
   aggregations: [],
   status: 'ready',

--- a/app/pages/lab/data-exports-batch-aggregations/components/expandable-container.jsx
+++ b/app/pages/lab/data-exports-batch-aggregations/components/expandable-container.jsx
@@ -26,7 +26,9 @@ export default function ExpandableContainer ({
   return (
     <div className="expandable-container">
       <div className="header">
-        {header}
+        <span onClick={onClick}>
+          {header}
+        </span>
         <button className="button" onClick={onClick}>
           <span className={`fa ${expanded ? 'fa-chevron-up' : 'fa-chevron-down'}`} />
         </button>

--- a/app/pages/lab/data-exports-batch-aggregations/components/expandable-container.jsx
+++ b/app/pages/lab/data-exports-batch-aggregations/components/expandable-container.jsx
@@ -25,13 +25,14 @@ export default function ExpandableContainer ({
     
   return (
     <div className="expandable-container">
-      <div className="flex-row">
+      <div className="header">
         {header}
-        <span className="spacer" />
-        <button onClick={onClick}>{expanded ? '🔼' : '🔽'}</button>
+        <button className="button" onClick={onClick}>
+          <span className={`fa ${expanded ? 'fa-chevron-up' : 'fa-chevron-down'}`} />
+        </button>
       </div>
       {expanded && (
-        <div>
+        <div className="body">
           {children}
         </div>
       )}

--- a/app/pages/lab/data-exports-batch-aggregations/components/expandable-container.jsx
+++ b/app/pages/lab/data-exports-batch-aggregations/components/expandable-container.jsx
@@ -24,7 +24,7 @@ export default function ExpandableContainer ({
   }
     
   return (
-    <div className="expandable-container">
+    <div className={`expandable-container ${expanded ? 'expanded' : 'collapsed'}`}>
       <div className="header">
         <span onClick={onClick}>
           {header}

--- a/app/pages/lab/data-exports-batch-aggregations/components/expandable-container.jsx
+++ b/app/pages/lab/data-exports-batch-aggregations/components/expandable-container.jsx
@@ -1,10 +1,11 @@
 /*
-Expandable Container
+Accordion / Expandable Container
 A typical accordion design.
 
 Component Props:
 - children: content to be displayed when container is expanded.
 - header: content to be displayed in the container's header.
+- headerAlign: "right" or "left"
 - startExpanded: does the container start off expanded? (boolean)
 
 TODO: accessibility pass
@@ -15,6 +16,7 @@ import React, { useState } from 'react';
 export default function ExpandableContainer ({
   children,
   header,
+  headerAlign = "left",
   startExpanded = false
 }) {
   const [expanded, setExpanded] = useState(startExpanded);  
@@ -24,15 +26,13 @@ export default function ExpandableContainer ({
   }
     
   return (
-    <div className={`expandable-container ${expanded ? 'expanded' : 'collapsed'}`}>
-      <div className="header">
-        <span onClick={onClick}>
-          {header}
-        </span>
-        <button className="button" onClick={onClick}>
-          <span className={`fa ${expanded ? 'fa-chevron-up' : 'fa-chevron-down'}`} />
-        </button>
-      </div>
+    <div className={`accordion ${expanded ? 'expanded' : 'collapsed'}`}>
+      <button className="header" onClick={onClick}>
+        {headerAlign === 'right' && (<span className="spacer" />)}
+        {header}
+        {headerAlign === 'left' && (<span className="spacer" />)}
+        <span className={`fa ${expanded ? 'fa-chevron-up' : 'fa-chevron-down'}`} />
+      </button>
       {expanded && (
         <div className="body">
           {children}

--- a/app/pages/lab/data-exports-batch-aggregations/components/workflow-item.jsx
+++ b/app/pages/lab/data-exports-batch-aggregations/components/workflow-item.jsx
@@ -61,8 +61,7 @@ export default function WorkflowItem ({
 
   return (
     <tr
-      className="workflow-item"
-      style={{ color: (selectionDisabled) ? '#a0a0a0' : undefined }}
+      className={`workflow-item ${(selectionDisabled) ? 'disabled' : ''}`}
     >
       <td>
         <input
@@ -81,7 +80,6 @@ export default function WorkflowItem ({
       <td>
         {workflow.id}
       </td>
-
       <td>
         {(apiData.status === 'success') && (
           <span>
@@ -94,7 +92,6 @@ export default function WorkflowItem ({
           </span>
         )}
       </td>
-
     </tr>
   );
 }

--- a/app/pages/lab/data-exports-batch-aggregations/components/workflows-export-checker.jsx
+++ b/app/pages/lab/data-exports-batch-aggregations/components/workflows-export-checker.jsx
@@ -33,7 +33,7 @@ function WorkflowsExportChecker ({
           </p>
           <p>
             <span className="fa fa-info-circle" />
-            <span>Want to include a newer export? Exit this configuration and generate a new Workflows export on the Data Exports tab of the Project Builder.</span>
+            <span>Want to include a newer export? Exit this configuration and generate a new Workflow export on the Data Exports tab of the Project Builder.</span>
           </p>
         </>
       )}

--- a/app/pages/lab/data-exports-batch-aggregations/components/workflows-export-checker.jsx
+++ b/app/pages/lab/data-exports-batch-aggregations/components/workflows-export-checker.jsx
@@ -44,7 +44,7 @@ function WorkflowsExportChecker ({
             <span>No export has been generated.</span>
           </p>
           <p>
-            A workflow export is necessary to generate a batch aggregation. Exit this configuration and generate a new a Workflows export first.
+            A workflow export is necessary to generate a batch aggregation. Exit this configuration and generate a new a <b>Workflows</b> export first.
           </p>
         </>
       )}

--- a/app/pages/lab/data-exports-batch-aggregations/components/workflows-export-checker.jsx
+++ b/app/pages/lab/data-exports-batch-aggregations/components/workflows-export-checker.jsx
@@ -20,18 +20,32 @@ function WorkflowsExportChecker ({
   return (
     <div className="workflows-export-checker">
       {status === 'fetching' && (
-        <p>🔄 Checking...</p>
+        <span
+          aria-label="Fetching..."
+          className="fa fa-spinner fa-spin"
+        />
       )}
       {status === 'success' && workflowsExport && (
         <>
-          <p>✅ Use the last export, generated {workflowsExportUpdatedAt?.toLocaleString()}</p>
-          <p>ℹ️ Want to include a newer export? Exit this configuration and generate a new Workflows export on the Data Exports tab of the Project Builder.</p>
+          <p className="bold">
+            <span className="fa fa-check-circle-o" />
+            <span>Use the last export, generated {workflowsExportUpdatedAt?.toLocaleString()}.</span>
+          </p>
+          <p>
+            <span className="fa fa-info-circle" />
+            <span>Want to include a newer export? Exit this configuration and generate a new Workflows export on the Data Exports tab of the Project Builder.</span>
+          </p>
         </>
       )}
       {status === 'no-data' && (
         <>
-          <p>❌ No workflow export has been generated.</p>
-          <p>A workflow export is necessary to generate a batch aggregation. Exit this configuration and generate a new a Workflows export first.</p>
+          <p className="bold warning">
+            <span className="fa fa-exclamation-triangle" />
+            <span>No export has been generated.</span>
+          </p>
+          <p>
+            A workflow export is necessary to generate a batch aggregation. Exit this configuration and generate a new a Workflows export first.
+          </p>
         </>
       )}
     </div>

--- a/app/pages/lab/data-exports-batch-aggregations/components/workflows-list.jsx
+++ b/app/pages/lab/data-exports-batch-aggregations/components/workflows-list.jsx
@@ -108,7 +108,7 @@ export default function WorkflowsList ({
       )}
 
       {(
-        apiData.status === 'no-data'
+        apiData.status === 'no-data'  // NOTE: no-data can never actually occur for fetching workflows.
         || (apiData.status === 'success' && apiData.workflows.length === 0)
       ) && (
         <div className="message">

--- a/app/pages/lab/data-exports-batch-aggregations/components/workflows-list.jsx
+++ b/app/pages/lab/data-exports-batch-aggregations/components/workflows-list.jsx
@@ -58,7 +58,7 @@ export default function WorkflowsList ({
       });
 
       // How many pages of results do we have?
-      const resultsMeta = workflowResourcesArray?.[0].getMeta()
+      const resultsMeta = workflowResourcesArray?.[0]?.getMeta()
       if (resultsMeta) {
         setMaxPage(resultsMeta.page_count)
       } else {
@@ -68,7 +68,7 @@ export default function WorkflowsList ({
       // On success, save the results.
       setApiData({
         workflows: workflowResourcesArray,
-        status: 'ready'
+        status: 'success'
       });
     
     } catch (err) {
@@ -100,47 +100,56 @@ export default function WorkflowsList ({
 
   return (
     <div className="workflows-list">
-      List of workflows - {apiData.status}
+      {apiData.status === 'fetching' && (
+        <span className="fa fa-spinner fa-spin" />
+      )}
 
-      <div>
-        Page
-        &nbsp;
-        <input
-          max={maxPage}
-          min="1"
-          onChange={pageInput_onChange}
-          type="number"
-          value={page}
-        />
-        &nbsp;
-        of {maxPage}
-      </div>
-
-      {apiData.status === 'success' && apiData.workflows.length === 0 && (
+      {(
+        apiData.status === 'no-data'
+        || (apiData.status === 'success' && apiData.workflows.length === 0)
+      ) && (
         <div className="message">
           There are no workflows for this project.
         </div>
       )}
 
-      <table>
-        <thead>
-          <tr>
-            <th scope="col">Workflow</th>
-            <th scope="col">ID</th>
-            <th scope="col">Last Requested</th>
-          </tr>
-        </thead>
-        <tbody>
-          {apiData.workflows?.map((wf) => (
-            <WorkflowItem
-              key={wf.id}
-              checked={wf.id === workflow?.id}
-              onChange={workflowItem_onChange}
-              workflow={wf}
-            />
-          ))}
-        </tbody>
-      </table>
+      {(apiData.status === 'success' && apiData.workflows.length > 0) && (
+        <div className="paging">
+          Page
+          &nbsp;
+          <input
+            max={maxPage}
+            min="1"
+            onChange={pageInput_onChange}
+            type="number"
+            value={page}
+          />
+          &nbsp;
+          of {maxPage}
+        </div>
+      )}
+
+      {(apiData.status === 'success' && apiData.workflows.length > 0) && (
+        <table>
+          <thead>
+            <tr>
+              <th scope="col">Workflow</th>
+              <th scope="col">ID</th>
+              <th scope="col">Last Requested</th>
+            </tr>
+          </thead>
+          <tbody>
+            {apiData.workflows?.map((wf) => (
+              <WorkflowItem
+                key={wf.id}
+                checked={wf.id === workflow?.id}
+                onChange={workflowItem_onChange}
+                workflow={wf}
+              />
+            ))}
+          </tbody>
+        </table>
+      )}
 
     </div>
   );

--- a/app/pages/lab/data-exports-batch-aggregations/components/workflows-list.jsx
+++ b/app/pages/lab/data-exports-batch-aggregations/components/workflows-list.jsx
@@ -101,7 +101,10 @@ export default function WorkflowsList ({
   return (
     <div className="workflows-list">
       {apiData.status === 'fetching' && (
-        <span className="fa fa-spinner fa-spin" />
+        <span
+          aria-label="Fetching..."
+          className="fa fa-spinner fa-spin"
+        />
       )}
 
       {(

--- a/app/pages/lab/data-exports-batch-aggregations/components/workflows-list.jsx
+++ b/app/pages/lab/data-exports-batch-aggregations/components/workflows-list.jsx
@@ -154,6 +154,12 @@ export default function WorkflowsList ({
         </table>
       )}
 
+      {apiData.status === 'error' && (
+        <div className="message error">
+          Unknown Error
+        </div>
+      )}
+
     </div>
   );
 }

--- a/app/pages/lab/data-exports-batch-aggregations/helpers/checkIsWorkflowValid.js
+++ b/app/pages/lab/data-exports-batch-aggregations/helpers/checkIsWorkflowValid.js
@@ -23,7 +23,6 @@ export default function checkIsWorkflowValid (workflow) {
   let countOfValidTasks = 0;
   let countOfInvalidTasks = 0;
 
-  console.log('+++ workflow', workflow);
   Object.values(workflow.tasks || {}).forEach(task => {
     if (VALID_TASK_TYPES.includes(task.type)) {
       countOfValidTasks++;

--- a/css/data-export-batch-aggregations.styl
+++ b/css/data-export-batch-aggregations.styl
@@ -137,7 +137,7 @@
           font-size: 16px
           vertical-align: center
       
-      &.expanded > .header
+      &.expanded > .header > span:nth-child(1)
         color: #404040
         font-size: 16px
         font-weight: 600

--- a/css/data-export-batch-aggregations.styl
+++ b/css/data-export-batch-aggregations.styl
@@ -282,12 +282,28 @@
       display: block
     
     table
-      border: 1px solid #f0f0f0
       border-collapse: collapse
+      margin-top: 5px
+    
+    thead
+      border-radius: 4px
+      border: 0.5px solid #a6A7a9
+      color: #5C5C5C;
+      font-size: 12px
+      font-weight: 600
+      letter-spacing: 0.6px
+      text-transform: uppercase
+
+      th
+        border: 0.5px solid #a6A7a9
     
     tbody
       max-height: 120px
       overflow: auto
+      color: #000
+      font-size: 16px
+      font-weight: 400
+      letter-spacing: 0.8px
 
     tr
       display: flex
@@ -298,21 +314,28 @@
     
     td:nth-child(1), th:nth-child(1)
       flex: 1 1 auto
+
+    td:nth-child(1)
+      flex-row()
+      align-items: flex-start
+      
+      input
+        cursor: pointer
+        margin: 6px 5px auto auto
+      
+      label
+        cursor: pointer
+        flex: 1 1 auto
     
     td:nth-child(2), th:nth-child(2)
-      flex: 0 0 20%
+      flex: 0 0 10%
     
     td:nth-child(3), th:nth-child(3)
       flex: 0 0 30%
 
-    table
-      
-      max-height: 10em
-      overflow: auto
-    
-    td, th
-      border: 1px solid #808080
-      
+  .workflow-item
+    &.disabled
+      color: #a6A7a9
 
   .paging
     color: #5c5c5c

--- a/css/data-export-batch-aggregations.styl
+++ b/css/data-export-batch-aggregations.styl
@@ -350,21 +350,6 @@
 
   .workflows-export-checker, .aggregation-summary
     
-    > p
-      flex-row()
-      color: #5C5C5C
-      font-size: 12px
-      font-weight: 400
-
-    > p.bold
-      color: #000000
-      font-size: 16px
-      font-weight: 500
-    
-    > p.warning, > p.bold.warning
-      background: none
-      color: #e45950
-    
     .fa-check-circle-o
       color: #52db72
       font-size: 24px
@@ -381,7 +366,48 @@
       font-size: 24px
       margin-right: 10px
       vertical-align: middle
+  
+  .workflows-export-checker
+        
+    > p
+      flex-row()
+      color: #5C5C5C
+      font-size: 12px
+      font-weight: 400
+
+    > p.bold
+      color: #000000
+      font-size: 16px
+      font-weight: 500
     
+    > p.warning, > p.bold.warning
+      background: none
+      color: #e45950
+  
+  .aggregation-summary
+
+    .summary-item
+      flex-row()
+      align-items: flex-start
+      margin: 4px auto
+      width: 300px
+      max-width: 100%
+
+      > .fa
+        margin-top: 8px
+      
+      p
+        margin: 4px 0
+
+    .warning, .bold.warning, .mega-bold.warning
+      background: none
+      color: #e45950
+    
+    .mega-bold
+      color: #404040
+      font-size: 16px
+      font-weight: 600
+        
     .generate-button
       display: block
       border-radius: 4px

--- a/css/data-export-batch-aggregations.styl
+++ b/css/data-export-batch-aggregations.styl
@@ -29,18 +29,6 @@
     background: none
     border: none
     cursor: pointer
-  
-  .workflows-list
-    table
-      border: 1px solid #f0f0f0
-      border-collapse: collapse
-      display: block
-      max-height: 10em
-      overflow: auto
-    
-    td, th
-      border: 1px solid #808080
-      padding: 5px 10px
 
   > dialog
     max-height: 90vh
@@ -123,7 +111,12 @@
       // void
 
   .batch-aggregations-results
-    // void
+    > .expandable-container > .header
+      color: #5C5C5C
+      font-size: 16px
+      font-weight: 600
+      letter-spacing: 0.8px
+      text-transform: uppercase
 
   .aggregations-list ul, ul.single-aggregation
       list-style: none
@@ -135,13 +128,24 @@
     padding: 5px
   
   .expandable-container
-    border: 1px solid LIGHT_GREY
-    padding: 5px
 
-    > div:nth-child(1)
-      background: #f8f8f8
-      padding: 5px
+    > .header
+      flex-row()
+
+      button
+        color: #a6A7a9
     
-    > div:nth-child(2)
-      padding: 5px
-      border: 1px solid LIGHT_GREY
+    > .body
+      // void
+  
+  .workflows-list
+    table
+      border: 1px solid #f0f0f0
+      border-collapse: collapse
+      display: block
+      max-height: 10em
+      overflow: auto
+    
+    td, th
+      border: 1px solid #808080
+      padding: 5px 10px

--- a/css/data-export-batch-aggregations.styl
+++ b/css/data-export-batch-aggregations.styl
@@ -167,7 +167,7 @@
     
     .aggregations-list ul
       display: grid
-      grid-template-columns: 50% 50%
+      grid-template-columns: 49% auto
       gap: 20px
 
   .aggregations-list ul, ul.single-aggregation

--- a/css/data-export-batch-aggregations.styl
+++ b/css/data-export-batch-aggregations.styl
@@ -144,6 +144,11 @@
       
       > .body
         margin-top: -30px
+      
+        > p
+          color: #5C5C5C
+          font-size: 12px
+          font-weight: 400
 
   .batch-aggregations-results
     > .expandable-container > .header
@@ -283,3 +288,11 @@
     td, th
       border: 1px solid #808080
       padding: 5px 10px
+
+  .paging
+    color: #5c5c5c
+    text-align: right
+    font-size: 12px
+    font-style: normal
+    font-weight: 400
+    letter-spacing: 0.6px

--- a/css/data-export-batch-aggregations.styl
+++ b/css/data-export-batch-aggregations.styl
@@ -52,11 +52,40 @@
     border-radius: 8px
     background: linear-gradient(180deg, rgba(255, 255, 255, 0.00) 0%, rgba(239, 242, 245, 0.40) 100%), #FFF
     box-shadow: 1px 1px 12px 8px rgba(0, 0, 0, 0.25)
+  
+  > .header
+    flex-row()
+    margin-bottom: 20px
+
+    h3
+      color: #404040
+      font-family: Karla
+      font-size: 16px
+      font-style: normal
+      font-weight: 600
+    
+    p
+      color: #5C5C5C
+      font-size: 12px
+      font-style: normal
+      margin: 0 0 0 20px
+      max-width: 500px
+      padding: 0
+
+      b
+        color: #000000
+        font-weight: 700
+    
+    .spacer
+      align-self: stretch
+      border-right: 0.5px solid #a6A7a9
+      margin-right: 20px
+      margin-left: 20px
 
   .batch-aggregations-dialog
-    padding: 0.5em 0 1em 0
+    padding: 1em 0
 
-    .dialog-header
+    > .header
       flex-row()
 
       h2
@@ -74,7 +103,7 @@
         color: #5C5C5C
         padding: 0
     
-    .dialog-body
+    > .body
       width: 90vw
       max-width: 800px
       max-height: 80vh

--- a/css/data-export-batch-aggregations.styl
+++ b/css/data-export-batch-aggregations.styl
@@ -157,7 +157,7 @@
     > .accordion > .header
       color: #5C5C5C
       font-size: 16px
-      font-weight: 600
+      font-weight: 400
       letter-spacing: 0.8px
       text-align: right
       text-transform: uppercase

--- a/css/data-export-batch-aggregations.styl
+++ b/css/data-export-batch-aggregations.styl
@@ -33,17 +33,6 @@
   .message
     &.error
       color: #e45950
-
-  > dialog
-    max-height: 90vh
-    max-width: 90vw
-    overflow: auto
-    padding: 5px 20px
-
-    border: none
-    border-radius: 8px
-    background: linear-gradient(180deg, rgba(255, 255, 255, 0.00) 0%, rgba(239, 242, 245, 0.40) 100%), #FFF
-    box-shadow: 1px 1px 12px 8px rgba(0, 0, 0, 0.25)
   
   > .header
     flex-row()
@@ -83,12 +72,24 @@
       font-weight: 500
       flex: 1 1 300px
       height: 40px
+  
+  > dialog
+    max-height: 90vh
+    max-width: 90vw
+    overflow: auto
+    padding: 0
+
+    border: none
+    border-radius: 8px
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.00) 0%, rgba(239, 242, 245, 0.40) 100%), #ffffff
+    box-shadow: 1px 1px 12px 8px rgba(0, 0, 0, 0.25)
 
   .batch-aggregations-dialog
     padding: 1em 0
 
     > .header
       flex-row()
+      padding: 0 20px
 
       h2
         flex: 1 1 auto
@@ -112,12 +113,38 @@
       overflow: auto
 
     .info
-      // void
+      color: #d47811;
+      font-family: Karla
+      // font-size: 12px
+      font-weight: 500
+      padding: 5px 20px
+    
+    .expandable-container
+      border-top: 0.5px solid #a6a7a9
+
+      > .header, > .body
+        padding: 20px
+      
+      > .header
+        color: #5C5C5C
+        font-size: 12px
+        font-weight: 400
+        vertical-align: center
+
+        b
+          display: inline-block
+          width: 20px
+          font-size: 16px
+          vertical-align: center
+      
+      &.expanded > .header
+        color: #404040
+        font-size: 16px
+        font-weight: 600
 
   .batch-aggregations-results
     > .expandable-container > .header
       color: #5C5C5C
-      cursor: pointer
       font-size: 16px
       font-weight: 600
       letter-spacing: 0.8px
@@ -233,6 +260,7 @@
       flex-row()
 
       > span
+        cursor: pointer
         flex: 1 1 auto
 
       button

--- a/css/data-export-batch-aggregations.styl
+++ b/css/data-export-batch-aggregations.styl
@@ -278,16 +278,41 @@
       // void
   
   .workflows-list
+    table, thead, tbody
+      display: block
+    
     table
       border: 1px solid #f0f0f0
       border-collapse: collapse
-      display: block
+    
+    tbody
+      max-height: 120px
+      overflow: auto
+
+    tr
+      display: flex
+
+    td, th
+      padding: 5px 10px
+      overflow: auto
+    
+    td:nth-child(1), th:nth-child(1)
+      flex: 1 1 auto
+    
+    td:nth-child(2), th:nth-child(2)
+      flex: 0 0 20%
+    
+    td:nth-child(3), th:nth-child(3)
+      flex: 0 0 30%
+
+    table
+      
       max-height: 10em
       overflow: auto
     
     td, th
       border: 1px solid #808080
-      padding: 5px 10px
+      
 
   .paging
     color: #5c5c5c

--- a/css/data-export-batch-aggregations.styl
+++ b/css/data-export-batch-aggregations.styl
@@ -141,6 +141,9 @@
         color: #404040
         font-size: 16px
         font-weight: 600
+      
+      > .body
+        margin-top: -30px
 
   .batch-aggregations-results
     > .expandable-container > .header

--- a/css/data-export-batch-aggregations.styl
+++ b/css/data-export-batch-aggregations.styl
@@ -119,7 +119,7 @@
       font-weight: 500
       padding: 5px 20px
     
-    .expandable-container
+    .accordion
       border-top: 0.5px solid #a6a7a9
 
       > .header, > .body
@@ -151,7 +151,7 @@
           font-weight: 400
 
   .batch-aggregations-results
-    > .expandable-container > .header
+    > .accordion > .header
       color: #5C5C5C
       font-size: 16px
       font-weight: 600
@@ -159,7 +159,7 @@
       text-align: right
       text-transform: uppercase
     
-    > .expandable-container > .body > p
+    > .accordion > .body > p
       text-align: right
       color: #5C5C5C
       font-size: 12px
@@ -262,16 +262,16 @@
       .download-button
         color: #000000
   
-  .expandable-container
+  .accordion
 
     > .header
       flex-row()
+      background: none
+      border: none
+      cursor: pointer
+      width: 100%
 
-      > span
-        cursor: pointer
-        flex: 1 1 auto
-
-      button
+      .fa
         color: #a6A7a9
     
     > .body

--- a/css/data-export-batch-aggregations.styl
+++ b/css/data-export-batch-aggregations.styl
@@ -30,6 +30,10 @@
     border: none
     cursor: pointer
 
+  .message
+    &.error
+      color: #e45950
+
   > dialog
     max-height: 90vh
     max-width: 90vw
@@ -138,6 +142,18 @@
     border-radius: 8px
     border: 1px solid #a6A7a9
     background: #ffffff
+
+    .message
+      display: flex
+      align-items: center
+      justify-content: center
+
+      grid-column: 1 / span 2
+      grid-row: 1
+      min-height: 60px
+      padding: 20px
+
+      border: 1px solid #f0f0f0
     
     .aggregation-id
       grid-column: 1 / span 2

--- a/css/data-export-batch-aggregations.styl
+++ b/css/data-export-batch-aggregations.styl
@@ -118,7 +118,7 @@
     .info
       color: #d47811
       font-family: Karla
-      // font-size: 12px
+      font-size: 12px
       font-weight: 500
       padding: 5px 20px
     

--- a/css/data-export-batch-aggregations.styl
+++ b/css/data-export-batch-aggregations.styl
@@ -129,6 +129,11 @@
       color: #5C5C5C
       font-size: 12px
       font-weight: 400
+    
+    .aggregations-list ul
+      display: grid
+      grid-template-columns: 50% 50%
+      gap: 20px
 
   .aggregations-list ul, ul.single-aggregation
       list-style: none

--- a/css/data-export-batch-aggregations.styl
+++ b/css/data-export-batch-aggregations.styl
@@ -81,6 +81,15 @@
       border-right: 0.5px solid #a6A7a9
       margin-right: 20px
       margin-left: 20px
+    
+    .button
+      border-radius: 4px
+      border: 0.5px solid #d47811
+      background: linear-gradient(91deg, rgba(240, 178, 0, 0.10) 0%, rgba(212, 120, 17, 0.10) 100%), #ffffff
+      color: #000000
+      font-weight: 500
+      flex: 1 1 300px
+      height: 40px
 
   .batch-aggregations-dialog
     padding: 1em 0

--- a/css/data-export-batch-aggregations.styl
+++ b/css/data-export-batch-aggregations.styl
@@ -113,7 +113,7 @@
       overflow: auto
 
     .info
-      color: #d47811;
+      color: #d47811
       font-family: Karla
       // font-size: 12px
       font-weight: 500
@@ -330,3 +330,18 @@
       font-size: 24px
       margin-right: 10px
       vertical-align: middle
+    
+    .generate-button
+      display: block
+      border-radius: 4px
+      border: 0.5px solid #d47811
+      background: #d47811
+      box-shadow: 1px 1px 4px 0 rgba(0, 0, 0, 0.25)
+      color: #000000
+      padding: 10px
+      width: 300px
+      max-width: 100%
+      margin: 20px auto 0 auto
+
+      &[disabled]
+        opacity: 0.4

--- a/css/data-export-batch-aggregations.styl
+++ b/css/data-export-batch-aggregations.styl
@@ -296,3 +296,37 @@
     font-style: normal
     font-weight: 400
     letter-spacing: 0.6px
+
+  .workflows-export-checker, .aggregation-summary
+    
+    > p
+      flex-row()
+      color: #5C5C5C
+      font-size: 12px
+      font-weight: 400
+
+    > p.bold
+      color: #000000
+      font-size: 16px
+      font-weight: 500
+    
+    > p.warning, > p.bold.warning
+      background: none
+      color: #e45950
+    
+    .fa-check-circle-o
+      color: #52db72
+      font-size: 24px
+      margin-right: 10px
+      vertical-align: middle
+
+    .fa-exclamation-triangle
+      color: #e45950
+      font-size: 20px
+      margin-right: 10px
+      vertical-align: middle
+    
+    .fa-info-circle
+      font-size: 24px
+      margin-right: 10px
+      vertical-align: middle

--- a/css/data-export-batch-aggregations.styl
+++ b/css/data-export-batch-aggregations.styl
@@ -131,9 +131,80 @@
       padding: 0
     
   .aggregation-item
-    border: 1px solid LIGHT_GREY
-    margin: 5px
-    padding: 5px
+    display: grid
+    grid-template-columns: 50% auto
+    grid-template-rows: auto auto auto
+
+    border-radius: 8px
+    border: 1px solid #a6A7a9
+    background: #ffffff
+    
+    .aggregation-id
+      grid-column: 1 / span 2
+      grid-row: 1
+      gap: 10px
+
+      h6
+        display: inline-block
+        margin: -1px auto auto -1px
+        padding: 7px 18px
+
+        border-radius: 8px 0 16px 0
+        background: linear-gradient(276deg, rgba(240, 178, 0, 0.80) 0%, rgba(212, 120, 17, 0.80) 100%), #f6d885
+        color: #404040
+        font-size: 14px
+        font-weight: 600
+
+    .aggregation-info
+      grid-column: 1
+      grid-row: 2
+      margin-left: 20px
+
+      color: #404040
+      font-size: 12px
+      font-weight: 400
+
+      .workflow-id
+        font-size: 14px
+        font-weight: 600
+      
+      .aggregation-updated-at
+        // void
+    
+    .aggregation-status
+      grid-column: 2
+      grid-row: 2
+      margin-right: 20px
+
+      color: #404040
+      font-size: 12px
+      font-weight: 400
+      text-align: right
+
+      .aggregation-status-completed
+        color: #52db72
+      
+      .aggregation-status-pending
+        color: #d47811
+    
+    .aggregation-controls
+      grid-column: 1 / span 2
+      grid-row: 3
+      margin: 0 20px 20px 20px
+      text-align: right
+
+      .button
+        font-size: 16px
+        font-weight: 500
+        margin: 0 10px
+        padding: 5px 10px
+        text-decoration: underline
+
+      .delete-button
+        color: #e45950
+      
+      .download-button
+        color: #000000
   
   .expandable-container
 

--- a/css/data-export-batch-aggregations.styl
+++ b/css/data-export-batch-aggregations.styl
@@ -13,6 +13,9 @@
   box-shadow: 1px 1px 4px 0 rgba(0, 0, 0, 0.25)
   padding: 20px
 
+  *
+    box-sizing: border-box
+
   flex-row()
     align-items: center
     display: flex
@@ -70,7 +73,7 @@
       color: #000000
       font-size: 16px
       font-weight: 500
-      flex: 1 1 300px
+      flex: 0 1 300px
       height: 40px
   
   > dialog

--- a/css/data-export-batch-aggregations.styl
+++ b/css/data-export-batch-aggregations.styl
@@ -87,6 +87,7 @@
       border: 0.5px solid #d47811
       background: linear-gradient(91deg, rgba(240, 178, 0, 0.10) 0%, rgba(212, 120, 17, 0.10) 100%), #ffffff
       color: #000000
+      font-size: 16px
       font-weight: 500
       flex: 1 1 300px
       height: 40px

--- a/css/data-export-batch-aggregations.styl
+++ b/css/data-export-batch-aggregations.styl
@@ -337,6 +337,9 @@
     &.disabled
       color: #a6A7a9
 
+    input[type=radio]
+      accent-color: #d47811
+
   .paging
     color: #5c5c5c
     text-align: right

--- a/css/data-export-batch-aggregations.styl
+++ b/css/data-export-batch-aggregations.styl
@@ -7,8 +7,11 @@
 // the more accurate but more mouthful .data-exports-batch-aggregations
 
 .batch-aggregations
-  border: 1px solid LIGHT_GREY
-  padding: 10px
+  border-radius: 8px
+  border: 0.5px solid #A6A7A9
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.00) 0%, rgba(239, 242, 245, 0.40) 100%), #ffffff
+  box-shadow: 1px 1px 4px 0 rgba(0, 0, 0, 0.25)
+  padding: 20px
 
   flex-row()
     align-items: center

--- a/css/data-export-batch-aggregations.styl
+++ b/css/data-export-batch-aggregations.styl
@@ -289,8 +289,6 @@
       margin-top: 5px
     
     thead
-      border-radius: 4px
-      border: 0.5px solid #a6A7a9
       color: #5C5C5C;
       font-size: 12px
       font-weight: 600
@@ -299,6 +297,15 @@
 
       th
         border: 0.5px solid #a6A7a9
+
+        &:first-child
+          border-radius: 4px 0 0 4px
+        
+        &:last-child
+          border-radius: 0 4px 4px 0
+
+        &:not(:first-child)
+          border-left: none
     
     tbody
       max-height: 120px

--- a/css/data-export-batch-aggregations.styl
+++ b/css/data-export-batch-aggregations.styl
@@ -113,9 +113,11 @@
   .batch-aggregations-results
     > .expandable-container > .header
       color: #5C5C5C
+      cursor: pointer
       font-size: 16px
       font-weight: 600
       letter-spacing: 0.8px
+      text-align: right
       text-transform: uppercase
 
   .aggregations-list ul, ul.single-aggregation
@@ -131,6 +133,9 @@
 
     > .header
       flex-row()
+
+      > span
+        flex: 1 1 auto
 
       button
         color: #a6A7a9

--- a/css/data-export-batch-aggregations.styl
+++ b/css/data-export-batch-aggregations.styl
@@ -341,7 +341,7 @@
       flex: 0 0 10%
     
     td:nth-child(3), th:nth-child(3)
-      flex: 0 0 30%
+      flex: 0 0 40%
 
   .workflow-item
     &.disabled

--- a/css/data-export-batch-aggregations.styl
+++ b/css/data-export-batch-aggregations.styl
@@ -119,6 +119,12 @@
       letter-spacing: 0.8px
       text-align: right
       text-transform: uppercase
+    
+    > .expandable-container > .body > p
+      text-align: right
+      color: #5C5C5C
+      font-size: 12px
+      font-weight: 400
 
   .aggregations-list ul, ul.single-aggregation
       list-style: none


### PR DESCRIPTION
## PR Overview

Part of: Batch Aggregation UI for Project Builder (#7326)
Follows: #7331

This PR is part of a project that adds "Batch Aggregations" to the Project Builder -> Data Exports page.

In part 3, we're finally getting rid of the basic grey boxes and putting in proper UI/visual design, based on the [Figma design](https://www.figma.com/design/NNCUlpRxNoOXjI86DVQ7QH/Data-Exports?node-id=0-1&p=f&t=KB0NRg7yaHZhMTIU-0).

Features & Scope:
- Expect a lot of content and design updates.
  - Notably, this PR is much more thorough with visually displaying components in their various states. e.g. AggregationsSummary shows when it's "checking..." if the workflow has an existing aggregation, and when it's "generating..." a new one. 
- **No** new features or functionality are intended in this PR.

Notes:
- for this PR, we'll use PFE's [FontAwesome 4](https://fontawesome.com/v4/icons/) for icons. There's currently an issue with how PFE imports SVG files in tests, so we'll need to solve that in a follow up before we can use the intended FEM-styled SVG icons.

Staging branch URL: https://pr-7337.pfe-preview.zooniverse.org/lab/1663/data-exports?env=staging (Illuminati test project)

### Testing

This should primarily be a content review & design review. (See [comment)](https://github.com/zooniverse/Panoptes-Front-End/pull/7337#issuecomment-3141679849)

For a functionality review, please check [7331's Testing Guide](https://github.com/zooniverse/Panoptes-Front-End/pull/7331#issuecomment-3120359007).

### Status

~~WIP~~

[2025.08.01:](https://github.com/zooniverse/Panoptes-Front-End/pull/7337#issuecomment-3141679849) Ready for review!