### PR TITLE
Fix:DataManager_update_error_surface_to_user

### DIFF
--- a/app/pages/lab-pages-editor/DataManager.jsx
+++ b/app/pages/lab-pages-editor/DataManager.jsx
@@ -13,23 +13,23 @@ and the workflow's preview URL.)
 /* eslint-disable react/react-in-jsx-scope */
 /* eslint-disable react/require-default-props */
 
-import { useEffect, useMemo, useState } from 'react';
-import PropTypes from 'prop-types';
-import apiClient from 'panoptes-client/lib/api-client';
-import { WorkflowContext } from './context.js';
-import checkIsPFEWorkflow from './helpers/checkIsPFEWorkflow.js';
-import checkIsWorkflowPartOfProject from './helpers/checkIsWorkflowPartOfProject.js';
+import { useEffect, useMemo, useState } from "react";
+import PropTypes from "prop-types";
+import apiClient from "panoptes-client/lib/api-client";
+import { WorkflowContext } from "./context.js";
+import checkIsPFEWorkflow from "./helpers/checkIsPFEWorkflow.js";
+import checkIsWorkflowPartOfProject from "./helpers/checkIsWorkflowPartOfProject.js";
 
 function DataManager({
   // key: to ensure DataManager renders FRESH (with states reset) whenever workflowId changes, use <DataManager key={workflowId} ... />
   children = null,
-  projectId = '',
-  workflowId = ''
+  projectId = "",
+  workflowId = "",
 }) {
   const [apiData, setApiData] = useState({
     project: null,
     workflow: null,
-    status: 'ready'
+    status: "ready",
   });
   const [updateCounter, setUpdateCounter] = useState(0); // Number of updates so far, only used to trigger useMemo.
   const isPFEWorkflow = checkIsPFEWorkflow(apiData.workflow);
@@ -45,28 +45,27 @@ function DataManager({
         setApiData({
           project: null,
           workflow: null,
-          status: 'fetching'
+          status: "fetching",
         });
 
-        const [ proj, wf ] = await Promise.all([
-          apiClient.type('projects').get(projectId),
-          apiClient.type('workflows').get(workflowId)
+        const [proj, wf] = await Promise.all([
+          apiClient.type("projects").get(projectId),
+          apiClient.type("workflows").get(workflowId),
         ]);
-        if (!proj) throw new Error('No project');
-        if (!wf) throw new Error('No workflow');
+        if (!proj) throw new Error("No project");
+        if (!wf) throw new Error("No workflow");
 
         setApiData({
           project: proj,
           workflow: wf,
-          status: 'ready'
+          status: "ready",
         });
-
       } catch (err) {
-        console.error('DataManager: ', err);
+        console.error("DataManager: ", err);
         setApiData({
           project: null,
           workflow: null,
-          status: 'error'
+          status: "error",
         });
       }
     }
@@ -81,9 +80,9 @@ function DataManager({
     function onWorkflowChange() {
       setUpdateCounter((uc) => uc + 1);
     }
-    wf?.listen('change', onWorkflowChange);
+    wf?.listen("change", onWorkflowChange);
     return () => {
-      wf?.stopListening('change', onWorkflowChange);
+      wf?.stopListening("change", onWorkflowChange);
     };
   }, [apiData.workflow]);
 
@@ -97,38 +96,50 @@ function DataManager({
 
       setApiData((prevState) => ({
         ...prevState,
-        status: 'updating'
+        status: "updating",
       }));
 
-      const newWorkflow = await wf.update(data).save();
+      try {
+        const newWorkflow = await wf.update(data).save();
 
-      setApiData((prevState) => ({
-        ...prevState,
-        workflow: newWorkflow, // Note: newWorkflow is actually the same as the old wf, so useMemo will have to listen to status changing instead.
-        status: 'ready'
-      }));
+        setApiData((prevState) => ({
+          ...prevState,
+          workflow: newWorkflow, // Note: newWorkflow is actually the same as the old wf, so useMemo will have to listen to status changing instead.
+          status: "ready",
+        }));
 
-      return newWorkflow;
+        return newWorkflow;
+      } catch (err) {
+        console.error("DataManager update error:", err);
+        setApiData((prevState) => ({
+          ...prevState,
+          status: "error",
+        }));
+      }
     }
 
     return {
       project: apiData.project,
       status: apiData.status,
       workflow: apiData.workflow,
-      update
+      update,
     };
   }, [apiData.project, apiData.workflow, apiData.status, updateCounter]);
 
   // Safety check: did this component receive its minimum input?
-  if (!workflowId) return (<div>ERROR: no Workflow ID specified</div>);
+  if (!workflowId) return <div>ERROR: no Workflow ID specified</div>;
 
   // Safety check: does this workflow belong to this project?
   if (apiData.workflow && apiData.project) {
-    const isWorkflowPartOfProject = checkIsWorkflowPartOfProject(apiData.workflow, apiData.project);
+    const isWorkflowPartOfProject = checkIsWorkflowPartOfProject(
+      apiData.workflow,
+      apiData.project
+    );
     if (!isWorkflowPartOfProject) {
       return (
         <div className="status-banner error">
-          ERROR: workflow {apiData.workflow.id} doesn't belong to project {apiData.project.id}
+          ERROR: workflow {apiData.workflow.id} doesn't belong to project{" "}
+          {apiData.project.id}
         </div>
       );
     }
@@ -139,16 +150,14 @@ function DataManager({
   // // if (!workflow) return null
 
   return (
-    <WorkflowContext.Provider
-      value={contextData}
-    >
-      {apiData.status === 'fetching' && (
+    <WorkflowContext.Provider value={contextData}>
+      {apiData.status === "fetching" && (
         <div className="status-banner fetching">Fetching data...</div>
       )}
-      {apiData.status === 'error' && (
+      {apiData.status === "error" && (
         <div className="status-banner error">ERROR: could not fetch data</div>
       )}
-      {isPFEWorkflow ? <PFEWorkflowWarning /> : children }
+      {isPFEWorkflow ? <PFEWorkflowWarning /> : children}
     </WorkflowContext.Provider>
   );
 }
@@ -163,7 +172,10 @@ first before allowing them
 function PFEWorkflowWarning() {
   return (
     <div className="pfe-workflow-warning">
-      <p>Sorry, but the new workflow editor doesn't support traditional workflows.</p>
+      <p>
+        Sorry, but the new workflow editor doesn't support traditional
+        workflows.
+      </p>
       <p>Please check back with us later, as we improve the workflow editor.</p>
     </div>
   );
@@ -172,10 +184,10 @@ function PFEWorkflowWarning() {
 DataManager.propTypes = {
   children: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.node),
-    PropTypes.node
+    PropTypes.node,
   ]),
   projectId: PropTypes.string,
-  workflowId: PropTypes.string
+  workflowId: PropTypes.string,
 };
 
 export default DataManager;


### PR DESCRIPTION
Staging branch URL: https://pr-{NUMBER}.pfe-preview.zooniverse.org

Fixes #7345.

## Describe your changes

Added error handling to the DataManager's `update()` function in the Pages Editor to properly catch and surface errors to users when workflow updates fail.

**Changes made:**
- Wrapped the `wf.update(data).save()` call in a try-catch block
- Added proper error state management by setting status to 'error' when updates fail
- Added console error logging for debugging purposes
- Ensures users get feedback when workflow updates fail due to permissions or other issues

This fixes the issue where users wouldn't know if their workflow changes failed to save, particularly in cases where they lack edit permissions for a workflow.

# Required Manual Testing

- [x] Does the non-logged in home page render correctly?
- [x] Does the logged in home page render correctly?
- [x] Does the projects page render correctly?
- [x] Can you load project home pages?

**Additional testing for this fix:**
- [x] Verify the Pages Editor shows appropriate error state when workflow updates fail
- [x] Check that successful workflow updates still work as expected

# Review Checklist

- [x] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [x] Does it work on mobile?
- [x] Can you `npm ci` and app works as expected?
- [x] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [x] Are the tests passing locally and on GitHub Actions?

<img width="819" height="623" alt="image" src="https://github.com/user-attachments/assets/8a608075-0d49-4990-a67e-bc2af15379dc" />
