### PR TITLE
Create admin checkbox for hiding the not-launch-approved banner

### DIFF
--- a/app/pages/admin/project-status/experimental-features.jsx
+++ b/app/pages/admin/project-status/experimental-features.jsx
@@ -20,6 +20,7 @@ const experimentalFeatures = [
   'freehandShape',
   'general feedback',
   'Gravity Spy Gold Standard',
+  'hideNotLaunchApprovedBanner', // Some projects do not want to be listed on the /projects landing page, but are actually approved by Zooniverse.
   'highlighter',
   'indexedSubjectSetNextPrevButtons',  // FEM only. Enables the "Next" and "Previous" buttons to appear on the SubjectSetProgressBanner, if and only if the Subject Set is indexed on the Subject Set Search API. Originally designed for Engaging Crowds 2021.
   'mini-course',

--- a/app/pages/project/home/project-home.jsx
+++ b/app/pages/project/home/project-home.jsx
@@ -34,6 +34,8 @@ const ProjectHomePage = (props) => {
 
   const showGetStartedLink = (!props.showWorkflowButtons && projectIsNotRedirected) || props.splits['workflow.assignment']
 
+  const hideNotLaunchApprovedBanner = props.project.experimental_tools?.includes('hideNotLaunchApprovedBanner')
+
   return (
     <div className="project-home-page">
       <div className="project-page project-background" style={backgroundStyle}>
@@ -73,7 +75,7 @@ const ProjectHomePage = (props) => {
               <i className="fa fa-external-link" />
             </a>}
         </div>
-        {!props.project.launch_approved &&
+        {!props.project.launch_approved && !hideNotLaunchApprovedBanner &&
           <Translate
             component="p"
             className="project-disclaimer"


### PR DESCRIPTION
Staging branch URL: https://pr-7349.pfe-preview.zooniverse.org/projects

This feature is requested for Mapping Prejudice, a project that is approved by the Zooniverse team, but does not want to be listed on the /projects landing page.

## Describe your changes.

- Create a checkbox in the experimental tools section of the project admin page
- Check for `hideNotLaunchApprovedBanner` in the project's experimental tools on the project home page

## How to Review

Run the app locally and.. 
- [ ] Visit a launched approved project like https://www.zooniverse.org/projects/brooke/i-fancy-cats?env=staging. The banner should not appear.
- [ ] Visit a not-launch-approved project like one of your test projects, and the banner should appear.
- [ ] Go to the admin page of the not-launch-approved project and toggle on "hideNotLaunchApprovedBanner" and the banner should be hidden on the project's home page.

This feature will be toggled for Mapping Prejudice only once this PR is merged and deployed.

