### PR TITLE
Caesar Status Indicator: Caesar badge now opens in new window/tab

### DIFF
--- a/app/fem-shared/components/caesar-status.jsx
+++ b/app/fem-shared/components/caesar-status.jsx
@@ -73,6 +73,8 @@ export default function CaesarStatus ({ workflow }) {
           <a
             className="caesar-status-badge"
             href={caesarWorkflowUrl}
+            rel="noopener noreferrer"
+            target="_blank"
           >
             <span className="caesar-status-badge-left">§</span>
             <span className="caesar-status-badge-center">Caesar</span>


### PR DESCRIPTION
## PR Overview

Affects: Caesar Status Indicator (see #7346)

This PR changes the behaviour of the "Caesar badge". Clicking on the Caesar badge (link) will now open the corresponding Caesar workflow page ([example](https://caesar-staging.zooniverse.org/workflows/3711)) in a **new browser window/tab,** instead of the _current_ browser window/tab.

<img width="400" alt="image" src="https://github.com/user-attachments/assets/4b65a674-45c8-403c-b558-b938b9dd2d05" />


Staging branch URL: https://pr-7356.pfe-preview.zooniverse.org/lab/1982/workflows/3711?env=staging

### Status

Ready for review 👌 
