### PR TITLE
Data Exports: add 'export failed' status message

### DIFF
--- a/app/partials/data-export-download-link.jsx
+++ b/app/partials/data-export-download-link.jsx
@@ -16,11 +16,16 @@ export default class DataExportDownloadLink extends React.Component {
 
         this.getExport = this.getExport.bind(this);
         this.recentAndReady = this.recentAndReady.bind(this);
+        this.recentAndFailed = this.recentAndFailed.bind(this);
         this.pending = this.pending.bind(this);
     }
 
     recentAndReady(exported) {
         return exported?.metadata && (exported.metadata.state === 'ready' || !exported.metadata.state);
+    }
+
+    recentAndFailed(exported) {
+        return exported?.metadata && (exported.metadata.state === 'failed' || !exported.metadata.state);
     }
 
     pending(exported) {
@@ -56,6 +61,10 @@ export default class DataExportDownloadLink extends React.Component {
             return (<span>
                 {`Most recent data available requested ${moment(this.state.mostRecent.updated_at).fromNow()}, `}
                 <a href={this.state.mostRecent.src}>download your data export</a>.
+              </span >);
+        } else if (this.recentAndFailed(this.state.mostRecent)) {
+            return (<span>
+                {`❌ Something went wrong while creating this export (${moment(this.state.mostRecent.updated_at).fromNow()})`}
               </span >);
         } else if (this.pending(this.state.mostRecent)) {
             return (<span>Export is being generated.</span>);


### PR DESCRIPTION
## PR Overview

Affects: Project Builder -> Data Exports page

This PR adds a "data export has failed" status message to the Data Exports page.

- Turns out, the /classifications_export, /subjects_export, /whatever_export, etc endpoints on Panoptes have a distinct "failed" state that we can detect, separate from the known "ready" (successful, completed export) and ~~"pending"~~ ~~"creating"~~ _working on it_ states. 
- **Without this fix, failed data exports will be perpetually displayed as "Export is being generated", _forever._**

> _Screenshot: example "data export failed" response from `https://panoptes-staging.zooniverse.org/api/projects/2003/subjects_export`._
>
> <img width="858" height="332" alt="image" src="https://github.com/user-attachments/assets/025f02ce-fe9d-4a8e-8321-6931b9d76f84" />

Staging branch URL: https://pr-7360.pfe-preview.zooniverse.org

### Testing

Baseline behaviour:
- Find a project with **successful** data exports, **pending** data exports, and/or **no** data exports.
- Go to the Data Exports page.
- Example: https://pr-7360.pfe-preview.zooniverse.org/lab/2021/data-exports?env=staging or https://pr-7360.pfe-preview.zooniverse.org/lab/1983/data-exports?env=staging
- Confirm that the "successful", "pending" and "never had a data export ever" messages are displaying correctly.

> _Screenshot: data exports, with some "successful" and "pending" messages_
> 
> <img width="739" height="178" alt="image" src="https://github.com/user-attachments/assets/3cd06f27-e7eb-4150-adfd-20e753fa2223" />
> 
> _Screenshot: data exports, with "never had one" messages_
> 
> <img width="459" height="171" alt="image" src="https://github.com/user-attachments/assets/e7124862-7ed8-4012-8599-d8aad84201b8" />

New behaviour:
- Find a project with **failed** data exports.
- Go to the Data Exports page.
- ~~Example: https://pr-7360.pfe-preview.zooniverse.org/lab/2021/data-exports?env=staging~~
  - CORRECTION: example - https://pr-7360.pfe-preview.zooniverse.org/lab/2003/data-exports?env=staging
- Confirm that the "failed" messages are displaying correctly.

> _Screenshot: data exports, with "failed" messages_
>
> <img width="679" height="177" alt="image" src="https://github.com/user-attachments/assets/e8d11081-3e3b-43f5-bb1a-f057855d2445" />

### Status

Ready for review. Low priority.

This was a 5 minute quick patch after a chat with @Tooyosi , who helpfully pointed out that this feature exists on the API side. 👍 
