### PR TITLE
FEM Project Redirects Batch 5

### DIFF
--- a/app/monorepoUtils.js
+++ b/app/monorepoUtils.js
@@ -126,7 +126,36 @@ export const SLUGS = [
   'mbarrierz/monkey-health-explorer',
   'jeyhansk/redshift-wrangler',
   'lolasolebo/eyes-on-eyes',
-  'teolixx/sunspot-detectives'
+  'teolixx/sunspot-detectives',
+  'lauraporturas/notes-from-nature-aphids-unfamiliar',
+  'albasu/climateviz',
+  'citizenreaders/picturing-childrens-stories',
+  'siren-project/siren-project',
+  'fwc/indigo-snake-watch',
+  'stephaniewilliams-ncdhc/north-carolina-primary-source-transcription',
+  'benjamin-dot-richards/oceaneyes',
+  'andreavarela89/iguanas-from-above',
+  'birgus2/western-shield-camera-watch',
+  'american-prairie/cameras-for-conservation',
+  'cindy-cifuentes/wesselman-woods-wildlife-watch',
+  'londonhogwatch/london-hogwatch-richmond-park',
+  'londonhogwatch/london-hogwatch',
+  'coolneighbors/backyard-worlds-cool-neighbors',
+  'caroline-cox/cloudcatcher',
+  'orionnau/rubin-comet-catchers',
+  'jebehm/wild-behavior-philadelphia',
+  'ywyh/delve-dwarf-galaxy-quest-milky-way-neighbors',
+  'alex-andersson/bursts-from-space-meerkat',
+  'ucla-seti-group/are-we-alone-in-the-universe',
+  'leslieazwell/back-bay-bird-identification',
+  'rebeccarhelm/the-living-sailor',
+  'chrismrp/radio-galaxy-zoo-lofar',
+  'rowan-aspire/drones-for-ducks',
+  'hongming-tang/radio-galaxy-zoo-emu',
+  'lcjohnso/local-group-cluster-search',
+  'mhnc-dot-up/dear-monsieur-sampaio-dot-dot-dot',
+  'physicsjosh/tag-trees'
+
 ];
 
 export function usesMonorepo(slug) {


### PR DESCRIPTION
FEM Project Redirects Batch 5

https://pr-7361.pfe-preview.zooniverse.org/projects

[Google Doc](https://docs.google.com/spreadsheets/d/1wmWFa51FDu-kS0OtSN1IcPdCR8iJXvPcI0oSu8-IshE/edit?gid=1028467830#gid=1028467830)

Static PR: https://github.com/zooniverse/static/pull/408

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
