### PR TITLE
Remove react-router Link from the Notes board SLTP link

### DIFF
--- a/app/talk/comment.cjsx
+++ b/app/talk/comment.cjsx
@@ -108,9 +108,9 @@ module.exports = createReactClass
   commentSubjectTitle: (comment, subject) ->
     {owner, name} = @props.params
     if (comment.focus_type is 'Subject') and (owner and name)
-      <Link to="/projects/#{owner}/#{name}/talk/subjects/#{comment.focus_id}" onClick={@logItemClick.bind this, "view-subject-direct"}>
+      <a href="https://www.zooniverse.org/projects/#{owner}/#{name}/talk/subjects/#{comment.focus_id}" onClick={@logItemClick.bind this, "view-subject-direct"}>
         Subject {subject.id}
-      </Link>
+      </a>
     else
       <span>Subject {subject.id}</span>
 


### PR DESCRIPTION
Staging branch URL: https://pr-7385.pfe-preview.zooniverse.org

Follows: https://github.com/zooniverse/Panoptes-Front-End/pull/7382

The link to a subject's SLTP page within a Talk Notes board should not route internallly.

I tested this at:
https://local.zooniverse.org:3735/projects/jeyhansk/redshift-wrangler/talk/5609/3880205?env=production and https://pr-7385.pfe-preview.zooniverse.org/projects/jeyhansk/redshift-wrangler/talk/5609/3880205
