### PR TITLE
fem-lab: Allow multi-image subjects to be displayed as separate frames first

### DIFF
--- a/app/pages/lab-fem/components/fem-multi-image-subject-options-editor.jsx
+++ b/app/pages/lab-fem/components/fem-multi-image-subject-options-editor.jsx
@@ -35,17 +35,33 @@ export default function FemMultiImageSubjectLayoutEditor ({
     })
   }
 
+  function handleSelectMode (e) {
+    const mode = e.target.value;
+    return workflow.update({
+      'configuration.multi_image_mode': mode
+    })
+  }
+
   const enableSwitchingChecked = !!workflow?.configuration?.enable_switching_flipbook_and_separate
+  const showSeparateFramesOptions = enableSwitchingChecked || workflow?.configuration?.multi_image_mode === 'separate'
   const enableAutoplayChecked = !!workflow?.configuration?.flipbook_autoplay
   const iterations = workflow?.configuration?.playIterations >= 0 ? workflow.configuration.playIterations : 3
   const layout = workflow?.configuration?.multi_image_layout || 'col'
   const cloneMarksChecked = !!workflow?.configuration?.multi_image_clone_markers
-
+  const mode = workflow?.configuration?.multi_image_mode || 'flipbook'
 
   return (
     <div className='multi-image-subject-layout-editor'>
       <span className="form-label">{`Multi-image options (Flipbook Viewer)`}</span><br/>
       <small className="form-help">Choose how to display subjects with multiple images.</small>
+      <div style={{ marginTop: '5px' }}>
+        <select id='multi_image_mode' onChange={handleSelectMode} value={mode}>
+          <option value='flipbook'>Show flipbook</option>
+          <option value='separate'>Show separate frames</option>
+        </select>
+        <label htmlFor='multi_image_mode'>{' '}View</label>
+        <small> - choose the view volunteers see first</small>
+      </div>
       <div>
         <select id='flipbook-play-iterations' onChange={handleSelectPlayIterations} value={iterations}>
           <option value=''>Infinite</option>
@@ -73,10 +89,10 @@ export default function FemMultiImageSubjectLayoutEditor ({
             checked={enableSwitchingChecked}
             onChange={toggleEnableSwitching}
           />
-          Allow Separate Frames View - <small>volunteers can choose flipbook or a separate frames view</small>
+          Allow to Choose View - <small>volunteers can choose flipbook or a separate frames view</small>
         </label>
       </div>
-      
+
       <div>
         <label>
           <input
@@ -88,7 +104,7 @@ export default function FemMultiImageSubjectLayoutEditor ({
         </label>
       </div>
 
-      {enableSwitchingChecked && <div>
+      {showSeparateFramesOptions && <div>
         <br />
         <span>Show separate frames as:</span>
         <br />


### PR DESCRIPTION
❌ https://github.com/zooniverse/front-end-monorepo/pull/7184 must be deployed before this PR is deployed (but please do review it!)

Staging branch URL: https://pr-7390.pfe-preview.zooniverse.org/lab/19645/workflows

Closes: https://github.com/zooniverse/front-end-monorepo/issues/7048

Add the select for choosing to display multi-image subjects as separate frames or flipbook first. At the time of building FEM's flipbook, it was undecided if there was going to be a general subject viewer dropdown in the lab, so this select was left out. Development of the lab is paused though, so all projects that use the FEM classifier should be able to display separate frames first if they want to.