### PR TITLE
Replace internal routes to /projects page with redirect to the static proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The app can be configured using the following environment variables:
 
 New GitHub PRs from within the Zooniverse organisation will be staged by Jenkins as part of the CI process. Once CI finishes, your changes should be staged at https://pr-{PR-Number}.pfe-preview.zooniverse.org. Jenkins sometimes times out before finishing the build. If a PR build fails, use the link to Jenkins (from your PR) to log in and try restarting the build.
 
-For testing with production data, you can add `env=production` to your development url, e.g. `localhost:3735/projects?env=production`. Note that it is removed on every page refresh.
+For testing with production data, you can add `env=production` to your development url, e.g. `localhost:3735/lab?env=production`. Note that it is removed on every page refresh.
 
 All the good stuff is in **./app**. Start at **./app/main.cjsx**
 

--- a/app/layout/site-footer.jsx
+++ b/app/layout/site-footer.jsx
@@ -81,9 +81,9 @@ class AppFooter extends React.Component {
           <nav className="app-footer__section app-footer__nav-lists">
             <ul className="app-footer__nav-list">
               <li>
-                {this.loggableLink(<Link to="/projects">
+                <a href="https://www.zooniverse.org/projects">
                   <Translate content="footer.discover.projectList" />
-                </Link>, 'footer.discover.projectList')}
+                </a>
               </li>
               <li>
                 {this.loggableLink(<Link to="/collections">

--- a/app/layout/site-nav.jsx
+++ b/app/layout/site-nav.jsx
@@ -94,14 +94,13 @@ const SiteNav = createReactClass({
             <Translate content="siteNav.home" />
           </a>
         }
-        <Link
-          to="/projects"
+        <a
+          href="https://www.zooniverse.org/projects"
           className="site-nav__link"
           activeClassName="site-nav__link--active"
-          onClick={!!this.logClick ? this.logClick.bind(this, 'mainNav.projects') : null}
         >
           <Translate content="siteNav.projects" />
-        </Link>{' '}
+        </a>{' '}
         <a href='https://www.zooniverse.org/about' className="site-nav__link">
           <Translate content="siteNav.about" />
         </a>{' '}

--- a/app/pages/accounts/accounts-page.jsx
+++ b/app/pages/accounts/accounts-page.jsx
@@ -89,9 +89,9 @@ function AccountsPage ({
                   </Link>
                 </li>
                 <li>
-                  <Link to="/projects">
+                  <a href="https://www.zooniverse.org/projects">
                     <Translate content="newAccountsPage.alreadySignedInLinks.gotoProjects" />
-                  </Link>
+                  </a>
                 </li>
               </ul>
             </div>

--- a/app/pages/lab/landing-page.cjsx
+++ b/app/pages/lab/landing-page.cjsx
@@ -46,9 +46,9 @@ module.exports = createReactClass
             <Translate content="labLanding.buttons.signIn" />
           </button>
 
-          <Link to="/projects" className="call-to-action standard-button landing-button">
+          <a href="https://www.zooniverse.org/projects" className="call-to-action standard-button landing-button">
             <Translate content="labLanding.buttons.backToProjects" />
-          </Link>
+          </a>
         </div>
 
         <div className="landing-links">

--- a/app/pages/reset-password/reset-password.jsx
+++ b/app/pages/reset-password/reset-password.jsx
@@ -82,7 +82,6 @@ class ResetPasswordPage extends React.Component {
           resetSuccess: true,
         });
         alert(resolve => <LoginDialog onSuccess={resolve} />);
-        this.context.router.push('/projects');
       })
       .catch((error) => {
         this.setState({

--- a/app/router.jsx
+++ b/app/router.jsx
@@ -161,8 +161,8 @@ export const routes = (
       <Route path="email" component={EmailSettingsPage} />
     </Route>
 
-    <Route path="projects" component={ProjectsPage}>
-      <IndexRoute component={FilteredProjectsList} />
+    <Route path="projects" onEnter={redirectToStaticProxy}>
+      <IndexRoute onEnter={redirectToStaticProxy} />
     </Route>
 
     <MonorepoRoutes />

--- a/app/rubin-2025/rubin-page.jsx
+++ b/app/rubin-2025/rubin-page.jsx
@@ -94,9 +94,9 @@ function RubinPage ({
               </p>
               <ul className="call-to-action">
                 <li>
-                  <Link to="/projects?discipline=astronomy&page=1&status=live">
+                  <a href="https://www.zooniverse.org/projects?discipline=space">
                     <Translate content='rubinPage.callToAction.toZooniverseProjects' />
-                  </Link>
+                  </a>
                 </li>
                 <li>
                   <a href="https://rubinobservatory.org/" rel="noopener nofollow noreferrer" target="_blank">


### PR DESCRIPTION
Staging branch URL: https://pr-7400.pfe-preview.zooniverse.org/lab

To be merged and deployed Jan 27.

## Describe your changes
- Replace react-router Links to /projects with an anchor tag to www
- Config the /projects Route in router.jsx to redirect to the static proxy

## How to review
- Anchor tags to Projects in the header and footer should go to www
- Check out https://local.zooniverse.org:3735/rubin. The link to Projects should be to www
- Same with https://local.zooniverse.org:3735/accounts when you're signed in
- Try to visit https://local.zooniverse.org:3735/projects and you'll be redirected
- When signed out, https://local.zooniverse.org:3735/lab has a link to Projects too
