### PR TITLE
Project Builder: add Field Guide Cleaner (admin-only)

### DIFF
--- a/app/pages/lab/field-guide/field-guide-cleaner.jsx
+++ b/app/pages/lab/field-guide/field-guide-cleaner.jsx
@@ -26,7 +26,7 @@ import { useEffect, useState } from 'react'
 export default function FieldGuideCleaner ({
   fieldGuide,
   icons = {},
-  userIsAdmin = true,
+  userIsAdmin = false,
 }) {
   if (!fieldGuide || !userIsAdmin) return null
 

--- a/app/pages/lab/field-guide/index.cjsx
+++ b/app/pages/lab/field-guide/index.cjsx
@@ -7,6 +7,7 @@ ArticleEditor = require './article-editor'
 FieldGuideCleaner = require('./field-guide-cleaner').default
 actions = require('./actions').default
 getAllLinked = require('../../../lib/get-all-linked').default
+isAdmin = require('../../../lib/is-admin')
 
 unless process.env.NODE_ENV is 'production'
   DEV_GUIDE = apiClient.type('field_guides').create
@@ -147,10 +148,13 @@ FieldGuideEditor = createReactClass
       <div className="form-help">
         <p>Information can be grouped into different sections, and each section should have a title and an icon. Content for each section is rendered with Markdown, so you can include any media you've uploaded for your project there.</p>
 
-        <FieldGuideCleaner
-          fieldGuide={@state.guide}
-          icons={@state.icons}
-        />
+        {isAdmin() && (
+          <FieldGuideCleaner
+            fieldGuide={@state.guide}
+            icons={@state.icons}
+            userIsAdmin={isAdmin()}
+          />
+        )}
       </div>
 
       {if @state.editing?


### PR DESCRIPTION
## PR Overview

Supports #7405 
Affects: Project Builder -> Edit Field Guide page **(Admin mode only)**
Staging branch URL: https://pr-7406.pfe-preview.zooniverse.org/lab/2023/guide?env=staging or https://pr-7406.pfe-preview.zooniverse.org/lab/24617/guide?env=production

This PR adds an admin-only tool, the Field Guide Cleaner, to the edit Field Guide page.

- As noted in 7405, there's a bug in the Edit Field Guide page that lets "cleared" icons _sometimes_ still stick around as part of a Field Guide's attached_images.
- This tool lists all images (icons) attached to a Field Guide, and shows which of those images are actually used in the Field Guide, and which are orphans.
- There's also a button that deletes (`attached_image_resource.delete()`) those orphaned icons.
- To enable this tool, ** you must have admin mode enabled.**

<img width="684" height="483" alt="image" src="https://github.com/user-attachments/assets/b2f0fe1a-9d60-49c4-8e19-d0684f527ddf" />

⚠️ **NOTE: this tool assumes that attached_images uploaded for a Field Guide aren't used anywhere else.** This is a pretty safe assumption given the use case, and given that the uploaded icons _are supposed to be deleted when their associated FG pages are deleted,_ but theoretically it's possible to do some really weird linkages with the Panoptes API if you're a mad scientist or something.

### Status

Ready for review.

I'm going ahead and running this for [Marine Lens: Florida Keys](https://www.zooniverse.org/lab/24617) to help solve their immediate issue.