### PR TITLE
PFE redirect: Name That Neutrino

### DIFF
--- a/app/slugList.js
+++ b/app/slugList.js
@@ -323,6 +323,7 @@ const PFE_SLUGS = [
   'hannah-dot-slesinski/chirp-check', // Audio subject with spectrogram isn't supported in FEM
   'hripsi-19/atmoselec-atmospheric-electricity-for-climate', // Issue with its combo task
   'hugo-ferreira/where-is-spoony', // Uses experimental "slider" subtask
+  'icecubeobservatory/name-that-neutrino',
   'laac-lscp/maturity-of-baby-sounds', // Audio subjects aren't supported in FEM's classifier
   'low-sky/bubblezoo-v1', // Oval drawing tool is a worse experience in FEM
   'marywestwood/the-cricket-wing', // Audio subject with spectrogram isn't supported in FEM


### PR DESCRIPTION
Add `icecubeobservatory/name-that-neutrino` to slug list to route to PFE.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
