### PR TITLE
ProjectNav: add randomiser for 'Classify' link for FEM projects

### DIFF
--- a/app/lib/nav-helpers/getProjectLinks.js
+++ b/app/lib/nav-helpers/getProjectLinks.js
@@ -73,7 +73,17 @@ function getProjectLinks({ project, projectRoles, user }) {
     const envQuery = env === 'staging' ? '?env=staging' : '';
     links.about.url = `${monorepoURL(i18nSlug)}/about${envQuery}`;
     links.about.isMonorepoLink = true;
-    links.classify.url = `${monorepoURL(i18nSlug)}/classify${envQuery}`;
+
+    // Hack/Fix: add a randomiser the to /classify route for FEM projects
+    // This overrides old/existing 308 Permanent Redirects for single-workflow
+    // projects on FEM.
+    // See https://github.com/zooniverse/front-end-monorepo/issues/7193
+    // REMOVE THIS on Mar 2027. All existing 308s will expire by then.
+    const classifyRandomiser = (envQuery.startsWith('?'))
+      ? `&rnd=${Math.floor(Math.random() * 1000000)}`
+      : `?rnd=${Math.floor(Math.random() * 1000000)}`;
+
+    links.classify.url = `${monorepoURL(i18nSlug)}/classify${envQuery}${classifyRandomiser}`;
     links.classify.isMonorepoLink = true;
   }
 


### PR DESCRIPTION
## PR Overview

Affects: 'Classify' link in the Project Nav, for every _FEM project[^1]_
Related to: zooniverse/front-end-monorepo#7193 and zooniverse/front-end-monorepo#7214

The base /classify path on FEM's project pages [(example)](https://www.zooniverse.org/projects/zooniverse/snapshot-wisconsin/classify) had a major bug where it redirected volunteers to the current active workflow[^2]... but using a _308 Permanent Redirect[^3]._ While this bug was fixed on FEM, _existing volunteers_ who had visited a /classify path before will _still have the 308 redirect permanently stored on their browser[^4]_ - hence, even with the fix (FEM PR 7214), they'd still be redirected.

This PR adds a _random value_ the "Classify" link (href) in the Project Nav, e.g. https://www.zooniverse.org/projects/zooniverse/snapshot-wisconsin/classify?rnd=342771

<img width="707" height="256" alt="image" src="https://github.com/user-attachments/assets/6990cd51-3837-411c-95ef-6abc7eceeb54" />

- This random value ensures that any time a volunteer clicks on "Classify" from say a Talk page, the HTTP request is treated as a _new request,_ and therefore the browser won't load up the previously saved 308 Permanent Redirect for the base /classify path.
- This random value is essentially ignored by the FEM's /classify page, so its addition causes no harm.
- PFE projects (e.g. https://local.zooniverse.org:3735/projects/zookeeper/galaxy-zoo/?env=production) are not affected by this change.

Staging branch URL: https://pr-7412.pfe-preview.zooniverse.org

[^1]: FEM projects are usually only encountered on PFE via their Talk, Collection, or Recents pages, e.g. https://www.zooniverse.org/projects/zooniverse/snapshot-wisconsin/talk
[^2]: for projects with one active workflow.
[^3]: it should have been a 307 Temporary Redirect, since the active workflow would change every time.
[^4]: well, the 308 has an expiry of one year, so technically we could wait it out until 4 Feb 2027... 😬 

### Testing

Use the following for testing:

- 🍎 PFE project: https://pr-7412.pfe-preview.zooniverse.org/projects/zookeeper/galaxy-zoo/talk?env=production
- 🍊 FEM project with one active workflow: https://pr-7412.pfe-preview.zooniverse.org/projects/zooniverse/snapshot-wisconsin/talk?env=production
- 🍌 FEM project with multiple active workflows: https://pr-7412.pfe-preview.zooniverse.org/projects/sumbredolphin/dolphin-spotting/talk?env=production

Testing Steps:

- For each project, ensure you're starting on the Talk page (which is a PFE page)
- Check the "Classify" link in the Project Nav.
  - 🍎 For the PFE project, ensure no ?rnd appears in the URL.
  - 🍊🍌 For the FEM projects, ensure a random ?rnd appears in the URL.
- Click on the "Classify" link. Ensure you're taken to the correct Classify page.
  - 🍎 For the PFE project, you should be taken to the base /classify route.
  - 🍊 For the FEM project with one workflow, you should be redirected **(via a 307 HTTP response)** to the single active workflow.
  - 🍌For the FEM project with many workflows, you should be taken to the base /classify route and be asked to choose from one of the available workflows.

### Status

Ready for review. This is a bit of a hack, but a necessary one, due to the nature of that darn 308. 😬 