### PR TITLE
Redirects: Galaxy Zoo to FEM, Galaxy Builder to PFE

### DIFF
--- a/app/slugList.js
+++ b/app/slugList.js
@@ -349,11 +349,11 @@ const PFE_SLUGS = [
   'rsengar/einstein-at-home-pulsar-seekers', // Feedback per step isn't supported in FEM
   'sassydumbledore/chimp-and-see', // Video in a flipbook isn't supported in FEM
   'tawakitom/penguins-from-above', // Subject image sizes difficult in FEM's classifier layout
+  'tingard/galaxy-builder', // custom slider interface on finished project
   'watchablewildlife/nebraska-wildlife-watch',
   'wildcam/wildcam-darien',
   'wwt/stream-team-emerging-insect-explorer',
   'xbonnin/solar-radio-burst-tracker', // Freehand segment line and freehand shape deprecated from FEM
-  'zookeeper/galaxy-zoo', // Uses experimental "slider" subtask
   'zooniverse/floating-forests',
   'zooniverse/intro2astro-hubbles-law', // Classrooms
   'zooniverse/measuring-the-anzacs', // Classrooms


### PR DESCRIPTION
Redirects:
Galaxy Zoo to FEM = https://www.zooniverse.org/projects/zookeeper/galaxy-zoo/
Galaxy Builder (finished, but custom slider interface) to PFE = https://www.zooniverse.org/projects/tingard/galaxy-builder

Staging branch URL: https://pr-7421.pfe-preview.zooniverse.org
Static PR: https://github.com/zooniverse/static/pull/434
