### PR TITLE
Project Builder: add circular Project logo preview (var B 🔴)

### DIFF
--- a/app/pages/lab/project-details.cjsx
+++ b/app/pages/lab/project-details.cjsx
@@ -128,6 +128,7 @@ module.exports = createReactClass
                       margin: '0 auto',
                     }}
                     src={@state.avatar?.src}
+                    alt='Preview of project avatar cropped to a circle'
                   />
                 </div>
               </div>


### PR DESCRIPTION
## PR Overview

Affects: Project Builder (Lab) -> Project Details page
Preview: https://pr-7423.pfe-preview.zooniverse.org/lab/19242

Our FEM pages displays Project Logos/Avatars as both 🟥 square (e.g. on the Projects page) and 🔴 circular (e.g. on the project's home page). Currently, we only show a _square logo_ in the project builder.

This PR updates our Project Builder (Lab) -> Project Details page with a "circular Project logo" preview.

<img width="400" alt="image" src="https://github.com/user-attachments/assets/e7384b9d-4a58-46cd-bce9-1fc819647c92" />

Functionality:

- If a Project has a Project Logo/Avatar, then...
  - ...an _additional_ image preview, with a _circular project logo,_ will be added in the description. 🆕
  - This circular project logo tries to follow the style on the FEM project page header.
  - The main square project logo remains unchanged.  
  - The text _"Your image will also be displayed as a circular logo on the project page. This is an example of how it will look like:"_ appears in the description. 🆕 
- If a Project doesn't have a  Project Logo/Avatar, then no changes. 

### Testing

You want to make sure the functionality works as advertised, and that this solution feels _right to you._

- Preview on a live Zooniverse project with a good logo: https://pr-7423.pfe-preview.zooniverse.org/lab/31309
- Preview a project with NO logo: https://pr-7423.pfe-preview.zooniverse.org/lab/16927
- Preview a project with a transparent logo: https://pr-7423.pfe-preview.zooniverse.org/lab/19242

⚠️ I haven't been able to test what happens when a new Project logo is added, or when an existing Project logo is replaced, because something is wonky with my file uploads. I'll follow up on this later, but if you can test this with your own projects and make sure nothing looks wonky, that'd be great.

### Status

This PR is an _initial proposed solution_  to the (fairly minor) problem of "yo FEM uses both square and circular logos". Be sure to compare this with Variant A 🔵 , found at: TODO

Tagging @seanmiller26 since this is a very rough idea and requires an expert's opinion on UI and UX.

Tagging @lcjohnso since this was brought up during our mini ZTM session earlier today.