### PR TITLE
Docs, config: update to match current use of Node 22

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,15 +24,13 @@ change dependencies in `package.json`.
 
 ### With Node.js
 
-Make sure you have Node 8 and `npm` 5 or greater. It's recommended you manage your Node installations with **nvm**.
+Make sure you have Node 22 and `npm` 10 or greater. It's recommended you manage your Node installations with **nvm**.
 
 - `npm ci` installs dependencies.
 
 - `npm start` builds and runs the site locally.
 
-⚠️ **Note 1:** _[npm ci](https://docs.npmjs.com/cli/v8/commands/npm-ci)_ (clean install) is preferred over _npm install,_ as it doesn't modify the package lock.
-
-⚠️ **Note 2:** as of Node 16.15, running _npm ci_ results in errors such as _npm ERR! ERESOLVE could not resolve_ and _Conflicting peer dependency: foobar@x.y.z_ You can bypass this problem by instead running `npm ci --legacy-peer-deps`. Please see [issue 6155](https://github.com/zooniverse/Panoptes-Front-End/issues/6155) for more details.
+⚠️ **Note:** _[npm ci](https://docs.npmjs.com/cli/v8/commands/npm-ci)_ (clean install) is preferred over _npm install,_ as it doesn't modify the package lock.
 
 ### Viewing the Website
 

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "whatwg-url": "~14.0.0"
   },
   "engines": {
-    "node": ">=20",
+    "node": ">=22",
     "npm": ">=10"
   },
   "license": "Apache-2.0",


### PR DESCRIPTION
## PR Overview

This PR updates our documentation and package.json, to reflect our current practice of using Node version 22.

- @mcbouslog discovered that running PFE tests on his localhost resulted in a bunch of `Exception during run: ReferenceError: navigator is not defined` errors. This was traced to his localhost being configured to use Node 20, which should've been caught by the package.json's `engines.node` config.
- Upon review, we realised that our GitHub YMLs and Dockerfile have long since been updated to use Node 22, _but our documentation has been lagging behind._

### Status

Ready for review.