### PR TITLE
Remove audio-only projects from slugList

### DIFF
--- a/app/slugList.js
+++ b/app/slugList.js
@@ -369,6 +369,7 @@ const PFE_SLUGS = [
   'marywestwood/the-cricket-wing', // Audio subject with spectrogram isn't supported in FEM
   'sandorkruk/istrox',
   'sladeaa/audioclassification',
+  'uw-leap/tots-and-tunes',
   'yli/humbug' // Audio subject with spectrogram isn't supported in FEM
 ]
 

--- a/app/slugList.js
+++ b/app/slugList.js
@@ -360,23 +360,15 @@ const PFE_SLUGS = [
   'zooniverse/measuring-the-anzacs', // Classrooms
   'zooniverse/zooniverse-in-schools', // Classrooms
   // Audio Projects
-  'annelistens/ocean-voices',
-  'cblume27/rhythms-of-the-night',
   'creisdorf/fire-and-birds',
   'creisdorf/savanna-spy-sound', // Audio subject with spectrogram isn't supported in FEM
   'cslab-upm/sky-sounds',
   'hannah-dot-slesinski/chirp-check', // Audio subject with spectrogram isn't supported in FEM
-  'laac-lscp/maturity-of-baby-sounds', // Audio subjects aren't supported in FEM's classifier
   'laaczooniverse/what-do-babies-say',
-  'library-of-congress/transcribe-american-dialect-recordings',
   'lydiakatsis/forest-sounds',
   'marywestwood/the-cricket-wing', // Audio subject with spectrogram isn't supported in FEM
-  'ollibruuh/bird-find', // Audio subjects aren't supported in FEM's classifier
-  'ollibruuh/frog-find', // Audio subjects aren't supported in FEM's classifier
   'sandorkruk/istrox',
   'sladeaa/audioclassification',
-  'uw-leap/tots-and-tunes',
-  'wingkitty/filk-archive',
   'yli/humbug' // Audio subject with spectrogram isn't supported in FEM
 ]
 


### PR DESCRIPTION
Removes audio-only projects from the slugList. This feature is now enabled in FEM and these projects are migrating.

Static PR: https://github.com/zooniverse/static/pull/440

## How to Review
- What user actions should my reviewer step through to review this PR?
- Are there plans for follow up PR’s to further fix this bug or develop this feature?

## Checklist

### General UX
- [ ] Staging branch URL: https://pr-{NUMBER}.pfe-preview.zooniverse.org/lab
- [ ] The component is accessible (double check especially if adding new code to this codebase). We recognize that not all legacy components of PFE will pass accessibility guidelines.
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)

### Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated

### Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected

### Maintenance
- [ ] If not from dependabot, the PR creator has described the update (major, minor, or patch version, changelog)
