### PR TITLE
Redirect the project stats page to the static proxy => FEM

### DIFF
--- a/app/pages/project/home/metadata.jsx
+++ b/app/pages/project/home/metadata.jsx
@@ -44,17 +44,17 @@ export default class ProjectMetadata extends React.Component {
 
   render() {
     const { project, translation } = this.props;
-    const statsLink = `/projects/${project.slug}/stats`;
+    const statsLink = `https://www.zooniverse.org/projects/${project.slug}/stats`;
 
     return (
       <div className="project-home-page__container">
         <div className="project-metadata">
-          <Link to={statsLink}>
+          <a href={statsLink}>
             <Translate
               content="project.home.metadata.statistics"
               with={{ title: translation.display_name }}
             />
-          </Link>
+          </a>
 
           {this.renderStatus()}
 

--- a/app/router.jsx
+++ b/app/router.jsx
@@ -51,7 +51,7 @@ import Collaborators from './pages/lab/collaborators.jsx'
 import PagesEditor from './pages/lab-pages-editor'
 import ProjectStatsPage from './pages/project/stats'
 import ProjectPageController from './pages/project/index'
-import PFE_SLUGS from './slugList.js';
+import PFE_SLUGS, { PRIVATE_PROJECT_SLUGS } from './slugList.js';
 
 // <Redirect from="home" to="/" /> doesn't work.
 class ONE_UP_REDIRECT extends React.Component {
@@ -73,8 +73,8 @@ class ONE_UP_REDIRECT extends React.Component {
  * @param {Object} nextState.params
  * @param {string} nextState.params.owner
  * @param {string} nextState.params.name
- * @param {Function} replace 
- * @param {Function} done 
+ * @param {Function} replace
+ * @param {Function} done
  */
 function redirectPfeToFem(nextState, replace, done) {
   try {
@@ -91,13 +91,30 @@ function redirectPfeToFem(nextState, replace, done) {
 }
 
 /**
+ * Redirect ProjectStatsPage to the static proxy unless the project slug is a known private project.
+*/
+function redirectPublicProjectsToFem(nextState, replace, done) {
+    try {
+    const { owner, name } = nextState.params
+    const isPrivateProject = PRIVATE_PROJECT_SLUGS.includes(`${owner}/${name}`)
+    if (isPrivateProject) {
+      done()
+    } else {
+      redirectToStaticProxy(nextState, replace, done)
+    }
+  } catch (error) {
+    done(error)
+  }
+}
+
+/**
  * Client-side redirect a route to the static proxy, by replacing the browser window location.
  * @param {Object} nextState
  * @param {Object} nextState.location
  * @param {string} nextState.location.pathname
  * @param {string} nextState.location.search
- * @param {Function} replace 
- * @param {Function} done 
+ * @param {Function} replace
+ * @param {Function} done
  */
 function redirectToStaticProxy(nextState, replace, done) {
   const { pathname, search } = nextState.location;
@@ -205,7 +222,7 @@ export const routes = (
         <Route path=":board" component={require('./talk/board')} />
         <Route path=":board/:discussion" component={require('./talk/discussion')} />
       </Route>
-      <Route path="stats" component={ProjectStatsPage} />
+      <Route path="stats" onEnter={redirectPublicProjectsToFem} component={ProjectStatsPage} />
       <Route path="favorites" component={require('./pages/collections/index')}>
         <IndexRoute component={require('./pages/collections/favorites-list')} />
         <Route path=":collection_owner" component={require('./pages/collections/favorites-list')} />
@@ -264,7 +281,7 @@ export const routes = (
         <Route path=":board" component={require('./talk/board')} />
         <Route path=":board/:discussion" component={require('./talk/discussion')} />
       </Route>
-      <Route path="stats" component={ProjectStatsPage} />
+      <Route path="stats" onEnter={redirectPublicProjectsToFem} component={ProjectStatsPage} />
       <Route path="favorites" component={require('./pages/collections/index')}>
         <IndexRoute component={require('./pages/collections/favorites-list')} />
         <Route path=":collection_owner" component={require('./pages/collections/favorites-list')} />

--- a/app/slugList.js
+++ b/app/slugList.js
@@ -7,37 +7,7 @@
   and https://github.com/zooniverse/static/blob/master/nginx-special-redirects.conf
 */
 
-const PFE_SLUGS = [
-  // Projects with a project.redirect property
-  'zooniverse/moon-zoo',
-  'zooniverse/solar-stormwatch',
-  'zooniverse/planet-hunters',
-  'zooniverse/old-weather',
-  'zooniverse/whale-fm',
-  'zooniverse/seti-live',
-  'zooniverse/seafloor-explorer',
-  'zooniverse/cyclone-center',
-  'zooniverse/bat-detective',
-  'zooniverse/cell-slider',
-  'zooniverse/planet-four-ouroboros',
-  'zooniverse/worm-watch-lab',
-  'zooniverse/plankton-portal-ouroboros',
-  'zooniverse/radio-galaxy-zoo',
-  'zooniverse/operation-war-diary',
-  'zooniverse/disk-detective-1-dot-0',
-  'zooniverse/sunspotter',
-  'zooniverse/condor-watch',
-  'zooniverse/asteroid-zoo',
-  'zooniverse/floating-forests-v1',
-  'zooniverse/higgs-hunters',
-  'zooniverse/science-gossip',
-  'zooniverse/orchid-observers',
-  'zooniverse/chimp-and-see-ouroboros',
-  'zooniverse/measuring-the-anzacs-original',
-  'drrogg/annotate',
-  'nypl/emigrant-city',
-  'bostonpubliclibrary/anti-slavery-manuscripts',
-  'judaicadh/scribes-of-the-cairo-geniza',
+export const PRIVATE_PROJECT_SLUGS = [
   // Private Projects
   'a-alam/classification-of-complex-radio-sources',
   'a-gordon/galaxy-tidal-feature-classifications',
@@ -309,7 +279,40 @@ const PFE_SLUGS = [
   'wragge/sydney-stock-exchange',
   'yjangordon/vlass-variables',
   'yntzevanderhoek/nkuba',
-  'zoeyyy/glitch-classification',
+  'zoeyyy/glitch-classification'
+]
+
+const OTHER_SLUGS = [
+  // Projects with a project.redirect property
+  'zooniverse/moon-zoo',
+  'zooniverse/solar-stormwatch',
+  'zooniverse/planet-hunters',
+  'zooniverse/old-weather',
+  'zooniverse/whale-fm',
+  'zooniverse/seti-live',
+  'zooniverse/seafloor-explorer',
+  'zooniverse/cyclone-center',
+  'zooniverse/bat-detective',
+  'zooniverse/cell-slider',
+  'zooniverse/planet-four-ouroboros',
+  'zooniverse/worm-watch-lab',
+  'zooniverse/plankton-portal-ouroboros',
+  'zooniverse/radio-galaxy-zoo',
+  'zooniverse/operation-war-diary',
+  'zooniverse/disk-detective-1-dot-0',
+  'zooniverse/sunspotter',
+  'zooniverse/condor-watch',
+  'zooniverse/asteroid-zoo',
+  'zooniverse/floating-forests-v1',
+  'zooniverse/higgs-hunters',
+  'zooniverse/science-gossip',
+  'zooniverse/orchid-observers',
+  'zooniverse/chimp-and-see-ouroboros',
+  'zooniverse/measuring-the-anzacs-original',
+  'drrogg/annotate',
+  'nypl/emigrant-city',
+  'bostonpubliclibrary/anti-slavery-manuscripts',
+  'judaicadh/scribes-of-the-cairo-geniza',
   // Assorted Special Cases
   'acre-ar/meteororum-ad-extremum-terrae', // Subject image sizes difficult in FEM's classifier layout
   'alicemead/sudan-road-access-logistics-cluster',
@@ -359,18 +362,20 @@ const PFE_SLUGS = [
   'zooniverse/intro2astro-hubbles-law', // Classrooms
   'zooniverse/measuring-the-anzacs', // Classrooms
   'zooniverse/zooniverse-in-schools', // Classrooms
-  // Audio Projects
+  // Audio + Spectrogram Projects
   'creisdorf/fire-and-birds',
-  'creisdorf/savanna-spy-sound', // Audio subject with spectrogram isn't supported in FEM
+  'creisdorf/savanna-spy-sound',
   'cslab-upm/sky-sounds',
-  'hannah-dot-slesinski/chirp-check', // Audio subject with spectrogram isn't supported in FEM
+  'hannah-dot-slesinski/chirp-check',
   'laaczooniverse/what-do-babies-say',
   'lydiakatsis/forest-sounds',
-  'marywestwood/the-cricket-wing', // Audio subject with spectrogram isn't supported in FEM
+  'marywestwood/the-cricket-wing',
   'sandorkruk/istrox',
   'sladeaa/audioclassification',
   'uw-leap/tots-and-tunes',
-  'yli/humbug' // Audio subject with spectrogram isn't supported in FEM
+  'yli/humbug'
 ]
+
+const PFE_SLUGS = [...PRIVATE_PROJECT_SLUGS, ...OTHER_SLUGS]
 
 export default PFE_SLUGS


### PR DESCRIPTION
## Linked Issue and/or Talk Post
Linked to https://github.com/zooniverse/static/pull/442

## Describe your changes
- Separate the list of project slugs into PRIVATE_PROJECT_SLUGS and OTHER_SLUGS so the list of private projects can be handled for the project /stats route.
- Redirect all project stats pages to the static proxy _unless_ it is a known private project held back on PFE.
- All other project routes should be unaffected.

## How to Review
- A known private project like `aprajita/swdemo `should display the PFE stats page: https://pr-7474.pfe-preview.zooniverse.org/projects/aprajita/swdemo/stats
- Any other project should get redirected to the FEM Project Stats page: https://pr-7474.pfe-preview.zooniverse.org/projects/zookeeper/galaxy-zoo/stats

## Checklist

### General UX
- [ ] Staging branch URL: https://pr-7474.pfe-preview.zooniverse.org/lab

### Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected
