### PR TITLE
Add message for empty recents page

### DIFF
--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -37,6 +37,7 @@ export default {
       tutorialTab: 'Tutorial'
     },
     recents: 'Your recent classifications',
+    recentsEmpty: 'The 20 most recent subjects you\'ve classified from the last 90 days are shown here',
     talk: 'Talk',
     taskHelpButton: 'Need some help with this task?',
     miniCourseButton: 'Restart the project mini-course',

--- a/app/pages/profile/recents.jsx
+++ b/app/pages/profile/recents.jsx
@@ -22,7 +22,7 @@ function Recents({ project, user }) {
           <Translate content="classifier.recents" component="h1" />
         </div>
       </div>
-      {(recents.length > 0) &&
+      {(recents.length > 0) ? (
         <div className="content-container collection-page-with-project-context">
           <ul className="collections-show">
             {recents.map((recent) => {
@@ -72,7 +72,13 @@ function Recents({ project, user }) {
             })}
           </ul>
         </div>
-      }
+      ) : (
+        <div>
+          <div>
+            <Translate content="classifier.recentsEmpty" component="p" />
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/app/pages/profile/recents.jsx
+++ b/app/pages/profile/recents.jsx
@@ -73,8 +73,8 @@ function Recents({ project, user }) {
           </ul>
         </div>
       ) : (
-        <div>
-          <div>
+        <div className="collections-container">
+          <div className="resource-results-counter collection-results-counter">
             <Translate content="classifier.recentsEmpty" component="p" />
           </div>
         </div>

--- a/css/project-page.styl
+++ b/css/project-page.styl
@@ -57,6 +57,11 @@
   width: 100%
   z-index: 2
 
+.project-page-wrapper
+  display: flex
+  flex: 1 0 auto
+  flex-direction: column
+
 .project-page
   background: PROJECT_BACKGROUND
   border-bottom: 5px solid TEAL_DARK


### PR DESCRIPTION
## Linked Issue and/or Talk Post
- closes #7473 

## Describe your changes
- add empty recents message "The 20 most recent subjects you\'ve classified from the last 90 days are shown here"
- refactor [project-page-wrapper](https://github.com/zooniverse/Panoptes-Front-End/blob/main/app/pages/project/index.jsx#L317) with flex to fill page
- style empty recents message similar to ["No collections found" message](https://github.com/zooniverse/Panoptes-Front-End/blob/main/app/pages/collections/list.cjsx#L191-L193)

## How to Review
- What user actions should my reviewer step through to review this PR?
  - find a project you don't have any recents for
  - note the page as is (for me https://www.zooniverse.org/projects/mschwamb/planet-four/recents?env=production)
  - note the page with these changes has an empty recents message, consistent styling, and fills page (for me https://local.zooniverse.org:3735/projects/mschwamb/planet-four/recents?env=production or https://pr-7477.pfe-preview.zooniverse.org/projects/mschwamb/planet-four/recents?env=production)
- Are there plans for follow up PR’s to further fix this bug or develop this feature? yes, see linked GitHub Project

## Checklist

### General UX
- [ ] Staging branch URL: https://pr-7477.pfe-preview.zooniverse.org/lab
- [ ] The component is accessible (double check especially if adding new code to this codebase). We recognize that not all legacy components of PFE will pass accessibility guidelines.
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)

### Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated

### Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected