### PR TITLE
Panoptes-Front-End: Add SegmentedLine tool to GeoDrawing task editor

### DIFF
--- a/app/classifier/tasks/drawing/min-max-editor.jsx
+++ b/app/classifier/tasks/drawing/min-max-editor.jsx
@@ -7,6 +7,15 @@ class MinMaxEditor extends React.Component {
     name: PropTypes.string,
     choice: PropTypes.object,
     workflow: PropTypes.object,
+    minKey: PropTypes.string,
+    maxKey: PropTypes.string,
+    minLimit: PropTypes.number,
+  };
+
+  static defaultProps = {
+    minKey: 'min',
+    maxKey: 'max',
+    minLimit: 0,
   };
 
   state = {
@@ -28,25 +37,25 @@ class MinMaxEditor extends React.Component {
   onChangeMin = (e) => {
     const tool = this.state.tool;
     if (e.target.value) {
-      tool.min = e.target.value;
+      tool[this.props.minKey] = e.target.value;
     } else {
-      delete tool.min;
+      delete tool[this.props.minKey];
     }
-    if (tool.max && tool.max < tool.min) {
-      tool.max = tool.min;
+    if (tool[this.props.maxKey] && tool[this.props.maxKey] < tool[this.props.minKey]) {
+      tool[this.props.maxKey] = tool[this.props.minKey];
     }
     this.updateWorkflow(tool);
   };
 
   onChangeMax = (e) => {
     const tool = this.state.tool;
-    const newMax = e.target.value && e.target.value < this.state.tool.min ?
-      this.state.tool.min :
+    const newMax = e.target.value && e.target.value < this.state.tool[this.props.minKey] ?
+      this.state.tool[this.props.minKey] :
       e.target.value;
     if (newMax) {
-      tool.max = newMax;
+      tool[this.props.maxKey] = newMax;
     } else {
-      delete tool.max;
+      delete tool[this.props.maxKey];
     }
     this.updateWorkflow(tool);
   };
@@ -66,10 +75,10 @@ class MinMaxEditor extends React.Component {
           <input
             type="number"
             inputMode="numeric"
-            name={`${this.props.name}.min`}
-            min="0"
-            value={this.state.tool.min}
-            placeholder="0"
+            name={`${this.props.name}.${this.props.minKey}`}
+            min={this.props.minLimit}
+            value={this.state.tool[this.props.minKey]}
+            placeholder={`${this.props.minLimit}`}
             size="5"
             style={{ width: '5ch' }}
             onChange={this.onChangeMin}
@@ -80,9 +89,9 @@ class MinMaxEditor extends React.Component {
           <input
             type="number"
             inputMode="numeric"
-            name={`${this.props.name}.max`}
-            min={this.state.tool.min ? this.state.tool.min : 0}
-            value={this.state.tool.max}
+            name={`${this.props.name}.${this.props.maxKey}`}
+            min={this.state.tool[this.props.minKey] ? this.state.tool[this.props.minKey] : this.props.minLimit}
+            value={this.state.tool[this.props.maxKey]}
             placeholder="∞"
             size="5"
             style={{ width: '5ch' }}

--- a/app/classifier/tasks/generic-editor.cjsx
+++ b/app/classifier/tasks/generic-editor.cjsx
@@ -309,59 +309,25 @@ module.exports = createReactClass
                         key="segmented-line-bounds"
                         className="workflow-choice-setting"
                       >
-                        <AutoSave resource={@props.workflow}>
-                          <strong>Points per line</strong>{' '}
-                          <small>(controls vertices within a single drawn line)</small>
-                          <br />
-                          <label>
-                            Min{' '}
-                            <input
-                              type="number"
-                              min="2"
-                              placeholder="2"
-                              name="#{@props.taskPrefix}.#{choicesKey}.#{index}.min_vertices"
-                              value={choice.min_vertices || ''}
-                              onChange={handleChange}
-                            />
-                          </label>{' '}
-                          <label>
-                            Max{' '}
-                            <input
-                              type="number"
-                              min="2"
-                              placeholder="no max"
-                              name="#{@props.taskPrefix}.#{choicesKey}.#{index}.max_vertices"
-                              value={choice.max_vertices || ''}
-                              onChange={handleChange}
-                            />
-                          </label>
-                          <br />
-                          <strong>Number of lines</strong>{' '}
-                          <small>(controls how many lines the volunteer may draw)</small>
-                          <br />
-                          <label>
-                            Min{' '}
-                            <input
-                              type="number"
-                              min="0"
-                              placeholder="0"
-                              name="#{@props.taskPrefix}.#{choicesKey}.#{index}.min"
-                              value={choice.min || ''}
-                              onChange={handleChange}
-                            />
-                          </label>{' '}
-                          <label>
-                            Max{' '}
-                            <input
-                              type="number"
-                              min="1"
-                              placeholder="no max"
-                              name="#{@props.taskPrefix}.#{choicesKey}.#{index}.max"
-                              value={choice.max || ''}
-                              onChange={handleChange}
-                            />
-                          </label>
-                        </AutoSave>
+                        <strong>Number of lines</strong>{' '}
+                        <small>(controls how many lines the volunteer may draw)</small>
+                        <MinMaxEditor
+                          key='min-max-lines'
+                          workflow={@props.workflow}
+                          name="#{@props.taskPrefix}.#{choicesKey}.#{index}"
+                          choice={choice}
+                        />
+                        <strong>Points per line</strong>{' '}
+                        <small>(controls vertices within a single drawn line)</small>
+                        <MinMaxEditor
+                          key='min-max-vertices'
+                          workflow={@props.workflow}
+                          name="#{@props.taskPrefix}.#{choicesKey}.#{index}"
+                          choice={choice}
+                          minKey='min_vertices'
+                          maxKey='max_vertices'
+                          minLimit={2}
+                        />
                       </div>
                     else
                       null

--- a/app/classifier/tasks/generic-editor.cjsx
+++ b/app/classifier/tasks/generic-editor.cjsx
@@ -256,6 +256,7 @@ module.exports = createReactClass
                         Geometry type{' '}
                         <select name="#{@props.taskPrefix}.#{choicesKey}.#{index}.type" value={choice.type} onChange={handleChange}>
                           <option key="Point" value="Point">Point</option>
+                          <option key="SegmentedLine" value="SegmentedLine">Segmented line</option>
                         </select>
                       </AutoSave>
                     </div>
@@ -302,6 +303,65 @@ module.exports = createReactClass
                             <small><sup>*</sup>per GeoJSON feature&apos;s <code>properties.uncertainty_radius</code> value (integer).</small>{' '}
                           </AutoSave>
                         </label>
+                      </div>
+                    else if choice.type is 'SegmentedLine'
+                      <div
+                        key="segmented-line-bounds"
+                        className="workflow-choice-setting"
+                      >
+                        <AutoSave resource={@props.workflow}>
+                          <strong>Points per line</strong>{' '}
+                          <small>(controls vertices within a single drawn line)</small>
+                          <br />
+                          <label>
+                            Min{' '}
+                            <input
+                              type="number"
+                              min="2"
+                              placeholder="2"
+                              name="#{@props.taskPrefix}.#{choicesKey}.#{index}.min_vertices"
+                              value={choice.min_vertices || ''}
+                              onChange={handleChange}
+                            />
+                          </label>{' '}
+                          <label>
+                            Max{' '}
+                            <input
+                              type="number"
+                              min="2"
+                              placeholder="no max"
+                              name="#{@props.taskPrefix}.#{choicesKey}.#{index}.max_vertices"
+                              value={choice.max_vertices || ''}
+                              onChange={handleChange}
+                            />
+                          </label>
+                          <br />
+                          <strong>Number of lines</strong>{' '}
+                          <small>(controls how many lines the volunteer may draw)</small>
+                          <br />
+                          <label>
+                            Min{' '}
+                            <input
+                              type="number"
+                              min="0"
+                              placeholder="0"
+                              name="#{@props.taskPrefix}.#{choicesKey}.#{index}.min"
+                              value={choice.min || ''}
+                              onChange={handleChange}
+                            />
+                          </label>{' '}
+                          <label>
+                            Max{' '}
+                            <input
+                              type="number"
+                              min="1"
+                              placeholder="no max"
+                              name="#{@props.taskPrefix}.#{choicesKey}.#{index}.max"
+                              value={choice.max || ''}
+                              onChange={handleChange}
+                            />
+                          </label>
+                        </AutoSave>
                       </div>
                     else
                       null


### PR DESCRIPTION
## Package
- Panoptes-Front-End (Lab / Project Builder)

## Linked Issue and/or Talk Post
- Closes #7459

## Describe your changes
- Add `SegmentedLine` to the Geometry type select inside a GeoDrawing task editor's tool entry, alongside the existing `Point` option, with the visible label "Segmented line"
- When a tool's type is set to SegmentedLine, render a tool-config block with two paired Min/Max inputs: **Points per line** (controls vertices within a single drawn line, fields `min_vertices` / `max_vertices`) and **Number of lines** (controls how many lines the volunteer may draw per task, fields `min` / `max`)
- All four inputs are number inputs with inline placeholder text (`2`, `no max`, `0`, `no max`) so an empty value reads as "use the open-ended default", and each has a `min` attribute reflecting its lower bound (2 for points-per-line, 0 for line-count min, 1 for line-count max)
- Mirrors the existing geoPoint tool editor shape inside the same file; no changes to any other tool type, no new selectors, no CSS additions

## How to Review
Helpful explanations that will make your reviewer happy:

What Zooniverse project should my reviewer use to review UX?
- `markbouslog/north-star-mapping-project` on production (project id `31513`, workflow `32087` "GeoDrawing SegmentedLine", subject set `136882` "Boundary Waters BWCAW (test)" with 6 BWCA-area lake subjects pre-loaded for end-to-end exercise).

What user actions should my reviewer step through to review this PR?
- [ ] run `npm start` in `Panoptes-Front-End`
- [ ] open https://local.zooniverse.org:3735/lab/31513/workflows/32087?env=production and sign in (the `?env=production` query param points panoptes-client at production Panoptes)
- [ ] in the workflow's task list, open the GeoDrawing task editor
- [ ] click "+ Add a tool" (or open an existing tool's Geometry-type select). Confirm the dropdown now offers two options: `Point` and `Segmented line`
- [ ] select `Segmented line`. Confirm a new tool-config block renders with the heading **Points per line** followed by Min and Max number inputs (placeholders `2` and `no max`), then **Number of lines** followed by Min and Max number inputs (placeholders `0` and `no max`)
- [ ] type a value into each input and confirm the AutoSave behavior writes through to the workflow record (panoptes-client patch fires against production Panoptes)
- [ ] switch the same tool's type back to `Point`; confirm the LineString-specific config block disappears and the existing Point editor renders unchanged
- [ ] (optional end-to-end) open https://www.zooniverse.org/projects/markbouslog/north-star-mapping-project/classify/workflow/32087 and confirm a subject loads in the GeoDrawing classifier with the two LineString tools the workflow currently has configured
- [ ] confirm no new console errors appear that aren't already present on `main` (existing PFE noise around `activeClassName` casing and bearer-token 401s is unrelated)

Which storybook stories should be reviewed?
- n/a. PFE doesn't ship a Storybook surface for `generic-editor.cjsx`; the Lab page above is the user-facing surface.

Are there plans for follow up PR's to further fix this bug or develop this feature?
- This is PR 9 of 9 in the CSSI Mapping Segmented Line milestone; the milestone closes with this PR. The FEM classifier side of the same milestone lands across [#7414](https://github.com/zooniverse/front-end-monorepo/pull/7414), [#7415](https://github.com/zooniverse/front-end-monorepo/pull/7415), [#7416](https://github.com/zooniverse/front-end-monorepo/pull/7416), [#7429](https://github.com/zooniverse/front-end-monorepo/pull/7429), [#7435](https://github.com/zooniverse/front-end-monorepo/pull/7435), [#7448](https://github.com/zooniverse/front-end-monorepo/pull/7448), [#7455](https://github.com/zooniverse/front-end-monorepo/pull/7455), and [#7468](https://github.com/zooniverse/front-end-monorepo/pull/7468)
- Later CSSI Mapping milestones extend this same editor file (`app/classifier/tasks/generic-editor.cjsx`): tile-layer editor (Map Layers), overlay-layer editor (WFS Overlays), basemap selector (Map Layers), Freehand mode checkbox on this LineString tool entry (Freehand Line Mode). Each ships as its own PR.
