### PR TITLE
fix: lazy-load images in Talk comments

### DIFF
--- a/app/components/wrapped-markdown.jsx
+++ b/app/components/wrapped-markdown.jsx
@@ -3,6 +3,10 @@ import React from 'react';
 import { Markdown } from 'markdownz';
 import { browserHistory } from 'react-router';
 
+const components = {
+  img: (props) => <img loading="lazy" {...props} />
+}
+
 class WrappedMarkdown extends React.Component {
   static propTypes = {
     content: PropTypes.string,
@@ -33,6 +37,7 @@ class WrappedMarkdown extends React.Component {
           content={this.props.content}
           project={this.props.project}
           header={this.props.header}
+          components={components}
         />
       </div>
     );


### PR DESCRIPTION
Modify the `WrappedMarkdown` component, which is used to display Talk comments, to add `loading="lazy"` to all `<img>` elements. This should improve image loading performance on discussions with many embedded images, eg. https://www.zooniverse.org/projects/zookeeper/galaxy-zoo/talk/1269/1184766

Test it out here: https://local.zooniverse.org:3735/projects/zookeeper/galaxy-zoo/talk/1269/1184766?env=production
Images further down the discussion should defer loading until you scroll down.

- Fixes #7481.

# Required Manual Testing

- [ ] Does the non-logged in home page render correctly?
- [ ] Does the logged in home page render correctly?
- [ ] Does the projects page render correctly?
- [ ] Can you load project home pages?
- [ ] Can you load the classification page?
- [ ] Can you submit a classification?
- [ ] Does talk load correctly?
- [ ] Can you post a talk comment?

# Review Checklist

- [ ] Does it work in all major browsers: Firefox, Chrome, Edge, Safari?
- [ ] Does it work on mobile?
- [ ] Can you `npm ci` and app works as expected?
- [ ] If the component is in coffeescript, is it converted to ES6? Is it free of eslint errors? Is the conversion its own commit?
- [ ] Are the tests passing locally and on GitHub Actions?

# Optional

- [ ] Have you replaced any `ChangeListener` or `PromiseRenderer` components with code that updates component state?
- [ ] If changes are made to the classifier, does the dev classifier still work?
- [ ] Have you [resized and compressed](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/image-optimization) any image you've added?
- [ ] Have you added in [flow type annotations](https://flowtype.org/docs/type-annotations.html)?
- [ ] Have you followed the [Springer guidelines for commit messages](https://github.com/springernature/frontend-playbook/blob/master/git/git.md#commit-messages)?
