### PR TITLE
Remove the note about mp3 and m4a in the project builder subject upload

### DIFF
--- a/app/pages/lab/subject-set.cjsx
+++ b/app/pages/lab/subject-set.cjsx
@@ -18,7 +18,7 @@ isAdmin = require '../../lib/is-admin'
 NOOP = Function.prototype
 
 VALID_SUBJECT_EXTENSIONS = ['.jpg', '.jpeg', '.png', '.gif', '.svg', '.mp3', '.mp4', '.m4a', '.mpeg', '.txt', '.json']
-VALID_FEM_EXTENSIONS = ['.jpg', '.jpeg', '.png', '.gif', '.mp4', '.mpeg', '.txt', '.json']
+VALID_FEM_EXTENSIONS = ['.jpg', '.jpeg', '.png', '.gif', '.mp3', '.mp4', '.m4a', '.mpeg', '.txt', '.json']
 
 VALID_FILE_TYPES = [
   'text/csv',
@@ -235,7 +235,7 @@ EditSubjectSetPage = createReactClass
             Subject images can be up to {MAX_FILE_SIZE / 1024}KB and any of: {<span key={ext}><code>{ext}</code>{', ' if VALID_FEM_EXTENSIONS[i + 1]?}</span> for ext, i in VALID_FEM_EXTENSIONS}{' '}
             and may not contain {<span key={char}><kbd>{char}</kbd>{', ' if INVALID_FILENAME_CHARS[i + 1]?}</span> for char, i in INVALID_FILENAME_CHARS}<br />
             <br />
-            If you have .svg, .m4a, or .mp3 subjects, please email us at contact@zooniverse.org. We can host your project on our legacy architecture until these formats are supported on our <a href='https://blog.zooniverse.org/2024/04/23/navigating-the-future-zooniverses-frontend-codebase-migration-and-design-evolution/'>new architecture</a>.
+            If you have .svg subjects, please email us at contact@zooniverse.org. We can host your project on our legacy architecture until these formats are supported on our <a href='https://blog.zooniverse.org/2024/04/23/navigating-the-future-zooniverses-frontend-codebase-migration-and-design-evolution/'>new architecture</a>.
           </UploadDropTarget>
         </p>}
       <div className="manifests-and-subjects">


### PR DESCRIPTION
## Linked Issue and/or Talk Post
https://github.com/zooniverse/front-end-monorepo/issues/7131
https://github.com/zooniverse/front-end-monorepo/issues/7211

## Describe your changes
- Remove the note about mp3 and m4a in the project builder subject upload

## How to Review
- https://pr-7485.pfe-preview.zooniverse.org/lab

## Checklist

### General UX
- [ ] Staging branch URL: https://pr-7485.pfe-preview.zooniverse.org/lab
- [ ] The component is accessible (double check especially if adding new code to this codebase). We recognize that not all legacy components of PFE will pass accessibility guidelines.
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
