### PR TITLE
Revert warnings for admin user classification widget

### DIFF
--- a/app/pages/admin/user-settings.jsx
+++ b/app/pages/admin/user-settings.jsx
@@ -111,11 +111,8 @@ class UserSettings extends Component {
           ))}
           </ul>
         </details>
-        <details style={{ background: '#c0c0c0' }}>
-          <summary>Semi-recent classifications {this.state.classifications.length}</summary>
-          <p>⚠️ WARNING: classifications are <b>not correctly sorted</b> by most recently created. Order of classifications is semi-random.</p>
-          <p>⚠️ WARNING: filtering by Subject ID <b>may not work</b> and return no results, even if the classification actually exists.</p>
-          <p>⚠️ WARNING: actually, this feature may be pretty much broken.</p>
+        <details>
+          <summary>Recent classifications {this.state.classifications.length}</summary>
           <form onSubmit={this.updateSubjectID}>
             <label for="subjectId">Filter by subject ID: </label>
             <input id="subjectId" name="subjectID" type="text" defaultValue='' pattern='\d+' />

--- a/app/pages/admin/user-settings/stats.js
+++ b/app/pages/admin/user-settings/stats.js
@@ -83,8 +83,8 @@ export function getUserProjects(user, callback, _page = 1) {
 
 export function getUserClassifications(user, subject_id, _page = 1) {
   return user.get('classifications', {
-    subject_id: subject_id ? subject_id : undefined,  // WARNING: might not actually work.
-    // sort: '-created_at',  // WARNING: sorting doesn't work for Classifications.
+    subject_id: subject_id ? subject_id : undefined,
+    sort: '-created_at',
     page: _page
   })
 }


### PR DESCRIPTION
After https://github.com/zooniverse/panoptes/pull/4465, the recent classification section of the user admin page now works as expected. Furthermore, no evidence that the "filter classifications by subject_id" functionality is not working as expected. Therefore, this PR reverts the warnings and stylings introduced by #7299.

Closes #7479 

## How to Review
- Try the user admin page for any user, see that the first page of results containing the most recent 20 classifications are returned in order.
- Staging branch URL: https://pr-7487.pfe-preview.zooniverse.org/admin/