### PR TITLE
Remove mobile validations on feedback

### DIFF
--- a/app/pages/lab/mobile/mobile-section-container.fixtures.js
+++ b/app/pages/lab/mobile/mobile-section-container.fixtures.js
@@ -95,20 +95,6 @@ const validationFixtures = {
       type: 'drawing'
     }
   },
-  taskFeedbackEnabled: {
-    task: {
-      type: 'drawing',
-      tools: [
-        {
-          type: 'rectangle',
-          details: []
-        }
-      ],
-      feedback: {
-        enabled: true
-      }
-    }
-  },
   workflowFlipbookEnabled: {
     workflow: {
       configuration: {

--- a/app/pages/lab/mobile/mobile-section-container.jsx
+++ b/app/pages/lab/mobile/mobile-section-container.jsx
@@ -39,10 +39,6 @@ function taskInstructionNotTooLong({ task }) {
   return convertBooleanToValidation(instruction ? instruction.length < VALID_QUESTION_LENGTH : false);
 }
 
-function taskFeedbackDisabled({ task }) {
-  return convertBooleanToValidation(!task.feedback || !task.feedback.enabled);
-}
-
 function workflowHasSingleTask({ workflow }) {
   return convertBooleanToValidation(filter(workflow.tasks, ({ type }) => type !== 'shortcut').length === 1);
 }
@@ -115,7 +111,6 @@ const validatorFns = {
   },
   drawing: {
     taskInstructionNotTooLong,
-    taskFeedbackDisabled,
     workflowHasSingleTask,
     drawingToolTypeIsValid,
     drawingTaskHasOneTool,
@@ -225,7 +220,6 @@ class MobileSectionContainer extends Component {
 MobileSectionContainer.propTypes = {
   task: PropTypes.shape({
     answers: PropTypes.array,
-    feedback: PropTypes.object,
     instruction: PropTypes.string,
     question: PropTypes.string,
     type: PropTypes.string,
@@ -247,10 +241,7 @@ MobileSectionContainer.defaultProps = {
     type: '',
     instruction: '',
     question: '',
-    answers: [],
-    feedback: {
-      enabled: false
-    }
+    answers: []
   }
 };
 

--- a/app/pages/lab/mobile/mobile-section-container.spec.js
+++ b/app/pages/lab/mobile/mobile-section-container.spec.js
@@ -118,11 +118,6 @@ describe('<MobileSectionContainer />', function () {
       testValidationProp('taskInstructionNotTooLong', validationFixtures.taskInstructionTooLong, false);
     });
 
-    it('should check whether the task uses feedback if the task type is drawing', function () {
-      testValidationProp('taskFeedbackDisabled', validationFixtures.workflowHasValidDrawingTask, true);
-      testValidationProp('taskFeedbackDisabled', validationFixtures.taskFeedbackEnabled, false);
-    });
-
     it('should check whether the workflow has a single task', function () {
       testValidationProp('workflowHasSingleTask');
       testValidationProp('workflowHasSingleTask', validationFixtures.workflowHasMultipleTasks, false);

--- a/app/pages/lab/mobile/mobile-section.jsx
+++ b/app/pages/lab/mobile/mobile-section.jsx
@@ -21,7 +21,6 @@ counterpart.registerTranslations('en', {
       workflowNotTooManyShortcuts: 'Has less than three shortcuts',
       workflowDoesNotContainShortcuts: 'Has no shortcuts',
       workflowDoesNotUseGroupedSubjectSelection: 'Does not use grouped subject selection',
-      taskFeedbackDisabled: 'Cannot provide feedback',
       workflowQuestionHasOneOrLessImages: 'Task question has no more than one image',
       workflowInstructionHasOneOrLessImages: 'Task instruction has no more than one image',
       drawingToolTypeIsValid: 'Drawing tool must be a rectangle tool',


### PR DESCRIPTION
## Linked Issue and/or Talk Post
- closes #7498 

## Describe your changes
- iteration on #7092 
- remove remaining mobile validations on workflow feedback

## How to Review
- What user actions should my reviewer step through to review this PR?
  - note failed validation on production: https://www.zooniverse.org/lab/5971/workflows/32400
  - note this PR changes fix,
    - local: https://local.zooniverse.org:3735/lab/5971/workflows/32400?env=production
    - staged branch: https://pr-7501.pfe-preview.zooniverse.org/lab/5971/workflows/32400?env=production
- Are there plans for follow up PR’s to further fix this bug or develop this feature? No.

## Checklist

### General UX
- [ ] Staging branch URL: https://pr-{NUMBER}.pfe-preview.zooniverse.org/lab
- [ ] The component is accessible (double check especially if adding new code to this codebase). We recognize that not all legacy components of PFE will pass accessibility guidelines.
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)

### Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated