### PR TITLE
Panoptes-Front-End: Add a Number of points editor to the GeoDrawing Point tool config

### DIFF
--- a/app/classifier/tasks/drawing/min-max-editor.jsx
+++ b/app/classifier/tasks/drawing/min-max-editor.jsx
@@ -9,12 +9,14 @@ class MinMaxEditor extends React.Component {
     workflow: PropTypes.object,
     minKey: PropTypes.string,
     maxKey: PropTypes.string,
+    maxPlaceholder: PropTypes.string,
     minLimit: PropTypes.number,
   };
 
   static defaultProps = {
     minKey: 'min',
     maxKey: 'max',
+    maxPlaceholder: '∞',
     minLimit: 0,
   };
 
@@ -92,7 +94,7 @@ class MinMaxEditor extends React.Component {
             name={`${this.props.name}.${this.props.maxKey}`}
             min={this.state.tool[this.props.minKey] ? this.state.tool[this.props.minKey] : this.props.minLimit}
             value={this.state.tool[this.props.maxKey]}
-            placeholder="∞"
+            placeholder={this.props.maxPlaceholder}
             size="5"
             style={{ width: '5ch' }}
             onChange={this.onChangeMax}

--- a/app/classifier/tasks/generic-editor.cjsx
+++ b/app/classifier/tasks/generic-editor.cjsx
@@ -286,7 +286,7 @@ module.exports = createReactClass
                     </div>
                     
                     if choice.type is 'Point'
-                      <div
+                      [<div
                         key="uncertainty_circle"
                         className="workflow-choice-setting"
                       >
@@ -304,6 +304,21 @@ module.exports = createReactClass
                           </AutoSave>
                         </label>
                       </div>
+
+                      <div
+                        key="point-bounds"
+                        className="workflow-choice-setting"
+                      >
+                        <strong>Number of points</strong>{' '}
+                        <small>(controls how many points the volunteer may create; leave Max blank so volunteers can only move points already in the subject)</small>
+                        <MinMaxEditor
+                          key='min-max-points'
+                          workflow={@props.workflow}
+                          name="#{@props.taskPrefix}.#{choicesKey}.#{index}"
+                          choice={choice}
+                          maxPlaceholder='0'
+                        />
+                      </div>]
                     else if choice.type is 'SegmentedLine'
                       <div
                         key="segmented-line-bounds"


### PR DESCRIPTION
## Package
- Panoptes-Front-End (Lab / Project Builder)

## Linked Issue and/or Talk Post
- n/a - no PFE issue was filed for this editor. It is the Lab-side counterpart of [#7362 front-end-monorepo](https://github.com/zooniverse/front-end-monorepo/issues/7362) (Point tool min/max), which closes via the companion classifier PR [#7526 front-end-monorepo](https://github.com/zooniverse/front-end-monorepo/pull/7526).

## Describe your changes
- Add a **Number of points** Min/Max editor to the GeoDrawing Point tool entry, rendered below the existing uncertainty-circle checkbox; the inputs write `min` / `max` on the tool config through the shared `MinMaxEditor` + AutoSave
- Both inputs use placeholder `0`: for the Point tool a blank Max means volunteers cannot create points (move-only), unlike SegmentedLine where blank means unlimited - the explanatory copy under the heading says exactly that
- Add a `maxPlaceholder` prop to `MinMaxEditor` (default `∞` unchanged) so the Point entry can show `0`; SegmentedLine entries are untouched
- Mirrors the SegmentedLine bounds-editor shape inside the same file; no new selectors, no CSS additions

## How to Review
Helpful explanations that will make your reviewer happy:

What Zooniverse project should my reviewer use to review UX?
- `markbouslog/northstar-mapping-project` on production (project id `31513`, workflow `32398` "GeoDrawing Point Create", subject set `136882` "Boundary Waters BWCAW (test)" with 6 bbox-only lake subjects pre-loaded for end-to-end exercise).

What user actions should my reviewer step through to review this PR?
- [x] run `npm start` in `Panoptes-Front-End`
- [x] open https://local.zooniverse.org:3735/lab/31513/workflows/32398?env=production&femLab=false and sign in (`?env=production` points panoptes-client at production Panoptes; `femLab=false` forces the legacy Workflow editor that renders this tool config)
- [x] in the workflow's task list, open the GeoDrawing task editor and expand the tool entry with Geometry type `Point`
- [x] confirm a **Number of points** block renders below the uncertainty-circle checkbox with Min and Max number inputs, both placeholder `0`, showing the workflow's live values (Min `1`, Max `3`)
- [x] edit a value and confirm AutoSave patches the workflow record, then restore Min `1` / Max `3` before leaving (the classifier fixture and its behavioral test expect those bounds)
- [x] switch the tool's Geometry type to `Segmented line` and confirm its bounds editors still show the unlimited (`∞` / `no max`) placeholders, then switch back to `Point`
- [x] (optional end-to-end) with the companion classifier PR checked out, confirm the classifier honors the configured bounds on the same workflow
- [x] confirm no new console errors appear that aren't already present on `main`

Which storybook stories should be reviewed?
- n/a. PFE doesn't ship a Storybook surface for `generic-editor.cjsx`; the Lab page above is the user-facing surface.

Are there plans for follow up PR's to further fix this bug or develop this feature?
- This completes the Lab side of the CSSI Mapping Point Refactor milestone. The classifier side is [#7526 front-end-monorepo](https://github.com/zooniverse/front-end-monorepo/pull/7526) (stacked on [#7524 front-end-monorepo](https://github.com/zooniverse/front-end-monorepo/pull/7524), Subject Definition); no further PFE PRs are planned in this milestone.
