### PR TITLE
Add map overlay-layer editor to GeoDrawing workflow config

### DIFF
--- a/app/pages/lab-fem/components/map-overlay-layers-editor.jsx
+++ b/app/pages/lab-fem/components/map-overlay-layers-editor.jsx
@@ -1,0 +1,140 @@
+import React from 'react';
+import AutoSave from '../../../components/auto-save.coffee';
+import handleInputChange from '../../../lib/handle-input-change.js';
+
+const OVERLAY_LAYERS_PATH = 'configuration.subject_viewer_config.overlay_layers';
+
+export default function MapOverlayLayersEditor({ workflow = null }) {
+  const handleChange = handleInputChange.bind(workflow);
+  const overlayLayers = workflow.configuration?.subject_viewer_config?.overlay_layers ?? [];
+
+  function writeOverlayLayers(next) {
+    workflow.update({ [OVERLAY_LAYERS_PATH]: next });
+  }
+
+  function addOverlayLayer() {
+    const current = overlayLayers.slice();
+    current.push({ type: 'wfs', label: '', url: '', typeName: '' });
+    writeOverlayLayers(current);
+  }
+
+  function removeOverlayLayer(index) {
+    const current = overlayLayers.slice();
+    current.splice(index, 1);
+    writeOverlayLayers(current);
+  }
+
+  return (
+    <div className="workflow-overlay-layers-editor">
+      <span className="form-label">Map overlay layers</span>
+      <br />
+      <small className="form-help">Configure WFS / GeoJSON vector overlays rendered on top of the active basemap during classification (e.g. county lines, hydrography, public lands).</small>
+      {overlayLayers.map((layer, index) => {
+        const urlMissing = !(layer.url ?? '').trim();
+        const typeNameMissing = layer.type === 'wfs' && !(layer.typeName ?? '').trim();
+        const urlPlaceholder = layer.type === 'geojson'
+          ? 'https://example.org/features.geojson'
+          : 'https://hydro.nationalmap.gov/arcgis/services/nhd/MapServer/WFSServer?';
+        return (
+          <div key={index} className="workflow-overlay-layer-row">
+            <AutoSave resource={workflow}>
+              <div className="workflow-overlay-layer-field workflow-overlay-layer-type-row" data-field="type">
+                <label>
+                  Type{' '}
+                  <br />
+                  <select
+                    name={`${OVERLAY_LAYERS_PATH}.${index}.type`}
+                    value={layer.type || 'wfs'}
+                    onChange={handleChange}
+                  >
+                    <option value="wfs">WFS (OGC Web Feature Service)</option>
+                    <option value="geojson">GeoJSON (static or {'{bbox}'}-templated URL)</option>
+                  </select>
+                </label>
+                <button
+                  type="button"
+                  className="workflow-overlay-layer-remove-button"
+                  title="Remove overlay layer"
+                  onClick={() => removeOverlayLayer(index)}
+                >&times;</button>
+              </div>
+              <div className="workflow-overlay-layer-field" data-field="label">
+                <label>
+                  Label
+                  <br />
+                  <input
+                    type="text"
+                    className="standard-input full"
+                    placeholder="This is what the volunteer will see..."
+                    name={`${OVERLAY_LAYERS_PATH}.${index}.label`}
+                    value={layer.label || ''}
+                    onChange={handleChange}
+                  />
+                </label>
+              </div>
+              <div className="workflow-overlay-layer-field" data-field="url">
+                <label>
+                  URL
+                  <br />
+                  <input
+                    type="text"
+                    className="standard-input full"
+                    placeholder={urlPlaceholder}
+                    name={`${OVERLAY_LAYERS_PATH}.${index}.url`}
+                    value={layer.url || ''}
+                    onChange={handleChange}
+                  />
+                </label>
+                {urlMissing && (
+                  <small className="workflow-overlay-layer-error" data-field="url" role="alert">
+                    Overlay layer requires a URL.
+                  </small>
+                )}
+              </div>
+              {layer.type === 'wfs' && (
+                <div className="workflow-overlay-layer-field" data-field="typeName">
+                  <label>
+                    typeName
+                    <br />
+                    <input
+                      type="text"
+                      className="standard-input full"
+                      placeholder="nhd:NHDFlowline"
+                      name={`${OVERLAY_LAYERS_PATH}.${index}.typeName`}
+                      value={layer.typeName || ''}
+                      onChange={handleChange}
+                    />
+                  </label>
+                  {typeNameMissing && (
+                    <small className="workflow-overlay-layer-error" data-field="typeName" role="alert">
+                      WFS overlays require a typeName (e.g. <code>nhd:NHDFlowline</code>).
+                    </small>
+                  )}
+                </div>
+              )}
+              <div className="workflow-overlay-layer-field" data-field="attributions">
+                <label>
+                  Attribution (optional)
+                  <br />
+                  <input
+                    type="text"
+                    className="standard-input full"
+                    name={`${OVERLAY_LAYERS_PATH}.${index}.attributions`}
+                    value={layer.attributions || ''}
+                    onChange={handleChange}
+                  />
+                </label>
+              </div>
+            </AutoSave>
+          </div>
+        );
+      })}
+      <button
+        type="button"
+        className="workflow-overlay-layer-add-button"
+        title="Add overlay layer"
+        onClick={addOverlayLayer}
+      >+ Add overlay layer</button>
+    </div>
+  );
+}

--- a/app/pages/lab-fem/components/map-overlay-layers-editor.spec.jsx
+++ b/app/pages/lab-fem/components/map-overlay-layers-editor.spec.jsx
@@ -1,0 +1,94 @@
+/* eslint prefer-arrow-callback: 0, func-names: 0, 'react/jsx-filename-extension': 0 */
+/* global describe, it */
+
+import { shallow } from 'enzyme';
+import React from 'react';
+import assert from 'assert';
+import sinon from 'sinon';
+import MapOverlayLayersEditor from './map-overlay-layers-editor';
+import mockPanoptesResource from '../../../../test/mock-panoptes-resource';
+
+function mountWithLayers(overlay_layers) {
+  const workflow = mockPanoptesResource('workflows', {
+    configuration: { subject_viewer_config: { overlay_layers } }
+  });
+  const wrapper = shallow(<MapOverlayLayersEditor workflow={workflow} />);
+  return { workflow, wrapper };
+}
+
+describe('MapOverlayLayersEditor: overlay_layers editor', function () {
+  it('renders an "Add overlay layer" button', function () {
+    const { wrapper } = mountWithLayers([]);
+    assert.equal(wrapper.find('.workflow-overlay-layer-add-button').length, 1);
+  });
+
+  it('clicking "Add overlay layer" appends a default wfs entry to workflow configuration', function () {
+    const { workflow, wrapper } = mountWithLayers([]);
+    wrapper.find('.workflow-overlay-layer-add-button').simulate('click');
+    const call = workflow.update.getCalls().find(c =>
+      c.args[0]['configuration.subject_viewer_config.overlay_layers']
+    );
+    assert.ok(call, 'expected workflow.update to be called for overlay_layers');
+    const next = call.args[0]['configuration.subject_viewer_config.overlay_layers'];
+    assert.equal(next.length, 1);
+    assert.equal(next[0].type, 'wfs');
+  });
+
+  it('renders one row per entry with type-select, label, and url inputs', function () {
+    const { wrapper } = mountWithLayers([
+      { type: 'wfs', label: 'Hydrography', url: 'https://example.org/wfs', typeName: 'nhd:NHDFlowline' },
+      { type: 'geojson', label: 'Project area', url: 'https://example.org/area.geojson' }
+    ]);
+    assert.equal(wrapper.find('.workflow-overlay-layer-row').length, 2);
+    assert.equal(wrapper.find('select[name="configuration.subject_viewer_config.overlay_layers.0.type"]').length, 1);
+    assert.equal(wrapper.find('input[name="configuration.subject_viewer_config.overlay_layers.0.label"]').length, 1);
+    assert.equal(wrapper.find('input[name="configuration.subject_viewer_config.overlay_layers.1.url"]').length, 1);
+  });
+
+  it('clicking the remove button on a row drops that entry from the workflow configuration', function () {
+    const { workflow, wrapper } = mountWithLayers([
+      { type: 'wfs', label: 'Hydrography', url: 'https://example.org/wfs', typeName: 'nhd:NHDFlowline' },
+      { type: 'geojson', label: 'Project area', url: 'https://example.org/area.geojson' }
+    ]);
+    wrapper.find('.workflow-overlay-layer-remove-button').at(0).simulate('click');
+    const call = workflow.update.getCalls().find(c =>
+      c.args[0]['configuration.subject_viewer_config.overlay_layers']
+    );
+    assert.ok(call, 'expected workflow.update to be called for overlay_layers');
+    const next = call.args[0]['configuration.subject_viewer_config.overlay_layers'];
+    assert.equal(next.length, 1);
+    assert.equal(next[0].type, 'geojson');
+  });
+
+  it('shows the typeName field only for wfs entries', function () {
+    const { wrapper } = mountWithLayers([
+      { type: 'wfs', label: '', url: 'https://example.org/wfs', typeName: 'nhd:NHDFlowline' },
+      { type: 'geojson', label: '', url: 'https://example.org/area.geojson' }
+    ]);
+    assert.equal(wrapper.find('input[name="configuration.subject_viewer_config.overlay_layers.0.typeName"]').length, 1);
+    assert.equal(wrapper.find('input[name="configuration.subject_viewer_config.overlay_layers.1.typeName"]').length, 0);
+  });
+
+  it('flags a missing url', function () {
+    const { wrapper } = mountWithLayers([
+      { type: 'geojson', label: 'No url yet', url: '' }
+    ]);
+    const errors = wrapper.find('.workflow-overlay-layer-error[data-field="url"]');
+    assert.equal(errors.length, 1);
+  });
+
+  it('flags a wfs entry missing its typeName', function () {
+    const { wrapper } = mountWithLayers([
+      { type: 'wfs', label: '', url: 'https://example.org/wfs', typeName: '' }
+    ]);
+    const errors = wrapper.find('.workflow-overlay-layer-error[data-field="typeName"]');
+    assert.equal(errors.length, 1);
+  });
+
+  it('renders an attribution input per row', function () {
+    const { wrapper } = mountWithLayers([
+      { type: 'geojson', label: '', url: 'https://example.org/area.geojson' }
+    ]);
+    assert.equal(wrapper.find('input[name="configuration.subject_viewer_config.overlay_layers.0.attributions"]').length, 1);
+  });
+});

--- a/app/pages/lab-fem/workflow.jsx
+++ b/app/pages/lab-fem/workflow.jsx
@@ -8,6 +8,7 @@ import { Link } from 'react-router';
 import LayoutOptions from './components/layout-options.jsx';
 import FemMultiImageSubjectOptionsEditor from './components/fem-multi-image-subject-options-editor.jsx';
 import MapTileLayersEditor from './components/map-tile-layers-editor.jsx';
+import MapOverlayLayersEditor from './components/map-overlay-layers-editor.jsx';
 import taskComponents from '../../classifier/tasks/index.js';
 import AutoSave from '../../components/auto-save.coffee';
 import WorkflowCreateForm from '../lab/workflow-create-form.cjsx';
@@ -414,6 +415,8 @@ class EditWorkflowPage extends Component {
             {Array.from(this.props.project.experimental_tools).includes('mapping') ?
               <div>
                 <MapTileLayersEditor workflow={this.props.workflow} />
+                <hr />
+                <MapOverlayLayersEditor workflow={this.props.workflow} />
                 <hr />
               </div> : undefined}
 

--- a/css/workflow-editor.styl
+++ b/css/workflow-editor.styl
@@ -147,3 +147,34 @@
 
 .workflow-tile-layer-add-button
   margin-top: 1em
+
+.workflow-overlay-layer-row
+  margin-bottom: 1.5em
+
+.workflow-overlay-layer-type-row
+  align-items: flex-end
+  display: flex
+  gap: 0.5em
+  justify-content: space-between
+
+  > label
+    flex: 0 0 auto
+
+  .workflow-overlay-layer-remove-button
+    flex: 0 0 auto
+
+.workflow-overlay-layer-remove-button
+  @extends $reset-button
+  background: gray
+  border-radius: 50%
+  box-shadow: 0 1px 1px rgba(black, 0.1)
+  color: white
+  height: 1.25em
+  line-height: 1
+  width: 1.25em
+
+  &:hover
+    background: red
+
+.workflow-overlay-layer-add-button
+  margin-top: 1em


### PR DESCRIPTION
## Linked Issue and/or Talk Post
- Closes #7466
- FEM classifier side: https://github.com/zooniverse/front-end-monorepo/pull/7541

## Describe your changes
- Add a Map overlay layers editor to the FEM Lab workflow page, below the Map tile layers editor (same `mapping` experimental-tool gate)
- Each entry has a Type select (WFS or GeoJSON, static or `{bbox}`-templated URL), Label, URL, typeName (WFS only), and optional Attribution, written to `configuration.subject_viewer_config.overlay_layers` through AutoSave
- Inline errors flag a missing URL and a WFS entry missing its typeName
- Mirrors `map-tile-layers-editor.jsx`; no changes to it

## How to Review
- What user actions should my reviewer step through to review this PR?
  - local: https://local.zooniverse.org:3735/lab/31513/workflows/32087?env=production
  - staged branch: https://pr-7505.pfe-preview.zooniverse.org/lab/31513/workflows/32087?env=production
  - workflow 32087 already has six overlay layers configured; they render as rows in the new "Map overlay layers" section
  - add a layer; working WFS values: 
    - URL `https://hydro.nationalmap.gov/arcgis/services/nhd/MapServer/WFSServer`
    - typeName `nhd:NHDFlowline`
    - Errors clear as you fill and the values autosave. Please remove the test row when done
  - switching a row's Type to GeoJSON hides typeName; a working `{bbox}`-templated URL is `https://hydro.nationalmap.gov/arcgis/rest/services/nhd/MapServer/6/query?where=1%3D1&geometry={bbox}&geometryType=esriGeometryEnvelope&inSR=3857&outSR=4326&f=geojson&resultRecordCount=200`
- Are there plans for follow up PR's to further fix this bug or develop this feature? 
  - No - this completes the Lab side of the WFS Overlays milestone.

## Checklist

### General UX
- [ ] Staging branch URL: https://pr-7505.pfe-preview.zooniverse.org/lab/31513/workflows/32087?env=production
- [ ] The component is accessible (double check especially if adding new code to this codebase). We recognize that not all legacy components of PFE will pass accessibility guidelines.
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)
