### PR TITLE
Add newberry/postcard-tag to private project slugs

### DIFF
--- a/app/slugList.js
+++ b/app/slugList.js
@@ -345,7 +345,7 @@ const OTHER_SLUGS = [
   'msbrhonclif/science-scribbler-key2cat', // Subject image sizes difficult in FEM's classifier layout
   'msbrhonclif/science-scribbler-placenta-profiles', // Subject image sizes difficult in FEM's classifier layout
   'mschwamb/planet-four', // Uses experimental "fan tool"
-  'newberry/postcard-tag', // Requested revert to PFE classifier with nexted combo tasks
+  'newberry/postcard-tag', // Requested revert to PFE classifier with nested combo tasks
   'nora-dot-eisner/planet-hunters-tess-mobile',
   'panettafordham/shadows-on-stone-identifying-sing-sings-incarcerated',
   'penguintom79/penguin-watch', // Uses experimental "shortcut"

--- a/app/slugList.js
+++ b/app/slugList.js
@@ -206,7 +206,6 @@ export const PRIVATE_PROJECT_SLUGS = [
   'nelvy/beard-satellites-clasification-test2',
   'newberry/art-in-miniature',
   'newberry/postcard-tag-old',
-  'newberry/postcard-tag',
   'nicholasfoster/te-manahuna-aoraki',
   'nicoadams/environment-project-clump-vetting',
   'nora-dot-eisner/classifying-the-classified',
@@ -346,6 +345,7 @@ const OTHER_SLUGS = [
   'msbrhonclif/science-scribbler-key2cat', // Subject image sizes difficult in FEM's classifier layout
   'msbrhonclif/science-scribbler-placenta-profiles', // Subject image sizes difficult in FEM's classifier layout
   'mschwamb/planet-four', // Uses experimental "fan tool"
+  'newberry/postcard-tag', // Requested revert to PFE classifier with nexted combo tasks
   'nora-dot-eisner/planet-hunters-tess-mobile',
   'panettafordham/shadows-on-stone-identifying-sing-sings-incarcerated',
   'penguintom79/penguin-watch', // Uses experimental "shortcut"

--- a/app/slugList.js
+++ b/app/slugList.js
@@ -206,6 +206,7 @@ export const PRIVATE_PROJECT_SLUGS = [
   'nelvy/beard-satellites-clasification-test2',
   'newberry/art-in-miniature',
   'newberry/postcard-tag-old',
+  'newberry/postcard-tag',
   'nicholasfoster/te-manahuna-aoraki',
   'nicoadams/environment-project-clump-vetting',
   'nora-dot-eisner/classifying-the-classified',


### PR DESCRIPTION
Route newberry/postcard-tag to PFE redirects.

https://www.zooniverse.org/projects/newberry/postcard-tag
https://www.zooniverse.org/lab/7540
https://github.com/zooniverse/static/pull/446

## How to Review
- What user actions should my reviewer step through to review this PR?
- Are there plans for follow up PR’s to further fix this bug or develop this feature?

## Checklist

### General UX
- [ ] Staging branch URL: https://pr-{NUMBER}.pfe-preview.zooniverse.org/lab
- [ ] The component is accessible (double check especially if adding new code to this codebase). We recognize that not all legacy components of PFE will pass accessibility guidelines.
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)

### Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated

### Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected

### Maintenance
- [ ] If not from dependabot, the PR creator has described the update (major, minor, or patch version, changelog)
