### PR TITLE
TranscriptionTask editor: fix missing colour patches

### DIFF
--- a/app/classifier/tasks/transcription/editor.jsx
+++ b/app/classifier/tasks/transcription/editor.jsx
@@ -5,6 +5,22 @@ import AutoSave from '../../../components/auto-save';
 import alert from  '../../../lib/alert';
 import SubTaskEditor from './SubtaskEditor';
 
+function ColourPatch ({ colour = '#000000' }) {
+  console.log(colour)
+  return (
+    <svg
+      style={{
+        display: 'inline',
+        height: '10px',
+        width: '10px',
+      }}
+      viewBox='0 0 10 10'
+    >
+      <rect x='0' y='0' width='10' height='10' fill={colour} />
+    </svg>
+  )
+}
+
 export default function TranscriptionTaskEditor({ task, taskPrefix, workflow }) {
   const handleChange = handleInputChange.bind(workflow)
 
@@ -54,13 +70,13 @@ export default function TranscriptionTaskEditor({ task, taskPrefix, workflow }) 
         <small className="form-help">
           This is a 2-click line mark tool which has pre-set colors. These colors map to the following states:
           <dl>
-            <dt><img src='https://via.placeholder.com/10x10.png/06FE76?text=+' /> Green</dt>
+            <dt><ColourPatch colour='#06FE76' /> Green</dt>
             <dd>A transcription line mark currently selected by the volunteer.</dd>
-            <dt><img src='https://via.placeholder.com/10x10.png/235DFF?text=+' /> Blue</dt>
+            <dt><ColourPatch colour='#235DFF' /> Blue</dt>
             <dd>A transcription line mark made by the volunteer.</dd>
-            <dt><img src='https://via.placeholder.com/10x10.png/FF40FF?text=+' /> Pink </dt>
+            <dt><ColourPatch colour='#FF40FF' /> Pink </dt>
             <dd>A transcription line mark made previously by another volunteer. This mark can be selected to create a new transcription to submit.</dd>
-            <dt><img src='https://via.placeholder.com/10x10.png/979797?text=+' /> Gray</dt>
+            <dt><ColourPatch colour='#a6a7a9' /> Gray</dt> {/* This was previously #979797 */}
             <dd>A transcription line mark which has reached consensus. The mark and transcriptions are view only.</dd>
           </dl>
         </small>


### PR DESCRIPTION
## PR Overview

Fixes #7507 
Fixes #7355 
Affects: Project Builder (Lab) -> Edit Workflow page -> Edit Transcription Task

This PR fixes the missing colour patches in the Edit Transcription Task's "Transcription Line Tool" helper section.

From this...

<img width="548" height="335" alt="Image" src="https://github.com/user-attachments/assets/206211a4-7125-4747-b278-f83e3617c6bc" />

To this...

<img width="521" height="291" alt="image" src="https://github.com/user-attachments/assets/65663a28-2c87-44e5-a0df-6f54c172dd41" />

### Testing

- Select any workflow with a Transcription Task, e.g. https://local.zooniverse.org:3735/lab/33284/workflows/32536?env=production
- Select that Transcription Task
- Confirm that the "Transcription Line Tool" helper section in the right-hand column is displaying the colours matching the Transcription Task on the FEM classifier. (For example, compare the colours on a Transcription Project like https://www.zooniverse.org/projects/printmigrationnetwork/print/ )

### Status

Ready for review.