### PR TITLE
Update GeoDrawing Point tool min-max editor subtext

### DIFF
--- a/app/classifier/tasks/generic-editor.cjsx
+++ b/app/classifier/tasks/generic-editor.cjsx
@@ -310,7 +310,7 @@ module.exports = createReactClass
                         className="workflow-choice-setting"
                       >
                         <strong>Number of points</strong>{' '}
-                        <small>(controls how many points the volunteer may create; leave Max blank so volunteers can only move points already in the subject)</small>
+                        <small>(controls how many points the volunteer may draw)</small>
                         <MinMaxEditor
                           key='min-max-points'
                           workflow={@props.workflow}


### PR DESCRIPTION
## Linked Issue and/or Talk Post
- linked to https://github.com/zooniverse/front-end-monorepo/pull/7542

## Describe your changes
- update GeoDrawing Point tool min-max editor subtext to reflect standard min-max regardless if features already in the subject

## How to Review
- What user actions should my reviewer step through to review this PR?
  - review GeoDrawing Point tool editor, like in https://7509.pfe-preview.zooniverse.org/lab/2030/workflows/3884
- Are there plans for follow up PR’s to further fix this bug or develop this feature? see linked GitHub project

## Checklist

### General UX
- [ ] Staging branch URL: https://7509.pfe-preview.zooniverse.org/lab
- [ ] The component is accessible (double check especially if adding new code to this codebase). We recognize that not all legacy components of PFE will pass accessibility guidelines.
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)

### Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected