### PR TITLE
Panoptes-Front-End: Add Geo Radial and Geo Box to the feedback strategy registry

### DIFF
--- a/app/features/feedback/shared/helpers/generate-rules.js
+++ b/app/features/feedback/shared/helpers/generate-rules.js
@@ -28,7 +28,11 @@ function generateRules(subject, workflow) {
 
       if (matchingSubjectRule) {
         const ruleStrategy = workflowRule.strategy;
-        const ruleGenerator = strategies[ruleStrategy].createRule;
+        const ruleGenerator = strategies[ruleStrategy] && strategies[ruleStrategy].createRule;
+        if (!ruleGenerator) {
+          console.warn(`Feedback: no runnable strategy ${ruleStrategy}, skipping rule ${workflowRule.id}`);
+          return result;
+        }
         return result.concat([ruleGenerator(matchingSubjectRule, workflowRule)]);
       } else {
         return result;

--- a/app/features/feedback/shared/helpers/generate-rules.spec.js
+++ b/app/features/feedback/shared/helpers/generate-rules.spec.js
@@ -117,7 +117,30 @@ describe('feedback: generateRules', function () {
         const subject = mockSubjectWithRule('1');
         expect(generateRules(subject, workflow)).to.be.empty;
       });
-      
+
+    })
+
+    describe('when the workflow rule has no runnable strategy', function () {
+      const workflow = {
+        tasks: {
+          T0: {
+            feedback: {
+              enabled: true,
+              rules: [{
+                id: '51',
+                strategy: 'geoRadial',
+                failureEnabled: true,
+                successEnabled: true
+              }]
+            }
+          }
+        }
+      };
+
+      it('should skip the rule instead of throwing', function () {
+        const subject = mockSubjectWithRule('51');
+        expect(generateRules(subject, workflow)).to.be.empty;
+      });
     })
   });
 });

--- a/app/features/feedback/shared/strategies/geo/box/README.md
+++ b/app/features/feedback/shared/strategies/geo/box/README.md
@@ -1,0 +1,6 @@
+# Feedback Strategy: Geo Box
+
+Determines whether a volunteer's geoDrawing point falls inside a rectangular target region on the map: a center lon/lat plus width, height, and clockwise rotation, in meters.
+
+This feedback is only available in the [Zooniverse Classifier](https://github.com/zooniverse/front-end-monorepo/tree/master/packages/lib-classifier#zooniverse-classifier).
+Please see the related [Geo Box documentation](https://github.com/zooniverse/front-end-monorepo/tree/master/packages/lib-classifier/src/store/feedback/strategies/geo/box#feedback-strategy-geo-box) in the Zooniverse Classifier.

--- a/app/features/feedback/shared/strategies/geo/box/index.js
+++ b/app/features/feedback/shared/strategies/geo/box/index.js
@@ -1,0 +1,9 @@
+import LabComponent from '../../drawing/lab-component';
+import validations from '../../drawing/validations';
+
+export default {
+  id: 'geoBox',
+  labComponent: LabComponent,
+  title: 'Geo Box',
+  validations
+};

--- a/app/features/feedback/shared/strategies/geo/radial/README.md
+++ b/app/features/feedback/shared/strategies/geo/radial/README.md
@@ -1,0 +1,6 @@
+# Feedback Strategy: Geo Radial
+
+Determines whether a volunteer's geoDrawing point is within a given distance in meters of a target lon/lat.
+
+This feedback is only available in the [Zooniverse Classifier](https://github.com/zooniverse/front-end-monorepo/tree/master/packages/lib-classifier#zooniverse-classifier).
+Please see the related [Geo Radial documentation](https://github.com/zooniverse/front-end-monorepo/tree/master/packages/lib-classifier/src/store/feedback/strategies/geo/radial#feedback-strategy-geo-radial) in the Zooniverse Classifier.

--- a/app/features/feedback/shared/strategies/geo/radial/index.js
+++ b/app/features/feedback/shared/strategies/geo/radial/index.js
@@ -1,0 +1,9 @@
+import LabComponent from '../../drawing/lab-component';
+import validations from '../../drawing/validations';
+
+export default {
+  id: 'geoRadial',
+  labComponent: LabComponent,
+  title: 'Geo Radial',
+  validations
+};

--- a/app/features/feedback/shared/strategies/index.js
+++ b/app/features/feedback/shared/strategies/index.js
@@ -3,12 +3,16 @@ import column from './drawing/column';
 import radial from './drawing/radial';
 import pointInEllipse from './drawing/pointInEllipse';
 import dud from './dud';
+import geoBox from './geo/box';
+import geoRadial from './geo/radial';
 import singleAnswerQuestion from './single-answer-question';
 import surveySimple from './survey/simple';
 
 export default {
   column,
   dud,
+  geoBox,
+  geoRadial,
   graph2drange,
   radial,
   pointInEllipse,


### PR DESCRIPTION
## Package
- Panoptes-Front-End (Lab / Project Builder)

## Linked Issue and/or Talk Post
- n/a - no PFE issue was filed. This is the Lab-side counterpart of the classifier PR [#7579 front-end-monorepo](https://github.com/zooniverse/front-end-monorepo/pull/7579) (geoRadial and geoBox feedback strategies for geoDrawing tasks).

## Describe your changes
- register **Geo Radial** and **Geo Box** in the shared feedback strategy registry as Lab-config-only entries, following the `graph2drange` precedent: `id`, `title`, `labComponent`, and `validations` only, with `createRule`/`reducer` living in the classifier
- reuse the shared drawing lab component and validations, so both strategies configure `defaultTolerance` (meters) and `hideSubjectViewer`
- skip feedback rules with no runnable strategy in PFE's own rule generation instead of throwing; this also covers the pre-existing `graph2drange` exposure for PFE-whitelisted projects
- add strategy READMEs pointing at the classifier documentation for the subject metadata conventions

## How to Review
Helpful explanations that will make your reviewer happy:

What Zooniverse project should my reviewer use to review UX?
- `markbouslog/northstar-mapping-project` on production (project id `31513`, workflow `32398` "GeoDrawing Point Create"). The workflow already carries two live rules (`dam-radial` geoRadial, `dam-box` geoBox) and subject set `138677` "BWCA Gold Standard POC" with per-subject targets, so the editor renders real config.

What user actions should my reviewer step through to review this PR?
- [ ] run `npm start` in `Panoptes-Front-End`
- [ ] open https://local.zooniverse.org:3735/lab/31513/workflows/32398?env=production&femLab=false and sign in (`?env=production` points panoptes-client at production Panoptes; `femLab=false` forces the legacy Workflow editor that renders the feedback section)
- [ ] open the GeoDrawing task editor; the feedback section lists the two existing rules (`dam-radial`, `dam-box`) without errors
- [ ] click **Create new feedback rule**; the strategy dropdown lists Geo Radial and Geo Box, and choosing either renders the Default Tolerance input and Hide Subject Viewer checkbox; close the modal without saving
- [ ] run `npm run test-one app/features/feedback/shared/helpers/generate-rules.spec.js` and confirm it passes, including the new no-runnable-strategy case
- [ ] confirm no new console errors appear that aren't already present on `main`

Which storybook stories should be reviewed?
- n/a. PFE doesn't ship a Storybook surface for the Lab feedback editor; the Lab page above is the user-facing surface.

Are there plans for follow up PR's to further fix this bug or develop this feature?
- No further PFE PRs are planned. The classifier side (strategies, meters math, and the map feedback viewer) is [#7579 front-end-monorepo](https://github.com/zooniverse/front-end-monorepo/pull/7579).
