### PR TITLE
Add link in project builder to AI Ethics page

### DIFF
--- a/app/pages/lab/about/index.cjsx
+++ b/app/pages/lab/about/index.cjsx
@@ -32,10 +32,5 @@ module.exports = createReactClass
           FAQ
         </Link>
       </span>
-      <p className="form-help about-tab-editor">
-        In this section:<br/>
-        Header 1 will appear <strong>orange</strong>.<br/>
-        Headers 2 - 6 and hyperlinks will appear <strong>dark-blue</strong>.
-      </p>
       {React.cloneElement(@props.children, {project: @props.project, user: @props.user})}
     </div>

--- a/app/pages/lab/about/research.cjsx
+++ b/app/pages/lab/about/research.cjsx
@@ -8,5 +8,6 @@ module.exports = createReactClass
   render: ->
     <div>
       <p className="form-help">This page is for you to describe your research motivations and goals to the volunteers. Feel free to add detail, but try to avoid jargon. This page renders markdown, so you can format it and add images via the Media Library and links.</p>
+      <p className="form-help">If your project is using AI or Machine Learning methods, or has training a model as a goal, please review our <a href='https://www.zooniverse.org/about/ai-ethics'>Zooniverse AI Ethics Framework</a> and <a href='https://help.zooniverse.org/next-steps/ai-ethics'>Guidance for Teams Running AI/ML-Engaged Zooniverse Projects</a>.</p>
       <ProjectPageEditor project={@props.project} page="science_case" pageTitle="Research" />
     </div>


### PR DESCRIPTION
## Linked Issue and/or Talk Post
Corresponds to https://github.com/zooniverse/front-end-monorepo/pull/7578

## Describe your changes
- Add paragraph with link to the new AI Ethics page in the About tab of the project builder
- Removed outdated note about headings styling from the About Project editor

## How to Review
- https://local.zooniverse.org:3735/lab

## Checklist

### General UX
- [ ] Staging branch URL: https://pr-{NUMBER}.pfe-preview.zooniverse.org/lab
- [ ] The component is accessible (double check especially if adding new code to this codebase). We recognize that not all legacy components of PFE will pass accessibility guidelines.
  - Can be used with a screen reader [BBC guide to VoiceOver](https://bbc.github.io/accessibility-news-and-you/assistive-technology/testing-steps/voiceover-mac.html)
  - Can be used from the keyboard [WebAIM guide to keyboard testing](https://webaim.org/techniques/keyboard/#testing)

### Bug Fix
- [ ] The PR creator has listed user actions to use when testing if bug is fixed
- [ ] The bug is fixed
- [ ] Unit tests are added or updated

### Refactoring
- [ ] The PR creator has described the reason for refactoring
- [ ] The refactored component(s) continue to work as expected

### Maintenance
- [ ] If not from dependabot, the PR creator has described the update (major, minor, or patch version, changelog)
